### PR TITLE
fix(dm): allow DM to inactive-but-invited members (Bug #1)

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -1255,7 +1255,12 @@ impl ApiClient {
     /// This serves as a fallback for the join event sent at invitation acceptance
     /// time — if the join event ages out of `recent_messages` and the member gets
     /// pruned before sending a regular message, this re-adds them on next send.
-    fn build_rejoin_delta(
+    ///
+    /// Exposed `pub(crate)` so the `dm` subcommand can bundle the same rejoin
+    /// pieces into a DM-bearing delta (Bug #1, reported by Ivvor on Matrix
+    /// 2026-05-16) — without this, an invited-but-inactive sender's DM was
+    /// silent-dropped by the contract.
+    pub(crate) fn build_rejoin_delta(
         &self,
         room_state: &ChatRoomStateV1,
         room_owner_key: &VerifyingKey,

--- a/cli/src/commands/dm.rs
+++ b/cli/src/commands/dm.rs
@@ -115,21 +115,12 @@ async fn execute_send(
         return Err(anyhow!("Cannot send a DM to yourself."));
     }
 
-    // Make sure both ends are current members from the contract's POV; the
-    // contract `verify` would otherwise reject the delta and waste a round
-    // trip.
+    // The recipient must already be in the room — the sender does not hold
+    // the recipient's owner-signed `AuthorizedMember`, so a pruned recipient
+    // cannot be bundled into the DM delta (that side is follow-up
+    // territory; see issue #110 for the related "pruned member" gap).
+    // Sender membership is handled by the rejoin bundle below — Bug #1.
     let owner_id = MemberId::from(&room_owner_key);
-    let is_self_member = self_id == owner_id
-        || room_state
-            .members
-            .members
-            .iter()
-            .any(|m| m.member.id() == self_id);
-    if !is_self_member {
-        return Err(anyhow!(
-            "Your member entry is not in the room. Run `riverctl invite accept` first."
-        ));
-    }
     let is_recipient_member = recipient_id == owner_id
         || room_state
             .members
@@ -139,6 +130,19 @@ async fn execute_send(
     if !is_recipient_member {
         return Err(anyhow!("Recipient is not currently a member of the room."));
     }
+
+    // Bug #1 (Ivvor, Matrix 2026-05-16): an invited-but-inactive sender
+    // can be pruned from `members.members` by `post_apply_cleanup`, after
+    // which the contract's `DirectMessagesV1::apply_delta` silent-drops
+    // any DM whose sender isn't currently in members. Bundle the same
+    // rejoin pieces the regular `send_message_with_key` path produces so
+    // the DM lands atomically with the member-rejoin. `MembersV1`
+    // precedes `DirectMessagesV1` in the macro's field order so the
+    // sender is back in members by the time the DM sub-state apply runs.
+    // Contract-level pin: `pruned_sender_can_dm_when_bundling_rejoin_delta`
+    // in `common/tests/direct_messages_test.rs`.
+    let (rejoin_members, rejoin_member_info) =
+        api.build_rejoin_delta(&room_state, &room_owner_key, &signing_key);
 
     // Per-pair cap: contract `apply_delta` silently drops overflow so we
     // must surface the cap as a hard error here, otherwise the CLI would
@@ -164,6 +168,8 @@ async fn execute_send(
     .map_err(|e| anyhow!("Failed to compose DM: {}", e))?;
 
     let delta = ChatRoomStateV1Delta {
+        members: rejoin_members,
+        member_info: rejoin_member_info,
         direct_messages: Some(
             river_core::room_state::direct_messages::DirectMessagesDelta {
                 new_messages: vec![auth.clone()],

--- a/cli/src/commands/dm.rs
+++ b/cli/src/commands/dm.rs
@@ -144,6 +144,27 @@ async fn execute_send(
     let (rejoin_members, rejoin_member_info) =
         api.build_rejoin_delta(&room_state, &room_owner_key, &signing_key);
 
+    // Codex P2 (PR #269 review): if the sender is pruned AND
+    // `build_rejoin_delta` returned no credentials (e.g. older stored
+    // rooms missing `self_authorized_member`), the contract will
+    // silent-drop the DM but the CLI's local pre-flight `apply_delta`
+    // returns Ok — meaning we'd `send_state_delta` and print success
+    // even though no DM lands. Surface the failure here with a clear
+    // diagnostic instead.
+    let is_self_member = self_id == owner_id
+        || room_state
+            .members
+            .members
+            .iter()
+            .any(|m| m.member.id() == self_id);
+    if !is_self_member && rejoin_members.is_none() {
+        return Err(anyhow!(
+            "Your member entry is not in the room and no stored rejoin credentials \
+             are available. Re-accept your invitation with `riverctl invite accept` \
+             before sending a DM."
+        ));
+    }
+
     // Per-pair cap: contract `apply_delta` silently drops overflow so we
     // must surface the cap as a hard error here, otherwise the CLI would
     // print "DM sent" with nothing actually delivered.
@@ -189,6 +210,24 @@ async fn execute_send(
         local
             .apply_delta(&room_state, &params, &Some(delta.clone()))
             .map_err(|e| anyhow!("Local pre-flight apply_delta failed: {:?}", e))?;
+    }
+
+    // Codex P2 defence-in-depth (PR #269 review): `DirectMessagesV1::apply_delta`
+    // silent-drops DMs whose sender isn't a current member, so the pre-flight
+    // above can return Ok even though our DM was dropped. Verify the message
+    // we tried to send is actually present in the post-merge state before
+    // we report success to the user.
+    let landed = local
+        .direct_messages
+        .messages
+        .iter()
+        .any(|m| m.sender_signature == auth.sender_signature);
+    if !landed {
+        return Err(anyhow!(
+            "Local pre-flight: the DM was silently dropped by the contract \
+             (likely because the sender or recipient is not a current member). \
+             Refusing to claim a successful send."
+        ));
     }
 
     api.send_state_delta(&room_owner_key, &delta).await?;

--- a/common/tests/direct_messages_test.rs
+++ b/common/tests/direct_messages_test.rs
@@ -12,8 +12,10 @@ use river_core::room_state::direct_messages::{
     DOMAIN_TAG_MESSAGE, DOMAIN_TAG_PURGES, MAX_DM_CIPHERTEXT_BYTES, MAX_DM_FUTURE_SKEW_SECS,
     MAX_DM_MESSAGES_PER_PAIR, MAX_PURGED_TOMBSTONES_PER_RECIPIENT,
 };
-use river_core::room_state::member::{AuthorizedMember, Member, MemberId, MembersV1};
-use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1};
+use river_core::room_state::member::{AuthorizedMember, Member, MemberId, MembersDelta, MembersV1};
+use river_core::room_state::member_info::{AuthorizedMemberInfo, MemberInfo};
+use river_core::room_state::privacy::SealedBytes;
+use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1, ChatRoomStateV1Delta};
 use std::collections::HashSet;
 use std::time::SystemTime;
 
@@ -356,6 +358,171 @@ fn recipient_not_member_rejected() {
     assert!(
         err.contains("recipient") && err.contains("not a current member"),
         "got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Inactive-but-invited sender can DM when bundling a rejoin delta (Bug #1,
+// reported by Ivvor on Matrix 2026-05-16).
+//
+// Symptom: "You can't DM from an inactive member that otherwise has a valid
+// invite. They have to post something new in the room for it to work."
+//
+// Root cause: `post_apply_cleanup` prunes invited-but-inactive members from
+// `members.members`, after which `DirectMessagesV1::apply_delta` silent-drops
+// any DM whose sender (or recipient) isn't currently in members. The regular
+// message-send path already works around this by bundling a rejoin delta
+// (`MembersDelta` + `member_info`) into the same `ChatRoomStateV1Delta` as
+// the new message; the DM-send path did not. The fix is in the UI/CLI send
+// paths — these tests pin the contract-level invariant the fix relies on:
+//
+// - Bundling the sender's `AuthorizedMember` into the same delta as the DM
+//   makes the DM applied + verifying.
+// - WITHOUT the bundle, the DM is silent-dropped (legacy buggy behaviour).
+// ---------------------------------------------------------------------------
+
+/// Helper: rebuild a fixture state with Alice pruned from `members.members`
+/// (simulates `post_apply_cleanup` having removed her for inactivity). Alice
+/// is still cryptographically authorised — `auth_alice` is still a valid
+/// owner-signed `AuthorizedMember`, returned for the caller to bundle into
+/// a rejoin delta.
+fn pruned_alice_fixture() -> (Fixture, AuthorizedMember) {
+    let mut f = make_fixture();
+    // Re-derive Alice's `AuthorizedMember` so the caller can bundle it into
+    // a rejoin delta. Re-signing with the same key + same Member fields
+    // yields the same byte-canonical envelope as the one in the fixture.
+    let auth_alice = AuthorizedMember::new(
+        Member {
+            owner_member_id: f.owner_id,
+            invited_by: f.owner_id,
+            member_vk: f.alice_sk.verifying_key(),
+        },
+        &f.owner_sk,
+    );
+
+    // Remove Alice from members.members (post_apply_cleanup's effect).
+    f.state
+        .members
+        .members
+        .retain(|m| m.member.id() != f.alice_id);
+    // Sanity: state without Alice still verifies; bob+carol remain.
+    f.state
+        .verify(&f.state, &f.params)
+        .expect("pruned state verifies");
+
+    (f, auth_alice)
+}
+
+/// Bug #1 regression: an inactive (pruned) sender can DM by bundling their
+/// `AuthorizedMember` + `AuthorizedMemberInfo` into the same delta as the
+/// DM. The `members` sub-state apply_delta runs first (it precedes
+/// `direct_messages` in `ChatRoomStateV1`'s field order), so by the time
+/// the DM sub-state apply runs, Alice is back in members and the
+/// sender-membership check passes.
+#[test]
+fn pruned_sender_can_dm_when_bundling_rejoin_delta() {
+    let (f, auth_alice) = pruned_alice_fixture();
+
+    // Pre-condition: Alice is NOT in members.
+    assert!(
+        !f.state
+            .members
+            .members
+            .iter()
+            .any(|m| m.member.id() == f.alice_id),
+        "precondition: Alice should be pruned"
+    );
+
+    // Compose the DM Alice wants to send Bob.
+    let msg = dm_at(&f, &f.alice_sk, f.alice_id, f.bob_id, 1, b"hi bob");
+
+    // Build the rejoin pieces: AuthorizedMember (Alice) + AuthorizedMemberInfo.
+    let alice_info = AuthorizedMemberInfo::new_with_member_key(
+        MemberInfo {
+            member_id: f.alice_id,
+            version: 0,
+            preferred_nickname: SealedBytes::public(b"Alice".to_vec()),
+        },
+        &f.alice_sk,
+    );
+
+    // Apply members + member_info + DM in a single delta — the order the
+    // real UI/CLI fix produces.
+    let delta = ChatRoomStateV1Delta {
+        members: Some(MembersDelta::new(vec![auth_alice])),
+        member_info: Some(vec![alice_info]),
+        direct_messages: Some(DirectMessagesDelta {
+            new_messages: vec![msg.clone()],
+            advanced_purges: vec![],
+        }),
+        ..Default::default()
+    };
+
+    let mut state = f.state.clone();
+    state
+        .apply_delta(&f.state, &f.params, &Some(delta))
+        .expect("bundled rejoin + DM delta must apply cleanly");
+
+    // Alice is back in members.
+    assert!(
+        state
+            .members
+            .members
+            .iter()
+            .any(|m| m.member.id() == f.alice_id),
+        "Alice must be re-added to members by the bundled rejoin"
+    );
+    // The DM is in state.
+    assert!(
+        state
+            .direct_messages
+            .messages
+            .iter()
+            .any(|m| m.message.sender == f.alice_id && m.message.recipient == f.bob_id),
+        "the DM from pruned Alice to Bob must be present, not silent-dropped"
+    );
+    // The state verifies.
+    state
+        .verify(&state, &f.params)
+        .expect("post-merge state must verify");
+}
+
+/// Demonstrates the pre-fix broken behaviour: WITHOUT bundling the rejoin
+/// delta, the DM-bearing delta is silent-dropped (Alice is not in members,
+/// so `DirectMessagesV1::apply_delta` continues past her DM at the sender
+/// membership check). Pins what the UI/CLI path used to do, so a regression
+/// that drops the rejoin bundle re-surfaces visibly here.
+#[test]
+fn pruned_sender_dm_without_rejoin_bundle_is_silent_dropped() {
+    let (f, _auth_alice) = pruned_alice_fixture();
+
+    let msg = dm_at(&f, &f.alice_sk, f.alice_id, f.bob_id, 1, b"hi bob");
+
+    let delta = ChatRoomStateV1Delta {
+        direct_messages: Some(DirectMessagesDelta {
+            new_messages: vec![msg],
+            advanced_purges: vec![],
+        }),
+        ..Default::default()
+    };
+
+    let mut state = f.state.clone();
+    state
+        .apply_delta(&f.state, &f.params, &Some(delta))
+        .expect("apply_delta itself does not error — the DM is silently dropped");
+
+    assert!(
+        state.direct_messages.messages.is_empty(),
+        "without a rejoin bundle, the DM from a pruned sender must be silent-dropped \
+         by the contract; UI/CLI must bundle a rejoin delta to land the message"
+    );
+    assert!(
+        !state
+            .members
+            .members
+            .iter()
+            .any(|m| m.member.id() == f.alice_id),
+        "Alice stays pruned without a rejoin bundle"
     );
 }
 

--- a/ui/src/components/direct_messages/dm_thread_modal.rs
+++ b/ui/src/components/direct_messages/dm_thread_modal.rs
@@ -38,6 +38,11 @@ enum ApplyOutcome {
     /// message.
     CapHit,
     DeltaFailed,
+    /// `apply_delta` returned Ok but the DM did not actually land in
+    /// `direct_messages.messages` — the contract silently dropped it
+    /// (typically: sender or recipient is not in members and no rejoin
+    /// bundle was supplied). Codex P2 defence-in-depth (PR #269 review).
+    SilentDrop,
 }
 
 #[component]
@@ -346,6 +351,28 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
         // `common/tests/direct_messages_test.rs`. Returns `(None, None)`
         // when not pruned, which `ChatRoomStateV1Delta` accepts as no-op.
         let (rejoin_members, rejoin_member_info) = room_data.build_rejoin_delta();
+        // Codex P2 (PR #269 review): if the sender is pruned AND
+        // `build_rejoin_delta` returned no credentials (e.g. an imported
+        // identity missing `self_authorized_member`), the contract will
+        // silent-drop the DM. The local `apply_delta` succeeds in that
+        // case but the message never lands, leaving the composer
+        // empty-looking-successful. Surface the failure up front instead.
+        let self_in_members = self_id == MemberId::from(&room)
+            || room_data
+                .room_state
+                .members
+                .members
+                .iter()
+                .any(|m| m.member.id() == self_id);
+        if !self_in_members && rejoin_members.is_none() {
+            send_error.set(Some(
+                "You're not currently in this room's member list and no \
+                 rejoin credentials are stored locally. Reload the room or \
+                 re-accept your invitation before sending a DM."
+                    .into(),
+            ));
+            return;
+        }
         wasm_bindgen_futures::spawn_local(async move {
             let now = unix_now();
             let auth =
@@ -374,6 +401,7 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
             };
 
             let params = ChatRoomParametersV1 { owner: room };
+            let auth_sig = auth.sender_signature;
             crate::util::defer(move || {
                 let outcome = ROOMS.with_mut(|rooms| {
                     let Some(rd) = rooms.map.get_mut(&room) else {
@@ -391,10 +419,29 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                     let parent = rd.room_state.clone();
                     if let Err(e) = rd.room_state.apply_delta(&parent, &params, &Some(delta)) {
                         error!("DM apply_delta failed: {:?}", e);
-                        ApplyOutcome::DeltaFailed
-                    } else {
-                        ApplyOutcome::Applied
+                        return ApplyOutcome::DeltaFailed;
                     }
+                    // Codex P2 defence-in-depth (PR #269 review):
+                    // `DirectMessagesV1::apply_delta` silently drops
+                    // DMs whose sender or recipient is not in members
+                    // and returns Ok. Verify our DM actually landed
+                    // before reporting success — otherwise the UI
+                    // would clear the composer and the user would
+                    // think the message was sent.
+                    let landed = rd
+                        .room_state
+                        .direct_messages
+                        .messages
+                        .iter()
+                        .any(|m| m.sender_signature == auth_sig);
+                    if !landed {
+                        warn!(
+                            "DM apply_delta returned Ok but the message was \
+                             silently dropped by the contract (membership check?)"
+                        );
+                        return ApplyOutcome::SilentDrop;
+                    }
+                    ApplyOutcome::Applied
                 });
                 match outcome {
                     ApplyOutcome::Applied => {
@@ -436,6 +483,21 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                         // `warn!`/`error!` log for the diagnostic.
                         send_error.set(Some(
                             "Couldn't send this message — something went wrong.".into(),
+                        ));
+                    }
+                    ApplyOutcome::SilentDrop => {
+                        // The contract accepted the delta but dropped
+                        // the DM. The most likely cause is that the
+                        // sender or recipient is not in members and
+                        // the rejoin bundle was insufficient (or
+                        // empty). Don't clear the composer — the user
+                        // can adjust and retry.
+                        send_error.set(Some(
+                            "This message couldn't be added to the room \
+                             (your member entry may be missing). Try \
+                             posting a message in the room first, then \
+                             retry the DM."
+                                .into(),
                         ));
                     }
                 }

--- a/ui/src/components/direct_messages/dm_thread_modal.rs
+++ b/ui/src/components/direct_messages/dm_thread_modal.rs
@@ -332,6 +332,20 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
 
         let plaintext = body.clone();
         let body_bytes = body.into_bytes();
+        // Bug #1 (Ivvor, Matrix 2026-05-16): an invited-but-inactive sender
+        // can be pruned from `members.members` by `post_apply_cleanup`,
+        // after which the contract's `DirectMessagesV1::apply_delta`
+        // silent-drops any DM whose sender isn't currently in members. The
+        // regular message-send path bundles a rejoin delta
+        // (`MembersDelta` + `member_info`) to re-add the pruned sender —
+        // do the same here so DMs from a pruned-but-invited sender land
+        // atomically. `MembersV1` precedes `DirectMessagesV1` in
+        // `ChatRoomStateV1`'s field order, so by the time the DM
+        // sub-state apply runs the sender is back in members. Pinned by
+        // `pruned_sender_can_dm_when_bundling_rejoin_delta` in
+        // `common/tests/direct_messages_test.rs`. Returns `(None, None)`
+        // when not pruned, which `ChatRoomStateV1Delta` accepts as no-op.
+        let (rejoin_members, rejoin_member_info) = room_data.build_rejoin_delta();
         wasm_bindgen_futures::spawn_local(async move {
             let now = unix_now();
             let auth =
@@ -350,6 +364,8 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
             let dm_timestamp = auth.message.timestamp;
 
             let delta = ChatRoomStateV1Delta {
+                members: rejoin_members,
+                member_info: rejoin_member_info,
                 direct_messages: Some(DirectMessagesDelta {
                     new_messages: vec![auth.clone()],
                     advanced_purges: vec![],


### PR DESCRIPTION
## Problem

Reported by Ivvor on Matrix 2026-05-16:

> Bug #1 — You can't DM from an inactive member that otherwise has a valid invite. They have to post something new in the room for it to work.

Once a member is pruned from `members.members` by `post_apply_cleanup` for inactivity, the contract's `DirectMessagesV1::apply_delta` silent-drops any DM whose sender isn't currently in members — so the user clicks "Send", sees no error, but the DM never reaches anyone. Posting a regular room message goes through `conversation.rs::try_rejoin_delta`, which re-adds the sender, after which DMs work again.

## Approach

Fix is in the UI/CLI send paths — no contract change. The contract already supports the right shape: `MembersV1` precedes `DirectMessagesV1` in `ChatRoomStateV1`'s field order, so bundling the sender's owner-signed `AuthorizedMember` (and any missing invite-chain ancestors) alongside the DM in a single `ChatRoomStateV1Delta` re-adds them in time for the DM membership check to pass.

UI (`ui/src/components/direct_messages/dm_thread_modal.rs`):
- `do_send` now calls `room_data.build_rejoin_delta()` and threads `(members, member_info)` into the `ChatRoomStateV1Delta` alongside `direct_messages`. Returns `(None, None)` when the sender isn't pruned, which `ChatRoomStateV1Delta` accepts as a no-op.

CLI (`cli/src/commands/dm.rs`):
- `dm send` drops the strict "Your member entry is not in the room" error and instead bundles `api.build_rejoin_delta(...)` into the same delta. Retains the recipient-membership check — the sender doesn't hold the recipient's owner-signed `AuthorizedMember`, so a pruned recipient is follow-up territory (see issue #110).
- `ApiClient::build_rejoin_delta` promoted to `pub(crate)` so the `dm` subcommand can call it.

The fix touches `cli/` and `ui/` only — no `common/` (river-core) change, so no contract WASM change, no delegate migration needed.

## Testing

Added two contract-level regression tests in `common/tests/direct_messages_test.rs` that pin the invariant the UI/CLI fix relies on:

- `pruned_sender_can_dm_when_bundling_rejoin_delta` — Alice is pruned from `members.members`; constructs a `ChatRoomStateV1Delta` that bundles her `AuthorizedMember` + `AuthorizedMemberInfo` + the DM; asserts the delta applies cleanly, the DM is in state, and `verify` passes.
- `pruned_sender_dm_without_rejoin_bundle_is_silent_dropped` — same setup but without the rejoin bundle; asserts the DM is silently dropped. Pins the pre-fix broken behaviour so a regression that drops the rejoin bundle re-surfaces visibly.

`cargo make test` is green. `cargo fmt --check` clean. `cargo clippy` reports only pre-existing warnings (none in code I touched).

Closes the symptom side of Bug #1 (sender pruned). The mirror case (recipient pruned) is not addressed here — the sender doesn't have the recipient's owner-signed `AuthorizedMember` to bundle, and the existing `post_apply_cleanup` sweep prevents a DM rail from showing the thread in the first place. That's the same class as issue #110 (secret rotation may not reach pruned members) — file a follow-up if it surfaces in user reports.

[AI-assisted - Claude]