### PR TITLE
fix(ui): break auth token reload loop on peer restart

### DIFF
--- a/ui/src/components/app/freenet_api/connection_manager.rs
+++ b/ui/src/components/app/freenet_api/connection_manager.rs
@@ -195,6 +195,13 @@ mod imp {
                 {
                     move || {
                         info!("WebSocket connected successfully");
+                        // Clear the reload-loop guard so a future node restart can
+                        // trigger a fresh reload without being falsely detected as a loop.
+                        if let Some(window) = web_sys::window() {
+                            if let Ok(Some(storage)) = window.local_storage() {
+                                let _ = storage.remove_item("river_last_auth_reload");
+                            }
+                        }
                         spawn_local(async move {
                             *SYNC_STATUS.write() =
                                 freenet_synchronizer::SynchronizerStatus::Connected;


### PR DESCRIPTION
## Summary

- When a Freenet peer restarts, the auth token embedded in the page HTML becomes invalid. River detects `AUTH_TOKEN_INVALID` and calls `location.reload()`, but the browser may serve cached HTML with the old token, causing an infinite white-flash reload loop.
- Replace `location.reload()` with cache-busting navigation (`set_href` with timestamp query param) to force the browser to fetch fresh HTML from the gateway.
- Add a localStorage-based guard that detects reload loops (reloaded within 10s) and stops with a static error message instead of looping forever.

## Test plan

- [x] Compiles on both native and wasm32 targets
- [ ] Manual test: restart Freenet peer while River UI is open, verify single reload with no loop
- [ ] Verify that after successful reload, the UI reconnects normally

[AI-assisted - Claude]