### PR TITLE
fix: always sanitize messages on startup

### DIFF
--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -398,22 +398,23 @@ impl ResponseHandler {
                                                                     .await;
 
                                                                         if result != crate::signing::MigrationResult::Failed {
+                                                                            let mut sanitized = false;
                                                                             ROOMS.with_mut(|rooms| {
                                                                             if let Some(room_data) = rooms.map.get_mut(&room_key_copy) {
                                                                                 room_data.key_migrated_to_delegate = true;
-                                                                                if result == crate::signing::MigrationResult::StaleKeyOverwritten {
-                                                                                    let params = river_core::room_state::ChatRoomParametersV1 {
-                                                                                        owner: room_key_copy,
-                                                                                    };
-                                                                                    crate::signing::remove_unverifiable_messages(
-                                                                                        &mut room_data.room_state,
-                                                                                        &params,
-                                                                                    );
-                                                                                }
+                                                                                // Always sanitize — bad messages may persist in delegate
+                                                                                // storage from before the key was fixed
+                                                                                let params = river_core::room_state::ChatRoomParametersV1 {
+                                                                                    owner: room_key_copy,
+                                                                                };
+                                                                                let removed = crate::signing::remove_unverifiable_messages(
+                                                                                    &mut room_data.room_state,
+                                                                                    &params,
+                                                                                );
+                                                                                sanitized = removed > 0;
                                                                             }
                                                                         });
-                                                                            // Ensure sanitized state is saved to delegate and synced
-                                                                            if result == crate::signing::MigrationResult::StaleKeyOverwritten {
+                                                                            if sanitized {
                                                                                 crate::components::app::mark_needs_sync(room_key_copy);
                                                                             }
                                                                         }

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -351,23 +351,26 @@ pub async fn handle_get_response(
                     let result =
                         crate::signing::migrate_signing_key(room_key, &signing_key_clone).await;
                     if result != crate::signing::MigrationResult::Failed {
+                        let mut sanitized = false;
                         ROOMS.with_mut(|rooms| {
                             if let Some(room_data) = rooms.map.get_mut(&owner_vk) {
                                 room_data.key_migrated_to_delegate = true;
-                                if result == crate::signing::MigrationResult::StaleKeyOverwritten {
-                                    let params = river_core::room_state::ChatRoomParametersV1 {
-                                        owner: owner_vk,
-                                    };
-                                    crate::signing::remove_unverifiable_messages(
-                                        &mut room_data.room_state,
-                                        &params,
-                                    );
-                                }
+                                // Always sanitize — bad messages may persist in delegate
+                                // storage from before the key was fixed
+                                let params = river_core::room_state::ChatRoomParametersV1 {
+                                    owner: owner_vk,
+                                };
+                                let removed = crate::signing::remove_unverifiable_messages(
+                                    &mut room_data.room_state,
+                                    &params,
+                                );
+                                sanitized = removed > 0;
                                 info!("Signing key migrated to delegate for new room");
                             }
                         });
-                        // Ensure sanitized state is saved to delegate and synced to contract
-                        crate::components::app::mark_needs_sync(owner_vk);
+                        if sanitized {
+                            crate::components::app::mark_needs_sync(owner_vk);
+                        }
                     }
                 });
 


### PR DESCRIPTION
## Problem

Follow-up to #170. Bad messages persisted in delegate storage survive across sessions. Once PR #169 fixed the stale key, subsequent startups return `AlreadyCurrent` from `migrate_signing_key()`, so the sanitization from #170 (gated on `StaleKeyOverwritten`) never runs. The bad messages keep blocking UPDATEs.

## Approach

Run `remove_unverifiable_messages()` on every successful migration, not just `StaleKeyOverwritten`. This is a one-time per-room cost at startup. Only calls `mark_needs_sync` if messages were actually removed, avoiding unnecessary sync cycles.

UI-only change, no WASM migration needed.

[AI-assisted - Claude]