### PR TITLE
chore: Bump freenet-stdlib to 0.1.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ river = { path = "cli", package = "river" }
 # Freenet dependencies
 freenet-scaffold = "0.2.1"
 freenet-scaffold-macro = "0.2.1"
-freenet-stdlib = { version = "0.1.22", features = ["contract"] }
+freenet-stdlib = { version = "0.1.23", features = ["contract"] }
 
 [workspace.package]
 version = "0.1.0"


### PR DESCRIPTION
## Summary

Updates freenet-stdlib dependency from v0.1.22 to v0.1.23.

## Changes

freenet-stdlib v0.1.23 includes:
- **Windows linking fix** for WASM import symbols (#39)
- Platform guards for `__frnt__logger__info`, `__frnt__rand__rand_bytes`, and `__frnt__time__utc_now`
- Allows contracts to compile on Windows without linker errors

## Testing

✅ room-contract builds successfully
✅ web-container-contract builds successfully
✅ chat-delegate builds successfully

## Notes

This dependency bump is ready to merge but will go out in the next River release. No breaking changes or behavior changes - only fixes Windows compilation.

Closes #39

[AI-assisted debugging and comment]