### PR TITLE
fix(ui): gate legacy delegate migration on current delegate response

### DIFF
--- a/.claude/rules/river-publish.md
+++ b/.claude/rules/river-publish.md
@@ -73,11 +73,31 @@ cargo make publish-all
 
 ## How Delegate Migration Works
 
-1. On startup, `set_up_chat_delegate()` fires `fire_legacy_migration_request()`
-2. `LEGACY_DELEGATES` is generated at compile time from `legacy_delegates.toml` by `ui/build.rs`
-3. Sends `GetRequest` for `rooms_data` to EACH legacy key
-4. Response handler migrates room data + signing keys to the current delegate
-5. `mark_legacy_migration_done()` sets localStorage flag to skip on next load
+Legacy migration is **gated on the current delegate's response** to avoid a
+race where stale legacy data overwrites newer state on the current delegate
+(freenet/river#253). The flow:
+
+1. On startup, `set_up_chat_delegate()` fires `fire_load_rooms_request()` for
+   the **current** delegate only. It does NOT fire the legacy probes.
+2. `LEGACY_DELEGATES` is generated at compile time from `legacy_delegates.toml`
+   by `ui/build.rs`.
+3. When the current delegate's `GetResponse` for `rooms_data` arrives:
+   - **Has authoritative data** (rooms or tombstones): call
+     `mark_legacy_migration_done()` (persists across sessions). Legacy probes
+     are never fired — current is the source of truth.
+   - **Empty or missing**: call `fire_legacy_migration_request()` to probe
+     each legacy key with `GetRequest` for `rooms_data`. Safe because current
+     has nothing to clobber.
+4. The response handler migrates room data + signing keys from each
+   responding legacy delegate to the current delegate.
+5. On a legacy delegate returning data, `mark_legacy_migration_done()` is
+   called after the post-merge save succeeds; on a legacy delegate returning
+   no data it is called immediately.
+
+**Trade-off**: a user with data in both current and legacy delegates will
+NOT have the legacy data merged. This is intentional — the alternative
+race destroys newer data, which is much worse than failing to recover
+older data the user has effectively abandoned.
 
 ## Migration Limitations
 

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -177,6 +177,64 @@ pub(crate) fn reset_ensure_subscription_dedup() {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Current delegate returned no `rooms_data` value at all — fire migration.
+    #[test]
+    fn decide_value_absent_fires_migration() {
+        assert_eq!(
+            decide_legacy_migration_action(false, false, false),
+            LegacyMigrationAction::FireMigration,
+        );
+    }
+
+    /// Current delegate returned `Some(serialized empty Rooms)` (placeholder
+    /// written by save_rooms_to_delegate before any room existed). This is
+    /// indistinguishable from "user has no data yet" — fire migration so users
+    /// with rooms only under a legacy delegate aren't stranded.
+    #[test]
+    fn decide_value_present_but_empty_fires_migration() {
+        assert_eq!(
+            decide_legacy_migration_action(true, false, false),
+            LegacyMigrationAction::FireMigration,
+        );
+    }
+
+    /// Current delegate has actual rooms — it is the source of truth.
+    /// Block legacy migration permanently to prevent the freenet/river#253
+    /// race where stale legacy data overwrites it.
+    #[test]
+    fn decide_has_rooms_marks_done() {
+        assert_eq!(
+            decide_legacy_migration_action(true, true, false),
+            LegacyMigrationAction::MarkDone,
+        );
+    }
+
+    /// Current delegate has only tombstones (user left all rooms). Still
+    /// authoritative state — the tombstones must be preserved, and a legacy
+    /// migration that re-introduces the abandoned rooms would defeat the
+    /// freenet/river#247 tombstone fix.
+    #[test]
+    fn decide_has_tombstones_only_marks_done() {
+        assert_eq!(
+            decide_legacy_migration_action(true, false, true),
+            LegacyMigrationAction::MarkDone,
+        );
+    }
+
+    /// Both rooms and tombstones present — definitely authoritative.
+    #[test]
+    fn decide_has_rooms_and_tombstones_marks_done() {
+        assert_eq!(
+            decide_legacy_migration_action(true, true, true),
+            LegacyMigrationAction::MarkDone,
+        );
+    }
+}
+
 /// Idempotent helper: ask the chat delegate to subscribe to a room
 /// contract, but only if we haven't already done so this session.
 ///
@@ -523,6 +581,47 @@ pub async fn send_delegate_request(
 // LEGACY DELEGATE MIGRATION IMPLEMENTATION
 // =============================================================================
 
+/// The action to take after the **current** delegate's `GetResponse` for
+/// `rooms_data` has been observed. See `decide_legacy_migration_action`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LegacyMigrationAction {
+    /// Current delegate has authoritative state (rooms or tombstones). Mark
+    /// legacy migration done so it never fires for this user.
+    MarkDone,
+    /// Current delegate is empty (no record, or a placeholder serialization
+    /// with no rooms and no tombstones). Fire the legacy probes — there is
+    /// nothing in current to clobber.
+    FireMigration,
+}
+
+/// Decide what to do with legacy migration based on the **current** delegate's
+/// `GetResponse` for `rooms_data`.
+///
+/// This encodes the gating invariant from freenet/river#253:
+/// - If the current delegate holds rooms or tombstones, it is the source of
+///   truth and legacy migration must be blocked permanently — a stale legacy
+///   snapshot would otherwise overwrite this newer state.
+/// - If the current delegate is empty (no record, or just a placeholder
+///   serialization with no rooms and no tombstones), legacy migration is
+///   safe to fire because there is nothing to clobber.
+///
+/// `current_has_rooms` is `true` if the current delegate returned at least
+/// one entry in `Rooms::map`. `current_has_tombstones` is `true` if at least
+/// one entry exists in `Rooms::removed_rooms`. `value_present` is `true` if
+/// the `GetResponse` carried `Some(_)` (regardless of whether the bytes
+/// deserialize to a non-empty `Rooms`).
+pub(crate) fn decide_legacy_migration_action(
+    value_present: bool,
+    current_has_rooms: bool,
+    current_has_tombstones: bool,
+) -> LegacyMigrationAction {
+    if value_present && (current_has_rooms || current_has_tombstones) {
+        LegacyMigrationAction::MarkDone
+    } else {
+        LegacyMigrationAction::FireMigration
+    }
+}
+
 /// localStorage key to track whether legacy migration has been attempted
 #[allow(dead_code)]
 const LEGACY_MIGRATION_FLAG: &str = "river_legacy_migration_done";
@@ -581,7 +680,7 @@ static LEGACY_MIGRATION_ATTEMPTED: AtomicBool = AtomicBool::new(false);
 /// may have data is unsafe because a legacy response can trigger a save that
 /// overwrites the current delegate's storage before its GET response arrives,
 /// destroying rooms the user created after the last legacy snapshot.
-pub async fn fire_legacy_migration_request() {
+pub(crate) async fn fire_legacy_migration_request() {
     // Check if migration has already been done (persistent across sessions)
     if is_legacy_migration_done() {
         info!("Legacy migration already done, skipping");

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -147,11 +147,13 @@ pub async fn set_up_chat_delegate() -> Result<(), String> {
             // response be handled by the response_handler through the message loop.
             //
             // The response handler will process GetResponse and populate ROOMS.
+            //
+            // Legacy migration is NOT fired here. It is gated on the current
+            // delegate's response: if the current delegate has data, migration is
+            // skipped (current is authoritative); if it is empty, migration is
+            // fired then. This prevents legacy responses from racing with the
+            // current delegate and clobbering newer state (freenet/river#253).
             fire_load_rooms_request().await;
-
-            // Also try to migrate from legacy delegate (fire and forget)
-            // TODO: Remove this after 2026-06-01
-            fire_legacy_migration_request().await;
 
             Ok(())
         }
@@ -573,7 +575,13 @@ static LEGACY_MIGRATION_ATTEMPTED: AtomicBool = AtomicBool::new(false);
 
 /// Fire requests to load rooms from all known legacy delegates (fire and forget).
 /// If any legacy delegate has room data, the response handler will migrate it.
-async fn fire_legacy_migration_request() {
+///
+/// **Must only be called once the current delegate has confirmed it has no
+/// rooms_data** (see freenet/river#253). Firing this while the current delegate
+/// may have data is unsafe because a legacy response can trigger a save that
+/// overwrites the current delegate's storage before its GET response arrives,
+/// destroying rooms the user created after the last legacy snapshot.
+pub async fn fire_legacy_migration_request() {
     // Check if migration has already been done (persistent across sessions)
     if is_legacy_migration_done() {
         info!("Legacy migration already done, skipping");

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -8,8 +8,8 @@ use super::error::SynchronizerError;
 use super::room_synchronizer::RoomSynchronizer;
 use crate::components::app::chat_delegate::{
     complete_pending_public_key_request, complete_pending_request, complete_pending_sign_request,
-    complete_pending_signing_key_request, is_legacy_delegate_key, mark_legacy_migration_done,
-    save_rooms_to_delegate, ROOMS_STORAGE_KEY,
+    complete_pending_signing_key_request, fire_legacy_migration_request, is_legacy_delegate_key,
+    mark_legacy_migration_done, save_rooms_to_delegate, ROOMS_STORAGE_KEY,
 };
 use crate::components::app::document_title::{mark_current_room_as_read, update_document_title};
 use crate::components::app::notifications::mark_initial_sync_complete;
@@ -244,6 +244,16 @@ impl ResponseHandler {
                                                         if is_legacy_delegate {
                                                             info!("Successfully loaded rooms from LEGACY delegate - migrating to new delegate");
                                                         } else {
+                                                            // Current delegate has valid rooms_data
+                                                            // — it is the source of truth. Block
+                                                            // legacy migration permanently (across
+                                                            // sessions) so a stale legacy snapshot
+                                                            // can never race with this state and
+                                                            // overwrite it (freenet/river#253).
+                                                            info!(
+                                                                "Current delegate has rooms_data — marking legacy migration done"
+                                                            );
+                                                            mark_legacy_migration_done();
                                                             info!("Successfully loaded rooms from delegate");
                                                         }
 
@@ -637,6 +647,17 @@ impl ResponseHandler {
                                                 if is_legacy_delegate {
                                                     info!("No rooms in legacy delegate - marking migration complete");
                                                     mark_legacy_migration_done();
+                                                } else {
+                                                    // Current delegate is empty. Now it is safe to
+                                                    // fire legacy migration — there is nothing in
+                                                    // current to clobber (freenet/river#253).
+                                                    info!(
+                                                        "Current delegate empty — firing legacy \
+                                                         migration"
+                                                    );
+                                                    crate::util::safe_spawn_local(async {
+                                                        fire_legacy_migration_request().await;
+                                                    });
                                                 }
                                             }
                                         } else {

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -8,8 +8,9 @@ use super::error::SynchronizerError;
 use super::room_synchronizer::RoomSynchronizer;
 use crate::components::app::chat_delegate::{
     complete_pending_public_key_request, complete_pending_request, complete_pending_sign_request,
-    complete_pending_signing_key_request, fire_legacy_migration_request, is_legacy_delegate_key,
-    mark_legacy_migration_done, save_rooms_to_delegate, ROOMS_STORAGE_KEY,
+    complete_pending_signing_key_request, decide_legacy_migration_action,
+    fire_legacy_migration_request, is_legacy_delegate_key, mark_legacy_migration_done,
+    save_rooms_to_delegate, LegacyMigrationAction, ROOMS_STORAGE_KEY,
 };
 use crate::components::app::document_title::{mark_current_room_as_read, update_document_title};
 use crate::components::app::notifications::mark_initial_sync_complete;
@@ -244,17 +245,34 @@ impl ResponseHandler {
                                                         if is_legacy_delegate {
                                                             info!("Successfully loaded rooms from LEGACY delegate - migrating to new delegate");
                                                         } else {
-                                                            // Current delegate has valid rooms_data
-                                                            // — it is the source of truth. Block
-                                                            // legacy migration permanently (across
-                                                            // sessions) so a stale legacy snapshot
-                                                            // can never race with this state and
-                                                            // overwrite it (freenet/river#253).
-                                                            info!(
-                                                                "Current delegate has rooms_data — marking legacy migration done"
-                                                            );
-                                                            mark_legacy_migration_done();
-                                                            info!("Successfully loaded rooms from delegate");
+                                                            // Gate legacy migration on whether
+                                                            // current holds authoritative state
+                                                            // (freenet/river#253). See
+                                                            // `decide_legacy_migration_action`
+                                                            // for the rules and rationale.
+                                                            match decide_legacy_migration_action(
+                                                                true,
+                                                                !loaded_rooms.map.is_empty(),
+                                                                !loaded_rooms
+                                                                    .removed_rooms
+                                                                    .is_empty(),
+                                                            ) {
+                                                                LegacyMigrationAction::MarkDone => {
+                                                                    info!(
+                                                                        "Current delegate has rooms_data — marking legacy migration done"
+                                                                    );
+                                                                    mark_legacy_migration_done();
+                                                                    info!("Successfully loaded rooms from delegate");
+                                                                }
+                                                                LegacyMigrationAction::FireMigration => {
+                                                                    info!(
+                                                                        "Current delegate has empty rooms_data — firing legacy migration"
+                                                                    );
+                                                                    crate::util::safe_spawn_local(async {
+                                                                        fire_legacy_migration_request().await;
+                                                                    });
+                                                                }
+                                                            }
                                                         }
 
                                                         // Tombstone filter for all downstream loops.
@@ -648,12 +666,19 @@ impl ResponseHandler {
                                                     info!("No rooms in legacy delegate - marking migration complete");
                                                     mark_legacy_migration_done();
                                                 } else {
-                                                    // Current delegate is empty. Now it is safe to
-                                                    // fire legacy migration — there is nothing in
-                                                    // current to clobber (freenet/river#253).
+                                                    // Current delegate has no `rooms_data` record
+                                                    // at all. Per `decide_legacy_migration_action`,
+                                                    // this is the FireMigration case — safe
+                                                    // because there is no current state to clobber
+                                                    // (freenet/river#253).
+                                                    debug_assert_eq!(
+                                                        decide_legacy_migration_action(
+                                                            false, false, false
+                                                        ),
+                                                        LegacyMigrationAction::FireMigration,
+                                                    );
                                                     info!(
-                                                        "Current delegate empty — firing legacy \
-                                                         migration"
+                                                        "Current delegate empty — firing legacy migration"
                                                     );
                                                     crate::util::safe_spawn_local(async {
                                                         fire_legacy_migration_request().await;


### PR DESCRIPTION
## Problem

A long-running River user reports newly-created rooms silently disappearing after page refresh (freenet/river#253). Root cause: a race between the current delegate's load-rooms response and the legacy migration probes.

\`set_up_chat_delegate()\` was firing both the current delegate's load-rooms request and the legacy migration probes concurrently at startup. Each legacy response that returned data triggered \`save_rooms_to_delegate()\`, writing whatever was currently in \`ROOMS\` to the **current** delegate's storage.

When a legacy response arrives before the current delegate's response, \`ROOMS\` still holds an empty or partial state, so the legacy-triggered save overwrites the current delegate with stale data. On next refresh, the current delegate returns the overwritten state and recently-created rooms are gone.

The user reports this happening repeatedly across refreshes, which is consistent with: the localStorage \"migration done\" flag only gets set after a successful save, so if save races and writes incomplete state, the flag may still be unset, and the migration re-runs each session.

## Approach

Gate legacy migration on the current delegate's response so it only fires when there is nothing to clobber:

- \`set_up_chat_delegate()\` no longer fires migration probes.
- When the current delegate returns rooms_data successfully, mark legacy migration done across sessions — current is the source of truth.
- When the current delegate returns no rooms_data, *then* fire the legacy migration probes. With current empty, no race possible.

Trade-off: a user with data in both current and legacy (e.g. an interrupted migration in the past) will not get the legacy data merged. But the alternative — the current behavior — actively destroys *newer* data, which is much worse. The legacy data path was always best-effort recovery from old WASM versions; the new state is what the user has been actively building.

## Testing

- \`cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync\` ✅
- \`cargo test -p river-core --test migration_test\` ✅ (4/4)
- \`cargo fmt --check\` ✅
- \`cargo clippy\` produces no new warnings (4 pre-existing warnings unchanged)

A deterministic unit test for this race is impractical: it requires WASM, WebSocket, Dioxus signals, and a specific async ordering. The fix is structural — legacy probes are gated behind a single response — so the proof is by inspection of the changed control flow.

Closes #253

[AI-assisted - Claude]