### PR TITLE
fix(ui): sync restored rooms via process_rooms, not a bare Subscribe

### DIFF
--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -16,12 +16,10 @@ use crate::components::app::chat_delegate::{
 };
 use crate::components::app::document_title::{mark_current_room_as_read, update_document_title};
 use crate::components::app::notifications::mark_initial_sync_complete;
-use crate::components::app::sync_info::{RoomSyncStatus, SYNC_INFO};
 use crate::components::app::{CURRENT_ROOM, ROOMS};
 use crate::room_data::CurrentRoom;
 use crate::room_data::Rooms;
 use crate::util::ecies::decrypt_with_symmetric_key;
-use crate::util::owner_vk_to_contract_key;
 use ciborium::de::from_reader;
 use dioxus::logger::tracing::{error, info, warn};
 use dioxus::prelude::ReadableExt;
@@ -49,7 +47,8 @@ pub struct ResponseHandler {
 pub struct ResponseFlags {
     /// True if a re-PUT should be scheduled (subscription failed but we have local state)
     pub needs_reput: bool,
-    /// True if subscriptions were initiated and need timeout monitoring
+    /// True if initial sync was kicked off for rooms loaded from delegate
+    /// storage and a subscription-timeout check should be scheduled.
     pub subscriptions_initiated: bool,
 }
 
@@ -676,49 +675,58 @@ impl ResponseHandler {
                                                         // clears the dedup entry on Err so a future
                                                         // load can retry.
 
-                                                        // Subscribe to each loaded room's contract
+                                                        // Drive initial sync for rooms loaded
+                                                        // from delegate storage through
+                                                        // process_rooms() — do NOT subscribe to the
+                                                        // contract directly here.
+                                                        //
+                                                        // A bare Subscribe is REJECTED by the node
+                                                        // when the contract's WASM/parameters are
+                                                        // not cached locally (freenet-core#3601) —
+                                                        // always the case for a room restored from
+                                                        // an exported backup, or any room not used
+                                                        // on this node before. The rejection comes
+                                                        // back as an Err API response, NOT a
+                                                        // SubscribeResponse{subscribed:false}, so
+                                                        // the re-PUT recovery in
+                                                        // handle_subscribe_response never runs and
+                                                        // the room is stuck on "Syncing room state
+                                                        // from the network..." forever
+                                                        // (freenet/river#287).
+                                                        //
+                                                        // process_rooms() ->
+                                                        // rooms_awaiting_subscription() does the
+                                                        // right thing per room: imported rooms
+                                                        // (default placeholder state) GET with
+                                                        // return_contract_code=true; full-state
+                                                        // rooms PUT with subscribe=true. Both cache
+                                                        // the contract WASM on the node BEFORE any
+                                                        // subscribe, so the subscription succeeds.
+                                                        let had_loaded_rooms =
+                                                            !room_keys.is_empty();
                                                         info!(
-                                                            "Subscribing to {} rooms loaded from delegate",
+                                                            "Scheduling initial sync for {} rooms loaded from delegate",
                                                             room_keys.len()
                                                         );
                                                         for room_key in room_keys {
-                                                            // Register the room in SYNC_INFO
-                                                            crate::util::defer(move || {
-                                                                SYNC_INFO
-                                                                    .write()
-                                                                    .register_new_room(room_key);
-                                                                SYNC_INFO
-                                                                    .write()
-                                                                    .update_sync_status(
-                                                                        &room_key,
-                                                                        RoomSyncStatus::Subscribing,
-                                                                    );
-                                                            });
-
-                                                            // Get contract key and subscribe
-                                                            let contract_key =
-                                                                owner_vk_to_contract_key(&room_key);
-                                                            if let Err(e) = self
-                                                                .room_synchronizer
-                                                                .subscribe_to_contract(
-                                                                    &contract_key,
-                                                                )
-                                                                .await
-                                                            {
-                                                                error!(
-                                                                    "Failed to subscribe to loaded room {:?}: {}",
-                                                                    contract_key.id(),
-                                                                    e
-                                                                );
-                                                            } else {
-                                                                info!(
-                                                                    "Successfully sent subscribe request for loaded room {:?}",
-                                                                    contract_key.id()
-                                                                );
-                                                                // Mark that subscriptions were initiated so timeout monitoring can be scheduled
-                                                                flags.subscriptions_initiated =
-                                                                    true;
-                                                            }
+                                                            // Queues a ProcessRooms cycle via the
+                                                            // NEEDS_SYNC effect. mark_needs_sync
+                                                            // defers the signal write
+                                                            // (setTimeout(0)), so it runs AFTER
+                                                            // the deferred ROOMS merge above — the
+                                                            // effect therefore sees the merged
+                                                            // rooms and process_rooms() picks each
+                                                            // one up as Disconnected.
+                                                            crate::components::app::mark_needs_sync(
+                                                                room_key,
+                                                            );
+                                                        }
+                                                        if had_loaded_rooms {
+                                                            // Schedule a subscription-timeout
+                                                            // check so a room whose PUT/GET
+                                                            // response never arrives is reset and
+                                                            // retried by rooms_awaiting_subscription().
+                                                            flags.subscriptions_initiated = true;
                                                         }
 
                                                         // TODO: Remove legacy migration code after 2026-03-01
@@ -1137,6 +1145,61 @@ mod tests {
                 /* user_has_selected */ true, /* is_legacy_delegate */ false,
             ),
             CurrentRoomRestore::SkipUserAlreadySelected,
+        );
+    }
+
+    /// Regression guard for freenet/river#287.
+    ///
+    /// A user restoring old room identities from exported backups hit a
+    /// never-ending "Syncing room state from the network..." spinner.
+    /// Root cause: the rooms-loaded-from-delegate path issued a bare
+    /// `Subscribe` request for every room. The node REJECTS a Subscribe
+    /// when the contract's WASM/parameters are not cached locally
+    /// (freenet-core#3601) — always true for a freshly-restored room.
+    /// That rejection arrives as an `Err` API response, not a
+    /// `SubscribeResponse { subscribed: false }`, so the re-PUT recovery
+    /// in `handle_subscribe_response` never runs and the room hangs.
+    ///
+    /// The fix routes rooms loaded from delegate storage through
+    /// `process_rooms()` (via `mark_needs_sync`), which PUTs full-state
+    /// rooms or GETs imported rooms with `return_contract_code = true` —
+    /// both cache the contract WASM on the node BEFORE any subscribe.
+    ///
+    /// `handle_api_response` is too deeply coupled to the Dioxus signal
+    /// runtime + WebSocket to drive in a unit test, so this is a
+    /// source-text pin (same approach as the #267 guards in
+    /// `room_synchronizer.rs`). It fails if a future change reintroduces
+    /// a direct subscribe from this response handler.
+    #[test]
+    fn issue_287_loaded_rooms_do_not_bare_subscribe() {
+        let src = include_str!("response_handler.rs");
+
+        // Built via concat! so this very test file does not itself
+        // contain the contiguous literal — otherwise include_str!() of
+        // this file would always trip the negative assertion below.
+        let bare_subscribe_helper = concat!("subscribe", "_to_contract");
+        assert!(
+            !src.contains(bare_subscribe_helper),
+            "response_handler.rs must not call the room-synchronizer's \
+             bare-subscribe helper: a bare Subscribe is rejected by the \
+             node when the contract WASM is not cached locally, which \
+             silently hangs sync for restored rooms (freenet/river#287). \
+             Subscribe only AFTER a PUT/GET caches the contract — route \
+             loaded rooms through process_rooms() instead."
+        );
+
+        // The rooms-loaded-from-delegate path must hand off to the
+        // NEEDS_SYNC -> ProcessRooms cycle so process_rooms() drives the
+        // contract-caching PUT/GET.
+        let marker = "Scheduling initial sync for";
+        let split_at = src.find(marker).expect(
+            "the rooms-loaded-from-delegate sync hand-off must exist — \
+             the #287 fix has been removed or moved",
+        );
+        assert!(
+            src[split_at..].contains("mark_needs_sync"),
+            "the rooms-loaded-from-delegate path must call mark_needs_sync \
+             to drive sync through process_rooms() (freenet/river#287)."
         );
     }
 }

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -1167,21 +1167,26 @@ mod tests {
     ///
     /// `handle_api_response` is too deeply coupled to the Dioxus signal
     /// runtime + WebSocket to drive in a unit test, so this is a
-    /// source-text pin (same approach as the #267 guards in
-    /// `room_synchronizer.rs`). It fails if a future change reintroduces
-    /// a direct subscribe from this response handler.
+    /// source-text pin on this file's PRODUCTION code (same approach as
+    /// the #267 guards in `room_synchronizer.rs`). It fails if a future
+    /// change reintroduces a direct subscribe, or drops the
+    /// `process_rooms()` hand-off, in the rooms-loaded path.
     #[test]
     fn issue_287_loaded_rooms_do_not_bare_subscribe() {
+        // include_str!() reads the WHOLE file, this test module included.
+        // Slice it off at `mod tests {` so the literals in the test
+        // itself can neither satisfy the positive assertion nor trip the
+        // negative one — the pin must reflect production code only.
         let src = include_str!("response_handler.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("response_handler.rs must have production code before `mod tests`");
 
-        // Built via concat! so this very test file does not itself
-        // contain the contiguous literal — otherwise include_str!() of
-        // this file would always trip the negative assertion below.
-        let bare_subscribe_helper = concat!("subscribe", "_to_contract");
         assert!(
-            !src.contains(bare_subscribe_helper),
-            "response_handler.rs must not call the room-synchronizer's \
-             bare-subscribe helper: a bare Subscribe is rejected by the \
+            !production.contains("subscribe_to_contract"),
+            "the rooms-loaded-from-delegate path must not call \
+             subscribe_to_contract: a bare Subscribe is rejected by the \
              node when the contract WASM is not cached locally, which \
              silently hangs sync for restored rooms (freenet/river#287). \
              Subscribe only AFTER a PUT/GET caches the contract — route \
@@ -1190,14 +1195,16 @@ mod tests {
 
         // The rooms-loaded-from-delegate path must hand off to the
         // NEEDS_SYNC -> ProcessRooms cycle so process_rooms() drives the
-        // contract-caching PUT/GET.
+        // contract-caching PUT/GET. If that block is removed or moved,
+        // the marker disappears from production code and `expect` fires.
         let marker = "Scheduling initial sync for";
-        let split_at = src.find(marker).expect(
-            "the rooms-loaded-from-delegate sync hand-off must exist — \
-             the #287 fix has been removed or moved",
+        let split_at = production.find(marker).expect(
+            "the rooms-loaded-from-delegate sync hand-off must exist in \
+             response_handler.rs production code — the #287 fix has been \
+             removed or moved",
         );
         assert!(
-            src[split_at..].contains("mark_needs_sync"),
+            production[split_at..].contains("mark_needs_sync"),
             "the rooms-loaded-from-delegate path must call mark_needs_sync \
              to drive sync through process_rooms() (freenet/river#287)."
         );


### PR DESCRIPTION
## Problem

Restoring old room identities from exported backups leaves River stuck on a
never-ending sync spinner — the room list shows the spinner forever and the
conversation pane shows *"Syncing room state from the network… You'll be able
to send messages once sync completes."* across restarts (freenet/river#287,
reported by @Ivvvor).

The most prominent console error is:

```
Cannot subscribe to contract XYZ: contract WASM/parameters not cached
locally. PUT the contract or GET the contract before subscribing.
```

**Root cause:** the rooms-loaded-from-delegate path in `handle_api_response`
(the `ROOMS_STORAGE_KEY` branch) issued a **bare `ContractRequest::Subscribe`**
for every loaded room. Since freenet-core#3601 the node *rejects* a Subscribe
when the contract's WASM/parameters are not cached locally — always the case
for a freshly-restored backup, or any room not previously used on this node.

That rejection is unrecoverable on the River side:

- It arrives as an **`Err` API response** (`ErrorKind::OperationError`), **not**
  a `SubscribeResponse { subscribed: false }`, so the re-PUT recovery in
  `handle_subscribe_response` never runs.
- The error string contains `"contract"` but not `"not found"`, so the
  `freenet_synchronizer` error handler (which only matches contract-not-found)
  ignores it too.
- The room was set to `Subscribing` before the bare Subscribe, so it stays
  stuck there.

## Approach

Stop subscribing directly from the response handler. Route rooms loaded from
delegate storage through `process_rooms()` (via `mark_needs_sync`), which is
the single path that already handles this correctly:

- **Imported rooms** (default placeholder state) → `GET` with
  `return_contract_code = true`
- **Full-state rooms** → `PUT` with `subscribe = true`

Both **cache the contract WASM on the node before any subscribe**, so the
subsequent subscription succeeds. `mark_needs_sync` defers its signal write,
so it runs after the deferred `ROOMS` merge and `process_rooms()` sees the
merged rooms. A subscription-timeout check is still scheduled as a safety net.

This deletes the duplicate, buggy sync path entirely — the standard
`process_rooms()` flow is now the only one.

## Behaviour change

Rooms loaded from delegate storage now go through `process_rooms()` on cold
start, so a full-state room gets a `PUT` (CRDT merge — idempotent) where it
previously got a bare `Subscribe`. Slightly more cold-start traffic, but it
is the same path already used for invitations and migrated rooms and is what
makes the WASM-cache reliable.

## Testing

- New regression test `issue_287_loaded_rooms_do_not_bare_subscribe` in
  `response_handler.rs`. `handle_api_response` is too deeply coupled to the
  Dioxus signal runtime to drive behaviourally, so it is a source-text pin
  over this file's **production code** (same approach as the #267 guards in
  `room_synchronizer.rs`); it fails if a bare subscribe is reintroduced or
  the `process_rooms()` hand-off is removed. Verified it **fails against the
  pre-fix code** (which has the `.subscribe_to_contract(` call) and **passes
  with the fix**.
- It runs in CI via the `Test river-ui` step (`cargo test -p river-ui --bins`)
  that #288 added to `build.yml` — `river-ui`'s native unit tests previously
  ran in no CI job. (An earlier revision of this PR added that same step; it
  was dropped on rebase since #288 landed it first.)
- Full `cargo test -p river-ui --bins`: all tests pass, 0 failed.
- `cargo fmt` + `cargo clippy -p river-ui` clean.

## Out of scope — follow-up #290

This PR fixes the evidenced #287 symptom (the bare-`Subscribe` rejection).
After the fix an imported room is synced via `process_rooms()`, which `GET`s
with `return_contract_code = true` — caching the WASM and, if the contract
still exists on the network, completing sync.

If a restored room's contract is **genuinely absent from the network** (a
long-abandoned room whose contract was dropped), the GET fails and River
retries while the `is_awaiting_initial_sync()`-driven spinner keeps spinning.
That is a distinct, pre-existing bug with a different precondition — filed as
**#290** (bounded retry + a terminal UI error state).

Closes #287

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
