### PR TITLE
Use ANTHROPIC_API_KEY for Claude workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,8 +87,9 @@ jobs:
 
       - name: Run Claude CI Analysis
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,8 +32,9 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,8 +33,9 @@ jobs:
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
Fixes Claude workflow failures by using `ANTHROPIC_API_KEY` environment variable instead of `claude_code_oauth_token` parameter.

## Problem
Claude workflows were failing with:
```
Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required
```

The org has `ANTHROPIC_API_KEY` configured but not `CLAUDE_CODE_OAUTH_TOKEN`.

## Solution
Updated all three Claude workflows to use the `ANTHROPIC_API_KEY` env var:
- `claude.yml`
- `claude-code-review.yml`
- `build.yml` (claude-ci-analysis job)

🤖 Generated with [Claude Code](https://claude.ai/code)