### PR TITLE
fix: update to freenet-stdlib 0.1.27 API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ river = { path = "cli", package = "river" }
 # Freenet dependencies
 freenet-scaffold = "0.2.1"
 freenet-scaffold-macro = "0.2.1"
-freenet-stdlib = { version = "0.1.24", features = ["contract"] }
+freenet-stdlib = { version = "0.1.27", features = ["contract"] }
 
 [workspace.package]
 version = "0.1.1"

--- a/contracts/room-contract/tests/common/mod.rs
+++ b/contracts/room-contract/tests/common/mod.rs
@@ -177,7 +177,7 @@ pub async fn subscribe_to_contract(client: &mut WebApi, key: ContractKey) -> Res
     println!("Sending Subscribe request to WebSocket...");
     let send_result = client
         .send(ClientRequest::ContractOp(ContractRequest::Subscribe {
-            key,
+            key: *key.id(), // Subscribe uses ContractInstanceId
             summary: None,
         }))
         .await;
@@ -518,7 +518,7 @@ pub async fn get_all_room_states(
     for (index, client) in clients.iter_mut().enumerate() {
         client
             .send(ClientRequest::ContractOp(ContractRequest::Get {
-                key,
+                key: *key.id(), // GET uses ContractInstanceId
                 return_contract_code: true,
                 subscribe: false,
             }))

--- a/ui/src/components/app/freenet_api/room_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/room_synchronizer.rs
@@ -146,7 +146,7 @@ impl RoomSynchronizer {
 
                 // Create a get request without subscription (will subscribe after response)
                 let get_request = ContractRequest::Get {
-                    key: contract_key,
+                    key: *contract_key.id(), // GET uses ContractInstanceId
                     return_contract_code: true, // I think this should be false but apparently that was triggering a bug
                     subscribe: false,
                 };
@@ -400,7 +400,7 @@ impl RoomSynchronizer {
         info!("Subscribing to contract with key: {}", contract_key.id());
 
         let subscribe_request = ContractRequest::Subscribe {
-            key: *contract_key,
+            key: *contract_key.id(), // Subscribe uses ContractInstanceId
             summary: None,
         };
 

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -185,9 +185,9 @@ fn create_room(room_name: &String, self_is: SelfIs) -> CreatedRoom {
     let parameters = ChatRoomParametersV1 { owner: owner_vk };
     let params_bytes = to_cbor_vec(&parameters);
     let contract_code = ContractCode::from(ROOM_CONTRACT_WASM);
-    let instance_id =
-        ContractInstanceId::from_params_and_code(Parameters::from(params_bytes), contract_code);
-    let contract_key = ContractKey::from(instance_id);
+    // Use the full ContractKey constructor that includes the code hash
+    let contract_key =
+        ContractKey::from_params_and_code(Parameters::from(params_bytes), &contract_code);
 
     CreatedRoom {
         owner_vk,

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -523,9 +523,9 @@ impl Rooms {
         let parameters = ChatRoomParametersV1 { owner: owner_vk };
         let params_bytes = to_cbor_vec(&parameters);
         let contract_code = ContractCode::from(ROOM_CONTRACT_WASM);
-        let instance_id =
-            ContractInstanceId::from_params_and_code(Parameters::from(params_bytes), contract_code);
-        let contract_key = ContractKey::from(instance_id);
+        // Use the full ContractKey constructor that includes the code hash
+        let contract_key =
+            ContractKey::from_params_and_code(Parameters::from(params_bytes), &contract_code);
         info!("🟢 Contract key generated: {:?}", contract_key);
 
         info!("🟢 Creating RoomData struct...");

--- a/ui/src/util.rs
+++ b/ui/src/util.rs
@@ -87,6 +87,6 @@ pub fn owner_vk_to_contract_key(owner_vk: &VerifyingKey) -> ContractKey {
     let params_bytes = to_cbor_vec(&params);
     let parameters = Parameters::from(params_bytes);
     let contract_code = ContractCode::from(ROOM_CONTRACT_WASM);
-    let instance_id = ContractInstanceId::from_params_and_code(parameters, contract_code);
-    ContractKey::from(instance_id)
+    // Use the full ContractKey constructor that includes the code hash
+    ContractKey::from_params_and_code(parameters, &contract_code)
 }


### PR DESCRIPTION
## Problem

freenet-stdlib 0.1.27 (published today) includes breaking API changes:
- `ContractRequest::Get.key` changed from `ContractKey` to `ContractInstanceId`
- `ContractRequest::Subscribe.key` changed from `ContractKey` to `ContractInstanceId`
- `ContractKey::from_id` was removed (ContractKey now requires code hash)

This broke the freenet-core CI's six-peer-regression test which builds River against the latest stdlib.

## Changes

**CLI (cli/src/api.rs)**:
- Use `ContractKey::from_params_and_code` instead of `ContractKey::from(instance_id)`
- Use `contract_key.id()` for GET and SUBSCRIBE requests

**UI (ui/src/)**:
- Same fixes as CLI for GET and SUBSCRIBE requests
- Update `owner_vk_to_contract_key` to use the correct constructor

**Tests (cli/tests/message_flow.rs)**:
- Add `ROOM_CONTRACT_WASM` constant and `owner_key_to_contract_key` helper
- Use helper to reconstruct ContractKey from owner key string

**Room Contract Tests (contracts/room-contract/tests/common/mod.rs)**:
- Use `key.id()` for GET and SUBSCRIBE requests

**Workspace Cargo.toml**:
- Bump freenet-stdlib from 0.1.24 to 0.1.27

## Related

- freenet/freenet-test-network#1 - Same fix for freenet-test-network
- Fixes freenet-core CI failure on main

## Note

Once both this PR and the freenet-test-network PR are merged and published to crates.io, the freenet-core CI should start passing again.

[AI-assisted - Claude]