### PR TITLE
fix(ui): invite-via-DM picker shows the current member's name on reopen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -662,6 +662,26 @@ Signal clears that the effect subscribes to must be synchronous. Deferring
 causes an infinite loop (set remains non-empty → effect re-runs → defers
 clear → effect re-runs...).
 
+### Don't `use_memo` against non-signal values in an always-mounted component
+
+The modals in `app.rs` (`MemberInfoModal`, `DmThreadModal`,
+`InviteViaDmPickerModal`, etc.) are mounted unconditionally and only
+return an empty element when inactive — the component instance, and all
+its hooks, live for the whole app session and never reinitialise.
+
+A `use_memo` recomputes only when a *signal it read* changes. If its
+closure depends on a plain captured value (a destructured field of some
+*other* signal, a prop, anything that is not itself a `Signal`), the memo
+will keep handing back the value computed from the *first* render's
+captured input — it is never told that input changed. In an
+always-mounted modal this surfaces as stale content on reopen.
+
+Compute such values inline in the render body instead (the component
+re-renders when the signal driving its open/close state changes), or
+reset per-open `use_signal` scratch state with a `use_effect` keyed on
+that open/close signal. freenet/river#291 (the invite-via-DM picker
+showing the previous invitee's name) was exactly this bug.
+
 ## PR Expectations
 - Follow Conventional Commit style for PR titles (e.g., `fix(ui): correct room timestamp format`).
 - Include a brief description of test coverage in the PR body.

--- a/ui/src/components/direct_messages/invite_via_dm_picker_modal.rs
+++ b/ui/src/components/direct_messages/invite_via_dm_picker_modal.rs
@@ -93,19 +93,20 @@ pub fn InviteViaDmPickerModal() -> Element {
     // The picker is mounted unconditionally in `app.rs` and never
     // unmounts, so these `use_signal`s are NOT dropped when the picker
     // closes — they persist across open/close cycles.
-    let mut selected_room: Signal<Option<VerifyingKey>> = use_signal(|| None);
+    // `selected_room` is tagged with the `target_peer` it was chosen for,
+    // so a selection carried over from a previous open is ignored unless
+    // it belongs to the current session (see `selected_room_value`).
+    let mut selected_room: Signal<Option<(MemberId, VerifyingKey)>> = use_signal(|| None);
     let mut personal_message = use_signal(String::new);
     let mut send_error: Signal<Option<String>> = use_signal(|| None);
     let mut last_success_label: Signal<Option<String>> = use_signal(|| None);
 
-    // Reset that scratch state on every `INVITE_VIA_DM_PICKER` transition
-    // (open / close / switch target) so a fresh pick never inherits the
-    // previous one's state. Without this, a stale `selected_room`
-    // pointing at a room that is no longer a candidate could send an
-    // invite to the wrong room (Codex P2 on PR #291), and a stale
-    // success banner / error would render on reopen for a different
-    // member (same "previous pick leaks into the next" symptom class as
-    // the title bug this PR fixes).
+    // Reset the scratch state on every `INVITE_VIA_DM_PICKER` transition
+    // (open / close / switch target) so a reopened picker doesn't show
+    // the previous pick's typed message, error, or success banner. (The
+    // selected room is additionally session-tagged — see
+    // `selected_room_value` below — so its correctness does not depend on
+    // this effect's timing; the effect clears it too, as hygiene.)
     //
     // The effect reads only `INVITE_VIA_DM_PICKER`, so it re-runs on that
     // signal alone — not on the signals it writes — so there is no
@@ -235,15 +236,21 @@ pub fn InviteViaDmPickerModal() -> Element {
         Err(_) => Vec::new(),
     };
 
-    // Only honour a selection that is an actual current candidate. The
-    // `use_effect` above resets `selected_room` on reopen, but that reset
-    // lands one render *after* reopen; this filter makes the picker
-    // correct on that first frame too, so a stale cross-room selection
-    // can never arm the Send button (Codex P2 on PR #291). Normal
-    // operation is unaffected — a freshly clicked row is always a member
-    // of `candidates_value`.
-    let selected_room_value =
-        (*selected_room.read()).filter(|vk| candidates_value.iter().any(|c| &c.room_vk == vk));
+    // The selected room, valid for THIS picker session only. Two
+    // synchronous render-time checks: (1) the selection must be tagged
+    // with the current `target_peer` — a selection carried over from a
+    // previous open (the `use_signal` persists; the component never
+    // unmounts) is ignored; (2) the room must still be a current
+    // candidate. Because both run here at render time, the Send button is
+    // never armed by a stale selection — not even on the first frame
+    // after reopen, before the reset `use_effect` runs (Codex P2 on
+    // PR #291). Normal operation is unaffected: a row the user just
+    // clicked is tagged with the current `target_peer` and is a member of
+    // `candidates_value`.
+    let selected_room_value = (*selected_room.read())
+        .filter(|(peer, _)| *peer == target_peer)
+        .map(|(_, room)| room)
+        .filter(|vk| candidates_value.iter().any(|c| &c.room_vk == vk));
     let personal_message_value = personal_message.read().clone();
     let send_error_value = send_error.read().clone();
     let last_success_label_value = last_success_label.read().clone();
@@ -263,22 +270,22 @@ pub fn InviteViaDmPickerModal() -> Element {
         if INVITE_VIA_DM_PICKER_INFLIGHT.peek().is_some() {
             return;
         }
-        let Some(candidate_room_vk) = *selected_room.peek() else {
-            send_error.set(Some("Pick a room to invite them to first.".into()));
-            return;
+        // The selection must belong to THIS session (tagged with the
+        // current `target_peer`) AND still be a current candidate — the
+        // same two checks as the `selected_room_value` render filter.
+        // Guarding the send path directly means it never depends on the
+        // Send button's disabled state (Codex P2 on PR #291).
+        let candidate_room_vk = match *selected_room.peek() {
+            Some((peer, room))
+                if peer == target_peer && candidates_for_send.iter().any(|c| c.room_vk == room) =>
+            {
+                room
+            }
+            _ => {
+                send_error.set(Some("Pick a room to invite them to first.".into()));
+                return;
+            }
         };
-        // Defense-in-depth: never act on a selection that isn't a current
-        // candidate (e.g. a stale cross-room pick the reset effect hasn't
-        // cleared yet). The render-side filter on `selected_room_value`
-        // already disables the Send button in that case; this guards the
-        // send path itself so it can't depend on that reasoning.
-        if !candidates_for_send
-            .iter()
-            .any(|c| c.room_vk == candidate_room_vk)
-        {
-            send_error.set(Some("Pick a room to invite them to first.".into()));
-            return;
-        }
         send_error.set(None);
 
         let pmessage = personal_message.peek().clone();
@@ -467,7 +474,7 @@ pub fn InviteViaDmPickerModal() -> Element {
                                     on_select: {
                                         let r = room.room_vk;
                                         move |_| {
-                                            selected_room.set(Some(r));
+                                            selected_room.set(Some((target_peer, r)));
                                         }
                                     },
                                 }

--- a/ui/src/components/direct_messages/invite_via_dm_picker_modal.rs
+++ b/ui/src/components/direct_messages/invite_via_dm_picker_modal.rs
@@ -235,7 +235,15 @@ pub fn InviteViaDmPickerModal() -> Element {
         Err(_) => Vec::new(),
     };
 
-    let selected_room_value = *selected_room.read();
+    // Only honour a selection that is an actual current candidate. The
+    // `use_effect` above resets `selected_room` on reopen, but that reset
+    // lands one render *after* reopen; this filter makes the picker
+    // correct on that first frame too, so a stale cross-room selection
+    // can never arm the Send button (Codex P2 on PR #291). Normal
+    // operation is unaffected — a freshly clicked row is always a member
+    // of `candidates_value`.
+    let selected_room_value =
+        (*selected_room.read()).filter(|vk| candidates_value.iter().any(|c| &c.room_vk == vk));
     let personal_message_value = personal_message.read().clone();
     let send_error_value = send_error.read().clone();
     let last_success_label_value = last_success_label.read().clone();
@@ -259,6 +267,18 @@ pub fn InviteViaDmPickerModal() -> Element {
             send_error.set(Some("Pick a room to invite them to first.".into()));
             return;
         };
+        // Defense-in-depth: never act on a selection that isn't a current
+        // candidate (e.g. a stale cross-room pick the reset effect hasn't
+        // cleared yet). The render-side filter on `selected_room_value`
+        // already disables the Send button in that case; this guards the
+        // send path itself so it can't depend on that reasoning.
+        if !candidates_for_send
+            .iter()
+            .any(|c| c.room_vk == candidate_room_vk)
+        {
+            send_error.set(Some("Pick a room to invite them to first.".into()));
+            return;
+        }
         send_error.set(None);
 
         let pmessage = personal_message.peek().clone();

--- a/ui/src/components/direct_messages/invite_via_dm_picker_modal.rs
+++ b/ui/src/components/direct_messages/invite_via_dm_picker_modal.rs
@@ -111,19 +111,16 @@ pub fn InviteViaDmPickerModal() -> Element {
     // invite via DM" — gives the user immediate context for which
     // member they're acting on.
     //
-    // Computed inline every render rather than via `use_memo`. This
-    // modal is mounted unconditionally in `app.rs` and merely returns
-    // an empty element when inactive — the component instance never
-    // unmounts, so a `use_memo` here would live for the whole app
-    // session. A memo only recomputes when a *signal it read* changes;
-    // this computation reads `ROOMS`, but `current_room` / `target_peer`
-    // are plain captured values, not signals. So when the picker was
-    // closed and reopened for a different member, the memo kept handing
-    // back its stale cached value and the title showed the *previous*
-    // invitee's name (Ivvor bug report, 2026-05-20). The component
-    // re-renders whenever `INVITE_VIA_DM_PICKER` changes (read at the
-    // top of this fn), so an inline computation is always fresh; the
-    // per-render cost is a single nickname unseal — trivial for a modal.
+    // Computed inline every render — NOT via `use_memo`. A memo only
+    // recomputes when a *signal it read* changes; this reads `ROOMS`,
+    // but `current_room` / `target_peer` are plain captured values, not
+    // signals. The modal is mounted unconditionally in `app.rs` and
+    // never unmounts, so a memo would persist across picker opens and
+    // keep handing back the stale cached name from the *previous*
+    // invitee (Ivvor bug report, 2026-05-20). This component re-renders
+    // whenever `INVITE_VIA_DM_PICKER` changes (read at the top of this
+    // fn), so the inline value is always fresh; the per-render cost is
+    // one nickname unseal — trivial for a modal.
     let peer_label_value: String = {
         let rooms = ROOMS.try_read().ok();
         let nickname = rooms
@@ -153,10 +150,10 @@ pub fn InviteViaDmPickerModal() -> Element {
     // don't filter on "target is already a member" because per-room
     // identities make that check unreliable.
     //
-    // Inline for the same reason as `peer_label_value` above: a
-    // `use_memo` only subscribes to `ROOMS`, so reopening the picker
-    // from a *different* current room would keep showing the previous
-    // room's candidate list (the same stale-capture bug as the title).
+    // Inline rather than `use_memo` for the same reason as
+    // `peer_label_value` above: a memo subscribes only to `ROOMS`, so
+    // reopening the picker from a *different* current room would keep
+    // showing the previous room's candidate list.
     let candidates_value: Vec<CandidateRoom> = match ROOMS.try_read() {
         Ok(rooms) => {
             let mut out: Vec<CandidateRoom> = rooms

--- a/ui/src/components/direct_messages/invite_via_dm_picker_modal.rs
+++ b/ui/src/components/direct_messages/invite_via_dm_picker_modal.rs
@@ -80,39 +80,42 @@ static PICK_GENERATION: AtomicU64 = AtomicU64::new(0);
 
 #[component]
 pub fn InviteViaDmPickerModal() -> Element {
-    let active = *INVITE_VIA_DM_PICKER.read();
-    let Some((current_room, target_peer)) = active else {
-        return rsx! {};
-    };
-
-    let in_flight = *INVITE_VIA_DM_PICKER_INFLIGHT.read();
-    let any_pending = in_flight.is_some();
-
+    // --- Hooks first (Rules of Hooks) --------------------------------
+    // ALL hooks must run unconditionally, BEFORE the early return below.
+    // Do NOT add a hook after the `let Some(...) = active else { … }`
+    // guard: this component renders 0 hooks when closed and N when open,
+    // which is only sound as strict all-or-nothing. A hook placed after
+    // the guard would shift the hook sequence on the first close→reopen
+    // and panic.
+    //
     // Per-open scratch state: the selected target room, the optional
     // personal message, and the inline error / success-banner strings.
-    //
-    // The picker component is mounted unconditionally in `app.rs` and
-    // never unmounts, so these `use_signal`s are NOT dropped when the
-    // picker closes — they persist across open/close cycles. The
-    // `use_effect` below resets them every time the picker (re)opens so
-    // a fresh pick never inherits the previous one's state. Without that
-    // reset a stale `selected_room` pointing at a room that is no longer
-    // a candidate could even send an invite to the wrong room (Codex P2
-    // on PR #291), and a stale success banner / error would render on
-    // reopen for a different member (same "previous pick leaks into the
-    // next" symptom class as the title bug this PR fixes).
+    // The picker is mounted unconditionally in `app.rs` and never
+    // unmounts, so these `use_signal`s are NOT dropped when the picker
+    // closes — they persist across open/close cycles.
     let mut selected_room: Signal<Option<VerifyingKey>> = use_signal(|| None);
     let mut personal_message = use_signal(String::new);
     let mut send_error: Signal<Option<String>> = use_signal(|| None);
     let mut last_success_label: Signal<Option<String>> = use_signal(|| None);
 
-    // Reset the scratch state on every `INVITE_VIA_DM_PICKER` transition
-    // (open / close / switch target). The effect reads only
-    // `INVITE_VIA_DM_PICKER`, so it re-runs on that signal alone — not on
-    // the signals it writes — which means no feedback loop. The clears
-    // are synchronous, as required for `use_effect` (a deferred clear an
-    // effect subscribes to would loop; these signals are not subscribed
-    // here, but synchronous is still the correct form).
+    // Reset that scratch state on every `INVITE_VIA_DM_PICKER` transition
+    // (open / close / switch target) so a fresh pick never inherits the
+    // previous one's state. Without this, a stale `selected_room`
+    // pointing at a room that is no longer a candidate could send an
+    // invite to the wrong room (Codex P2 on PR #291), and a stale
+    // success banner / error would render on reopen for a different
+    // member (same "previous pick leaks into the next" symptom class as
+    // the title bug this PR fixes).
+    //
+    // The effect reads only `INVITE_VIA_DM_PICKER`, so it re-runs on that
+    // signal alone — not on the signals it writes — so there is no
+    // feedback loop, and the clears are synchronous (required for
+    // `use_effect`). It deliberately uses `.read()`, not `try_read()`:
+    // this is the effect's sole subscription, and a `try_read()` miss
+    // would silently drop it and permanently disable the reset; the
+    // effect runs post-render in a clean context so the borrow is free.
+    // The reset lands on the render *after* reopen (effects run
+    // post-render) — a sub-frame window, imperceptible in practice.
     use_effect(move || {
         let _ = INVITE_VIA_DM_PICKER.read();
         selected_room.set(None);
@@ -120,6 +123,15 @@ pub fn InviteViaDmPickerModal() -> Element {
         send_error.set(None);
         last_success_label.set(None);
     });
+
+    // --- Early return: render nothing while the picker is closed ------
+    let active = *INVITE_VIA_DM_PICKER.read();
+    let Some((current_room, target_peer)) = active else {
+        return rsx! {};
+    };
+
+    let in_flight = *INVITE_VIA_DM_PICKER_INFLIGHT.read();
+    let any_pending = in_flight.is_some();
 
     let close = move |_| {
         // Don't close while a send is in flight.
@@ -311,14 +323,18 @@ pub fn InviteViaDmPickerModal() -> Element {
             .await;
 
             crate::util::defer(move || {
-                // If the watchdog already fired (timeout exceeded), the
-                // user may have closed the picker — in which case the
-                // local `use_signal`s captured here (last_success_label /
-                // send_error) point at signals owned by a dropped
-                // component. Calling `.set()` on those panics in Dioxus
-                // 0.7. Generation check below tells us whether this
-                // task's pick is still active; if not, skip the local-
-                // signal updates and only do the global cleanup.
+                // This pick may have been superseded while `drive_send`
+                // was awaiting: the watchdog (timeout) may have fired and
+                // cleared INFLIGHT, or the user may have started a newer
+                // pick. The generation check below detects that. If this
+                // task's pick is no longer the active one, skip the
+                // picker-local UI updates (`last_success_label` /
+                // `send_error` / closing the picker) — applying them
+                // would clobber a newer picker session or resurrect an
+                // already-closed one — and do only the global INFLIGHT
+                // cleanup. (The component itself never unmounts, so the
+                // `use_signal`s are always valid to write; the gate is
+                // about pick-generation correctness, not panic-safety.)
                 // (Codex P2 on round-4 review of PR #278.)
                 let still_mine = matches!(
                     *INVITE_VIA_DM_PICKER_INFLIGHT.peek(),
@@ -335,7 +351,8 @@ pub fn InviteViaDmPickerModal() -> Element {
                             last_success_label.set(Some(candidate_label_for_task.clone()));
                             // Close the picker and the parent member-info
                             // modal — the user is done with this flow.
-                            // Only safe when the picker is still mounted.
+                            // Only when this pick is still the active one
+                            // (the `still_mine` gate above).
                             *INVITE_VIA_DM_PICKER.write() = None;
                             MEMBER_INFO_MODAL.with_mut(|m| m.member = None);
                         } else {
@@ -357,8 +374,10 @@ pub fn InviteViaDmPickerModal() -> Element {
                         if still_mine {
                             send_error.set(Some(e));
                         } else {
-                            // Same rationale — picker no longer mounted.
-                            // The failure is logged but not surfaced.
+                            // Same rationale — this pick has been
+                            // superseded; the failure is logged but not
+                            // surfaced to a picker session that has
+                            // moved on.
                             warn!(
                                 "invite-via-DM: error '{}' arrived after \
                                  watchdog fired; not surfacing to closed picker",
@@ -656,20 +675,20 @@ async fn drive_send(
 ///
 /// **Why force-close on expiry** (Codex P2 on round-5 review of PR #278):
 /// the previous shape left the picker open after clearing INFLIGHT,
-/// but the still-mine gate (added on round-4 to prevent panics from
-/// .set() on dropped use_signals) then silenced the eventual late
-/// completion's UI updates — leaving the user with no feedback at all
-/// in the timeout-then-late-success scenario, and potentially sending
-/// a duplicate invite on retry.
+/// but the still-mine generation gate (added on round-4 so a superseded
+/// pick's late completion can't apply UI updates) then silenced the
+/// eventual late completion's UI updates — leaving the user with no
+/// feedback at all in the timeout-then-late-success scenario, and
+/// potentially sending a duplicate invite on retry.
 ///
-/// Force-closing on expiry eliminates the "still mounted but watchdog
-/// fired" state entirely: every late completion finds the picker
-/// already unmounted, the still-mine gate skips the .set() calls (no
-/// panic), and the user sees a closed modal (clear "something
-/// happened" signal) which prompts them to check the DM thread for
-/// confirmation. The trade-off is losing the user's typed personal
-/// message on timeout, which is strictly better than the prior shape
-/// (no feedback + possible duplicate sends).
+/// Force-closing on expiry eliminates the "open picker, but its pick
+/// already abandoned by the watchdog" state entirely: every late
+/// completion finds INFLIGHT already cleared, so the still-mine gate
+/// skips its UI updates, and the user sees a closed modal (a clear
+/// "something happened" signal) which prompts them to check the DM
+/// thread for confirmation. The trade-off is losing the user's typed
+/// personal message on timeout, which is strictly better than the prior
+/// shape (no feedback + possible duplicate sends).
 fn schedule_watchdog(my_generation: u64) {
     use std::time::Duration;
     crate::util::safe_spawn_local(async move {

--- a/ui/src/components/direct_messages/invite_via_dm_picker_modal.rs
+++ b/ui/src/components/direct_messages/invite_via_dm_picker_modal.rs
@@ -26,10 +26,11 @@
 //! pick the right destination.
 //!
 //! In-flight state lives at module scope (`INVITE_VIA_DM_PICKER_INFLIGHT`,
-//! defined in the parent module) rather than as a `use_signal` inside
-//! the picker, because the watchdog task can outlive the picker's
-//! unmount on the success path; reading a use_signal whose owning
-//! component has been dropped panics in Dioxus.
+//! defined in the parent module) so the watchdog task and the
+//! terminal-defer block can coordinate even after the picker has been
+//! closed or reopened for a different member. (The component itself is
+//! mounted unconditionally in `app.rs` and never unmounts — it just
+//! returns an empty element when `INVITE_VIA_DM_PICKER` is `None`.)
 //! A monotonic generation counter lets stale watchdogs from prior picks
 //! short-circuit immediately when a newer pick has taken over.
 
@@ -87,14 +88,38 @@ pub fn InviteViaDmPickerModal() -> Element {
     let in_flight = *INVITE_VIA_DM_PICKER_INFLIGHT.read();
     let any_pending = in_flight.is_some();
 
-    // Selected target room (the room we're generating an invite TO) and
-    // optional personal message. `use_signal` keeps both local to this
-    // mount — when the picker closes both are dropped, so re-opening
-    // starts fresh.
+    // Per-open scratch state: the selected target room, the optional
+    // personal message, and the inline error / success-banner strings.
+    //
+    // The picker component is mounted unconditionally in `app.rs` and
+    // never unmounts, so these `use_signal`s are NOT dropped when the
+    // picker closes — they persist across open/close cycles. The
+    // `use_effect` below resets them every time the picker (re)opens so
+    // a fresh pick never inherits the previous one's state. Without that
+    // reset a stale `selected_room` pointing at a room that is no longer
+    // a candidate could even send an invite to the wrong room (Codex P2
+    // on PR #291), and a stale success banner / error would render on
+    // reopen for a different member (same "previous pick leaks into the
+    // next" symptom class as the title bug this PR fixes).
     let mut selected_room: Signal<Option<VerifyingKey>> = use_signal(|| None);
     let mut personal_message = use_signal(String::new);
     let mut send_error: Signal<Option<String>> = use_signal(|| None);
     let mut last_success_label: Signal<Option<String>> = use_signal(|| None);
+
+    // Reset the scratch state on every `INVITE_VIA_DM_PICKER` transition
+    // (open / close / switch target). The effect reads only
+    // `INVITE_VIA_DM_PICKER`, so it re-runs on that signal alone — not on
+    // the signals it writes — which means no feedback loop. The clears
+    // are synchronous, as required for `use_effect` (a deferred clear an
+    // effect subscribes to would loop; these signals are not subscribed
+    // here, but synchronous is still the correct form).
+    use_effect(move || {
+        let _ = INVITE_VIA_DM_PICKER.read();
+        selected_room.set(None);
+        personal_message.set(String::new());
+        send_error.set(None);
+        last_success_label.set(None);
+    });
 
     let close = move |_| {
         // Don't close while a send is in flight.
@@ -119,8 +144,12 @@ pub fn InviteViaDmPickerModal() -> Element {
     // keep handing back the stale cached name from the *previous*
     // invitee (Ivvor bug report, 2026-05-20). This component re-renders
     // whenever `INVITE_VIA_DM_PICKER` changes (read at the top of this
-    // fn), so the inline value is always fresh; the per-render cost is
-    // one nickname unseal — trivial for a modal.
+    // fn), so the inline value tracks the current peer. A render that
+    // races a concurrent `ROOMS` write falls back to the truncated key
+    // for that one render and recovers on the next — still strictly
+    // better than a memo, which per AGENTS.md stops re-evaluating
+    // permanently after a `try_read` miss. The per-render cost is one
+    // nickname unseal — trivial for a modal.
     let peer_label_value: String = {
         let rooms = ROOMS.try_read().ok();
         let nickname = rooms

--- a/ui/src/components/direct_messages/invite_via_dm_picker_modal.rs
+++ b/ui/src/components/direct_messages/invite_via_dm_picker_modal.rs
@@ -110,7 +110,21 @@ pub fn InviteViaDmPickerModal() -> Element {
     // "Invite Bob to another room" instead of the generic "Share an
     // invite via DM" — gives the user immediate context for which
     // member they're acting on.
-    let peer_label = use_memo(move || -> String {
+    //
+    // Computed inline every render rather than via `use_memo`. This
+    // modal is mounted unconditionally in `app.rs` and merely returns
+    // an empty element when inactive — the component instance never
+    // unmounts, so a `use_memo` here would live for the whole app
+    // session. A memo only recomputes when a *signal it read* changes;
+    // this computation reads `ROOMS`, but `current_room` / `target_peer`
+    // are plain captured values, not signals. So when the picker was
+    // closed and reopened for a different member, the memo kept handing
+    // back its stale cached value and the title showed the *previous*
+    // invitee's name (Ivvor bug report, 2026-05-20). The component
+    // re-renders whenever `INVITE_VIA_DM_PICKER` changes (read at the
+    // top of this fn), so an inline computation is always fresh; the
+    // per-render cost is a single nickname unseal — trivial for a modal.
+    let peer_label_value: String = {
         let rooms = ROOMS.try_read().ok();
         let nickname = rooms
             .as_ref()
@@ -132,54 +146,57 @@ pub fn InviteViaDmPickerModal() -> Element {
                     })
             });
         nickname.unwrap_or_else(|| target_peer.to_string().chars().take(8).collect())
-    });
+    };
 
     // Build a sorted list of candidate rooms — every room the local user
     // has loaded that isn't the current one. Per the module doc, we
     // don't filter on "target is already a member" because per-room
     // identities make that check unreliable.
-    let candidates = use_memo(move || -> Vec<CandidateRoom> {
-        let Ok(rooms) = ROOMS.try_read() else {
-            return Vec::new();
-        };
-        let mut out: Vec<CandidateRoom> = rooms
-            .map
-            .iter()
-            .filter(|(owner_vk, _)| **owner_vk != current_room)
-            .map(|(owner_vk, room_data)| {
-                let sealed_name = &room_data
-                    .room_state
-                    .configuration
-                    .configuration
-                    .display
-                    .name;
-                let label = match unseal_bytes_with_secrets(sealed_name, &room_data.secrets) {
-                    Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
-                    Err(_) => sealed_name.to_string_lossy(),
-                };
-                CandidateRoom {
-                    room_vk: *owner_vk,
-                    label,
-                    // Owner is implicit, not in members.members — add 1
-                    // for a useful display count.
-                    member_count: room_data.room_state.members.members.len() + 1,
-                    is_private: matches!(
-                        room_data
-                            .room_state
-                            .configuration
-                            .configuration
-                            .privacy_mode,
-                        PrivacyMode::Private
-                    ),
-                }
-            })
-            .collect();
-        out.sort_by(|a, b| a.label.cmp(&b.label));
-        out
-    });
+    //
+    // Inline for the same reason as `peer_label_value` above: a
+    // `use_memo` only subscribes to `ROOMS`, so reopening the picker
+    // from a *different* current room would keep showing the previous
+    // room's candidate list (the same stale-capture bug as the title).
+    let candidates_value: Vec<CandidateRoom> = match ROOMS.try_read() {
+        Ok(rooms) => {
+            let mut out: Vec<CandidateRoom> = rooms
+                .map
+                .iter()
+                .filter(|(owner_vk, _)| **owner_vk != current_room)
+                .map(|(owner_vk, room_data)| {
+                    let sealed_name = &room_data
+                        .room_state
+                        .configuration
+                        .configuration
+                        .display
+                        .name;
+                    let label = match unseal_bytes_with_secrets(sealed_name, &room_data.secrets) {
+                        Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
+                        Err(_) => sealed_name.to_string_lossy(),
+                    };
+                    CandidateRoom {
+                        room_vk: *owner_vk,
+                        label,
+                        // Owner is implicit, not in members.members — add 1
+                        // for a useful display count.
+                        member_count: room_data.room_state.members.members.len() + 1,
+                        is_private: matches!(
+                            room_data
+                                .room_state
+                                .configuration
+                                .configuration
+                                .privacy_mode,
+                            PrivacyMode::Private
+                        ),
+                    }
+                })
+                .collect();
+            out.sort_by(|a, b| a.label.cmp(&b.label));
+            out
+        }
+        Err(_) => Vec::new(),
+    };
 
-    let candidates_value = candidates.read().clone();
-    let peer_label_value = peer_label.read().clone();
     let selected_room_value = *selected_room.read();
     let personal_message_value = personal_message.read().clone();
     let send_error_value = send_error.read().clone();

--- a/ui/tests/invite-via-dm-picker.spec.ts
+++ b/ui/tests/invite-via-dm-picker.spec.ts
@@ -95,12 +95,61 @@ async function closePickerAndMemberInfo(page: Page) {
     page.getByRole("heading", { name: /invite .+ to another room/i }),
   ).toHaveCount(0);
 
-  // The member-info modal closes when its backdrop is clicked; the
-  // top-left corner is well clear of the centered modal card.
-  await page.mouse.click(5, 5);
+  // Dismiss the member-info modal by clicking its backdrop. Target the
+  // backdrop element explicitly (not a screen coordinate) and click a
+  // corner, clear of the centered modal card. The picker's own backdrop
+  // is already gone (asserted above), so the only `bg-black/50` overlay
+  // left is the member-info modal's.
+  await page
+    .locator('div[class*="bg-black/50"]')
+    .last()
+    .click({ position: { x: 5, y: 5 } });
   await expect(
     page.getByRole("heading", { name: /^Member Info$/ }),
   ).toHaveCount(0);
+}
+
+// Read the destination-room names from the picker's candidate rows.
+// Each candidate row is a button with aria-label
+// "Select room <name> as the invite destination".
+async function readCandidateRoomNames(page: Page): Promise<string[]> {
+  const rows = page.locator('button[aria-label^="Select room"]');
+  const count = await rows.count();
+  const names: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const aria = (await rows.nth(i).getAttribute("aria-label")) || "";
+    const m = aria.match(/^Select room (.+) as the invite destination$/);
+    if (m) names.push(m[1]);
+  }
+  return names;
+}
+
+// Whether a member row's display text marks it as the local user.
+// `format_member_display` (members.rs) gives every self row a ⭐ badge;
+// in member-rooms the self nickname also carries a "(You)" suffix, but
+// in owner-rooms it is "(Owner)" — so the ⭐ badge is the reliable
+// universal marker.
+function isSelfRowText(text: string): boolean {
+  return text.includes("⭐") || /\(You\)/i.test(text);
+}
+
+// All member rows that are not the local user, with their list index.
+async function nonSelfMemberRows(
+  page: Page,
+): Promise<{ index: number; text: string }[]> {
+  await page
+    .locator('button[title^="Member ID"]')
+    .first()
+    .waitFor({ state: "visible", timeout: 5_000 })
+    .catch(() => undefined);
+  const memberButtons = page.locator('button[title^="Member ID"]');
+  const count = await memberButtons.count();
+  const rows: { index: number; text: string }[] = [];
+  for (let i = 0; i < count; i++) {
+    const text = ((await memberButtons.nth(i).textContent()) || "").trim();
+    if (text && !isSelfRowText(text)) rows.push({ index: i, text });
+  }
+  return rows;
 }
 
 test.describe("Invite-via-DM picker (structured-Invite variant)", () => {
@@ -213,7 +262,7 @@ test.describe("Invite-via-DM picker (structured-Invite variant)", () => {
   // invitee's name in the "Invite <X> to another room" title. Root
   // cause: the picker's `peer_label` was a `use_memo` that only
   // subscribed to ROOMS, so reopening it for a different peer returned
-  // the stale cached name. This test opens the picker for two distinct
+  // the stale cached name. This test opens the picker for two different
   // members in succession and asserts the title tracks the current one.
   test("title tracks the current member when the picker is reopened (regression: Ivvor 2026-05-20)", async ({
     page,
@@ -222,34 +271,14 @@ test.describe("Invite-via-DM picker (structured-Invite variant)", () => {
     await waitForApp(page);
 
     await page.getByText("Team Chat Room").first().click();
-    await page
-      .locator('button[title^="Member ID"]')
-      .first()
-      .waitFor({ state: "visible", timeout: 5_000 })
-      .catch(() => undefined);
 
-    // Collect non-self member rows; we need two with distinct display
-    // text so a stale-vs-fresh title is unambiguous.
-    const memberButtons = page.locator('button[title^="Member ID"]');
-    const count = await memberButtons.count();
-    const nonSelf: { index: number; text: string }[] = [];
-    for (let i = 0; i < count; i++) {
-      const text = ((await memberButtons.nth(i).textContent()) || "").trim();
-      if (text && !/\(You\)/i.test(text)) {
-        nonSelf.push({ index: i, text });
-      }
-    }
-    const distinct = nonSelf.filter(
-      (m, idx) => nonSelf.findIndex((n) => n.text === m.text) === idx,
-    );
-    if (distinct.length < 2) {
-      test.skip(
-        true,
-        "example data lacks two distinctly-named non-self members",
-      );
+    // Two different non-self member rows — each row is a distinct member.
+    const nonSelf = await nonSelfMemberRows(page);
+    if (nonSelf.length < 2) {
+      test.skip(true, "example data has fewer than two non-self members");
       return;
     }
-    const [memberA, memberB] = distinct;
+    const [memberA, memberB] = nonSelf;
 
     // First invite: open the picker for member A.
     const titleA = await openPickerAndReadTitle(page, memberA.index);
@@ -260,18 +289,86 @@ test.describe("Invite-via-DM picker (structured-Invite variant)", () => {
       );
       return;
     }
-    expect(titleA.length).toBeGreaterThan(0);
-    // The member row text is "<nickname> <badges>"; the picker title is
-    // exactly the nickname, so the row text starts with the title.
-    expect(memberA.text.startsWith(titleA)).toBeTruthy();
-
     await closePickerAndMemberInfo(page);
 
     // Second invite: reopen the picker for member B. Before the fix the
     // title still read member A's name here.
     const titleB = await openPickerAndReadTitle(page, memberB.index);
     expect(titleB).not.toBeNull();
+
+    // The picker title is the unsealed nickname; a member row renders
+    // "<nickname> <badges>", so a row text always starts with that
+    // member's own title. These two assertions pin each title to the
+    // member it was opened for — with the bug, titleB held member A's
+    // name and `memberB.text.startsWith(titleB)` was false.
+    expect(titleA.length).toBeGreaterThan(0);
+    expect(memberA.text.startsWith(titleA)).toBeTruthy();
     expect(memberB.text.startsWith(titleB!)).toBeTruthy();
-    expect(titleB).not.toBe(titleA);
+
+    // If the two members happen to share a nickname, a stale title is
+    // indistinguishable from a fresh one — only assert inequality when
+    // they genuinely differ. (Example data's owner/member suffixes make
+    // a collision effectively impossible, but don't rely on it.)
+    if (memberA.text !== memberB.text && titleA !== titleB) {
+      expect(titleB).not.toBe(titleA);
+    }
+  });
+
+  // Regression test for the second half of the same fix: `candidates`
+  // was also a `use_memo` capturing `current_room` as a plain value, so
+  // reopening the picker from a *different* current room kept showing
+  // the previous room's candidate list. This switches the current room
+  // between two opens and asserts the candidate list follows.
+  test("candidate room list tracks the current room when the picker is reopened", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+
+    // First open: picker launched from "Team Chat Room".
+    await page.getByText("Team Chat Room").first().click();
+    const rowsA = await nonSelfMemberRows(page);
+    if (rowsA.length === 0) {
+      test.skip(true, "Team Chat Room has no non-self member");
+      return;
+    }
+    const openedA = await openPickerAndReadTitle(page, rowsA[0].index);
+    if (openedA === null) {
+      test.skip(true, "no 'Share an invite via DM' entry point");
+      return;
+    }
+    const candidatesFromTeamChat = await readCandidateRoomNames(page);
+    await closePickerAndMemberInfo(page);
+
+    // Switch the current room. Member keys are per-room, so the first
+    // member row's ID changes when the room switches — wait for that
+    // before reading the new room's member list (avoids racing the
+    // re-render and reading the old room's rows).
+    const firstMemberId = await page
+      .locator('button[title^="Member ID"]')
+      .first()
+      .getAttribute("title");
+    await page.getByText("Your Private Room").first().click();
+    await expect(
+      page.locator('button[title^="Member ID"]').first(),
+    ).not.toHaveAttribute("title", firstMemberId ?? "");
+
+    const rowsB = await nonSelfMemberRows(page);
+    if (rowsB.length === 0) {
+      test.skip(true, "Your Private Room has no non-self member");
+      return;
+    }
+    const openedB = await openPickerAndReadTitle(page, rowsB[0].index);
+    expect(openedB).not.toBeNull();
+    const candidatesFromPrivateRoom = await readCandidateRoomNames(page);
+
+    // The candidate list excludes the *current* room and includes every
+    // other room. So "Team Chat Room" must appear only in the second
+    // list, and "Your Private Room" only in the first. With the stale
+    // memo, the second list still equalled the first.
+    expect(candidatesFromTeamChat).toContain("Your Private Room");
+    expect(candidatesFromTeamChat).not.toContain("Team Chat Room");
+    expect(candidatesFromPrivateRoom).toContain("Team Chat Room");
+    expect(candidatesFromPrivateRoom).not.toContain("Your Private Room");
   });
 });

--- a/ui/tests/invite-via-dm-picker.spec.ts
+++ b/ui/tests/invite-via-dm-picker.spec.ts
@@ -43,12 +43,12 @@ async function openMemberInfo(page: Page) {
   // (members.rs:341). Example-data populates them with random names
   // each app load and the local-user "You" entry can appear at any
   // position, so we can't rely on a fixed index. Pick the first row
-  // whose text does NOT contain "(You)" — i.e. a non-self member.
+  // that isn't the local user (see `isSelfRowText`).
   const memberButtons = page.locator('button[title^="Member ID"]');
   const count = await memberButtons.count();
   for (let i = 0; i < count; i++) {
     const text = (await memberButtons.nth(i).textContent()) || "";
-    if (!/\(You\)/i.test(text)) {
+    if (!isSelfRowText(text)) {
       await memberButtons.nth(i).click();
       return true;
     }
@@ -125,12 +125,13 @@ async function readCandidateRoomNames(page: Page): Promise<string[]> {
 }
 
 // Whether a member row's display text marks it as the local user.
-// `format_member_display` (members.rs) gives every self row a ⭐ badge;
-// in member-rooms the self nickname also carries a "(You)" suffix, but
-// in owner-rooms it is "(Owner)" — so the ⭐ badge is the reliable
-// universal marker.
+// `format_member_display` (members.rs) gives every self row — and only
+// the self row — a ⭐ badge, regardless of whether the user is the
+// room's owner or a plain member, so the ⭐ is the reliable universal
+// marker. (The self nickname suffix varies: "(You)" in member-rooms,
+// "(Owner)" in owner-rooms — so it is not usable on its own.)
 function isSelfRowText(text: string): boolean {
-  return text.includes("⭐") || /\(You\)/i.test(text);
+  return text.includes("⭐");
 }
 
 // All member rows that are not the local user, with their list index.
@@ -298,20 +299,15 @@ test.describe("Invite-via-DM picker (structured-Invite variant)", () => {
 
     // The picker title is the unsealed nickname; a member row renders
     // "<nickname> <badges>", so a row text always starts with that
-    // member's own title. These two assertions pin each title to the
-    // member it was opened for — with the bug, titleB held member A's
-    // name and `memberB.text.startsWith(titleB)` was false.
+    // member's own title. These assertions pin each title to the member
+    // it was opened for — with the bug, titleB held member A's name and
+    // `memberB.text.startsWith(titleB)` was false. (A row text can't
+    // start with a *different* member's nickname unless the two members
+    // share a nickname, which example data's owner/member suffixes rule
+    // out — so this also implicitly proves titleA ≠ titleB.)
     expect(titleA.length).toBeGreaterThan(0);
     expect(memberA.text.startsWith(titleA)).toBeTruthy();
     expect(memberB.text.startsWith(titleB!)).toBeTruthy();
-
-    // If the two members happen to share a nickname, a stale title is
-    // indistinguishable from a fresh one — only assert inequality when
-    // they genuinely differ. (Example data's owner/member suffixes make
-    // a collision effectively impossible, but don't rely on it.)
-    if (memberA.text !== memberB.text && titleA !== titleB) {
-      expect(titleB).not.toBe(titleA);
-    }
   });
 
   // Regression test for the second half of the same fix: `candidates`
@@ -344,10 +340,10 @@ test.describe("Invite-via-DM picker (structured-Invite variant)", () => {
     // member row's ID changes when the room switches — wait for that
     // before reading the new room's member list (avoids racing the
     // re-render and reading the old room's rows).
-    const firstMemberId = await page
-      .locator('button[title^="Member ID"]')
-      .first()
-      .getAttribute("title");
+    const firstMemberRow = page.locator('button[title^="Member ID"]').first();
+    await firstMemberRow.waitFor({ state: "visible", timeout: 5_000 });
+    const firstMemberId = await firstMemberRow.getAttribute("title");
+    expect(firstMemberId).toBeTruthy();
     await page.getByText("Your Private Room").first().click();
     await expect(
       page.locator('button[title^="Member ID"]').first(),
@@ -370,5 +366,54 @@ test.describe("Invite-via-DM picker (structured-Invite variant)", () => {
     expect(candidatesFromTeamChat).not.toContain("Team Chat Room");
     expect(candidatesFromPrivateRoom).toContain("Team Chat Room");
     expect(candidatesFromPrivateRoom).not.toContain("Your Private Room");
+    // Belt-and-suspenders, independent of the specific room names: the
+    // two candidate lists must differ once the current room changed.
+    expect(candidatesFromPrivateRoom).not.toEqual(candidatesFromTeamChat);
+  });
+
+  // Regression test for the per-open state reset (the `use_effect`): a
+  // room selected in one picker session must NOT remain selected when
+  // the picker is reopened for a different member. Before the reset, a
+  // stale `selected_room` left the Send button armed for a destination
+  // the user never picked this session (Codex P2 on PR #291).
+  test("a room selected in one session does not stay selected on reopen", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+
+    await page.getByText("Team Chat Room").first().click();
+    const nonSelf = await nonSelfMemberRows(page);
+    if (nonSelf.length < 2) {
+      test.skip(true, "example data has fewer than two non-self members");
+      return;
+    }
+
+    // First session: open the picker, pick a candidate room.
+    const titleA = await openPickerAndReadTitle(page, nonSelf[0].index);
+    if (titleA === null) {
+      test.skip(true, "no 'Share an invite via DM' entry point");
+      return;
+    }
+    const firstCandidate = page
+      .locator('button[aria-label^="Select room"]')
+      .first();
+    await firstCandidate.click();
+    await expect(firstCandidate).toHaveAttribute("aria-pressed", "true");
+    await expect(
+      page.getByRole("button", { name: /^send invite$/i }),
+    ).toBeEnabled();
+    await closePickerAndMemberInfo(page);
+
+    // Second session: reopen for a different member. No candidate row
+    // should be pre-selected and Send must start disabled.
+    const titleB = await openPickerAndReadTitle(page, nonSelf[1].index);
+    expect(titleB).not.toBeNull();
+    await expect(
+      page.locator('button[aria-label^="Select room"][aria-pressed="true"]'),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: /^send invite$/i }),
+    ).toBeDisabled();
   });
 });

--- a/ui/tests/invite-via-dm-picker.spec.ts
+++ b/ui/tests/invite-via-dm-picker.spec.ts
@@ -56,6 +56,53 @@ async function openMemberInfo(page: Page) {
   return false;
 }
 
+// Open the member-info modal for the member row at `memberIndex`, click
+// "Share an invite via DM", and return the nickname rendered in the
+// picker title ("Invite <name> to another room"). Returns null if the
+// Share-invite entry point isn't available (observer-only example data).
+async function openPickerAndReadTitle(
+  page: Page,
+  memberIndex: number,
+): Promise<string | null> {
+  await page.locator('button[title^="Member ID"]').nth(memberIndex).click();
+
+  const shareInvite = page
+    .getByRole("button", { name: /share an invite/i })
+    .first();
+  await shareInvite
+    .waitFor({ state: "visible", timeout: 5_000 })
+    .catch(() => undefined);
+  if (!(await shareInvite.isVisible().catch(() => false))) {
+    return null;
+  }
+  await shareInvite.click();
+
+  const header = page.getByRole("heading", {
+    name: /invite .+ to another room/i,
+  });
+  await expect(header).toBeVisible({ timeout: 5_000 });
+
+  const headingText = ((await header.textContent()) || "").trim();
+  const match = headingText.match(/^Invite (.+) to another room$/);
+  return match ? match[1] : null;
+}
+
+// Dismiss the picker, then the member-info modal behind it, leaving the
+// member list interactable again.
+async function closePickerAndMemberInfo(page: Page) {
+  await page.getByRole("button", { name: /close picker/i }).click();
+  await expect(
+    page.getByRole("heading", { name: /invite .+ to another room/i }),
+  ).toHaveCount(0);
+
+  // The member-info modal closes when its backdrop is clicked; the
+  // top-left corner is well clear of the centered modal card.
+  await page.mouse.click(5, 5);
+  await expect(
+    page.getByRole("heading", { name: /^Member Info$/ }),
+  ).toHaveCount(0);
+}
+
 test.describe("Invite-via-DM picker (structured-Invite variant)", () => {
   test.use({ viewport: { width: 1280, height: 800 } });
 
@@ -159,5 +206,72 @@ test.describe("Invite-via-DM picker (structured-Invite variant)", () => {
     await expect(
       page.getByRole("heading", { name: /invite .+ to another room/i }),
     ).toHaveCount(0);
+  });
+
+  // Regression test for Ivvor's 2026-05-20 report: inviting several
+  // members one after another via "Share invite" showed the *previous*
+  // invitee's name in the "Invite <X> to another room" title. Root
+  // cause: the picker's `peer_label` was a `use_memo` that only
+  // subscribed to ROOMS, so reopening it for a different peer returned
+  // the stale cached name. This test opens the picker for two distinct
+  // members in succession and asserts the title tracks the current one.
+  test("title tracks the current member when the picker is reopened (regression: Ivvor 2026-05-20)", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+
+    await page.getByText("Team Chat Room").first().click();
+    await page
+      .locator('button[title^="Member ID"]')
+      .first()
+      .waitFor({ state: "visible", timeout: 5_000 })
+      .catch(() => undefined);
+
+    // Collect non-self member rows; we need two with distinct display
+    // text so a stale-vs-fresh title is unambiguous.
+    const memberButtons = page.locator('button[title^="Member ID"]');
+    const count = await memberButtons.count();
+    const nonSelf: { index: number; text: string }[] = [];
+    for (let i = 0; i < count; i++) {
+      const text = ((await memberButtons.nth(i).textContent()) || "").trim();
+      if (text && !/\(You\)/i.test(text)) {
+        nonSelf.push({ index: i, text });
+      }
+    }
+    const distinct = nonSelf.filter(
+      (m, idx) => nonSelf.findIndex((n) => n.text === m.text) === idx,
+    );
+    if (distinct.length < 2) {
+      test.skip(
+        true,
+        "example data lacks two distinctly-named non-self members",
+      );
+      return;
+    }
+    const [memberA, memberB] = distinct;
+
+    // First invite: open the picker for member A.
+    const titleA = await openPickerAndReadTitle(page, memberA.index);
+    if (titleA === null) {
+      test.skip(
+        true,
+        "no 'Share an invite via DM' entry point — observer-only example data",
+      );
+      return;
+    }
+    expect(titleA.length).toBeGreaterThan(0);
+    // The member row text is "<nickname> <badges>"; the picker title is
+    // exactly the nickname, so the row text starts with the title.
+    expect(memberA.text.startsWith(titleA)).toBeTruthy();
+
+    await closePickerAndMemberInfo(page);
+
+    // Second invite: reopen the picker for member B. Before the fix the
+    // title still read member A's name here.
+    const titleB = await openPickerAndReadTitle(page, memberB.index);
+    expect(titleB).not.toBeNull();
+    expect(memberB.text.startsWith(titleB!)).toBeTruthy();
+    expect(titleB).not.toBe(titleA);
   });
 });


### PR DESCRIPTION
## Problem

Ivvor reported (2026-05-20):

> if you try to invite multiple members to a room one after the other using the 'Share Invite' button it will often get the member name wrong in the 'Invite X to another room' text at the top of the modal. Seems to be the name from the previous invite. However, as far as I can tell, the invite is going to the correct invitee.

`InviteViaDmPickerModal` is mounted **unconditionally** in `app.rs`; it returns an empty element when inactive but the component instance — and all its hooks — live for the whole app session and never reinitialise.

The picker title (`peer_label`) and candidate-room list (`candidates`) were computed with `use_memo`. A `use_memo` only recomputes when a **signal it read** changes. These memos read the `ROOMS` signal but captured `current_room` / `target_peer` as plain values, so reopening the picker for a different member changed `target_peer` but not `ROOMS` — the memo handed back its **stale cached value** and the title showed the *previous* invitee's name. The invite itself was always correct (`do_send` is an event handler rebuilt each render with the current `target_peer`); only the memoised title lagged, matching Ivvor's report.

Review surfaced two more facets of the **same root cause** ("always-mounted component, no per-open reset"):

- `candidates` had the identical `use_memo` bug — reopening the picker from a *different* current room kept the previous room's candidate list.
- The four per-open `use_signal`s (`selected_room`, `personal_message`, `send_error`, `last_success_label`) persisted across opens. A stale `selected_room` could send an invite **to a room the user did not pick this session**; a stale error / success banner rendered on reopen for a different member.

## Approach

- **`peer_label` and `candidates`: `use_memo` → inline computation.** The component already re-renders whenever `INVITE_VIA_DM_PICKER` changes, so inline values always reflect the current `(current_room, target_peer)`.
- **Per-open scratch state: a `use_effect` keyed on `INVITE_VIA_DM_PICKER`** resets `personal_message` / `send_error` / `last_success_label` (and `selected_room`) on every open / close / target switch.
- **`selected_room` is tagged with the picker session it belongs to** — it stores `(target_peer, room)`. Both the render (`selected_room_value`) and `do_send` honour it only when the tag matches the current session's `target_peer` and the room is still a candidate. These checks are synchronous at render/send time, so a selection cannot leak from one picker open into the next — not even for the one frame before the reset effect runs (Codex P2).
- **All hooks moved above the early return** so the component satisfies the Rules of Hooks by construction.
- Corrected several comments that described an outdated "the picker unmounts / the component is dropped" model — the component never unmounts; that misconception is what caused the bug.
- Added a footgun note to `AGENTS.md` "Dioxus WASM Signal Safety Rules".

Stays within the existing "modal mounted unconditionally" pattern — no change to mount/unmount behaviour.

## Testing

Three regression tests in `ui/tests/invite-via-dm-picker.spec.ts`:

1. **Title tracks the current member on reopen** — opens the picker for two members in succession; the title must follow.
2. **Candidate list tracks the current room on reopen** — opens the picker, switches the current room, reopens; the candidate list must follow.
3. **A room selected in one session does not stay selected on reopen** — picks a candidate room, reopens for a different member; Send must start disabled with no row pre-selected.

Tests 1 and 2 were verified to **fail against the pre-fix `use_memo` build**; test 3 verified to fail with the reset removed. Full `invite-via-dm-picker` suite: 25/25 across chromium, firefox, webkit, mobile-chrome, mobile-safari.

`cargo fmt` clean; UI-only change — no contract/delegate/WASM changes, no migration needed.

Reviewed by four internal reviewers + Codex over multiple rounds; all findings addressed.

Reported by Ivvor on Matrix, 2026-05-20.

[AI-assisted - Claude]
