### PR TITLE
fix(ui): stop legacy delegate migration retry spam on reconnect

### DIFF
--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -13,7 +13,7 @@ use river_core::chat_delegate::{
     ChatDelegateKey, ChatDelegateRequestMsg, ChatDelegateResponseMsg, RequestId, RoomKey,
 };
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Mutex;
 
 // Constant for the rooms storage key
@@ -508,12 +508,27 @@ pub fn mark_legacy_migration_done() {
     }
 }
 
+/// Guard to prevent repeated legacy migration attempts within the same session.
+/// The migration is fire-and-forget: if the legacy delegates don't exist on the node,
+/// the node returns "delegate not found" errors that never reach the response handler's
+/// success path, so `mark_legacy_migration_done()` is never called. Without this guard,
+/// every WebSocket reconnect would re-fire all 3 legacy delegate requests, creating a
+/// tight error spam loop (~9 errors every 3 seconds).
+static LEGACY_MIGRATION_ATTEMPTED: AtomicBool = AtomicBool::new(false);
+
 /// Fire requests to load rooms from all known legacy delegates (fire and forget).
 /// If any legacy delegate has room data, the response handler will migrate it.
 async fn fire_legacy_migration_request() {
-    // Check if migration has already been done
+    // Check if migration has already been done (persistent across sessions)
     if is_legacy_migration_done() {
         info!("Legacy migration already done, skipping");
+        return;
+    }
+
+    // Only attempt migration once per session to avoid error spam on reconnect.
+    // If the legacy delegates aren't installed, retrying won't help.
+    if LEGACY_MIGRATION_ATTEMPTED.swap(true, Ordering::Relaxed) {
+        info!("Legacy migration already attempted this session, skipping");
         return;
     }
 

--- a/ui/src/components/app/freenet_api/freenet_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/freenet_synchronizer.rs
@@ -4,7 +4,7 @@ use super::connection_manager::ConnectionManager;
 use super::error::SynchronizerError;
 use super::response_handler::ResponseHandler;
 use super::room_synchronizer::RoomSynchronizer;
-use crate::components::app::chat_delegate::set_up_chat_delegate;
+use crate::components::app::chat_delegate::{mark_legacy_migration_done, set_up_chat_delegate};
 use crate::components::app::sync_info::{RoomSyncStatus, SYNC_INFO};
 use crate::components::app::{ROOMS, SYNC_STATUS, WEB_API};
 use crate::util::{owner_vk_to_contract_key, sleep};
@@ -380,6 +380,17 @@ impl FreenetSynchronizer {
                             }
                             Err(e) => {
                                 error!("Received error in API response: {}", e);
+
+                                // "delegate X not found in store" errors from legacy migration
+                                // requests should permanently mark migration as done. The old
+                                // delegate WASM was never installed on this node, so retrying
+                                // across sessions will never succeed.
+                                if e.to_string().contains("delegate")
+                                    && e.to_string().contains("not found")
+                                {
+                                    info!("Delegate not found error (likely legacy migration) - marking migration complete");
+                                    mark_legacy_migration_done();
+                                }
 
                                 // Special handling for "not supported" errors
                                 if e.to_string().contains("not supported") {


### PR DESCRIPTION
## Problem

When legacy delegate WASMs aren't installed on a user's node (the common case for users who never ran old River versions), the node returns "delegate not found" errors. These errors bypass the response handler's success path, so `mark_legacy_migration_done()` is never called. Every WebSocket reconnect calls `set_up_chat_delegate()` → `fire_legacy_migration_request()`, re-firing all 3 legacy delegate requests and producing ~9 errors every 3 seconds indefinitely.

This causes:
- Hundreds of "delegate X not found in store" errors flooding the log
- River UI cycling between connected/disconnected states (the red/orange indicator Puro reported)
- Masking real errors under the noise

Discovered via diagnostic report NB54V9 from user Puro, who saw continuous connect/disconnect cycling and error log full of delegate-not-found spam for keys matching legacy V1, V2, and V3.

## Approach

Two complementary fixes:

1. **Session-level guard** (`AtomicBool`): Prevents `fire_legacy_migration_request()` from running more than once per session. If the legacy delegates aren't installed, retrying on reconnect won't help. This immediately stops the error spam.

2. **Permanent migration flag on "not found" errors**: When the synchronizer receives a "delegate not found" error response, it calls `mark_legacy_migration_done()` to set the localStorage flag. This prevents retry across app restarts too — the old delegate WASM will never appear, so there's nothing to migrate.

The existing migration path is preserved: if a legacy delegate IS installed and has data, the first attempt will succeed, the response handler will migrate the data, and mark migration done normally.

## Testing

- `cargo test -p river-core` passes (delegate key formula test still validates BLAKE3 computation)
- `cargo fmt -- --check` clean
- Manual verification: the three error log keys (`GKksNjtAJCNApRbWZNEyQysdTkhBMChTio7Yo74mnxAr`, `2zhxhAeh6qxPB75na1g2nNCdg6WQQdntm73XKnwhCuPs`, `2njmy16nWGcC12ehugTN2m66tM2kFhQXKQUL14KeYHob`) confirmed to match legacy V1, V2, V3 delegate keys exactly via base58 decoding

Note: `cargo check -p river-ui` requires pre-built WASM artifacts (`chat_delegate.wasm`) and CSS assets that aren't available in a fresh worktree — this is a pre-existing build dependency, not related to this change.

[AI-assisted - Claude]