### PR TITLE
fix(ci): switch freenet dev-dep from git to crates.io

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,11 +65,7 @@ jobs:
       working-directory: ./ui
 
     - name: Prefetch dependencies
-      run: |
-        cargo fetch --locked || {
-          echo "Locked prefetch failed; falling back to non-locked fetch (lockfile likely outdated).";
-          cargo fetch;
-        }
+      run: cargo fetch
       
     - name: Build Project
       run: cargo make build

--- a/contracts/room-contract/Cargo.toml
+++ b/contracts/room-contract/Cargo.toml
@@ -30,7 +30,7 @@ wasm-crypto = ["ed25519-compact"]
 
 [dev-dependencies]
 anyhow = "1.0"
-freenet = { git = "https://github.com/freenet/freenet-core.git", branch = "main" }
+freenet = "0.1.179"
 once_cell.workspace = true
 tempfile = "3.0"
 testresult = "0.4"


### PR DESCRIPTION
## Problem

The `freenet` dev-dependency in room-contract used a git reference to freenet-core main branch (`{ git = "...", branch = "main" }`), making CI builds non-reproducible. Since `Cargo.lock` is gitignored, every CI run resolves dependencies fresh. When freenet-core's transitive dependencies change (e.g., freenet-stdlib 0.1.40 → 0.2.x), the build breaks with incompatible type errors (`WebApi` not found).

This caused the build failure on PR #161.

## Approach

- **Switch `freenet` dev-dep** from git (main branch) to crates.io (`"0.1.179"`). This gives deterministic resolution — the version on crates.io has a fixed dependency tree.
- **Simplify CI prefetch** from `cargo fetch --locked || cargo fetch` to just `cargo fetch`. The `--locked` flag requires a committed `Cargo.lock`, which this repo doesn't have (it's gitignored), so it always failed.

## Testing

- `cargo check -p room-contract` — compiles cleanly
- `cargo test -p room-contract` — all tests pass
- `freenet 0.1.179` depends on `freenet-stdlib ^0.1.40`, matching the workspace's `0.1.40`

[AI-assisted - Claude]