### PR TITLE
fix: mobile-responsive layout with drawer navigation

### DIFF
--- a/ui/assets/main.css
+++ b/ui/assets/main.css
@@ -632,34 +632,22 @@ span[title$="reaction(s)"] {
     to { opacity: 1; }
 }
 
+/* Mobile welcome message adjustments */
 @media (max-width: 768px) {
-    .chat-container {
-        flex-direction: column;
-    }
-    
-    .room-list, .member-list {
-        width: 100%;
-        max-height: 200px;
-    }
-    
-    .main-chat {
-        height: calc(100vh - 400px);
-    }
-    
     .welcome-message {
         margin: 10px;
         padding: 1rem;
     }
-    
+
     .welcome-message img {
         width: 80px;
         margin-bottom: 1rem;
     }
-    
+
     .welcome-message h1 {
         font-size: 1.5rem;
     }
-    
+
     .welcome-message p {
         font-size: 1rem;
     }

--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -22,11 +22,22 @@ use crate::room_data::{CurrentRoom, Rooms};
 use dioxus::document::{Link, Stylesheet};
 use dioxus::logger::tracing::{debug, error, info};
 use dioxus::prelude::*;
+use dioxus_free_icons::icons::fa_solid_icons::{FaBars, FaUsers, FaXmark};
+use dioxus_free_icons::Icon;
 use ed25519_dalek::VerifyingKey;
 use freenet_stdlib::client_api::WebApi;
 use river_core::room_state::member::MemberId;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::window;
+
+/// Which panel is open as an overlay on mobile. None = conversation only.
+#[derive(Clone, Copy, PartialEq)]
+pub enum MobilePanel {
+    Rooms,
+    Members,
+}
+
+pub static MOBILE_PANEL: GlobalSignal<Option<MobilePanel>> = Global::new(|| None);
 
 pub static ROOMS: GlobalSignal<Rooms> = Global::new(initial_rooms);
 pub static CURRENT_ROOM: GlobalSignal<CurrentRoom> =
@@ -177,12 +188,83 @@ pub fn App() -> Element {
         Stylesheet { href: asset!("/assets/styles.css") }
         Stylesheet { href: asset!("/assets/main.css") }
 
-        // Main chat layout - grid with fixed sidebars and flexible center
-        div { class: "flex h-screen bg-bg overflow-hidden",
-            RoomList {}
-            Conversation {}
-            MemberList {}
+        // Outer wrapper: flex-col for mobile header + main content
+        div { class: "flex flex-col h-screen relative",
+
+        // Mobile header bar (hidden on md+)
+        div { class: "md:hidden flex items-center justify-between px-3 py-2 bg-panel border-b border-border flex-shrink-0",
+            button {
+                class: "p-2 rounded-lg text-text-muted hover:text-accent hover:bg-surface transition-colors",
+                onclick: move |_| {
+                    let current = *MOBILE_PANEL.read();
+                    *MOBILE_PANEL.write() = match current {
+                        Some(MobilePanel::Rooms) => None,
+                        _ => Some(MobilePanel::Rooms),
+                    };
+                },
+                if *MOBILE_PANEL.read() == Some(MobilePanel::Rooms) {
+                    Icon { icon: FaXmark, width: 20, height: 20 }
+                } else {
+                    Icon { icon: FaBars, width: 20, height: 20 }
+                }
+            }
+            img {
+                class: "w-8 h-8",
+                src: asset!("/assets/river_logo.svg"),
+                alt: "River"
+            }
+            button {
+                class: "p-2 rounded-lg text-text-muted hover:text-accent hover:bg-surface transition-colors",
+                onclick: move |_| {
+                    let current = *MOBILE_PANEL.read();
+                    *MOBILE_PANEL.write() = match current {
+                        Some(MobilePanel::Members) => None,
+                        _ => Some(MobilePanel::Members),
+                    };
+                },
+                if *MOBILE_PANEL.read() == Some(MobilePanel::Members) {
+                    Icon { icon: FaXmark, width: 20, height: 20 }
+                } else {
+                    Icon { icon: FaUsers, width: 20, height: 20 }
+                }
+            }
         }
+
+        // Main chat layout
+        div { class: "flex flex-1 min-h-0 bg-bg overflow-hidden",
+            // Desktop: always visible sidebar. Mobile: overlay when active.
+            div {
+                class: {
+                    let mobile_rooms = *MOBILE_PANEL.read() == Some(MobilePanel::Rooms);
+                    if mobile_rooms {
+                        "absolute inset-0 top-[49px] z-30 md:relative md:inset-auto md:top-auto md:z-auto md:block"
+                    } else {
+                        "hidden md:block"
+                    }
+                },
+                RoomList {}
+            }
+
+            // Conversation: always visible
+            div { class: "flex-1 flex flex-col min-w-0",
+                Conversation {}
+            }
+
+            // Desktop: always visible sidebar. Mobile: overlay when active.
+            div {
+                class: {
+                    let mobile_members = *MOBILE_PANEL.read() == Some(MobilePanel::Members);
+                    if mobile_members {
+                        "absolute inset-0 top-[49px] z-30 md:relative md:inset-auto md:top-auto md:z-auto md:block"
+                    } else {
+                        "hidden md:block"
+                    }
+                },
+                MemberList {}
+            }
+        }
+
+        } // close outer flex-col wrapper
         EditRoomModal {}
         MemberInfoModal {}
         CreateRoomModal {}

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -243,7 +243,7 @@ pub fn MemberList() -> Element {
     }
 
     rsx! {
-        aside { class: "w-56 flex-shrink-0 bg-panel border-l border-border flex flex-col",
+        aside { class: "w-full h-full md:w-56 flex-shrink-0 bg-panel border-l border-border flex flex-col",
             // Header
             div { class: "px-4 py-3 border-b border-border flex-shrink-0",
                 h2 { class: "text-sm font-semibold text-text-muted uppercase tracking-wide flex items-center gap-2",

--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -5,7 +5,7 @@ pub(crate) mod room_name_field;
 
 use crate::components::app::chat_delegate::save_rooms_to_delegate;
 use crate::components::app::document_title::mark_current_room_as_read;
-use crate::components::app::{CREATE_ROOM_MODAL, CURRENT_ROOM, ROOMS};
+use crate::components::app::{CREATE_ROOM_MODAL, CURRENT_ROOM, MOBILE_PANEL, ROOMS};
 use crate::room_data::CurrentRoom;
 use crate::util::ecies::unseal_bytes_with_secrets;
 use dioxus::logger::tracing::error;
@@ -84,9 +84,9 @@ pub fn RoomList() -> Element {
     });
 
     rsx! {
-        aside { class: "w-64 flex-shrink-0 bg-panel border-r border-border flex flex-col overflow-y-auto",
-            // Logo (explicit h-24 to match w-24 since SVG is square, prevents CLS)
-            div { class: "p-4 flex justify-center",
+        aside { class: "w-full h-full md:w-64 flex-shrink-0 bg-panel border-r border-border flex flex-col overflow-y-auto",
+            // Logo (hidden on mobile — shown in mobile header instead)
+            div { class: "p-4 hidden md:flex justify-center",
                 img {
                     class: "w-24 h-24",
                     src: asset!("/assets/river_logo.svg"),
@@ -130,6 +130,8 @@ pub fn RoomList() -> Element {
                                 onclick: move |_| {
                                     *CURRENT_ROOM.write() = CurrentRoom { owner_key: Some(room_key) };
                                     mark_current_room_as_read();
+                                    // Close mobile drawer
+                                    *MOBILE_PANEL.write() = None;
                                     spawn(async move {
                                         if let Err(e) = save_rooms_to_delegate().await {
                                             error!("Failed to save current room selection: {}", e);


### PR DESCRIPTION
## Problem

The River UI is completely unusable on mobile screens. The three-column layout (RoomList 256px + Conversation + MemberList 224px = 480px minimum) overflows on mobile viewports (320-430px), causing panels to overlap.

Screenshot showing the broken state on iPhone:
- Sidebar and members panel overlap the conversation
- No way to dismiss or toggle panels
- Touch targets are too small

## Solution

Implement a mobile-first responsive layout using Tailwind `md:` breakpoints:

- **Desktop (md+)**: Unchanged — same 3-column layout as before
- **Mobile (<md)**: Single-column with drawer navigation
  - Mobile header bar with hamburger (rooms) and members toggle buttons
  - Panels show as full-screen overlays (`absolute inset-0`) on mobile
  - Tapping a room auto-closes the drawer
  - Logo moved to mobile header (hidden in sidebar on mobile)

Also removes stale CSS media queries that targeted non-existent class names (`.chat-container`, `.room-list`, `.member-list`).

## Testing

- Verify desktop layout is unchanged at ≥768px
- On mobile/narrow viewport: hamburger opens rooms panel, members icon opens members panel
- Selecting a room closes the drawer and shows the conversation
- Both panels can be toggled open/closed

Fixes #141