### PR TITLE
fix(dm): plain-language copy for thread modal footer

### DIFF
--- a/ui/src/components/direct_messages/dm_thread_modal.rs
+++ b/ui/src/components/direct_messages/dm_thread_modal.rs
@@ -1,5 +1,5 @@
 //! Per-pair DM thread modal: decrypts inbound DMs, composes outbound ones,
-//! and offers a "Purge thread" button that produces a fresh
+//! and offers a "Delete their messages" button that produces a fresh
 //! `AuthorizedRecipientPurges` envelope tombstoning every inbound DM in the
 //! current view.
 
@@ -524,13 +524,15 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                     }
                     div { class: "flex justify-between items-center pt-1",
                         span { class: "text-[10px] text-text-muted",
-                            "End-to-end encrypted to this member's room key. The contract enforces caps; the gateway can't read content."
+                            "Only "
+                            span { class: "text-accent", "{peer_label}" }
+                            " can read these messages."
                         }
                         button {
                             class: "text-xs text-text-muted hover:text-red-400 transition-colors",
                             onclick: purge_thread,
-                            title: "Tombstone every inbound DM in this thread on the network.",
-                            "Purge thread"
+                            title: "Removes messages they sent you from the network. Cannot be undone.",
+                            "Delete their messages"
                         }
                     }
                 }

--- a/ui/src/components/direct_messages/dm_thread_modal.rs
+++ b/ui/src/components/direct_messages/dm_thread_modal.rs
@@ -281,7 +281,7 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
         let existing = pair_message_count(&room_data.room_state.direct_messages, self_id, peer);
         if existing >= MAX_DM_MESSAGES_PER_PAIR {
             send_error.set(Some(format!(
-                    "Per-pair cap reached ({}/{}). Ask the recipient to purge older DMs in this thread before sending more.",
+                    "This thread is full ({}/{} messages). Ask them to delete some older messages first.",
                     existing, MAX_DM_MESSAGES_PER_PAIR
                 )));
             return;
@@ -350,17 +350,16 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                     }
                     ApplyOutcome::CapHit => {
                         send_error.set(Some(format!(
-                                "Per-pair cap reached ({}/{}) while sending. Ask the recipient to purge older DMs in this thread before sending more.",
+                                "This thread is full ({}/{} messages). Ask them to delete some older messages first.",
                                 MAX_DM_MESSAGES_PER_PAIR, MAX_DM_MESSAGES_PER_PAIR
                             )));
                     }
                     ApplyOutcome::RoomGone => {
-                        send_error.set(Some("Room is no longer loaded.".into()));
+                        send_error.set(Some("This room is no longer loaded.".into()));
                     }
                     ApplyOutcome::DeltaFailed => {
-                        send_error.set(Some(
-                            "Failed to add DM to local state (verify it via console).".into(),
-                        ));
+                        send_error
+                            .set(Some("Couldn't send this message. Please try again.".into()));
                     }
                 }
             });
@@ -394,7 +393,7 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                 .map(|m| m.purge_token())
                 .collect();
             if tokens.is_empty() {
-                send_error.set(Some("No inbound DMs to purge in this thread.".into()));
+                send_error.set(Some("No messages from them to delete.".into()));
                 return;
             }
 
@@ -410,7 +409,9 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                     Ok(e) => e,
                     Err(e) => {
                         warn!("advance_recipient_purges failed: {}", e);
-                        send_error.set(Some(format!("Purge build failed: {}", e)));
+                        send_error.set(Some(
+                            "Couldn't delete those messages. Please try again.".into(),
+                        ));
                         return;
                     }
                 };
@@ -441,7 +442,7 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                     mark_needs_sync(room);
                 } else {
                     send_error.set(Some(
-                        "Failed to apply purge envelope (verify it via console).".into(),
+                        "Couldn't delete those messages. Please try again.".into(),
                     ));
                 }
             });
@@ -524,14 +525,14 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                     }
                     div { class: "flex justify-between items-center pt-1",
                         span { class: "text-[10px] text-text-muted",
-                            "Only "
+                            "Only you and "
                             span { class: "text-accent", "{peer_label}" }
                             " can read these messages."
                         }
                         button {
                             class: "text-xs text-text-muted hover:text-red-400 transition-colors",
                             onclick: purge_thread,
-                            title: "Removes messages they sent you from the network. Cannot be undone.",
+                            title: "Removes messages they sent you from the network. Your own sent messages stay. Cannot be undone.",
                             "Delete their messages"
                         }
                     }

--- a/ui/src/components/direct_messages/dm_thread_modal.rs
+++ b/ui/src/components/direct_messages/dm_thread_modal.rs
@@ -281,7 +281,7 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
         let existing = pair_message_count(&room_data.room_state.direct_messages, self_id, peer);
         if existing >= MAX_DM_MESSAGES_PER_PAIR {
             send_error.set(Some(format!(
-                    "This thread is full ({}/{} messages). Ask them to delete some older messages first.",
+                    "This thread is full ({}/{} messages). Ask them to delete some of the older messages you've sent.",
                     existing, MAX_DM_MESSAGES_PER_PAIR
                 )));
             return;
@@ -350,7 +350,7 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                     }
                     ApplyOutcome::CapHit => {
                         send_error.set(Some(format!(
-                                "This thread is full ({}/{} messages). Ask them to delete some older messages first.",
+                                "This thread is full ({}/{} messages). Ask them to delete some of the older messages you've sent.",
                                 MAX_DM_MESSAGES_PER_PAIR, MAX_DM_MESSAGES_PER_PAIR
                             )));
                     }
@@ -358,8 +358,14 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                         send_error.set(Some("This room is no longer loaded.".into()));
                     }
                     ApplyOutcome::DeltaFailed => {
-                        send_error
-                            .set(Some("Couldn't send this message. Please try again.".into()));
+                        // No "please try again" — `apply_delta` failures
+                        // are deterministic (signature / membership /
+                        // tombstone / cap), so retrying byte-identical
+                        // input gives the same result. See the
+                        // `warn!`/`error!` log for the diagnostic.
+                        send_error.set(Some(
+                            "Couldn't send this message — something went wrong.".into(),
+                        ));
                     }
                 }
             });
@@ -410,7 +416,7 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                     Err(e) => {
                         warn!("advance_recipient_purges failed: {}", e);
                         send_error.set(Some(
-                            "Couldn't delete those messages. Please try again.".into(),
+                            "Couldn't delete those messages — something went wrong.".into(),
                         ));
                         return;
                     }
@@ -442,7 +448,7 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                     mark_needs_sync(room);
                 } else {
                     send_error.set(Some(
-                        "Couldn't delete those messages. Please try again.".into(),
+                        "Couldn't delete those messages — something went wrong.".into(),
                     ));
                 }
             });
@@ -524,6 +530,14 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                         }
                     }
                     div { class: "flex justify-between items-center pt-1",
+                        // The "you" half of the disclaimer is backed by
+                        // the OUTBOUND_DMS local plaintext cache (#256).
+                        // On-wire encryption is to `{peer}` only —
+                        // the sender cannot decrypt the network copy.
+                        // If you delete or break that cache, this
+                        // disclaimer becomes inaccurate ("you" can no
+                        // longer read your own outbound bubbles) and
+                        // should be revisited.
                         span { class: "text-[10px] text-text-muted",
                             "Only you and "
                             span { class: "text-accent", "{peer_label}" }


### PR DESCRIPTION
## Problem

Two strings in the DM thread modal used developer jargon that users couldn't reasonably parse:

* **"Purge thread"** — "purge" is contract terminology, and the button doesn't actually delete the whole thread: it only removes the inbound half (messages the peer sent you), because that's the only half a recipient is allowed to tombstone.
* **"End-to-end encrypted to this member's room key. The contract enforces caps; the gateway can't read content."** — "caps" was shorthand for `MAX_DM_MESSAGES_PER_PAIR` (a 100-msg internal cap that isn't a security property anyway). "Gateway" was just wrong: HTTP gateways serve the web app, but the message itself travels Freenet's peer-to-peer mesh. The relevant fact is "only the recipient can decrypt this."

## Approach

Replace both strings with concise, jargon-free copy:

| Where | Before | After |
|-------|--------|-------|
| Button label | `Purge thread` | `Delete their messages` |
| Button tooltip | `Tombstone every inbound DM in this thread on the network.` | `Removes messages they sent you from the network. Cannot be undone.` |
| Footer disclaimer | `End-to-end encrypted to this member's room key. The contract enforces caps; the gateway can't read content.` | `Only {peer} can read these messages.` |

The button label now accurately reflects the asymmetric scope (only inbound is purgeable) without claiming the action is local-only; the tooltip handles the "and it's network-wide / irreversible" qualifier. The disclaimer drops the cap mention (an internal limit, not a security property) and uses the peer's nickname so the assertion lands concretely.

Also fixed the file-level rustdoc to match the new button text.

## Testing

- [x] `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync` — clean
- [ ] Manual: open a DM thread, confirm new strings render with the peer's nickname interpolated; click "Delete their messages" and confirm the existing purge flow still works

UI-only change; no contract / delegate / wire format touched, no migration required.

[AI-assisted - Claude]