### PR TITLE
fix: overwrite stale delegate signing key after re-invitation

### DIFF
--- a/ui/src/signing.rs
+++ b/ui/src/signing.rs
@@ -189,8 +189,9 @@ pub async fn migrate_signing_key(room_key: RoomKey, signing_key: &SigningKey) ->
                 info!("Signing key already migrated to delegate for room");
                 return true;
             } else {
-                warn!("Delegate has different key for room - using local signing");
-                return false;
+                // Delegate has a stale key (e.g. from before re-invitation).
+                // Overwrite it so delegate signing produces valid signatures.
+                warn!("Delegate has stale key for room - overwriting with current key");
             }
         }
         Ok(None) => {


### PR DESCRIPTION
## Problem

After PR #164 (delegate signing API change), all users were re-invited. The re-invitation updates the user's `self_sk` (signing key) in the UI, but the chat delegate retains the **old** signing key. 

`migrate_signing_key()` detects the mismatch at startup but returns `false` instead of overwriting the stale key. Since `sign_message_with_fallback()` tries the delegate first and the delegate "succeeds" (signs with the wrong key), the fallback (correct key) is never reached. Every message signed this way fails signature verification on all peers — creating a one-way split brain where the sender sees their own messages (optimistic local state) but nobody else does.

## Approach

Change the key-mismatch branch in `migrate_signing_key()` from early-return to fall-through, so it reaches the existing `store_signing_key` + verify path. This overwrites the stale delegate key with the current one. The fix is 3 lines in `ui/src/signing.rs`.

No delegate WASM changes — only UI-side logic, so no delegate migration needed.

## Testing

- Verified `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync` passes
- The fix was diagnosed from production logs showing `State verification failed: Invalid message signature` on Ian's node starting at 06:04 UTC March 13, correlated with the delegate warning `Delegate has different key for room`

[AI-assisted - Claude]