### PR TITLE
feat(ui): show unread message badges on rooms in the rooms list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,16 @@ jobs:
       # silent drift in the ECIES derivation.
       run: cargo test -p river-core --lib --features ecies-randomized ecies
 
+    - name: Test river-ui (UI crate unit tests)
+      env:
+        RUST_MIN_STACK: 8388608
+        CARGO_TARGET_DIR: ${{ github.workspace }}/target
+      # The river-ui crate carries native unit tests (pure helpers such as
+      # unread counting, room-data merge logic, signing). They had no CI
+      # coverage before — the WASM build can't run them and no step invoked
+      # `cargo test -p river-ui`. This step gates them on every push.
+      run: cargo test -p river-ui --bins
+
   ui-playwright-tests:
     runs-on: freenet-default-runner
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ cargo make test-web-container
 cargo make test-common
 cargo make test-chat-delegate
 cargo make test-web-container-integration
+cargo test -p river-ui --bins      # river-ui crate native unit tests (CI-gated)
 ```
 
 ### Local UI Testing with dx serve

--- a/ui/src/components/app/document_title.rs
+++ b/ui/src/components/app/document_title.rs
@@ -115,6 +115,10 @@ fn get_current_room_name() -> Option<String> {
 /// Only a marker entirely absent from the buffer (evicted by the bounded
 /// ring buffer) triggers the "treat everything as unread" fallback —
 /// otherwise a stale marker would silently report zero unread.
+///
+/// Assumes `recent.messages` is in chronological `(time, id)` order — the
+/// invariant `MessagesV1::apply_delta` maintains — so the slice after the
+/// marker's index is exactly the set of messages newer than the marker.
 pub fn count_unread_in_room_data(room_data: &crate::room_data::RoomData) -> usize {
     let self_member_id: MemberId = room_data.self_sk.verifying_key().into();
     let recent = &room_data.room_state.recent_messages;
@@ -591,5 +595,46 @@ mod tests {
         // Only messages 3 and 4 follow the marker → 2 unread (not 3 — the
         // already-read message 1 must stay read despite the deletion).
         assert_eq!(count_unread_in_room_data(&rd), 2);
+    }
+
+    #[test]
+    fn empty_room_with_marker_counts_zero() {
+        // A marker over an empty buffer: `position` is `None` → `start` 0 →
+        // empty slice → 0, with no panic on the empty-slice index.
+        let (self_sk, _) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let orphan = msg(&owner_sk, &owner_vk, 1).id();
+        let rd = room(self_sk, owner_vk, vec![], Some(orphan));
+        assert_eq!(count_unread_in_room_data(&rd), 0);
+    }
+
+    #[test]
+    fn helper_agrees_with_display_messages_filter() {
+        // Drift guard: the helper hand-mirrors `MessagesV1::display_messages`'s
+        // action/deleted filter. With no marker, the count must equal
+        // `display_messages()` filtered to other authors — if the two
+        // predicates ever diverge, this fails.
+        let (self_sk, self_vk) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let self_id: MemberId = (&self_vk).into();
+        let messages = vec![
+            msg(&owner_sk, &owner_vk, 1),
+            msg(&owner_sk, &owner_vk, 2),
+            msg(&self_sk, &owner_vk, 3),
+        ];
+        let deleted = messages[1].id();
+        let mut rd = room(self_sk, owner_vk, messages, None);
+        rd.room_state
+            .recent_messages
+            .actions_state
+            .deleted
+            .insert(deleted);
+        let expected = rd
+            .room_state
+            .recent_messages
+            .display_messages()
+            .filter(|m| m.message.author != self_id)
+            .count();
+        assert_eq!(count_unread_in_room_data(&rd), expected);
     }
 }

--- a/ui/src/components/app/document_title.rs
+++ b/ui/src/components/app/document_title.rs
@@ -108,33 +108,47 @@ fn get_current_room_name() -> Option<String> {
 /// users that arrived after `last_read_message_id`. Pure — takes a borrowed
 /// `RoomData` so callers that already hold a `ROOMS` read guard (the
 /// room-list badge memo, the title's cross-room sum) don't re-lock.
+///
+/// If `last_read_message_id` is set but no longer present in
+/// `recent_messages` (the marker was evicted from the bounded ring buffer),
+/// every other-authored message is treated as unread — otherwise a stale
+/// marker would silently report zero unread.
 pub fn count_unread_in_room_data(room_data: &crate::room_data::RoomData) -> usize {
     let self_member_id: MemberId = room_data.self_sk.verifying_key().into();
     let last_read_id = room_data.last_read_message_id.as_ref();
 
-    // If no messages have been read, count all messages from others
-    // If we have a last read ID, count messages after it from others
+    // `unread` counts other-authored messages after the last-read marker;
+    // `from_others` is the running total, used as a fallback when the marker
+    // is absent (no marker yet, or pruned out of the buffer).
     let mut found_last_read = last_read_id.is_none();
-    let mut unread_count = 0;
+    let mut unread = 0;
+    let mut from_others = 0;
 
     for msg in room_data.room_state.recent_messages.display_messages() {
-        let msg_id = msg.id();
+        let from_other = msg.message.author != self_member_id;
+        if from_other {
+            from_others += 1;
+        }
 
-        // Check if this is the last read message
+        // The last read message itself is not unread; only what follows is.
         if let Some(last_id) = last_read_id {
-            if &msg_id == last_id {
+            if &msg.id() == last_id {
                 found_last_read = true;
-                continue; // Don't count the last read message itself
+                continue;
             }
         }
 
-        // Count messages after the last read message from other users
-        if found_last_read && msg.message.author != self_member_id {
-            unread_count += 1;
+        if found_last_read && from_other {
+            unread += 1;
         }
     }
 
-    unread_count
+    // Marker set but never seen → it was pruned; fall back to "all unread"
+    // rather than silently reporting zero.
+    if last_read_id.is_some() && !found_last_read {
+        return from_others;
+    }
+    unread
 }
 
 /// Count total unread messages across all rooms — room messages plus
@@ -409,4 +423,138 @@ pub fn DocumentTitleUpdater() -> Element {
     });
 
     rsx! {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::ROOM_CONTRACT_WASM;
+    use crate::room_data::RoomData;
+    use crate::util::to_cbor_vec;
+    use ed25519_dalek::{SigningKey, VerifyingKey};
+    use freenet_stdlib::prelude::{ContractCode, ContractKey, Parameters};
+    use river_core::room_state::message::{AuthorizedMessageV1, MessageV1, RoomMessageBody};
+    use river_core::room_state::ChatRoomParametersV1;
+    use river_core::ChatRoomStateV1;
+    use std::collections::HashMap;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    /// Build a signed display message from `author_sk`, distinct per `n`.
+    fn msg(author_sk: &SigningKey, owner_vk: &VerifyingKey, n: u64) -> AuthorizedMessageV1 {
+        AuthorizedMessageV1::new(
+            MessageV1 {
+                room_owner: MemberId::from(owner_vk),
+                author: MemberId::from(&author_sk.verifying_key()),
+                content: RoomMessageBody::public(format!("message {n}")),
+                time: UNIX_EPOCH + Duration::from_secs(n),
+            },
+            author_sk,
+        )
+    }
+
+    /// Minimal `RoomData` carrying just the fields `count_unread_in_room_data`
+    /// reads: `self_sk`, `recent_messages`, and `last_read_message_id`.
+    fn room(
+        self_sk: SigningKey,
+        owner_vk: VerifyingKey,
+        messages: Vec<AuthorizedMessageV1>,
+        last_read_message_id: Option<MessageId>,
+    ) -> RoomData {
+        let mut room_state = ChatRoomStateV1::default();
+        room_state.recent_messages.messages = messages;
+        let contract_key = ContractKey::from_params_and_code(
+            Parameters::from(to_cbor_vec(&ChatRoomParametersV1 { owner: owner_vk })),
+            ContractCode::from(ROOM_CONTRACT_WASM),
+        );
+        RoomData {
+            owner_vk,
+            room_state,
+            self_sk,
+            contract_key,
+            last_read_message_id,
+            secrets: HashMap::new(),
+            current_secret_version: None,
+            last_secret_rotation: None,
+            key_migrated_to_delegate: false,
+            self_authorized_member: None,
+            invite_chain: vec![],
+            self_member_info: None,
+            previous_contract_key: None,
+        }
+    }
+
+    fn keypair() -> (SigningKey, VerifyingKey) {
+        let sk = SigningKey::generate(&mut rand::thread_rng());
+        let vk = sk.verifying_key();
+        (sk, vk)
+    }
+
+    #[test]
+    fn no_marker_counts_all_other_authored_messages() {
+        let (self_sk, _) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let messages = vec![
+            msg(&owner_sk, &owner_vk, 1),
+            msg(&owner_sk, &owner_vk, 2),
+            msg(&owner_sk, &owner_vk, 3),
+        ];
+        let rd = room(self_sk, owner_vk, messages, None);
+        assert_eq!(count_unread_in_room_data(&rd), 3);
+    }
+
+    #[test]
+    fn excludes_messages_authored_by_self() {
+        let (self_sk, _) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        // 2 from the owner, 2 from self → only the owner's count as unread.
+        let messages = vec![
+            msg(&owner_sk, &owner_vk, 1),
+            msg(&self_sk, &owner_vk, 2),
+            msg(&owner_sk, &owner_vk, 3),
+            msg(&self_sk, &owner_vk, 4),
+        ];
+        let rd = room(self_sk, owner_vk, messages, None);
+        assert_eq!(count_unread_in_room_data(&rd), 2);
+    }
+
+    #[test]
+    fn counts_only_messages_after_the_last_read_marker() {
+        let (self_sk, _) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let messages = vec![
+            msg(&owner_sk, &owner_vk, 1),
+            msg(&owner_sk, &owner_vk, 2),
+            msg(&owner_sk, &owner_vk, 3),
+            msg(&owner_sk, &owner_vk, 4),
+        ];
+        // Mark the 2nd message read → messages 3 and 4 remain unread.
+        let marker = messages[1].id();
+        let rd = room(self_sk, owner_vk, messages, Some(marker));
+        assert_eq!(count_unread_in_room_data(&rd), 2);
+    }
+
+    #[test]
+    fn last_read_marker_itself_is_not_counted() {
+        let (self_sk, _) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let messages = vec![msg(&owner_sk, &owner_vk, 1), msg(&owner_sk, &owner_vk, 2)];
+        // Marker is the latest message → nothing after it → 0 unread.
+        let marker = messages[1].id();
+        let rd = room(self_sk, owner_vk, messages, Some(marker));
+        assert_eq!(count_unread_in_room_data(&rd), 0);
+    }
+
+    #[test]
+    fn pruned_marker_falls_back_to_all_other_authored() {
+        // Regression: if last_read_message_id points at a message that has
+        // been evicted from the recent-messages ring buffer, the room must
+        // still surface its unread messages instead of silently showing 0.
+        let (self_sk, _) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        // Marker derived from a message that is NOT placed into the room.
+        let evicted = msg(&owner_sk, &owner_vk, 99);
+        let messages = vec![msg(&owner_sk, &owner_vk, 1), msg(&owner_sk, &owner_vk, 2)];
+        let rd = room(self_sk, owner_vk, messages, Some(evicted.id()));
+        assert_eq!(count_unread_in_room_data(&rd), 2);
+    }
 }

--- a/ui/src/components/app/document_title.rs
+++ b/ui/src/components/app/document_title.rs
@@ -104,51 +104,39 @@ fn get_current_room_name() -> Option<String> {
 
 /// Count unread messages in a single room's [`RoomData`].
 ///
-/// Only counts display messages (non-action, non-deleted) authored by other
-/// users that arrived after `last_read_message_id`. Pure — takes a borrowed
+/// Counts display messages (non-action, non-deleted) authored by other
+/// users that fall after `last_read_message_id`. Pure — takes a borrowed
 /// `RoomData` so callers that already hold a `ROOMS` read guard (the
 /// room-list badge memo, the title's cross-room sum) don't re-lock.
 ///
-/// If `last_read_message_id` is set but no longer present in
-/// `recent_messages` (the marker was evicted from the bounded ring buffer),
-/// every other-authored message is treated as unread — otherwise a stale
-/// marker would silently report zero unread.
+/// The marker is located in the full ordered message list, not the
+/// display-filtered view: a last-read message that was later *deleted* is
+/// still a valid position marker, so messages read before it stay read.
+/// Only a marker entirely absent from the buffer (evicted by the bounded
+/// ring buffer) triggers the "treat everything as unread" fallback —
+/// otherwise a stale marker would silently report zero unread.
 pub fn count_unread_in_room_data(room_data: &crate::room_data::RoomData) -> usize {
     let self_member_id: MemberId = room_data.self_sk.verifying_key().into();
-    let last_read_id = room_data.last_read_message_id.as_ref();
+    let recent = &room_data.room_state.recent_messages;
 
-    // `unread` counts other-authored messages after the last-read marker;
-    // `from_others` is the running total, used as a fallback when the marker
-    // is absent (no marker yet, or pruned out of the buffer).
-    let mut found_last_read = last_read_id.is_none();
-    let mut unread = 0;
-    let mut from_others = 0;
+    // Index just past the last-read marker. No marker — or a marker that has
+    // been evicted from the buffer entirely — starts at 0 (everything counts).
+    let start = match room_data.last_read_message_id.as_ref() {
+        None => 0,
+        Some(id) => match recent.messages.iter().position(|m| &m.id() == id) {
+            Some(idx) => idx + 1,
+            None => 0,
+        },
+    };
 
-    for msg in room_data.room_state.recent_messages.display_messages() {
-        let from_other = msg.message.author != self_member_id;
-        if from_other {
-            from_others += 1;
-        }
-
-        // The last read message itself is not unread; only what follows is.
-        if let Some(last_id) = last_read_id {
-            if &msg.id() == last_id {
-                found_last_read = true;
-                continue;
-            }
-        }
-
-        if found_last_read && from_other {
-            unread += 1;
-        }
-    }
-
-    // Marker set but never seen → it was pruned; fall back to "all unread"
-    // rather than silently reporting zero.
-    if last_read_id.is_some() && !found_last_read {
-        return from_others;
-    }
-    unread
+    recent.messages[start..]
+        .iter()
+        // Mirror `MessagesV1::display_messages`: skip action and deleted msgs.
+        .filter(|m| {
+            !m.message.content.is_action() && !recent.actions_state.deleted.contains(&m.id())
+        })
+        .filter(|m| m.message.author != self_member_id)
+        .count()
 }
 
 /// Count total unread messages across all rooms — room messages plus
@@ -555,6 +543,53 @@ mod tests {
         let evicted = msg(&owner_sk, &owner_vk, 99);
         let messages = vec![msg(&owner_sk, &owner_vk, 1), msg(&owner_sk, &owner_vk, 2)];
         let rd = room(self_sk, owner_vk, messages, Some(evicted.id()));
+        assert_eq!(count_unread_in_room_data(&rd), 2);
+    }
+
+    #[test]
+    fn deleted_messages_are_not_counted() {
+        // `display_messages` filters deleted messages; the helper must too.
+        let (self_sk, _) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let messages = vec![
+            msg(&owner_sk, &owner_vk, 1),
+            msg(&owner_sk, &owner_vk, 2),
+            msg(&owner_sk, &owner_vk, 3),
+        ];
+        let deleted = messages[1].id();
+        let mut rd = room(self_sk, owner_vk, messages, None);
+        rd.room_state
+            .recent_messages
+            .actions_state
+            .deleted
+            .insert(deleted);
+        // 3 messages, 1 deleted → 2 displayable, all from others.
+        assert_eq!(count_unread_in_room_data(&rd), 2);
+    }
+
+    #[test]
+    fn deleted_last_read_marker_still_anchors_the_count() {
+        // Regression for the Codex re-review finding: a last-read message
+        // that is later deleted must still anchor the count. Messages read
+        // before it must NOT re-surface as unread just because the marker
+        // is no longer in the display-filtered view.
+        let (self_sk, _) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let messages = vec![
+            msg(&owner_sk, &owner_vk, 1),
+            msg(&owner_sk, &owner_vk, 2), // last read, then deleted
+            msg(&owner_sk, &owner_vk, 3),
+            msg(&owner_sk, &owner_vk, 4),
+        ];
+        let marker = messages[1].id();
+        let mut rd = room(self_sk, owner_vk, messages, Some(marker.clone()));
+        rd.room_state
+            .recent_messages
+            .actions_state
+            .deleted
+            .insert(marker);
+        // Only messages 3 and 4 follow the marker → 2 unread (not 3 — the
+        // already-read message 1 must stay read despite the deletion).
         assert_eq!(count_unread_in_room_data(&rd), 2);
     }
 }

--- a/ui/src/components/app/document_title.rs
+++ b/ui/src/components/app/document_title.rs
@@ -102,16 +102,13 @@ fn get_current_room_name() -> Option<String> {
     }
 }
 
-/// Count unread messages in a room.
-/// Only counts display messages (non-action, non-deleted) from other users.
-pub fn count_unread_messages_in_room(room_owner: &ed25519_dalek::VerifyingKey) -> usize {
-    let Ok(rooms) = ROOMS.try_read() else {
-        return 0;
-    };
-    let Some(room_data) = rooms.map.get(room_owner) else {
-        return 0;
-    };
-
+/// Count unread messages in a single room's [`RoomData`].
+///
+/// Only counts display messages (non-action, non-deleted) authored by other
+/// users that arrived after `last_read_message_id`. Pure — takes a borrowed
+/// `RoomData` so callers that already hold a `ROOMS` read guard (the
+/// room-list badge memo, the title's cross-room sum) don't re-lock.
+pub fn count_unread_in_room_data(room_data: &crate::room_data::RoomData) -> usize {
     let self_member_id: MemberId = room_data.self_sk.verifying_key().into();
     let last_read_id = room_data.last_read_message_id.as_ref();
 
@@ -152,7 +149,7 @@ pub fn count_total_unread_messages() -> usize {
     let Ok(rooms) = ROOMS.try_read() else {
         return 0;
     };
-    let room_unread: usize = rooms.map.keys().map(count_unread_messages_in_room).sum();
+    let room_unread: usize = rooms.map.values().map(count_unread_in_room_data).sum();
     let dm_unread: usize = count_unread_dms(&rooms);
     room_unread + dm_unread
 }

--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -5,7 +5,9 @@ pub(crate) mod receive_invitation_modal;
 pub(crate) mod room_name_field;
 
 use crate::components::app::chat_delegate::save_rooms_to_delegate;
-use crate::components::app::document_title::mark_current_room_as_read;
+use crate::components::app::document_title::{
+    count_unread_in_room_data, mark_current_room_as_read,
+};
 use crate::components::app::{MobileView, CREATE_ROOM_MODAL, CURRENT_ROOM, MOBILE_VIEW, ROOMS};
 use crate::components::members::{ConnectionStatusIndicator, ImportIdentityModal};
 use crate::components::room_list::dm_rail_section::DmRailSection;
@@ -93,7 +95,19 @@ pub fn RoomList() -> Element {
                     .configuration
                     .privacy_mode
                     == PrivacyMode::Private;
-                (room_key, room_name, is_current, awaiting_sync, is_private)
+                // Unread badge: same per-room count the document title uses,
+                // surfaced in the rail so users who don't get browser
+                // notifications (e.g. not on a localhost node) can still see
+                // which rooms have new messages.
+                let unread = count_unread_in_room_data(room_data);
+                (
+                    room_key,
+                    room_name,
+                    is_current,
+                    awaiting_sync,
+                    is_private,
+                    unread,
+                )
             })
             .collect::<Vec<_>>()
     });
@@ -135,12 +149,13 @@ pub fn RoomList() -> Element {
 
             // Room list
             ul { class: "flex-1 px-2 py-1 space-y-0.5",
-                {room_items.read().iter().map(|(room_key, room_name, is_current, awaiting_sync, is_private)| {
+                {room_items.read().iter().map(|(room_key, room_name, is_current, awaiting_sync, is_private, unread)| {
                     let room_key = *room_key;
                     let room_name = room_name.clone();
                     let is_current = *is_current;
                     let awaiting_sync = *awaiting_sync;
                     let is_private = *is_private;
+                    let unread = *unread;
                     rsx! {
                         li { key: "{room_key:?}",
                             button {
@@ -177,6 +192,14 @@ pub fn RoomList() -> Element {
                                         }
                                     }
                                     span { class: "block truncate flex-1", "{room_name}" }
+                                    if unread > 0 {
+                                        span {
+                                            class: "ml-2 flex-shrink-0 inline-flex items-center justify-center px-2 py-0.5 rounded-full text-xs font-medium bg-accent text-white",
+                                            title: "{unread} unread",
+                                            "aria-label": "{unread} unread messages",
+                                            "{unread}"
+                                        }
+                                    }
                                     if awaiting_sync {
                                         div { class: "animate-spin w-3 h-3 border-2 border-text-muted border-t-transparent rounded-full flex-shrink-0" }
                                     }

--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -192,9 +192,16 @@ pub fn RoomList() -> Element {
                                         }
                                     }
                                     span { class: "block truncate flex-1", "{room_name}" }
-                                    if unread > 0 {
+                                    // Unread badge — hidden for the current
+                                    // room (its messages are marked read on
+                                    // open, so a badge there would only
+                                    // flicker). Styling mirrors the DM rail
+                                    // badge plus `flex-shrink-0` so a long
+                                    // truncated room name can't squash it.
+                                    if unread > 0 && !is_current {
                                         span {
                                             class: "ml-2 flex-shrink-0 inline-flex items-center justify-center px-2 py-0.5 rounded-full text-xs font-medium bg-accent text-white",
+                                            "data-testid": "room-unread-badge",
                                             title: "{unread} unread",
                                             "aria-label": "{unread} unread messages",
                                             "{unread}"

--- a/ui/tests/room-unread-badge.spec.ts
+++ b/ui/tests/room-unread-badge.spec.ts
@@ -32,7 +32,7 @@ test.describe("Rooms list unread badge", () => {
     });
     await expect(roomBtn).toBeVisible({ timeout: 5_000 });
 
-    const badge = roomBtn.locator('[title$="unread"]');
+    const badge = roomBtn.locator('[data-testid="room-unread-badge"]');
     await expect(badge).toBeVisible();
     await expect(badge).toHaveText(/^\d+$/);
     expect(Number(await badge.textContent())).toBeGreaterThan(0);
@@ -46,7 +46,7 @@ test.describe("Rooms list unread badge", () => {
       name: "Public Discussion Room",
     });
     await expect(roomBtn).toBeVisible({ timeout: 5_000 });
-    await expect(roomBtn.locator('[title$="unread"]')).toBeVisible();
+    await expect(roomBtn.locator('[data-testid="room-unread-badge"]')).toBeVisible();
 
     await roomBtn.click();
     await expect(
@@ -54,7 +54,7 @@ test.describe("Rooms list unread badge", () => {
     ).toBeVisible({ timeout: 5_000 });
 
     // Opening the room marks every message read, so the badge disappears.
-    await expect(roomBtn.locator('[title$="unread"]')).toHaveCount(0, {
+    await expect(roomBtn.locator('[data-testid="room-unread-badge"]')).toHaveCount(0, {
       timeout: 5_000,
     });
   });

--- a/ui/tests/room-unread-badge.spec.ts
+++ b/ui/tests/room-unread-badge.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect, Page } from "@playwright/test";
+
+// Regression test for: unread message counts were surfaced in the document
+// <title> and the DM rail, but rooms in the Rooms list had no unread
+// indicator. Users who don't receive browser notifications (e.g. not
+// connected to a localhost node) had no way to tell which rooms had new
+// messages.
+//
+// Requested by Ian Clarke, 2026-05-20.
+
+async function waitForApp(page: Page) {
+  await page.waitForSelector(".app-root", { timeout: 30_000 });
+  await expect(page.locator("aside, .app-root button")).not.toHaveCount(0);
+}
+
+test.describe("Rooms list unread badge", () => {
+  // Force a desktop viewport so the room rail is visible on the mobile
+  // Playwright projects too.
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("a room with unread messages shows a numeric badge", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+
+    // "Public Discussion Room" — the local user is only an observer, so
+    // every example message is authored by someone else and (with no
+    // last-read marker yet) counts as unread.
+    const roomBtn = page.getByRole("button", {
+      name: "Public Discussion Room",
+    });
+    await expect(roomBtn).toBeVisible({ timeout: 5_000 });
+
+    const badge = roomBtn.locator('[title$="unread"]');
+    await expect(badge).toBeVisible();
+    await expect(badge).toHaveText(/^\d+$/);
+    expect(Number(await badge.textContent())).toBeGreaterThan(0);
+  });
+
+  test("selecting a room clears its unread badge", async ({ page }) => {
+    await page.goto("/");
+    await waitForApp(page);
+
+    const roomBtn = page.getByRole("button", {
+      name: "Public Discussion Room",
+    });
+    await expect(roomBtn).toBeVisible({ timeout: 5_000 });
+    await expect(roomBtn.locator('[title$="unread"]')).toBeVisible();
+
+    await roomBtn.click();
+    await expect(
+      page.getByRole("heading", { name: "Public Discussion Room" })
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Opening the room marks every message read, so the badge disappears.
+    await expect(roomBtn.locator('[title$="unread"]')).toHaveCount(0, {
+      timeout: 5_000,
+    });
+  });
+});


### PR DESCRIPTION
## Problem

Unread message counts were surfaced in the document `<title>` and on DM threads in the rail, but rooms in the **Rooms list** had no unread indicator. Users who don't receive browser notifications (e.g. not connected to a localhost node) had no way to tell which rooms had new messages.

Reported by Ian Clarke: *"PLEASE add unread message indicators to rooms in the rooms list. I don't get the notifications from River in the browser because I'm not usually accessing from a localhost node."*

## Approach

- Extracted the per-room unread count into a pure `count_unread_in_room_data(&RoomData)` helper, reused without re-locking the `ROOMS` signal. The room-list memo already holds a `ROOMS` read guard and calls it directly per room; the document title's cross-room sum uses the same helper, so the title and the sum of room badges are now structurally guaranteed to agree.
- Each room row renders a numeric badge — same blue pill styling as the DM rail's unread badge (plus `flex-shrink-0`) — when its unread count is non-zero. The badge is suppressed on the currently-selected room, whose messages are marked read on open.
- Counting reuses the existing `last_read_message_id` semantics — no new unread semantics are introduced; the badge is a second view of the data already driving the title.

## Review fixes (multi-model review found these, all addressed)

- **Stale-marker undercount:** `count_unread_in_room_data` returned 0 when `last_read_message_id` pointed at a message evicted from the bounded recent-messages ring buffer. It now falls back to counting all other-authored messages when the marker is genuinely absent.
- **Deleted-marker over-count (Codex P2):** the fallback above located the marker only via `display_messages()`, which filters deleted messages — so a *deleted* last-read message looked "evicted" and made already-read messages re-surface as unread. Fixed by locating the marker in the full ordered `messages` list; the fallback now fires only on true eviction.
- **CI gap:** added `cargo test -p river-ui --bins` to `build.yml`. The river-ui crate's ~170 native unit tests never ran in CI — only `room-contract` and `river-core` were tested.

## Testing

- 9 Rust unit tests for `count_unread_in_room_data`: no-marker, after-marker, marker-excluded, self-author-excluded, evicted-marker fallback, deleted-message filter, deleted-marker anchoring (regression pin for the Codex P2), empty-buffer edge, and a drift guard cross-checking the helper's filter against `MessagesV1::display_messages`.
- Playwright `room-unread-badge.spec.ts` (5 browser projects): badge appears for a room with unread messages; badge clears when the room is opened.
- Existing `title-unread-badge.spec.ts` still passes, confirming the shared-helper refactor preserved document-title behaviour.
- `cargo clippy` / `cargo fmt` clean.

Changes are confined to the `ui` crate plus a CI workflow step and an `AGENTS.md` test-command line (no contract/delegate/common code, no WASM regeneration).

[AI-assisted - Claude]