### PR TITLE
chore(cli): update freenet-test-network to 0.1.19

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -78,6 +78,6 @@ toml = "0.8"
 directories = "5.0"
 
 [dev-dependencies]
-freenet-test-network = "0.1.17"
+freenet-test-network = "0.1.19"
 tempfile = "3"
 assert_cmd = "2"


### PR DESCRIPTION
## Summary
Update freenet-test-network to 0.1.19 which generates X25519 keys instead of RSA.

## Why
This supports freenet-core PR https://github.com/freenet/freenet-core/pull/2533 which replaces RSA with X25519 for the transport layer key exchange.

The test network needs to generate compatible key formats for the six-peer-regression test to pass.

[AI-assisted - Claude]