### PR TITLE
Fix message bubble class to handle text overflow of long links

### DIFF
--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1380,7 +1380,7 @@ fn MessageGroupComponent(
                                                 // Message bubble (overlaps reply strip bottom when reply exists)
                                                 div {
                                                     class: format!(
-                                                        "px-3 py-2 text-sm {} {} {} {}",
+                                                        "px-3 py-2 text-sm overflow-auto {} {} {} {}",
                                                         if is_self {
                                                             "bg-accent text-white"
                                                         } else {


### PR DESCRIPTION
Helps make
<img width="271" height="166" alt="image" src="https://github.com/user-attachments/assets/6e62ae5c-2cd2-480d-ab4f-43f1cd49efb2" />
look better like 
<img width="905" height="94" alt="image" src="https://github.com/user-attachments/assets/b04b4678-1421-4e1c-8da0-9f72e452daa3" />

with a scrollbar