### PR TITLE
fix(ui): show feedback when Export Identity Copy to Clipboard is clicked

### DIFF
--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -348,6 +348,7 @@ pub fn MemberList() -> Element {
 #[component]
 fn ExportIdentityModal(is_active: Signal<bool>) -> Element {
     let mut token_text = use_signal(String::new);
+    let mut copy_button_text = use_signal(|| "Copy to Clipboard".to_string());
 
     // Generate the export token when modal opens
     use_effect(move || {
@@ -448,6 +449,7 @@ fn ExportIdentityModal(is_active: Signal<bool>) -> Element {
     let handle_copy = move |_| {
         let text = token_text.read().clone();
         crate::util::copy_to_clipboard(&text);
+        copy_button_text.set("Copied!".to_string());
     };
 
     rsx! {
@@ -456,6 +458,7 @@ fn ExportIdentityModal(is_active: Signal<bool>) -> Element {
             onclick: move |_| {
                 is_active.set(false);
                 token_text.set(String::new());
+                copy_button_text.set("Copy to Clipboard".to_string());
             },
             div {
                 class: "bg-panel border border-border rounded-xl shadow-lg p-6 max-w-xl w-full mx-4",
@@ -480,13 +483,14 @@ fn ExportIdentityModal(is_active: Signal<bool>) -> Element {
                         onclick: move |_| {
                             is_active.set(false);
                             token_text.set(String::new());
+                            copy_button_text.set("Copy to Clipboard".to_string());
                         },
                         "Close"
                     }
                     button {
                         class: "px-4 py-2 bg-accent hover:bg-accent-hover text-white text-sm font-medium rounded-lg transition-colors",
                         onclick: handle_copy,
-                        "Copy to Clipboard"
+                        "{copy_button_text}"
                     }
                 }
             }

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -347,8 +347,21 @@ pub fn MemberList() -> Element {
 
 #[component]
 fn ExportIdentityModal(is_active: Signal<bool>) -> Element {
+    const COPY_BUTTON_DEFAULT: &str = "Copy to Clipboard";
     let mut token_text = use_signal(String::new);
-    let mut copy_button_text = use_signal(|| "Copy to Clipboard".to_string());
+    // Label flips to "Copied!" on click and is reset by the close-side effect
+    // below so reopening always starts on the default label.
+    let mut copy_button_text = use_signal(|| COPY_BUTTON_DEFAULT.to_string());
+
+    // Reset modal state whenever the modal is dismissed, regardless of which
+    // close path the user took (backdrop click, Close button, or any future
+    // path like an X icon or Escape key handler).
+    use_effect(move || {
+        if !*is_active.read() {
+            token_text.set(String::new());
+            copy_button_text.set(COPY_BUTTON_DEFAULT.to_string());
+        }
+    });
 
     // Generate the export token when modal opens
     use_effect(move || {
@@ -455,11 +468,7 @@ fn ExportIdentityModal(is_active: Signal<bool>) -> Element {
     rsx! {
         div {
             class: "fixed inset-0 bg-black/50 flex items-center justify-center z-50",
-            onclick: move |_| {
-                is_active.set(false);
-                token_text.set(String::new());
-                copy_button_text.set("Copy to Clipboard".to_string());
-            },
+            onclick: move |_| is_active.set(false),
             div {
                 class: "bg-panel border border-border rounded-xl shadow-lg p-6 max-w-xl w-full mx-4",
                 onclick: move |e| e.stop_propagation(),
@@ -480,11 +489,7 @@ fn ExportIdentityModal(is_active: Signal<bool>) -> Element {
                 div { class: "flex justify-end gap-3 mt-4",
                     button {
                         class: "px-4 py-2 bg-surface hover:bg-surface-hover text-text text-sm rounded-lg transition-colors border border-border",
-                        onclick: move |_| {
-                            is_active.set(false);
-                            token_text.set(String::new());
-                            copy_button_text.set("Copy to Clipboard".to_string());
-                        },
+                        onclick: move |_| is_active.set(false),
                         "Close"
                     }
                     button {

--- a/ui/tests/copy-clipboard-feedback.spec.ts
+++ b/ui/tests/copy-clipboard-feedback.spec.ts
@@ -51,6 +51,39 @@ test.describe("Export Identity copy feedback", () => {
     ).toBeVisible({ timeout: 2_000 });
   });
 
+  test("dismissing via the backdrop also resets the button text", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectRoom(page);
+
+    const exportButton = page.getByRole("button", { name: "Export ID" });
+    await exportButton.click();
+
+    const copyButton = page.getByRole("button", { name: "Copy to Clipboard" });
+    await expect(copyButton).toBeVisible({ timeout: 5_000 });
+    await copyButton.click();
+    await expect(
+      page.getByRole("button", { name: "Copied!" })
+    ).toBeVisible({ timeout: 2_000 });
+
+    // Click the backdrop (anywhere outside the inner panel). The modal panel
+    // calls stop_propagation, so a click in the corner reaches the backdrop.
+    await page.mouse.click(5, 5);
+    await expect(
+      page.getByRole("button", { name: "Copied!" })
+    ).toHaveCount(0);
+
+    await exportButton.click();
+    await expect(
+      page.getByRole("button", { name: "Copy to Clipboard" })
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(
+      page.getByRole("button", { name: "Copied!" })
+    ).toHaveCount(0);
+  });
+
   test("reopening the modal resets the button text", async ({ page }) => {
     await page.goto("/");
     await waitForApp(page);

--- a/ui/tests/copy-clipboard-feedback.spec.ts
+++ b/ui/tests/copy-clipboard-feedback.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect, Page } from "@playwright/test";
+
+// Regression test for the Export Identity "Copy to Clipboard" button. Before
+// the fix, clicking the button copied the token but gave no visual feedback,
+// leaving the user unsure whether anything had happened (Matrix bug report
+// from Ivvor, 2026-04-30).
+
+async function waitForApp(page: Page) {
+  await page.waitForSelector(".app-root", { timeout: 30_000 });
+  await expect(page.locator("aside, .app-root button")).not.toHaveCount(0);
+}
+
+// Use a room where the test user is a member (not the owner) so the
+// "Export ID" affordance is available.
+const ROOM_NAME = "Public Discussion Room";
+
+async function selectRoom(page: Page) {
+  const vp = page.viewportSize();
+  if (vp && vp.width < 1024) {
+    await page.setViewportSize({ width: 1280, height: vp.height });
+  }
+  const roomBtn = page.getByRole("button", { name: ROOM_NAME });
+  await expect(roomBtn).toBeVisible({ timeout: 5_000 });
+  await roomBtn.click();
+  await expect(
+    page.getByRole("heading", { name: ROOM_NAME })
+  ).toBeVisible({ timeout: 5_000 });
+}
+
+test.describe("Export Identity copy feedback", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("clicking Copy to Clipboard updates the button to 'Copied!'", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectRoom(page);
+
+    const exportButton = page.getByRole("button", { name: "Export ID" });
+    await expect(exportButton).toBeVisible({ timeout: 5_000 });
+    await exportButton.click();
+
+    const copyButton = page.getByRole("button", { name: "Copy to Clipboard" });
+    await expect(copyButton).toBeVisible({ timeout: 5_000 });
+
+    await copyButton.click();
+
+    await expect(
+      page.getByRole("button", { name: "Copied!" })
+    ).toBeVisible({ timeout: 2_000 });
+  });
+
+  test("reopening the modal resets the button text", async ({ page }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectRoom(page);
+
+    const exportButton = page.getByRole("button", { name: "Export ID" });
+    await exportButton.click();
+
+    const copyButton = page.getByRole("button", { name: "Copy to Clipboard" });
+    await expect(copyButton).toBeVisible({ timeout: 5_000 });
+    await copyButton.click();
+    await expect(
+      page.getByRole("button", { name: "Copied!" })
+    ).toBeVisible({ timeout: 2_000 });
+
+    // Close via the explicit Close button.
+    await page.getByRole("button", { name: "Close" }).click();
+    await expect(
+      page.getByRole("button", { name: "Copied!" })
+    ).toHaveCount(0);
+
+    // Reopen — the button must say "Copy to Clipboard" again, not stay stuck on "Copied!".
+    await exportButton.click();
+    await expect(
+      page.getByRole("button", { name: "Copy to Clipboard" })
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(
+      page.getByRole("button", { name: "Copied!" })
+    ).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Problem

Reported on Matrix by Ivvor (2026-04-30):

> If you use Export ID in River and hit 'Copy to Clipboard' you get no feedback that anything has happened.

The Export Identity modal silently copied the token. Users had no way of knowing whether the click had succeeded.

## Approach

Mirror the pattern already used by the two other clipboard buttons in the UI (invitation modal copy buttons in `invite_member_modal.rs`, the share-your-key button in `not_member_notification.rs`): a `use_signal` holds the button label, the click handler swaps it to "Copied!", and the modal-close paths reset it back to "Copy to Clipboard" so reopening starts fresh.

Audited the rest of the codebase for similar copy buttons missing feedback. The Export Identity modal was the only one — the invitation and share-your-key buttons already did this.

## Testing

Added `ui/tests/copy-clipboard-feedback.spec.ts` covering:

- Clicking "Copy to Clipboard" updates the button to "Copied!".
- Closing the modal and reopening it resets the label to "Copy to Clipboard".

Verified the regression test fails on `main` (the bug) and passes with the fix applied. Full chromium test suite (26 tests) still passes.

[AI-assisted - Claude]