### PR TITLE
feat(common): deterministic room secret derivation

### DIFF
--- a/common/src/key_derivation.rs
+++ b/common/src/key_derivation.rs
@@ -1,0 +1,105 @@
+//! Deterministic derivation of room secrets from the owner's signing key.
+
+use crate::room_state::privacy::SecretVersion;
+use ed25519_dalek::VerifyingKey;
+
+/// Derive a 32-byte room secret deterministically from the owner's signing
+/// key seed, the room owner's verifying key, and the secret version.
+///
+/// Construction: blake3 keyed-hash with the signing key seed as the key.
+/// blake3's keyed-hash mode is a secure PRF (HMAC-equivalent) and acceptable
+/// as a KDF when the output size matches blake3's native 32 bytes.
+///
+/// Domain separation:
+/// - `b"river-rotate-v1"` identifies the application protocol and version.
+///   Must be a hard-coded constant per blake3 KDF guidance.
+/// - `owner_vk` binds the secret to a specific room.
+/// - `version` binds the secret to a specific rotation.
+///
+/// Determinism: identical inputs always produce identical 32-byte outputs.
+/// Multiple replicas of the same delegate (e.g. running on different devices
+/// for the same owner) compute byte-identical secrets without coordination.
+pub fn derive_room_secret(
+    signing_key_seed: &[u8; 32],
+    owner_vk: &VerifyingKey,
+    version: SecretVersion,
+) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new_keyed(signing_key_seed);
+    hasher.update(b"river-rotate-v1");
+    hasher.update(owner_vk.as_bytes());
+    hasher.update(&version.to_le_bytes());
+    *hasher.finalize().as_bytes()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    fn vk_from_seed(seed: [u8; 32]) -> VerifyingKey {
+        SigningKey::from_bytes(&seed).verifying_key()
+    }
+
+    #[test]
+    fn derive_is_deterministic() {
+        let seed = [7u8; 32];
+        let vk = vk_from_seed([1u8; 32]);
+        let a = derive_room_secret(&seed, &vk, 0);
+        let b = derive_room_secret(&seed, &vk, 0);
+        assert_eq!(a, b, "identical inputs must produce identical outputs");
+    }
+
+    #[test]
+    fn derive_separates_versions() {
+        let seed = [7u8; 32];
+        let vk = vk_from_seed([1u8; 32]);
+        let v0 = derive_room_secret(&seed, &vk, 0);
+        let v1 = derive_room_secret(&seed, &vk, 1);
+        assert_ne!(v0, v1, "different versions must produce different outputs");
+    }
+
+    #[test]
+    fn derive_separates_owners() {
+        let seed = [7u8; 32];
+        let vk_a = vk_from_seed([1u8; 32]);
+        let vk_b = vk_from_seed([2u8; 32]);
+        let a = derive_room_secret(&seed, &vk_a, 0);
+        let b = derive_room_secret(&seed, &vk_b, 0);
+        assert_ne!(a, b, "different owners must produce different outputs");
+    }
+
+    #[test]
+    fn derive_separates_keys() {
+        let seed_a = [7u8; 32];
+        let seed_b = [8u8; 32];
+        let vk = vk_from_seed([1u8; 32]);
+        let a = derive_room_secret(&seed_a, &vk, 0);
+        let b = derive_room_secret(&seed_b, &vk, 0);
+        assert_ne!(
+            a, b,
+            "different signing key seeds must produce different outputs"
+        );
+    }
+
+    /// Known-answer test that locks the construction in place. If this test
+    /// fails, the derivation algorithm has changed and any deployed clients
+    /// will compute incompatible secrets. Update the expected bytes ONLY when
+    /// intentionally changing the construction (and treat that as a breaking
+    /// protocol change requiring a new domain-separation tag).
+    #[test]
+    fn derive_known_answer_v1() {
+        let seed = [0u8; 32];
+        let vk = SigningKey::from_bytes(&[1u8; 32]).verifying_key();
+        let actual = derive_room_secret(&seed, &vk, 0);
+        let expected: [u8; 32] = [
+            0x64, 0x1f, 0xfc, 0x73, 0x82, 0x69, 0x6a, 0x1b, 0xab, 0xd9, 0xeb, 0xa1, 0x7e, 0x48,
+            0x4c, 0x06, 0x26, 0x55, 0x46, 0xc3, 0x5e, 0xf9, 0xed, 0x06, 0xa6, 0x89, 0xc4, 0x8e,
+            0x20, 0x5b, 0x32, 0x6f,
+        ];
+        assert_eq!(
+            actual, expected,
+            "construction changed; KAT mismatch. Actual = {:02x?}",
+            actual
+        );
+    }
+}

--- a/common/src/key_derivation.rs
+++ b/common/src/key_derivation.rs
@@ -3,29 +3,72 @@
 use crate::room_state::privacy::SecretVersion;
 use ed25519_dalek::VerifyingKey;
 
+/// Hard-coded context string for the protocol-root key derivation step.
+/// Per blake3 KDF guidance this MUST be a compile-time constant. ANY change
+/// to the input set fed into the per-call keyed-hash phase below requires
+/// bumping this string (e.g. to `"river-rotate v2 ..."`) and the
+/// corresponding known-answer test vectors.
+const ROOT_CONTEXT: &str = "river-rotate v1 2026-04 room-secret-root";
+
 /// Derive a 32-byte room secret deterministically from the owner's signing
 /// key seed, the room owner's verifying key, and the secret version.
 ///
-/// Construction: blake3 keyed-hash with the signing key seed as the key.
-/// blake3's keyed-hash mode is a secure PRF (HMAC-equivalent) and acceptable
-/// as a KDF when the output size matches blake3's native 32 bytes.
+/// # Construction
 ///
-/// Domain separation:
-/// - `b"river-rotate-v1"` identifies the application protocol and version.
-///   Must be a hard-coded constant per blake3 KDF guidance.
-/// - `owner_vk` binds the secret to a specific room.
-/// - `version` binds the secret to a specific rotation.
+/// Two-phase blake3 KDF:
 ///
-/// Determinism: identical inputs always produce identical 32-byte outputs.
-/// Multiple replicas of the same delegate (e.g. running on different devices
-/// for the same owner) compute byte-identical secrets without coordination.
+/// 1. `root = blake3::derive_key(ROOT_CONTEXT, signing_key_seed)` — the
+///    canonical blake3 KDF mode, with a hard-coded context string that
+///    bakes in the protocol version and a date stamp. This separates the
+///    protocol-version commitment from the per-call inputs.
+/// 2. `secret = keyed_hash(root, owner_vk || version_le)` — keyed-hash with
+///    the per-call inputs. blake3 keyed-hash is a secure PRF.
+///
+/// Future input additions are limited to phase 2 and require bumping the
+/// `ROOT_CONTEXT` string (which forces a new known-answer test vector and
+/// makes the protocol break visible at code-review time). Future protocol
+/// version bumps just change the context string.
+///
+/// # Invariants
+///
+/// `signing_key_seed` MUST be the 32-byte ed25519 seed (the bytes returned
+/// by `SigningKey::to_bytes()`), not the expanded 64-byte secret, not random
+/// bytes, not the verifying key, not a stretched value. Passing any other
+/// 32-byte input produces a "valid" but undefined output and breaks the
+/// multi-replica determinism that is the entire point of this function.
+///
+/// `version: SecretVersion` is `u32`. Widening the type is a breaking
+/// protocol change requiring a new `ROOT_CONTEXT` (because the
+/// `to_le_bytes()` length changes).
+///
+/// # Determinism
+///
+/// Identical inputs always produce identical 32-byte outputs across all
+/// platforms. blake3 is endian-agnostic; `version.to_le_bytes()` is
+/// explicit; `VerifyingKey::as_bytes()` returns the canonical 32-byte
+/// compressed ed25519 point. Multiple replicas of the same delegate (e.g.
+/// a user running River on laptop + phone) compute byte-identical secrets
+/// without coordination.
+///
+/// # Security trade-off
+///
+/// Anyone with `signing_key_seed` can derive every past and every future
+/// secret for this room. This is acceptable for River's threat model: the
+/// signing key already authorises every room operation, so seed compromise
+/// is already terminal. The trade-off buys multi-device determinism without
+/// distributed coordination. Apps that need historical forward secrecy
+/// against signing-key compromise must not use this construction.
+///
+/// A removed member who held `secret_v_n` does not have the seed and so
+/// cannot derive `secret_v_{n+1}` — forward secrecy against a removed
+/// member holds, which is the property that matters for room rotation.
 pub fn derive_room_secret(
     signing_key_seed: &[u8; 32],
     owner_vk: &VerifyingKey,
     version: SecretVersion,
 ) -> [u8; 32] {
-    let mut hasher = blake3::Hasher::new_keyed(signing_key_seed);
-    hasher.update(b"river-rotate-v1");
+    let root = blake3::derive_key(ROOT_CONTEXT, signing_key_seed);
+    let mut hasher = blake3::Hasher::new_keyed(&root);
     hasher.update(owner_vk.as_bytes());
     hasher.update(&version.to_le_bytes());
     *hasher.finalize().as_bytes()
@@ -81,20 +124,97 @@ mod tests {
         );
     }
 
+    #[test]
+    fn derive_locks_input_ordering() {
+        // If the implementation accidentally swapped the order of
+        // `update(owner_vk)` and `update(version_le)`, then
+        // `derive(seed, vk_a, 1)` would equal `derive(seed, vk_b, 0)`
+        // for some adversarially-chosen vk_b. This test ensures the
+        // ordering is locked: distinct (owner, version) pairs at the
+        // same axis-product position must not collide.
+        let seed = [7u8; 32];
+        let vk_a = vk_from_seed([1u8; 32]);
+        let vk_b = vk_from_seed([2u8; 32]);
+        assert_ne!(
+            derive_room_secret(&seed, &vk_a, 1),
+            derive_room_secret(&seed, &vk_b, 0),
+        );
+        assert_ne!(
+            derive_room_secret(&seed, &vk_a, 0),
+            derive_room_secret(&seed, &vk_b, 1),
+        );
+    }
+
     /// Known-answer test that locks the construction in place. If this test
     /// fails, the derivation algorithm has changed and any deployed clients
     /// will compute incompatible secrets. Update the expected bytes ONLY when
     /// intentionally changing the construction (and treat that as a breaking
-    /// protocol change requiring a new domain-separation tag).
+    /// protocol change requiring a new ROOT_CONTEXT string).
+    ///
+    /// To independently verify these vectors, run blake3 from outside Rust:
+    ///
+    ///   # Phase 1: derive the root key.
+    ///   #   blake3::derive_key(ROOT_CONTEXT, signing_key_seed)
+    ///   # Phase 2: keyed_hash(root, owner_vk_bytes || version_le_4).
+    ///
+    /// e.g. with python's `blake3` package:
+    ///   import blake3
+    ///   root = blake3.blake3(b'\x00'*32,
+    ///       derive_key_context='river-rotate v1 2026-04 room-secret-root'
+    ///   ).digest()
+    ///   # owner_vk for SigningKey::from_bytes([1u8;32]) — paste 32 bytes
+    ///   secret = blake3.blake3(owner_vk_bytes + (0).to_bytes(4,'little'),
+    ///       key=root).digest()
     #[test]
-    fn derive_known_answer_v1() {
+    fn derive_known_answer_v1_zero_seed_zero_version() {
         let seed = [0u8; 32];
         let vk = SigningKey::from_bytes(&[1u8; 32]).verifying_key();
         let actual = derive_room_secret(&seed, &vk, 0);
         let expected: [u8; 32] = [
-            0x64, 0x1f, 0xfc, 0x73, 0x82, 0x69, 0x6a, 0x1b, 0xab, 0xd9, 0xeb, 0xa1, 0x7e, 0x48,
-            0x4c, 0x06, 0x26, 0x55, 0x46, 0xc3, 0x5e, 0xf9, 0xed, 0x06, 0xa6, 0x89, 0xc4, 0x8e,
-            0x20, 0x5b, 0x32, 0x6f,
+            0xdd, 0x18, 0x9c, 0xce, 0x07, 0x93, 0x74, 0x85, 0x6e, 0xb7, 0xa2, 0x01, 0x61, 0x8e,
+            0x58, 0x86, 0xa1, 0xe9, 0xe5, 0x59, 0x8b, 0x33, 0x34, 0x08, 0x43, 0x00, 0x2c, 0xbb,
+            0x90, 0x91, 0xe1, 0xa9,
+        ];
+        assert_eq!(
+            actual, expected,
+            "construction changed; KAT mismatch. Actual = {:02x?}",
+            actual
+        );
+    }
+
+    /// Multi-byte-significant version vector. Catches a future regression
+    /// that swapped `to_le_bytes` for `to_be_bytes`, which would produce
+    /// identical output for `version=0` or `version=1` but a different
+    /// output here.
+    #[test]
+    fn derive_known_answer_v1_multi_byte_version() {
+        let seed = [0u8; 32];
+        let vk = SigningKey::from_bytes(&[1u8; 32]).verifying_key();
+        let actual = derive_room_secret(&seed, &vk, 0x01020304);
+        let expected: [u8; 32] = [
+            0xaa, 0x8f, 0x7d, 0x5a, 0xb5, 0x15, 0x84, 0x66, 0x78, 0x72, 0x28, 0xd6, 0x88, 0x54,
+            0xf6, 0x5d, 0x39, 0xac, 0xe3, 0x13, 0x07, 0x8f, 0x29, 0xa9, 0xfb, 0xad, 0x88, 0x79,
+            0x70, 0xd3, 0xfe, 0x67,
+        ];
+        assert_eq!(
+            actual, expected,
+            "construction changed; KAT mismatch. Actual = {:02x?}",
+            actual
+        );
+    }
+
+    /// All-`0xFF` seed vector. Catches a buggy "if seed is zero, fall back
+    /// to unkeyed mode" regression and exercises non-zero key bytes through
+    /// blake3's keyed-hash internals.
+    #[test]
+    fn derive_known_answer_v1_all_ff_seed() {
+        let seed = [0xFFu8; 32];
+        let vk = SigningKey::from_bytes(&[1u8; 32]).verifying_key();
+        let actual = derive_room_secret(&seed, &vk, 0);
+        let expected: [u8; 32] = [
+            0x60, 0xb5, 0x60, 0x0b, 0x12, 0xfc, 0xaa, 0x0c, 0x52, 0xda, 0x76, 0x59, 0x95, 0xf6,
+            0x9c, 0xb3, 0xeb, 0x54, 0x37, 0xd5, 0x67, 0x53, 0xc0, 0x24, 0x97, 0x67, 0x19, 0xf1,
+            0xe4, 0x31, 0x7e, 0x87,
         ];
         assert_eq!(
             actual, expected,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod chat_delegate;
 pub mod crypto_values;
+pub mod key_derivation;
 pub mod room_state;
 pub mod util;
 pub mod web_container;

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -437,7 +437,11 @@ impl RoomData {
         // Get current version and increment
         let new_version = self.room_state.secrets.current_version + 1;
 
-        // Generate new secret
+        // Generate new secret.
+        // TODO(#228 PR 2): swap to deterministic derivation via
+        // `river_core::key_derivation::derive_room_secret(&self.self_sk.to_bytes(),
+        // &self.owner_vk, new_version)` so multi-device replicas produce
+        // byte-identical secrets without coordination.
         let new_secret = crate::util::ecies::generate_room_secret();
 
         // Create the secret version record


### PR DESCRIPTION
## Problem

Re-enabling private rooms with delegate-driven secret rotation (#228) requires multiple replicas of the same chat delegate (e.g. a user running River on laptop and phone) to compute byte-identical room secrets without coordination. Today, rotation generates a fresh random secret in `RoomData::rotate_secret` (`ui/src/room_data.rs:441`), which means two replicas rotating concurrently produce divergent state. This blocks the delegate-driven architecture described in #228.

We need a deterministic key-derivation function keyed on the owner's signing key seed, with proper domain separation so secrets don't collide across rooms or rotation versions.

## Approach

Add a single pure helper, `common::key_derivation::derive_room_secret`. It uses a two-phase blake3 construction:

```rust
let root = blake3::derive_key(ROOT_CONTEXT, signing_key_seed);
let mut hasher = blake3::Hasher::new_keyed(&root);
hasher.update(owner_vk.as_bytes());
hasher.update(&version.to_le_bytes());
*hasher.finalize().as_bytes()
```

Phase 1 (`blake3::derive_key`) is the canonical blake3 KDF mode with a hard-coded context string (`"river-rotate v1 2026-04 room-secret-root"`). Phase 2 keyed-hash mixes in the per-call inputs. Splitting these phases means a future protocol-version bump just changes the context string, and a future input addition is confined to phase 2 — both make a wire-format break visible at code-review time rather than silent.

The function is intentionally unused in this PR; PR 2 will wire it into `RoomData::rotate_secret` (a `TODO(#228 PR 2)` marker is included at the swap site). Splitting derivation from wiring keeps the cryptographic construction easy to scrutinize independently.

### Why not derive directly from `signing_key`?

An earlier draft proposed a separate `rotation_seed`. The supposed benefit was compromise recovery, but in practice signing-key compromise is already terminal (the attacker controls the room identity), and a separate seed adds state without a realistic recovery scenario. Direct derivation from the signing key seed is simpler with the same effective security. See #228 for the full reasoning.

### Trade-off

Anyone with the signing key seed can derive every past and future secret. This is acceptable for River's threat model — the signing key already authorises every room operation — and buys multi-device determinism without distributed coordination. A removed member who held `secret_v_n` cannot derive `secret_v_{n+1}` (they don't have the seed), so forward secrecy against removed members holds. Apps that need historical forward secrecy against signing-key compromise must not use this construction.

## Testing

Eight unit tests in `common/src/key_derivation.rs`:

- `derive_is_deterministic` — same inputs produce same output
- `derive_separates_versions` — different versions produce different outputs
- `derive_separates_owners` — different owners produce different outputs
- `derive_separates_keys` — different signing key seeds produce different outputs
- `derive_locks_input_ordering` — locks the order of `update(owner_vk)` vs `update(version)` (catches argument-swap regressions)
- `derive_known_answer_v1_zero_seed_zero_version` — KAT for `seed = [0u8; 32]`, `version = 0`
- `derive_known_answer_v1_multi_byte_version` — KAT for `version = 0x01020304` (catches `to_le_bytes` to `to_be_bytes` regressions)
- `derive_known_answer_v1_all_ff_seed` — KAT for `seed = [0xFFu8; 32]` (exercises non-zero key bytes)

The KAT comment includes a Python `blake3` snippet for independent verification — vectors can be regenerated outside the implementation-under-test if needed.

`cargo test -p river-core`: 192 passed, 0 failed.
`cargo clippy -p river-core --all-targets --all-features`: clean.

No delegate or contract WASM changes (function is dead code; baseline hashes preserved). `cargo make check-migration`: "Committed WASM matches HEAD — no migration needed."

## Review

This PR was reviewed by four parallel internal review agents (code-first, testing, skeptical, big-picture) per the multi-model-review rule. No blockers were raised; the second commit on this branch addresses consensus suggestions:

- Construction hardening (two-phase blake3 KDF replacing single-phase keyed-hash; closes the concatenation-fragility concern raised by code-first and skeptical reviewers).
- Documented `signing_key_seed` invariants explicitly.
- Documented the security trade-off in the docstring.
- Added cross-axis swap test and two additional KAT vectors per the testing reviewer.
- Added external-verification recipe to the KAT comment per the big-picture reviewer.
- Added a `TODO(#228 PR 2)` marker at the planned swap site.

Closes #228 partial — derivation helper only; rotation wiring follows in PR 2.

[AI-assisted - Claude]