### PR TITLE
fix(ui): post document title to parent shell via postMessage

### DIFF
--- a/ui/src/components/app/document_title.rs
+++ b/ui/src/components/app/document_title.rs
@@ -43,10 +43,11 @@ fn set_document_title(title: &str) {
             document.set_title(title);
         }
         // Notify parent shell page to update browser tab title
-        let escaped = title.replace('\\', "\\\\").replace('"', "\\\"");
+        let safe_title = js_sys::JSON::stringify(&wasm_bindgen::JsValue::from_str(title))
+            .unwrap_or_else(|_| js_sys::JsString::from("\"\""));
         let _ = js_sys::eval(&format!(
-            r#"try {{ window.parent.postMessage({{"__freenet_shell__":true,"type":"title","title":"{}"}}, "*") }} catch(e) {{}}"#,
-            escaped
+            r#"try {{ window.parent.postMessage({{"__freenet_shell__":true,"type":"title","title":{}}}, "*") }} catch(e) {{}}"#,
+            safe_title
         ));
     }
 }


### PR DESCRIPTION
## Problem

River runs inside a sandboxed iframe served by the Freenet gateway. When `document.title` is set (e.g., to show the room name), it only updates the iframe's internal document title — the browser tab still shows the parent shell page's title ("Freenet Contract", now "Freenet" after freenet/freenet-core#3313).

Users see a generic title instead of the room name they're chatting in (freenet/river#116).

## Approach

When `set_document_title()` is called, in addition to setting `document.title` on the iframe document, we now also send a `postMessage` to the parent shell page with `{__freenet_shell__: true, type: "title", title: "..."}`. The shell page's message handler (added in freenet/freenet-core#3313) picks this up and sets the browser tab title.

Uses `js_sys::eval` for the postMessage call to avoid needing additional web-sys feature flags. The call is wrapped in try/catch so it's a no-op when not running inside the shell iframe (e.g., during `dx serve` development).

## Testing

- River UI builds successfully (`cargo make build-ui`)
- No new dependencies needed (`js-sys` already in workspace)
- The postMessage is a no-op when there's no parent frame, so existing dev workflows (`dx serve`) are unaffected

## Dependencies

Requires freenet/freenet-core#3313 (shell message handler) to be deployed for the title to actually update in the browser tab.

## Fixes

Fixes #116

[AI-assisted - Claude]