### PR TITLE
fix(cli): filter deleted messages in subscription delta stream

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -2569,23 +2569,29 @@ impl ApiClient {
                                             // Fetch full room state to check deleted status
                                             // and get display context (nicknames, reactions)
                                             drop(web_api);
-                                            if let Ok(room_state) =
-                                                self.get_room(room_owner_key, false).await
-                                            {
-                                                // Skip deleted messages (fixes #173: phantom messages)
-                                                if !room_state
-                                                    .recent_messages
-                                                    .actions_state
-                                                    .deleted
-                                                    .contains(&msg.id())
-                                                {
-                                                    Self::output_message(
-                                                        &room_state,
-                                                        msg,
-                                                        room_owner_key,
-                                                        &format,
-                                                    )?;
-                                                    new_message_count += 1;
+                                            match self.get_room(room_owner_key, false).await {
+                                                Ok(room_state) => {
+                                                    // Skip deleted messages (fixes #173: phantom messages)
+                                                    if !room_state
+                                                        .recent_messages
+                                                        .actions_state
+                                                        .deleted
+                                                        .contains(&msg.id())
+                                                    {
+                                                        Self::output_message(
+                                                            &room_state,
+                                                            msg,
+                                                            room_owner_key,
+                                                            &format,
+                                                        )?;
+                                                        new_message_count += 1;
+                                                    }
+                                                }
+                                                Err(e) => {
+                                                    // Remove from seen so the message can be
+                                                    // retried on the next delta
+                                                    debug!("Failed to fetch room state: {}", e);
+                                                    seen_messages.remove(&msg_id);
                                                 }
                                             }
                                             web_api = self.web_api.lock().await;


### PR DESCRIPTION
## Problem

`riverctl message stream --subscribe` shows "phantom" messages — deleted messages that keep reappearing every time a subscription delta arrives. This was reported in #173 on the Freenet Official room, where a deleted message from SpaceCowboy26 would reappear each time any new message was posted.

The River UI was unaffected because it uses `display_messages()` which properly filters deleted messages.

## Root Cause

Two gaps in the Delta path of `subscribe_and_stream` in `cli/src/api.rs`:

1. **Pre-population gap**: `seen_messages` was populated using `display_messages()` which excludes deleted messages. This meant deleted messages were never marked as "seen", so they'd appear as "new" in every subscription delta.

2. **Delta filtering gap**: The Delta processing path only checked `is_action()` to skip action messages (edits/deletes/reactions themselves), but never checked whether the *target* message was deleted via `actions_state.deleted`. A deleted text message is not an action — it's a regular message with a separate delete action targeting it.

In contrast, the State path already used `display_messages()` which correctly filters both action messages and deleted messages.

## Approach

- Pre-populate `seen_messages` from ALL non-action messages in `recent_messages.messages` (including deleted ones), not just `display_messages()`
- In the Delta path, after fetching the room state (which rebuilds `actions_state`), check `actions_state.deleted.contains(&msg.id())` before displaying

## Testing

- Verified the fix compiles cleanly with `cargo build -p riverctl`
- `cargo clippy` and `cargo fmt` pass
- This is a CLI-only change (no contract/delegate/common changes) so no WASM migration needed
- The bug can be verified manually by running `riverctl message stream <room> --subscribe` on the Freenet Official room — the phantom message from SpaceCowboy26 should no longer appear

Closes #173

[AI-assisted - Claude]