### PR TITLE
fix(ui): stop re-prompting for nickname on invite-link reload

### DIFF
--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -15,7 +15,8 @@ use crate::components::members::Invitation;
 use crate::components::room_list::create_room_modal::CreateRoomModal;
 use crate::components::room_list::edit_room_modal::EditRoomModal;
 use crate::components::room_list::receive_invitation_modal::{
-    load_invitation_from_storage, save_invitation_to_storage, ReceiveInvitationModal,
+    is_invitation_processed, load_invitation_from_storage, mark_invitation_processed,
+    save_invitation_to_storage, ReceiveInvitationModal,
 };
 use crate::invites::PendingInvites;
 use crate::room_data::{CurrentRoom, Rooms};
@@ -106,35 +107,58 @@ pub fn App() -> Element {
         synchronizer.start().await;
     });
 
-    // Check URL for invitation parameter, then fall back to localStorage
+    // Check URL for invitation parameter, then fall back to localStorage.
+    //
+    // The URL is also rewritten via `history.replaceState` to drop the
+    // `?invitation=...` parameter, but that call may be blocked when River is
+    // embedded in the gateway's sandboxed iframe (which has no
+    // `allow-same-origin`). To stay correct when the URL cannot be cleaned,
+    // we record a fingerprint of every invitation we have already shown the
+    // user and skip it on subsequent loads. See issue #215.
     let mut found_invitation = false;
     if let Some(window) = window() {
         if let Ok(search) = window.location().search() {
             if let Ok(params) = web_sys::UrlSearchParams::new_with_str(&search) {
                 if let Some(invitation_code) = params.get("invitation") {
-                    if let Ok(invitation) = Invitation::from_encoded_string(&invitation_code) {
+                    let already_processed = is_invitation_processed(&invitation_code);
+                    if already_processed {
+                        info!("Skipping invitation in URL: already processed in this browser");
+                    } else if let Ok(invitation) = Invitation::from_encoded_string(&invitation_code)
+                    {
                         info!("Received invitation from URL: {:?}", invitation);
+                        // Record the fingerprint immediately. The modal flow
+                        // also calls `mark_invitation_processed` on Accept,
+                        // but recording it here covers the case where the
+                        // user reloads before clicking anything.
+                        mark_invitation_processed(&invitation_code);
                         save_invitation_to_storage(&invitation);
                         receive_invitation.set(Some(invitation));
                         found_invitation = true;
+                    }
 
-                        // Remove invitation parameter from URL to prevent re-processing on refresh
-                        params.delete("invitation");
-                        let new_search = params.to_string().as_string().unwrap_or_default();
-                        let new_url = if new_search.is_empty() {
-                            window.location().pathname().unwrap_or_default()
-                        } else {
-                            format!(
-                                "{}?{}",
-                                window.location().pathname().unwrap_or_default(),
-                                new_search
-                            )
-                        };
-                        if let Ok(history) = window.history() {
-                            let _ = history.replace_state_with_url(
-                                &wasm_bindgen::JsValue::NULL,
-                                "",
-                                Some(&new_url),
+                    // Best-effort: remove the invitation parameter from the
+                    // URL. May fail in the sandboxed iframe; the processed
+                    // fingerprint above is the authoritative guard.
+                    params.delete("invitation");
+                    let new_search = params.to_string().as_string().unwrap_or_default();
+                    let new_url = if new_search.is_empty() {
+                        window.location().pathname().unwrap_or_default()
+                    } else {
+                        format!(
+                            "{}?{}",
+                            window.location().pathname().unwrap_or_default(),
+                            new_search
+                        )
+                    };
+                    if let Ok(history) = window.history() {
+                        if let Err(e) = history.replace_state_with_url(
+                            &wasm_bindgen::JsValue::NULL,
+                            "",
+                            Some(&new_url),
+                        ) {
+                            debug!(
+                                "history.replaceState failed (likely sandboxed iframe): {:?}",
+                                e
                             );
                         }
                     }

--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -15,7 +15,7 @@ use crate::components::members::Invitation;
 use crate::components::room_list::create_room_modal::CreateRoomModal;
 use crate::components::room_list::edit_room_modal::EditRoomModal;
 use crate::components::room_list::receive_invitation_modal::{
-    is_invitation_processed, load_invitation_from_storage, mark_invitation_processed,
+    clear_invitation_from_storage, is_invitation_processed, load_invitation_from_storage,
     save_invitation_to_storage, ReceiveInvitationModal,
 };
 use crate::invites::PendingInvites;
@@ -113,32 +113,33 @@ pub fn App() -> Element {
     // `?invitation=...` parameter, but that call may be blocked when River is
     // embedded in the gateway's sandboxed iframe (which has no
     // `allow-same-origin`). To stay correct when the URL cannot be cleaned,
-    // we record a fingerprint of every invitation we have already shown the
-    // user and skip it on subsequent loads. See issue #215.
+    // we record a fingerprint of every invitation the user has acted on
+    // (Accept or any dismiss) and skip it on subsequent loads. The
+    // fingerprint is keyed off `Invitation::to_encoded_string()` (canonical
+    // CBOR + base58, see `invitation_round_trip_is_byte_stable` test) so
+    // load-from-storage and load-from-URL produce the same key for the same
+    // invitation. See issue #215.
     let mut found_invitation = false;
     if let Some(window) = window() {
         if let Ok(search) = window.location().search() {
             if let Ok(params) = web_sys::UrlSearchParams::new_with_str(&search) {
                 if let Some(invitation_code) = params.get("invitation") {
-                    let already_processed = is_invitation_processed(&invitation_code);
-                    if already_processed {
-                        info!("Skipping invitation in URL: already processed in this browser");
-                    } else if let Ok(invitation) = Invitation::from_encoded_string(&invitation_code)
-                    {
-                        info!("Received invitation from URL: {:?}", invitation);
-                        // Record the fingerprint immediately. The modal flow
-                        // also calls `mark_invitation_processed` on Accept,
-                        // but recording it here covers the case where the
-                        // user reloads before clicking anything.
-                        mark_invitation_processed(&invitation_code);
-                        save_invitation_to_storage(&invitation);
-                        receive_invitation.set(Some(invitation));
-                        found_invitation = true;
+                    if let Ok(invitation) = Invitation::from_encoded_string(&invitation_code) {
+                        if is_invitation_processed(&invitation.to_encoded_string()) {
+                            debug!(
+                                "Skipping invitation in URL: already accepted or dismissed in this browser"
+                            );
+                        } else {
+                            info!("Received invitation from URL: {:?}", invitation);
+                            save_invitation_to_storage(&invitation);
+                            receive_invitation.set(Some(invitation));
+                            found_invitation = true;
+                        }
                     }
 
                     // Best-effort: remove the invitation parameter from the
                     // URL. May fail in the sandboxed iframe; the processed
-                    // fingerprint above is the authoritative guard.
+                    // fingerprint is the authoritative guard.
                     params.delete("invitation");
                     let new_search = params.to_string().as_string().unwrap_or_default();
                     let new_url = if new_search.is_empty() {
@@ -167,11 +168,21 @@ pub fn App() -> Element {
         }
     }
 
-    // Recover invitation from localStorage if not found in URL (e.g. after page reload)
+    // Recover invitation from localStorage if not found in URL (e.g. after
+    // page reload before subscription completed). Skip if the user has
+    // already acted on this invitation in a previous session. Without this
+    // check, a reload mid-subscription re-opens the modal with a nickname
+    // prompt even though the user already accepted, because PENDING_INVITES
+    // is in-memory only.
     if !found_invitation {
         if let Some(invitation) = load_invitation_from_storage() {
-            info!("Recovered pending invitation from localStorage");
-            receive_invitation.set(Some(invitation));
+            if is_invitation_processed(&invitation.to_encoded_string()) {
+                debug!("Discarding recovered invitation: already processed");
+                clear_invitation_from_storage();
+            } else {
+                info!("Recovered pending invitation from localStorage");
+                receive_invitation.set(Some(invitation));
+            }
         }
     }
 

--- a/ui/src/components/room_list/receive_invitation_modal.rs
+++ b/ui/src/components/room_list/receive_invitation_modal.rs
@@ -9,6 +9,10 @@ use ed25519_dalek::VerifyingKey;
 use river_core::room_state::member::MemberId;
 
 const INVITATION_STORAGE_KEY: &str = "river_pending_invitation";
+const PROCESSED_INVITATIONS_KEY: &str = "river_processed_invitations";
+/// Cap on the number of remembered invitation fingerprints. Old entries are
+/// evicted FIFO so localStorage stays bounded across many invite cycles.
+const MAX_PROCESSED_INVITATIONS: usize = 64;
 
 /// Save invitation to localStorage so it survives page reloads
 pub fn save_invitation_to_storage(invitation: &Invitation) {
@@ -37,6 +41,88 @@ pub fn clear_invitation_from_storage() {
             let _ = storage.remove_item(INVITATION_STORAGE_KEY);
         }
     }
+}
+
+/// Short, stable identifier for an invitation, suitable for storage in a set.
+/// 16 bytes of BLAKE3 over the encoded form gives a 2^128 collision space.
+fn invitation_fingerprint(encoded: &str) -> String {
+    let hash = blake3::hash(encoded.as_bytes());
+    let bytes = &hash.as_bytes()[..16];
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{:02x}", b));
+    }
+    s
+}
+
+fn read_processed_list() -> Vec<String> {
+    let Some(window) = web_sys::window() else {
+        return Vec::new();
+    };
+    let Ok(Some(storage)) = window.local_storage() else {
+        return Vec::new();
+    };
+    let Ok(Some(raw)) = storage.get_item(PROCESSED_INVITATIONS_KEY) else {
+        return Vec::new();
+    };
+    raw.split('\n')
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+fn write_processed_list(list: &[String]) {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let Ok(Some(storage)) = window.local_storage() else {
+        return;
+    };
+    let joined = list.join("\n");
+    if let Err(e) = storage.set_item(PROCESSED_INVITATIONS_KEY, &joined) {
+        warn!("Failed to persist processed invitations: {:?}", e);
+    }
+}
+
+/// Append `fingerprint` to `list`, deduplicating and capping length.
+/// Returns `Some(new_list)` if anything changed, `None` if already present.
+fn append_fingerprint(
+    mut list: Vec<String>,
+    fingerprint: String,
+    cap: usize,
+) -> Option<Vec<String>> {
+    if list.contains(&fingerprint) {
+        return None;
+    }
+    list.push(fingerprint);
+    if list.len() > cap {
+        let drop = list.len() - cap;
+        list.drain(0..drop);
+    }
+    Some(list)
+}
+
+/// Mark an invitation (by its encoded URL form) as processed so future page
+/// loads do not re-prompt for a nickname. Called on Accept (entry to the
+/// flow) rather than on subscription success: the URL parameter itself is the
+/// trigger, and reloading after the user has chosen what to do with this
+/// invitation should not surface it again even if `history.replaceState`
+/// failed (e.g. inside the gateway's sandboxed iframe, which has no
+/// `allow-same-origin`).
+pub fn mark_invitation_processed(encoded: &str) {
+    let fingerprint = invitation_fingerprint(encoded);
+    let list = read_processed_list();
+    if let Some(new_list) = append_fingerprint(list, fingerprint, MAX_PROCESSED_INVITATIONS) {
+        write_processed_list(&new_list);
+    }
+}
+
+/// Returns true if `encoded` matches an invitation already processed in this
+/// browser. Used by the URL parser to skip stale `?invitation=...` params left
+/// behind by a sandbox that blocks `history.replaceState`.
+pub fn is_invitation_processed(encoded: &str) -> bool {
+    let fingerprint = invitation_fingerprint(encoded);
+    read_processed_list().iter().any(|f| f == &fingerprint)
 }
 
 /// Main component for the invitation modal
@@ -374,6 +460,12 @@ fn render_new_invitation(inv: Invitation, mut invitation: Signal<Option<Invitati
 
 /// Handles the invitation acceptance process
 fn accept_invitation(inv: Invitation, nickname: String) {
+    // Mark this invitation processed up front. The user has now made a choice
+    // for this URL parameter; even if subscription fails or the page is
+    // reloaded mid-flow, we should not re-prompt for a nickname on every
+    // refresh just because the URL still carries `?invitation=...`.
+    mark_invitation_processed(&inv.to_encoded_string());
+
     let room_owner = inv.room;
     let authorized_member = inv.invitee.clone();
     let invitee_signing_key = inv.invitee_signing_key.clone();
@@ -434,5 +526,64 @@ fn accept_invitation(inv: Invitation, nickname: String) {
                 MemberId::from(room_owner)
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_is_deterministic() {
+        let a = invitation_fingerprint("invitation-code-xyz");
+        let b = invitation_fingerprint("invitation-code-xyz");
+        assert_eq!(a, b, "same input must hash to same fingerprint");
+    }
+
+    #[test]
+    fn fingerprint_distinguishes_inputs() {
+        let a = invitation_fingerprint("invitation-a");
+        let b = invitation_fingerprint("invitation-b");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn fingerprint_is_compact_hex() {
+        let fp = invitation_fingerprint("anything");
+        assert_eq!(fp.len(), 32, "16 bytes hex-encoded = 32 chars");
+        assert!(
+            fp.chars().all(|c| c.is_ascii_hexdigit()),
+            "fingerprint must be hex"
+        );
+    }
+
+    #[test]
+    fn append_dedups() {
+        let list = vec!["a".to_string(), "b".to_string()];
+        assert!(
+            append_fingerprint(list, "a".to_string(), 64).is_none(),
+            "duplicate should return None to skip the write"
+        );
+    }
+
+    #[test]
+    fn append_evicts_fifo_when_at_cap() {
+        let list = vec!["1".to_string(), "2".to_string(), "3".to_string()];
+        let result = append_fingerprint(list, "4".to_string(), 3).expect("change occurred");
+        assert_eq!(
+            result,
+            vec!["2".to_string(), "3".to_string(), "4".to_string()],
+            "oldest entry should be evicted to make room"
+        );
+    }
+
+    #[test]
+    fn append_evicts_multiple_when_above_cap() {
+        // Simulates raising the cap or pre-existing oversized state
+        let list: Vec<String> = (0..10).map(|i| i.to_string()).collect();
+        let result = append_fingerprint(list, "new".to_string(), 3).expect("change occurred");
+        assert_eq!(result.len(), 3);
+        assert_eq!(result.last().unwrap(), "new");
+        assert_eq!(result[0], "8");
     }
 }

--- a/ui/src/components/room_list/receive_invitation_modal.rs
+++ b/ui/src/components/room_list/receive_invitation_modal.rs
@@ -125,6 +125,18 @@ pub fn is_invitation_processed(encoded: &str) -> bool {
     read_processed_list().iter().any(|f| f == &fingerprint)
 }
 
+/// Dismiss the modal *persistently*: mark the invitation as processed,
+/// clear it from `INVITATION_STORAGE_KEY`, and close the modal. Use this for
+/// every user-initiated dismiss (Decline, Cancel, Close, Dismiss-on-error).
+/// Without the fingerprint mark, a reload would re-surface the modal in the
+/// sandboxed-iframe environment where `history.replaceState` cannot strip
+/// the `?invitation=...` URL parameter.
+fn dismiss_invitation_persistently(inv: &Invitation, mut invitation: Signal<Option<Invitation>>) {
+    mark_invitation_processed(&inv.to_encoded_string());
+    clear_invitation_from_storage();
+    invitation.set(None);
+}
+
 /// Main component for the invitation modal
 #[component]
 pub fn ReceiveInvitationModal(invitation: Signal<Option<Invitation>>) -> Element {
@@ -173,7 +185,7 @@ fn render_invitation_content(inv: Invitation, invitation: Signal<Option<Invitati
     match status {
         Some(PendingRoomStatus::PendingSubscription) => render_pending_subscription_state(),
         Some(PendingRoomStatus::Subscribing) => render_subscribing_state(),
-        Some(PendingRoomStatus::Error(e)) => render_error_state(&e, &inv.room, invitation),
+        Some(PendingRoomStatus::Error(e)) => render_error_state(&e, &inv, invitation),
         Some(PendingRoomStatus::Subscribed) => {
             // Room subscribed and retrieved successfully, close modal
             render_subscribed_state(&inv.room, invitation)
@@ -211,10 +223,11 @@ fn render_subscribing_state() -> Element {
 /// Renders the error state when room retrieval fails
 fn render_error_state(
     error: &str,
-    room_key: &VerifyingKey,
-    mut invitation: Signal<Option<Invitation>>,
+    inv: &Invitation,
+    invitation: Signal<Option<Invitation>>,
 ) -> Element {
-    let room_key = *room_key; // Copy type, avoid clone
+    let room_key = inv.room; // Copy type, avoid clone
+    let inv_for_dismiss = inv.clone();
 
     rsx! {
         div {
@@ -244,8 +257,7 @@ fn render_error_state(
                     class: "px-4 py-2 bg-surface hover:bg-surface-hover text-text rounded-lg transition-colors",
                     onclick: move |_| {
                         PENDING_INVITES.write().map.remove(&room_key);
-                        clear_invitation_from_storage();
-                        invitation.set(None);
+                        dismiss_invitation_persistently(&inv_for_dismiss, invitation);
                     },
                     "Dismiss"
                 }
@@ -287,7 +299,7 @@ fn render_invitation_options(inv: Invitation, invitation: Signal<Option<Invitati
     drop(rooms);
 
     if current_key_is_member {
-        render_already_member(invitation)
+        render_already_member(inv, invitation)
     } else if invited_member_exists {
         render_restore_access_option(inv, invitation)
     } else {
@@ -318,8 +330,10 @@ fn check_membership_status(inv: &Invitation, current_rooms: &Rooms) -> (bool, bo
     }
 }
 
-/// Renders the UI when the user is already a member of the room
-fn render_already_member(mut invitation: Signal<Option<Invitation>>) -> Element {
+/// Renders the UI when the user is already a member of the room.
+/// Closing this modal must mark the invitation processed so a reload (with
+/// the URL parameter still present) doesn't re-open it.
+fn render_already_member(inv: Invitation, invitation: Signal<Option<Invitation>>) -> Element {
     rsx! {
         p { class: "text-text mb-4", "You are already a member of this room with your current key." }
         button {
@@ -331,8 +345,7 @@ fn render_already_member(mut invitation: Signal<Option<Invitation>>) -> Element 
                 });
             },
             onclick: move |_| {
-                clear_invitation_from_storage();
-                invitation.set(None);
+                dismiss_invitation_persistently(&inv, invitation);
             },
             "Close"
         }
@@ -342,7 +355,7 @@ fn render_already_member(mut invitation: Signal<Option<Invitation>>) -> Element 
 /// Renders the UI for restoring access to an existing member
 fn render_restore_access_option(
     inv: Invitation,
-    mut invitation: Signal<Option<Invitation>>,
+    invitation: Signal<Option<Invitation>>,
 ) -> Element {
     rsx! {
         p { class: "text-text mb-2", "This invitation is for a member that already exists in the room." }
@@ -360,12 +373,13 @@ fn render_restore_access_option(
                 onclick: {
                     let room = inv.room;
                     let member_vk = inv.invitee.member.member_vk;
-                    let mut invitation = invitation;
+                    let inv_for_restore = inv.clone();
+                    let inv_for_dismiss = inv.clone();
 
                     move |_| {
                         // Defer signal mutations to a clean execution context to
                         // prevent RefCell re-entrant borrow panics.
-                        let inv_clone = inv.invitee.clone();
+                        let inv_clone = inv_for_restore.invitee.clone();
                         crate::util::defer(move || {
                             ROOMS.with_mut(|rooms| {
                                 if let Some(room_data) = rooms.map.get_mut(&room) {
@@ -377,17 +391,18 @@ fn render_restore_access_option(
                             });
                             crate::components::app::mark_needs_sync(room);
                         });
-                        clear_invitation_from_storage();
-                        invitation.set(None);
+                        dismiss_invitation_persistently(&inv_for_dismiss, invitation);
                     }
                 },
                 "Restore Access"
             }
             button {
                 class: "px-4 py-2 bg-surface hover:bg-surface-hover text-text rounded-lg transition-colors",
-                onclick: move |_| {
-                    clear_invitation_from_storage();
-                    invitation.set(None);
+                onclick: {
+                    let inv_for_cancel = inv.clone();
+                    move |_| {
+                        dismiss_invitation_persistently(&inv_for_cancel, invitation);
+                    }
                 },
                 "Cancel"
             }
@@ -396,7 +411,7 @@ fn render_restore_access_option(
 }
 
 /// Renders the UI for a new invitation
-fn render_new_invitation(inv: Invitation, mut invitation: Signal<Option<Invitation>>) -> Element {
+fn render_new_invitation(inv: Invitation, invitation: Signal<Option<Invitation>>) -> Element {
     // Clone the invitation for the closures
     let inv_for_accept = inv.clone();
     let inv_for_enter = inv.clone();
@@ -448,9 +463,11 @@ fn render_new_invitation(inv: Invitation, mut invitation: Signal<Option<Invitati
             }
             button {
                 class: "px-4 py-2 bg-surface hover:bg-surface-hover text-text rounded-lg transition-colors",
-                onclick: move |_| {
-                    clear_invitation_from_storage();
-                    invitation.set(None);
+                onclick: {
+                    let inv_for_decline = inv.clone();
+                    move |_| {
+                        dismiss_invitation_persistently(&inv_for_decline, invitation);
+                    }
                 },
                 "Decline"
             }
@@ -585,5 +602,72 @@ mod tests {
         assert_eq!(result.len(), 3);
         assert_eq!(result.last().unwrap(), "new");
         assert_eq!(result[0], "8");
+    }
+
+    #[test]
+    fn append_evicts_at_actual_production_cap() {
+        // Guards against off-by-one regressions in the eviction math at the
+        // configured MAX_PROCESSED_INVITATIONS boundary.
+        let mut list: Vec<String> = (0..MAX_PROCESSED_INVITATIONS)
+            .map(|i| i.to_string())
+            .collect();
+        assert_eq!(list.len(), MAX_PROCESSED_INVITATIONS);
+        list = append_fingerprint(list, "new".to_string(), MAX_PROCESSED_INVITATIONS)
+            .expect("change occurred");
+        assert_eq!(list.len(), MAX_PROCESSED_INVITATIONS);
+        assert_eq!(list.last().unwrap(), "new");
+        assert_eq!(list[0], "1", "oldest (\"0\") should have been evicted");
+    }
+
+    /// `Invitation::to_encoded_string` must round-trip byte-for-byte. The
+    /// fingerprint dedup compares hashes of the canonical form, so two calls
+    /// to `to_encoded_string` for the same `Invitation` (one at URL parse
+    /// time, one at dismiss time) must produce the same bytes; otherwise
+    /// `is_invitation_processed` will not recognize a previously-marked
+    /// invitation across a page reload, defeating the fix.
+    #[test]
+    fn invitation_round_trip_is_byte_stable() {
+        use ed25519_dalek::SigningKey;
+        use rand::rngs::OsRng;
+        use river_core::room_state::member::{AuthorizedMember, Member};
+
+        let owner_sk = SigningKey::generate(&mut OsRng);
+        let invitee_sk = SigningKey::generate(&mut OsRng);
+
+        let member = Member {
+            owner_member_id: owner_sk.verifying_key().into(),
+            invited_by: owner_sk.verifying_key().into(),
+            member_vk: invitee_sk.verifying_key(),
+        };
+        let authorized = AuthorizedMember::new(member, &owner_sk);
+
+        let inv = Invitation {
+            room: owner_sk.verifying_key(),
+            invitee_signing_key: invitee_sk,
+            invitee: authorized,
+        };
+
+        let first = inv.to_encoded_string();
+        let second = inv.to_encoded_string();
+        assert_eq!(
+            first, second,
+            "to_encoded_string must be deterministic across calls"
+        );
+
+        // Round-trip: encode -> decode -> encode must produce the same bytes.
+        let decoded = Invitation::from_encoded_string(&first)
+            .expect("our own encoded form must decode cleanly");
+        let re_encoded = decoded.to_encoded_string();
+        assert_eq!(
+            first, re_encoded,
+            "encode->decode->encode must be byte-stable; otherwise the fingerprint dedup breaks across reloads"
+        );
+
+        // And the fingerprints must match too.
+        assert_eq!(
+            invitation_fingerprint(&first),
+            invitation_fingerprint(&re_encoded),
+            "fingerprints of round-tripped encodings must be equal"
+        );
     }
 }


### PR DESCRIPTION
## Problem

When a user opens a River invite URL (`?invitation=...`), enters a nickname, and accepts, **reloading the page asks for a nickname again**. Reported on Matrix by GenY2K; workaround posted by Ivvor:

> After your identity has joined the River room, just close the page and use the River link from the local dashboard. Otherwise the invite gets stuck always asking for a new nickname, because the invite query never goes away across page refreshes.

The existing code at `ui/src/components/app.rs` attempts to clean the URL via `history.replaceState` after parsing the invitation, but the call can fail silently inside the gateway's sandboxed iframe. The actual sandbox attribute on the gateway is `sandbox=\"allow-scripts allow-forms allow-popups\"` (verified in `freenet-core/crates/core/src/server/path_handlers.rs:366`) — no `allow-same-origin`, so the iframe document gets an opaque origin and `history.replaceState` cannot satisfy its same-origin URL check. The URL keeps `?invitation=...` and the modal re-opens on every reload.

(`localStorage` is unaffected: opaque origins still get their own isolated localStorage scope. River's chat delegate uses it successfully in production.)

## Approach

Don't rely on URL cleanup. Instead, record a small fingerprint (16 bytes of BLAKE3, hex-encoded) of every invitation the user has acted on (Accept or any dismiss) in `localStorage` under `river_processed_invitations`. Skip the invitation on subsequent loads when its fingerprint is already in the set.

- Fingerprints are computed from `Invitation::to_encoded_string()` (canonical CBOR + base58) so URL-time and dismiss-time fingerprints match for the same invitation. Round-trip stability is verified by a unit test.
- Both the URL-parse path and the localStorage recovery path consult the fingerprint set. Without the recovery-path check, a reload mid-subscription would re-open the modal because `PENDING_INVITES` is in-memory only.
- A `dismiss_invitation_persistently` helper routes every user-initiated dismiss (Accept, Decline, Cancel, Close, Dismiss-on-error) through the same code path, so all exit paths are sticky against reload.
- The fingerprint is **not** marked at URL parse time — only on a definitive user action. A user who reloads the page before deciding still sees the modal again, matching pre-PR behaviour.
- The processed list is bounded at 64 entries with FIFO eviction so localStorage stays small.
- Best-effort URL cleanup is preserved and now logs `replaceState` failures at `debug!` so the iframe-sandbox hypothesis can be confirmed from real telemetry.

Why a fingerprint and not the raw encoded invitation? The encoded form is hundreds of bytes; storing 64 of them is ~30KB. A 16-byte hash gives a 2^128 collision space and keeps the list under 2KB.

### What this PR does NOT fix

Issue #215 listed three suspected root causes; this PR addresses #1 (localStorage persistence) and #2 (replaceState failure in sandbox). Root cause #3 (the `render_already_member` race when `ROOMS` hasn't loaded yet) is intentionally deferred — once the dismiss-path fingerprint guards are in place, the `?invitation=` parameter no longer survives any user action, so the race is much narrower in practice. Filing a separate follow-up if it actually causes problems.

### Considered alternatives

- **Drop URL cleanup entirely.** Would leave the parameter visible to anyone copying the URL out of the address bar. Cleanup is still useful when it works.
- **Try a different URL-rewrite mechanism (e.g. `location.replace`).** Would trigger a full page reload and lose any in-flight state.
- **Auto-resume the subscription on reload using a saved nickname.** Better UX for the rare reload-mid-subscription case but expands scope. Filed as #218.

## Testing

Eight unit tests in `receive_invitation_modal.rs`:

- `fingerprint_is_deterministic`: same input hashes to same fingerprint
- `fingerprint_distinguishes_inputs`: different inputs produce different fingerprints
- `fingerprint_is_compact_hex`: 32 hex chars (16 bytes), all hex digits
- `append_dedups`: duplicate fingerprint returns `None` (skips localStorage write)
- `append_evicts_fifo_when_at_cap`: oldest entry evicted to make room
- `append_evicts_multiple_when_above_cap`: handles oversized state from a possible future cap change
- `append_evicts_at_actual_production_cap`: guards against off-by-one regressions at the configured `MAX_PROCESSED_INVITATIONS = 64`
- `invitation_round_trip_is_byte_stable`: `Invitation::to_encoded_string()` is deterministic across calls AND encode->decode->encode is byte-stable, so URL-time and dismiss-time fingerprints match for the same invitation. Without this, the dedup silently fails across reloads.

Storage helpers (`read_processed_list`, `write_processed_list`, `mark_invitation_processed`, `is_invitation_processed`) depend on `web_sys::window()` and can only run under WebAssembly, so they are exercised through the extracted pure helper `append_fingerprint`.

### Manual test plan

Run against a local Freenet node (`freenet local`) with `cargo make publish-river`:

1. Owner publishes an invite link.
2. Joiner opens the link, enters a nickname, clicks Accept, waits for the room to appear.
3. Joiner reloads the page. **Expected:** room loads with no modal. **Before this fix:** modal re-opens with the nickname prompt.
4. Open a fresh invite link. Click **Decline**. Reload. **Expected:** no modal (Decline is sticky).
5. Open a fresh invite link. Reload **without** clicking anything. **Expected:** modal re-opens (URL parse only marks on a definitive user action).
6. Inspect `localStorage` in devtools: key `river_processed_invitations` should contain 32-char hex fingerprints, one per accepted/dismissed invitation.

### CI gap

This bug shipped because there is no automated coverage of the invite-from-URL flow inside the sandboxed iframe environment. River's Playwright suite runs in a same-origin sandbox (it adds `allow-same-origin` so WASM can load from the dev server), which masks the `replaceState` failure that triggers the bug. Filed as #217 to add a Playwright fixture under the gateway's actual sandbox attributes (or a same-origin variant that spies on `replaceState` to throw). Filed as a follow-up so this PR stays focused on the fix; the unit tests already cover the new logic.

Closes #215

[AI-assisted - Claude]