### PR TITLE
feat(ui): beautify freenet web-contract URLs in chat messages

### DIFF
--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -406,6 +406,11 @@ fn markdown_to_html(text: &str) -> String {
 /// to all of them, and shorten the visible text of bare Freenet web-contract
 /// URLs to a `freenet:<id-prefix>[/<path>]` label (only when the visible text
 /// equals the href, so user-customized link text is left alone).
+///
+/// Assumes the markdown crate emits anchors as `<a href="...">...</a>` with
+/// `href` as the first attribute. Both `extract_href` and the `replacen` here
+/// rely on that shape; if it ever changes, target/rel injection silently
+/// no-ops and beautification is skipped.
 fn finalize_anchors(html: &str) -> String {
     let mut out = String::with_capacity(html.len() + 32);
     let mut rest = html;
@@ -454,12 +459,17 @@ fn extract_href(opening_tag: &str) -> Option<String> {
 /// If `url` is a Freenet web-contract URL, return a beautified label like
 /// `freenet:UDzGbcWr` or `freenet:UDzGbcWr/index.html`. Returns None for any
 /// other URL so the caller falls back to the original link text.
+///
+/// The marker must appear at the start of the URL path, not just anywhere
+/// in the URL — otherwise links like `https://x/redirect?next=/v1/contract/web/<id>/`
+/// would be mis-presented as Freenet links.
 fn beautify_freenet_label(url: &str) -> Option<String> {
     let scheme_end = url.find("://")?;
     let after_scheme = &url[scheme_end + 3..];
-    const MARKER: &str = "/v1/contract/web/";
-    let marker_pos = after_scheme.find(MARKER)?;
-    let after_marker = &after_scheme[marker_pos + MARKER.len()..];
+    // Locate the path: skip authority (host[:port]) up to the first '/'.
+    let path_start = after_scheme.find('/')?;
+    let path = &after_scheme[path_start..];
+    let after_marker = path.strip_prefix("/v1/contract/web/")?;
 
     let id_end = after_marker
         .find(|c: char| !c.is_ascii_alphanumeric())
@@ -469,6 +479,13 @@ fn beautify_freenet_label(url: &str) -> Option<String> {
     }
     let id = &after_marker[..id_end];
     let suffix = &after_marker[id_end..];
+    // Defense in depth: refuse to beautify if the path/query carries raw HTML
+    // metacharacters. The markdown crate URL-encodes these today, but this
+    // value is rendered via dangerous_inner_html with no further escaping,
+    // so we'd rather skip the rewrite than risk smuggling markup.
+    if suffix.contains(['<', '>', '"']) {
+        return None;
+    }
     // A bare trailing slash adds no information; drop it.
     let suffix = if suffix == "/" { "" } else { suffix };
 
@@ -2278,6 +2295,74 @@ mod tests {
         assert!(
             html.contains(&format!(">{url}</a>")),
             "non-web contract URL should keep its full text: {html}"
+        );
+    }
+
+    #[test]
+    fn marker_in_query_string_not_beautified() {
+        // External redirect URLs that happen to embed the marker in a query
+        // parameter must NOT be presented as Freenet links — that would be a
+        // phishing vector (caught by Codex review of #223).
+        let url = format!("https://evil.example/redirect?next=/v1/contract/web/{SAMPLE_ID}/");
+        let html = message_to_html(&url);
+        assert!(
+            !html.contains("freenet:"),
+            "marker buried in query must not produce a freenet: label: {html}"
+        );
+    }
+
+    #[test]
+    fn marker_after_userinfo_or_path_segment_not_beautified() {
+        // Marker buried deeper in the path must not match either.
+        let url = format!("https://evil.example/foo/v1/contract/web/{SAMPLE_ID}/");
+        let html = message_to_html(&url);
+        assert!(
+            !html.contains("freenet:"),
+            "marker as a deeper path segment must not match: {html}"
+        );
+    }
+
+    #[test]
+    fn multiple_freenet_links_in_one_message() {
+        let url_a = format!("http://127.0.0.1:7509/v1/contract/web/{SAMPLE_ID}/");
+        let other = "AAAAAAAAbbbbCCCCddddEEEEffffGGGGhhhhIIIIjjj";
+        let url_b = format!("http://127.0.0.1:7509/v1/contract/web/{other}/foo.html");
+        let html = message_to_html(&format!("see {url_a} and also {url_b} thanks"));
+        assert!(
+            html.contains(">freenet:UDzGbcWr</a>"),
+            "first link should be shortened: {html}"
+        );
+        assert!(
+            html.contains(">freenet:AAAAAAAA/foo.html</a>"),
+            "second link should be shortened: {html}"
+        );
+        assert!(
+            html.matches("<a ").count() == 2,
+            "both anchors should be present: {html}"
+        );
+    }
+
+    #[test]
+    fn empty_contract_id_not_beautified() {
+        // /v1/contract/web// has no id — bail out and leave the original.
+        let url = "http://127.0.0.1:7509/v1/contract/web//".to_string();
+        let html = message_to_html(&url);
+        assert!(
+            !html.contains("freenet:"),
+            "empty contract id must not produce a label: {html}"
+        );
+    }
+
+    #[test]
+    fn ampersand_in_query_keeps_full_url() {
+        // GFM HTML-escapes `&` to `&amp;` in BOTH href and text content, so the
+        // h == inner equality still holds and beautification proceeds with the
+        // entity-encoded suffix.
+        let url = format!("http://127.0.0.1:7509/v1/contract/web/{SAMPLE_ID}/?a=1&b=2");
+        let html = message_to_html(&url);
+        assert!(
+            html.contains(">freenet:UDzGbcWr/?a=1&amp;b=2</a>"),
+            "ampersand-bearing query should be kept (entity-encoded): {html}"
         );
     }
 }

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -399,17 +399,81 @@ fn markdown_to_html(text: &str) -> String {
     let html = markdown::to_html_with_options(text, &markdown::Options::gfm())
         .unwrap_or_else(|_| markdown::to_html(text));
 
-    // Add target="_blank" and rel="noopener noreferrer" to all links
-    make_links_open_in_new_tab(&html)
+    finalize_anchors(&html)
 }
 
-/// Add target="_blank" and rel="noopener noreferrer" to all anchor tags in HTML.
-fn make_links_open_in_new_tab(html: &str) -> String {
-    // Replace <a href=" with <a target="_blank" rel="noopener noreferrer" href="
-    html.replace(
-        "<a href=\"",
-        "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"",
-    )
+/// Walk anchor tags in HTML once: add target="_blank" rel="noopener noreferrer"
+/// to all of them, and shorten the visible text of bare Freenet web-contract
+/// URLs to a `freenet:<id-prefix>[/<path>]` label (only when the visible text
+/// equals the href, so user-customized link text is left alone).
+fn finalize_anchors(html: &str) -> String {
+    let mut out = String::with_capacity(html.len() + 32);
+    let mut rest = html;
+    while let Some(pos) = rest.find("<a ") {
+        out.push_str(&rest[..pos]);
+        let tag = &rest[pos..];
+        let Some(open_end) = tag.find('>') else {
+            out.push_str(tag);
+            return out;
+        };
+        let opening = &tag[..=open_end];
+        let after_open = &tag[open_end + 1..];
+        let Some(close_pos) = after_open.find("</a>") else {
+            out.push_str(tag);
+            return out;
+        };
+        let inner = &after_open[..close_pos];
+        let tail = &after_open[close_pos + 4..];
+
+        let opening = opening.replacen(
+            "<a href=\"",
+            "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"",
+            1,
+        );
+        let href = extract_href(&opening);
+        let new_inner = match href.as_deref() {
+            Some(h) if h == inner => beautify_freenet_label(h).unwrap_or_else(|| inner.to_string()),
+            _ => inner.to_string(),
+        };
+
+        out.push_str(&opening);
+        out.push_str(&new_inner);
+        out.push_str("</a>");
+        rest = tail;
+    }
+    out.push_str(rest);
+    out
+}
+
+fn extract_href(opening_tag: &str) -> Option<String> {
+    let start = opening_tag.find("href=\"")? + "href=\"".len();
+    let end = opening_tag[start..].find('"')?;
+    Some(opening_tag[start..start + end].to_string())
+}
+
+/// If `url` is a Freenet web-contract URL, return a beautified label like
+/// `freenet:UDzGbcWr` or `freenet:UDzGbcWr/index.html`. Returns None for any
+/// other URL so the caller falls back to the original link text.
+fn beautify_freenet_label(url: &str) -> Option<String> {
+    let scheme_end = url.find("://")?;
+    let after_scheme = &url[scheme_end + 3..];
+    const MARKER: &str = "/v1/contract/web/";
+    let marker_pos = after_scheme.find(MARKER)?;
+    let after_marker = &after_scheme[marker_pos + MARKER.len()..];
+
+    let id_end = after_marker
+        .find(|c: char| !c.is_ascii_alphanumeric())
+        .unwrap_or(after_marker.len());
+    if id_end == 0 {
+        return None;
+    }
+    let id = &after_marker[..id_end];
+    let suffix = &after_marker[id_end..];
+    // A bare trailing slash adds no information; drop it.
+    let suffix = if suffix == "/" { "" } else { suffix };
+
+    let id_prefix = &id[..id.len().min(8)];
+    Some(format!("freenet:{id_prefix}{suffix}"))
 }
 
 #[component]
@@ -2115,6 +2179,105 @@ mod tests {
         assert!(
             html.contains("<br"),
             "newlines should become hard breaks: {html}"
+        );
+    }
+
+    const SAMPLE_ID: &str = "UDzGbcWrKN748tYbhvbPCCCQrZc9r9xkN3tUuun5Rts";
+
+    #[test]
+    fn freenet_web_url_label_shortened() {
+        let url = format!("http://127.0.0.1:7509/v1/contract/web/{SAMPLE_ID}/");
+        let html = message_to_html(&url);
+        assert!(
+            html.contains(&format!("href=\"{url}\"")),
+            "href should be preserved: {html}"
+        );
+        assert!(
+            html.contains(">freenet:UDzGbcWr</a>"),
+            "label should be shortened to 8-char prefix: {html}"
+        );
+        assert!(
+            !html.contains(&format!(">{url}</a>")),
+            "raw URL should not appear as link text: {html}"
+        );
+    }
+
+    #[test]
+    fn freenet_web_url_with_path_keeps_path() {
+        let url = format!("http://127.0.0.1:7509/v1/contract/web/{SAMPLE_ID}/index.html");
+        let html = message_to_html(&url);
+        assert!(
+            html.contains(">freenet:UDzGbcWr/index.html</a>"),
+            "label should include path: {html}"
+        );
+    }
+
+    #[test]
+    fn freenet_web_url_https_handled() {
+        let url = format!("https://nova.locut.us/v1/contract/web/{SAMPLE_ID}/");
+        let html = message_to_html(&url);
+        assert!(
+            html.contains(">freenet:UDzGbcWr</a>"),
+            "https URL should also be beautified: {html}"
+        );
+    }
+
+    #[test]
+    fn freenet_web_url_with_query_kept() {
+        let url = format!("http://127.0.0.1:7509/v1/contract/web/{SAMPLE_ID}/?invite=abc");
+        let html = message_to_html(&url);
+        assert!(
+            html.contains(">freenet:UDzGbcWr/?invite=abc</a>"),
+            "query string should be kept: {html}"
+        );
+    }
+
+    #[test]
+    fn custom_markdown_link_text_preserved() {
+        let url = format!("http://127.0.0.1:7509/v1/contract/web/{SAMPLE_ID}/");
+        let html = message_to_html(&format!("see [my room]({url}) here"));
+        assert!(
+            html.contains(">my room</a>"),
+            "user-supplied link text should be preserved: {html}"
+        );
+        assert!(
+            !html.contains("freenet:UDzGbcWr"),
+            "should not rewrite when link text is custom: {html}"
+        );
+    }
+
+    #[test]
+    fn non_freenet_url_unchanged() {
+        let html = message_to_html("https://example.com/foo/bar");
+        assert!(
+            html.contains(">https://example.com/foo/bar</a>"),
+            "unrelated URLs should keep their full text: {html}"
+        );
+    }
+
+    #[test]
+    fn freenet_url_in_code_span_unchanged() {
+        let url = format!("http://127.0.0.1:7509/v1/contract/web/{SAMPLE_ID}/");
+        let html = message_to_html(&format!("run `curl {url}`"));
+        assert!(
+            !html.contains("<a "),
+            "URL inside backticks should not be linkified: {html}"
+        );
+        assert!(
+            !html.contains("freenet:UDzGbcWr"),
+            "URL inside backticks should not be beautified: {html}"
+        );
+    }
+
+    #[test]
+    fn non_web_contract_path_left_alone() {
+        // /v1/contract/<id>/ (no /web/) is not a real browsable route; leave the
+        // link text as-is rather than pretend we beautified it.
+        let url = format!("http://127.0.0.1:7509/v1/contract/{SAMPLE_ID}/");
+        let html = message_to_html(&url);
+        assert!(
+            html.contains(&format!(">{url}</a>")),
+            "non-web contract URL should keep its full text: {html}"
         );
     }
 }


### PR DESCRIPTION
## Problem

Pasted Freenet web-contract URLs are long (~80 chars for a 43-char base58 ID plus host/port/path), so they dominate every chat line they appear in. The contract ID is opaque to humans and the surrounding `http://127.0.0.1:7509/v1/contract/web/...` boilerplate adds noise without information.

## Approach

After the markdown crate produces HTML, walk the resulting `<a>` tags once and:

- Always inject `target=\"_blank\" rel=\"noopener noreferrer\"` (this used to be a separate `make_links_open_in_new_tab` pass — merged into the same walk so we don't traverse the HTML twice).
- For anchors whose `href` matches `http(s)://<host>(:<port>)?/v1/contract/web/<id>(/<path>)?` AND whose visible text equals the `href` (i.e. GFM-autolinked, not user-supplied), replace the visible text with `freenet:<id-prefix-8>[<suffix>]`. The `href` is unchanged, so clicking still goes to the original URL.

| URL pasted | Visible label |
|---|---|
| `http://127.0.0.1:7509/v1/contract/web/UDzGbcWrKN748tYbhvbPCCCQrZc9r9xkN3tUuun5Rts/` | `freenet:UDzGbcWr` |
| `…/web/UDzGbcWr…/index.html` | `freenet:UDzGbcWr/index.html` |
| `…/web/UDzGbcWr…/?invite=abc` | `freenet:UDzGbcWr/?invite=abc` |
| `[my room](http://…/web/UDzGbcWr…/)` | `my room` (unchanged — user gave custom text) |
| `\`http://…/web/UDzGbcWr…/\`` (in code span) | unchanged (still inside `<code>`) |

Only `/v1/contract/web/` URLs are rewritten — confirmed in freenet-core that `/v1/contract/<id>/` (no `/web/`) is not a registered HTTP route.

No emoji, no spaces, no trailing-suffix ellipsis. The `freenet:` prefix mimics `mailto:` style and signals this is a link without pretending to be a real URL scheme that browsers understand.

## Testing

8 new unit tests in `conversation.rs` covering: the basic case, paths, https, query strings, custom link text being preserved, non-freenet URLs, code spans, and the non-`/web/` case being left alone. All 13 conversation tests pass.

UI-only change. No WASM rebuild, no migration.

[AI-assisted - Claude]