### PR TITLE
feat(messages): add support for message editing, deletion, and reactions

### DIFF
--- a/cli/src/commands/member.rs
+++ b/cli/src/commands/member.rs
@@ -147,7 +147,10 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
             match api.ban_member(&owner_vk, &member_id).await {
                 Ok(()) => match format {
                     OutputFormat::Human => {
-                        println!("{}", format!("Member '{}' has been banned.", member_id).green());
+                        println!(
+                            "{}",
+                            format!("Member '{}' has been banned.", member_id).green()
+                        );
                     }
                     OutputFormat::Json => {
                         println!(

--- a/common/tests/private_room_test.rs
+++ b/common/tests/private_room_test.rs
@@ -648,5 +648,8 @@ fn test_encrypted_messages_in_private_room() {
         RoomMessageBody::Public { .. } => {
             panic!("Expected encrypted message in private room");
         }
+        _ => {
+            panic!("Expected regular message, not action message");
+        }
     }
 }

--- a/delegates/chat-delegate/src/handlers.rs
+++ b/delegates/chat-delegate/src/handlers.rs
@@ -65,7 +65,14 @@ pub(crate) fn handle_application_message(
             message_bytes,
         } => {
             logging::info(format!("Delegate received SignMessage for room: {room_key:?}").as_str());
-            handle_sign_request(&mut context, origin, room_key, request_id, message_bytes, app_msg.app)
+            handle_sign_request(
+                &mut context,
+                origin,
+                room_key,
+                request_id,
+                message_bytes,
+                app_msg.app,
+            )
         }
         ChatDelegateRequestMsg::SignMember {
             room_key,
@@ -73,7 +80,14 @@ pub(crate) fn handle_application_message(
             member_bytes,
         } => {
             logging::info(format!("Delegate received SignMember for room: {room_key:?}").as_str());
-            handle_sign_request(&mut context, origin, room_key, request_id, member_bytes, app_msg.app)
+            handle_sign_request(
+                &mut context,
+                origin,
+                room_key,
+                request_id,
+                member_bytes,
+                app_msg.app,
+            )
         }
         ChatDelegateRequestMsg::SignBan {
             room_key,
@@ -81,7 +95,14 @@ pub(crate) fn handle_application_message(
             ban_bytes,
         } => {
             logging::info(format!("Delegate received SignBan for room: {room_key:?}").as_str());
-            handle_sign_request(&mut context, origin, room_key, request_id, ban_bytes, app_msg.app)
+            handle_sign_request(
+                &mut context,
+                origin,
+                room_key,
+                request_id,
+                ban_bytes,
+                app_msg.app,
+            )
         }
         ChatDelegateRequestMsg::SignConfig {
             room_key,
@@ -89,7 +110,14 @@ pub(crate) fn handle_application_message(
             config_bytes,
         } => {
             logging::info(format!("Delegate received SignConfig for room: {room_key:?}").as_str());
-            handle_sign_request(&mut context, origin, room_key, request_id, config_bytes, app_msg.app)
+            handle_sign_request(
+                &mut context,
+                origin,
+                room_key,
+                request_id,
+                config_bytes,
+                app_msg.app,
+            )
         }
         ChatDelegateRequestMsg::SignMemberInfo {
             room_key,
@@ -116,7 +144,14 @@ pub(crate) fn handle_application_message(
             logging::info(
                 format!("Delegate received SignSecretVersion for room: {room_key:?}").as_str(),
             );
-            handle_sign_request(&mut context, origin, room_key, request_id, record_bytes, app_msg.app)
+            handle_sign_request(
+                &mut context,
+                origin,
+                room_key,
+                request_id,
+                record_bytes,
+                app_msg.app,
+            )
         }
         ChatDelegateRequestMsg::SignEncryptedSecret {
             room_key,
@@ -126,7 +161,14 @@ pub(crate) fn handle_application_message(
             logging::info(
                 format!("Delegate received SignEncryptedSecret for room: {room_key:?}").as_str(),
             );
-            handle_sign_request(&mut context, origin, room_key, request_id, secret_bytes, app_msg.app)
+            handle_sign_request(
+                &mut context,
+                origin,
+                room_key,
+                request_id,
+                secret_bytes,
+                app_msg.app,
+            )
         }
         ChatDelegateRequestMsg::SignUpgrade {
             room_key,
@@ -134,7 +176,14 @@ pub(crate) fn handle_application_message(
             upgrade_bytes,
         } => {
             logging::info(format!("Delegate received SignUpgrade for room: {room_key:?}").as_str());
-            handle_sign_request(&mut context, origin, room_key, request_id, upgrade_bytes, app_msg.app)
+            handle_sign_request(
+                &mut context,
+                origin,
+                room_key,
+                request_id,
+                upgrade_bytes,
+                app_msg.app,
+            )
         }
     }
 }

--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -14,8 +14,8 @@ use crate::components::room_list::edit_room_modal::EditRoomModal;
 use crate::components::room_list::receive_invitation_modal::ReceiveInvitationModal;
 use crate::invites::PendingInvites;
 use crate::room_data::{CurrentRoom, Rooms};
-use dioxus::logger::tracing::{debug, error, info};
 use dioxus::document::Stylesheet;
+use dioxus::logger::tracing::{debug, error, info};
 use dioxus::prelude::*;
 use ed25519_dalek::VerifyingKey;
 use freenet_stdlib::client_api::WebApi;
@@ -84,10 +84,18 @@ pub fn App() -> Element {
                         let new_url = if new_search.is_empty() {
                             window.location().pathname().unwrap_or_default()
                         } else {
-                            format!("{}?{}", window.location().pathname().unwrap_or_default(), new_search)
+                            format!(
+                                "{}?{}",
+                                window.location().pathname().unwrap_or_default(),
+                                new_search
+                            )
                         };
                         if let Ok(history) = window.history() {
-                            let _ = history.replace_state_with_url(&wasm_bindgen::JsValue::NULL, "", Some(&new_url));
+                            let _ = history.replace_state_with_url(
+                                &wasm_bindgen::JsValue::NULL,
+                                "",
+                                Some(&new_url),
+                            );
                         }
                     }
                 }

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -206,14 +206,46 @@ fn get_request_key(request: &ChatDelegateRequestMsg) -> Vec<u8> {
         }
 
         // Signing operations - use prefix + room_key + request_id for uniqueness
-        ChatDelegateRequestMsg::SignMessage { room_key, request_id, .. }
-        | ChatDelegateRequestMsg::SignMember { room_key, request_id, .. }
-        | ChatDelegateRequestMsg::SignBan { room_key, request_id, .. }
-        | ChatDelegateRequestMsg::SignConfig { room_key, request_id, .. }
-        | ChatDelegateRequestMsg::SignMemberInfo { room_key, request_id, .. }
-        | ChatDelegateRequestMsg::SignSecretVersion { room_key, request_id, .. }
-        | ChatDelegateRequestMsg::SignEncryptedSecret { room_key, request_id, .. }
-        | ChatDelegateRequestMsg::SignUpgrade { room_key, request_id, .. } => {
+        ChatDelegateRequestMsg::SignMessage {
+            room_key,
+            request_id,
+            ..
+        }
+        | ChatDelegateRequestMsg::SignMember {
+            room_key,
+            request_id,
+            ..
+        }
+        | ChatDelegateRequestMsg::SignBan {
+            room_key,
+            request_id,
+            ..
+        }
+        | ChatDelegateRequestMsg::SignConfig {
+            room_key,
+            request_id,
+            ..
+        }
+        | ChatDelegateRequestMsg::SignMemberInfo {
+            room_key,
+            request_id,
+            ..
+        }
+        | ChatDelegateRequestMsg::SignSecretVersion {
+            room_key,
+            request_id,
+            ..
+        }
+        | ChatDelegateRequestMsg::SignEncryptedSecret {
+            room_key,
+            request_id,
+            ..
+        }
+        | ChatDelegateRequestMsg::SignUpgrade {
+            room_key,
+            request_id,
+            ..
+        } => {
             let mut key = SIGN_PREFIX.to_vec();
             key.extend_from_slice(room_key);
             key.extend_from_slice(&request_id.to_le_bytes());

--- a/ui/src/components/app/freenet_api/constants.rs
+++ b/ui/src/components/app/freenet_api/constants.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 
 /// Fallback WebSocket URL for non-browser environments
-const FALLBACK_WEBSOCKET_URL: &str = "ws://localhost:7509/v1/contract/command?encodingProtocol=native";
+const FALLBACK_WEBSOCKET_URL: &str =
+    "ws://localhost:7509/v1/contract/command?encodingProtocol=native";
 
 /// Get the WebSocket URL for connecting to the Freenet node.
 /// Derives the URL from the current window.location, allowing River to work
@@ -14,7 +15,10 @@ pub fn get_websocket_url() -> String {
         let host = location.host().unwrap_or_default(); // includes port
 
         let ws_protocol = if protocol == "https:" { "wss:" } else { "ws:" };
-        format!("{}//{}/v1/contract/command?encodingProtocol=native", ws_protocol, host)
+        format!(
+            "{}//{}/v1/contract/command?encodingProtocol=native",
+            ws_protocol, host
+        )
     } else {
         FALLBACK_WEBSOCKET_URL.to_string()
     }

--- a/ui/src/components/app/freenet_api/freenet_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/freenet_synchronizer.rs
@@ -115,9 +115,12 @@ impl FreenetSynchronizer {
                     let callback = Closure::<dyn Fn()>::new(move || {
                         if let Some(window) = web_sys::window() {
                             if let Some(document) = window.document() {
-                                if document.visibility_state() == web_sys::VisibilityState::Visible {
+                                if document.visibility_state() == web_sys::VisibilityState::Visible
+                                {
                                     info!("Page became visible, checking connection health");
-                                    if let Err(e) = visibility_tx.unbounded_send(SynchronizerMessage::PageBecameVisible) {
+                                    if let Err(e) = visibility_tx
+                                        .unbounded_send(SynchronizerMessage::PageBecameVisible)
+                                    {
                                         error!("Failed to send PageBecameVisible message: {}", e);
                                     }
                                 }
@@ -166,7 +169,9 @@ impl FreenetSynchronizer {
                             let error_str = e.to_string();
                             if error_str.contains("WebSocket") || error_str.contains("not open") {
                                 warn!("WebSocket error during room processing, triggering reconnection");
-                                if let Err(e) = message_tx.unbounded_send(SynchronizerMessage::ConnectionLost) {
+                                if let Err(e) =
+                                    message_tx.unbounded_send(SynchronizerMessage::ConnectionLost)
+                                {
                                     error!("Failed to send ConnectionLost: {}", e);
                                 }
                             }
@@ -196,14 +201,17 @@ impl FreenetSynchronizer {
                         info!("Page visibility changed to visible, checking connection status");
                         if !connection_manager.is_connected() {
                             info!("Connection is not active after wake, triggering reconnection");
-                            if let Err(e) = message_tx.unbounded_send(SynchronizerMessage::Connect) {
+                            if let Err(e) = message_tx.unbounded_send(SynchronizerMessage::Connect)
+                            {
                                 error!("Failed to send Connect message after wake: {}", e);
                             }
                         } else {
                             // Connection appears active, trigger a room sync to verify
                             // This will fail fast if the connection is actually dead
                             info!("Connection appears active, triggering room sync to verify");
-                            if let Err(e) = message_tx.unbounded_send(SynchronizerMessage::ProcessRooms) {
+                            if let Err(e) =
+                                message_tx.unbounded_send(SynchronizerMessage::ProcessRooms)
+                            {
                                 error!("Failed to send ProcessRooms message after wake: {}", e);
                             }
                         }
@@ -295,9 +303,9 @@ impl FreenetSynchronizer {
                                                 ))
                                                 .await;
                                                 info!("Re-PUT delay elapsed, triggering ProcessRooms to PUT contract");
-                                                if let Err(e) =
-                                                    tx.unbounded_send(SynchronizerMessage::ProcessRooms)
-                                                {
+                                                if let Err(e) = tx.unbounded_send(
+                                                    SynchronizerMessage::ProcessRooms,
+                                                ) {
                                                     error!("Failed to schedule re-PUT: {}", e);
                                                 }
                                             });
@@ -313,10 +321,13 @@ impl FreenetSynchronizer {
                                                 ))
                                                 .await;
                                                 info!("Subscription timeout check triggered");
-                                                if let Err(e) =
-                                                    tx.unbounded_send(SynchronizerMessage::ProcessRooms)
-                                                {
-                                                    error!("Failed to schedule timeout check: {}", e);
+                                                if let Err(e) = tx.unbounded_send(
+                                                    SynchronizerMessage::ProcessRooms,
+                                                ) {
+                                                    error!(
+                                                        "Failed to schedule timeout check: {}",
+                                                        e
+                                                    );
                                                 }
                                             });
                                         }

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -176,9 +176,15 @@ impl ResponseHandler {
                                         response.clone(),
                                     ),
                                     // Signing response - use both room_key and request_id for correlation
-                                    ChatDelegateResponseMsg::SignResponse { room_key, request_id, .. } => {
-                                        complete_pending_sign_request(room_key, *request_id, response.clone())
-                                    }
+                                    ChatDelegateResponseMsg::SignResponse {
+                                        room_key,
+                                        request_id,
+                                        ..
+                                    } => complete_pending_sign_request(
+                                        room_key,
+                                        *request_id,
+                                        response.clone(),
+                                    ),
                                 };
 
                                 if completed {

--- a/ui/src/components/app/freenet_api/response_handler/subscribe_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/subscribe_response.rs
@@ -53,7 +53,9 @@ pub fn handle_subscribe_response(key: ContractKey, subscribed: bool) -> bool {
                 );
                 SYNC_INFO.write().update_sync_status(
                     &owner_vk,
-                    RoomSyncStatus::Error("Subscription failed - contract not found on network".to_string()),
+                    RoomSyncStatus::Error(
+                        "Subscription failed - contract not found on network".to_string(),
+                    ),
                 );
                 false
             }

--- a/ui/src/components/app/freenet_api/room_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/room_synchronizer.rs
@@ -190,7 +190,7 @@ impl RoomSynchronizer {
 
                 // Create a get request without subscription (will subscribe after response)
                 let get_request = ContractRequest::Get {
-                    key: *contract_key.id(), // GET uses ContractInstanceId
+                    key: *contract_key.id(),    // GET uses ContractInstanceId
                     return_contract_code: true, // I think this should be false but apparently that was triggering a bug
                     subscribe: false,
                 };
@@ -295,8 +295,10 @@ impl RoomSynchronizer {
                             );
                             // Update sync status to error using with_mut
                             SYNC_INFO.with_mut(|sync_info| {
-                                sync_info
-                                    .update_sync_status(owner_vk, RoomSyncStatus::Error(e.to_string()));
+                                sync_info.update_sync_status(
+                                    owner_vk,
+                                    RoomSyncStatus::Error(e.to_string()),
+                                );
                             });
                         }
                     }

--- a/ui/src/components/app/notifications.rs
+++ b/ui/src/components/app/notifications.rs
@@ -435,6 +435,11 @@ fn get_message_preview(
                 "[Encrypted message]".to_string()
             }
         }
+        // Action messages don't generate notification previews
+        RoomMessageBody::Edit { .. } => "[Edited a message]".to_string(),
+        RoomMessageBody::Delete { .. } => "[Deleted a message]".to_string(),
+        RoomMessageBody::Reaction { emoji, .. } => format!("Reacted with {}", emoji),
+        RoomMessageBody::RemoveReaction { .. } => "[Removed a reaction]".to_string(),
     };
 
     // Truncate to ~50 chars for notification

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -914,10 +914,19 @@ fn MessageGroupComponent(
                                         let msg_id_for_delete = msg.message_id.clone();
                                         let is_picker_open = open_emoji_picker.read().as_ref() == Some(&msg_id_str);
                                         rsx! {
+                                            // Invisible backdrop to catch outside clicks when picker is open
+                                            if is_picker_open {
+                                                div {
+                                                    class: "fixed inset-0 z-40",
+                                                    onclick: move |_| open_emoji_picker.set(None),
+                                                }
+                                            }
                                             div {
                                                 class: format!(
-                                                    "absolute top-0 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity z-10 flex items-center gap-0.5 bg-panel rounded-lg shadow-md border border-border p-1 {}",
-                                                    if is_self { "left-0 -translate-x-full -ml-2" } else { "right-0 translate-x-full ml-2" }
+                                                    "absolute top-0 -translate-y-1/2 transition-opacity z-50 flex items-center gap-0.5 bg-panel rounded-lg shadow-md border border-border p-1 {} {}",
+                                                    if is_self { "left-0 -translate-x-full -ml-2" } else { "right-0 translate-x-full ml-2" },
+                                                    // Keep visible when picker is open, otherwise use hover
+                                                    if is_picker_open { "opacity-100" } else { "opacity-0 group-hover:opacity-100" }
                                                 ),
                                                 // Reaction trigger with expandable picker
                                                 div { class: "relative",
@@ -938,11 +947,11 @@ fn MessageGroupComponent(
                                                         },
                                                         "😊"
                                                     }
-                                                    // Emoji picker dropdown
+                                                    // Emoji picker dropdown - vertical layout
                                                     if is_picker_open {
                                                         div {
                                                             class: format!(
-                                                                "absolute top-full mt-1 p-1.5 bg-panel rounded-xl shadow-lg border border-border flex gap-1 z-20 {}",
+                                                                "absolute top-full mt-1 p-1 bg-panel rounded-xl shadow-xl border border-border grid grid-cols-2 gap-0.5 z-50 {}",
                                                                 if is_self { "right-0" } else { "left-0" }
                                                             ),
                                                             onclick: move |e: MouseEvent| e.stop_propagation(),
@@ -952,7 +961,7 @@ fn MessageGroupComponent(
                                                                 rsx! {
                                                                     button {
                                                                         key: "{emoji}",
-                                                                        class: "p-1.5 rounded-lg hover:bg-surface hover:scale-110 transition-all text-lg",
+                                                                        class: "p-2 rounded-lg hover:bg-surface hover:scale-110 transition-all text-xl",
                                                                         title: "React with {emoji}",
                                                                         onclick: move |_| {
                                                                             on_react.call((msg_id.clone(), emoji_str.clone()));

--- a/ui/src/components/conversation/message_actions.rs
+++ b/ui/src/components/conversation/message_actions.rs
@@ -1,0 +1,138 @@
+use dioxus::prelude::*;
+use river_core::room_state::member::MemberId;
+use river_core::room_state::message::MessageId;
+
+/// Common emoji reactions to show in the picker
+pub const REACTION_EMOJIS: &[&str] = &["👍", "❤️", "😂", "😮", "😢", "😡", "🎉", "🤔"];
+
+/// Props for the message actions component
+#[derive(Props, Clone, PartialEq)]
+pub struct MessageActionsProps {
+    /// The message ID for this message
+    pub message_id: MessageId,
+    /// Whether the current user is the author of this message
+    pub is_own_message: bool,
+    /// Current user's ID for checking existing reactions
+    pub self_member_id: MemberId,
+    /// Callback when edit is clicked
+    pub on_edit: EventHandler<MessageId>,
+    /// Callback when delete is clicked
+    pub on_delete: EventHandler<MessageId>,
+    /// Callback when a reaction is toggled (message_id, emoji)
+    pub on_toggle_reaction: EventHandler<(MessageId, String)>,
+}
+
+/// Message actions component - shows on hover/click
+#[component]
+pub fn MessageActions(props: MessageActionsProps) -> Element {
+    let mut show_emoji_picker = use_signal(|| false);
+    let message_id = props.message_id.clone();
+    let message_id_for_edit = message_id.clone();
+    let message_id_for_delete = message_id.clone();
+
+    rsx! {
+        div {
+            class: "flex items-center gap-0.5 bg-panel rounded-lg shadow-lg border border-border p-0.5",
+            // Emoji reaction button
+            div { class: "relative",
+                button {
+                    class: "p-1.5 rounded hover:bg-surface transition-colors text-text-muted hover:text-text",
+                    title: "Add reaction",
+                    onclick: move |_| {
+                        show_emoji_picker.set(!show_emoji_picker());
+                    },
+                    "😀"
+                }
+                // Emoji picker dropdown
+                if show_emoji_picker() {
+                    div {
+                        class: "absolute bottom-full left-0 mb-1 bg-panel rounded-lg shadow-lg border border-border p-2 z-50",
+                        div { class: "flex flex-wrap gap-1 max-w-[200px]",
+                            {REACTION_EMOJIS.iter().map(|emoji| {
+                                let emoji_str = emoji.to_string();
+                                let msg_id = message_id.clone();
+                                rsx! {
+                                    button {
+                                        key: "{emoji}",
+                                        class: "p-1.5 rounded hover:bg-surface transition-colors text-lg",
+                                        title: "React with {emoji}",
+                                        onclick: move |_| {
+                                            props.on_toggle_reaction.call((msg_id.clone(), emoji_str.clone()));
+                                            show_emoji_picker.set(false);
+                                        },
+                                        "{emoji}"
+                                    }
+                                }
+                            })}
+                        }
+                    }
+                }
+            }
+            // Edit button (only for own messages)
+            if props.is_own_message {
+                button {
+                    class: "p-1.5 rounded hover:bg-surface transition-colors text-text-muted hover:text-text",
+                    title: "Edit message",
+                    onclick: move |_| {
+                        props.on_edit.call(message_id_for_edit.clone());
+                    },
+                    "✏️"
+                }
+            }
+            // Delete button (only for own messages)
+            if props.is_own_message {
+                button {
+                    class: "p-1.5 rounded hover:bg-error-bg hover:text-red-600 transition-colors text-text-muted",
+                    title: "Delete message",
+                    onclick: move |_| {
+                        props.on_delete.call(message_id_for_delete.clone());
+                    },
+                    "🗑️"
+                }
+            }
+        }
+    }
+}
+
+/// Props for an inline reaction button (shown when hovering a message)
+#[derive(Props, Clone, PartialEq)]
+pub struct QuickReactionProps {
+    pub message_id: MessageId,
+    pub on_toggle_reaction: EventHandler<(MessageId, String)>,
+}
+
+/// Quick reaction button - a simpler inline option
+#[component]
+pub fn QuickReactionButton(props: QuickReactionProps) -> Element {
+    let mut show_picker = use_signal(|| false);
+
+    rsx! {
+        div { class: "relative inline-block",
+            button {
+                class: "opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-surface text-text-muted hover:text-text text-sm",
+                onclick: move |_| show_picker.set(!show_picker()),
+                "+"
+            }
+            if show_picker() {
+                div {
+                    class: "absolute bottom-full right-0 mb-1 bg-panel rounded-lg shadow-lg border border-border p-1 flex gap-0.5 z-50",
+                    {REACTION_EMOJIS.iter().take(6).map(|emoji| {
+                        let emoji_str = emoji.to_string();
+                        let message_id = props.message_id.clone();
+                        rsx! {
+                            button {
+                                key: "{emoji}",
+                                class: "p-1 rounded hover:bg-surface transition-colors",
+                                onclick: move |_| {
+                                    props.on_toggle_reaction.call((message_id.clone(), emoji_str.clone()));
+                                    show_picker.set(false);
+                                },
+                                "{emoji}"
+                            }
+                        }
+                    })}
+                }
+            }
+        }
+    }
+}

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -256,17 +256,17 @@ pub fn MemberList() -> Element {
     }
 
     rsx! {
-        aside { class: "w-56 flex-shrink-0 bg-panel border-l border-border flex flex-col overflow-y-auto",
+        aside { class: "w-56 flex-shrink-0 bg-panel border-l border-border flex flex-col",
             // Header
-            div { class: "px-4 py-3 border-b border-border",
+            div { class: "px-4 py-3 border-b border-border flex-shrink-0",
                 h2 { class: "text-sm font-semibold text-text-muted uppercase tracking-wide flex items-center gap-2",
                     Icon { icon: FaUsers, width: 16, height: 16 }
                     span { "Members" }
                 }
             }
 
-            // Member list
-            ul { class: "flex-1 px-2 py-2 space-y-0.5",
+            // Member list - scrollable independently
+            ul { class: "flex-1 px-2 py-2 space-y-0.5 overflow-y-auto min-h-0",
                 for (display_name, member_id) in members {
                     li { key: "{member_id}",
                         button {
@@ -281,8 +281,8 @@ pub fn MemberList() -> Element {
                 }
             }
 
-            // Invite button
-            div { class: "p-3 border-t border-border",
+            // Invite button - fixed at bottom
+            div { class: "p-3 border-t border-border flex-shrink-0",
                 button {
                     class: "w-full flex items-center justify-center gap-2 px-3 py-2 bg-accent hover:bg-accent-hover text-white text-sm font-medium rounded-lg transition-colors",
                     onclick: move |_| invite_modal_active.set(true),
@@ -291,8 +291,8 @@ pub fn MemberList() -> Element {
                 }
             }
 
-            // Connection status indicator
-            div { class: "px-3 pb-3",
+            // Connection status indicator - fixed at bottom
+            div { class: "px-3 pb-3 flex-shrink-0",
                 div {
                     class: format!(
                         "w-full px-3 py-1.5 rounded-full flex items-center justify-center text-xs font-medium {}",

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -199,6 +199,7 @@ fn create_room(room_name: &String, self_is: SelfIs) -> CreatedRoom {
             current_secret: None,
             current_secret_version: None,
             last_secret_rotation: None,
+            key_migrated_to_delegate: true, // Example data doesn't need migration
         },
     }
 }

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -11,7 +11,13 @@ use lipsum::lipsum;
 use rand::rngs::OsRng;
 use river_core::room_state::ChatRoomParametersV1;
 use river_core::{
-    room_state::{configuration::*, member::*, member_info::*, message::*, privacy::{RoomDisplayMetadata, SealedBytes}},
+    room_state::{
+        configuration::*,
+        member::*,
+        member_info::*,
+        message::*,
+        privacy::{RoomDisplayMetadata, SealedBytes},
+    },
     ChatRoomStateV1,
 };
 use std::collections::HashMap;
@@ -32,7 +38,10 @@ pub fn create_example_rooms() -> Rooms {
     let room3 = create_room(&"Your Private Room".to_string(), SelfIs::Owner);
     map.insert(room3.owner_vk, room3.room_data);
 
-    Rooms { map, current_room_key: None }
+    Rooms {
+        map,
+        current_room_key: None,
+    }
 }
 
 struct CreatedRoom {
@@ -88,7 +97,9 @@ fn create_room(room_name: &String, self_is: SelfIs) -> CreatedRoom {
             MemberInfo {
                 member_id: owner_id,
                 version: 0,
-                preferred_nickname: SealedBytes::public((random_full_name() + " (Owner)").into_bytes()),
+                preferred_nickname: SealedBytes::public(
+                    (random_full_name() + " (Owner)").into_bytes(),
+                ),
             },
             owner_sk,
         ));
@@ -110,7 +121,9 @@ fn create_room(room_name: &String, self_is: SelfIs) -> CreatedRoom {
                 MemberInfo {
                     member_id: self_id,
                     version: 0,
-                    preferred_nickname: SealedBytes::public((random_full_name() + " (You)").into_bytes()),
+                    preferred_nickname: SealedBytes::public(
+                        (random_full_name() + " (You)").into_bytes(),
+                    ),
                 },
                 &self_sk,
             ));
@@ -149,7 +162,9 @@ fn create_room(room_name: &String, self_is: SelfIs) -> CreatedRoom {
             MemberInfo {
                 member_id: other_member_id,
                 version: 0,
-                preferred_nickname: SealedBytes::public((random_full_name() + " (Member)").into_bytes()),
+                preferred_nickname: SealedBytes::public(
+                    (random_full_name() + " (Member)").into_bytes(),
+                ),
             },
             &other_member_sk,
         ));

--- a/ui/src/pending_invites.rs
+++ b/ui/src/pending_invites.rs
@@ -19,13 +19,13 @@ pub enum PendingRoomStatus {
 
 #[derive(Clone)]
 pub struct PendingInvites {
-    pub map: HashMap<VerifyingKey, PendingRoomJoin>
+    pub map: HashMap<VerifyingKey, PendingRoomJoin>,
 }
 
 impl Default for PendingInvites {
     fn default() -> Self {
         Self {
-            map: HashMap::new()
+            map: HashMap::new(),
         }
     }
 }

--- a/ui/src/util.rs
+++ b/ui/src/util.rs
@@ -61,7 +61,7 @@ pub fn format_utc_as_local_time(timestamp_ms: i64) -> String {
 
     #[cfg(not(target_arch = "wasm32"))]
     {
-        use chrono::{TimeZone, Utc, Local};
+        use chrono::{Local, TimeZone, Utc};
         let utc_time = Utc.timestamp_millis_opt(timestamp_ms).unwrap();
         utc_time.with_timezone(&Local).format("%H:%M").to_string()
     }
@@ -76,9 +76,12 @@ pub fn format_utc_as_full_datetime(timestamp_ms: i64) -> String {
 
     #[cfg(not(target_arch = "wasm32"))]
     {
-        use chrono::{TimeZone, Utc, Local};
+        use chrono::{Local, TimeZone, Utc};
         let utc_time = Utc.timestamp_millis_opt(timestamp_ms).unwrap();
-        utc_time.with_timezone(&Local).format("%a, %b %d, %Y %H:%M:%S").to_string()
+        utc_time
+            .with_timezone(&Local)
+            .format("%a, %b %d, %Y %H:%M:%S")
+            .to_string()
     }
 }
 


### PR DESCRIPTION
## Problem

Users cannot edit or delete their own messages, nor can they react to messages with emoji. This limits the expressiveness and usability of the chat experience. (Issue #67)

## Approach

Implements message actions (edit, delete, reactions) as special message types that flow through the normal message timeline:

1. **Actions are messages**: New `RoomMessageBody` variants (`Edit`, `Delete`, `Reaction`, `RemoveReaction`) are stored as signed messages in the timeline
2. **Computed state**: `MessagesV1::actions_state` tracks the effective state (edited content, deleted messages, reactions) - rebuilt from action messages on each delta
3. **Authorization**: Only the original message author can edit/delete their own messages. Anyone can add reactions, and users can only remove their own reactions
4. **Display**: UI shows "(edited)" indicator on edited messages and displays reaction badges below messages

This approach preserves the append-only, signed message model while enabling interactive features.

### Why this design over alternatives?

- **Actions as messages** allows them to sync naturally through the existing delta mechanism
- **Computed state with `#[serde(skip)]`** avoids signature invalidation issues - the signed message content is never mutated
- **Authorization in `rebuild_actions_state()`** means invalid actions (e.g., editing someone else's message) are simply ignored, not rejected

## Testing

### New unit tests added (7 tests):
- `test_edit_action` - Verify edit applies and `edited` flag is set
- `test_edit_by_non_author_ignored` - Verify unauthorized edits don't apply
- `test_delete_action` - Verify deleted messages are marked and filtered from display
- `test_reaction_action` - Verify reactions from multiple users aggregate correctly
- `test_remove_reaction_action` - Verify users can remove their own reactions
- `test_action_on_deleted_message_ignored` - Verify actions on deleted targets are no-op
- `test_display_messages_filters_actions` - Verify action messages are not shown directly

### Local validation:
- `cargo test -p river-core` - All 94 tests pass
- `cargo clippy -p river-core` - No errors (some pre-existing warnings)
- `cargo fmt` - All code formatted

### What still needs testing:
- Full UI testing with multiple simulated users (requires dev server setup)
- Multi-peer sync testing to verify actions propagate correctly

## Breaking Change

This adds new `RoomMessageBody` enum variants, which will cause deserialization errors for older clients. This is acceptable during alpha. Before production, consider adding `#[serde(other)]` fallback variant.

## Critical Files

| File | Changes |
|------|---------|
| `common/src/room_state/message.rs` | +569 lines: New variants, computed state, delta processing, helper methods, tests |
| `ui/src/components/conversation.rs` | +109 lines: Display edited indicator and reactions |
| `ui/src/components/conversation/message_actions.rs` | New file: Context menu/emoji picker component (basic structure) |
| `ui/src/components/app/notifications.rs` | Handle new message types in notification previews |

## Future Work (not in this PR)

- Wire up context menu to actually send Edit/Delete/Reaction messages
- Add emoji picker UI interaction
- CLI support for edit/delete/react commands

Closes #67

[AI-assisted - Claude]