### PR TITLE
perf(ui): demote roomstate console dumps from info! to debug!

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -66,6 +66,12 @@ ciborium = "0.2.2"
 js-sys = "0.3.64"
 thiserror = "2.0.12"
 log = "0.4" # Add log crate
+# Compile-time gate so `debug!`/`trace!` macros are dropped entirely in
+# release builds. This is belt-and-suspenders on top of the runtime
+# filter `dioxus_logger` sets up (Info in release, Debug in dev) — if
+# that runtime filter ever regresses, the macros still won't emit. See
+# https://docs.rs/tracing/latest/tracing/level_filters/index.html#compile-time-filters
+tracing = { version = "0.1", default-features = false, features = ["std", "release_max_level_info"] }
 
 # Internal dependencies
 river-core = { workspace = true, features = ["ecies", "ecies-randomized"] }

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -1,5 +1,5 @@
 use crate::components::app::{CURRENT_ROOM, ROOMS, WEB_API};
-use dioxus::logger::tracing::{error, info, warn};
+use dioxus::logger::tracing::{debug, error, info, warn};
 use dioxus::prelude::*;
 use freenet_stdlib::client_api::ClientRequest::DelegateOp;
 use freenet_stdlib::client_api::DelegateRequest;
@@ -433,7 +433,7 @@ fn get_request_key(request: &ChatDelegateRequestMsg) -> Vec<u8> {
 pub async fn send_delegate_request(
     request: ChatDelegateRequestMsg,
 ) -> Result<ChatDelegateResponseMsg, String> {
-    info!("Sending delegate request: {:?}", request);
+    debug!("Sending delegate request: {:?}", request);
 
     // Get the key bytes for tracking this request
     let key_bytes = get_request_key(&request);
@@ -502,7 +502,7 @@ pub async fn send_delegate_request(
     match select(receiver, timeout).await {
         Either::Left((response, _)) => match response {
             Ok(resp) => {
-                info!("Received delegate response: {:?}", resp);
+                debug!("Received delegate response: {:?}", resp);
                 Ok(resp)
             }
             Err(_) => Err("Response channel was cancelled".to_string()),

--- a/ui/src/components/app/freenet_api/freenet_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/freenet_synchronizer.rs
@@ -8,7 +8,7 @@ use crate::components::app::chat_delegate::{mark_legacy_migration_done, set_up_c
 use crate::components::app::sync_info::{RoomSyncStatus, SYNC_INFO};
 use crate::components::app::{ROOMS, SYNC_STATUS, WEB_API};
 use crate::util::{owner_vk_to_contract_key, sleep};
-use dioxus::logger::tracing::{error, info, warn};
+use dioxus::logger::tracing::{debug, error, info, warn};
 use dioxus::prelude::*;
 use ed25519_dalek::SigningKey;
 use ed25519_dalek::VerifyingKey;
@@ -352,11 +352,11 @@ impl FreenetSynchronizer {
                                                     info!("Value #{} is ApplicationMessage, processed: {}, payload size: {}",
                                                           i, app_msg.processed, app_msg.payload.len());
                                                 }
-                                                _ => info!("Value #{} is: {:?}", i, v),
+                                                _ => debug!("Value #{} is: {:?}", i, v),
                                             }
                                         }
                                     }
-                                    _ => info!("Other response type: {:?}", host_response),
+                                    _ => debug!("Other response type: {:?}", host_response),
                                 }
 
                                 match response_handler.handle_api_response(host_response).await {

--- a/ui/src/components/app/freenet_api/response_handler/update_notification.rs
+++ b/ui/src/components/app/freenet_api/response_handler/update_notification.rs
@@ -3,7 +3,7 @@ use crate::components::app::freenet_api::room_synchronizer::RoomSynchronizer;
 use crate::components::app::sync_info::SYNC_INFO;
 use crate::components::app::WEB_API;
 use crate::util::{from_cbor_slice, owner_vk_to_contract_key};
-use dioxus::logger::tracing::{info, warn};
+use dioxus::logger::tracing::{debug, info, warn};
 use dioxus::prelude::ReadableExt;
 use ed25519_dalek::VerifyingKey;
 use freenet_stdlib::client_api::{ClientRequest, ContractRequest};
@@ -72,21 +72,31 @@ pub fn handle_update_notification(
             let new_state: ChatRoomStateV1 = from_cbor_slice::<ChatRoomStateV1>(&state);
             follow_upgrade_pointer_if_needed(&new_state, &room_owner_vk);
 
-            // Regular state update (also process normally for merge)
-            info!("Received new state in UpdateNotification: {:?}", new_state);
+            info!(
+                "UpdateNotification: state ({} messages, {} members)",
+                new_state.recent_messages.messages.len(),
+                new_state.members.members.len()
+            );
+            debug!("Received new state in UpdateNotification: {:?}", new_state);
             room_synchronizer.update_room_state(&room_owner_vk, &new_state);
         }
         UpdateData::Delta(delta) => {
             let new_delta: ChatRoomStateV1Delta = from_cbor_slice::<ChatRoomStateV1Delta>(&delta);
-            info!("Received new delta in UpdateNotification: {:?}", new_delta);
+            info!("UpdateNotification: delta received");
+            debug!("Received new delta in UpdateNotification: {:?}", new_delta);
             room_synchronizer.apply_delta(&room_owner_vk, new_delta);
         }
         UpdateData::StateAndDelta { state, delta } => {
+            let new_state: ChatRoomStateV1 = from_cbor_slice::<ChatRoomStateV1>(&state);
             info!(
+                "UpdateNotification: state+delta ({} messages, {} members)",
+                new_state.recent_messages.messages.len(),
+                new_state.members.members.len()
+            );
+            debug!(
                 "Received state and delta in UpdateNotification state: {:?} delta: {:?}",
                 state, delta
             );
-            let new_state: ChatRoomStateV1 = from_cbor_slice::<ChatRoomStateV1>(&state);
             follow_upgrade_pointer_if_needed(&new_state, &room_owner_vk);
 
             room_synchronizer.update_room_state(&room_owner_vk, &new_state);

--- a/ui/src/components/app/freenet_api/room_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/room_synchronizer.rs
@@ -16,7 +16,7 @@ use crate::constants::ROOM_CONTRACT_WASM;
 use crate::invites::PendingRoomStatus;
 use crate::util::ecies::decrypt_with_symmetric_key;
 use crate::util::{owner_vk_to_contract_key, to_cbor_vec};
-use dioxus::logger::tracing::{error, info, warn};
+use dioxus::logger::tracing::{debug, error, info, warn};
 use dioxus::prelude::*;
 use ed25519_dalek::VerifyingKey;
 use freenet_scaffold::ComposableState;
@@ -86,9 +86,9 @@ impl RoomSynchronizer {
 
                 // Log the delta being applied, especially any member_info with versions
                 if let Some(member_info) = &delta.member_info {
-                    info!("Applying member_info delta with {} items", member_info.len());
+                    debug!("Applying member_info delta with {} items", member_info.len());
                     for info in member_info {
-                        info!("Delta contains member_info with version: {} for member: {:?}, nickname: {}",
+                        debug!("Delta contains member_info with version: {} for member: {:?}, nickname: {}",
                               info.member_info.version,
                               info.member_info.member_id,
                               info.member_info.preferred_nickname);
@@ -96,10 +96,10 @@ impl RoomSynchronizer {
                 }
 
                 // Log current versions before applying delta
-                info!("Current member_info state before delta ({} items):",
+                debug!("Current member_info state before delta ({} items):",
                       room_data.room_state.member_info.member_info.len());
                 for info in &room_data.room_state.member_info.member_info {
-                    info!("Current member_info version: {} for member: {:?}, nickname: {}",
+                    debug!("Current member_info version: {} for member: {:?}, nickname: {}",
                           info.member_info.version,
                           info.member_info.member_id,
                           info.member_info.preferred_nickname);
@@ -152,10 +152,10 @@ impl RoomSynchronizer {
                         }
 
                         // Log versions after applying delta
-                        info!("Updated member_info state after delta ({} items):",
+                        debug!("Updated member_info state after delta ({} items):",
                               room_data.room_state.member_info.member_info.len());
                         for info in &room_data.room_state.member_info.member_info {
-                            info!("Updated member_info version: {} for member: {:?}, nickname: {}",
+                            debug!("Updated member_info version: {} for member: {:?}, nickname: {}",
                                   info.member_info.version,
                                   info.member_info.member_id,
                                   info.member_info.preferred_nickname);
@@ -819,7 +819,7 @@ impl RoomSynchronizer {
                     .iter()
                     .map(|m| m.id())
                     .collect();
-                info!(
+                debug!(
                     "update_room_state: Captured {} old message IDs for room {:?}",
                     old_ids.len(),
                     MemberId::from(room_owner_vk)
@@ -829,7 +829,7 @@ impl RoomSynchronizer {
                 let secrets = room_data.secrets.clone();
                 (Some(old_ids), Some(self_id), Some(member_info), secrets)
             } else {
-                info!(
+                debug!(
                     "update_room_state: Room {:?} not found in ROOMS when capturing old IDs",
                     MemberId::from(room_owner_vk)
                 );
@@ -838,7 +838,7 @@ impl RoomSynchronizer {
         };
 
         // Log incoming state message count
-        info!(
+        debug!(
             "update_room_state: Incoming state has {} messages for room {:?}",
             state.recent_messages.messages.len(),
             MemberId::from(room_owner_vk)
@@ -853,12 +853,12 @@ impl RoomSynchronizer {
         ROOMS.with_mut(|rooms| {
             if let Some(room_data) = rooms.map.get_mut(&room_owner_vk) {
                 // Log member info versions before merge
-                info!(
+                debug!(
                     "Before merge - Local member info versions ({} items):",
                     room_data.room_state.member_info.member_info.len()
                 );
                 for info in &room_data.room_state.member_info.member_info {
-                    info!(
+                    debug!(
                         "  Member: {:?}, Version: {}, Nickname: {}",
                         info.member_info.member_id,
                         info.member_info.version,
@@ -866,12 +866,12 @@ impl RoomSynchronizer {
                     );
                 }
 
-                info!(
+                debug!(
                     "Before merge - Incoming state member info versions ({} items):",
                     state.member_info.member_info.len()
                 );
                 for info in &state.member_info.member_info {
-                    info!(
+                    debug!(
                         "  Member: {:?}, Version: {}, Nickname: {}",
                         info.member_info.member_id,
                         info.member_info.version,
@@ -922,12 +922,12 @@ impl RoomSynchronizer {
                         }
 
                         // Log member info versions after merge
-                        info!(
+                        debug!(
                             "After merge - Updated member info versions ({} items):",
                             room_data.room_state.member_info.member_info.len()
                         );
                         for info in &room_data.room_state.member_info.member_info {
-                            info!(
+                            debug!(
                                 "  Member: {:?}, Version: {}, Nickname: {}",
                                 info.member_info.member_id,
                                 info.member_info.version,


### PR DESCRIPTION
## Summary
- `UpdateNotification`, the delegate request/response handler, and the delta/state merge paths in `room_synchronizer` were all dumping the full `ChatRoomStateV1` / `Delta` payloads at `info!` level via `{:?}`.
- These fire on every contract notification and every delta merge, so a single room reload pumps hundreds of large strings into the JS console — which retains them.
- Demote the full Debug payloads to `debug!` (filtered out by the default dioxus logger init). Keep a short `info!` summary line (`N messages, M members`) so the lifecycle is still visible.

## Context
User report from Ivvor (Matrix, 2026-05-15):
> Throughout all this I was still noticing memory footprint issues. Indeed, the PC I was using to run tests, froze up about 15 mins ago and I'm still waiting for it to unfreeze.
>
> Devtools couldn't find source of memory spikes. Using codex to look through the River code in conjunction with my observations its best guess was that dumping huge amounts of data to the JS console might be causing it. Mainly repeated dumps of roomstate. This would match with the peaks happening during room reloads/refreshes.

The codex diagnosis matches exactly what these `info!` calls do.

## Test plan
- [x] `cargo check --target wasm32-unknown-unknown --features no-sync` for `river-ui` passes
- [x] `cargo check -p river-core` passes
- [ ] Manual: load a room with many messages, observe the JS console no longer fills with `ChatRoomStateV1 { ... }` dumps every refresh
- [ ] Manual: verify `RUST_LOG=debug` / debug build still shows the full dumps when needed for diagnostics

## Out of scope
The other issues Ivvor reported in the same message — new members initially seeing encrypted messages until refresh, and owner-can't-send-messages during initial sync — are separate sync/decryption bugs in the private-room back-fill path and will be filed as a separate issue.

[AI-assisted - Claude]