### PR TITLE
Fixes reference from MIT to LGPL license

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,4 +304,4 @@ authenticity.
 
 ## License
 
-River is open-source software licensed under the MIT License. See [LICENSE](LICENSE) for details.
+River is open-source software licensed under the LGPL License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
Just found this while looking around.