### PR TITLE
fix(ui): send contract-migration upgrade pointer as a delta

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,16 @@ jobs:
         CARGO_TARGET_DIR: ${{ github.workspace }}/target
       run: cargo test -p river-core --test migration_test
 
+    - name: Test river-core lib (room_state, crypto, CRDT unit tests)
+      env:
+        RUST_MIN_STACK: 8388608
+        CARGO_TARGET_DIR: ${{ github.workspace }}/target
+      # Runs the river-core library unit tests — room_state verification,
+      # CRDT convergence, contract-migration regressions, etc. Previously
+      # only the `ecies`-named subset ran in CI (see the step below), so the
+      # bulk of the suite had no CI coverage.
+      run: cargo test -p river-core --lib
+
     - name: Test river-core ecies (deterministic + randomized helpers)
       env:
         RUST_MIN_STACK: 8388608

--- a/common/src/room_state.rs
+++ b/common/src/room_state.rs
@@ -1434,4 +1434,73 @@ mod tests {
             "State should be partially modified"
         );
     }
+
+    /// Regression test for freenet/river#127: the contract-migration upgrade
+    /// pointer is delivered to the old contract as a minimal `apply_delta`,
+    /// NOT as a full-state UPDATE.
+    ///
+    /// A full `UpdateData::State` is run through the old contract's
+    /// `validate_state` -> `ChatRoomStateV1::verify`. The old code built that
+    /// state with `..Default::default()`, whose `configuration` is unsigned,
+    /// so verification failed with "Invalid signature" and the pointer never
+    /// landed. Applying only the `upgrade` field as a delta runs
+    /// `OptionalUpgradeV1::apply_delta`, which validates just the upgrade
+    /// signature against the contract's owner parameter.
+    #[test]
+    fn test_upgrade_pointer_applies_as_delta() {
+        use crate::room_state::upgrade::{AuthorizedUpgradeV1, UpgradeV1};
+
+        let (state, parameters, owner_signing_key) = create_empty_chat_room_state();
+        // Sanity: the baseline room state is itself valid and has no pointer.
+        assert!(
+            state.verify(&state, &parameters).is_ok(),
+            "baseline room state should verify"
+        );
+        assert!(
+            state.upgrade.0.is_none(),
+            "baseline room state should have no upgrade pointer"
+        );
+
+        let upgrade = UpgradeV1 {
+            owner_member_id: MemberId::from(&parameters.owner),
+            version: 1,
+            new_chatroom_address: blake3::Hash::from([7u8; 32]),
+        };
+        let authorized = AuthorizedUpgradeV1::new(upgrade, &owner_signing_key);
+
+        // FIX: apply the upgrade pointer as a minimal delta — the path the old
+        // contract takes for `UpdateData::Delta`. The pointer must land and the
+        // resulting state must still verify.
+        let delta = ChatRoomStateV1Delta {
+            upgrade: Some(authorized.clone()),
+            ..Default::default()
+        };
+        let mut updated = state.clone();
+        updated
+            .apply_delta(&state, &parameters, &Some(delta))
+            .expect("applying the upgrade-pointer delta must succeed");
+        assert_eq!(
+            updated.upgrade.0.as_ref(),
+            Some(&authorized),
+            "the upgrade pointer must land on the old contract's state"
+        );
+        assert!(
+            updated.verify(&updated, &parameters).is_ok(),
+            "the state with the upgrade pointer applied must still verify"
+        );
+
+        // Why not a full-state UPDATE: a `..Default::default()` state — the old
+        // (#127) approach — fails `verify` because its default `configuration`
+        // is unsigned, so the runtime's `validate_state` rejected it.
+        let buggy_full_state = ChatRoomStateV1 {
+            upgrade: OptionalUpgradeV1(Some(authorized)),
+            ..Default::default()
+        };
+        assert!(
+            buggy_full_state
+                .verify(&buggy_full_state, &parameters)
+                .is_err(),
+            "a `..Default::default()` full-state upgrade must fail verification (the #127 bug)"
+        );
+    }
 }

--- a/ui/src/components/app/freenet_api/room_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/room_synchronizer.rs
@@ -690,13 +690,14 @@ impl RoomSynchronizer {
                     }
                 }
 
-                // Owner only: send upgrade pointer to old contract for old-client compat
+                // Owner only: send upgrade pointer to old contract for old-client compat.
+                // `is_owner` guarantees `room_data.self_sk` is the owner key, so the
+                // `AuthorizedUpgradeV1` signature validates against the old contract's
+                // `parameters.owner`.
                 if is_owner {
-                    use river_core::room_state::upgrade::{
-                        AuthorizedUpgradeV1, OptionalUpgradeV1, UpgradeV1,
-                    };
+                    use river_core::room_state::upgrade::{AuthorizedUpgradeV1, UpgradeV1};
 
-                    let upgrade_state = {
+                    let upgrade_delta = {
                         let rooms = ROOMS.read();
                         if let Some(room_data) = rooms.map.get(owner_vk) {
                             let new_contract_id = room_data.contract_key.id();
@@ -711,8 +712,21 @@ impl RoomSynchronizer {
                             let authorized_upgrade =
                                 AuthorizedUpgradeV1::new(upgrade, &room_data.self_sk);
 
-                            ChatRoomStateV1 {
-                                upgrade: OptionalUpgradeV1(Some(authorized_upgrade)),
+                            // Send a minimal delta carrying ONLY the upgrade
+                            // pointer — not a full `UpdateData::State`. A full
+                            // state UPDATE is run through the old contract's
+                            // `validate_state` -> `ChatRoomStateV1::verify`; the
+                            // previous `..Default::default()` state failed that
+                            // with "Invalid signature" because its default
+                            // `configuration` is unsigned (issue #127). A delta
+                            // is applied via `apply_delta`, which validates only
+                            // the upgrade signature against the contract's owner
+                            // parameter — so the payload is just the signed
+                            // upgrade pointer (~100 bytes), no unsigned default
+                            // `configuration` is ever substituted, and
+                            // full-state verification is never tripped.
+                            ChatRoomStateV1Delta {
+                                upgrade: Some(authorized_upgrade),
                                 ..Default::default()
                             }
                         } else {
@@ -722,7 +736,7 @@ impl RoomSynchronizer {
 
                     let update_request = ContractRequest::Update {
                         key: *old_contract_key,
-                        data: UpdateData::State(to_cbor_vec(&upgrade_state).into()),
+                        data: UpdateData::Delta(to_cbor_vec(&upgrade_delta).into()),
                     };
 
                     if let Some(web_api) = WEB_API.write().as_mut() {


### PR DESCRIPTION
## Problem

When a room contract is migrated to a new WASM version, the owner's UI sends an upgrade-pointer UPDATE to the *old* contract so old clients can discover the new contract. That UPDATE was a full `UpdateData::State` built with `..Default::default()` for every field except `upgrade`.

A full state UPDATE is run through the old contract's `validate_state` → `ChatRoomStateV1::verify`. The default `configuration` sub-state is unsigned, so verification fails:

```
UPDATE operation failed: invalid contract update, reason: State verification failed: Invalid signature: signature error
```

and the upgrade pointer never lands — old clients can't follow the migration.

## Approach

Send a minimal `UpdateData::Delta` carrying only the `upgrade` field. The old contract applies it via `apply_delta`, which validates just the upgrade signature against the contract's owner parameter. This:

- never trips full-state `validate_state` / `verify` (the bug);
- never drags the room's members/messages/secrets through the old WASM's `merge` / `post_apply_cleanup`;
- avoids sending a `version`-bearing full state that an older WASM generation could reject;
- is a ~100-byte payload instead of the whole room state.

This is the delta option issue #127 lists first under "Expected Behavior".

## Testing

- `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync` — compiles
- `cargo test -p river-core --lib` — 173 tests pass, including the new `test_upgrade_pointer_applies_as_delta`: it applies the upgrade delta via `apply_delta`, asserts the pointer lands and the result still verifies, and characterizes the #127 bug (a `..Default::default()` full state fails `verify`).
- Adds a `cargo test -p river-core --lib` CI step — the river-core lib suite previously ran in CI only filtered to `ecies`-named tests, so the new regression test (and most of the suite) had no CI coverage.

Note: this branch was rebased onto current `main` (the original branch was ~200 commits stale); the README Node.js-install hunk from the old PR is already in `main`.

Closes #127

[AI-assisted - Claude]