### PR TITLE
fix(ui): replace autofocus with onmounted focus for sandboxed iframe compatibility

### DIFF
--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1576,7 +1576,12 @@ fn MessageGroupComponent(
                                                             if is_self { "bg-white/10 text-white placeholder-white/50 border border-white/20" } else { "bg-bg text-text border border-border" }
                                                         ),
                                                         value: "{edit_text}",
-                                                        autofocus: true,
+                                                        onmounted: move |cx| {
+                                                            let element = cx.data();
+                                                            wasm_bindgen_futures::spawn_local(async move {
+                                                                let _ = element.set_focus(true).await;
+                                                            });
+                                                        },
                                                         oninput: move |e| edit_text.set(e.value().clone()),
                                                     }
                                                     div { class: "flex justify-end gap-3 mt-3",

--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -152,7 +152,12 @@ pub fn MemberInfoModal() -> Element {
             div {
                 class: "fixed inset-0 z-50 flex items-center justify-center",
                 tabindex: "0",
-                autofocus: true,
+                onmounted: move |cx| {
+                    let element = cx.data();
+                    wasm_bindgen_futures::spawn_local(async move {
+                        let _ = element.set_focus(true).await;
+                    });
+                },
                 onkeydown: move |evt: KeyboardEvent| {
                     if evt.key() == Key::Escape || evt.key() == Key::Enter {
                         evt.prevent_default();

--- a/ui/src/components/room_list/receive_invitation_modal.rs
+++ b/ui/src/components/room_list/receive_invitation_modal.rs
@@ -230,7 +230,6 @@ fn render_error_state(
                 class: "flex gap-3",
                 button {
                     class: "px-4 py-2 bg-accent hover:bg-accent-hover text-white font-medium rounded-lg transition-colors",
-                    autofocus: true,
                     onmounted: move |cx| {
                         let element = cx.data();
                         wasm_bindgen_futures::spawn_local(async move {
@@ -316,7 +315,6 @@ fn render_already_member(mut invitation: Signal<Option<Invitation>>) -> Element 
         p { class: "text-text mb-4", "You are already a member of this room with your current key." }
         button {
             class: "px-4 py-2 bg-accent hover:bg-accent-hover text-white font-medium rounded-lg transition-colors",
-            autofocus: true,
             onmounted: move |cx| {
                 let element = cx.data();
                 wasm_bindgen_futures::spawn_local(async move {
@@ -344,7 +342,6 @@ fn render_restore_access_option(
             class: "flex gap-3",
             button {
                 class: "px-4 py-2 bg-yellow-500 hover:bg-yellow-600 text-white font-medium rounded-lg transition-colors",
-                autofocus: true,
                 onmounted: move |cx| {
                     let element = cx.data();
                     wasm_bindgen_futures::spawn_local(async move {
@@ -409,7 +406,12 @@ fn render_new_invitation(inv: Invitation, mut invitation: Signal<Option<Invitati
                 class: "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent",
                 r#type: "text",
                 value: "{nickname}",
-                autofocus: true,
+                onmounted: move |cx| {
+                    let element = cx.data();
+                    wasm_bindgen_futures::spawn_local(async move {
+                        let _ = element.set_focus(true).await;
+                    });
+                },
                 oninput: move |evt| nickname.set(evt.value().clone()),
                 onkeydown: move |evt: KeyboardEvent| {
                     if evt.key() == Key::Enter && !nickname.read().trim().is_empty() {


### PR DESCRIPTION
## Problem

1. **Autofocus errors in sandboxed iframes**: Browsers block the `autofocus` HTML attribute in cross-origin subframes, producing console errors. The Freenet gateway deliberately excludes `allow-same-origin` from the iframe sandbox for security isolation between contracts, so `autofocus` never works.

2. **Fragile CI builds**: The `freenet` dev-dependency in room-contract used a git reference to freenet-core main branch. When CI's lockfile prefetch failed, the non-locked fallback could resolve to a different commit with incompatible transitive dependencies (freenet-stdlib version mismatch), breaking the build.

## Approach

**Autofocus fix**: Replace all `autofocus: true` attributes with `onmounted` handlers that call `set_focus(true)` programmatically. Focus calls from within the iframe's own script context are not blocked by the cross-origin restriction. The reporter suggested adding `allow-same-origin` to the sandbox, but this would be a security regression — it would allow malicious contracts to access other contracts' localStorage and the parent page's auth token.

**Dependency fix**: Switch `freenet` dev-dependency from git (main branch) to crates.io (0.1.179) for reproducible builds. Simplify CI prefetch since Cargo.lock is gitignored.

## Testing

- Verified WASM compilation: `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync`
- Room-contract tests pass: `cargo test -p room-contract`
- The `onmounted` + `set_focus` pattern was already used successfully in several places

Closes #157

[AI-assisted - Claude]