### PR TITLE
fix(ui): leave room sticks across reloads via removed_rooms tombstone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ node_modules/
 # Playwright test results
 ui/tests/test-results/
 
+# Syncthing in-flight transfer files (`.syncthing.<name>.tmp` are
+# created by the syncthing daemon while a file is being received).
+**/.syncthing.*.tmp

--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -295,6 +295,7 @@ fn initial_rooms() -> Rooms {
     Rooms {
         map: std::collections::HashMap::new(),
         current_room_key: None,
+        removed_rooms: std::collections::HashSet::new(),
         migrated_rooms: Vec::new(),
     }
 }

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -21,6 +21,7 @@ use crate::util::ecies::{decrypt_secret_from_member_blob, decrypt_with_symmetric
 use crate::util::owner_vk_to_contract_key;
 use ciborium::de::from_reader;
 use dioxus::logger::tracing::{error, info, warn};
+use dioxus::prelude::ReadableExt;
 
 use freenet_stdlib::client_api::{ContractResponse, HostResponse};
 use freenet_stdlib::prelude::OutboundDelegateMsg;
@@ -246,31 +247,64 @@ impl ResponseHandler {
                                                             info!("Successfully loaded rooms from delegate");
                                                         }
 
+                                                        // Tombstone filter for all downstream loops.
+                                                        // Includes both: (a) tombstones in the
+                                                        // incoming loaded_rooms, and (b) tombstones
+                                                        // already in the current in-memory ROOMS —
+                                                        // because legacy delegates predate the
+                                                        // tombstone field, the receiver's set is
+                                                        // the authoritative one (freenet/river#247).
+                                                        let tombstoned: std::collections::HashSet<
+                                                            ed25519_dalek::VerifyingKey,
+                                                        > = {
+                                                            let mut t =
+                                                                loaded_rooms.removed_rooms.clone();
+                                                            let cur = ROOMS.read();
+                                                            for vk in &cur.removed_rooms {
+                                                                t.insert(*vk);
+                                                            }
+                                                            t
+                                                        };
+
                                                         // Restore the current room selection if saved
+                                                        // — but NOT if the saved key was since
+                                                        // tombstoned (skeptical-review H2).
                                                         if let Some(saved_room_key) =
                                                             loaded_rooms.current_room_key
                                                         {
-                                                            info!("Restoring current room selection from delegate");
-                                                            crate::util::defer(move || {
-                                                                *CURRENT_ROOM.write() =
-                                                                    CurrentRoom {
-                                                                        owner_key: Some(
-                                                                            saved_room_key,
-                                                                        ),
-                                                                    };
-                                                            });
+                                                            if tombstoned.contains(&saved_room_key)
+                                                            {
+                                                                info!("Skipping current-room restore — saved room was left");
+                                                            } else {
+                                                                info!("Restoring current room selection from delegate");
+                                                                crate::util::defer(move || {
+                                                                    *CURRENT_ROOM.write() =
+                                                                        CurrentRoom {
+                                                                            owner_key: Some(
+                                                                                saved_room_key,
+                                                                            ),
+                                                                        };
+                                                                });
+                                                            }
                                                         }
 
                                                         // Collect room keys and signing keys before merge
                                                         // (must extract before loaded_rooms is moved into defer)
+                                                        // Filter out tombstoned rooms so we don't
+                                                        // re-subscribe / re-sync rooms the user
+                                                        // explicitly left (skeptical-review H1).
                                                         let room_keys: Vec<_> = loaded_rooms
                                                             .map
                                                             .keys()
                                                             .copied()
+                                                            .filter(|k| !tombstoned.contains(k))
                                                             .collect();
                                                         let signing_keys: Vec<_> = loaded_rooms
                                                             .map
                                                             .iter()
+                                                            .filter(|(key, _)| {
+                                                                !tombstoned.contains(*key)
+                                                            })
                                                             .map(|(key, room_data)| {
                                                                 (
                                                                     *key,
@@ -285,15 +319,19 @@ impl ResponseHandler {
                                                         // contract_id) up-front so we can fire
                                                         // EnsureRoomSubscription after the
                                                         // signing-key migration completes.
+                                                        // Tombstoned rooms filtered out — no point
+                                                        // asking the delegate to rotate a room the
+                                                        // user has left.
                                                         let owned_rooms_for_subscription: Vec<_> =
                                                             loaded_rooms
                                                                 .map
                                                                 .iter()
-                                                                .filter(|(_, rd)| {
-                                                                    rd.owner_vk
-                                                                        == rd
-                                                                            .self_sk
-                                                                            .verifying_key()
+                                                                .filter(|(key, rd)| {
+                                                                    !tombstoned.contains(*key)
+                                                                        && rd.owner_vk
+                                                                            == rd
+                                                                                .self_sk
+                                                                                .verifying_key()
                                                                 })
                                                                 .map(|(_, rd)| {
                                                                     let cid_array: [u8; 32] =

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -115,6 +115,12 @@ pub async fn handle_get_response(
             // Update the room data
             crate::util::defer(move || {
                 ROOMS.with_mut(|rooms| {
+                // Accepting an invitation is an explicit rejoin — clear any
+                // prior leave tombstone for this room so the merge path
+                // doesn't silently filter the room out again later. See
+                // freenet/river#247.
+                rooms.removed_rooms.remove(&owner_vk);
+
                 // Get the entry for this room
                 let entry = rooms.map.entry(owner_vk);
 

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -577,6 +577,11 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
                 // prevent RefCell re-entrant borrow panics.
                 crate::util::defer(move || {
                     ROOMS.with_mut(|rooms| {
+                        // Importing a room is an explicit rejoin — clear any
+                        // prior leave tombstone for this owner_key so the
+                        // merge path doesn't silently filter the room out
+                        // on next reload (freenet/river#247).
+                        rooms.removed_rooms.remove(&owner_key);
                         rooms.map.insert(owner_key, room_data);
                     });
 

--- a/ui/src/components/room_list/edit_room_modal.rs
+++ b/ui/src/components/room_list/edit_room_modal.rs
@@ -280,7 +280,11 @@ pub fn EditRoomModal() -> Element {
                                                 // Defer signal mutations to a clean execution
                                                 // context to prevent RefCell re-entrant borrow panics.
                                                 crate::util::defer(move || {
-                                                    ROOMS.write().map.remove(&room_vk);
+                                                    // `leave_room` removes from `map` AND adds the
+                                                    // owner VK to `removed_rooms`. The tombstone
+                                                    // is what makes leave survive across reloads /
+                                                    // legacy-delegate merges (freenet/river#247).
+                                                    ROOMS.write().leave_room(room_vk);
 
                                                     // Check and potentially clear CURRENT_ROOM
                                                     if CURRENT_ROOM.read().owner_key == Some(room_vk) {
@@ -290,7 +294,8 @@ pub fn EditRoomModal() -> Element {
                                                     // Close the modal *last*
                                                     EDIT_ROOM_MODAL.write().room = None;
 
-                                                    // Save updated rooms to delegate storage
+                                                    // Save updated rooms (including the tombstone)
+                                                    // to delegate storage.
                                                     info!("Room removed, saving to delegate");
                                                     spawn(async move {
                                                         if let Err(e) = save_rooms_to_delegate().await {

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -46,6 +46,7 @@ pub fn create_example_rooms() -> Rooms {
     Rooms {
         map,
         current_room_key: None,
+        removed_rooms: std::collections::HashSet::new(),
         migrated_rooms: Vec::new(),
     }
 }

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -707,6 +707,18 @@ pub struct Rooms {
     pub map: HashMap<VerifyingKey, RoomData>,
     #[serde(default)]
     pub current_room_key: Option<VerifyingKey>,
+    /// Rooms the user has explicitly left. Persisted alongside `map` so
+    /// the leave action survives across reloads and across legacy-delegate
+    /// migrations. Without this set, `Rooms::merge` re-adds the room from
+    /// any legacy delegate whose stored `rooms_data` still contained it
+    /// (see freenet/river#247 — Ivvor's report 2026-05-14).
+    ///
+    /// CRDT semantics: monotonically grows. A room key in `removed_rooms`
+    /// MUST NOT also appear in `map`. Add to this set when the user
+    /// explicitly leaves; clear from this set if/when the user
+    /// deliberately rejoins (e.g. accepts a fresh invitation).
+    #[serde(default)]
+    pub removed_rooms: std::collections::HashSet<VerifyingKey>,
     /// Rooms whose contract key changed due to WASM update.
     /// Each entry is (owner_vk, old_contract_key) for rooms where the owner
     /// should send an upgrade pointer to the old contract.
@@ -878,8 +890,29 @@ impl Rooms {
     }
 
     /// Merge the other Rooms into this Rooms (eg. when Rooms are loaded from storage)
+    ///
+    /// Union of `removed_rooms` tombstones: any room key the user has
+    /// explicitly left on either side stays left. Rooms in `removed_rooms`
+    /// are filtered out of the merge — that prevents a legacy delegate's
+    /// stale `rooms_data` from re-adding a room the user has already
+    /// removed (see freenet/river#247).
     pub fn merge(&mut self, other: Rooms) -> Result<(), String> {
+        // Tombstones first: take the union before anything else, so the
+        // filter below sees the combined set.
+        for vk in other.removed_rooms {
+            self.removed_rooms.insert(vk);
+        }
+        // Defensive: if a room ended up in both `map` and `removed_rooms`
+        // (shouldn't happen — leave path adds to removed and removes from
+        // map atomically), the tombstone wins.
+        self.map.retain(|vk, _| !self.removed_rooms.contains(vk));
+
         for (vk, mut room_data) in other.map {
+            // Honour tombstones — never re-add a room the user has left.
+            if self.removed_rooms.contains(&vk) {
+                continue;
+            }
+
             // Capture the old contract key before regeneration
             let old_contract_key = room_data.contract_key;
 
@@ -909,6 +942,15 @@ impl Rooms {
             }
         }
         Ok(())
+    }
+
+    /// Mark a room as explicitly left. Removes from `map` AND adds the
+    /// owner VK to `removed_rooms` so future merges don't re-add it.
+    ///
+    /// Idempotent — safe to call multiple times with the same key.
+    pub fn leave_room(&mut self, room_vk: VerifyingKey) {
+        self.map.remove(&room_vk);
+        self.removed_rooms.insert(room_vk);
     }
 }
 
@@ -1415,6 +1457,158 @@ mod tests {
         let delegate_secret =
             river_core::key_derivation::derive_room_secret(&owner_sk.to_bytes(), &owner_vk, 1);
         assert_eq!(ui_secret, delegate_secret);
+    }
+
+    /// Regression test for freenet/river#247: leaving a room must add it
+    /// to `removed_rooms` so subsequent merges (e.g. legacy-delegate
+    /// migration) don't silently re-add the room.
+    ///
+    /// Scenario:
+    /// 1. User has room R in `map`.
+    /// 2. User leaves R via `leave_room(R)` — should remove from `map`
+    ///    AND add R's owner VK to `removed_rooms`.
+    /// 3. On reload, the legacy migration produces a `Rooms` value that
+    ///    still contains R (because legacy delegate's stored rooms_data
+    ///    was never purged when superseded).
+    /// 4. `current_rooms.merge(legacy_rooms)` must NOT re-add R.
+    #[test]
+    fn leave_room_tombstone_prevents_merge_re_adding() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let member_sk = SigningKey::generate(&mut rng);
+        let owner_vk = owner_sk.verifying_key();
+
+        let room_data = {
+            let config = AuthorizedConfigurationV1::new(Configuration::default(), &owner_sk);
+            let mut state = ChatRoomStateV1 {
+                configuration: config,
+                ..Default::default()
+            };
+            let member = Member {
+                owner_member_id: owner_vk.into(),
+                invited_by: owner_vk.into(),
+                member_vk: member_sk.verifying_key(),
+            };
+            state
+                .members
+                .members
+                .push(AuthorizedMember::new(member, &owner_sk));
+            let params = ChatRoomParametersV1 { owner: owner_vk };
+            let params_bytes = to_cbor_vec(&params);
+            let contract_key = ContractKey::from_params_and_code(
+                Parameters::from(params_bytes),
+                &ContractCode::from(ROOM_CONTRACT_WASM),
+            );
+            RoomData {
+                owner_vk,
+                room_state: state,
+                self_sk: member_sk.clone(),
+                contract_key,
+                last_read_message_id: None,
+                secrets: HashMap::new(),
+                current_secret_version: None,
+                last_secret_rotation: None,
+                key_migrated_to_delegate: false,
+                self_authorized_member: None,
+                invite_chain: vec![],
+                self_member_info: None,
+                previous_contract_key: None,
+            }
+        };
+
+        let mut current = Rooms {
+            map: HashMap::new(),
+            current_room_key: None,
+            removed_rooms: std::collections::HashSet::new(),
+            migrated_rooms: Vec::new(),
+        };
+        current.map.insert(owner_vk, room_data.clone());
+
+        // Step 2: leave the room.
+        current.leave_room(owner_vk);
+        assert!(!current.map.contains_key(&owner_vk));
+        assert!(current.removed_rooms.contains(&owner_vk));
+
+        // Step 3: legacy-delegate snapshot still has the room.
+        let mut legacy = Rooms {
+            map: HashMap::new(),
+            current_room_key: None,
+            removed_rooms: std::collections::HashSet::new(),
+            migrated_rooms: Vec::new(),
+        };
+        legacy.map.insert(owner_vk, room_data);
+
+        // Step 4: merge must not re-add.
+        current.merge(legacy).expect("merge");
+        assert!(
+            !current.map.contains_key(&owner_vk),
+            "merge must respect the removed_rooms tombstone"
+        );
+        assert!(
+            current.removed_rooms.contains(&owner_vk),
+            "tombstone must survive the merge"
+        );
+    }
+
+    /// Merge unions tombstones from both sides — if EITHER side has the
+    /// room in `removed_rooms`, it must stay out (and any matching
+    /// `map` entry on the receiver side is dropped).
+    #[test]
+    fn merge_unions_removed_rooms_tombstones() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let owner_vk = owner_sk.verifying_key();
+        let member_sk = SigningKey::generate(&mut rng);
+
+        let room_data = {
+            let config = AuthorizedConfigurationV1::new(Configuration::default(), &owner_sk);
+            let state = ChatRoomStateV1 {
+                configuration: config,
+                ..Default::default()
+            };
+            let params = ChatRoomParametersV1 { owner: owner_vk };
+            let params_bytes = to_cbor_vec(&params);
+            let contract_key = ContractKey::from_params_and_code(
+                Parameters::from(params_bytes),
+                &ContractCode::from(ROOM_CONTRACT_WASM),
+            );
+            RoomData {
+                owner_vk,
+                room_state: state,
+                self_sk: member_sk,
+                contract_key,
+                last_read_message_id: None,
+                secrets: HashMap::new(),
+                current_secret_version: None,
+                last_secret_rotation: None,
+                key_migrated_to_delegate: false,
+                self_authorized_member: None,
+                invite_chain: vec![],
+                self_member_info: None,
+                previous_contract_key: None,
+            }
+        };
+
+        // Receiver has the room in `map`. Sender has it in `removed_rooms`.
+        // After merge, neither side has it.
+        let mut receiver = Rooms {
+            map: HashMap::new(),
+            current_room_key: None,
+            removed_rooms: std::collections::HashSet::new(),
+            migrated_rooms: Vec::new(),
+        };
+        receiver.map.insert(owner_vk, room_data);
+        let mut sender = Rooms {
+            map: HashMap::new(),
+            current_room_key: None,
+            removed_rooms: std::collections::HashSet::new(),
+            migrated_rooms: Vec::new(),
+        };
+        sender.removed_rooms.insert(owner_vk);
+
+        receiver.merge(sender).expect("merge");
+        assert!(!receiver.map.contains_key(&owner_vk));
+        assert!(receiver.removed_rooms.contains(&owner_vk));
     }
 
     /// Rotation refuses to wrap when the current version is `u32::MAX`,

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -743,7 +743,7 @@ pub struct Rooms {
 
 impl PartialEq for Rooms {
     fn eq(&self, other: &Self) -> bool {
-        self.map == other.map
+        self.map == other.map && self.removed_rooms == other.removed_rooms
     }
 }
 
@@ -959,12 +959,14 @@ impl Rooms {
         Ok(())
     }
 
-    /// Mark a room as explicitly left. Removes from `map` AND adds the
+    /// Mark a room as explicitly left. Removes from `map`, drops any
+    /// pending upgrade-pointer entry in `migrated_rooms`, and adds the
     /// owner VK to `removed_rooms` so future merges don't re-add it.
     ///
     /// Idempotent — safe to call multiple times with the same key.
     pub fn leave_room(&mut self, room_vk: VerifyingKey) {
         self.map.remove(&room_vk);
+        self.migrated_rooms.retain(|(vk, _)| vk != &room_vk);
         self.removed_rooms.insert(room_vk);
     }
 }

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -713,10 +713,25 @@ pub struct Rooms {
     /// any legacy delegate whose stored `rooms_data` still contained it
     /// (see freenet/river#247 — Ivvor's report 2026-05-14).
     ///
-    /// CRDT semantics: monotonically grows. A room key in `removed_rooms`
-    /// MUST NOT also appear in `map`. Add to this set when the user
-    /// explicitly leaves; clear from this set if/when the user
-    /// deliberately rejoins (e.g. accepts a fresh invitation).
+    /// Invariants:
+    /// * A room key in `removed_rooms` MUST NOT also appear in `map`.
+    ///   `Rooms::merge` enforces this defensively via `retain`.
+    /// * On explicit rejoin (accepting an invitation or importing an
+    ///   export of the room), the tombstone is cleared. The set is
+    ///   therefore NOT strictly grow-only — it's a leave-on / rejoin-off
+    ///   marker. Rejoin clears are local to the device that does the
+    ///   rejoin; a second device that doesn't see the rejoin keeps the
+    ///   tombstone and won't auto-re-add the room. Treated as acceptable
+    ///   for the multi-device case because the leave was an explicit
+    ///   user action on the original device; if the second device wants
+    ///   the room back, it can rejoin explicitly there too.
+    ///
+    /// Sites that insert into `map` MUST also clear the corresponding
+    /// entry from `removed_rooms` if the insert represents an explicit
+    /// rejoin (see `members.rs` import-identity flow, `get_response.rs`
+    /// invitation-accept flow). Sites that get state passively from the
+    /// network (e.g. `UpdateNotification` handlers calling `get_mut`)
+    /// should NOT clear the tombstone — the user explicitly left.
     #[serde(default)]
     pub removed_rooms: std::collections::HashSet<VerifyingKey>,
     /// Rooms whose contract key changed due to WASM update.
@@ -1548,6 +1563,119 @@ mod tests {
             current.removed_rooms.contains(&owner_vk),
             "tombstone must survive the merge"
         );
+    }
+
+    /// Backward-compat: a `rooms_data` blob serialised before this PR
+    /// does not contain the `removed_rooms` field. `#[serde(default)]`
+    /// must populate it as an empty set so existing users' delegate
+    /// state deserialises cleanly on first load post-deploy.
+    #[test]
+    fn rooms_deserialises_pre_247_blob_with_default_removed_rooms() {
+        // Pre-#247 shape: just `map` and `current_room_key`. Build a
+        // ciborium-encoded representation by hand. Map type 0xa2 = 2
+        // entries; text "map" → empty map; text "current_room_key" → null.
+        // Equivalent to ciborium-encoding a small adhoc serde struct.
+        #[derive(Serialize)]
+        struct LegacyRooms {
+            map: HashMap<VerifyingKey, RoomData>,
+            current_room_key: Option<VerifyingKey>,
+        }
+        let legacy = LegacyRooms {
+            map: HashMap::new(),
+            current_room_key: None,
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        ciborium::ser::into_writer(&legacy, &mut buf).unwrap();
+        let decoded: Rooms = ciborium::de::from_reader(buf.as_slice()).unwrap();
+        assert!(decoded.removed_rooms.is_empty());
+        assert!(decoded.map.is_empty());
+        assert!(decoded.current_room_key.is_none());
+    }
+
+    /// Round-trip: serialise a `Rooms` containing a tombstone, deserialise,
+    /// and verify the tombstone survives. This pins the wire-format for
+    /// the new field so a future serde rename / shape change can't drop
+    /// the tombstone silently.
+    #[test]
+    fn rooms_round_trip_preserves_removed_rooms_tombstone() {
+        let mut rng = rand::thread_rng();
+        let vk = SigningKey::generate(&mut rng).verifying_key();
+        let mut original = Rooms {
+            map: HashMap::new(),
+            current_room_key: None,
+            removed_rooms: std::collections::HashSet::new(),
+            migrated_rooms: Vec::new(),
+        };
+        original.removed_rooms.insert(vk);
+
+        let mut buf: Vec<u8> = Vec::new();
+        ciborium::ser::into_writer(&original, &mut buf).unwrap();
+        let decoded: Rooms = ciborium::de::from_reader(buf.as_slice()).unwrap();
+        assert!(decoded.removed_rooms.contains(&vk));
+    }
+
+    /// Tombstone-clear semantics: an empty `removed_rooms` is implicit
+    /// for new rooms; a tombstoned key that's re-cleared (e.g. by
+    /// invitation accept) must NOT block the next merge.
+    #[test]
+    fn cleared_tombstone_allows_merge_to_re_add() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let member_sk = SigningKey::generate(&mut rng);
+        let owner_vk = owner_sk.verifying_key();
+
+        let room_data = {
+            let config = AuthorizedConfigurationV1::new(Configuration::default(), &owner_sk);
+            let state = ChatRoomStateV1 {
+                configuration: config,
+                ..Default::default()
+            };
+            let params = ChatRoomParametersV1 { owner: owner_vk };
+            let params_bytes = to_cbor_vec(&params);
+            let contract_key = ContractKey::from_params_and_code(
+                Parameters::from(params_bytes),
+                &ContractCode::from(ROOM_CONTRACT_WASM),
+            );
+            RoomData {
+                owner_vk,
+                room_state: state,
+                self_sk: member_sk,
+                contract_key,
+                last_read_message_id: None,
+                secrets: HashMap::new(),
+                current_secret_version: None,
+                last_secret_rotation: None,
+                key_migrated_to_delegate: false,
+                self_authorized_member: None,
+                invite_chain: vec![],
+                self_member_info: None,
+                previous_contract_key: None,
+            }
+        };
+
+        let mut current = Rooms {
+            map: HashMap::new(),
+            current_room_key: None,
+            removed_rooms: std::collections::HashSet::new(),
+            migrated_rooms: Vec::new(),
+        };
+        // Step 1: leave the room.
+        current.leave_room(owner_vk);
+        // Step 2: simulate explicit rejoin clearing the tombstone (what
+        // the invitation-accept and import-identity paths do).
+        current.removed_rooms.remove(&owner_vk);
+        // Step 3: merge an incoming snapshot that has the room.
+        let mut incoming = Rooms {
+            map: HashMap::new(),
+            current_room_key: None,
+            removed_rooms: std::collections::HashSet::new(),
+            migrated_rooms: Vec::new(),
+        };
+        incoming.map.insert(owner_vk, room_data);
+        current.merge(incoming).expect("merge");
+        // Room must be back since the tombstone was cleared.
+        assert!(current.map.contains_key(&owner_vk));
+        assert!(!current.removed_rooms.contains(&owner_vk));
     }
 
     /// Merge unions tombstones from both sides — if EITHER side has the


### PR DESCRIPTION
Closes #247.

## Problem

Ivvor's report (2026-05-14 17:03):
> every time i leave the private room on the second node it's coming back after a refresh a little while later

\`Confirm Leave\` in \`ui/src/components/room_list/edit_room_modal.rs:283\` only did \`ROOMS.write().map.remove(&room_vk)\` and saved rooms_data to the current delegate. On reload, \`fire_legacy_migration_request()\` probed all 17 entries in \`legacy_delegates.toml\`. Some legacy delegate's on-disk \`rooms_data\` still contained the room — that data was never purged when the delegate was superseded. \`Rooms::merge\` was purely additive, so the room came back.

## Fix

Add a \`removed_rooms: HashSet&lt;VerifyingKey&gt;\` tombstone set to the serialised \`Rooms\` struct (with \`#[serde(default)]\` for backward compatibility). \`Rooms::merge\` now unions tombstones from both sides and filters all entries against the union; \`map\` entries on the receiver matching a tombstone are also dropped (defensive). New \`Rooms::leave_room(vk)\` helper does both mutations atomically. Invitation acceptance clears the tombstone for explicit rejoin.

## Tests

- \`leave_room_tombstone_prevents_merge_re_adding\` — full scenario from the report.
- \`merge_unions_removed_rooms_tombstones\` — if either side has the tombstone, it's honoured.
- 14/14 \`room_data::tests\` pass (was 12).

## Deploy footprint

UI-only. \`chat_delegate.wasm\` and \`room_contract.wasm\` are byte-identical to #245. No migration entry. No riverctl republish. Just \`cargo make publish-river\`.

## Recovery for currently-stuck users

After this lands and users reload, the next time they leave a room the tombstone is recorded. Their previous leave attempts (without tombstone) won't survive — they'll need to leave once more after the upgrade.

## Test plan

- [ ] CI green
- [ ] Multi-perspective reviews
- [ ] Merge + \`cargo make publish-river\`

[AI-assisted - Claude]