### PR TITLE
fix(cli): fetch fresh network state so pruned members can rejoin

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -1129,8 +1129,8 @@ impl ApiClient {
 
     /// Send a message using an explicit signing key (without requiring local storage)
     ///
-    /// This fetches the room state from the network and validates the sender is a member
-    /// before sending. Useful for automation, bots, and CI/CD pipelines.
+    /// This fetches the room state from the network and attempts to re-add the sender
+    /// if they were pruned for inactivity. Useful for automation, bots, and CI/CD pipelines.
     pub async fn send_message_with_key(
         &self,
         room_owner_key: &VerifyingKey,
@@ -1161,8 +1161,21 @@ impl ApiClient {
             river_core::room_state::message::AuthorizedMessageV1::new(message, signing_key);
 
         // Check if we need to re-add ourselves (pruned for inactivity)
+        let is_member = room_state
+            .members
+            .members
+            .iter()
+            .any(|m| m.member.member_vk == sender_vk);
         let (members_delta, member_info_delta) =
             self.build_rejoin_delta(&room_state, room_owner_key, signing_key);
+
+        if !is_member && members_delta.is_none() {
+            return Err(anyhow!(
+                "Signing key is not a current member of this room and no stored membership \
+                 credentials were found for automatic rejoin. If you were pruned for inactivity, \
+                 ensure you first accepted an invitation via `riverctl invite accept`."
+            ));
+        }
 
         // Create a delta with the new message
         let delta = ChatRoomStateV1Delta {


### PR DESCRIPTION
## Problem

After the active-member pruning feature (commit 58ab2e74), riverctl users who got pruned from the member list couldn't send visible messages. Two bugs:

1. **`send_message_with_key`**: Early `is_member` check at line 1157 returned an error *before* reaching `build_rejoin_delta`, blocking pruned members entirely
2. **All storage-based methods** (`send_message`, `edit_message`, `delete_message`, `add_reaction`, `remove_reaction`, `send_reply`, `set_nickname`): Used stale local state from file storage where the member still appeared present, so `build_rejoin_delta` never detected the pruning and didn't include the re-add delta. The network then silently dropped the message since the author wasn't in the member list.

The UI doesn't have this problem because it reads from live-synced state via Freenet subscriptions.

## Approach

- Remove the early `is_member` gate in `send_message_with_key` — let `build_rejoin_delta` handle the re-add
- In all storage-based methods, fetch fresh state from the network (`self.get_room()`) before calling `build_rejoin_delta`, so it can detect pruning and bundle the member re-add delta

## Testing

- `cargo test -p riverctl` — all pass
- `cargo test -p river-core` — all pass  
- `cargo clippy -p riverctl` — clean
- `cargo fmt -- --check` — clean

Fixes #133

[AI-assisted - Claude]