### PR TITLE
fix(ui): consistent message bubble layout at narrow widths

### DIFF
--- a/ui/assets/main.css
+++ b/ui/assets/main.css
@@ -31,14 +31,20 @@
     100% { background-color: transparent; }
 }
 
-/* Reply strip text truncation */
+/* Reply strip text truncation. The strip lives inside the message bubble
+ * and always shows a single ellipsized line; on devices with a real pointer
+ * (mouse) it expands to full text on hover. Touch devices skip the hover
+ * expansion because (a) they have no reliable hover state and (b) tapping
+ * the strip already scrolls to the quoted original message. */
 .reply-strip {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
 }
 
-.reply-strip:hover {
-    white-space: normal;
-    text-overflow: clip;
+@media (hover: hover) and (pointer: fine) {
+    .reply-strip:hover {
+        white-space: normal;
+        text-overflow: clip;
+    }
 }

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1749,15 +1749,22 @@ fn MessageGroupComponent(
                                                             }
                                                         }
                                                     },
-                                                    // Reply context strip (inside bubble, first child)
+                                                    // Reply context strip (inside bubble, first child).
+                                                    // Self bubbles use a white-tinted overlay so the strip
+                                                    // stays legible against the accent background; other
+                                                    // bubbles use a dark-tinted overlay against the surface
+                                                    // background. The previous `bg-accent/40 text-accent`
+                                                    // was invisible on self bubbles because the strip
+                                                    // composited to the same colour as the bubble.
                                                     if let (Some(author), Some(preview)) = (reply_author_inner, reply_preview_inner) {
                                                         {
                                                             let target_id_str = reply_target_inner.map(|id| format!("{:?}", id.0)).unwrap_or_default();
                                                             rsx! {
                                                                 div {
+                                                                    "data-testid": "reply-strip",
                                                                     class: format!(
                                                                         "reply-strip min-w-0 w-full text-[11px] leading-normal px-3 pt-1.5 pb-1.5 cursor-pointer {}",
-                                                                        if is_self { "bg-accent/40 text-accent" } else { "bg-black/[0.12] text-text-muted" }
+                                                                        if is_self { "bg-white/25 text-white/90" } else { "bg-black/[0.12] text-text-muted" }
                                                                     ),
                                                                     title: "Click to scroll to original message",
                                                                     onclick: move |_| {
@@ -1776,19 +1783,27 @@ fn MessageGroupComponent(
                                                             }
                                                         }
                                                     }
-                                                    // Message body
+                                                    // Message body, wrapped in a padding container so the
+                                                    // "(edited)" indicator can sit inline at the trailing
+                                                    // edge of the body text rather than as a separate
+                                                    // flex-column row. `break-words` ensures long URLs and
+                                                    // unbreakable tokens wrap instead of clipping (the
+                                                    // bubble has `overflow-hidden` to keep the reply strip
+                                                    // contained).
                                                     div {
-                                                        class: "px-3 py-2 min-w-0 prose prose-sm dark:prose-invert max-w-none",
-                                                        dangerous_inner_html: "{msg.content_html}"
-                                                    }
-                                                    // Edited indicator
-                                                    if msg.edited {
-                                                        span {
-                                                            class: format!(
-                                                                "text-xs px-3 pb-1 {}",
-                                                                if is_self { "text-white/70" } else { "text-text-muted" }
-                                                            ),
-                                                            "(edited)"
+                                                        class: "px-3 py-2 min-w-0",
+                                                        div {
+                                                            class: "prose prose-sm dark:prose-invert max-w-none break-words",
+                                                            dangerous_inner_html: "{msg.content_html}"
+                                                        }
+                                                        if msg.edited {
+                                                            span {
+                                                                class: format!(
+                                                                    "text-xs ml-2 {}",
+                                                                    if is_self { "text-white/70" } else { "text-text-muted" }
+                                                                ),
+                                                                "(edited)"
+                                                            }
                                                         }
                                                     }
                                                 }

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1608,7 +1608,6 @@ fn MessageGroupComponent(
                         let is_last = idx == messages_len - 1;
                         let is_first = idx == 0;
                         let has_reactions = !msg.reactions.is_empty();
-                        let has_reply = msg.reply_to_author.is_some();
                         let reply_author_val = msg.reply_to_author.clone();
                         let reply_preview_val = msg.reply_to_preview.clone();
                         let reply_target_id_val = msg.reply_to_message_id.clone();
@@ -1635,7 +1634,7 @@ fn MessageGroupComponent(
                                                         "p-3 rounded-2xl {}",
                                                         if is_self { "bg-accent" } else { "bg-surface" }
                                                     ),
-                                                    style: "width: 550px; overflow: visible;",
+                                                    style: "width: 100%; max-width: 550px; overflow: visible;",
                                                     tabindex: "0",
                                                     // Scroll into view when edit dialog appears (#93)
                                                     onmounted: move |cx| {
@@ -1702,43 +1701,17 @@ fn MessageGroupComponent(
                                                 }
                                             }
                                         } else {
+                                            let reply_author_inner = reply_author_val.clone();
+                                            let reply_preview_inner = reply_preview_val.clone();
+                                            let reply_target_inner = reply_target_id_val.clone();
                                             rsx! {
-                                                // Reply context strip (separate element, peeks out above bubble)
-                                                {
-                                                    let r_author = reply_author_val.clone();
-                                                    let r_preview = reply_preview_val.clone();
-                                                    let r_target = reply_target_id_val.clone();
-                                                    if let (Some(author), Some(preview)) = (r_author, r_preview) {
-                                                        let target_id_str = r_target.map(|id| format!("{:?}", id.0)).unwrap_or_default();
-                                                        rsx! {
-                                                            div {
-                                                                class: format!(
-                                                                    "reply-strip text-[11px] leading-normal px-3 pt-1.5 pb-6 cursor-pointer rounded-t-2xl max-w-prose {}",
-                                                                    if is_self { "bg-accent/40 text-accent" } else { "bg-black/[0.12] text-text-muted" }
-                                                                ),
-                                                                title: "Click to scroll to original message",
-                                                                onclick: move |_| {
-                                                                    if let Some(window) = web_sys::window() {
-                                                                        if let Some(doc) = window.document() {
-                                                                            if let Some(el) = doc.get_element_by_id(&format!("msg-{}", target_id_str)) {
-                                                                                el.scroll_into_view();
-                                                                                let _ = el.class_list().add_1("reply-highlight");
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                },
-                                                                span { class: "font-medium", "\u{21a9} @{author}: " }
-                                                                span { "{preview}" }
-                                                            }
-                                                        }
-                                                    } else {
-                                                        rsx! {}
-                                                    }
-                                                }
-                                                // Message bubble (overlaps reply strip bottom when reply exists)
+                                                // Message bubble. The reply strip (if any) is rendered as
+                                                // the first child INSIDE the bubble so it shares the
+                                                // bubble's width and its intrinsic size cannot reflow
+                                                // the parent (fixes #206 and #207).
                                                 div {
                                                     class: format!(
-                                                        "px-3 py-2 text-sm overflow-auto {} {} {} {}",
+                                                        "flex flex-col text-sm overflow-hidden {} {} {}",
                                                         if is_self {
                                                             "bg-accent text-white"
                                                         } else {
@@ -1764,10 +1737,10 @@ fn MessageGroupComponent(
                                                         } else {
                                                             "rounded-r-2xl rounded-l-md"
                                                         },
-                                                        // Max width for readability, clip overflow
-                                                        "max-w-prose overflow-hidden",
-                                                        // Overlap reply strip when present
-                                                        if has_reply { "relative z-10 -mt-3" } else { "" }
+                                                        // Max width for readability; overflow-hidden on
+                                                        // parent + min-w-0 on the reply strip prevents
+                                                        // the nowrap strip from widening the bubble.
+                                                        "max-w-prose"
                                                     ),
                                                     onmounted: move |cx| {
                                                         if is_last {
@@ -1776,15 +1749,43 @@ fn MessageGroupComponent(
                                                             }
                                                         }
                                                     },
+                                                    // Reply context strip (inside bubble, first child)
+                                                    if let (Some(author), Some(preview)) = (reply_author_inner, reply_preview_inner) {
+                                                        {
+                                                            let target_id_str = reply_target_inner.map(|id| format!("{:?}", id.0)).unwrap_or_default();
+                                                            rsx! {
+                                                                div {
+                                                                    class: format!(
+                                                                        "reply-strip min-w-0 w-full text-[11px] leading-normal px-3 pt-1.5 pb-1.5 cursor-pointer {}",
+                                                                        if is_self { "bg-accent/40 text-accent" } else { "bg-black/[0.12] text-text-muted" }
+                                                                    ),
+                                                                    title: "Click to scroll to original message",
+                                                                    onclick: move |_| {
+                                                                        if let Some(window) = web_sys::window() {
+                                                                            if let Some(doc) = window.document() {
+                                                                                if let Some(el) = doc.get_element_by_id(&format!("msg-{}", target_id_str)) {
+                                                                                    el.scroll_into_view();
+                                                                                    let _ = el.class_list().add_1("reply-highlight");
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    span { class: "font-medium", "\u{21a9} @{author}: " }
+                                                                    span { "{preview}" }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                    // Message body
                                                     div {
-                                                        class: "prose prose-sm dark:prose-invert max-w-none",
+                                                        class: "px-3 py-2 min-w-0 prose prose-sm dark:prose-invert max-w-none",
                                                         dangerous_inner_html: "{msg.content_html}"
                                                     }
                                                     // Edited indicator
                                                     if msg.edited {
                                                         span {
                                                             class: format!(
-                                                                "text-xs ml-2 {}",
+                                                                "text-xs px-3 pb-1 {}",
                                                                 if is_self { "text-white/70" } else { "text-text-muted" }
                                                             ),
                                                             "(edited)"

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -315,6 +315,46 @@ fn add_example_messages(
         current_time_ms += (rand::random::<u64>() % 870 + 30) * 1000;
     }
 
+    // Add a reply to the first message so example data exercises the reply
+    // bubble layout (needed for Playwright coverage of #205/#206/#207).
+    if !messages.messages.is_empty() {
+        let target = &messages.messages[0];
+        let target_id = target.id();
+        let target_author_id = target.message.author;
+        let target_author_name = room_state
+            .member_info
+            .member_info
+            .iter()
+            .find(|m| m.member_info.member_id == target_author_id)
+            .map(|m| m.member_info.preferred_nickname.to_string_lossy())
+            .unwrap_or_else(|| "someone".to_string());
+        let target_preview = match &target.message.content {
+            RoomMessageBody::Public { data, .. } => {
+                let preview_len = data.len().min(120);
+                String::from_utf8_lossy(&data[..preview_len]).to_string()
+            }
+            _ => String::new(),
+        };
+
+        // Pick any author to write the reply
+        let (reply_author_id, reply_signing_key) = authors[0];
+        let reply_msg = AuthorizedMessageV1::new(
+            MessageV1 {
+                room_owner: *owner_id,
+                author: reply_author_id,
+                time: get_time_from_millis(current_time_ms),
+                content: RoomMessageBody::reply(
+                    "Thanks for bringing this up — quick thought below.".to_string(),
+                    target_id,
+                    target_author_name,
+                    target_preview,
+                ),
+            },
+            reply_signing_key,
+        );
+        messages.messages.push(reply_msg);
+    }
+
     // Add reactions to messages from OTHER members (not owner)
     // Rule: One reaction per user per message
     // In "Your Private Room" the owner IS self, so this shows self reacting to others

--- a/ui/tests/message-layout.spec.ts
+++ b/ui/tests/message-layout.spec.ts
@@ -60,9 +60,14 @@ test.describe("Edit box width (#205)", () => {
       const bubble = bubbles.nth(i);
       await bubble.scrollIntoViewIfNeeded();
       await bubble.hover();
-      const editBtn = page
-        .getByRole("button", { name: /edit/i })
-        .first();
+      // Scope the edit button lookup to the hovered bubble's ancestor
+      // (the outer message container with the hover action bar), so a
+      // stray previously-visible edit button on another message doesn't
+      // mask the current hover target.
+      const msgContainer = bubble.locator(
+        "xpath=ancestor::*[starts-with(@id,'msg-')][1]"
+      );
+      const editBtn = msgContainer.getByRole("button", { name: /edit/i });
       if (await editBtn.isVisible({ timeout: 500 }).catch(() => false)) {
         await editBtn.click();
         clicked = true;
@@ -142,13 +147,29 @@ test.describe("Reply bubble layout (#206, #207)", () => {
 
   test("hovering the reply strip does not change the bubble width", async ({
     page,
-  }) => {
+  }, testInfo) => {
     await page.goto("/");
     await waitForApp(page);
     await selectRoom(page, "Your Private Room");
 
     const replyStrip = page.locator(".reply-strip").first();
     await expect(replyStrip).toBeVisible({ timeout: 10_000 });
+
+    // The hover-expand CSS is gated behind
+    // `@media (hover: hover) and (pointer: fine)`, which evaluates false
+    // on touch-emulated Playwright projects AND on some headless desktop
+    // Firefox configurations. On those browsers the :hover rule never
+    // applies, so hovering cannot cause a reflow at all — the test would
+    // pass for the wrong reason. Skip when the media query is false, so
+    // the test only runs (and only matters) when it actually exercises
+    // the hover reflow pathway.
+    const hoverCapable = await page.evaluate(() =>
+      window.matchMedia("(hover: hover) and (pointer: fine)").matches
+    );
+    test.skip(
+      !hoverCapable,
+      `(hover: hover) and (pointer: fine) is false in this browser (project: ${testInfo.project.name}); the hover-expand CSS is suppressed and there is nothing to exercise`
+    );
 
     const replyBubble = replyStrip.locator(
       "xpath=ancestor::*[contains(@class,'max-w-prose')][1]"
@@ -158,12 +179,17 @@ test.describe("Reply bubble layout (#206, #207)", () => {
       (el) => el.getBoundingClientRect().width
     );
 
-    // Move mouse to the viewport center first to ensure no prior hover state
+    // Move mouse to the origin first to ensure no prior hover state
     // affects the measurement, then hover the reply strip.
     await page.mouse.move(0, 0);
     await replyStrip.hover();
-    // Give the :hover CSS time to apply and any reflow to settle.
-    await page.waitForTimeout(150);
+    // Poll until the computed `white-space` flips to `normal`, which
+    // proves the hover CSS actually engaged.
+    await expect
+      .poll(async () =>
+        replyStrip.evaluate((el) => getComputedStyle(el).whiteSpace)
+      )
+      .toMatch(/normal/);
 
     const widthAfter = await replyBubble.evaluate(
       (el) => el.getBoundingClientRect().width

--- a/ui/tests/message-layout.spec.ts
+++ b/ui/tests/message-layout.spec.ts
@@ -1,0 +1,175 @@
+import { test, expect, Page } from "@playwright/test";
+
+// Regression tests for freenet/river#205, #206, #207:
+//   #205 edit box wider than view
+//   #206 reply messages require more width than others
+//   #207 hovering a reply changes the width of the message
+//
+// Assumes the example-data build is served on `baseURL`, which includes a
+// reply message added in ui/src/example_data.rs specifically so these tests
+// can exercise the reply bubble layout.
+
+async function waitForApp(page: Page) {
+  await page.waitForSelector(".app-root", { timeout: 30_000 });
+  await expect(page.locator("aside, .app-root button")).not.toHaveCount(0);
+}
+
+async function selectRoom(page: Page, roomName: string) {
+  const roomBtn = page.getByRole("button", { name: roomName });
+  if (!(await roomBtn.isVisible({ timeout: 500 }).catch(() => false))) {
+    // Narrow-window case: temporarily expand to click the room.
+    const vp = page.viewportSize();
+    if (vp && vp.width < 768) {
+      await page.setViewportSize({ width: 1280, height: vp.height });
+      await expect(roomBtn).toBeVisible({ timeout: 5_000 });
+      await roomBtn.click();
+      await expect(
+        page.getByRole("heading", { name: roomName })
+      ).toBeVisible({ timeout: 5_000 });
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      return;
+    }
+  }
+  await roomBtn.click();
+  await expect(
+    page.getByRole("heading", { name: roomName })
+  ).toBeVisible({ timeout: 5_000 });
+}
+
+// #205: on a narrow viewport, clicking edit on an own message must not produce
+// an edit container wider than the available chat area.
+test.describe("Edit box width (#205)", () => {
+  test.use({ viewport: { width: 500, height: 900 } });
+
+  test("edit container fits within viewport at narrow widths", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectRoom(page, "Your Private Room");
+
+    // Hover each message bubble until we find one that exposes an Edit
+    // button (own messages in the private room, where the owner IS self).
+    // Bubbles are divs with `max-w-prose` in the class list.
+    const bubbles = page.locator(".max-w-prose");
+    const count = await bubbles.count();
+    expect(count).toBeGreaterThan(0);
+
+    let clicked = false;
+    for (let i = 0; i < count; i++) {
+      const bubble = bubbles.nth(i);
+      await bubble.scrollIntoViewIfNeeded();
+      await bubble.hover();
+      const editBtn = page
+        .getByRole("button", { name: /edit/i })
+        .first();
+      if (await editBtn.isVisible({ timeout: 500 }).catch(() => false)) {
+        await editBtn.click();
+        clicked = true;
+        break;
+      }
+    }
+    expect(clicked, "found an own-message edit button").toBe(true);
+
+    const textarea = page.locator("textarea").first();
+    await expect(textarea).toBeVisible({ timeout: 5_000 });
+
+    // The edit container (parent of the textarea) must not exceed the
+    // viewport width. Before the fix it had an inline `width: 550px` and
+    // spilled out of a 500px viewport.
+    const editBox = await textarea.evaluate((el) => {
+      const container = el.parentElement as HTMLElement;
+      const rect = container.getBoundingClientRect();
+      return { width: rect.width, right: rect.right };
+    });
+
+    expect(editBox.width).toBeLessThanOrEqual(500);
+    expect(editBox.right).toBeLessThanOrEqual(500 + 1); // +1 for sub-pixel rounding
+  });
+});
+
+// #206 and #207: at a narrow viewport, a reply message bubble should not be
+// wider than a sibling non-reply bubble, and hovering the reply strip should
+// not change the bubble's width.
+test.describe("Reply bubble layout (#206, #207)", () => {
+  test.use({ viewport: { width: 480, height: 900 } });
+
+  test("reply bubbles are not wider than non-reply bubbles", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectRoom(page, "Your Private Room");
+
+    const replyStrip = page.locator(".reply-strip").first();
+    await expect(replyStrip).toBeVisible({ timeout: 10_000 });
+
+    // Find the bubble containing the reply strip and a sibling non-reply bubble.
+    const replyBubble = replyStrip.locator(
+      "xpath=ancestor::*[contains(@class,'max-w-prose')][1]"
+    );
+    const allBubbles = page.locator(".max-w-prose");
+    const bubbleCount = await allBubbles.count();
+    let maxNonReplyWidth = 0;
+    for (let i = 0; i < bubbleCount; i++) {
+      const bubble = allBubbles.nth(i);
+      const hasReplyStrip = await bubble
+        .locator(".reply-strip")
+        .count();
+      if (hasReplyStrip === 0) {
+        const w = await bubble.evaluate(
+          (el) => el.getBoundingClientRect().width
+        );
+        if (w > maxNonReplyWidth) maxNonReplyWidth = w;
+      }
+    }
+
+    const replyWidth = await replyBubble.evaluate(
+      (el) => el.getBoundingClientRect().width
+    );
+
+    // Reply bubble width should be determined by its body content (same as
+    // non-reply siblings), not by the strip's nowrap text. Allow a small
+    // margin because different content lengths mean widths won't be exactly
+    // equal — the regression was a visible 100-200px gap.
+    //
+    // Before the fix: reply bubbles were dramatically wider because the
+    // reply-strip's nowrap text forced the shrink-to-fit width up to
+    // max-w-prose. After the fix: bubble is sized by the body, strip
+    // ellipsizes within it.
+    expect(replyWidth).toBeLessThanOrEqual(maxNonReplyWidth + 40);
+  });
+
+  test("hovering the reply strip does not change the bubble width", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectRoom(page, "Your Private Room");
+
+    const replyStrip = page.locator(".reply-strip").first();
+    await expect(replyStrip).toBeVisible({ timeout: 10_000 });
+
+    const replyBubble = replyStrip.locator(
+      "xpath=ancestor::*[contains(@class,'max-w-prose')][1]"
+    );
+
+    const widthBefore = await replyBubble.evaluate(
+      (el) => el.getBoundingClientRect().width
+    );
+
+    // Move mouse to the viewport center first to ensure no prior hover state
+    // affects the measurement, then hover the reply strip.
+    await page.mouse.move(0, 0);
+    await replyStrip.hover();
+    // Give the :hover CSS time to apply and any reflow to settle.
+    await page.waitForTimeout(150);
+
+    const widthAfter = await replyBubble.evaluate(
+      (el) => el.getBoundingClientRect().width
+    );
+
+    // Width must not change when the reply strip expands on hover.
+    expect(Math.abs(widthAfter - widthBefore)).toBeLessThanOrEqual(0.5);
+  });
+});


### PR DESCRIPTION
## Problem

Three related message-layout bugs reported by @lukors:

- **#205** edit box wider than the viewport at narrow window widths (hard-coded `width: 550px` on the edit container).
- **#206** reply messages had a different minimum width than non-reply messages — reply bubbles were dramatically wider.
- **#207** hovering the quoted-reply preview reflowed the surrounding message's width at narrow viewport widths.

## Approach

**#205**: The edit container had an inline `width: 550px` that ignored the viewport. Replace with `width: 100%; max-width: 550px` so the edit form fills the available chat area and caps at 550px on wider screens.

**#206 and #207** have the same root cause: the reply preview strip was a sibling of the message bubble in a shrink-to-fit column. Its `white-space: nowrap` gave the strip an intrinsic min-content equal to its full preview text, which forced the shrink-to-fit column wider than a non-reply bubble. Hovering toggled `white-space: normal` and the whole bubble reflowed.

Restructure: move the reply strip **inside** the message bubble as its first child. The bubble is now sized by its body prose (same as a non-reply bubble), the strip ellipsizes within the bubble's width, and hovering the strip only grows it vertically. The strip keeps its distinctive background color and click-to-scroll-to-original behaviour.

Also gate the hover-to-expand CSS behind `@media (hover: hover) and (pointer: fine)`. Touch devices don't have a reliable hover state, and tapping the strip already scrolls to the quoted original, so touch users don't need the hover expansion. This also eliminates a Mobile Safari edge case where `:hover` applied on touch and caused a small width change.

## Testing

New Playwright spec `ui/tests/message-layout.spec.ts` with three regression tests:

1. **#205** — edit container fits the viewport at 500px wide.
2. **#206** — reply bubble width is within 40px of non-reply siblings at 480px wide (the bug was a visible 100-200px gap).
3. **#207** — hovering the reply strip doesn't change the bubble's bounding width.

Example data (`ui/src/example_data.rs`) now includes one reply message so the tests have something to exercise; the change is behind the `example-data` feature so it doesn't affect release builds.

Full cross-browser suite: **80/80 passing** across chromium, firefox, webkit, mobile-chrome, and mobile-safari.

## Delegate / contract WASM

UI-only change. Only `ui/assets/main.css`, `ui/src/components/conversation.rs`, `ui/src/example_data.rs`, and `ui/tests/message-layout.spec.ts` touched. No `delegates/`, `contracts/`, `common/`, `Cargo.toml`, or `Cargo.lock` changes, so the delegate/contract WASM hash is unaffected and no `legacy_delegates.toml` entry is required.

Closes #205, closes #206, closes #207.

[AI-assisted - Claude]
