### PR TITLE
fix(cli): increase riverctl WebSocket timeouts to stabilize gateway tests

### DIFF
--- a/cli/contracts/README.md
+++ b/cli/contracts/README.md
@@ -1,0 +1,16 @@
+# River CLI Contracts
+
+This directory contains the WASM contracts used by the River CLI.
+
+## room_contract.wasm
+
+This is a copy of the room contract from `../ui/public/contracts/room_contract.wasm`.
+
+**Important:** This file MUST be kept in sync with the UI version and committed to the repository for crates.io publishing.
+
+To update:
+```bash
+cp ../ui/public/contracts/room_contract.wasm contracts/
+```
+
+The build.rs script will use this file when building from a crates.io package, and will use the UI version when building from the workspace.


### PR DESCRIPTION
## Summary
- Increase riverctl timeouts: PUT/GET from 2s to 10s; SUBSCRIBE from 1s to 5s
- Correct misleading error text (PUT vs GET) on timeout

## Rationale
Gateway/regression runs intermittently hit 2s GET timeouts during room creation and invitation accept steps under real gateway latency. Longer, still conservative timeouts reduce flakiness while preserving fast paths.

## Impact
- Stabilizes gateway framework tests (room creation, invite accept)
- No protocol changes; purely client-side wait tuning

## Testing
- Built `riverctl` in release
- Verified compilation
- Ran gateway framework basic pattern locally; observed fewer timeouts