### PR TITLE
fix(ui): repopulate room_data.secrets on every state ingestion path (#251)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,6 +338,19 @@ design.
     duplicate-version dedup in `RoomSecretsV1::apply_delta` (`secret.rs:140-145`).
   - The previous "weekly rotation" trigger was removed — it only fired while
     the UI was open, which defeated the point of a scheduled rotation.
+- **In-memory secret repopulation** (#251): `room_data.secrets:
+  HashMap<u32, [u8; 32]>` is `#[serde(skip)]` and must be rebuilt from
+  `room_state.secrets.encrypted_secrets` after EVERY network state
+  ingestion — initial GET, refresh/suspension GET, delegate-load merge,
+  `apply_delta`, and full-state `update_room_state`. The helper
+  `RoomData::repopulate_secrets_from_state` is the single source of
+  truth; any new ingestion path MUST call it (the
+  `repopulate_secrets_call_sites_pinned` test pins the existing call
+  sites by source-grep so dropping one fails CI). Skipping the helper
+  causes the bug from #251: newly-joined private-room members render
+  `[Encrypted message - secret vN not available]` until they
+  hard-refresh, because the back-filled blob arrives in a *subsequent*
+  state update that the in-memory map never sees.
 - Key files:
   - `common/src/room_state/privacy.rs`, `secret.rs`, `configuration.rs`
   - `common/src/key_derivation.rs`

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -19,7 +19,7 @@ use crate::components::app::sync_info::{RoomSyncStatus, SYNC_INFO};
 use crate::components::app::{CURRENT_ROOM, ROOMS};
 use crate::room_data::CurrentRoom;
 use crate::room_data::Rooms;
-use crate::util::ecies::{decrypt_secret_from_member_blob, decrypt_with_symmetric_key};
+use crate::util::ecies::decrypt_with_symmetric_key;
 use crate::util::owner_vk_to_contract_key;
 use ciborium::de::from_reader;
 use dioxus::logger::tracing::{error, info, warn};
@@ -37,7 +37,6 @@ use std::collections::HashMap;
 pub use subscribe_response::handle_subscribe_response;
 pub use update_notification::handle_update_notification;
 pub use update_response::handle_update_response;
-use x25519_dalek::PublicKey as X25519PublicKey;
 
 /// Handles responses from the Freenet API
 pub struct ResponseHandler {
@@ -379,51 +378,13 @@ impl ResponseHandler {
 
                                                                 // Re-decrypt ALL secret versions for each room (secrets are #[serde(skip)])
                                                                 for room_data in current_rooms.map.values_mut() {
-                                                                    if room_data.room_state.configuration.configuration.privacy_mode == PrivacyMode::Private {
-                                                                        let member_id = MemberId::from(&room_data.self_sk.verifying_key());
-                                                                        let current_version = room_data.room_state.secrets.current_version;
-                                                                        let self_sk = room_data.self_sk.clone();
-
-                                                                        // Extract encrypted secret data to avoid borrow issues
-                                                                        let member_secrets: Vec<_> = room_data
-                                                                            .room_state
-                                                                            .secrets
-                                                                            .encrypted_secrets
-                                                                            .iter()
-                                                                            .filter(|s| s.secret.member_id == member_id)
-                                                                            .map(|s| (
-                                                                                s.secret.secret_version,
-                                                                                s.secret.ciphertext.clone(),
-                                                                                s.secret.nonce,
-                                                                                s.secret.sender_ephemeral_public_key,
-                                                                            ))
-                                                                            .collect();
-
-                                                                        if member_secrets.is_empty() {
-                                                                            warn!("No encrypted secrets found for member {:?}", member_id);
-                                                                        } else {
-                                                                            info!("Found {} encrypted secrets for member {:?}", member_secrets.len(), member_id);
-                                                                            for (version, ciphertext, nonce, ephemeral_key_bytes) in member_secrets {
-                                                                                let ephemeral_key = X25519PublicKey::from(ephemeral_key_bytes);
-                                                                                match decrypt_secret_from_member_blob(
-                                                                                    &ciphertext,
-                                                                                    &nonce,
-                                                                                    &ephemeral_key,
-                                                                                    &self_sk,
-                                                                                ) {
-                                                                                    Ok(decrypted_secret) => {
-                                                                                        info!("Re-decrypted room secret version {} for member {:?}", version, member_id);
-                                                                                        room_data.set_secret(decrypted_secret, version);
-                                                                                    }
-                                                                                    Err(e) => {
-                                                                                        warn!("Failed to re-decrypt room secret version {}: {}", version, e);
-                                                                                    }
-                                                                                }
-                                                                            }
-                                                                        }
-
-                                                                        // Ensure current_secret_version is set to the actual current version
-                                                                        room_data.current_secret_version = Some(current_version);
+                                                                    let decrypted = room_data.repopulate_secrets_from_state();
+                                                                    if room_data.is_private() {
+                                                                        info!(
+                                                                            "LoadRooms merge: decrypted {} room secret(s) for {:?}",
+                                                                            decrypted,
+                                                                            MemberId::from(&room_data.self_sk.verifying_key())
+                                                                        );
                                                                     }
                                                                 }
 

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -510,6 +510,15 @@ pub async fn handle_get_response(
                             );
                             room_data.room_state = retrieved_state;
                             room_data.capture_self_membership_data(&params);
+                            // #251: a refresh/suspension GET on an imported room
+                            // may be the first state arrival carrying our
+                            // encrypted_secrets back-fill. The wholesale state
+                            // replacement above wipes `secrets` (it's
+                            // #[serde(skip)], but room_state replacement
+                            // shouldn't leave the in-memory map referring to a
+                            // previous state's versions). Repopulate from the
+                            // freshly-installed state.
+                            let _ = room_data.repopulate_secrets_from_state();
                         } else {
                             let current_state = room_data.room_state.clone();
                             match room_data
@@ -522,6 +531,13 @@ pub async fn handle_get_response(
                                         MemberId::from(owner_vk)
                                     );
                                     room_data.capture_self_membership_data(&params);
+                                    // #251: the refresh/suspension GET may be
+                                    // the first response carrying a
+                                    // newly-back-filled or newly-rotated
+                                    // encrypted_secrets blob for us. Without
+                                    // this, the in-memory `secrets` map stays
+                                    // stale until the next subscription update.
+                                    let _ = room_data.repopulate_secrets_from_state();
                                 }
                                 Err(e) => {
                                     error!(

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -512,12 +512,15 @@ pub async fn handle_get_response(
                             room_data.capture_self_membership_data(&params);
                             // #251: a refresh/suspension GET on an imported room
                             // may be the first state arrival carrying our
-                            // encrypted_secrets back-fill. The wholesale state
-                            // replacement above wipes `secrets` (it's
-                            // #[serde(skip)], but room_state replacement
-                            // shouldn't leave the in-memory map referring to a
-                            // previous state's versions). Repopulate from the
-                            // freshly-installed state.
+                            // encrypted_secrets back-fill. The wholesale
+                            // `room_state = retrieved_state` above does NOT
+                            // touch the in-memory `secrets` HashMap (that's a
+                            // separate #[serde(skip)] field on `RoomData`), so
+                            // any stale entries from a previous state would
+                            // linger; repopulate decrypts whatever versions
+                            // the new state carries for us, and the contains-
+                            // key guard inside the helper makes lingering
+                            // entries from a prior state harmless.
                             let _ = room_data.repopulate_secrets_from_state();
                         } else {
                             let current_state = room_data.room_state.clone();

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -6,7 +6,7 @@ use crate::components::app::{CURRENT_ROOM, PENDING_INVITES, ROOMS, WEB_API};
 use crate::constants::ROOM_CONTRACT_WASM;
 use crate::invites::PendingRoomStatus;
 use crate::room_data::RoomData;
-use crate::util::ecies::{decrypt_secret_from_member_blob, decrypt_with_symmetric_key};
+use crate::util::ecies::decrypt_with_symmetric_key;
 use crate::util::{
     from_cbor_slice, get_current_system_time, owner_vk_to_contract_key, to_cbor_vec,
 };
@@ -25,7 +25,6 @@ use river_core::room_state::privacy::{PrivacyMode, SealedBytes};
 use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1};
 use std::collections::HashMap;
 use std::sync::Arc;
-use x25519_dalek::PublicKey as X25519PublicKey;
 
 pub async fn handle_get_response(
     _room_synchronizer: &mut RoomSynchronizer,
@@ -176,50 +175,12 @@ pub async fn handle_get_response(
                 }
 
                 // Decrypt ALL room secret versions if this is a private room
-                if room_data.room_state.configuration.configuration.privacy_mode == PrivacyMode::Private {
-                    let current_version = room_data.room_state.secrets.current_version;
-
-                    // Extract encrypted secret data to avoid borrow issues
-                    let member_secrets: Vec<_> = room_data
-                        .room_state
-                        .secrets
-                        .encrypted_secrets
-                        .iter()
-                        .filter(|s| s.secret.member_id == member_id)
-                        .map(|s| (
-                            s.secret.secret_version,
-                            s.secret.ciphertext.clone(),
-                            s.secret.nonce,
-                            s.secret.sender_ephemeral_public_key,
-                        ))
-                        .collect();
-
-                    if member_secrets.is_empty() {
-                        warn!("No encrypted secrets found for member {:?}", member_id);
-                    } else {
-                        info!("Found {} encrypted secrets for member {:?}", member_secrets.len(), member_id);
-                        for (version, ciphertext, nonce, ephemeral_key_bytes) in member_secrets {
-                            let ephemeral_key = X25519PublicKey::from(ephemeral_key_bytes);
-
-                            match decrypt_secret_from_member_blob(
-                                &ciphertext,
-                                &nonce,
-                                &ephemeral_key,
-                                &self_sk,
-                            ) {
-                                Ok(decrypted_secret) => {
-                                    info!("Successfully decrypted room secret version {} for member {:?}", version, member_id);
-                                    room_data.set_secret(decrypted_secret, version);
-                                }
-                                Err(e) => {
-                                    warn!("Failed to decrypt room secret version {}: {}", version, e);
-                                }
-                            }
-                        }
-                    }
-
-                    // Ensure current_secret_version is set to the actual current version
-                    room_data.current_secret_version = Some(current_version);
+                let decrypted = room_data.repopulate_secrets_from_state();
+                if room_data.is_private() {
+                    info!(
+                        "GET response: decrypted {} room secret(s) for member {:?}",
+                        decrypted, member_id
+                    );
                 }
 
                 // Set the member's nickname in member_info regardless of whether they were already in the room

--- a/ui/src/components/app/freenet_api/room_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/room_synchronizer.rs
@@ -29,7 +29,7 @@ use freenet_stdlib::{
 };
 use river_core::room_state::member::MemberId;
 use river_core::room_state::member_info::MemberInfoV1;
-use river_core::room_state::message::{MessageId, RoomMessageBody};
+use river_core::room_state::message::{AuthorizedMessageV1, MessageId, RoomMessageBody};
 use river_core::room_state::privacy::PrivacyMode;
 use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1, ChatRoomStateV1Delta};
 use std::collections::HashMap;
@@ -105,9 +105,14 @@ impl RoomSynchronizer {
                           info.member_info.preferred_nickname);
                 }
 
-                // Capture data for notifications before we modify room_data
+                // Capture data for notifications before we modify room_data.
+                // self_member_id is independent of room_state so it's fine to
+                // snapshot pre-merge. room_secrets is captured AFTER the merge
+                // + repopulate below — see #251 / Codex P3: a delta carrying a
+                // back-filled secret AND new private messages would otherwise
+                // leave the notification path using the pre-merge (empty) map
+                // and rendering encrypted placeholders in the preview.
                 let self_member_id: MemberId = room_data.self_sk.verifying_key().into();
-                let room_secrets = room_data.secrets.clone();
 
                 // Clone the state to avoid borrowing issues
                 let state_clone = room_data.room_state.clone();
@@ -193,6 +198,11 @@ impl RoomSynchronizer {
                             record_receive_times(&msg_ids);
 
                             let updated_member_info = room_data.room_state.member_info.clone();
+                            // Capture secrets AFTER repopulate so the
+                            // notification preview can decrypt private messages
+                            // encrypted at a version that was back-filled in
+                            // this same delta. See #251 / Codex P3.
+                            let room_secrets = room_data.secrets.clone();
                             pending_notification = Some((messages, self_member_id, updated_member_info, room_secrets));
                         }
 
@@ -819,8 +829,13 @@ impl RoomSynchronizer {
 
     /// Inner implementation of update_room_state, runs in a clean execution context on WASM.
     fn update_room_state_inner(room_owner_vk: VerifyingKey, state: ChatRoomStateV1) {
-        // Capture data needed for notifications BEFORE the mutable borrow
-        let (old_message_ids, self_member_id, member_info_clone, room_secrets) = {
+        // Capture data needed for notifications BEFORE the mutable borrow.
+        // room_secrets is NOT captured here — see #251 / Codex P3: a state
+        // update may carry a back-filled secret AND new private messages in
+        // the same payload; the pre-merge map would be stale by the time we
+        // try to decrypt the new messages for the notification preview.
+        // It's re-captured post-merge + post-repopulate inside `with_mut`.
+        let (old_message_ids, self_member_id, member_info_clone) = {
             let Ok(rooms) = ROOMS.try_read() else {
                 warn!("update_room_state: ROOMS is currently borrowed, skipping update");
                 return;
@@ -840,14 +855,13 @@ impl RoomSynchronizer {
                 );
                 let self_id = MemberId::from(&room_data.self_sk.verifying_key());
                 let member_info = room_data.room_state.member_info.clone();
-                let secrets = room_data.secrets.clone();
-                (Some(old_ids), Some(self_id), Some(member_info), secrets)
+                (Some(old_ids), Some(self_id), Some(member_info))
             } else {
                 debug!(
                     "update_room_state: Room {:?} not found in ROOMS when capturing old IDs",
                     MemberId::from(room_owner_vk)
                 );
-                (None, None, None, HashMap::new())
+                (None, None, None)
             }
         };
 
@@ -858,8 +872,13 @@ impl RoomSynchronizer {
             MemberId::from(room_owner_vk)
         );
 
-        // Will be populated inside with_mut if new messages are detected
-        let mut pending_notification: Option<(Vec<_>, MemberId)> = None;
+        // Will be populated inside with_mut if new messages are detected.
+        // Tuple: (new_messages, self_member_id, room_secrets_post_repopulate).
+        // room_secrets travels with the notification so the preview can
+        // decrypt messages encrypted at a version back-filled in this same
+        // update. See #251 / Codex P3.
+        type PendingNotification = (Vec<AuthorizedMessageV1>, MemberId, HashMap<u32, [u8; 32]>);
+        let mut pending_notification: Option<PendingNotification> = None;
         // Updated member_info captured after state merge (so new sender nicknames are included)
         let mut updated_member_info: Option<MemberInfoV1> = None;
         let room_owner_copy = room_owner_vk;
@@ -1015,9 +1034,14 @@ impl RoomSynchronizer {
                                 }
 
                                 // Store for notification after with_mut completes
-                                // Capture member_info from the UPDATED state so new sender nicknames are included
+                                // Capture member_info from the UPDATED state so new sender nicknames are included.
+                                // Capture room_secrets AFTER the merge + repopulate
+                                // above so the notification preview can decrypt
+                                // messages whose secret was back-filled in this
+                                // update. See #251 / Codex P3.
                                 updated_member_info = Some(room_data.room_state.member_info.clone());
-                                pending_notification = Some((new_messages, self_id));
+                                let room_secrets = room_data.secrets.clone();
+                                pending_notification = Some((new_messages, self_id, room_secrets));
                             } else {
                                 info!(
                                     "No new messages detected for room {:?} (old_ids: {}, post-merge: {})",
@@ -1058,8 +1082,10 @@ impl RoomSynchronizer {
         update_document_title();
 
         // Now safe to call notify_new_messages (it calls ROOMS.read() internally)
-        // Use updated_member_info (captured after state merge) so new sender nicknames are included
-        if let (Some((new_messages, self_id)), Some(member_info)) = (
+        // Use updated_member_info (captured after state merge) so new sender nicknames are included.
+        // room_secrets travels in `pending_notification` so it reflects the
+        // post-repopulate state (see #251 / Codex P3).
+        if let (Some((new_messages, self_id, room_secrets)), Some(member_info)) = (
             pending_notification,
             updated_member_info.or(member_info_clone),
         ) {

--- a/ui/src/components/app/freenet_api/room_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/room_synchronizer.rs
@@ -122,6 +122,20 @@ impl RoomSynchronizer {
                         let is_private = room_data.room_state.configuration.configuration.privacy_mode
                             == PrivacyMode::Private;
                         if is_private {
+                            // #251: bring `room_data.secrets` up to date with any
+                            // encrypted blobs that the delta carried in for us
+                            // (e.g. the delegate's PR #245 back-fill on join, or
+                            // a rotation). Must run BEFORE the action_state
+                            // rebuild below, which reads `get_secret_for_version`.
+                            let new_secrets = room_data.repopulate_secrets_from_state();
+                            if new_secrets > 0 {
+                                debug!(
+                                    "apply_delta: decrypted {} new room secret(s) for {:?}",
+                                    new_secrets,
+                                    MemberId::from(owner_vk)
+                                );
+                            }
+
                             // Decrypt all private action messages using version-aware lookup
                             let decrypted_actions: HashMap<MessageId, Vec<u8>> = room_data
                                 .room_state
@@ -892,6 +906,21 @@ impl RoomSynchronizer {
                         let is_private = room_data.room_state.configuration.configuration.privacy_mode
                             == PrivacyMode::Private;
                         if is_private {
+                            // #251: bring `room_data.secrets` up to date with any
+                            // encrypted blobs that this state update carried in
+                            // for us (e.g. the delegate's PR #245 back-fill on
+                            // join, or a rotation). Must run BEFORE the
+                            // action_state rebuild below, which reads
+                            // `get_secret_for_version`.
+                            let new_secrets = room_data.repopulate_secrets_from_state();
+                            if new_secrets > 0 {
+                                debug!(
+                                    "update_room_state: decrypted {} new room secret(s) for {:?}",
+                                    new_secrets,
+                                    MemberId::from(room_owner_vk)
+                                );
+                            }
+
                             // Decrypt all private action messages using version-aware lookup
                             let decrypted_actions: HashMap<MessageId, Vec<u8>> = room_data
                                 .room_state

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -234,10 +234,20 @@ impl RoomData {
 
         // Align `current_secret_version` with the contract's notion of
         // current, preserving the existing get_response / load-rooms
-        // behaviour. `set_secret` only ever advances this pointer; the
+        // behaviour. `set_secret` only ever advances the pointer; this
         // explicit assignment also covers the case where the blob for
-        // `current_version` hasn't arrived yet (we'll fall back to None
-        // in `get_secret()` until it does).
+        // `current_version` hasn't arrived yet (we'll fall back to
+        // `None` in `get_secret()` until it does, which makes the send
+        // path no-op rather than encrypt with a stale key).
+        //
+        // The assignment is unconditional and CAN move the pointer
+        // backwards in the pathological case where local state holds a
+        // newer decrypted version than the post-merge contract state.
+        // This relies on the `RoomSecretsV1` invariant
+        // (`common/src/room_state/secret.rs:166-174,192-213`) that
+        // `current_version == max(versions)` and is monotonically
+        // non-decreasing under merge — so the merge that immediately
+        // precedes this call cannot move `current_version` backwards.
         let current_version = self.room_state.secrets.current_version;
         self.current_secret_version = Some(current_version);
 
@@ -2034,6 +2044,50 @@ mod tests {
         let decrypted = room.repopulate_secrets_from_state();
         assert_eq!(decrypted, 0);
         assert!(room.secrets.is_empty());
+    }
+
+    /// Source-grep pin test: every state-ingestion path in the
+    /// synchronizer AND response-handler must call
+    /// `repopulate_secrets_from_state`. The helper is the load-bearing
+    /// fix for #251 — if a future refactor drops the call from any
+    /// path, the regression returns silently (the unit tests above only
+    /// verify the helper's contract, not that its call sites still
+    /// exist). See the bug-prevention-patterns guidance on source-grep
+    /// pins in `~/code/freenet/.claude/rules/bug-prevention-patterns.md`.
+    ///
+    /// If you add a NEW state-ingestion path, update this test's
+    /// expected count.
+    #[test]
+    fn repopulate_secrets_call_sites_pinned() {
+        // (path-for-error-messages, expected_call_count, file_contents)
+        let sites: &[(&str, usize, &str)] = &[
+            (
+                "ui/src/components/app/freenet_api/room_synchronizer.rs",
+                2, // apply_delta_inner + update_room_state_inner
+                include_str!("components/app/freenet_api/room_synchronizer.rs"),
+            ),
+            (
+                "ui/src/components/app/freenet_api/response_handler.rs",
+                1, // handle_load_rooms_response
+                include_str!("components/app/freenet_api/response_handler.rs"),
+            ),
+            (
+                "ui/src/components/app/freenet_api/response_handler/get_response.rs",
+                3, // pending-invite branch + existing-room (replace) + existing-room (merge)
+                include_str!("components/app/freenet_api/response_handler/get_response.rs"),
+            ),
+        ];
+
+        for (path, expected, contents) in sites {
+            let actual = contents.matches("repopulate_secrets_from_state(").count();
+            assert_eq!(
+                actual, *expected,
+                "expected {} call(s) to `repopulate_secrets_from_state` in {}, found {}. \
+                 Removing this call regresses #251 — see RoomData::repopulate_secrets_from_state \
+                 doc-comment.",
+                expected, path, actual
+            );
+        }
     }
 
     /// Helper must be a no-op on public rooms — there are no secrets to

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -2055,6 +2055,14 @@ mod tests {
     /// exist). See the bug-prevention-patterns guidance on source-grep
     /// pins in `~/code/freenet/.claude/rules/bug-prevention-patterns.md`.
     ///
+    /// The match is a literal substring (`"repopulate_secrets_from_state("`)
+    /// rather than a regex, so a comment elsewhere in the file that
+    /// merely mentions the function name will inflate the count and
+    /// fail the assertion — that's a deliberate fail-closed posture.
+    /// If you legitimately want to reference the function in prose,
+    /// avoid the trailing `(` (e.g. write
+    /// "see `repopulate_secrets_from_state`" without parens).
+    ///
     /// If you add a NEW state-ingestion path, update this test's
     /// expected count.
     #[test]

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use crate::util::ecies::encrypt_secret_for_member;
+use crate::util::ecies::{decrypt_secret_from_member_blob_raw, encrypt_secret_for_member};
 use crate::util::get_current_system_time;
 use crate::{constants::ROOM_CONTRACT_WASM, util::to_cbor_vec};
 use ed25519_dalek::{SigningKey, VerifyingKey};
@@ -156,6 +156,92 @@ impl RoomData {
             self.current_secret_version = Some(version);
             self.last_secret_rotation = Some(get_current_system_time());
         }
+    }
+
+    /// Decrypt any `EncryptedSecretForMemberV1` blobs in the merged room
+    /// state into the in-memory [`Self::secrets`] map for every version
+    /// not already present, and align [`Self::current_secret_version`]
+    /// with the contract's `current_version`.
+    ///
+    /// No-op on public rooms.
+    ///
+    /// Must be called on EVERY private-room state ingestion path —
+    /// initial GET, full-state update, delta apply, delegate-load merge —
+    /// because `secrets` is `#[serde(skip)]` (rebuilt from encrypted
+    /// blobs each time) AND because the chat delegate's PR #245
+    /// back-fill of `encrypted_secrets` for a newly-joined member is
+    /// asynchronous from the initial subscribe. Before #251 only the
+    /// initial-load paths ran this loop, so the post-subscribe update
+    /// carrying the back-filled blob never repopulated the map and the
+    /// new member rendered every message as
+    /// `[Encrypted message - secret vN not available]` until they hard-
+    /// refreshed.
+    ///
+    /// Returns the number of new versions decrypted (for logging).
+    pub fn repopulate_secrets_from_state(&mut self) -> usize {
+        use dioxus::logger::tracing::warn;
+
+        if !self.is_private() {
+            return 0;
+        }
+
+        // (secret_version, ciphertext, nonce, sender_ephemeral_x25519_pk_bytes)
+        type PendingBlob = (u32, Vec<u8>, [u8; 12], [u8; 32]);
+
+        let member_id = MemberId::from(&self.self_sk.verifying_key());
+
+        // Snapshot the encrypted blobs we don't yet have plaintext for,
+        // so we can release the borrow on `room_state` before calling
+        // `set_secret` (which holds `&mut self`).
+        let pending: Vec<PendingBlob> = self
+            .room_state
+            .secrets
+            .encrypted_secrets
+            .iter()
+            .filter(|s| s.secret.member_id == member_id)
+            .filter(|s| !self.secrets.contains_key(&s.secret.secret_version))
+            .map(|s| {
+                (
+                    s.secret.secret_version,
+                    s.secret.ciphertext.clone(),
+                    s.secret.nonce,
+                    s.secret.sender_ephemeral_public_key,
+                )
+            })
+            .collect();
+
+        let self_sk = self.self_sk.clone();
+        let mut decrypted_count = 0usize;
+        for (version, ciphertext, nonce, ephemeral_key_bytes) in pending {
+            match decrypt_secret_from_member_blob_raw(
+                &ciphertext,
+                &nonce,
+                &ephemeral_key_bytes,
+                &self_sk,
+            ) {
+                Ok(secret) => {
+                    self.set_secret(secret, version);
+                    decrypted_count += 1;
+                }
+                Err(e) => {
+                    warn!(
+                        "repopulate_secrets_from_state: failed to decrypt v{} for member {:?}: {}",
+                        version, member_id, e
+                    );
+                }
+            }
+        }
+
+        // Align `current_secret_version` with the contract's notion of
+        // current, preserving the existing get_response / load-rooms
+        // behaviour. `set_secret` only ever advances this pointer; the
+        // explicit assignment also covers the case where the blob for
+        // `current_version` hasn't arrived yet (we'll fall back to None
+        // in `get_secret()` until it does).
+        let current_version = self.room_state.secrets.current_version;
+        self.current_secret_version = Some(current_version);
+
+        decrypted_count
     }
 
     /// Check if the secret needs rotation (weekly rotation or never rotated)
@@ -1758,5 +1844,238 @@ mod tests {
             res.unwrap_err().contains("u32::MAX"),
             "rotation must refuse to wrap version"
         );
+    }
+
+    // ====================================================================
+    // #251: repopulate_secrets_from_state must run on every network state
+    // ingestion path, not just initial GET / load-rooms. Before #251 only
+    // the initial-load paths repopulated `room_data.secrets`, so the
+    // delegate's PR #245 back-fill of `encrypted_secrets` (which arrives
+    // in a subsequent state update) never made it into the in-memory map
+    // and the new member rendered everything as `[Encrypted message -
+    // secret vN not available]` until they hard-refreshed.
+    // ====================================================================
+
+    /// Fixture: build a private room state from the INVITEE perspective —
+    /// owner config, invitee is a member, version record exists for `v0`,
+    /// but `encrypted_secrets` is empty (the bug's initial GET case).
+    /// The local `secrets` HashMap is also empty.
+    fn make_private_invitee_room(
+        owner_sk: &SigningKey,
+        invitee_sk: &SigningKey,
+    ) -> ([u8; 32], RoomData) {
+        let owner_vk = owner_sk.verifying_key();
+        let invitee_vk = invitee_sk.verifying_key();
+        let owner_id: MemberId = owner_vk.into();
+
+        let mut config = Configuration {
+            owner_member_id: owner_id,
+            privacy_mode: PrivacyMode::Private,
+            ..Configuration::default()
+        };
+        config.configuration_version = 1;
+
+        let mut room_state = ChatRoomStateV1 {
+            configuration: AuthorizedConfigurationV1::new(config, owner_sk),
+            ..Default::default()
+        };
+
+        let member = Member {
+            owner_member_id: owner_id,
+            invited_by: owner_id,
+            member_vk: invitee_vk,
+        };
+        room_state
+            .members
+            .members
+            .push(AuthorizedMember::new(member, owner_sk));
+
+        let v0_secret =
+            river_core::key_derivation::derive_room_secret(&owner_sk.to_bytes(), &owner_vk, 0);
+        let v0_record = SecretVersionRecordV1 {
+            version: 0,
+            cipher_spec: RoomCipherSpec::Aes256Gcm,
+            created_at: get_current_system_time(),
+        };
+        room_state
+            .secrets
+            .versions
+            .push(AuthorizedSecretVersionRecord::new(v0_record, owner_sk));
+        room_state.secrets.current_version = 0;
+        // Deliberately leave encrypted_secrets empty — this is the
+        // post-subscribe / pre-back-fill state.
+
+        let params = ChatRoomParametersV1 { owner: owner_vk };
+        let params_bytes = to_cbor_vec(&params);
+        let contract_key = ContractKey::from_params_and_code(
+            Parameters::from(params_bytes),
+            &ContractCode::from(ROOM_CONTRACT_WASM),
+        );
+
+        let room = RoomData {
+            owner_vk,
+            room_state,
+            self_sk: invitee_sk.clone(),
+            contract_key,
+            last_read_message_id: None,
+            secrets: HashMap::new(),
+            current_secret_version: None,
+            last_secret_rotation: None,
+            key_migrated_to_delegate: false,
+            self_authorized_member: None,
+            invite_chain: vec![],
+            self_member_info: None,
+            previous_contract_key: None,
+        };
+
+        (v0_secret, room)
+    }
+
+    /// Push an encrypted-secret blob for `recipient_vk` at `version` into
+    /// the room state. Models what the chat delegate's PR #245 back-fill
+    /// does when a new member joins.
+    fn append_encrypted_secret_for(
+        room_state: &mut ChatRoomStateV1,
+        owner_sk: &SigningKey,
+        recipient_vk: &VerifyingKey,
+        secret: &[u8; 32],
+        version: u32,
+    ) {
+        let (ciphertext, nonce, ephemeral_pk) = encrypt_secret_for_member(secret, recipient_vk);
+        let blob = EncryptedSecretForMemberV1 {
+            member_id: MemberId::from(recipient_vk),
+            secret_version: version,
+            ciphertext,
+            nonce,
+            sender_ephemeral_public_key: ephemeral_pk.to_bytes(),
+            provider: MemberId::from(&owner_sk.verifying_key()),
+        };
+        room_state
+            .secrets
+            .encrypted_secrets
+            .push(AuthorizedEncryptedSecretForMember::new(blob, owner_sk));
+    }
+
+    /// Regression for #251: the timeline that produces the user-visible
+    /// symptom. Initial GET hands the invitee a state with NO encrypted
+    /// blob for them. Owner's delegate later back-fills the blob in a
+    /// subsequent update. After applying the update,
+    /// `repopulate_secrets_from_state` must decrypt the new blob so the
+    /// renderer can read the room without the user having to hard-refresh.
+    #[test]
+    fn repopulate_secrets_after_delegate_backfill_picks_up_new_blob() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+
+        let (v0_secret, mut room) = make_private_invitee_room(&owner_sk, &invitee_sk);
+
+        // 1. Initial GET state: no blob for invitee yet. Helper is a
+        //    no-op for decryption; current_secret_version still aligns
+        //    with the contract's view.
+        let decrypted = room.repopulate_secrets_from_state();
+        assert_eq!(
+            decrypted, 0,
+            "no encrypted_secrets entries for invitee yet, so nothing to decrypt"
+        );
+        assert!(room.secrets.is_empty());
+        assert_eq!(room.current_secret_version, Some(0));
+
+        // 2. Owner's delegate runs the PR #245 back-fill and ships an
+        //    update that adds the encrypted blob for the invitee.
+        append_encrypted_secret_for(
+            &mut room.room_state,
+            &owner_sk,
+            &invitee_sk.verifying_key(),
+            &v0_secret,
+            0,
+        );
+
+        // 3. The fix: subsequent state ingestion (apply_delta /
+        //    update_room_state) must re-run the helper so the new blob
+        //    gets decrypted.
+        let decrypted = room.repopulate_secrets_from_state();
+        assert_eq!(decrypted, 1, "the new back-filled blob must be decrypted");
+        assert_eq!(
+            room.secrets.get(&0u32),
+            Some(&v0_secret),
+            "decrypted plaintext must match the original room secret"
+        );
+        assert_eq!(room.current_secret_version, Some(0));
+
+        // 4. Idempotency: calling repopulate again with no new blobs is
+        //    a no-op (filtered out by the `contains_key` guard).
+        let decrypted = room.repopulate_secrets_from_state();
+        assert_eq!(
+            decrypted, 0,
+            "already-decrypted versions must not be re-decrypted"
+        );
+    }
+
+    /// Helper must skip blobs intended for other members — we can't
+    /// decrypt them with our own signing key and shouldn't try.
+    #[test]
+    fn repopulate_secrets_skips_blobs_for_other_members() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let stranger_sk = SigningKey::generate(&mut rng);
+
+        let (v0_secret, mut room) = make_private_invitee_room(&owner_sk, &invitee_sk);
+        // Back-fill a blob, but for a different member.
+        append_encrypted_secret_for(
+            &mut room.room_state,
+            &owner_sk,
+            &stranger_sk.verifying_key(),
+            &v0_secret,
+            0,
+        );
+
+        let decrypted = room.repopulate_secrets_from_state();
+        assert_eq!(decrypted, 0);
+        assert!(room.secrets.is_empty());
+    }
+
+    /// Helper must be a no-op on public rooms — there are no secrets to
+    /// decrypt and the `secrets` map should stay empty.
+    #[test]
+    fn repopulate_secrets_is_noop_on_public_room() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let member_sk = SigningKey::generate(&mut rng);
+        let owner_vk = owner_sk.verifying_key();
+
+        let config = AuthorizedConfigurationV1::new(Configuration::default(), &owner_sk);
+        let room_state = ChatRoomStateV1 {
+            configuration: config,
+            ..Default::default()
+        };
+        let params = ChatRoomParametersV1 { owner: owner_vk };
+        let params_bytes = to_cbor_vec(&params);
+        let contract_key = ContractKey::from_params_and_code(
+            Parameters::from(params_bytes),
+            &ContractCode::from(ROOM_CONTRACT_WASM),
+        );
+
+        let mut room = RoomData {
+            owner_vk,
+            room_state,
+            self_sk: member_sk,
+            contract_key,
+            last_read_message_id: None,
+            secrets: HashMap::new(),
+            current_secret_version: None,
+            last_secret_rotation: None,
+            key_migrated_to_delegate: false,
+            self_authorized_member: None,
+            invite_chain: vec![],
+            self_member_info: None,
+            previous_contract_key: None,
+        };
+
+        let decrypted = room.repopulate_secrets_from_state();
+        assert_eq!(decrypted, 0);
+        assert!(room.secrets.is_empty());
+        assert_eq!(room.current_secret_version, None);
     }
 }

--- a/ui/src/util/ecies.rs
+++ b/ui/src/util/ecies.rs
@@ -7,7 +7,7 @@
 #![allow(unused_imports)]
 
 pub use river_core::ecies::{
-    decrypt, decrypt_secret_from_member_blob, decrypt_with_symmetric_key,
-    encrypt_secret_for_member, encrypt_with_symmetric_key, generate_room_secret, seal_bytes,
-    unseal_bytes, unseal_bytes_with_secrets,
+    decrypt, decrypt_secret_from_member_blob, decrypt_secret_from_member_blob_raw,
+    decrypt_with_symmetric_key, encrypt_secret_for_member, encrypt_with_symmetric_key,
+    generate_room_secret, seal_bytes, unseal_bytes, unseal_bytes_with_secrets,
 };


### PR DESCRIPTION
## Problem

Closes #251.

When a private-room invitee subscribes, the initial `GET` response often arrives *before* the owner's chat delegate runs the PR #245 back-fill of `encrypted_secrets`. The back-fill ships in a subsequent state update.

The decrypt-into-`room_data.secrets` loop was duplicated in `get_response.rs` and `response_handler.rs::handle_load_rooms_response`, but the network-update paths in `room_synchronizer.rs` (`apply_delta_inner` and `update_room_state_inner`) merged the new encrypted blobs into `ChatRoomStateV1` and never decrypted them into the in-memory map that the renderer reads.

Net effect (Ivvor on Matrix, 2026-05-15):
- Newly-joined member renders every message as `[Encrypted message - secret v0 not available (have: [])]`.
- Both sides "aren't syncing" — each sends messages encrypted at a version the other doesn't have in their HashMap.
- Hard-refreshing fixes it, because reload re-runs the `LoadRooms` decryption loop.

## Approach

Extract the decryption block into `RoomData::repopulate_secrets_from_state(&mut self) -> usize`:
- No-op on public rooms.
- Snapshots blobs in `room_state.secrets.encrypted_secrets` whose `member_id == self` and whose `secret_version` isn't already in `self.secrets`.
- Decrypts each, calls `self.set_secret(...)`.
- Aligns `self.current_secret_version` with the contract's `secrets.current_version` (preserves prior get_response / load-rooms behaviour).

Call it from every state ingestion path:
- `get_response.rs:178+` (initial GET) — replaces the inline duplicate.
- `response_handler.rs::handle_load_rooms_response` (delegate-load merge) — replaces the inline duplicate.
- `room_synchronizer.rs::apply_delta_inner` — new call site, **before** the per-private-room `actions_state` rebuild so newly-decrypted action messages resolve in the same tick.
- `room_synchronizer.rs::update_room_state_inner` — same.

The helper is idempotent (filtered by `!self.secrets.contains_key(version)`), so it's safe to call on every update without measurable cost on the steady-state case.

## Testing

Three unit tests in `ui/src/room_data.rs`:

- `repopulate_secrets_after_delegate_backfill_picks_up_new_blob` — direct reproduction of Ivvor's repro: invitee state starts with `secrets` empty and `encrypted_secrets` empty (initial GET); first call to helper is a no-op; owner delegate back-fills the blob; second call to helper decrypts it and populates the map. Pinned the idempotency case too (third call decrypts 0).
- `repopulate_secrets_skips_blobs_for_other_members` — helper must not try to decrypt blobs sealed for a different member's key.
- `repopulate_secrets_is_noop_on_public_room` — pinned the early-return for `is_private() == false`.

All 95 `river-ui` tests pass. Workspace `cargo make test` green. `cargo clippy` clean for the touched code (no new warnings).

Manual repro will be exercised in the batched Playwright run before the next River publish.

## Other items from Ivvor's report

The "memory growth" complaint is tracked separately in #246. The "owner can't send messages" sub-symptom in the 3-member case is plausibly the same bug from the owner side — owner's tab also gets stuck if a rotation-driven update arrives that brings in a new current_version for which the owner already had the secret but the apply_delta path didn't refresh `current_secret_version`. This patch's `current_secret_version = Some(current_version)` line at the end of `repopulate_secrets_from_state` covers that case symmetrically.

[AI-assisted - Claude]