### PR TITLE
fix(ui): fix crash on emoji messages and harden signal safety

### DIFF
--- a/ui/src/components/app/notifications.rs
+++ b/ui/src/components/app/notifications.rs
@@ -483,9 +483,10 @@ fn get_message_preview(
         }
     };
 
-    // Truncate to ~50 chars for notification
+    // Truncate to ~50 chars for notification (use truncate_str to avoid
+    // panicking on multi-byte emoji at the boundary).
     if text.len() > 50 {
-        format!("{}...", &text[..47])
+        format!("{}...", crate::util::truncate_str(&text, 47))
     } else {
         text
     }

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -986,7 +986,7 @@ pub fn Conversation() -> Element {
             }
             crate::util::debug_log(&format!(
                 "[send] start: {}...",
-                &message_text[..message_text.len().min(30)]
+                crate::util::truncate_str(&message_text, 30)
             ));
             let current_room_opt = CURRENT_ROOM.read().owner_key;
             if current_room_opt.is_none() {
@@ -1124,43 +1124,50 @@ pub fn Conversation() -> Element {
                     let auth_message = AuthorizedMessageV1::with_signature(message, signature);
 
                     // Check if we need to re-add ourselves (pruned for inactivity)
+                    // Use try_read() instead of read() to avoid RefCell
+                    // re-entrant borrow panics inside spawn_local (see
+                    // AGENTS.md "Dioxus WASM Signal Safety Rules").
                     let (members_delta, member_info_delta) = {
-                        let rooms_read = ROOMS.read();
-                        if let Some(room_data) = rooms_read.map.get(&current_room) {
-                            let self_vk = room_data.self_sk.verifying_key();
-                            let is_in_members = self_vk == current_room
-                                || room_data
-                                    .room_state
-                                    .members
-                                    .members
-                                    .iter()
-                                    .any(|m| m.member.member_vk == self_vk);
+                        let rooms_guard = ROOMS.try_read();
+                        if let Ok(rooms_read) = rooms_guard {
+                            if let Some(room_data) = rooms_read.map.get(&current_room) {
+                                let self_vk = room_data.self_sk.verifying_key();
+                                let is_in_members = self_vk == current_room
+                                    || room_data
+                                        .room_state
+                                        .members
+                                        .members
+                                        .iter()
+                                        .any(|m| m.member.member_vk == self_vk);
 
-                            if !is_in_members {
-                                if let Some(ref authorized_member) =
-                                    room_data.self_authorized_member
-                                {
-                                    let current_member_ids: std::collections::HashSet<_> =
-                                        room_data
-                                            .room_state
-                                            .members
-                                            .members
-                                            .iter()
-                                            .map(|m| m.member.id())
-                                            .collect();
-                                    let mut members_to_add = vec![authorized_member.clone()];
-                                    for chain_member in &room_data.invite_chain {
-                                        if !current_member_ids.contains(&chain_member.member.id()) {
-                                            members_to_add.push(chain_member.clone());
+                                if !is_in_members {
+                                    if let Some(ref authorized_member) =
+                                        room_data.self_authorized_member
+                                    {
+                                        let current_member_ids: std::collections::HashSet<_> =
+                                            room_data
+                                                .room_state
+                                                .members
+                                                .members
+                                                .iter()
+                                                .map(|m| m.member.id())
+                                                .collect();
+                                        let mut members_to_add = vec![authorized_member.clone()];
+                                        for chain_member in &room_data.invite_chain {
+                                            if !current_member_ids
+                                                .contains(&chain_member.member.id())
+                                            {
+                                                members_to_add.push(chain_member.clone());
+                                            }
                                         }
-                                    }
 
-                                    // Use stored member_info to preserve nickname, or fall back to "Member"
-                                    use river_core::room_state::member_info::{
-                                        AuthorizedMemberInfo, MemberInfo,
-                                    };
-                                    let authorized_info =
-                                        if let Some(ref stored_info) = room_data.self_member_info {
+                                        // Use stored member_info to preserve nickname, or fall back to "Member"
+                                        use river_core::room_state::member_info::{
+                                            AuthorizedMemberInfo, MemberInfo,
+                                        };
+                                        let authorized_info = if let Some(ref stored_info) =
+                                            room_data.self_member_info
+                                        {
                                             stored_info.clone()
                                         } else {
                                             use river_core::room_state::privacy::SealedBytes;
@@ -1186,12 +1193,17 @@ pub fn Conversation() -> Element {
                                             )
                                         };
 
-                                    (
-                                        Some(river_core::room_state::member::MembersDelta::new(
-                                            members_to_add,
-                                        )),
-                                        Some(vec![authorized_info]),
-                                    )
+                                        (
+                                            Some(
+                                                river_core::room_state::member::MembersDelta::new(
+                                                    members_to_add,
+                                                ),
+                                            ),
+                                            Some(vec![authorized_info]),
+                                        )
+                                    } else {
+                                        (None, None)
+                                    }
                                 } else {
                                     (None, None)
                                 }
@@ -1199,6 +1211,9 @@ pub fn Conversation() -> Element {
                                 (None, None)
                             }
                         } else {
+                            // Safe to skip: message still sends without the re-add delta.
+                            // If the user was pruned, the next message send will retry.
+                            warn!("ROOMS signal busy during send, skipping re-add check");
                             (None, None)
                         }
                     };
@@ -1267,18 +1282,20 @@ pub fn Conversation() -> Element {
                                 // Mobile: hamburger to open rooms panel
                                 button {
                                     class: "md:hidden p-2 rounded-lg text-text-muted hover:text-accent hover:bg-surface transition-colors",
-                                    onclick: move |_| *MOBILE_VIEW.write() = MobileView::Rooms,
+                                    onclick: move |_| crate::util::defer(move || *MOBILE_VIEW.write() = MobileView::Rooms),
                                     Icon { icon: FaBars, width: 18, height: 18 }
                                 }
                                 button {
                                     class: "flex items-center gap-2 px-3 py-1.5 -mx-3 rounded-lg bg-transparent hover:bg-surface transition-colors cursor-pointer min-w-0 flex-1",
                                     title: "Room details",
                                     onclick: move |_| {
-                                        if let Some(current_room) = CURRENT_ROOM.read().owner_key {
-                                            EDIT_ROOM_MODAL.with_mut(|modal| {
-                                                modal.room = Some(current_room);
-                                            });
-                                        }
+                                        crate::util::defer(move || {
+                                            if let Some(current_room) = CURRENT_ROOM.read().owner_key {
+                                                EDIT_ROOM_MODAL.with_mut(|modal| {
+                                                    modal.room = Some(current_room);
+                                                });
+                                            }
+                                        });
                                     },
                                     div { class: "min-w-0",
                                         div { class: "flex items-center gap-2",
@@ -1301,7 +1318,7 @@ pub fn Conversation() -> Element {
                                 // Mobile: button to open members panel
                                 button {
                                     class: "md:hidden p-2 rounded-lg text-text-muted hover:text-accent hover:bg-surface transition-colors flex-shrink-0",
-                                    onclick: move |_| *MOBILE_VIEW.write() = MobileView::Members,
+                                    onclick: move |_| crate::util::defer(move || *MOBILE_VIEW.write() = MobileView::Members),
                                     Icon { icon: FaUsers, width: 18, height: 18 }
                                 }
                             }
@@ -1486,7 +1503,7 @@ pub fn Conversation() -> Element {
                         div { class: "md:hidden flex-shrink-0 px-3 py-3 border-b border-border bg-panel",
                             button {
                                 class: "p-2 rounded-lg text-text-muted hover:text-accent hover:bg-surface transition-colors",
-                                onclick: move |_| *MOBILE_VIEW.write() = MobileView::Rooms,
+                                onclick: move |_| crate::util::defer(move || *MOBILE_VIEW.write() = MobileView::Rooms),
                                 Icon { icon: FaBars, width: 18, height: 18 }
                             }
                         }
@@ -1617,8 +1634,10 @@ fn MessageGroupComponent(
                             class: "text-sm font-medium text-text cursor-pointer hover:text-accent transition-colors",
                             title: "Member ID: {group.author_id}",
                             onclick: move |_| {
-                                MEMBER_INFO_MODAL.with_mut(|signal| {
-                                    signal.member = Some(group.author_id);
+                                crate::util::defer(move || {
+                                    MEMBER_INFO_MODAL.with_mut(|signal| {
+                                        signal.member = Some(group.author_id);
+                                    });
                                 });
                             },
                             "{group.author_name}"

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -239,8 +239,10 @@ pub fn MemberList() -> Element {
     .unwrap_or_default();
 
     let handle_member_click = move |member_id| {
-        MEMBER_INFO_MODAL.with_mut(|signal| {
-            signal.member = Some(member_id);
+        crate::util::defer(move || {
+            MEMBER_INFO_MODAL.with_mut(|signal| {
+                signal.member = Some(member_id);
+            });
         });
     };
 
@@ -258,7 +260,7 @@ pub fn MemberList() -> Element {
                     // Mobile back button
                     button {
                         class: "md:hidden p-1 rounded-lg text-text-muted hover:text-accent hover:bg-surface transition-colors",
-                        onclick: move |_| *MOBILE_VIEW.write() = MobileView::Chat,
+                        onclick: move |_| crate::util::defer(move || *MOBILE_VIEW.write() = MobileView::Chat),
                         Icon { icon: FaArrowLeft, width: 14, height: 14 }
                     }
                     h2 { class: "text-sm font-semibold text-text-muted uppercase tracking-wide flex items-center gap-2",

--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -39,8 +39,10 @@ pub fn MemberInfoModal() -> Element {
     // Event handlers
     let handle_close_modal = {
         move |_| {
-            MEMBER_INFO_MODAL.with_mut(|signal| {
-                signal.member = None;
+            crate::util::defer(move || {
+                MEMBER_INFO_MODAL.with_mut(|signal| {
+                    signal.member = None;
+                });
             });
         }
     };
@@ -161,8 +163,10 @@ pub fn MemberInfoModal() -> Element {
                 onkeydown: move |evt: KeyboardEvent| {
                     if evt.key() == Key::Escape || evt.key() == Key::Enter {
                         evt.prevent_default();
-                        MEMBER_INFO_MODAL.with_mut(|signal| {
-                            signal.member = None;
+                        crate::util::defer(move || {
+                            MEMBER_INFO_MODAL.with_mut(|signal| {
+                                signal.member = None;
+                            });
                         });
                     }
                 },

--- a/ui/src/components/members/member_info_modal/ban_button.rs
+++ b/ui/src/components/members/member_info_modal/ban_button.rs
@@ -39,8 +39,10 @@ pub fn BanButton(member_to_ban: MemberId, is_downstream: bool, nickname: String)
             };
 
             // Close modal immediately for better UX
-            MEMBER_INFO_MODAL.with_mut(|modal| {
-                modal.member = None;
+            crate::util::defer(move || {
+                MEMBER_INFO_MODAL.with_mut(|modal| {
+                    modal.member = None;
+                });
             });
 
             spawn_local(async move {

--- a/ui/src/components/members/member_info_modal/invited_by_field.rs
+++ b/ui/src/components/members/member_info_modal/invited_by_field.rs
@@ -16,9 +16,11 @@ pub fn InvitedByField(invited_by: String, inviter_id: Option<MemberId>) -> Eleme
                             span {
                                 class: "text-accent hover:text-accent-hover cursor-pointer transition-colors",
                                 onclick: move |_event| {
-                                    MEMBER_INFO_MODAL.with_mut(|uim| {
-                                        uim.member = inviter_id;
-                                    })
+                                    crate::util::defer(move || {
+                                        MEMBER_INFO_MODAL.with_mut(|uim| {
+                                            uim.member = inviter_id;
+                                        });
+                                    });
                                 },
                                 "{invited_by}"
                             }

--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -95,7 +95,7 @@ pub fn RoomList() -> Element {
             div { class: "md:hidden flex items-center px-3 py-2 border-b border-border flex-shrink-0",
                 button {
                     class: "p-2 rounded-lg text-text-muted hover:text-accent hover:bg-surface transition-colors",
-                    onclick: move |_| *MOBILE_VIEW.write() = MobileView::Chat,
+                    onclick: move |_| crate::util::defer(move || *MOBILE_VIEW.write() = MobileView::Chat),
                     Icon { icon: FaArrowLeft, width: 16, height: 16 }
                 }
                 span { class: "ml-2 text-sm font-semibold text-text", "Rooms" }

--- a/ui/src/util.rs
+++ b/ui/src/util.rs
@@ -263,6 +263,21 @@ fn is_debug_enabled() -> bool {
     })
 }
 
+/// Truncate a string to at most `max_bytes` bytes without splitting a
+/// multi-byte UTF-8 character.  Returns the longest prefix whose byte
+/// length is ≤ `max_bytes` and that ends on a char boundary.
+pub fn truncate_str(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    // Walk backwards from `max_bytes` to find a char boundary.
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
 /// Append a debug message to a floating on-screen log overlay.
 /// Only active when `?debug=1` is in the URL query string.
 /// On mobile browsers where console is inaccessible, this lets the user
@@ -387,4 +402,72 @@ pub fn owner_vk_to_contract_key(owner_vk: &VerifyingKey) -> ContractKey {
     let contract_code = ContractCode::from(ROOM_CONTRACT_WASM);
     // Use the full ContractKey constructor that includes the code hash
     ContractKey::from_params_and_code(parameters, &contract_code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_str_ascii_shorter_than_max() {
+        assert_eq!(truncate_str("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_str_ascii_at_max() {
+        assert_eq!(truncate_str("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_str_ascii_longer_than_max() {
+        assert_eq!(truncate_str("hello world", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_str_emoji_at_boundary() {
+        // 👀 is 4 bytes (F0 9F 91 80). "Hello 👀 world" has 👀 at bytes 6..10.
+        // Truncating at 8 should back up to byte 6 (before the emoji).
+        assert_eq!(truncate_str("Hello 👀 world", 8), "Hello ");
+    }
+
+    #[test]
+    fn truncate_str_the_actual_bug() {
+        // The exact crash: "That moment when you...👀👀👀!" truncated at 30
+        // "That moment when you..." = 23 bytes, each 👀 = 4 bytes.
+        // Byte 30 is inside the second 👀 (bytes 27..31), so we back up to 27.
+        let msg = "That moment when you...\u{1F440}\u{1F440}\u{1F440}!";
+        let result = truncate_str(msg, 30);
+        assert_eq!(result, "That moment when you...👀");
+        assert!(!std::panic::catch_unwind(|| truncate_str(msg, 30)).is_err());
+    }
+
+    #[test]
+    fn truncate_str_all_emoji() {
+        // Each 👀 is 4 bytes. 5 bytes should return one emoji (4 bytes).
+        assert_eq!(truncate_str("👀👀👀", 5), "👀");
+    }
+
+    #[test]
+    fn truncate_str_max_zero() {
+        assert_eq!(truncate_str("hello", 0), "");
+    }
+
+    #[test]
+    fn truncate_str_empty() {
+        assert_eq!(truncate_str("", 10), "");
+    }
+
+    #[test]
+    fn truncate_str_two_byte_utf8() {
+        // 'é' is 2 bytes (C3 A9). "café" = [63 61 66 C3 A9] = 5 bytes.
+        // Truncating at 4 should back up to byte 3 (before 'é').
+        assert_eq!(truncate_str("café", 4), "caf");
+    }
+
+    #[test]
+    fn truncate_str_three_byte_utf8() {
+        // '€' is 3 bytes (E2 82 AC). "a€b" = [61 E2 82 AC 62] = 5 bytes.
+        // Truncating at 3 should back up to byte 1 (before '€').
+        assert_eq!(truncate_str("a€b", 3), "a");
+    }
 }


### PR DESCRIPTION
## Problem

River crashes with "RefCell already borrowed" when sending messages containing multi-byte emoji characters. Reported by luckytango on Matrix — sending a message with 👀 triggered a panic that corrupted Dioxus internal state.

Root cause: `&message_text[..message_text.len().min(30)]` at conversation.rs:989 panics when a multi-byte UTF-8 character straddles the 30-byte boundary. The 👀 emoji is 4 bytes (27..31), so slicing at byte 30 is inside the character. This panic cascades into "RefCell already borrowed" at dioxus-core diff/node.rs:70.

Secondary: several onclick handlers mutated GlobalSignals without `defer()`, violating AGENTS.md signal safety rules.

## Approach

1. Added `truncate_str()` helper in util.rs that respects UTF-8 char boundaries
2. Changed debug log truncation to use the safe helper
3. Changed `ROOMS.read()` → `ROOMS.try_read()` inside spawn_local (preventive)
4. Wrapped 6 onclick GlobalSignal mutations with `defer()` across conversation.rs, members.rs, room_list.rs

## Testing

- `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync` passes
- `cargo fmt` clean
- Verified the crash is reproducible with the exact message from the bug report ("That moment when you...👀👀👀!")

[AI-assisted - Claude]