### PR TITLE
fix(common): deterministic Vec ordering in apply_delta for CRDT convergence

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -37,3 +37,4 @@ rand.workspace = true
 ed25519-dalek = { workspace = true, features = ["rand_core"] }
 x25519-dalek.workspace = true
 aes-gcm.workspace = true
+ciborium.workspace = true

--- a/common/src/room_state/member.rs
+++ b/common/src/room_state/member.rs
@@ -162,6 +162,9 @@ impl ComposableState for MembersV1 {
         // Always enforce max members limit
         self.remove_excess_members(parameters, max_members);
 
+        // Sort for deterministic ordering (CRDT convergence requirement)
+        self.members.sort_by_key(|m| m.member.id());
+
         Ok(())
     }
 }

--- a/common/src/room_state/member_info.rs
+++ b/common/src/room_state/member_info.rs
@@ -137,6 +137,10 @@ impl ComposableState for MemberInfoV1 {
                 || member_map.contains_key(&info.member_info.member_id)
         });
 
+        // Sort for deterministic ordering (CRDT convergence requirement)
+        self.member_info
+            .sort_by_key(|info| info.member_info.member_id);
+
         Ok(())
     }
 }

--- a/common/src/room_state/secret.rs
+++ b/common/src/room_state/secret.rs
@@ -222,6 +222,11 @@ impl ComposableState for RoomSecretsV1 {
             });
         }
 
+        // Sort for deterministic ordering (CRDT convergence requirement)
+        self.versions.sort_by_key(|v| v.record.version);
+        self.encrypted_secrets
+            .sort_by_key(|s| (s.secret.secret_version, s.secret.member_id));
+
         Ok(())
     }
 }

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -51,6 +51,7 @@ wasm-bindgen-futures.workspace = true
 lipsum = "0.9.1"
 
 # Utilities
+blake3.workspace = true
 chrono.workspace = true
 markdown = "1.0.0-alpha.21"
 ciborium = "0.2.2"

--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -185,6 +185,7 @@ fn initial_rooms() -> Rooms {
     Rooms {
         map: std::collections::HashMap::new(),
         current_room_key: None,
+        migrated_rooms: Vec::new(),
     }
 }
 

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -41,6 +41,7 @@ pub fn create_example_rooms() -> Rooms {
     Rooms {
         map,
         current_room_key: None,
+        migrated_rooms: Vec::new(),
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds deterministic sorting at the end of `apply_delta` for members, member_info, secrets, and bans to ensure identical serialized state regardless of delta application order
- Fixes the root cause of 87 different state versions observed for contract `xqyyifd4LEGnZSMZaYGtahBBn5VfHgHLcMGWL83cYqt`
- Adds graceful contract upgrade: when WASM changes, the owner's UI sends an upgrade pointer to the old contract

## Changes

### Part 1: Sorting fixes (common crate)

| File | Fix |
|------|-----|
| `member.rs` | Sort by `MemberId` after apply_delta |
| `member_info.rs` | Sort by `member_id` after apply_delta |
| `secret.rs` | Sort versions by version, encrypted_secrets by `(secret_version, member_id)` |
| `ban.rs` | Fix tie-breaking with `BanId` in excess removal + add final sort |

### Part 2: Graceful contract upgrade (UI)

| File | Change |
|------|--------|
| `room_data.rs` | Track `migrated_rooms` when WASM update changes contract key in `merge()` |
| `room_synchronizer.rs` | Owner sends `UpgradeV1` pointer to old contract after PUT to new contract |
| `app.rs`, `example_data.rs` | Initialize new `migrated_rooms` field |

### Part 3: Tests

- New `test_full_state_merge_commutativity` test: verifies `merge(A,B) == merge(B,A)` at serialized byte level
- All 131 existing common crate tests pass

## Test plan

- [x] `cargo make test-common` — 131 tests pass (including new commutativity test)
- [x] `cargo make test-chat-delegate` — 9 tests pass
- [x] `cargo check --workspace` — compiles cleanly
- [ ] `cargo make publish-river` — deploy updated UI and verify convergence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-assisted - Claude]