### PR TITLE
fix(ui): unbreak room header description links

### DIFF
--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1439,7 +1439,7 @@ pub fn Conversation() -> Element {
                                 // clicks to the modal-opening onclick handler.
                                 div { class: "min-w-0 flex-1",
                                     button {
-                                        class: "flex items-center gap-2 px-3 py-1.5 -mx-3 rounded-lg bg-transparent hover:bg-surface transition-colors cursor-pointer min-w-0 max-w-full",
+                                        class: "flex items-center gap-2 px-3 py-1.5 -mx-3 rounded-lg bg-transparent hover:bg-surface transition-colors cursor-pointer min-w-0 w-full",
                                         title: "Room details",
                                         onclick: move |_| {
                                             crate::util::defer(move || {

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1433,33 +1433,35 @@ pub fn Conversation() -> Element {
                                     onclick: move |_| crate::util::defer(move || *MOBILE_VIEW.write() = MobileView::Rooms),
                                     Icon { icon: FaBars, width: 18, height: 18 }
                                 }
-                                button {
-                                    class: "flex items-center gap-2 px-3 py-1.5 -mx-3 rounded-lg bg-transparent hover:bg-surface transition-colors cursor-pointer min-w-0 flex-1",
-                                    title: "Room details",
-                                    onclick: move |_| {
-                                        crate::util::defer(move || {
-                                            if let Some(current_room) = CURRENT_ROOM.read().owner_key {
-                                                EDIT_ROOM_MODAL.with_mut(|modal| {
-                                                    modal.room = Some(current_room);
-                                                });
-                                            }
-                                        });
-                                    },
-                                    div { class: "min-w-0",
-                                        div { class: "flex items-center gap-2",
-                                            h2 { class: "text-lg font-semibold text-text truncate",
-                                                "{current_room_label}"
-                                            }
-                                            span {
-                                                class: "text-text-muted flex-shrink-0",
-                                                Icon { icon: FaCircleInfo, width: 16, height: 16 }
-                                            }
+                                // Description is a sibling of the title button, not a child:
+                                // `<a>` is interactive content and cannot be nested inside
+                                // `<button>` per the HTML spec. Nesting also bubbles link
+                                // clicks to the modal-opening onclick handler.
+                                div { class: "min-w-0 flex-1",
+                                    button {
+                                        class: "flex items-center gap-2 px-3 py-1.5 -mx-3 rounded-lg bg-transparent hover:bg-surface transition-colors cursor-pointer min-w-0 max-w-full",
+                                        title: "Room details",
+                                        onclick: move |_| {
+                                            crate::util::defer(move || {
+                                                if let Some(current_room) = CURRENT_ROOM.read().owner_key {
+                                                    EDIT_ROOM_MODAL.with_mut(|modal| {
+                                                        modal.room = Some(current_room);
+                                                    });
+                                                }
+                                            });
+                                        },
+                                        h2 { class: "text-lg font-semibold text-text truncate",
+                                            "{current_room_label}"
                                         }
-                                        if let Some(desc_html) = current_room_description_html.read().as_ref() {
-                                            div {
-                                                class: "prose prose-sm dark:prose-invert max-w-none text-xs text-text-muted truncate [&>p]:m-0 [&>p]:inline",
-                                                dangerous_inner_html: "{desc_html}"
-                                            }
+                                        span {
+                                            class: "text-text-muted flex-shrink-0",
+                                            Icon { icon: FaCircleInfo, width: 16, height: 16 }
+                                        }
+                                    }
+                                    if let Some(desc_html) = current_room_description_html.read().as_ref() {
+                                        div {
+                                            class: "prose prose-sm dark:prose-invert max-w-none text-xs text-text-muted truncate [&>p]:m-0 [&>p]:inline",
+                                            dangerous_inner_html: "{desc_html}"
                                         }
                                     }
                                 }

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -26,16 +26,21 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 pub fn create_example_rooms() -> Rooms {
     let mut map = HashMap::new();
 
-    // Room where you're just an observer (not a member)
-    let room1 = create_room(&"Public Discussion Room".to_string(), SelfIs::Observer);
+    // Room where you're just an observer (not a member). Description includes links
+    // so the room header link-rendering path is exercised in example/playwright builds.
+    let room1 = create_room(
+        &"Public Discussion Room".to_string(),
+        SelfIs::Observer,
+        Some("Welcome | [Website](https://freenet.org/) · [Docs](https://docs.freenet.org/)"),
+    );
     map.insert(room1.owner_vk, room1.room_data);
 
     // Room where you're a member
-    let room2 = create_room(&"Team Chat Room".to_string(), SelfIs::Member);
+    let room2 = create_room(&"Team Chat Room".to_string(), SelfIs::Member, None);
     map.insert(room2.owner_vk, room2.room_data);
 
     // Room where you're the owner
-    let room3 = create_room(&"Your Private Room".to_string(), SelfIs::Owner);
+    let room3 = create_room(&"Your Private Room".to_string(), SelfIs::Owner, None);
     map.insert(room3.owner_vk, room3.room_data);
 
     Rooms {
@@ -59,7 +64,7 @@ enum SelfIs {
 
 // Function to create a room with an owner and members, self_is determines whether
 // the user of the UI is the owner, a member, or an observer (not an owner or member)
-fn create_room(room_name: &String, self_is: SelfIs) -> CreatedRoom {
+fn create_room(room_name: &String, self_is: SelfIs, description: Option<&str>) -> CreatedRoom {
     let mut csprng = OsRng;
 
     // Create self - the user actually using the app
@@ -82,7 +87,7 @@ fn create_room(room_name: &String, self_is: SelfIs) -> CreatedRoom {
     let mut config = Configuration::default();
     config.display = RoomDisplayMetadata {
         name: SealedBytes::public(room_name.clone().into_bytes()),
-        description: None,
+        description: description.map(|d| SealedBytes::public(d.as_bytes().to_vec())),
     };
     config.owner_member_id = owner_id;
     room_state.configuration = AuthorizedConfigurationV1::new(config, owner_sk);

--- a/ui/tests/room-header-links.spec.ts
+++ b/ui/tests/room-header-links.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect, Page } from "@playwright/test";
+
+// The room header description renders user-supplied markdown that may include
+// `<a>` links. Those links must live outside the clickable "room details"
+// button — `<a>` inside `<button>` is invalid HTML and bubbles link clicks to
+// the modal-opening onclick handler.
+
+const ROOM_WITH_LINKS = "Public Discussion Room";
+
+async function waitForApp(page: Page) {
+  await page.waitForSelector(".app-root", { timeout: 30_000 });
+  await expect(page.locator("aside, .app-root button")).not.toHaveCount(0);
+}
+
+async function selectRoom(page: Page, roomName: string) {
+  const vp = page.viewportSize();
+  // Use desktop layout for this regression test; mobile navigation is exercised
+  // elsewhere and is orthogonal to the bug under test.
+  if (vp && vp.width < 1024) {
+    await page.setViewportSize({ width: 1280, height: vp.height });
+  }
+  const roomBtn = page.getByRole("button", { name: roomName });
+  await expect(roomBtn).toBeVisible({ timeout: 5_000 });
+  await roomBtn.click();
+  await expect(
+    page.getByRole("heading", { name: roomName })
+  ).toBeVisible({ timeout: 5_000 });
+}
+
+test.describe("Room header description links", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("links in description are NOT nested inside <button>", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectRoom(page, ROOM_WITH_LINKS);
+
+    const header = page.locator(".border-b.border-border.bg-panel").first();
+    const link = header.locator('a[href="https://freenet.org/"]');
+    await expect(link).toBeVisible();
+
+    const hasButtonAncestor = await link.evaluate((el) =>
+      el.closest("button") !== null
+    );
+    expect(hasButtonAncestor).toBe(false);
+  });
+
+  test("clicking a description link does NOT open the room details modal", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectRoom(page, ROOM_WITH_LINKS);
+
+    const header = page.locator(".border-b.border-border.bg-panel").first();
+    const link = header.locator('a[href="https://freenet.org/"]');
+    await expect(link).toBeVisible();
+
+    // Neutralise navigation so the click stays on the page.
+    await link.evaluate((el) => {
+      el.removeAttribute("target");
+      el.addEventListener("click", (e) => e.preventDefault(), {
+        once: true,
+      });
+    });
+
+    await link.click();
+
+    // The room details modal title is "Room Details" (rendered by
+    // edit_room_modal). It must not have appeared.
+    await expect(
+      page.getByRole("heading", { name: /Room Details/i })
+    ).toHaveCount(0);
+  });
+
+  test("clicking the room title still opens the room details modal", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectRoom(page, ROOM_WITH_LINKS);
+
+    const header = page.locator(".border-b.border-border.bg-panel").first();
+    // The title button has title="Room details".
+    const titleButton = header.locator('button[title="Room details"]');
+    await expect(titleButton).toBeVisible();
+    await titleButton.click();
+
+    await expect(
+      page.getByRole("heading", { name: /Room Details/i })
+    ).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/ui/tests/room-header-links.spec.ts
+++ b/ui/tests/room-header-links.spec.ts
@@ -58,7 +58,10 @@ test.describe("Room header description links", () => {
     const link = header.locator('a[href="https://freenet.org/"]');
     await expect(link).toBeVisible();
 
-    // Neutralise navigation so the click stays on the page.
+    // Neutralise navigation so the click stays on the page. We deliberately
+    // do NOT stop propagation: the test exists to catch a click bubbling up
+    // to the room-details button, so the click must still reach any ancestor
+    // handler that would (incorrectly) be wired up.
     await link.evaluate((el) => {
       el.removeAttribute("target");
       el.addEventListener("click", (e) => e.preventDefault(), {
@@ -68,8 +71,12 @@ test.describe("Room header description links", () => {
 
     await link.click();
 
-    // The room details modal title is "Room Details" (rendered by
-    // edit_room_modal). It must not have appeared.
+    // The room details modal opens via crate::util::defer (setTimeout(0)),
+    // so a synchronous toHaveCount(0) immediately after the click could pass
+    // before the deferred handler runs. Wait one tick so any incorrectly
+    // bubbled click has had time to render the modal.
+    await page.waitForTimeout(50);
+
     await expect(
       page.getByRole("heading", { name: /Room Details/i })
     ).toHaveCount(0);


### PR DESCRIPTION
## Problem

The room header wrapped both the title and the description in a single
`<button>` that opens the room details modal on click. Because the
description renders user markdown via `dangerous_inner_html`, any `<a>`
in the description ended up nested inside that button.

Two consequences:
1. `<a>` is interactive content and is invalid as a descendant of `<button>` per the HTML spec.
2. Link clicks bubble to the button's onclick handler, opening the room details modal instead of navigating to the link target.

In real-world usage (e.g. the official Freenet room) most header links visibly opened the modal rather than the linked page, breaking the documented \"Website / Local Dashboard / Network Telemetry\" navigation strip.

## Approach

Restructure the header so the description sits as a sibling of the title button, not as a child:

- The clickable \"Room details\" button now contains only the title row (`<h2>` + info icon).
- The description `div` lives next to the button, so its `<a>` links are no longer nested in interactive content and clicks do not bubble to the modal trigger.
- Visual layout (title above description, both filling the middle column of the header) is preserved by wrapping both in a `min-w-0 flex-1` div.

## Testing

New Playwright spec `ui/tests/room-header-links.spec.ts` covers:

- Header links have no `<button>` ancestor (catches the structural bug directly).
- Clicking a header description link does not open the room details modal.
- Clicking the title still does open the modal (no regression to the intended click target).

To give the test a target without reaching for a real Freenet node, the `Public Discussion Room` example-data entry now ships with a short markdown description containing two links. `create_room()` gained an optional `description` parameter; the other two example rooms pass `None`.

Verified manually:
- Reverting only the source change makes the structural test fail with `expected false, received true` for the `closest('button')` check, then passes again with the fix restored.
- Existing `responsive-layout.spec.ts` and `message-layout.spec.ts` suites still pass on chromium.
- New regression spec passes across all 5 configured Playwright projects (chromium, firefox, webkit, mobile-chrome, mobile-safari).
- `cargo check -p river-ui --target wasm32-unknown-unknown` clean for both `--features no-sync` and `--features no-sync,example-data`.

No delegate or contract WASM changes — UI-only fix, no migration required.

Closes #225

[AI-assisted - Claude]