### PR TITLE
fix(ui): improve not-member notification copy

### DIFF
--- a/ui/src/components/conversation/not_member_notification.rs
+++ b/ui/src/components/conversation/not_member_notification.rs
@@ -25,9 +25,11 @@ pub fn NotMemberNotification(user_verifying_key: VerifyingKey) -> Element {
     rsx! {
         div { class: "mx-4 mb-4 p-4 bg-warning-bg border-l-4 border-yellow-500 rounded-r-lg",
             p { class: "mb-3 text-sm text-text",
-                "You are not a member of this room. Share this key with a current member so they can invite you:"
+                "You're not a member of this room yet. To join, go back to where you received your invite link and request a new one."
             }
-            p { class: "mb-2 text-sm font-semibold text-text", "Your verifying key:" }
+            p { class: "mb-2 text-sm text-text-muted",
+                "Alternatively, share your key with a current member to be invited directly:"
+            }
             div { class: "flex gap-2",
                 input {
                     class: "flex-1 px-3 py-2 bg-surface border border-border rounded-lg text-xs text-text font-mono",


### PR DESCRIPTION
## Summary
- Updated the not-member notification that shows where the message input would normally be
- Old copy told users to "share this key with a current member" which caused confusion (users asked on Matrix how to "verify their key" when they just needed a new invite)
- New copy directs users to go back to where they received their invite link as the primary action
- Key-sharing kept as a secondary "alternatively" option

## Screenshot
![not-member-notification](/tmp/not-member-notification.png)

## Test plan
- [ ] Verify notification renders correctly in dark and light mode
- [ ] Verify Copy button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-assisted - Claude]