### PR TITLE
fix: set realistic connection limits for six-peer regression test

### DIFF
--- a/cli/tests/message_flow.rs
+++ b/cli/tests/message_flow.rs
@@ -960,6 +960,8 @@ async fn run_message_flow_test(peer_count: usize, rounds: usize) -> Result<()> {
     let network = TestNetwork::builder()
         .gateways(1)
         .peers(scenario.peer_count)
+        .min_connections(4)
+        .max_connections(5)
         .binary(FreenetBinary::Workspace {
             path: freenet_core.clone(),
             profile: BuildProfile::Debug,


### PR DESCRIPTION
## Problem

The six-peer-regression CI test in freenet-core has been consistently failing since Feb 15 06:02 UTC. The root cause: peers default to `min_connections=25` but only 7 nodes exist (6 peers + 1 gateway). Peers can never reach the minimum, causing perpetual topology management churn that destabilizes existing connections and breaks UPDATE propagation paths.

## Solution

Set `min_connections(4)` and `max_connections(5)` on the `TestNetwork::builder()` — realistic targets for a 7-node network. This eliminates the connection churn while still exercising topology management.

## Testing

This fix addresses the consistent six-peer-regression failures across all branches in freenet-core CI (topology-sim, fix/2888-improve-reservation-cleanup, claude/test-anomaly-detection).

[AI-assisted - Claude]