### PR TITLE
fix(ui): clear unread badge when tab transitions visible to hidden

### DIFF
--- a/ui/src/components/app/document_title.rs
+++ b/ui/src/components/app/document_title.rs
@@ -13,6 +13,7 @@ use crate::util::ecies::unseal_bytes_with_secrets;
 use dioxus::logger::tracing::{debug, info, warn};
 use dioxus::prelude::*;
 use river_core::room_state::member::MemberId;
+use river_core::room_state::message::MessageId;
 use std::cell::RefCell;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
@@ -235,16 +236,73 @@ pub fn mark_current_room_as_read() {
     update_document_title();
 }
 
+/// Mark every room as read up to its latest currently-known message.
+///
+/// Called when the tab transitions from visible to hidden: the user had the
+/// chance to see anything already in state, so only messages arriving *after*
+/// this point should count as unread in the title badge.
+pub fn mark_all_rooms_as_read() {
+    let updates: Vec<(ed25519_dalek::VerifyingKey, MessageId)> = {
+        let Ok(rooms) = ROOMS.try_read() else {
+            return;
+        };
+        rooms
+            .map
+            .iter()
+            .filter_map(|(owner_key, room_data)| {
+                let latest = room_data
+                    .room_state
+                    .recent_messages
+                    .display_messages()
+                    .last()
+                    .map(|msg| msg.id())?;
+                if room_data.last_read_message_id.as_ref() == Some(&latest) {
+                    None
+                } else {
+                    Some((*owner_key, latest))
+                }
+            })
+            .collect()
+    };
+
+    if updates.is_empty() {
+        return;
+    }
+
+    ROOMS.with_mut(|rooms| {
+        for (owner_key, latest) in &updates {
+            if let Some(room_data) = rooms.map.get_mut(owner_key) {
+                room_data.last_read_message_id = Some(latest.clone());
+            }
+        }
+    });
+
+    info!("Marked {} room(s) as read on tab hide", updates.len());
+
+    crate::util::safe_spawn_local(async {
+        if let Err(e) = save_rooms_to_delegate().await {
+            warn!("Failed to save rooms after marking all as read: {}", e);
+        }
+    });
+}
+
 /// Handle visibility change event
 fn on_visibility_change() {
     let is_visible = get_visibility_state();
-    debug!("Visibility changed: {}", is_visible);
+    let was_visible = *DOCUMENT_VISIBLE.read();
+    debug!("Visibility changed: {} -> {}", was_visible, is_visible);
 
     *DOCUMENT_VISIBLE.write() = is_visible;
 
     if is_visible {
         // Tab became visible - mark current room as read
         mark_current_room_as_read();
+    } else if was_visible {
+        // Tab is going from visible to hidden. The user just had the page
+        // active, so anything currently in state should be considered seen.
+        // Only messages that arrive *after* this point should drive the
+        // unread badge in the title.
+        mark_all_rooms_as_read();
     }
 
     update_document_title();

--- a/ui/src/components/app/document_title.rs
+++ b/ui/src/components/app/document_title.rs
@@ -269,20 +269,27 @@ pub fn mark_all_rooms_as_read() {
         return;
     }
 
-    ROOMS.with_mut(|rooms| {
-        for (owner_key, latest) in &updates {
-            if let Some(room_data) = rooms.map.get_mut(owner_key) {
-                room_data.last_read_message_id = Some(latest.clone());
+    // Defer the signal mutation: this function fires from the raw
+    // `visibilitychange` JS event callback, which has no Dioxus scope on the
+    // stack. Going through `defer()` pushes the runtime + root scope so signal
+    // subscriber notifications can find a current scope, and breaks the call
+    // stack so no other RefCell borrows are active when subscribers re-read.
+    crate::util::defer(move || {
+        ROOMS.with_mut(|rooms| {
+            for (owner_key, latest) in &updates {
+                if let Some(room_data) = rooms.map.get_mut(owner_key) {
+                    room_data.last_read_message_id = Some(latest.clone());
+                }
             }
-        }
-    });
+        });
 
-    info!("Marked {} room(s) as read on tab hide", updates.len());
+        info!("Marked {} room(s) as read on tab hide", updates.len());
 
-    crate::util::safe_spawn_local(async {
-        if let Err(e) = save_rooms_to_delegate().await {
-            warn!("Failed to save rooms after marking all as read: {}", e);
-        }
+        crate::util::safe_spawn_local(async {
+            if let Err(e) = save_rooms_to_delegate().await {
+                warn!("Failed to save rooms after marking all as read: {}", e);
+            }
+        });
     });
 }
 

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -36,9 +36,17 @@ pub struct RoomData {
     pub room_state: ChatRoomStateV1,
     pub self_sk: SigningKey,
     pub contract_key: ContractKey,
-    /// The last message ID that was read by the user (for unread tracking)
-    /// Messages after this ID from other users are considered unread.
-    /// This is persisted to delegate storage.
+    /// The last message ID that was read by the user (for unread tracking).
+    /// Messages after this ID from other users are considered unread when
+    /// computing the title badge.
+    ///
+    /// Advanced when (a) the user opens this room, (b) a message arrives
+    /// while the user is viewing this room with the tab visible, and
+    /// (c) the tab transitions from visible to hidden — at which point every
+    /// room is advanced to its latest message, so only messages arriving
+    /// *after* the tab is hidden contribute to the badge.
+    ///
+    /// Persisted to delegate storage.
     #[serde(default)]
     pub last_read_message_id: Option<MessageId>,
     /// All decrypted room secrets by version (if room is private)

--- a/ui/tests/playwright.config.ts
+++ b/ui/tests/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   timeout: 60_000,
   retries: 2,
   use: {
-    baseURL: "http://localhost:8082",
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8082",
     navigationTimeout: 30_000,
     actionTimeout: 10_000,
   },

--- a/ui/tests/title-unread-badge.spec.ts
+++ b/ui/tests/title-unread-badge.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect, Page } from "@playwright/test";
+
+// Regression test for: when the tab loses focus, the title incorrectly shows
+// "(N) River - …" with a non-zero unread count even though the user was just
+// active on the page. The fix marks every room as read at the moment of the
+// visible -> hidden transition, so only messages arriving *after* that point
+// drive the unread badge.
+//
+// Reported by Ian Clarke, 2026-05-06.
+
+async function waitForApp(page: Page) {
+  await page.waitForSelector(".app-root", { timeout: 30_000 });
+  await expect(page.locator("aside, .app-root button")).not.toHaveCount(0);
+}
+
+// Force the tab into the "hidden" visibility state. We override the
+// `document.hidden` and `document.visibilityState` getters and dispatch the
+// `visibilitychange` event the same way Chromium / WebKit / Firefox do when
+// the tab goes to the background.
+async function setTabHidden(page: Page) {
+  await page.evaluate(() => {
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => true,
+    });
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "hidden",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+}
+
+test.describe("Document title unread badge", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("hiding the tab while active does not introduce an unread badge", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+
+    // Wait for the title to settle. Example data has multiple rooms but no
+    // room is auto-selected, so the title starts as "River".
+    await expect(page).toHaveTitle("River", { timeout: 5_000 });
+
+    // Simulate the user switching to a different tab.
+    await setTabHidden(page);
+
+    // The title must NOT gain a "(N)" badge: while the tab was visible the
+    // user had the chance to see all messages already in state.
+    await expect(page).not.toHaveTitle(/^\(\d+\) /, { timeout: 2_000 });
+    await expect(page).toHaveTitle("River");
+  });
+
+  test("hiding the tab after selecting a room keeps the plain title", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+
+    const roomBtn = page.getByRole("button", { name: "Public Discussion Room" });
+    await expect(roomBtn).toBeVisible({ timeout: 5_000 });
+    await roomBtn.click();
+    await expect(
+      page.getByRole("heading", { name: "Public Discussion Room" })
+    ).toBeVisible({ timeout: 5_000 });
+
+    await expect(page).toHaveTitle("River - Public Discussion Room", {
+      timeout: 5_000,
+    });
+
+    await setTabHidden(page);
+
+    await expect(page).not.toHaveTitle(/^\(\d+\) /, { timeout: 2_000 });
+    await expect(page).toHaveTitle("River - Public Discussion Room");
+  });
+});

--- a/ui/tests/title-unread-badge.spec.ts
+++ b/ui/tests/title-unread-badge.spec.ts
@@ -31,6 +31,20 @@ async function setTabHidden(page: Page) {
   });
 }
 
+async function setTabVisible(page: Page) {
+  await page.evaluate(() => {
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => false,
+    });
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+}
+
 test.describe("Document title unread badge", () => {
   test.use({ viewport: { width: 1280, height: 800 } });
 
@@ -74,5 +88,27 @@ test.describe("Document title unread badge", () => {
 
     await expect(page).not.toHaveTitle(/^\(\d+\) /, { timeout: 2_000 });
     await expect(page).toHaveTitle("River - Public Discussion Room");
+  });
+
+  // Defensive: if hide -> show -> hide cycles introduce churn (e.g. by
+  // counting messages twice or by toggling state in the wrong direction)
+  // the title would gain a badge on the second hide. With the fix it should
+  // not — there are no new messages between the two hides.
+  test("hide -> show -> hide cycle does not introduce a badge", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await expect(page).toHaveTitle("River", { timeout: 5_000 });
+
+    await setTabHidden(page);
+    await expect(page).toHaveTitle("River");
+
+    await setTabVisible(page);
+    await expect(page).toHaveTitle("River");
+
+    await setTabHidden(page);
+    await expect(page).not.toHaveTitle(/^\(\d+\) /, { timeout: 2_000 });
+    await expect(page).toHaveTitle("River");
   });
 });


### PR DESCRIPTION
## Problem

The document title showed `(N) River - <room>` the moment the tab lost focus, even when the user had been actively on the page. Reproduced as: title is `River - Freenet` while focused, then becomes `(3) River - Freenet` immediately after switching tabs.

The unread count was summed across **all** rooms via `count_total_unread_messages()`. For rooms the user had never visited, `last_read_message_id` was `None`, so every message from other authors counted as unread. While the tab was visible the format `(Some(name), true, _)` hid the count, but the moment the tab went hidden the format flipped to `(Some(name), false, count)` and the badge appeared — even though the user had been right there.

## Approach

On the visible -> hidden transition in `on_visibility_change`, advance every room's `last_read_message_id` to its latest currently-known display message (new `mark_all_rooms_as_read`). The user had the tab in front of them, so anything already in state is treated as seen. Only messages arriving *after* this moment contribute to the badge while the tab is hidden — which is the behaviour Slack/Discord users expect.

Existing semantics are preserved: when tab becomes visible again, `mark_current_room_as_read` still runs; when messages arrive in the current room while visible, `room_synchronizer.rs` still marks them read.

## Testing

New Playwright regression test `ui/tests/title-unread-badge.spec.ts`:

- Title stays `River` after hiding the tab when no room is selected (example data has 3 unvisited rooms with messages).
- Title stays `River - Public Discussion Room` after hiding the tab while a room is selected.

Verified the test fails on `main` with `(11) River - Public Discussion Room` and passes with the fix. Full Playwright suite (5 browsers, 145 tests) passes.

Also: `ui/tests/playwright.config.ts` now reads `PLAYWRIGHT_BASE_URL` so the suite can run against a non-default port.

## Notes

- UI-only change — no delegate/contract WASM modified, no migration needed.
- Touches: `ui/src/components/app/document_title.rs`, `ui/tests/playwright.config.ts`, new `ui/tests/title-unread-badge.spec.ts`.

[AI-assisted - Claude]