### PR TITLE
docs: add Node.js/npm prerequisites to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ To build and run the River UI locally for development:
    # This example is for Ubuntu and may be different on your system
    sudo apt-get install libssl-dev
 
+   # Install Node.js (v20+) and npm
+   # See https://nodejs.org/en/download for installation instructions.
+   # Note: system packages (e.g. `apt-get install npm`) may ship outdated
+   # versions that don't work — install from the official site instead.
+
    # Install build tools
    cargo install dioxus-cli
    cargo install cargo-make
@@ -84,6 +89,9 @@ To build and run the River UI locally for development:
    # Initialize freenet submodule
    git submodule init
    git submodule update
+
+   # Install Node.js dependencies (Tailwind CSS)
+   cd ui && npm install && cd ..
 
    # Run development server with example data
    cargo make dev-example


### PR DESCRIPTION
## Problem

The README's "Building and Running the UI" section lists Rust, cargo-make, and dioxus-cli as prerequisites but doesn't mention Node.js/npm. The `cargo make dev-example` task depends on `build-tailwind`, which runs `npm run build:css` in the `ui/` directory. Anyone following the documented steps on a fresh clone gets a confusing failure when npm isn't installed or when `node_modules` is missing.

## Approach

- Added Node.js (v20+) installation step to the prerequisites, with a note that system packages may be outdated (as the issue reporter discovered)
- Added `cd ui && npm install && cd ..` step before `cargo make dev-example`

## Testing

Verified the instructions are consistent with `Makefile.toml` task graph (`dev-example` → `build-tailwind` → `npm run build:css` in `./ui`) and `ui/package.json` devDependencies.

Closes #120

[AI-assisted - Claude]