### PR TITLE
chore(deps): pin minimum freenet-stdlib 0.1.27 and freenet-test-network 0.1.16

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,7 +51,7 @@ atty = "0.2"
 
 # Internal dependencies
 river-core = { version = "0.1.1", path = "../common" }
-freenet-stdlib = { version = "0.1.20", features = ["net"] }
+freenet-stdlib = { version = "0.1.27", features = ["net"] }
 freenet-scaffold = "0.2.1"
 
 # Serialization (for contract state)
@@ -78,6 +78,6 @@ toml = "0.8"
 directories = "5.0"
 
 [dev-dependencies]
-freenet-test-network = "0.1.9"
+freenet-test-network = "0.1.16"
 tempfile = "3"
 assert_cmd = "2"


### PR DESCRIPTION
## Problem

The CI is failing with a deserialization error:
```
Error: Failed to receive response: client error: error while deserializing: tag for enum is not valid, found 143
```

This suggests a bincode serialization format mismatch between the riverctl client and freenet-core node.

## Solution

Pin minimum version requirements in cli/Cargo.toml:
- **freenet-stdlib 0.1.27**: Required for the ContractKey/ContractInstanceId API changes
- **freenet-test-network 0.1.16**: Updated with stdlib 0.1.27 compatibility

This ensures that all components use the same version of the client API types, preventing serialization mismatches.

## Testing

- Verified `cargo check` passes
- This should fix the CI deserialization error in freenet-core's six-peer-regression test

[AI-assisted - Claude]