### PR TITLE
fix(cli): update test to match new JSON content format

### DIFF
--- a/cli/tests/message_flow.rs
+++ b/cli/tests/message_flow.rs
@@ -373,10 +373,9 @@ fn decode_plaintext_messages(values: &[Value]) -> Vec<String> {
     values
         .iter()
         .filter_map(|entry| {
+            // CLI now outputs content as a plain string via effective_text()
             entry
                 .get("content")
-                .and_then(|content| content.get("Public"))
-                .and_then(|public| public.get("plaintext"))
                 .and_then(|text| text.as_str())
                 .map(|s| s.to_string())
         })


### PR DESCRIPTION
## Problem

The `message-actions` merge changed the CLI's JSON output format for messages. Previously, the `message list --json` command output:

```json
{"content": {"Public": {"plaintext": "message text"}}}
```

Now it outputs:

```json
{"content": "message text"}
```

This is because the CLI now uses `effective_text()` which returns a plain String (allowing edited message content), rather than serializing the raw `RoomMessageBody` structure.

The test's `decode_plaintext_messages` function expected the old nested format, causing the six-peer-regression test in freenet-core CI to fail with "room1-user1 missing expected messages".

## Solution

Updated `decode_plaintext_messages` to extract the `content` field directly as a string, matching the new JSON format.

## Testing

- Verified the test compiles
- This is a test-only change that aligns the test with the new CLI behavior

## Impact

Fixes freenet-core CI's six-peer-regression test which is currently failing due to this format mismatch.

[AI-assisted - Claude]