### PR TITLE
build: bump freenet-stdlib to 0.1.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ river = { path = "cli", package = "river" }
 # Freenet dependencies
 freenet-scaffold = "0.2.1"
 freenet-scaffold-macro = "0.2.1"
-freenet-stdlib = { version = "0.1.29", features = ["contract"] }
+freenet-stdlib = { version = "0.1.30", features = ["contract"] }
 
 [workspace.package]
 version = "0.1.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,7 +51,7 @@ atty = "0.2"
 
 # Internal dependencies
 river-core = { version = "0.1.1", path = "../common" }
-freenet-stdlib = { version = "0.1.29", features = ["net"] }
+freenet-stdlib = { version = "0.1.30", features = ["net"] }
 freenet-scaffold = "0.2.1"
 
 # Serialization (for contract state)


### PR DESCRIPTION
## Problem

River UI was logging "Successfully sent update" even when messages were being silently dropped due to a closed WebSocket connection. This caused messages between users to not be delivered with no error indication.

Root cause: The WebSocket spec specifies that `send()` silently discards data when the socket is in CLOSING or CLOSED state. `freenet-stdlib`'s `WebApi::send()` was returning `Ok(())` even when the underlying WebSocket wasn't open.

## Solution

freenet-stdlib 0.1.30 adds:
1. Check `ready_state` before sending - returns error if WebSocket is not OPEN
2. Enables `onclose` callback to notify clients when connection drops

River will now properly receive errors when WebSocket sends fail, enabling proper error handling and reconnection logic.

## Testing

- `cargo check` passes
- This is a dependency bump; the fix is in freenet-stdlib

[AI-assisted - Claude]