### PR TITLE
fix: update default WebSocket port from 50509 to 7509

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ cargo make publish-river
 RUST_MIN_STACK=16777216 cargo make publish-river-debug
 
 # Verify River build time after publishing (CRITICAL step)
-curl -s http://127.0.0.1:50509/v1/contract/web/BcfxyjCH4snaknrBoCiqhYc9UFvmiJvhsp5d4L5DuvRa/ | grep -o 'Built: [^<]*' | head -1
+curl -s http://127.0.0.1:7509/v1/contract/web/BcfxyjCH4snaknrBoCiqhYc9UFvmiJvhsp5d4L5DuvRa/ | grep -o 'Built: [^<]*' | head -1
 ```
 
 ## Architecture Overview
@@ -151,7 +151,7 @@ From CONVENTIONS.md:
    - See debugging notes in freenet-core `freenet-invitation-bug.local/`
 
 ### WebSocket Connection
-- River connects to Freenet at `ws://127.0.0.1:50509/ws/v1`
+- River connects to Freenet at `ws://127.0.0.1:7509/ws/v1`
 - Default WebSocket message size limit: 100MB (after fix in freenet v0.1.12+)
 - Check connection status in browser DevTools Network tab
 
@@ -161,7 +161,7 @@ From CONVENTIONS.md:
 tail -f ~/freenet-debug.log | grep -E "(River|contract|WebSocket)"
 
 # Check if River is being served correctly
-curl http://127.0.0.1:50509/v1/contract/web/BcfxyjCH4snaknrBoCiqhYc9UFvmiJvhsp5d4L5DuvRa/
+curl http://127.0.0.1:7509/v1/contract/web/BcfxyjCH4snaknrBoCiqhYc9UFvmiJvhsp5d4L5DuvRa/
 
 # Test contract operations directly (requires contract-test tool)
 cd contract-test && cargo run -- --get <contract-key>

--- a/cli/QUICK_START.md
+++ b/cli/QUICK_START.md
@@ -51,7 +51,7 @@ riverctl -f json <command>
 ## Common Issues
 
 1. **WebSocket connection fails**: Make sure Freenet is running (`freenet network`)
-2. **Connection refused**: Ensure Freenet is running on the default port (50509)
+2. **Connection refused**: Ensure Freenet is running on the default port (7509)
 
 ## Environment Variables
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -23,7 +23,7 @@ See [QUICK_START.md](QUICK_START.md) for basic usage examples and getting starte
 
 ## Requirements
 
-- A running Freenet node (accessible at `ws://127.0.0.1:50509`)
+- A running Freenet node (accessible at `ws://127.0.0.1:7509`)
 - Rust 1.70 or higher (for building from source)
 
 ## Architecture

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -29,7 +29,7 @@ struct Cli {
     #[arg(
         long,
         global = true,
-        default_value = "ws://127.0.0.1:50509/v1/contract/command?encodingProtocol=native"
+        default_value = "ws://127.0.0.1:7509/v1/contract/command?encodingProtocol=native"
     )]
     node_url: String,
 

--- a/ui/src/components/app/freenet_api/constants.rs
+++ b/ui/src/components/app/freenet_api/constants.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 /// WebSocket URL for connecting to local Freenet node
-pub const WEBSOCKET_URL: &str = "ws://localhost:50509/v1/contract/command?encodingProtocol=native";
+pub const WEBSOCKET_URL: &str = "ws://localhost:7509/v1/contract/command?encodingProtocol=native";
 
 /// Default timeout for WebSocket connection in milliseconds
 pub const CONNECTION_TIMEOUT_MS: u64 = 5000;

--- a/ui/src/components/members/invite_member_modal.rs
+++ b/ui/src/components/members/invite_member_modal.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use wasm_bindgen::JsCast;
 
 const BASE_URL: &str =
-    "http://127.0.0.1:50509/v1/contract/web/BcfxyjCH4snaknrBoCiqhYc9UFvmiJvhsp5d4L5DuvRa/";
+    "http://127.0.0.1:7509/v1/contract/web/BcfxyjCH4snaknrBoCiqhYc9UFvmiJvhsp5d4L5DuvRa/";
 
 #[component]
 pub fn InviteMemberModal(is_active: Signal<bool>) -> Element {


### PR DESCRIPTION
## Summary

Updates River to use the new default Freenet WebSocket port 7509 instead of 50509, which is blocked by Windows firewall.

## Background

Port 50509 falls within Windows 10/11's excluded port range (50000-50059), preventing Freenet nodes from starting on Windows systems. The Freenet core is changing the default port to 7509 to fix this issue.

## Changes

Updated default port from 50509 to 7509 across **6 files**:

**Code:**
- `cli/src/main.rs` - CLI default WebSocket URL
- `ui/src/components/app/freenet_api/constants.rs` - UI WebSocket constants
- `ui/src/components/members/invite_member_modal.rs` - UI invite modal URL

**Documentation:**
- `CLAUDE.md` - Development documentation (3 occurrences)
- `cli/README.md` - CLI documentation
- `cli/QUICK_START.md` - Quick start guide

## Testing

- ✅ All code changes compile
- ✅ No remaining references to port 50509
- ✅ URLs updated consistently

## Backward Compatibility

Users on custom port configurations can override using:
```bash
river-cli --node-url "ws://127.0.0.1:50509/v1/contract/command?encodingProtocol=native"
```

## Coordinated Release

**⚠️ IMPORTANT**: This PR should be released in coordination with freenet/freenet-core#1938, which updates the Freenet core default port to 7509.

Related to freenet/freenet-core#1751

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Ian Clarke <sanity@users.noreply.github.com>