### PR TITLE
fix(ui): prevent message layout overflow and clipping

### DIFF
--- a/ui/assets/main.css
+++ b/ui/assets/main.css
@@ -87,6 +87,12 @@ html, body {
     overflow-wrap: break-word;
     word-break: break-word;
 }
+
+/* Ensure message content wraps and doesn't cause horizontal overflow */
+.prose {
+    overflow-wrap: break-word;
+    word-break: break-word;
+}
 .new-message {
     padding: 1rem;
     min-width: 0; /* Allow flex item to shrink */

--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -164,7 +164,7 @@ pub fn App() -> Element {
         Stylesheet { href: asset!("/assets/main.css") }
 
         // Main chat layout - grid with fixed sidebars and flexible center
-        div { class: "flex h-screen bg-bg",
+        div { class: "flex h-screen bg-bg overflow-hidden",
             RoomList {}
             Conversation {}
             MemberList {}

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1223,7 +1223,7 @@ fn MessageGroupComponent(
     rsx! {
         div {
             class: format!(
-                "flex {}",
+                "flex min-w-0 {}",
                 if is_self { "justify-end" } else { "justify-start" }
             ),
             div {
@@ -1408,8 +1408,8 @@ fn MessageGroupComponent(
                                                                 "rounded-r-2xl rounded-l-md"
                                                             }
                                                         },
-                                                        // Max width for readability
-                                                        "max-w-prose",
+                                                        // Max width for readability, clip overflow
+                                                        "max-w-prose overflow-hidden",
                                                         // Overlap reply strip when present
                                                         if has_reply { "relative z-10 -mt-3" } else { "" }
                                                     ),


### PR DESCRIPTION
## Problem

Users reported message bubbles being clipped on the left side in the chat UI. The root cause is that the page body and top-level layout container had no horizontal overflow protection (`overflow: visible`), so any content slightly wider than the viewport (long URLs, browser rendering differences, specific font metrics) could cause horizontal page scrolling, shifting messages left and clipping them behind the sidebar.

Additionally, `overflow-hidden` was missing from message bubbles (`max-w-prose`), meaning long unbroken content could overflow bubble boundaries and push the layout wider.

## Approach

Three defensive CSS fixes that prevent horizontal overflow at multiple levels:

1. **Top-level layout** (`app.rs`): Add `overflow-hidden` to the `flex h-screen` container — prevents any horizontal page scroll regardless of content
2. **Message group container** (`conversation.rs`): Add `min-w-0` to the flex wrapper — ensures proper flex shrinking below content width
3. **Message bubbles** (`conversation.rs`): Restore `overflow-hidden` on `max-w-prose` — clips long content within bubble boundaries
4. **Prose content** (`main.css`): Add `overflow-wrap: break-word` to `.prose` — ensures message text wraps instead of overflowing

## Testing

- Verified layout renders correctly at 1024, 1280, 1536, 1809, and 1920px viewports
- Confirmed no horizontal overflow at any viewport size via Playwright
- Verified fix doesn't clip modals (they're siblings of the layout div, not children)
- `position: fixed` elements (connection status) unaffected by parent overflow

[AI-assisted - Claude]