### PR TITLE
feat(ui): re-enable private room creation (#228 Phase 4)

### DIFF
--- a/ui/src/components/room_list/create_room_modal.rs
+++ b/ui/src/components/room_list/create_room_modal.rs
@@ -6,6 +6,7 @@ use ed25519_dalek::SigningKey;
 pub fn CreateRoomModal() -> Element {
     let mut room_name = use_signal(String::new);
     let mut nickname = use_signal(String::new);
+    let mut is_private = use_signal(|| false);
     let create_room = move |_| {
         use dioxus::logger::tracing::info;
         info!("🔵 Create room button clicked");
@@ -23,7 +24,7 @@ pub fn CreateRoomModal() -> Element {
         // Keep a clone of the signing key for delegate storage (self_sk is moved into room creation)
         let sk_clone = self_sk.clone();
         let nick = nickname.read().clone();
-        let private = false; // Private rooms temporarily disabled
+        let private = *is_private.read();
         info!(
             "🔵 Creating {} room with nickname: {}",
             if private { "private" } else { "public" },
@@ -105,6 +106,7 @@ pub fn CreateRoomModal() -> Element {
             info!("🔵 Resetting form fields...");
             room_name.set(String::new());
             nickname.set(String::new());
+            is_private.set(false);
             info!("🔵 Closing modal...");
             CREATE_ROOM_MODAL.with_mut(|modal| {
                 modal.show = false;
@@ -164,15 +166,15 @@ pub fn CreateRoomModal() -> Element {
                         }
                     }
 
-                    label { class: "flex items-center gap-3 cursor-not-allowed opacity-50",
+                    label { class: "flex items-center gap-3 cursor-pointer",
                         input {
                             r#type: "checkbox",
                             class: "w-4 h-4 rounded border-border text-accent focus:ring-accent/50",
-                            checked: false,
-                            disabled: true,
+                            checked: "{is_private}",
+                            onchange: move |evt| is_private.set(evt.value() == "true")
                         }
-                        span { class: "text-sm text-text-muted",
-                            "Private rooms temporarily disabled"
+                        span { class: "text-sm text-text",
+                            "Private room (messages will be encrypted)"
                         }
                     }
                 }


### PR DESCRIPTION
## Problem

Private room creation was temporarily disabled in 58ab2e74 ("feat: message-based member lifecycle with automatic pruning") because the UI-driven rotation scheme couldn't handle auto-pruned membership changes happening while the owner was offline. The disable lived as `let private = false; // Private rooms temporarily disabled` at `ui/src/components/room_list/create_room_modal.rs:26`.

## Approach

Now safe to re-enable: #233 added deterministic key derivation, #235 moved rotation into the chat delegate with the dual-path scheme:

- **UI synchronous fast-path** — owner-driven cases (ban, manual rotate) rotate immediately.
- **Delegate async catch-up** — `ContractNotification`-triggered rotation handles background member-set changes (auto-prune, peer state updates) when the UI isn't open.

Both paths use `derive_room_secret` so they produce byte-identical secrets and converge via the contract's duplicate-version dedup.

With that in place, the rationale for the disable no longer holds.

## Changes

- Restore the `is_private` signal (was hardcoded `false`).
- Restore the modal checkbox to its previous interactive state, with label "Private room (messages will be encrypted)".
- Reset the signal on form close.

## Testing

No new tests — this is a one-line behavioral revert restoring the pre-58ab2e74 UI. Functional testing of private rooms covered by:

- `common/tests/private_room_test.rs` — 5 integration tests (existing).
- `delegates/chat-delegate/src/subscription/tests.rs` — 20 unit tests covering the rotation pipeline (from #235).
- Verified `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync` clean.
- `cargo fmt --check` clean.

## Closes

#228 partial — Phase 4 of the private-rooms re-enablement (PR 1 #233, PR 2 #235, Phase 4 this PR). Phase 3 (weekly rotation via WakeupFired) remains pending on freenet-core#3972 but is non-blocking — ContractNotification-driven rotation handles all the cases the old weekly-sync did.

[AI-assisted - Claude]