### PR TITLE
feat: recover rooms stranded across room-contract WASM generations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
       # upgrade-chain cycle guards). No prior step ran or even compiled them.
       run: cargo test -p riverctl --lib
 
-    - name: Test river-core ecies (deterministic + randomized helpers)
+    - name: Test river-core lib (ecies + migration registry)
       env:
         RUST_MIN_STACK: 8388608
         CARGO_TARGET_DIR: ${{ github.workspace }}/target
@@ -118,8 +118,10 @@ jobs:
       # deterministic `encrypt_secret_for_member` path used by the chat
       # delegate, plus the randomized-helper round-trips used by the UI.
       # See freenet/river#241 — these tests pin the wire format and catch
-      # silent drift in the ECIES derivation.
-      run: cargo test -p river-core --lib --features ecies-randomized ecies
+      # silent drift in the ECIES derivation. The `migration` feature also
+      # gates the `migration` module's unit tests (legacy room-contract key
+      # derivation, newest-first ordering — freenet/river#292).
+      run: cargo test -p river-core --lib --features ecies-randomized ecies migration
 
     - name: Test river-ui (UI crate unit tests)
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,12 @@ jobs:
       # silent drift in the ECIES derivation. The `migration` feature also
       # gates the `migration` module's unit tests (legacy room-contract key
       # derivation, newest-first ordering — freenet/river#292).
-      run: cargo test -p river-core --lib --features ecies-randomized ecies migration
+      #
+      # `--features` takes ONE comma-separated value; passing space-separated
+      # feature names makes cargo treat the extras as positional test-name
+      # filters (and a second one is a hard "unexpected argument" error).
+      # `ecies-randomized` enables `ecies` transitively.
+      run: cargo test -p river-core --lib --features ecies-randomized,migration
 
     - name: Test river-ui (UI crate unit tests)
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,22 @@ jobs:
         CARGO_TARGET_DIR: ${{ github.workspace }}/target
       run: cargo test -p river-core --test migration_test
 
+    - name: Test room-contract migration registry (#292)
+      env:
+        RUST_MIN_STACK: 8388608
+        CARGO_TARGET_DIR: ${{ github.workspace }}/target
+      # Validates common/legacy_room_contracts.toml is well-formed. A separate
+      # --test target from migration_test, so it needs its own invocation.
+      run: cargo test -p river-core --test room_contract_migration_test
+
+    - name: Test riverctl (CLI crate unit tests, incl. #292 recovery)
+      env:
+        RUST_MIN_STACK: 8388608
+        CARGO_TARGET_DIR: ${{ github.workspace }}/target
+      # riverctl carries native unit tests (legacy-key derivation parity,
+      # upgrade-chain cycle guards). No prior step ran or even compiled them.
+      run: cargo test -p riverctl --lib
+
     - name: Test river-core ecies (deterministic + randomized helpers)
       env:
         RUST_MIN_STACK: 8388608

--- a/.github/workflows/check-room-contract-migration.yml
+++ b/.github/workflows/check-room-contract-migration.yml
@@ -1,0 +1,25 @@
+name: Check Room-Contract Migration
+
+on:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check-room-contract-migration:
+    runs-on: freenet-default-runner
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Install b3sum
+      run: command -v b3sum || cargo install b3sum --locked
+
+    - name: Verify committed room-contract WASM changes include a migration entry
+      run: |
+        ./scripts/check-room-contract-migration.sh --ci \
+          "${{ github.event.pull_request.base.sha }}" \
+          "${{ github.event.pull_request.head.sha }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -441,6 +441,17 @@ All legacy delegate entries are defined in `legacy_delegates.toml` at the repo r
 This file is the **only** place migration entries are managed. The UI's build.rs generates
 Rust code from it at compile time. CI reads it directly for validation.
 
+### Single Source of Truth: `common/legacy_room_contracts.toml`
+
+The room contract has its own registry, `common/legacy_room_contracts.toml`,
+recording the BLAKE3 code hash of every previous room-contract WASM generation.
+A client re-derives the contract key any owner's room used under each generation
+and probes them newest-to-oldest to recover a room dormant across one or more
+WASM upgrades (freenet/river#292). `common/build.rs` generates
+`LEGACY_ROOM_CONTRACT_CODE_HASHES` from it; the `river-core` `migration` feature
+exposes the lookup. It lives inside the `common` crate (not the repo root) so it
+ships with the published `river-core` crate and riverctl keeps the full registry.
+
 ### Upgrade Workflow
 
 When you change code that affects delegate or contract WASM:
@@ -448,18 +459,22 @@ When you change code that affects delegate or contract WASM:
 ```bash
 # 1. Add old delegate hash to migration registry
 cargo make add-migration
+#    AND, if the room-contract WASM changed, add its old hash too:
+cargo make add-room-contract-migration
 
 # 2. Build new WASMs and copy to all committed locations
 cargo make sync-wasm
 
 # 3. Run migration tests
 cargo test -p river-core --test migration_test
+cargo test -p river-core --test room_contract_migration_test
 
 # 4. Verify UI compiles with new generated code
 cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync
 
 # 5. Commit everything
-git add legacy_delegates.toml ui/public/contracts/ cli/contracts/
+git add legacy_delegates.toml common/legacy_room_contracts.toml \
+    ui/public/contracts/ cli/contracts/
 git commit -m "fix: update WASMs with delegate migration entry"
 ```
 
@@ -468,19 +483,23 @@ git commit -m "fix: update WASMs with delegate migration entry"
 - **`cargo make check-migration`** — local check: builds delegate WASM and verifies migration entry exists if hash changed
 - **`cargo test -p river-core --test migration_test`** — validates TOML entries: correct hex, 32-byte keys, delegate_key = BLAKE3(code_hash)
 - **CI `check-delegate-migration` workflow** — builds base and PR WASMs, verifies old hash is in `legacy_delegates.toml`
+- **CI `check-room-contract-migration` workflow** — verifies a changed room-contract WASM's old hash is in `common/legacy_room_contracts.toml`
 - **CI `check-cli-wasm` workflow** — verifies `ui/public/contracts/` and `cli/contracts/` WASMs are in sync
 
 ### Key Files
 
 | File | Purpose |
 |------|---------|
-| `legacy_delegates.toml` | Single source of truth for migration entries |
-| `ui/build.rs` | Generates Rust const array from TOML at compile time |
+| `legacy_delegates.toml` | Single source of truth for delegate migration entries |
+| `common/legacy_room_contracts.toml` | Single source of truth for room-contract generations (#292) |
+| `ui/build.rs` | Generates `LEGACY_DELEGATES` const from the delegate TOML |
+| `common/build.rs` | Generates `LEGACY_ROOM_CONTRACT_CODE_HASHES` from the room-contract TOML |
+| `common/src/migration.rs` | Re-derives legacy room-contract keys for backward recovery (#292) |
 | `ui/src/components/app/chat_delegate.rs` | Uses generated `LEGACY_DELEGATES` for runtime migration |
-| `scripts/check-migration.sh` | Local + CI migration validation |
-| `scripts/add-migration.sh` | Computes keys and appends entry to TOML |
+| `scripts/check-migration.sh` / `scripts/add-migration.sh` | Delegate migration validation / entry |
+| `scripts/check-room-contract-migration.sh` / `scripts/add-room-contract-migration.sh` | Room-contract registry validation / entry |
 | `scripts/sync-wasm.sh` | Builds all WASMs and copies to committed locations |
-| `common/tests/migration_test.rs` | Validates TOML entries are well-formed |
+| `common/tests/migration_test.rs` / `common/tests/room_contract_migration_test.rs` | Validate TOML entries are well-formed |
 
 ### Technical Details
 - **Delegate key formula**: `BLAKE3(BLAKE3(wasm) || params)` — both steps use BLAKE3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -457,7 +457,10 @@ ships with the published `river-core` crate and riverctl keeps the full registry
 When you change code that affects delegate or contract WASM:
 
 ```bash
-# 1. Add old delegate hash to migration registry
+# 1. BEFORE rebuilding any WASM, record the OLD (currently-committed) hashes.
+#    Both scripts hash the WASM as it sits on disk now, so they must run
+#    before step 2 rebuilds it. If your changes already rebuilt the WASM,
+#    `git checkout HEAD -- ui/public/contracts/ cli/contracts/` first.
 cargo make add-migration
 #    AND, if the room-contract WASM changed, add its old hash too:
 cargo make add-room-contract-migration

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -594,6 +594,25 @@ read -p "Description of what changed: " DESCRIPTION
 scripts/add-migration.sh "$NEXT_VERSION" "$DESCRIPTION"
 '''
 
+[tasks.check-room-contract-migration]
+description = "Check if room-contract WASM changed and a registry entry is needed (#292)"
+script = ["scripts/check-room-contract-migration.sh"]
+
+[tasks.add-room-contract-migration]
+description = "Add registry entry for currently committed room-contract WASM (#292)"
+script = '''
+#!/bin/bash
+set -e
+
+# Auto-detect next version number from the room-contract registry TOML.
+LAST_VERSION=$(grep '^version' common/legacy_room_contracts.toml | tail -1 | sed 's/.*"V\([0-9]*\)".*/\1/')
+NEXT_VERSION="V$((LAST_VERSION + 1))"
+
+echo "Next version: $NEXT_VERSION"
+read -p "Description of what changed: " DESCRIPTION
+scripts/add-room-contract-migration.sh "$NEXT_VERSION" "$DESCRIPTION"
+'''
+
 [tasks.sync-wasm]
 description = "Build all WASMs and copy to committed locations"
 script = ["scripts/sync-wasm.sh"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -31,6 +31,12 @@ cwd = "./ui"
 
 [tasks.build-room-contract]
 description = "Build the room contract WASM"
+# The `-p room-contract` scoping is load-bearing: it builds ONLY the contract
+# and its deps, so Cargo never unifies the river-core `migration` feature
+# (enabled by river-ui / riverctl) into this WASM. Building the contract under
+# a whole-workspace `cargo build` would unify `migration` on and could move the
+# contract key. Keep this `-p room-contract` — never `--workspace`. See
+# `common/src/migration.rs` and freenet/river#292.
 command = "cargo"
 args = ["build", "--profile", "${BUILD_PROFILE}", "--target", "${CONTRACT_TARGET}", "-p", "room-contract", "--target-dir", "target"]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -50,7 +50,7 @@ dialoguer = "0.11"
 atty = "0.2"
 
 # Internal dependencies
-river-core = { version = "0.1.6", path = "../common", features = ["ecies", "ecies-randomized"] }
+river-core = { version = "0.1.6", path = "../common", features = ["ecies", "ecies-randomized", "migration"] }
 freenet-stdlib = { workspace = true, features = ["net"] }
 freenet-scaffold = "0.2.2"
 

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -501,15 +501,22 @@ impl ApiClient {
         id: ContractInstanceId,
         timeout: Duration,
     ) -> Option<(ChatRoomStateV1, ContractInstanceId)> {
-        let state = self.try_get_state(id, timeout).await?;
+        let state = self.try_get_state(room_owner_key, id, timeout).await?;
         Some(self.follow_upgrade_chain(room_owner_key, state, id).await)
     }
 
     /// GET a `ChatRoomStateV1` from a contract instance, returning `None` for an
     /// absent contract, a timeout, an empty/default state, or a state whose
     /// bytes do not deserialize (an incompatible older generation).
+    ///
+    /// "No usable state" is defined as a `configuration` whose signature does
+    /// not verify against `owner_vk` — the same predicate the UI uses
+    /// (`RoomData::is_awaiting_initial_sync`). A real room always carries an
+    /// owner-signed configuration; an absent or never-initialised contract
+    /// does not.
     async fn try_get_state(
         &self,
+        owner_vk: &VerifyingKey,
         id: ContractInstanceId,
         timeout: Duration,
     ) -> Option<ChatRoomStateV1> {
@@ -534,9 +541,9 @@ impl ApiClient {
                 state, ..
             }))) => match ciborium::de::from_reader::<ChatRoomStateV1, _>(&state[..]) {
                 Ok(mut room_state) => {
-                    // A genuinely absent / never-initialised contract reads back
-                    // as the default state — not a real room.
-                    if room_state == ChatRoomStateV1::default() {
+                    // A real room always carries an owner-signed configuration;
+                    // an absent / never-initialised contract does not.
+                    if room_state.configuration.verify_signature(owner_vk).is_err() {
                         return None;
                     }
                     room_state.recent_messages.rebuild_actions_state();
@@ -560,7 +567,7 @@ impl ApiClient {
     /// self-referential pointer cannot loop forever (freenet/river#292, Part 3).
     async fn follow_upgrade_chain(
         &self,
-        _room_owner_key: &VerifyingKey,
+        room_owner_key: &VerifyingKey,
         mut state: ChatRoomStateV1,
         mut id: ContractInstanceId,
     ) -> (ChatRoomStateV1, ContractInstanceId) {
@@ -572,7 +579,10 @@ impl ApiClient {
             let Some(next) = next_upgrade_hop(&state, &mut visited) else {
                 break;
             };
-            match self.try_get_state(next, UPGRADE_HOP_TIMEOUT).await {
+            match self
+                .try_get_state(room_owner_key, next, UPGRADE_HOP_TIMEOUT)
+                .await
+            {
                 Some(next_state) => {
                     info!("Followed upgrade pointer to newer contract generation {next}");
                     state = next_state;
@@ -1197,7 +1207,9 @@ impl ApiClient {
             match prev_key_str.parse::<ContractInstanceId>() {
                 Ok(prev_id) => {
                     info!("Trying GET from previous contract {prev_id} for migration");
-                    network_state = self.try_get_state(prev_id, LEGACY_PROBE_TIMEOUT).await;
+                    network_state = self
+                        .try_get_state(room_owner_key, prev_id, LEGACY_PROBE_TIMEOUT)
+                        .await;
                 }
                 Err(e) => warn!("Stored previous_contract_key is not a valid contract id: {e}"),
             }
@@ -1209,7 +1221,7 @@ impl ApiClient {
             for legacy_key in river_core::migration::legacy_contract_keys_for_owner(room_owner_key)
             {
                 if let Some(state) = self
-                    .try_get_state(*legacy_key.id(), LEGACY_PROBE_TIMEOUT)
+                    .try_get_state(room_owner_key, *legacy_key.id(), LEGACY_PROBE_TIMEOUT)
                     .await
                 {
                     info!("Found state on a previous contract generation for migration");

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -24,12 +24,25 @@ use serde_json::json;
 use std::collections::HashSet;
 use std::io::Write;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio_tungstenite::connect_async;
 use tracing::{debug, info, warn};
 
 // Load the room contract WASM copied by build.rs
 const ROOM_CONTRACT_WASM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/room_contract.wasm"));
+
+/// Timeout for the GET against the current room contract.
+const CURRENT_GET_TIMEOUT: Duration = Duration::from_secs(30);
+/// Per-probe timeout when searching older contract generations (freenet/river#292).
+/// Kept short because a backward search may probe many generations; an existing
+/// contract responds quickly, only an absent one runs the timeout down.
+const LEGACY_PROBE_TIMEOUT: Duration = Duration::from_secs(8);
+/// Timeout for a single hop while following an `OptionalUpgradeV1` pointer chain.
+const UPGRADE_HOP_TIMEOUT: Duration = Duration::from_secs(15);
+/// Maximum upgrade-pointer hops to follow before giving up — guards against a
+/// cyclic or runaway chain.
+const MAX_UPGRADE_HOPS: usize = 32;
 
 /// Compute the contract key for a room from its owner verifying key.
 /// This uses the current bundled WASM to ensure consistency.
@@ -373,189 +386,261 @@ impl ApiClient {
         let contract_key = self.ensure_room_migrated(room_owner_key).await?;
         info!("Getting room state for contract: {}", contract_key.id());
 
+        // Fetch the room state, recovering it across older contract-WASM
+        // generations if the current contract has no state (freenet/river#292).
+        let (room_state, found_id) = self
+            .fetch_room_state_with_recovery(room_owner_key, *contract_key.id())
+            .await?;
+
+        info!(
+            "Retrieved room state with {} messages",
+            room_state.recent_messages.messages.len()
+        );
+
+        if subscribe {
+            self.subscribe_to_contract(found_id).await?;
+        }
+
+        Ok(room_state)
+    }
+
+    /// Fetch a room's state, recovering it across contract-WASM generations.
+    ///
+    /// The room contract key is `BLAKE3(room_contract.wasm, params)`, so every
+    /// WASM upgrade moves the key. A room dormant across one or more upgrades
+    /// has its live state stranded under an older-generation key. This:
+    ///   1. GETs the current contract (walking any upgrade-pointer chain forward);
+    ///   2. if that yields nothing, probes every known previous generation
+    ///      newest-to-oldest until one returns state;
+    ///   3. migrates a recovered state forward onto the current contract so the
+    ///      room is no longer stranded.
+    ///
+    /// Returns the recovered state and the contract instance it should be
+    /// subscribed to.
+    async fn fetch_room_state_with_recovery(
+        &self,
+        room_owner_key: &VerifyingKey,
+        current_id: ContractInstanceId,
+    ) -> Result<(ChatRoomStateV1, ContractInstanceId)> {
+        // 1. Current generation (plus any forward upgrade-pointer chain).
+        if let Some((state, id)) = self
+            .try_fetch_room(room_owner_key, current_id, CURRENT_GET_TIMEOUT)
+            .await
+        {
+            return Ok((state, id));
+        }
+
+        // 2. Backward search across previous contract generations.
+        let legacy_keys = river_core::migration::legacy_contract_keys_for_owner(room_owner_key);
+        info!(
+            "Room not present on current contract {}; probing {} previous contract generation(s)",
+            current_id,
+            legacy_keys.len()
+        );
+        for (i, legacy_key) in legacy_keys.iter().enumerate() {
+            if let Some((state, found_id)) = self
+                .try_fetch_room(room_owner_key, *legacy_key.id(), LEGACY_PROBE_TIMEOUT)
+                .await
+            {
+                info!(
+                    "Recovered room from a previous contract generation (probe {}/{})",
+                    i + 1,
+                    legacy_keys.len()
+                );
+                // Migrate the recovered state forward onto the current contract
+                // so the room is no longer stranded on an old generation. The
+                // current contract was just confirmed empty/absent, so this PUT
+                // creates it; the room contract's CRDT merge keeps a concurrent
+                // migrator's PUT safe.
+                if found_id != current_id {
+                    match self.put_room_state(room_owner_key, &state).await {
+                        Ok(()) => info!(
+                            "Migrated recovered room forward onto current contract {current_id}"
+                        ),
+                        Err(e) => warn!(
+                            "Could not migrate recovered room forward (returning it anyway): {e}"
+                        ),
+                    }
+                }
+                return Ok((state, current_id));
+            }
+        }
+
+        Err(anyhow!(
+            "Room not found on the current contract or any of the {} known previous \
+             contract generations. The room may never have existed, or its state may \
+             have been garbage-collected from the network.",
+            legacy_keys.len()
+        ))
+    }
+
+    /// GET a room state from `id`, then walk any `OptionalUpgradeV1` pointer
+    /// chain forward to the newest generation that still has state. Returns
+    /// `None` if `id` has no usable state.
+    async fn try_fetch_room(
+        &self,
+        room_owner_key: &VerifyingKey,
+        id: ContractInstanceId,
+        timeout: Duration,
+    ) -> Option<(ChatRoomStateV1, ContractInstanceId)> {
+        let state = self.try_get_state(id, timeout).await?;
+        Some(self.follow_upgrade_chain(room_owner_key, state, id).await)
+    }
+
+    /// GET a `ChatRoomStateV1` from a contract instance, returning `None` for an
+    /// absent contract, a timeout, an empty/default state, or a state whose
+    /// bytes do not deserialize (an incompatible older generation).
+    async fn try_get_state(
+        &self,
+        id: ContractInstanceId,
+        timeout: Duration,
+    ) -> Option<ChatRoomStateV1> {
         let get_request = ContractRequest::Get {
-            key: *contract_key.id(),    // GET uses ContractInstanceId
-            return_contract_code: true, // Request full contract to enable caching
-            subscribe: false,           // Always false, we'll subscribe separately if needed
+            key: id,
+            return_contract_code: false,
+            subscribe: false,
             blocking_subscribe: false,
         };
-
-        let client_request = ClientRequest::ContractOp(get_request);
-
         let mut web_api = self.web_api.lock().await;
-        tracing::info!("ACCEPT: sending GET for contract {}", contract_key.id());
-        web_api
-            .send(client_request)
+        if web_api
+            .send(ClientRequest::ContractOp(get_request))
             .await
-            .map_err(|e| anyhow!("Failed to send GET request: {}", e))?;
-
-        let response =
-            match tokio::time::timeout(std::time::Duration::from_secs(30), web_api.recv()).await {
-                Ok(result) => {
-                    result.map_err(|e| anyhow!("Failed to receive GET response: {}", e))?
-                }
-                Err(_) => return Err(anyhow!("Timeout waiting for GET response after 30 seconds")),
-            };
-
-        match response {
-            HostResponse::ContractResponse(contract_response) => {
-                match contract_response {
-                    ContractResponse::GetResponse { state, .. } => {
-                        // Deserialize the state properly
-                        let mut room_state: ChatRoomStateV1 = ciborium::de::from_reader(&state[..])
-                            .map_err(|e| anyhow!("Failed to deserialize room state: {}", e))?;
-
-                        // Rebuild actions state (edits, deletes, reactions) from message content
-                        room_state.recent_messages.rebuild_actions_state();
-
-                        info!(
-                            "Successfully retrieved room state with {} messages",
-                            room_state.recent_messages.messages.len()
-                        );
-
-                        // Follow upgrade pointer (single hop) if present
-                        if let Some(ref authorized_upgrade) = room_state.upgrade.0 {
-                            let new_address = authorized_upgrade.upgrade.new_chatroom_address;
-                            let current_id_bytes = contract_key.id().as_bytes();
-                            let mut current_hash = [0u8; 32];
-                            current_hash.copy_from_slice(current_id_bytes);
-
-                            if blake3::Hash::from(current_hash) != new_address {
-                                info!("Following upgrade pointer to new contract: {}", new_address);
-                                // Drop the lock before recursive call
-                                drop(web_api);
-
-                                // Follow the pointer by constructing a new contract ID
-                                let new_id = ContractInstanceId::new(*new_address.as_bytes());
-                                let follow_request = ContractRequest::Get {
-                                    key: new_id,
-                                    return_contract_code: true,
-                                    subscribe: false,
-                                    blocking_subscribe: false,
-                                };
-
-                                let mut web_api = self.web_api.lock().await;
-                                web_api
-                                    .send(ClientRequest::ContractOp(follow_request))
-                                    .await
-                                    .map_err(|e| {
-                                        anyhow!("Failed to follow upgrade pointer: {}", e)
-                                    })?;
-
-                                match tokio::time::timeout(
-                                    std::time::Duration::from_secs(15),
-                                    web_api.recv(),
-                                )
-                                .await
-                                {
-                                    Ok(Ok(HostResponse::ContractResponse(
-                                        ContractResponse::GetResponse {
-                                            state: new_state, ..
-                                        },
-                                    ))) => {
-                                        let mut followed_state: ChatRoomStateV1 =
-                                            ciborium::de::from_reader(&new_state[..]).map_err(
-                                                |e| {
-                                                    anyhow!(
-                                                        "Failed to deserialize followed state: {}",
-                                                        e
-                                                    )
-                                                },
-                                            )?;
-                                        followed_state.recent_messages.rebuild_actions_state();
-                                        info!("Successfully followed upgrade pointer");
-
-                                        // Subscribe to the new contract if requested
-                                        if subscribe {
-                                            let new_id =
-                                                ContractInstanceId::new(*new_address.as_bytes());
-                                            let subscribe_request = ContractRequest::Subscribe {
-                                                key: new_id,
-                                                summary: None,
-                                            };
-                                            let mut web_api = self.web_api.lock().await;
-                                            if let Err(e) = web_api
-                                                .send(ClientRequest::ContractOp(subscribe_request))
-                                                .await
-                                            {
-                                                warn!(
-                                                    "Failed to subscribe to followed contract: {}",
-                                                    e
-                                                );
-                                            }
-                                        }
-
-                                        return Ok(followed_state);
-                                    }
-                                    _ => {
-                                        info!(
-                                            "Could not follow upgrade pointer, using current state"
-                                        );
-                                    }
-                                }
-                                return Ok(room_state);
-                            }
-                        }
-
-                        // Drop the lock before subscribing
-                        drop(web_api);
-
-                        // If subscribe was requested, do it separately
-                        if subscribe {
-                            info!("Subscribing to contract to receive updates");
-                            let subscribe_request = ContractRequest::Subscribe {
-                                key: *contract_key.id(), // Subscribe uses ContractInstanceId
-                                summary: None,
-                            };
-
-                            let subscribe_client_request =
-                                ClientRequest::ContractOp(subscribe_request);
-
-                            let mut web_api = self.web_api.lock().await;
-                            web_api
-                                .send(subscribe_client_request)
-                                .await
-                                .map_err(|e| anyhow!("Failed to send SUBSCRIBE request: {}", e))?;
-
-                            // Wait for subscription response
-                            let subscribe_response = match tokio::time::timeout(
-                                std::time::Duration::from_secs(5),
-                                web_api.recv(),
-                            )
-                            .await
-                            {
-                                Ok(result) => result.map_err(|e| {
-                                    anyhow!("Failed to receive subscription response: {}", e)
-                                })?,
-                                Err(_) => {
-                                    return Err(anyhow!(
-                                        "Timeout waiting for SUBSCRIBE response after 5 seconds"
-                                    ))
-                                }
-                            };
-
-                            match subscribe_response {
-                                HostResponse::ContractResponse(
-                                    ContractResponse::SubscribeResponse { subscribed, .. },
-                                ) => {
-                                    if subscribed {
-                                        info!("Successfully subscribed to contract");
-                                    } else {
-                                        return Err(anyhow!("Failed to subscribe to contract"));
-                                    }
-                                }
-                                _ => {
-                                    return Err(anyhow!("Unexpected response to SUBSCRIBE request"))
-                                }
-                            }
-                        }
-
-                        Ok(room_state)
+            .is_err()
+        {
+            return None;
+        }
+        let recv = tokio::time::timeout(timeout, web_api.recv()).await;
+        drop(web_api);
+        match recv {
+            Ok(Ok(HostResponse::ContractResponse(ContractResponse::GetResponse {
+                state, ..
+            }))) => match ciborium::de::from_reader::<ChatRoomStateV1, _>(&state[..]) {
+                Ok(mut room_state) => {
+                    // A genuinely absent / never-initialised contract reads back
+                    // as the default state — not a real room.
+                    if room_state == ChatRoomStateV1::default() {
+                        return None;
                     }
-                    _ => Err(anyhow!("Unexpected contract response type")),
+                    room_state.recent_messages.rebuild_actions_state();
+                    Some(room_state)
+                }
+                Err(e) => {
+                    debug!("State at {id} did not deserialize ({e}); skipping generation");
+                    None
+                }
+            },
+            _ => None,
+        }
+    }
+
+    /// Follow an `OptionalUpgradeV1` pointer chain forward from `id`, hop by hop,
+    /// until a state has no upgrade pointer or a hop's target has no state.
+    /// Bounded by [`MAX_UPGRADE_HOPS`] and a visited-set so a cyclic or
+    /// self-referential pointer cannot loop forever (freenet/river#292, Part 3).
+    async fn follow_upgrade_chain(
+        &self,
+        _room_owner_key: &VerifyingKey,
+        mut state: ChatRoomStateV1,
+        mut id: ContractInstanceId,
+    ) -> (ChatRoomStateV1, ContractInstanceId) {
+        let mut visited: HashSet<ContractInstanceId> = HashSet::new();
+        visited.insert(id);
+        for _ in 0..MAX_UPGRADE_HOPS {
+            let Some(authorized_upgrade) = state.upgrade.0.as_ref() else {
+                break;
+            };
+            let next = ContractInstanceId::new(
+                *authorized_upgrade.upgrade.new_chatroom_address.as_bytes(),
+            );
+            if !visited.insert(next) {
+                // Self-pointer or cycle — stop with the best state so far.
+                break;
+            }
+            match self.try_get_state(next, UPGRADE_HOP_TIMEOUT).await {
+                Some(next_state) => {
+                    info!("Followed upgrade pointer to newer contract generation {next}");
+                    state = next_state;
+                    id = next;
+                }
+                None => break, // Pointer dangles; keep the best state we have.
+            }
+        }
+        (state, id)
+    }
+
+    /// PUT a room state onto the *current* room contract. Used to migrate a
+    /// state recovered from an older generation forward (freenet/river#292).
+    async fn put_room_state(
+        &self,
+        room_owner_key: &VerifyingKey,
+        room_state: &ChatRoomStateV1,
+    ) -> Result<()> {
+        let parameters = ChatRoomParametersV1 {
+            owner: *room_owner_key,
+        };
+        let mut params_bytes = Vec::new();
+        ciborium::ser::into_writer(&parameters, &mut params_bytes)
+            .map_err(|e| anyhow!("Failed to serialize parameters: {e}"))?;
+        let contract_code = ContractCode::from(ROOM_CONTRACT_WASM);
+        let contract_container = ContractContainer::from(ContractWasmAPIVersion::V1(
+            WrappedContract::new(Arc::new(contract_code), Parameters::from(params_bytes)),
+        ));
+        let mut state_bytes = Vec::new();
+        ciborium::ser::into_writer(room_state, &mut state_bytes)
+            .map_err(|e| anyhow!("Failed to serialize room state: {e}"))?;
+        let put_request = ContractRequest::Put {
+            contract: contract_container,
+            state: WrappedState::new(state_bytes),
+            related_contracts: Default::default(),
+            subscribe: false,
+            blocking_subscribe: false,
+        };
+        let mut web_api = self.web_api.lock().await;
+        web_api
+            .send(ClientRequest::ContractOp(put_request))
+            .await
+            .map_err(|e| anyhow!("Failed to send PUT: {e}"))?;
+        match tokio::time::timeout(Duration::from_secs(60), web_api.recv()).await {
+            Ok(Ok(HostResponse::ContractResponse(ContractResponse::PutResponse { .. })))
+            | Ok(Ok(HostResponse::Ok))
+            | Ok(Ok(HostResponse::ContractResponse(ContractResponse::UpdateNotification {
+                ..
+            }))) => Ok(()),
+            Ok(Ok(other)) => Err(anyhow!("Unexpected response to PUT: {other:?}")),
+            Ok(Err(e)) => Err(anyhow!("Error receiving PUT response: {e}")),
+            Err(_) => Err(anyhow!("Timeout during PUT")),
+        }
+    }
+
+    /// Subscribe to a contract instance and wait for confirmation.
+    async fn subscribe_to_contract(&self, id: ContractInstanceId) -> Result<()> {
+        info!("Subscribing to contract {id} to receive updates");
+        let subscribe_request = ContractRequest::Subscribe {
+            key: id,
+            summary: None,
+        };
+        let mut web_api = self.web_api.lock().await;
+        web_api
+            .send(ClientRequest::ContractOp(subscribe_request))
+            .await
+            .map_err(|e| anyhow!("Failed to send SUBSCRIBE request: {e}"))?;
+        match tokio::time::timeout(Duration::from_secs(5), web_api.recv()).await {
+            Ok(Ok(HostResponse::ContractResponse(ContractResponse::SubscribeResponse {
+                subscribed,
+                ..
+            }))) => {
+                if subscribed {
+                    info!("Successfully subscribed to contract");
+                    Ok(())
+                } else {
+                    Err(anyhow!("Failed to subscribe to contract"))
                 }
             }
-            _ => Err(anyhow!("Unexpected response type: {:?}", response)),
+            Ok(Ok(_)) => Err(anyhow!("Unexpected response to SUBSCRIBE request")),
+            Ok(Err(e)) => Err(anyhow!("Failed to receive subscription response: {e}")),
+            Err(_) => Err(anyhow!(
+                "Timeout waiting for SUBSCRIBE response after 5 seconds"
+            )),
         }
     }
 
@@ -1073,70 +1158,70 @@ impl ApiClient {
         }
     }
 
-    /// Try to get the latest state for migration. First tries the old contract key
-    /// (previous_contract_key), falls back to local cached state.
+    /// Find the freshest state to migrate forward, searching the network across
+    /// contract generations and merging in the local cache.
+    ///
+    /// Tries, in order: the immediately-previous contract key recorded in
+    /// storage; then every known previous contract generation newest-first
+    /// (covers a room dormant across several WASM upgrades — freenet/river#292).
+    /// Whatever network state is found is CRDT-merged with the local cache, so
+    /// the migrating PUT carries the real network state rather than a possibly
+    /// stale local snapshot. Falls back to the local cache only when nothing is
+    /// reachable on-network.
     async fn get_migration_state(
         &self,
         room_owner_key: &VerifyingKey,
         local_state: &ChatRoomStateV1,
         previous_contract_key_str: &Option<String>,
     ) -> Result<ChatRoomStateV1> {
-        // If we have a previous contract key, try to GET from it for fresher state
+        let mut network_state: Option<ChatRoomStateV1> = None;
+
+        // Fast path: the immediately-previous contract key recorded in storage.
         if let Some(prev_key_str) = previous_contract_key_str {
-            info!(
-                "Trying GET from old contract {} for migration",
-                prev_key_str
-            );
-            let prev_id: ContractInstanceId = prev_key_str
-                .parse()
-                .map_err(|e| anyhow!("Invalid previous contract key: {}", e))?;
+            match prev_key_str.parse::<ContractInstanceId>() {
+                Ok(prev_id) => {
+                    info!("Trying GET from previous contract {prev_id} for migration");
+                    network_state = self.try_get_state(prev_id, LEGACY_PROBE_TIMEOUT).await;
+                }
+                Err(e) => warn!("Stored previous_contract_key is not a valid contract id: {e}"),
+            }
+        }
 
-            let get_request = ContractRequest::Get {
-                key: prev_id,
-                return_contract_code: false,
-                subscribe: false,
-                blocking_subscribe: false,
-            };
-
-            let mut web_api = self.web_api.lock().await;
-            if let Ok(()) = web_api
-                .send(ClientRequest::ContractOp(get_request))
-                .await
-                .map_err(|e| anyhow!("Failed to GET old contract: {}", e))
+        // Deep path: probe every known previous contract generation
+        // newest-first. Covers a room dormant across several WASM upgrades.
+        if network_state.is_none() {
+            for legacy_key in river_core::migration::legacy_contract_keys_for_owner(room_owner_key)
             {
-                match tokio::time::timeout(std::time::Duration::from_secs(10), web_api.recv()).await
+                if let Some(state) = self
+                    .try_get_state(*legacy_key.id(), LEGACY_PROBE_TIMEOUT)
+                    .await
                 {
-                    Ok(Ok(HostResponse::ContractResponse(ContractResponse::GetResponse {
-                        state,
-                        ..
-                    }))) => {
-                        if let Ok(mut old_state) =
-                            ciborium::de::from_reader::<ChatRoomStateV1, _>(&state[..])
-                        {
-                            info!("Got state from old contract, using for migration");
-                            old_state.recent_messages.rebuild_actions_state();
-                            // Merge with local state to get the best of both
-                            let mut merged = old_state.clone();
-                            let params = ChatRoomParametersV1 {
-                                owner: *room_owner_key,
-                            };
-                            if let Err(e) = merged.merge(&old_state, &params, local_state) {
-                                info!(
-                                    "Merge with local state failed ({}), using old contract state",
-                                    e
-                                );
-                                return Ok(old_state);
-                            }
-                            return Ok(merged);
-                        }
-                    }
-                    _ => {
-                        info!("Could not GET from old contract, using local cached state");
-                    }
+                    info!("Found state on a previous contract generation for migration");
+                    network_state = Some(state);
+                    break;
                 }
             }
         }
-        Ok(local_state.clone())
+
+        match network_state {
+            Some(net_state) => {
+                // CRDT-merge the network state with the local cache so neither a
+                // fresher network state nor unsynced local edits are lost.
+                let params = ChatRoomParametersV1 {
+                    owner: *room_owner_key,
+                };
+                let mut merged = net_state.clone();
+                if let Err(e) = merged.merge(&net_state, &params, local_state) {
+                    info!("Merge with local state failed ({e}); using network state alone");
+                    return Ok(net_state);
+                }
+                Ok(merged)
+            }
+            None => {
+                info!("No network state on any contract generation; using local cached state");
+                Ok(local_state.clone())
+            }
+        }
     }
 
     /// Send an upgrade pointer to the old contract key for old-client compatibility.
@@ -2814,5 +2899,44 @@ impl ApiClient {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod migration_recovery_tests {
+    use super::*;
+
+    /// The legacy registry derives a contract key exactly as the live code path
+    /// (`compute_contract_key` / `owner_vk_to_contract_key`) does. If this ever
+    /// drifts, every backward probe would target the wrong contract instance
+    /// and silently fail to recover any room. (freenet/river#292)
+    #[test]
+    fn legacy_derivation_matches_live_key_for_current_wasm() {
+        // Any valid signing key works; SigningKey::from_bytes treats the bytes
+        // as the seed and is infallible for any 32-byte input.
+        let owner = SigningKey::from_bytes(&[7u8; 32]).verifying_key();
+        let current_code_hash: [u8; 32] = *blake3::hash(ROOM_CONTRACT_WASM).as_bytes();
+        let via_registry =
+            river_core::migration::contract_key_for_code_hash(&owner, &current_code_hash);
+        let via_live = compute_contract_key(&owner);
+        assert_eq!(
+            via_registry.id(),
+            via_live.id(),
+            "registry-derived key must match the live owner_vk_to_contract_key derivation"
+        );
+    }
+
+    /// The current room-contract WASM must NOT be in the legacy registry — the
+    /// registry holds only *previous* generations. Listing the current hash
+    /// would make a probe redundantly re-fetch the current contract.
+    #[test]
+    fn current_wasm_is_not_in_legacy_registry() {
+        let current_code_hash: [u8; 32] = *blake3::hash(ROOM_CONTRACT_WASM).as_bytes();
+        assert!(
+            !river_core::migration::LEGACY_ROOM_CONTRACT_CODE_HASHES.contains(&current_code_hash),
+            "current room-contract WASM hash {} is listed in legacy_room_contracts.toml; \
+             the registry must contain only previous generations",
+            blake3::hash(ROOM_CONTRACT_WASM).to_hex()
+        );
     }
 }

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -522,7 +522,11 @@ impl ApiClient {
     ) -> Option<ChatRoomStateV1> {
         let get_request = ContractRequest::Get {
             key: id,
-            return_contract_code: false,
+            // Request the contract code: a legacy generation's contract may not
+            // be cached on this node, and asking for the code lets the GET
+            // resolve / cache it rather than failing. The pre-recovery
+            // `get_room` used `true`; the recovery probes need the same.
+            return_contract_code: true,
             subscribe: false,
             blocking_subscribe: false,
         };

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -44,6 +44,24 @@ const UPGRADE_HOP_TIMEOUT: Duration = Duration::from_secs(15);
 /// cyclic or runaway chain.
 const MAX_UPGRADE_HOPS: usize = 32;
 
+/// Decide the next contract to follow from `state`'s upgrade pointer.
+///
+/// Returns `Some(next)` when `state` carries an `OptionalUpgradeV1` pointer to
+/// a contract not yet in `visited` — and records it in `visited`. Returns
+/// `None` when there is no pointer, or it targets an already-visited contract
+/// (a self-pointer or a cycle). Pure; the network GET is the caller's job.
+/// Extracted from `follow_upgrade_chain` so the cycle guard is unit-testable
+/// without a node (freenet/river#292).
+fn next_upgrade_hop(
+    state: &ChatRoomStateV1,
+    visited: &mut HashSet<ContractInstanceId>,
+) -> Option<ContractInstanceId> {
+    let authorized_upgrade = state.upgrade.0.as_ref()?;
+    let next = ContractInstanceId::new(*authorized_upgrade.upgrade.new_chatroom_address.as_bytes());
+    // `HashSet::insert` returns false if `next` was already present — a cycle.
+    visited.insert(next).then_some(next)
+}
+
 /// Compute the contract key for a room from its owner verifying key.
 /// This uses the current bundled WASM to ensure consistency.
 pub fn compute_contract_key(owner_vk: &VerifyingKey) -> ContractKey {
@@ -525,7 +543,10 @@ impl ApiClient {
                     Some(room_state)
                 }
                 Err(e) => {
-                    debug!("State at {id} did not deserialize ({e}); skipping generation");
+                    // A state that doesn't deserialize means a genuine
+                    // backwards-compat break in an older generation's
+                    // `ChatRoomStateV1` — surface it rather than hiding it.
+                    warn!("State at {id} did not deserialize ({e}); skipping generation");
                     None
                 }
             },
@@ -546,16 +567,11 @@ impl ApiClient {
         let mut visited: HashSet<ContractInstanceId> = HashSet::new();
         visited.insert(id);
         for _ in 0..MAX_UPGRADE_HOPS {
-            let Some(authorized_upgrade) = state.upgrade.0.as_ref() else {
+            // `next_upgrade_hop` carries the no-pointer / self-pointer / cycle
+            // decision (pure, unit-tested); the network GET is done here.
+            let Some(next) = next_upgrade_hop(&state, &mut visited) else {
                 break;
             };
-            let next = ContractInstanceId::new(
-                *authorized_upgrade.upgrade.new_chatroom_address.as_bytes(),
-            );
-            if !visited.insert(next) {
-                // Self-pointer or cycle — stop with the best state so far.
-                break;
-            }
             match self.try_get_state(next, UPGRADE_HOP_TIMEOUT).await {
                 Some(next_state) => {
                     info!("Followed upgrade pointer to newer contract generation {next}");
@@ -2937,6 +2953,59 @@ mod migration_recovery_tests {
             "current room-contract WASM hash {} is listed in legacy_room_contracts.toml; \
              the registry must contain only previous generations",
             blake3::hash(ROOM_CONTRACT_WASM).to_hex()
+        );
+    }
+
+    /// Build a `ChatRoomStateV1` carrying an upgrade pointer to the contract
+    /// instance whose 32-byte id is `target`.
+    fn state_pointing_at(target: [u8; 32]) -> ChatRoomStateV1 {
+        use river_core::room_state::upgrade::{AuthorizedUpgradeV1, OptionalUpgradeV1, UpgradeV1};
+        let sk = SigningKey::from_bytes(&[9u8; 32]);
+        let upgrade = UpgradeV1 {
+            owner_member_id: MemberId::from(&sk.verifying_key()),
+            version: 1,
+            new_chatroom_address: blake3::Hash::from(target),
+        };
+        ChatRoomStateV1 {
+            upgrade: OptionalUpgradeV1(Some(AuthorizedUpgradeV1::new(upgrade, &sk))),
+            ..Default::default()
+        }
+    }
+
+    /// `next_upgrade_hop` returns `None` for a state with no upgrade pointer —
+    /// the chain walk terminates.
+    #[test]
+    fn next_upgrade_hop_none_without_pointer() {
+        let mut visited = HashSet::new();
+        assert!(next_upgrade_hop(&ChatRoomStateV1::default(), &mut visited).is_none());
+    }
+
+    /// `next_upgrade_hop` follows a pointer to an unvisited contract and
+    /// records it in the visited-set.
+    #[test]
+    fn next_upgrade_hop_follows_unvisited_pointer() {
+        let target = [5u8; 32];
+        let mut visited = HashSet::new();
+        let next = next_upgrade_hop(&state_pointing_at(target), &mut visited)
+            .expect("a pointer to a fresh contract must be followed");
+        assert_eq!(next, ContractInstanceId::new(target));
+        assert!(
+            visited.contains(&next),
+            "the followed target must be recorded"
+        );
+    }
+
+    /// `next_upgrade_hop` returns `None` when the pointer targets an
+    /// already-visited contract — the cycle guard that stops a chain that
+    /// loops back on itself.
+    #[test]
+    fn next_upgrade_hop_stops_on_cycle() {
+        let target = [5u8; 32];
+        let mut visited = HashSet::new();
+        visited.insert(ContractInstanceId::new(target));
+        assert!(
+            next_upgrade_hop(&state_pointing_at(target), &mut visited).is_none(),
+            "a pointer back to an already-visited contract must stop the walk"
         );
     }
 }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -56,6 +56,19 @@ ecies = ["dep:aes-gcm", "dep:curve25519-dalek", "dep:sha2", "dep:x25519-dalek"]
 # (and transitively `getrandom`). Only safe to enable in builds with a
 # working CSPRNG — i.e. the UI, which runs in a browser, or native tests.
 ecies-randomized = ["ecies", "dep:rand"]
+# Legacy room-contract migration registry + helpers (freenet/river#292).
+# Enabled ONLY by the client crates (river-ui, riverctl). Deliberately OFF for
+# the room-contract and chat-delegate WASM builds so the `migration` module is
+# never compiled into them — that keeps their WASM bytes (and therefore their
+# contract/delegate keys) byte-identical. The recovery logic is a pure client
+# concern; the contract itself never derives legacy keys.
+migration = []
+
+[build-dependencies]
+# Used by build.rs to parse legacy_room_contracts.toml and generate the
+# LEGACY_ROOM_CONTRACT_CODE_HASHES registry (freenet/river#292).
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
 
 [dev-dependencies]
 rand.workspace = true

--- a/common/build.rs
+++ b/common/build.rs
@@ -1,0 +1,116 @@
+//! Build script for `river-core`.
+//!
+//! Generates `legacy_room_contracts.rs` from `legacy_room_contracts.toml`, the
+//! registry of every previous room-contract WASM generation. The generated
+//! `LEGACY_ROOM_CONTRACT_CODE_HASHES` const is consumed by
+//! `src/migration.rs` to re-derive older-generation contract keys so a
+//! long-dormant room can be recovered. See freenet/river#292.
+//!
+//! This mirrors `ui/build.rs::generate_legacy_delegates()` for the chat
+//! delegate. The TOML lives inside this crate (not at the repo root) so it is
+//! published with `river-core` and riverctl built from crates.io keeps the
+//! full registry.
+
+use serde::Deserialize;
+use std::env;
+use std::fs;
+use std::path::Path;
+
+#[derive(Deserialize)]
+struct LegacyRoomContracts {
+    entry: Vec<LegacyEntry>,
+}
+
+#[derive(Deserialize)]
+struct LegacyEntry {
+    version: String,
+    description: String,
+    date: String,
+    code_hash: String,
+}
+
+fn main() {
+    let toml_path = Path::new("legacy_room_contracts.toml");
+    println!("cargo:rerun-if-changed=legacy_room_contracts.toml");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest = Path::new(&out_dir).join("legacy_room_contracts.rs");
+
+    let toml_content = match fs::read_to_string(toml_path) {
+        Ok(c) => c,
+        Err(e) => {
+            // During docs.rs or other non-workspace builds the file may be
+            // absent; fall back to an empty registry rather than failing.
+            eprintln!("cargo:warning=legacy_room_contracts.toml not found ({e}), using empty list");
+            fs::write(
+                &dest,
+                "pub const LEGACY_ROOM_CONTRACT_CODE_HASHES: &[[u8; 32]] = &[];\n",
+            )
+            .unwrap();
+            return;
+        }
+    };
+
+    let parsed: LegacyRoomContracts =
+        toml::from_str(&toml_content).expect("Failed to parse legacy_room_contracts.toml");
+
+    let mut code = String::new();
+    code.push_str(
+        "// AUTO-GENERATED from legacy_room_contracts.toml — do not edit.\n\
+         // Regenerate by editing legacy_room_contracts.toml and rebuilding.\n\n\
+         pub const LEGACY_ROOM_CONTRACT_CODE_HASHES: &[[u8; 32]] = &[\n",
+    );
+
+    for entry in &parsed.entry {
+        let ch_bytes = hex_to_byte_array(&entry.code_hash, &entry.version);
+        code.push_str(&format!(
+            "    // {}: {} ({})\n",
+            entry.version, entry.description, entry.date
+        ));
+        code.push_str(&format_byte_array(&ch_bytes, "    "));
+    }
+
+    code.push_str("];\n");
+
+    // Only write if the content changed, to avoid spurious recompilation.
+    let existing = fs::read_to_string(&dest).unwrap_or_default();
+    if existing != code {
+        fs::write(&dest, &code).unwrap();
+    }
+}
+
+fn hex_to_byte_array(hex: &str, version: &str) -> [u8; 32] {
+    if hex.len() != 64 {
+        panic!(
+            "{version} code_hash hex string has {} chars, expected 64",
+            hex.len()
+        );
+    }
+    let bytes: Vec<u8> = (0..hex.len())
+        .step_by(2)
+        .map(|i| {
+            u8::from_str_radix(&hex[i..i + 2], 16)
+                .unwrap_or_else(|_| panic!("{version} code_hash has invalid hex"))
+        })
+        .collect();
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&bytes);
+    arr
+}
+
+fn format_byte_array(arr: &[u8; 32], indent: &str) -> String {
+    let mut s = format!("{indent}[\n");
+    for chunk in arr.chunks(10) {
+        s.push_str(&format!("{indent}    "));
+        for (i, b) in chunk.iter().enumerate() {
+            if i > 0 {
+                s.push_str(", ");
+            }
+            s.push_str(&format!("{b}"));
+        }
+        s.push_str(",\n");
+    }
+    s.push_str(&format!("{indent}],\n"));
+    s
+}

--- a/common/legacy_room_contracts.toml
+++ b/common/legacy_room_contracts.toml
@@ -1,0 +1,183 @@
+# Legacy Room-Contract Registry
+#
+# Single source of truth for all previous room-contract WASM generations.
+#
+# The room contract key is BLAKE3(room_contract.wasm, params) where
+# params = { owner: VerifyingKey }. Every time the bundled room-contract WASM
+# changes, the key for a given owner moves. A client only has ONE WASM compiled
+# in, so it can derive exactly ONE key per owner — the current one.
+#
+# This registry records the BLAKE3 code hash of every PREVIOUS room-contract
+# WASM so a client can re-derive older-generation contract keys for any owner
+# and probe them (newest-to-oldest) when the current key has no state. This is
+# how a room that has been dormant across several WASM upgrades is recovered.
+# See freenet/river#292.
+#
+# This is the room-contract analogue of `legacy_delegates.toml` (which covers
+# the chat delegate). It lives inside the `common` crate, not at the repo root,
+# so it ships inside the published `river-core` crate and riverctl built from
+# crates.io still has the full registry.
+#
+# Fields:
+#   code_hash = BLAKE3 hash of the raw room-contract WASM bytes (hex).
+#               This is exactly what `b3sum room_contract.wasm` prints and
+#               what freenet-stdlib's `CodeHash::from_code` computes.
+#
+# The CURRENT room-contract WASM hash is NOT listed here — it is computed at
+# runtime from the bundled bytes. Only PREVIOUS generations belong here.
+#
+# Entries are ordered oldest-first (V1 = oldest). Probing walks newest-first.
+#
+# To add a new entry:  cargo make add-room-contract-migration
+# To validate entries: cargo make check-room-contract-migration
+#
+# NOTE on recoverability: states written by generations before private rooms /
+# in-room DMs use an older `ChatRoomStateV1` shape. `ChatRoomStateV1` is
+# CBOR-map encoded and every field added since is `#[serde(default)]`, so newer
+# code can still deserialize them. If a generation's state ever fails to
+# deserialize, the recovery probe skips that generation gracefully rather than
+# failing — analogous to the V4-V6 removal in legacy_delegates.toml.
+
+[[entry]]
+version = "V1"
+description = "ci: resilient prefetch to fix Build failure (#31)"
+date = "2025-08-11"
+code_hash = "415d03916cccddca057d343ce0f5c8dc89606221d0b260f3dfc7344f64dd5b38"
+
+[[entry]]
+version = "V2"
+description = "feat(cli): add subscription-based streaming mode"
+date = "2025-12-17"
+code_hash = "da9cc449afaed575633cbff6cda171ba5323a0d3a5fe5c9d9e513b3801f8d020"
+
+[[entry]]
+version = "V3"
+description = "fix(test): use canonical WASM path to prevent contract key mismatch"
+date = "2025-12-25"
+code_hash = "92e6540d4618d3283fa5b2b21c3b620e913875e1facbb65cef07176a8e58f735"
+
+[[entry]]
+version = "V4"
+description = "build: update room contract wasm with ban verification fix"
+date = "2025-12-27"
+code_hash = "e26efcefb8cc368b64a1668701ead9d2542eef0374526555b9f7e36c49f8ebe1"
+
+[[entry]]
+version = "V5"
+description = "feat(cli): add message edit/delete/react commands and fix actions state"
+date = "2026-01-25"
+code_hash = "a974940b17e683632ce16af8191edeb6fbfaa8848730eeba01155160d1cc6cbe"
+
+[[entry]]
+version = "V6"
+description = "fix(cli): add timeout to GET request in get_room"
+date = "2026-01-26"
+code_hash = "f4c2a5dd5abe819f7c8c6175bcf717538b13cb550c26a5fd51a79f26e158a803"
+
+[[entry]]
+version = "V7"
+description = "fix(contract): skip removed members in apply_delta instead of erroring"
+date = "2026-02-08"
+code_hash = "51bbaa53b64be732f3ea696b89b92767bdaa4ed041c7caf5e79bf6ef78f01906"
+
+[[entry]]
+version = "V8"
+description = "fix(contract): return empty bytes for no-change deltas instead of CBOR null"
+date = "2026-02-08"
+code_hash = "f6f373d3822daf4b0f560929901dff8a1168537d482a4f1aa320f809004777df"
+
+[[entry]]
+version = "V9"
+description = "fix(contract): optimize Ed25519 verification in room contract WASM"
+date = "2026-02-09"
+code_hash = "749ff97d995857d7aea6eb99013c6cecd619f77e6cf3b12c113faaf0b6ddfcf0"
+
+[[entry]]
+version = "V10"
+description = "fix: update room contract WASM with ban verify fix"
+date = "2026-02-13"
+code_hash = "ed21a2b80ad36463395f26b749aac2b1d5d5255a4196c81f07bde366572106b7"
+
+[[entry]]
+version = "V11"
+description = "build: update room contract WASM with invite chain fix"
+date = "2026-02-13"
+code_hash = "c85118f3205cfd7def2fbb38581b2738c380e412449bd3bdb0eb41e9bdac64d0"
+
+[[entry]]
+version = "V12"
+description = "fix(ui): preserve nickname when re-adding pruned user"
+date = "2026-02-14"
+code_hash = "5a560db6f70534fda2c1229d8ca5959d92ce344439d101e8deba20d3060fc48f"
+
+[[entry]]
+version = "V13"
+description = "chore: commit pending WASM rebuild and publish-all tooling"
+date = "2026-02-23"
+code_hash = "32d5897e35353dcf85bb4e390640dc06f31dae9f8322e07e94835b48fe8efb35"
+
+[[entry]]
+version = "V14"
+description = "feat(ui,cli): expose all room config fields + rebuild stale WASM"
+date = "2026-03-01"
+code_hash = "0e8ce55ea25ac26b5062c532a09e96600ba901cefc0be0196f7ea35b73cde3a2"
+
+[[entry]]
+version = "V15"
+description = "fix: update WASMs and add V6 delegate migration entry"
+date = "2026-03-07"
+code_hash = "218086d8f20e52fa0d06cb8605f9b65645f5401876462a3a3bd69c102953752c"
+
+[[entry]]
+version = "V16"
+description = "build: fix stdlib 0.3.2 compatibility and add delegate migration"
+date = "2026-03-12"
+code_hash = "d37574c2658fdd8346e8e1294c4f4221fa61cbd1eda619ccc9d683d3bd17fee8"
+
+[[entry]]
+version = "V17"
+description = "fix: restore correct room_contract.wasm broken by b18587db"
+date = "2026-03-19"
+code_hash = "567c7e73d5603568f5251f25cc1406d8c6bb485de000c37c2e5358fd6e3818fd"
+
+[[entry]]
+version = "V18"
+description = "fix: update WASMs for freenet-core v0.2.12 with delegate migration"
+date = "2026-03-24"
+code_hash = "fda405cb0248ecaf8904bf17f237e13dc7e9d7e1b6cce128639b9e1412df1bf8"
+
+[[entry]]
+version = "V19"
+description = "build(deps): bump freenet-stdlib 0.3.5 -> 0.6.0 (#214)"
+date = "2026-04-14"
+code_hash = "ade1e4a05e968e479bdf5eeec551e4af1400f860cc0f7421a850e0f35bf5e45f"
+
+[[entry]]
+version = "V20"
+description = "feat(common): in-room encrypted direct messages (#230 Phase 1) (#240)"
+date = "2026-05-13"
+code_hash = "1788e91cd3a836f34c742789ce0be6336e5aa2d7d96a81a472333686ffe653fd"
+
+[[entry]]
+version = "V21"
+description = "fix(delegate): remove wasm-bindgen contamination from committed WASM (#242)"
+date = "2026-05-14"
+code_hash = "c65673a57232c339977566b34f728fcae65a144f0d09f8a030d196e31b2f6100"
+
+[[entry]]
+version = "V22"
+description = "feat: hide stale DM threads from left rail (#265)"
+date = "2026-05-16"
+code_hash = "c4b03c8b126c437db6bbcfba79ba01311f5788866ccf61b12e3dc7cbfbd51394"
+
+[[entry]]
+version = "V23"
+description = "fix(room-contract): accept private messages at any known secret version (#270)"
+date = "2026-05-17"
+code_hash = "385ab5bcfeab73171a8de520c5e24fff7d8b10ca97238227a8d3c8f28eeb8306"
+
+[[entry]]
+version = "V24"
+description = "fix(private-rooms): UI rotate back-fill + PUT join_event + #110 prune exemption (#272)"
+date = "2026-05-17"
+code_hash = "1bda909cd769dd404a4775005a3e6bcbf5cbecf4795b628df587e9997c7c0414"

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -3,6 +3,11 @@ pub mod crypto_values;
 #[cfg(feature = "ecies")]
 pub mod ecies;
 pub mod key_derivation;
+/// Legacy room-contract migration registry (freenet/river#292). Gated on the
+/// `migration` feature so the room-contract / chat-delegate WASM builds (which
+/// do not enable it) keep byte-identical WASM and stable keys.
+#[cfg(feature = "migration")]
+pub mod migration;
 pub mod room_state;
 pub mod util;
 pub mod web_container;

--- a/common/src/migration.rs
+++ b/common/src/migration.rs
@@ -21,6 +21,16 @@
 //! (and therefore their contract/delegate keys) byte-identical. The recovery
 //! logic is a pure client concern; the contract itself never derives legacy
 //! keys.
+//!
+//! This byte-identity guarantee holds because the committed room-contract /
+//! chat-delegate WASM is built with a package-scoped `cargo build -p
+//! room-contract` / `-p chat-delegate` (see `scripts/sync-wasm.sh` and the
+//! `build-room-contract` task in `Makefile.toml`). Cargo only unifies features
+//! across packages built in the *same* invocation, so a package-scoped build
+//! never turns `migration` on for the contract. A whole-workspace
+//! `cargo build` WOULD unify `migration` onto `river-core` everywhere — so the
+//! contract WASM must never be built that way. The `check-room-contract-
+//! migration` CI workflow is the backstop if it ever is.
 
 use crate::room_state::ChatRoomParametersV1;
 use ed25519_dalek::VerifyingKey;

--- a/common/src/migration.rs
+++ b/common/src/migration.rs
@@ -1,0 +1,135 @@
+//! Legacy room-contract migration registry (freenet/river#292).
+//!
+//! The room contract key is `BLAKE3(room_contract.wasm, params)` with
+//! `params = { owner: VerifyingKey }`, so every room-contract WASM upgrade
+//! moves the key for every owner. A client only has the *current* WASM
+//! compiled in, so on its own it can derive exactly one key per owner — the
+//! current one.
+//!
+//! [`LEGACY_ROOM_CONTRACT_CODE_HASHES`] records the BLAKE3 code hash of every
+//! previous room-contract WASM generation (generated at build time from
+//! `legacy_room_contracts.toml`). Combined with an owner's verifying key, each
+//! hash yields the contract key that owner's room used under that generation,
+//! which lets a client probe older generations newest-to-oldest to recover a
+//! room that has been dormant across several WASM upgrades.
+//!
+//! This is the room-contract analogue of the chat delegate's
+//! `legacy_delegates.toml` registry.
+//!
+//! Gated behind the `migration` cargo feature so the room-contract and
+//! chat-delegate WASM builds never compile it — that keeps their WASM bytes
+//! (and therefore their contract/delegate keys) byte-identical. The recovery
+//! logic is a pure client concern; the contract itself never derives legacy
+//! keys.
+
+use crate::room_state::ChatRoomParametersV1;
+use ed25519_dalek::VerifyingKey;
+use freenet_stdlib::prelude::{ContractKey, Parameters};
+
+mod generated {
+    include!(concat!(env!("OUT_DIR"), "/legacy_room_contracts.rs"));
+}
+
+/// BLAKE3 code hashes of every *previous* room-contract WASM generation,
+/// ordered oldest-first. Generated at build time from
+/// `legacy_room_contracts.toml`. The current generation's hash is intentionally
+/// absent — it is computed at runtime from the bundled WASM bytes.
+pub use generated::LEGACY_ROOM_CONTRACT_CODE_HASHES;
+
+/// CBOR-encode the room contract parameters for `owner_vk`.
+///
+/// This must match exactly how the UI (`owner_vk_to_contract_key`) and CLI
+/// encode `ChatRoomParametersV1` — otherwise derived legacy keys would not
+/// match the keys real rooms were stored under.
+fn encode_params(owner_vk: &VerifyingKey) -> Vec<u8> {
+    let params = ChatRoomParametersV1 { owner: *owner_vk };
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&params, &mut buf)
+        .expect("CBOR serialization of ChatRoomParametersV1 cannot fail");
+    buf
+}
+
+/// Derive the room contract key for `owner_vk` under a specific WASM code hash.
+///
+/// Reproduces what `ContractKey::from_params_and_code` computes, but from the
+/// 32-byte code hash alone — no WASM bytes required. The actual hashing is
+/// delegated to freenet-stdlib's `ContractKey::from_params` so the algorithm
+/// stays in lock-step with the library rather than being re-implemented here.
+pub fn contract_key_for_code_hash(owner_vk: &VerifyingKey, code_hash: &[u8; 32]) -> ContractKey {
+    let code_hash_b58 = bs58::encode(code_hash)
+        .with_alphabet(bs58::Alphabet::BITCOIN)
+        .into_string();
+    ContractKey::from_params(code_hash_b58, Parameters::from(encode_params(owner_vk)))
+        .expect("base58 encoding of a 32-byte array always decodes back to 32 bytes")
+}
+
+/// All legacy room-contract keys for `owner_vk`, ordered **newest-first**.
+///
+/// A backward-search probe walks this list in order so it locates the most
+/// recent dormant generation before older ones — the newest generation with
+/// live state is the one whose snapshot is least stale.
+pub fn legacy_contract_keys_for_owner(owner_vk: &VerifyingKey) -> Vec<ContractKey> {
+    LEGACY_ROOM_CONTRACT_CODE_HASHES
+        .iter()
+        .rev()
+        .map(|code_hash| contract_key_for_code_hash(owner_vk, code_hash))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+
+    #[test]
+    fn registry_is_non_empty_and_hashes_are_distinct() {
+        // The registry must carry every historical generation; a regression
+        // that wiped it would silently disable backward recovery.
+        assert!(
+            !LEGACY_ROOM_CONTRACT_CODE_HASHES.is_empty(),
+            "legacy room-contract registry is empty"
+        );
+        let mut seen = std::collections::HashSet::new();
+        for hash in LEGACY_ROOM_CONTRACT_CODE_HASHES {
+            assert!(
+                seen.insert(*hash),
+                "duplicate code hash in legacy room-contract registry: {}",
+                hex::encode(hash)
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_keys_are_newest_first_and_complete() {
+        let owner = SigningKey::generate(&mut OsRng).verifying_key();
+        let keys = legacy_contract_keys_for_owner(&owner);
+        assert_eq!(keys.len(), LEGACY_ROOM_CONTRACT_CODE_HASHES.len());
+        // Newest-first: index 0 corresponds to the last registry entry.
+        let newest = LEGACY_ROOM_CONTRACT_CODE_HASHES.last().unwrap();
+        assert_eq!(keys[0], contract_key_for_code_hash(&owner, newest));
+    }
+
+    #[test]
+    fn keys_are_owner_specific() {
+        // Every owner gets a different key for the same code hash, so a probe
+        // can never accidentally read another owner's room.
+        let owner_a = SigningKey::generate(&mut OsRng).verifying_key();
+        let owner_b = SigningKey::generate(&mut OsRng).verifying_key();
+        let code_hash = LEGACY_ROOM_CONTRACT_CODE_HASHES[0];
+        assert_ne!(
+            contract_key_for_code_hash(&owner_a, &code_hash),
+            contract_key_for_code_hash(&owner_b, &code_hash),
+        );
+    }
+
+    #[test]
+    fn derivation_is_deterministic() {
+        let owner = SigningKey::generate(&mut OsRng).verifying_key();
+        let code_hash = LEGACY_ROOM_CONTRACT_CODE_HASHES[0];
+        assert_eq!(
+            contract_key_for_code_hash(&owner, &code_hash),
+            contract_key_for_code_hash(&owner, &code_hash),
+        );
+    }
+}

--- a/common/tests/room_contract_migration_test.rs
+++ b/common/tests/room_contract_migration_test.rs
@@ -1,0 +1,95 @@
+//! Validates that `common/legacy_room_contracts.toml` — the registry of every
+//! previous room-contract WASM generation (freenet/river#292) — is well-formed.
+//!
+//! Each `code_hash` must be a 64-char hex string (a 32-byte BLAKE3 hash), all
+//! hashes must be distinct, and all version labels must be distinct. A
+//! malformed registry would silently break cross-generation room recovery.
+
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+
+#[derive(Deserialize)]
+struct LegacyRoomContracts {
+    entry: Vec<Entry>,
+}
+
+#[derive(Deserialize)]
+struct Entry {
+    version: String,
+    #[allow(dead_code)]
+    description: String,
+    #[allow(dead_code)]
+    date: String,
+    code_hash: String,
+}
+
+fn load_entries() -> Vec<Entry> {
+    // `cargo test` runs with the crate dir (`common/`) as the working dir, but
+    // tolerate being invoked from the workspace root too.
+    let paths = [
+        Path::new("legacy_room_contracts.toml"),
+        Path::new("common/legacy_room_contracts.toml"),
+    ];
+    let toml_path = paths
+        .iter()
+        .find(|p| p.exists())
+        .unwrap_or_else(|| panic!("legacy_room_contracts.toml not found in {:?}", paths));
+
+    let content = fs::read_to_string(toml_path).unwrap();
+    let parsed: LegacyRoomContracts =
+        toml::from_str(&content).expect("Failed to parse legacy_room_contracts.toml");
+    parsed.entry
+}
+
+#[test]
+fn registry_is_non_empty() {
+    assert!(
+        !load_entries().is_empty(),
+        "legacy_room_contracts.toml has no entries"
+    );
+}
+
+#[test]
+fn every_code_hash_is_a_32_byte_hex_string() {
+    for entry in load_entries() {
+        assert_eq!(
+            entry.code_hash.len(),
+            64,
+            "{}: code_hash must be 64 hex chars (32 bytes), got {}",
+            entry.version,
+            entry.code_hash.len()
+        );
+        assert!(
+            entry.code_hash.chars().all(|c| c.is_ascii_hexdigit()),
+            "{}: code_hash contains non-hex characters",
+            entry.version
+        );
+    }
+}
+
+#[test]
+fn code_hashes_are_distinct() {
+    let mut seen = HashSet::new();
+    for entry in load_entries() {
+        assert!(
+            seen.insert(entry.code_hash.clone()),
+            "{}: duplicate code_hash {}",
+            entry.version,
+            entry.code_hash
+        );
+    }
+}
+
+#[test]
+fn versions_are_distinct() {
+    let mut seen = HashSet::new();
+    for entry in load_entries() {
+        assert!(
+            seen.insert(entry.version.clone()),
+            "duplicate version label {}",
+            entry.version
+        );
+    }
+}

--- a/scripts/add-room-contract-migration.sh
+++ b/scripts/add-room-contract-migration.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Add a migration entry for the currently committed room-contract WASM.
+#
+# Run this BEFORE your change rebuilds room_contract.wasm: it records the OLD
+# contract generation's BLAKE3 code hash in common/legacy_room_contracts.toml,
+# so clients can probe the old contract key and recover a room that was dormant
+# across the upgrade (freenet/river#292). If your changes already rebuilt the
+# WASM, restore it first: `git checkout HEAD -- ui/public/contracts/`.
+#
+# Usage:
+#   scripts/add-room-contract-migration.sh "V25" "Description of what changed"
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TOML="$REPO_ROOT/common/legacy_room_contracts.toml"
+COMMITTED="$REPO_ROOT/ui/public/contracts/room_contract.wasm"
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+command -v b3sum >/dev/null 2>&1 || die "b3sum not found. Install with: cargo install b3sum"
+[ -f "$COMMITTED" ] || die "Committed room-contract WASM not found: $COMMITTED"
+[ -f "$TOML" ] || die "Registry not found: $TOML"
+
+VERSION="${1:?Usage: add-room-contract-migration.sh VERSION DESCRIPTION}"
+DESCRIPTION="${2:?Usage: add-room-contract-migration.sh VERSION DESCRIPTION}"
+
+# code_hash = BLAKE3(wasm) — exactly what CodeHash::from_code computes.
+CODE_HASH=$(b3sum "$COMMITTED" | cut -d' ' -f1)
+
+echo "Committed room-contract WASM: $COMMITTED"
+echo "  code_hash: $CODE_HASH"
+
+if grep -qF "$CODE_HASH" "$TOML"; then
+    echo ""
+    echo "This code_hash is already in $TOML — no action needed."
+    exit 0
+fi
+
+DATE=$(date +%Y-%m-%d)
+cat >> "$TOML" << EOF
+
+[[entry]]
+version = "$VERSION"
+description = "$DESCRIPTION"
+date = "$DATE"
+code_hash = "$CODE_HASH"
+EOF
+
+echo ""
+echo "Added $VERSION to $TOML"
+echo ""
+echo "Next steps:"
+echo "  1. cargo make sync-wasm     # rebuild + copy the NEW room-contract WASM"
+echo "  2. cargo test -p river-core --test room_contract_migration_test"
+echo "  3. git add common/legacy_room_contracts.toml ui/public/contracts/ cli/contracts/"
+echo "  4. git commit"

--- a/scripts/check-room-contract-migration.sh
+++ b/scripts/check-room-contract-migration.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Check if the committed room-contract WASM changed and a migration entry is needed.
+#
+# The committed WASM at `ui/public/contracts/room_contract.wasm` is what ships
+# to users — the UI embeds it via `include_bytes!` and the CLI bundles a synced
+# copy. Any change to it moves the room contract key (BLAKE3(wasm, params)) for
+# every owner and strands every room on the old key — UNLESS the OLD code hash
+# is recorded in `common/legacy_room_contracts.toml`, which lets clients probe
+# older generations to recover a dormant room (freenet/river#292).
+#
+# Usage:
+#   scripts/check-room-contract-migration.sh                         # HEAD vs working tree
+#   scripts/check-room-contract-migration.sh --ci BASE_SHA HEAD_SHA  # CI mode: two commits
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TOML_PATH="common/legacy_room_contracts.toml"
+WASM_PATH="ui/public/contracts/room_contract.wasm"
+
+cd "$REPO_ROOT"
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+command -v b3sum >/dev/null 2>&1 || die "b3sum not found. Install with: cargo install b3sum"
+
+# Extract all code_hash values from TOML content on stdin.
+known_hashes_from_stdin() {
+    grep '^code_hash' | sed 's/.*= *"\([^"]*\)".*/\1/'
+}
+
+# BLAKE3-hash the committed WASM at a given git ref. Outputs "" if missing.
+wasm_hash_at_ref() {
+    local ref="$1"
+    if git cat-file -e "$ref:$WASM_PATH" 2>/dev/null; then
+        git show "$ref:$WASM_PATH" | b3sum | cut -d' ' -f1
+    else
+        echo ""
+    fi
+}
+
+wasm_hash_file() {
+    b3sum "$1" | cut -d' ' -f1
+}
+
+if [ "${1:-}" = "--ci" ]; then
+    BASE_SHA="${2:?Usage: check-room-contract-migration.sh --ci BASE_SHA HEAD_SHA}"
+    HEAD_SHA="${3:?Usage: check-room-contract-migration.sh --ci BASE_SHA HEAD_SHA}"
+
+    BASE_HASH=$(wasm_hash_at_ref "$BASE_SHA")
+    HEAD_HASH=$(wasm_hash_at_ref "$HEAD_SHA")
+
+    if [ -z "$BASE_HASH" ]; then
+        echo "Committed room-contract WASM did not exist at base ($BASE_SHA) — treating as new file, no migration needed."
+        exit 0
+    fi
+    if [ -z "$HEAD_HASH" ]; then
+        die "Committed room-contract WASM ($WASM_PATH) was deleted at head ($HEAD_SHA). Refusing to proceed."
+    fi
+
+    echo "Room-contract WASM hash on base ($BASE_SHA): $BASE_HASH"
+    echo "Room-contract WASM hash on head ($HEAD_SHA): $HEAD_HASH"
+
+    if [ "$BASE_HASH" = "$HEAD_HASH" ]; then
+        echo "Room-contract WASM unchanged — no migration entry needed."
+        exit 0
+    fi
+
+    echo ""
+    echo "Room-contract WASM CHANGED: $BASE_HASH -> $HEAD_HASH"
+    echo ""
+
+    # The head branch's registry must contain the BASE (old) hash.
+    if git show "$HEAD_SHA:$TOML_PATH" 2>/dev/null | known_hashes_from_stdin | grep -qF "$BASE_HASH"; then
+        echo "Old hash found in $TOML_PATH — migration entry exists."
+        exit 0
+    fi
+
+    echo "FAILED: Old room-contract hash $BASE_HASH is NOT in $TOML_PATH on HEAD!"
+    echo ""
+    echo "When the committed room-contract WASM changes, the OLD hash MUST be added to"
+    echo "$TOML_PATH so clients can recover rooms stranded on the old contract key."
+    echo ""
+    echo "To fix:"
+    echo "  1. Revert the WASM change, OR"
+    echo "  2. Run: cargo make add-room-contract-migration  (before committing the new WASM)"
+    exit 1
+else
+    # Local mode: compare HEAD's committed WASM to the working-tree file.
+    [ -f "$WASM_PATH" ] || die "Committed room-contract WASM not found: $WASM_PATH"
+
+    WORKING_HASH=$(wasm_hash_file "$WASM_PATH")
+    HEAD_HASH=$(wasm_hash_at_ref "HEAD")
+
+    if [ -z "$HEAD_HASH" ]; then
+        echo "Committed room-contract WASM not tracked at HEAD — no migration needed (new file)."
+        exit 0
+    fi
+
+    echo "Room-contract WASM hash at HEAD:    $HEAD_HASH"
+    echo "Room-contract WASM hash in working: $WORKING_HASH"
+
+    if [ "$HEAD_HASH" = "$WORKING_HASH" ]; then
+        echo "Committed room-contract WASM matches HEAD — no migration entry needed."
+        exit 0
+    fi
+
+    echo ""
+    echo "Committed room-contract WASM was modified in working tree: $HEAD_HASH -> $WORKING_HASH"
+    echo ""
+
+    if grep '^code_hash' "$TOML_PATH" | grep -qF "$HEAD_HASH"; then
+        echo "Old hash found in $TOML_PATH — migration entry exists."
+        exit 0
+    fi
+
+    echo "Old hash NOT in $TOML_PATH!"
+    echo ""
+    echo "To fix:"
+    echo "  1. Revert the WASM change: git checkout HEAD -- $WASM_PATH"
+    echo "  2. OR run: cargo make add-room-contract-migration  (before committing the new WASM)"
+    exit 1
+fi

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -76,7 +76,7 @@ log = "0.4" # Add log crate
 tracing = { version = "0.1", default-features = false, features = ["std", "release_max_level_info"] }
 
 # Internal dependencies
-river-core = { workspace = true, features = ["ecies", "ecies-randomized"] }
+river-core = { workspace = true, features = ["ecies", "ecies-randomized", "migration"] }
 
 # Freenet dependencies
 freenet-scaffold.workspace = true

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -714,6 +714,14 @@ mod tests {
 
     // ===== ENSURE_SUBSCRIPTION_SENT dedup-on-failure tests (Bug #6) =====
     //
+    // Serializes the tests below that mutate the process-global
+    // `ENSURE_SUBSCRIPTION_SENT` static. Each starts with
+    // `reset_ensure_subscription_dedup()`, which clears the WHOLE set — so
+    // without serialization a parallel test's reset wipes another test's
+    // entries mid-run, a shared-mutable-state flake. `into_inner()` recovers
+    // a poisoned lock so one failing test doesn't cascade-fail the rest.
+    static DEDUP_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    //
     // These tests pin the contract that the per-session dedup must NOT
     // hold across a failed `EnsureRoomSubscription`. Before the Bug #6
     // fix, the dedup set was populated up-front and never cleared, so a
@@ -736,6 +744,7 @@ mod tests {
     /// `Ok(false)` no-op return.
     #[test]
     fn ensure_subscription_dedup_blocks_second_call() {
+        let _dedup_guard = DEDUP_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         reset_ensure_subscription_dedup();
         let vk = sk(7).verifying_key().to_bytes();
 
@@ -757,6 +766,7 @@ mod tests {
     /// load that lost the signing-key/EnsureRoomSubscription race.
     #[test]
     fn ensure_subscription_dedup_cleared_after_failure_allows_retry() {
+        let _dedup_guard = DEDUP_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         reset_ensure_subscription_dedup();
         let vk = sk(8).verifying_key().to_bytes();
 
@@ -790,6 +800,7 @@ mod tests {
     /// silently re-enable retries for every other room in the session.
     #[test]
     fn clear_ensure_subscription_sent_is_scoped_to_supplied_vk() {
+        let _dedup_guard = DEDUP_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         reset_ensure_subscription_dedup();
         let vk_a = sk(9).verifying_key().to_bytes();
         let vk_b = sk(10).verifying_key().to_bytes();

--- a/ui/src/components/app/freenet_api.rs
+++ b/ui/src/components/app/freenet_api.rs
@@ -3,6 +3,7 @@
 //! Handles WebSocket communication with Freenet network, manages room subscriptions,
 //! and processes state updates.
 
+pub mod backward_probe;
 pub mod connection_manager;
 pub mod constants;
 pub mod error;

--- a/ui/src/components/app/freenet_api/backward_probe.rs
+++ b/ui/src/components/app/freenet_api/backward_probe.rs
@@ -42,6 +42,7 @@
 //! rather than stalling forever. Without this a dormant room — exactly what
 //! this feature targets — could be left permanently stuck.
 
+use crate::components::app::sync_info::{RoomSyncStatus, SYNC_INFO};
 use crate::util::{owner_vk_to_legacy_contract_keys, safe_spawn_local, sleep, to_cbor_vec};
 use dioxus::logger::tracing::{info, warn};
 use ed25519_dalek::VerifyingKey;
@@ -49,6 +50,7 @@ use freenet_stdlib::client_api::{ClientRequest, ContractRequest};
 use freenet_stdlib::prelude::{ContractInstanceId, ContractKey};
 use river_core::room_state::ChatRoomStateV1;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{LazyLock, Mutex, MutexGuard};
 use std::time::Duration;
 
@@ -81,7 +83,15 @@ pub struct ProbeState {
     /// Captured up front so the seed path never depends on a fallible signal
     /// read at probe-completion time.
     pub local_snapshot: ChatRoomStateV1,
+    /// Unique token for this outstanding GET. The timeout watchdog captures it
+    /// and only fires if the entry still carries the SAME epoch — so a stale
+    /// watchdog from a completed probe cannot consume a later probe's entry
+    /// that happens to re-use the same legacy contract id.
+    pub epoch: u64,
 }
+
+/// Monotonic source of [`ProbeState::epoch`] values.
+static PROBE_EPOCH: AtomicU64 = AtomicU64::new(0);
 
 /// Maps the `ContractInstanceId` of the currently-outstanding legacy GET to
 /// the probe it belongs to. Plain `Mutex` map — see the module docs.
@@ -98,6 +108,13 @@ fn probes() -> MutexGuard<'static, HashMap<ContractInstanceId, ProbeState>> {
 /// GET. Used by `handle_get_response` to route legacy-key responses.
 pub fn is_probe_instance(instance_id: &ContractInstanceId) -> bool {
     probes().contains_key(instance_id)
+}
+
+/// Whether the outstanding probe for `instance_id` still carries `epoch`. The
+/// timeout watchdog uses this so it acts only on the exact probe GET it was
+/// armed for — never on a later probe that re-used the same contract id.
+fn probe_has_epoch(instance_id: &ContractInstanceId, epoch: u64) -> bool {
+    probes().get(instance_id).map(|p| p.epoch) == Some(epoch)
 }
 
 /// Take (remove) the probe entry for `instance_id`, if any. The caller has
@@ -131,6 +148,13 @@ pub fn start_backward_probe(owner_vk: VerifyingKey, local_snapshot: ChatRoomStat
 
     // Don't start a second probe for an owner that already has one running.
     // Return `true` so the caller still treats recovery as in-flight.
+    //
+    // There is no gap to race here: a probe always has exactly one
+    // `BACKWARD_PROBES` entry while in flight. `handle_probe_get_response`
+    // runs `take_probe` → `advance_backward_probe` → `fire_probe_get`
+    // (which re-inserts the next hop) with NO `.await` in between, so on
+    // single-threaded WASM no other task — including this guard — can
+    // observe the table mid-advance.
     if probes().values().any(|p| p.owner_vk == owner_vk) {
         info!(
             "Backward probe already in progress for {:?}, not restarting",
@@ -165,6 +189,7 @@ pub fn advance_backward_probe(state: ProbeState) -> bool {
         mut remaining,
         hops,
         local_snapshot,
+        epoch: _, // each hop's GET gets a fresh epoch from `fire_probe_get`
     } = state;
 
     if remaining.is_empty() {
@@ -199,6 +224,7 @@ fn fire_probe_get(
     local_snapshot: ChatRoomStateV1,
 ) {
     let instance_id = *key.id();
+    let epoch = PROBE_EPOCH.fetch_add(1, Ordering::Relaxed);
 
     // Register the probe BEFORE sending the GET so the response handler can
     // resolve the legacy key when the reply arrives. Plain mutex — synchronous,
@@ -210,8 +236,20 @@ fn fire_probe_get(
             remaining,
             hops,
             local_snapshot,
+            epoch,
         },
     );
+
+    // Keep the room out of the subscription-timeout sweep: a probe in flight
+    // IS active subscription progress. Each hop refreshes `subscribing_since`
+    // (hops are <= PROBE_GET_TIMEOUT apart, well under REPUT_DELAY_MS), so
+    // `rooms_awaiting_subscription` does not reclaim the room mid-probe and
+    // re-issue redundant current-key GETs / a duplicate probe.
+    crate::util::defer(move || {
+        SYNC_INFO.with_mut(|sync_info| {
+            sync_info.update_sync_status(&owner_vk, RoomSyncStatus::Subscribing);
+        });
+    });
 
     info!(
         "Backward probe hop {} for {:?}: GET legacy contract {}",
@@ -243,11 +281,13 @@ fn fire_probe_get(
         }
     });
 
-    // Watchdog: if no real GET response consumes this probe entry within
-    // PROBE_GET_TIMEOUT, synthesize an empty response so the probe advances.
+    // Watchdog: if no real GET response consumes THIS probe entry (matched by
+    // epoch, so a stale watchdog from a finished probe can't fire against a
+    // later probe that re-used the same contract id) within PROBE_GET_TIMEOUT,
+    // synthesize an empty response so the probe advances.
     safe_spawn_local(async move {
         sleep(PROBE_GET_TIMEOUT).await;
-        if is_probe_instance(&instance_id) {
+        if probe_has_epoch(&instance_id, epoch) {
             warn!(
                 "Backward-probe GET for {instance_id} timed out after {}s — \
                  treating the legacy generation as absent and advancing",
@@ -282,6 +322,7 @@ mod tests {
             remaining: Vec::new(),
             hops: 1,
             local_snapshot: ChatRoomStateV1::default(),
+            epoch: 0,
         });
         assert!(
             !advanced,
@@ -303,10 +344,48 @@ mod tests {
             remaining: vec![dummy_key],
             hops: MAX_PROBE_HOPS,
             local_snapshot: ChatRoomStateV1::default(),
+            epoch: 0,
         });
         assert!(
             !advanced,
             "a probe at the hop cap must report false so the caller seeds the current key"
+        );
+    }
+
+    /// Probe-table semantics: `take_probe` consumes the entry exactly once, so
+    /// a real GET response and the timeout watchdog cannot both advance the
+    /// same hop; and `probe_has_epoch` rejects a stale-epoch watchdog.
+    #[test]
+    fn take_probe_is_single_shot_and_epoch_guarded() {
+        let id = ContractInstanceId::new([200u8; 32]);
+        probes().insert(
+            id,
+            ProbeState {
+                owner_vk: test_owner(5),
+                remaining: Vec::new(),
+                hops: 1,
+                local_snapshot: ChatRoomStateV1::default(),
+                epoch: 42,
+            },
+        );
+        assert!(is_probe_instance(&id));
+        assert!(probe_has_epoch(&id, 42), "the armed epoch must match");
+        assert!(
+            !probe_has_epoch(&id, 99),
+            "a watchdog from a different probe epoch must NOT match"
+        );
+
+        assert!(
+            take_probe(&id).is_some(),
+            "take_probe returns the entry once"
+        );
+        assert!(
+            !is_probe_instance(&id),
+            "after take_probe the entry is gone — the watchdog/real-response loser no-ops"
+        );
+        assert!(
+            take_probe(&id).is_none(),
+            "a second take_probe returns None"
         );
     }
 }

--- a/ui/src/components/app/freenet_api/backward_probe.rs
+++ b/ui/src/components/app/freenet_api/backward_probe.rs
@@ -15,30 +15,53 @@
 //! * Current key empty/absent → probe legacy keys newest-to-oldest. The first
 //!   that returns real state is the room's last-active state; adopt it AND PUT
 //!   it forward onto the current key so the room is no longer stranded.
-//! * Neither current nor any legacy key has state → only then may the device's
-//!   stale local snapshot be PUT to seed the current key.
+//! * Neither current nor any legacy key has state → only then is the device's
+//!   local snapshot PUT to seed the current key.
 //!
-//! ## Routing
+//! ## Routing & bookkeeping
 //!
 //! A GET response for a *legacy* contract key cannot be resolved back to an
 //! `owner_vk` via `SYNC_INFO` (keyed by the current contract id) or via
 //! `RoomData::contract_key` (also the current id). [`BACKWARD_PROBES`] is the
-//! side-table that maps a probe's legacy `ContractInstanceId` back to the
-//! owner being recovered, plus the remaining legacy keys still to try.
+//! side-table that maps a probe's legacy `ContractInstanceId` back to the probe
+//! it belongs to.
+//!
+//! It is a plain `Mutex`-guarded map, NOT a Dioxus signal: it is internal
+//! bookkeeping with zero UI reactivity (no component or memo ever reads it),
+//! so it must not carry signal semantics. This is the same shape as
+//! `chat_delegate::ENSURE_SUBSCRIPTION_SENT`. Using a plain `Mutex` means
+//! mutations need no `defer()` and cannot cause a re-entrant signal borrow.
+//!
+//! ## Liveness — every probe GET has a watchdog
+//!
+//! A legacy generation whose contract has been garbage-collected from the
+//! network may never produce a `GetResponse`. Every probe GET is therefore
+//! paired with a [`PROBE_GET_TIMEOUT`] watchdog: if the response has not
+//! arrived by then, the watchdog synthesizes an empty response so the probe
+//! advances to the next generation (and ultimately seeds the current key)
+//! rather than stalling forever. Without this a dormant room — exactly what
+//! this feature targets — could be left permanently stuck.
 
-use crate::util::owner_vk_to_legacy_contract_keys;
+use crate::util::{owner_vk_to_legacy_contract_keys, safe_spawn_local, sleep, to_cbor_vec};
 use dioxus::logger::tracing::{info, warn};
-use dioxus::prelude::{Global, GlobalSignal, ReadableExt};
 use ed25519_dalek::VerifyingKey;
 use freenet_stdlib::client_api::{ClientRequest, ContractRequest};
 use freenet_stdlib::prelude::{ContractInstanceId, ContractKey};
+use river_core::room_state::ChatRoomStateV1;
 use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex, MutexGuard};
+use std::time::Duration;
 
 /// Hard cap on how many legacy generations a single probe will walk before
 /// giving up. `owner_vk_to_legacy_contract_keys` is already bounded by the
-/// size of the legacy registry, but this is a defence-in-depth guard against
-/// a runaway chain if the registry ever grows unexpectedly large.
-const MAX_PROBE_HOPS: usize = 32;
+/// size of the legacy registry; this is defence-in-depth against a runaway
+/// chain if the registry ever grows unexpectedly large.
+const MAX_PROBE_HOPS: usize = 64;
+
+/// How long to wait for a probe GET response before treating the legacy
+/// generation as absent and advancing. An existing contract responds well
+/// inside this; only a garbage-collected one runs the timeout down.
+const PROBE_GET_TIMEOUT: Duration = Duration::from_secs(12);
 
 /// State of an in-progress backward probe for one room.
 #[derive(Clone)]
@@ -47,47 +70,56 @@ pub struct ProbeState {
     pub owner_vk: VerifyingKey,
     /// Legacy contract keys not yet tried, ordered newest-first. The key
     /// currently outstanding (whose GET we're awaiting) is NOT in this list —
-    /// it's tracked by its instance id being a `BACKWARD_PROBES` map key.
+    /// it is the `BACKWARD_PROBES` map key.
     pub remaining: Vec<ContractKey>,
     /// Hops taken so far, for the [`MAX_PROBE_HOPS`] cap.
     pub hops: usize,
+    /// The device's local room snapshot, captured when the probe started.
+    /// Used to (a) CRDT-merge with any recovered state before PUTting it
+    /// forward, so unsynced local edits are not dropped, and (b) seed the
+    /// current key as the genuine last resort if every generation is empty.
+    /// Captured up front so the seed path never depends on a fallible signal
+    /// read at probe-completion time.
+    pub local_snapshot: ChatRoomStateV1,
 }
 
 /// Maps the `ContractInstanceId` of the currently-outstanding legacy GET to
-/// the probe it belongs to. A GET response for a legacy key is resolved back
-/// to its `owner_vk` by looking up `key.id()` here.
-pub static BACKWARD_PROBES: GlobalSignal<HashMap<ContractInstanceId, ProbeState>> =
-    Global::new(HashMap::new);
+/// the probe it belongs to. Plain `Mutex` map — see the module docs.
+static BACKWARD_PROBES: LazyLock<Mutex<HashMap<ContractInstanceId, ProbeState>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Lock the probe table, recovering from a poisoned mutex (a panic while the
+/// lock was held must not wedge all future recovery).
+fn probes() -> MutexGuard<'static, HashMap<ContractInstanceId, ProbeState>> {
+    BACKWARD_PROBES.lock().unwrap_or_else(|e| e.into_inner())
+}
 
 /// Whether `instance_id` is the contract id of an outstanding backward-probe
 /// GET. Used by `handle_get_response` to route legacy-key responses.
-///
-/// On the (rare) event that `BACKWARD_PROBES` is concurrently borrowed,
-/// returns `false` — the GET response then falls through to the normal
-/// owner-resolution path rather than the probe handler. A legacy-key
-/// response that misses the probe route is harmless (it won't resolve to
-/// an owner and is dropped); the probe's outstanding entry stays put and
-/// a later cycle can still drive it.
 pub fn is_probe_instance(instance_id: &ContractInstanceId) -> bool {
-    BACKWARD_PROBES
-        .try_read()
-        .map(|probes| probes.contains_key(instance_id))
-        .unwrap_or(false)
+    probes().contains_key(instance_id)
+}
+
+/// Take (remove) the probe entry for `instance_id`, if any. The caller has
+/// just received (or synthesized, on timeout) the GET response for that
+/// legacy key and is now responsible for either recovering the state or
+/// advancing to the next hop.
+pub fn take_probe(instance_id: &ContractInstanceId) -> Option<ProbeState> {
+    probes().remove(instance_id)
 }
 
 /// Start a backward probe for `owner_vk`'s room: GET the newest legacy
 /// contract key. Called when the current-key GET came back empty.
 ///
-/// Returns `true` if a probe was started (there is at least one legacy
-/// generation to try, or one is already running for this owner) — the
-/// caller should then NOT seed the current key, the probe will recover
-/// or exhaust. Returns `false` when there are no legacy generations at
-/// all, in which case the caller must fall back to seeding the current
-/// key with the local snapshot (there is nothing to recover).
+/// `local_snapshot` is the device's current room state, captured by the
+/// caller; it rides along in [`ProbeState`] for the merge / last-resort seed.
 ///
-/// Spawns the GET via `safe_spawn_local`; signal mutation of
-/// `BACKWARD_PROBES` is wrapped in `defer`.
-pub fn start_backward_probe(owner_vk: VerifyingKey) -> bool {
+/// Returns `true` if a probe is in flight (one was started, or one was
+/// already running for this owner) — the caller must then NOT seed the
+/// current key; the probe owns recovery-or-seed. Returns `false` only when
+/// there are no legacy generations at all, in which case the caller falls
+/// back to seeding the current key itself.
+pub fn start_backward_probe(owner_vk: VerifyingKey, local_snapshot: ChatRoomStateV1) -> bool {
     let mut legacy_keys = owner_vk_to_legacy_contract_keys(&owner_vk);
     if legacy_keys.is_empty() {
         info!(
@@ -98,16 +130,13 @@ pub fn start_backward_probe(owner_vk: VerifyingKey) -> bool {
     }
 
     // Don't start a second probe for an owner that already has one running.
-    // Return `true` so the caller still treats recovery as in-flight and
-    // does not seed the current key behind the probe's back.
-    if let Ok(probes) = BACKWARD_PROBES.try_read() {
-        if probes.values().any(|p| p.owner_vk == owner_vk) {
-            info!(
-                "Backward probe already in progress for {:?}, not restarting",
-                river_core::room_state::member::MemberId::from(owner_vk)
-            );
-            return true;
-        }
+    // Return `true` so the caller still treats recovery as in-flight.
+    if probes().values().any(|p| p.owner_vk == owner_vk) {
+        info!(
+            "Backward probe already in progress for {:?}, not restarting",
+            river_core::room_state::member::MemberId::from(owner_vk)
+        );
+        return true;
     }
 
     // The newest legacy key becomes the outstanding GET; the rest stay in
@@ -118,23 +147,24 @@ pub fn start_backward_probe(owner_vk: VerifyingKey) -> bool {
         river_core::room_state::member::MemberId::from(owner_vk),
         legacy_keys.len() + 1
     );
-    fire_probe_get(owner_vk, first, legacy_keys, 1);
+    fire_probe_get(owner_vk, first, legacy_keys, 1, local_snapshot);
     true
 }
 
 /// Advance an in-progress probe to its next legacy key. Called when a legacy
-/// GET came back empty.
+/// GET came back empty (or its watchdog fired).
 ///
 /// Returns `true` if the probe advanced (a GET for the next legacy key was
 /// fired). Returns `false` when the probe is exhausted — every legacy
-/// generation has been tried and none held real state. On `false` the
-/// caller must perform the last-resort seed of the current contract key
-/// with the device's local snapshot.
+/// generation has been tried and none held real state. On `false` the caller
+/// performs the last-resort seed of the current contract key with the
+/// device's local snapshot.
 pub fn advance_backward_probe(state: ProbeState) -> bool {
     let ProbeState {
         owner_vk,
         mut remaining,
         hops,
+        local_snapshot,
     } = state;
 
     if remaining.is_empty() {
@@ -155,33 +185,33 @@ pub fn advance_backward_probe(state: ProbeState) -> bool {
     }
 
     let next = remaining.remove(0);
-    fire_probe_get(owner_vk, next, remaining, hops + 1);
+    fire_probe_get(owner_vk, next, remaining, hops + 1, local_snapshot);
     true
 }
 
-/// Register `key` as the outstanding probe GET for `owner_vk` and send the
-/// GET request. `remaining` is the not-yet-tried tail of legacy keys.
+/// Register `key` as the outstanding probe GET for `owner_vk`, send the GET,
+/// and arm a watchdog so an absent legacy generation cannot stall the probe.
 fn fire_probe_get(
     owner_vk: VerifyingKey,
     key: ContractKey,
     remaining: Vec<ContractKey>,
     hops: usize,
+    local_snapshot: ChatRoomStateV1,
 ) {
     let instance_id = *key.id();
-    let probe = ProbeState {
-        owner_vk,
-        remaining,
-        hops,
-    };
 
     // Register the probe BEFORE sending the GET so the response handler can
-    // resolve the legacy key when the reply arrives. Deferred per the Dioxus
-    // signal-safety rules (this can run inside a response-handler task).
-    crate::util::defer(move || {
-        BACKWARD_PROBES.with_mut(|probes| {
-            probes.insert(instance_id, probe);
-        });
-    });
+    // resolve the legacy key when the reply arrives. Plain mutex — synchronous,
+    // no defer, no signal re-entrancy.
+    probes().insert(
+        instance_id,
+        ProbeState {
+            owner_vk,
+            remaining,
+            hops,
+            local_snapshot,
+        },
+    );
 
     info!(
         "Backward probe hop {} for {:?}: GET legacy contract {}",
@@ -190,7 +220,7 @@ fn fire_probe_get(
         instance_id
     );
 
-    crate::util::safe_spawn_local(async move {
+    safe_spawn_local(async move {
         let get_request = ContractRequest::Get {
             key: instance_id,
             // Legacy generations need their own WASM cached for the GET to
@@ -199,49 +229,59 @@ fn fire_probe_get(
             subscribe: false,
             blocking_subscribe: false,
         };
-        if let Some(web_api) = crate::components::app::WEB_API.write().as_mut() {
-            if let Err(e) = web_api.send(ClientRequest::ContractOp(get_request)).await {
-                warn!("Failed to send backward-probe GET: {}", e);
-                // Drop the probe entry so a future probe for this owner can
-                // start fresh rather than silently colliding with a dead one.
-                crate::util::defer(move || {
-                    BACKWARD_PROBES.with_mut(|probes| {
-                        probes.remove(&instance_id);
-                    });
-                });
-            }
+        let send_result = if let Some(web_api) = crate::components::app::WEB_API.write().as_mut() {
+            web_api.send(ClientRequest::ContractOp(get_request)).await
+        } else {
+            Ok(()) // WebAPI gone — let the watchdog drive the probe forward.
+        };
+        if let Err(e) = send_result {
+            warn!("Failed to send backward-probe GET for {instance_id}: {e}");
+            // Leave the entry in place: the watchdog below treats the missing
+            // response as empty and advances the probe, so a transient send
+            // failure still walks to the next generation rather than silently
+            // abandoning recovery.
         }
     });
-}
 
-/// Take (remove) the probe entry for `instance_id`, if any. The caller has
-/// just received the GET response for that legacy key and is now responsible
-/// for either recovering the state or advancing to the next hop.
-pub fn take_probe(instance_id: &ContractInstanceId) -> Option<ProbeState> {
-    let mut taken = None;
-    BACKWARD_PROBES.with_mut(|probes| {
-        taken = probes.remove(instance_id);
+    // Watchdog: if no real GET response consumes this probe entry within
+    // PROBE_GET_TIMEOUT, synthesize an empty response so the probe advances.
+    safe_spawn_local(async move {
+        sleep(PROBE_GET_TIMEOUT).await;
+        if is_probe_instance(&instance_id) {
+            warn!(
+                "Backward-probe GET for {instance_id} timed out after {}s — \
+                 treating the legacy generation as absent and advancing",
+                PROBE_GET_TIMEOUT.as_secs()
+            );
+            // An empty/default state routes through the same handler as a real
+            // empty response: it advances the probe, or seeds on exhaustion.
+            let empty = to_cbor_vec(&ChatRoomStateV1::default());
+            crate::components::app::freenet_api::response_handler::get_response::handle_probe_get_response(
+                key, empty,
+            )
+            .await;
+        }
     });
-    taken
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn test_owner(seed: u8) -> VerifyingKey {
+        ed25519_dalek::SigningKey::from_bytes(&[seed; 32]).verifying_key()
+    }
+
     /// `advance_backward_probe` with an empty `remaining` must report
-    /// exhaustion (`false`) — the probe ends, no panic, no further GET.
-    /// The caller uses the `false` return to trigger the last-resort
-    /// seed of the current contract key.
+    /// exhaustion (`false`) — the probe ends, no panic, no further GET. The
+    /// caller uses the `false` return to seed the current contract key.
     #[test]
     fn advance_with_empty_remaining_reports_exhausted() {
-        let owner = ed25519_dalek::SigningKey::from_bytes(&[3u8; 32]).verifying_key();
-        // Should not panic and should not require a Dioxus runtime — the
-        // exhausted branch returns before touching any signal.
         let advanced = advance_backward_probe(ProbeState {
-            owner_vk: owner,
+            owner_vk: test_owner(3),
             remaining: Vec::new(),
             hops: 1,
+            local_snapshot: ChatRoomStateV1::default(),
         });
         assert!(
             !advanced,
@@ -250,18 +290,19 @@ mod tests {
     }
 
     /// A probe that has hit `MAX_PROBE_HOPS` must also report exhaustion
-    /// (`false`) even when `remaining` is non-empty — the runaway guard
-    /// must not silently swallow the need to seed.
+    /// (`false`) even when `remaining` is non-empty — the runaway guard must
+    /// not silently swallow the need to seed.
     #[test]
     fn advance_at_hop_cap_reports_exhausted() {
-        let owner = ed25519_dalek::SigningKey::from_bytes(&[4u8; 32]).verifying_key();
         let dummy_code = freenet_stdlib::prelude::ContractCode::from(b"dummy".to_vec());
         let dummy_params = freenet_stdlib::prelude::Parameters::from(b"dummy".to_vec());
-        let dummy_key = ContractKey::from_params_and_code(dummy_params, &dummy_code);
+        let dummy_key =
+            freenet_stdlib::prelude::ContractKey::from_params_and_code(dummy_params, &dummy_code);
         let advanced = advance_backward_probe(ProbeState {
-            owner_vk: owner,
+            owner_vk: test_owner(4),
             remaining: vec![dummy_key],
             hops: MAX_PROBE_HOPS,
+            local_snapshot: ChatRoomStateV1::default(),
         });
         assert!(
             !advanced,

--- a/ui/src/components/app/freenet_api/backward_probe.rs
+++ b/ui/src/components/app/freenet_api/backward_probe.rs
@@ -1,0 +1,271 @@
+//! Backward-probe recovery for rooms stranded under an older room-contract
+//! generation (freenet/river#292).
+//!
+//! The room contract key is `BLAKE3(room_contract.wasm, params)`. Every
+//! room-contract WASM upgrade moves the key for every owner, so a room that
+//! was dormant across one or more upgrades has its live state stranded under
+//! an older-generation contract key.
+//!
+//! ## Design principle (the same gating the chat delegate uses — #253)
+//!
+//! **The current contract key is always authoritative.** The backward probe
+//! fires ONLY when the current key has no usable state:
+//!
+//! * Current key has state → adopt it. Never probe backward.
+//! * Current key empty/absent → probe legacy keys newest-to-oldest. The first
+//!   that returns real state is the room's last-active state; adopt it AND PUT
+//!   it forward onto the current key so the room is no longer stranded.
+//! * Neither current nor any legacy key has state → only then may the device's
+//!   stale local snapshot be PUT to seed the current key.
+//!
+//! ## Routing
+//!
+//! A GET response for a *legacy* contract key cannot be resolved back to an
+//! `owner_vk` via `SYNC_INFO` (keyed by the current contract id) or via
+//! `RoomData::contract_key` (also the current id). [`BACKWARD_PROBES`] is the
+//! side-table that maps a probe's legacy `ContractInstanceId` back to the
+//! owner being recovered, plus the remaining legacy keys still to try.
+
+use crate::util::owner_vk_to_legacy_contract_keys;
+use dioxus::logger::tracing::{info, warn};
+use dioxus::prelude::{Global, GlobalSignal, ReadableExt};
+use ed25519_dalek::VerifyingKey;
+use freenet_stdlib::client_api::{ClientRequest, ContractRequest};
+use freenet_stdlib::prelude::{ContractInstanceId, ContractKey};
+use std::collections::HashMap;
+
+/// Hard cap on how many legacy generations a single probe will walk before
+/// giving up. `owner_vk_to_legacy_contract_keys` is already bounded by the
+/// size of the legacy registry, but this is a defence-in-depth guard against
+/// a runaway chain if the registry ever grows unexpectedly large.
+const MAX_PROBE_HOPS: usize = 32;
+
+/// State of an in-progress backward probe for one room.
+#[derive(Clone)]
+pub struct ProbeState {
+    /// The owner whose stranded room we're recovering.
+    pub owner_vk: VerifyingKey,
+    /// Legacy contract keys not yet tried, ordered newest-first. The key
+    /// currently outstanding (whose GET we're awaiting) is NOT in this list —
+    /// it's tracked by its instance id being a `BACKWARD_PROBES` map key.
+    pub remaining: Vec<ContractKey>,
+    /// Hops taken so far, for the [`MAX_PROBE_HOPS`] cap.
+    pub hops: usize,
+}
+
+/// Maps the `ContractInstanceId` of the currently-outstanding legacy GET to
+/// the probe it belongs to. A GET response for a legacy key is resolved back
+/// to its `owner_vk` by looking up `key.id()` here.
+pub static BACKWARD_PROBES: GlobalSignal<HashMap<ContractInstanceId, ProbeState>> =
+    Global::new(HashMap::new);
+
+/// Whether `instance_id` is the contract id of an outstanding backward-probe
+/// GET. Used by `handle_get_response` to route legacy-key responses.
+///
+/// On the (rare) event that `BACKWARD_PROBES` is concurrently borrowed,
+/// returns `false` — the GET response then falls through to the normal
+/// owner-resolution path rather than the probe handler. A legacy-key
+/// response that misses the probe route is harmless (it won't resolve to
+/// an owner and is dropped); the probe's outstanding entry stays put and
+/// a later cycle can still drive it.
+pub fn is_probe_instance(instance_id: &ContractInstanceId) -> bool {
+    BACKWARD_PROBES
+        .try_read()
+        .map(|probes| probes.contains_key(instance_id))
+        .unwrap_or(false)
+}
+
+/// Start a backward probe for `owner_vk`'s room: GET the newest legacy
+/// contract key. Called when the current-key GET came back empty.
+///
+/// Returns `true` if a probe was started (there is at least one legacy
+/// generation to try, or one is already running for this owner) — the
+/// caller should then NOT seed the current key, the probe will recover
+/// or exhaust. Returns `false` when there are no legacy generations at
+/// all, in which case the caller must fall back to seeding the current
+/// key with the local snapshot (there is nothing to recover).
+///
+/// Spawns the GET via `safe_spawn_local`; signal mutation of
+/// `BACKWARD_PROBES` is wrapped in `defer`.
+pub fn start_backward_probe(owner_vk: VerifyingKey) -> bool {
+    let mut legacy_keys = owner_vk_to_legacy_contract_keys(&owner_vk);
+    if legacy_keys.is_empty() {
+        info!(
+            "No legacy room-contract generations — skipping backward probe for {:?}",
+            river_core::room_state::member::MemberId::from(owner_vk)
+        );
+        return false;
+    }
+
+    // Don't start a second probe for an owner that already has one running.
+    // Return `true` so the caller still treats recovery as in-flight and
+    // does not seed the current key behind the probe's back.
+    if let Ok(probes) = BACKWARD_PROBES.try_read() {
+        if probes.values().any(|p| p.owner_vk == owner_vk) {
+            info!(
+                "Backward probe already in progress for {:?}, not restarting",
+                river_core::room_state::member::MemberId::from(owner_vk)
+            );
+            return true;
+        }
+    }
+
+    // The newest legacy key becomes the outstanding GET; the rest stay in
+    // `remaining` for subsequent hops.
+    let first = legacy_keys.remove(0);
+    info!(
+        "Starting backward probe for {:?}: {} legacy generation(s) to try",
+        river_core::room_state::member::MemberId::from(owner_vk),
+        legacy_keys.len() + 1
+    );
+    fire_probe_get(owner_vk, first, legacy_keys, 1);
+    true
+}
+
+/// Advance an in-progress probe to its next legacy key. Called when a legacy
+/// GET came back empty.
+///
+/// Returns `true` if the probe advanced (a GET for the next legacy key was
+/// fired). Returns `false` when the probe is exhausted — every legacy
+/// generation has been tried and none held real state. On `false` the
+/// caller must perform the last-resort seed of the current contract key
+/// with the device's local snapshot.
+pub fn advance_backward_probe(state: ProbeState) -> bool {
+    let ProbeState {
+        owner_vk,
+        mut remaining,
+        hops,
+    } = state;
+
+    if remaining.is_empty() {
+        info!(
+            "Backward probe for {:?} exhausted all legacy generations — \
+             no stranded state found",
+            river_core::room_state::member::MemberId::from(owner_vk)
+        );
+        return false;
+    }
+    if hops >= MAX_PROBE_HOPS {
+        warn!(
+            "Backward probe for {:?} hit MAX_PROBE_HOPS ({}) — aborting",
+            river_core::room_state::member::MemberId::from(owner_vk),
+            MAX_PROBE_HOPS
+        );
+        return false;
+    }
+
+    let next = remaining.remove(0);
+    fire_probe_get(owner_vk, next, remaining, hops + 1);
+    true
+}
+
+/// Register `key` as the outstanding probe GET for `owner_vk` and send the
+/// GET request. `remaining` is the not-yet-tried tail of legacy keys.
+fn fire_probe_get(
+    owner_vk: VerifyingKey,
+    key: ContractKey,
+    remaining: Vec<ContractKey>,
+    hops: usize,
+) {
+    let instance_id = *key.id();
+    let probe = ProbeState {
+        owner_vk,
+        remaining,
+        hops,
+    };
+
+    // Register the probe BEFORE sending the GET so the response handler can
+    // resolve the legacy key when the reply arrives. Deferred per the Dioxus
+    // signal-safety rules (this can run inside a response-handler task).
+    crate::util::defer(move || {
+        BACKWARD_PROBES.with_mut(|probes| {
+            probes.insert(instance_id, probe);
+        });
+    });
+
+    info!(
+        "Backward probe hop {} for {:?}: GET legacy contract {}",
+        hops,
+        river_core::room_state::member::MemberId::from(owner_vk),
+        instance_id
+    );
+
+    crate::util::safe_spawn_local(async move {
+        let get_request = ContractRequest::Get {
+            key: instance_id,
+            // Legacy generations need their own WASM cached for the GET to
+            // resolve on a node that has never seen that contract.
+            return_contract_code: true,
+            subscribe: false,
+            blocking_subscribe: false,
+        };
+        if let Some(web_api) = crate::components::app::WEB_API.write().as_mut() {
+            if let Err(e) = web_api.send(ClientRequest::ContractOp(get_request)).await {
+                warn!("Failed to send backward-probe GET: {}", e);
+                // Drop the probe entry so a future probe for this owner can
+                // start fresh rather than silently colliding with a dead one.
+                crate::util::defer(move || {
+                    BACKWARD_PROBES.with_mut(|probes| {
+                        probes.remove(&instance_id);
+                    });
+                });
+            }
+        }
+    });
+}
+
+/// Take (remove) the probe entry for `instance_id`, if any. The caller has
+/// just received the GET response for that legacy key and is now responsible
+/// for either recovering the state or advancing to the next hop.
+pub fn take_probe(instance_id: &ContractInstanceId) -> Option<ProbeState> {
+    let mut taken = None;
+    BACKWARD_PROBES.with_mut(|probes| {
+        taken = probes.remove(instance_id);
+    });
+    taken
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `advance_backward_probe` with an empty `remaining` must report
+    /// exhaustion (`false`) — the probe ends, no panic, no further GET.
+    /// The caller uses the `false` return to trigger the last-resort
+    /// seed of the current contract key.
+    #[test]
+    fn advance_with_empty_remaining_reports_exhausted() {
+        let owner = ed25519_dalek::SigningKey::from_bytes(&[3u8; 32]).verifying_key();
+        // Should not panic and should not require a Dioxus runtime — the
+        // exhausted branch returns before touching any signal.
+        let advanced = advance_backward_probe(ProbeState {
+            owner_vk: owner,
+            remaining: Vec::new(),
+            hops: 1,
+        });
+        assert!(
+            !advanced,
+            "an exhausted probe must report false so the caller seeds the current key"
+        );
+    }
+
+    /// A probe that has hit `MAX_PROBE_HOPS` must also report exhaustion
+    /// (`false`) even when `remaining` is non-empty — the runaway guard
+    /// must not silently swallow the need to seed.
+    #[test]
+    fn advance_at_hop_cap_reports_exhausted() {
+        let owner = ed25519_dalek::SigningKey::from_bytes(&[4u8; 32]).verifying_key();
+        let dummy_code = freenet_stdlib::prelude::ContractCode::from(b"dummy".to_vec());
+        let dummy_params = freenet_stdlib::prelude::Parameters::from(b"dummy".to_vec());
+        let dummy_key = ContractKey::from_params_and_code(dummy_params, &dummy_code);
+        let advanced = advance_backward_probe(ProbeState {
+            owner_vk: owner,
+            remaining: vec![dummy_key],
+            hops: MAX_PROBE_HOPS,
+        });
+        assert!(
+            !advanced,
+            "a probe at the hop cap must report false so the caller seeds the current key"
+        );
+    }
+}

--- a/ui/src/components/app/freenet_api/backward_probe.rs
+++ b/ui/src/components/app/freenet_api/backward_probe.rs
@@ -42,7 +42,8 @@
 //! rather than stalling forever. Without this a dormant room — exactly what
 //! this feature targets — could be left permanently stuck.
 
-use crate::components::app::sync_info::{RoomSyncStatus, SYNC_INFO};
+use crate::components::app::freenet_api::constants::REPUT_DELAY_MS;
+use crate::components::app::sync_info::SYNC_INFO;
 use crate::util::{owner_vk_to_legacy_contract_keys, safe_spawn_local, sleep, to_cbor_vec};
 use dioxus::logger::tracing::{info, warn};
 use ed25519_dalek::VerifyingKey;
@@ -64,6 +65,15 @@ const MAX_PROBE_HOPS: usize = 64;
 /// generation as absent and advancing. An existing contract responds well
 /// inside this; only a garbage-collected one runs the timeout down.
 const PROBE_GET_TIMEOUT: Duration = Duration::from_secs(12);
+
+// Load-bearing invariant: a probe re-stamps `subscribing_since` every hop, and
+// consecutive hops are at most `PROBE_GET_TIMEOUT` apart (the watchdog). That
+// only keeps the room out of `rooms_awaiting_subscription`'s sweep if a hop is
+// shorter than the sweep's `REPUT_DELAY_MS` threshold. Pinned at compile time.
+const _: () = assert!(
+    (PROBE_GET_TIMEOUT.as_millis() as u64) < REPUT_DELAY_MS,
+    "PROBE_GET_TIMEOUT must stay below REPUT_DELAY_MS or a probe is reclaimed mid-walk"
+);
 
 /// State of an in-progress backward probe for one room.
 #[derive(Clone)]
@@ -242,12 +252,15 @@ fn fire_probe_get(
 
     // Keep the room out of the subscription-timeout sweep: a probe in flight
     // IS active subscription progress. Each hop refreshes `subscribing_since`
-    // (hops are <= PROBE_GET_TIMEOUT apart, well under REPUT_DELAY_MS), so
-    // `rooms_awaiting_subscription` does not reclaim the room mid-probe and
-    // re-issue redundant current-key GETs / a duplicate probe.
+    // (hops are <= PROBE_GET_TIMEOUT apart, below REPUT_DELAY_MS — see the
+    // compile-time assert above), so `rooms_awaiting_subscription` does not
+    // reclaim the room mid-probe and re-issue a redundant GET / duplicate
+    // probe. `touch_subscribing_since` only refreshes the timestamp — it does
+    // not force the status — so it no-ops harmlessly if the room is absent
+    // from SYNC_INFO or has genuinely already reached `Subscribed`.
     crate::util::defer(move || {
         SYNC_INFO.with_mut(|sync_info| {
-            sync_info.update_sync_status(&owner_vk, RoomSyncStatus::Subscribing);
+            sync_info.touch_subscribing_since(&owner_vk);
         });
     });
 

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -1,4 +1,6 @@
-mod get_response;
+// `pub(crate)` so the backward-probe watchdog (freenet_api::backward_probe)
+// can call `get_response::handle_probe_get_response` on timeout (#292).
+pub(crate) mod get_response;
 mod put_response;
 mod subscribe_response;
 mod update_notification;

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -119,8 +119,13 @@ pub async fn handle_get_response(
         // guards. We pass `key.id()` as `delivered_from` so a pointer
         // that targets the contract that just delivered it is not
         // chased into an infinite loop.
-        {
-            let probed_state: ChatRoomStateV1 = from_cbor_slice::<ChatRoomStateV1>(&state);
+        //
+        // Decode defensively (`try_from_cbor_slice`): this state can come
+        // from a cross-generation pointer target whose `ChatRoomStateV1`
+        // layout the current type cannot decode — same hazard the backward
+        // probe guards against. An undeserializable state simply means
+        // "no upgrade pointer to follow", so the chain terminates here.
+        if let Some(probed_state) = try_from_cbor_slice::<ChatRoomStateV1>(&state) {
             follow_upgrade_pointer_if_needed(&probed_state, &owner_vk, Some(*key.id()));
         }
         // This GET response consumed any outstanding upgrade-target

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -870,6 +870,11 @@ pub(crate) async fn handle_probe_get_response(key: ContractKey, state: Vec<u8>) 
             key.id()
         );
 
+        // No need to follow this recovered state's own upgrade pointer: the
+        // probe walks generations newest-first, so every generation newer than
+        // this one was already probed and found empty. The newest-first probe
+        // order subsumes forward upgrade-pointer following.
+        //
         // CRDT-merge the recovered state with the device's local snapshot
         // BEFORE PUTting it forward, so unsynced local edits the device made
         // offline are not dropped from the migrating PUT. This matches the

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -592,7 +592,18 @@ pub async fn handle_get_response(
                      starting backward probe (freenet/river#292)",
                     MemberId::from(owner_vk)
                 );
-                if start_backward_probe(owner_vk) {
+                // Capture the device's local snapshot now and hand it to the
+                // probe. It rides along in `ProbeState` so the probe can both
+                // CRDT-merge it with any recovered state and use it for the
+                // last-resort seed — without a fallible signal read at
+                // probe-completion time.
+                let local_snapshot = ROOMS
+                    .read()
+                    .map
+                    .get(&owner_vk)
+                    .map(|rd| rd.room_state.clone())
+                    .unwrap_or_default();
+                if start_backward_probe(owner_vk, local_snapshot) {
                     // A probe is in flight. It is responsible for either
                     // recovering stranded state (CRDT-merge + PUT-forward)
                     // or, on full exhaustion, seeding the current key with
@@ -832,10 +843,11 @@ pub async fn handle_get_response(
 ///   (older) legacy key. If the probe is now exhausted — every
 ///   generation tried, nothing found — seed the CURRENT contract key
 ///   with the device's local snapshot as the genuine last resort.
-async fn handle_probe_get_response(key: ContractKey, state: Vec<u8>) {
+pub(crate) async fn handle_probe_get_response(key: ContractKey, state: Vec<u8>) {
     let Some(probe) = take_probe(key.id()) else {
-        // Race: the probe entry was already consumed (e.g. a duplicate
-        // GET response). Nothing to do.
+        // Race: the probe entry was already consumed — e.g. the real GET
+        // response and the timeout watchdog both fired. Whichever ran first
+        // owns the outcome; the loser lands here. Nothing to do.
         warn!(
             "Probe GET response for {} had no matching probe entry — ignoring",
             key.id()
@@ -858,25 +870,31 @@ async fn handle_probe_get_response(key: ContractKey, state: Vec<u8>) {
             key.id()
         );
 
-        // CRDT-merge the recovered state into the room's RoomData. If the
-        // room is still a placeholder (a fresh import), replace wholesale
-        // — exactly as the normal imported-room GET path does, because
-        // the placeholder's `owner_member_id` differs and `merge` would
-        // reject it.
-        let merged_state = recovered_state.clone();
+        // CRDT-merge the recovered state with the device's local snapshot
+        // BEFORE PUTting it forward, so unsynced local edits the device made
+        // offline are not dropped from the migrating PUT. This matches the
+        // CLI's `get_migration_state`, which merges network + local.
+        let params = ChatRoomParametersV1 { owner: owner_vk };
+        let merged_state = merge_room_states(recovered_state, &probe.local_snapshot, &params);
+
+        // Adopt the merged state into the room's RoomData. If the room is
+        // still a placeholder (a fresh import), replace wholesale — exactly
+        // as the normal imported-room GET path does, because the placeholder's
+        // `owner_member_id` differs and `merge` would reject it.
+        let rooms_state = merged_state.clone();
         crate::util::defer(move || {
             ROOMS.with_mut(|rooms| {
                 if let Some(room_data) = rooms.map.get_mut(&owner_vk) {
                     let params = ChatRoomParametersV1 { owner: owner_vk };
                     if room_data.is_awaiting_initial_sync() {
-                        room_data.room_state = merged_state;
+                        room_data.room_state = rooms_state;
                         room_data.capture_self_membership_data(&params);
                         let _ = room_data.repopulate_secrets_from_state();
                     } else {
                         let current_state = room_data.room_state.clone();
                         match room_data
                             .room_state
-                            .merge(&current_state, &params, &merged_state)
+                            .merge(&current_state, &params, &rooms_state)
                         {
                             Ok(_) => {
                                 room_data.capture_self_membership_data(&params);
@@ -902,9 +920,9 @@ async fn handle_probe_get_response(key: ContractKey, state: Vec<u8>) {
             });
         });
 
-        // PUT the recovered state forward onto the current contract key
-        // so the room is no longer stranded, and subscribe to it.
-        put_state_to_current_key(owner_vk, recovered_state, "recovered (backward probe)").await;
+        // PUT the merged state forward onto the current contract key so the
+        // room is no longer stranded, and subscribe to it.
+        put_state_to_current_key(owner_vk, merged_state, "recovered (backward probe)").await;
 
         crate::util::defer(move || {
             SYNC_INFO.with_mut(|sync_info| {
@@ -920,7 +938,10 @@ async fn handle_probe_get_response(key: ContractKey, state: Vec<u8>) {
         return;
     }
 
-    // Legacy key empty — advance to the next older generation.
+    // Legacy key empty — advance to the next older generation. Capture the
+    // local snapshot first so the exhaustion seed below has it without a
+    // fallible signal read (the probe is consumed by `advance_backward_probe`).
+    let local_snapshot = probe.local_snapshot.clone();
     if advance_backward_probe(probe) {
         info!(
             "Backward probe for room {:?}: legacy contract {} empty, advancing",
@@ -930,34 +951,43 @@ async fn handle_probe_get_response(key: ContractKey, state: Vec<u8>) {
         return;
     }
 
-    // Probe exhausted — no legacy generation held real state. Last
-    // resort: seed the current contract key with the device's local
-    // snapshot. This is the ONLY path on which the stale local snapshot
-    // is allowed onto the network (the core design principle of #292).
+    // Probe exhausted — no legacy generation held real state. Last resort:
+    // seed the current contract key with the device's local snapshot. This is
+    // the ONLY path on which the local snapshot is PUT onto the network (the
+    // core design principle of #292). The snapshot was captured up front, so
+    // this seed always runs — it never depends on a signal read here.
     info!(
         "Backward probe for room {:?} exhausted — seeding current contract key \
          with the local snapshot (last resort)",
         MemberId::from(owner_vk)
     );
-    let local_snapshot = {
-        let Ok(rooms) = ROOMS.try_read() else {
-            warn!(
-                "Backward probe exhausted for {:?} but ROOMS is borrowed — \
-                 cannot seed; the next sync cycle will retry",
-                MemberId::from(owner_vk)
-            );
-            return;
-        };
-        rooms.map.get(&owner_vk).map(|rd| rd.room_state.clone())
-    };
-    if let Some(local_snapshot) = local_snapshot {
-        put_state_to_current_key(owner_vk, local_snapshot, "local snapshot (last resort)").await;
-        crate::util::defer(move || {
-            SYNC_INFO.with_mut(|sync_info| {
-                sync_info.register_new_room(owner_vk);
-                sync_info.update_sync_status(&owner_vk, RoomSyncStatus::Subscribing);
-            });
+    put_state_to_current_key(owner_vk, local_snapshot, "local snapshot (last resort)").await;
+    crate::util::defer(move || {
+        SYNC_INFO.with_mut(|sync_info| {
+            sync_info.register_new_room(owner_vk);
+            sync_info.update_sync_status(&owner_vk, RoomSyncStatus::Subscribing);
         });
+    });
+}
+
+/// CRDT-merge `local` into `primary`, returning the merged state. On a merge
+/// failure (genuinely incompatible states) returns `primary` unchanged rather
+/// than losing it.
+fn merge_room_states(
+    primary: ChatRoomStateV1,
+    local: &ChatRoomStateV1,
+    params: &ChatRoomParametersV1,
+) -> ChatRoomStateV1 {
+    let mut merged = primary.clone();
+    match merged.merge(&primary, params, local) {
+        Ok(()) => merged,
+        Err(e) => {
+            warn!(
+                "Backward probe: merge of recovered + local state failed ({e}); \
+                 using recovered state alone"
+            );
+            primary
+        }
     }
 }
 

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -1513,4 +1513,79 @@ mod tests {
         );
         assert_eq!(j1.message.time, fixed_time);
     }
+
+    /// freenet/river#292 Task 3/4 — the backward-probe trigger gate.
+    ///
+    /// `handle_get_response` fires the backward probe when a GET for the
+    /// room's CURRENT contract key comes back with no real state. "No
+    /// real state" is defined exactly as
+    /// `configuration.verify_signature(&owner_vk).is_err()` — the same
+    /// predicate as `RoomData::is_awaiting_initial_sync`.
+    ///
+    /// This test pins the two ends of that predicate:
+    /// * a default `ChatRoomStateV1` — what an empty contract returns,
+    ///   and what a freshly-imported (Task 4) or migrated room carries
+    ///   before its first sync — MUST be classified as "no real state",
+    ///   so the probe fires;
+    /// * a genuine owner-signed configuration MUST be classified as
+    ///   "real state", so the probe does NOT fire and the authoritative
+    ///   current-key state is adopted instead.
+    ///
+    /// If this gate ever inverted, an imported room several generations
+    /// behind would either never recover (probe never fires) or would
+    /// clobber good current-key state with a needless probe.
+    #[test]
+    fn backward_probe_gate_classifies_real_vs_empty_state() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let owner_vk = owner_sk.verifying_key();
+
+        // Empty / default state — an empty contract, or a fresh import
+        // before sync. Its configuration is signed by the all-zero key.
+        let empty = ChatRoomStateV1::default();
+        assert!(
+            empty.configuration.verify_signature(&owner_vk).is_err(),
+            "default ChatRoomStateV1 must NOT verify against a real owner — \
+             this is what makes the backward probe fire for a stranded import"
+        );
+
+        // Genuine owner-signed configuration — the probe must NOT fire.
+        let real = ChatRoomStateV1 {
+            configuration: AuthorizedConfigurationV1::new(Configuration::default(), &owner_sk),
+            ..Default::default()
+        };
+        assert!(
+            real.configuration.verify_signature(&owner_vk).is_ok(),
+            "an owner-signed configuration must verify — the current key is \
+             authoritative and the probe must not run"
+        );
+    }
+
+    /// freenet/river#292 Task 3/4 — source-grep pin: a freshly imported
+    /// room flows through `ImportIdentityModal` into `ROOMS` with default
+    /// state, then through `process_rooms` (GET-first because
+    /// `is_awaiting_initial_sync`) and lands in the existing-room branch
+    /// of `handle_get_response`. That branch MUST route through
+    /// `start_backward_probe` so an import several generations behind
+    /// recovers real state instead of spinning or showing stale IDs.
+    ///
+    /// A future refactor that drops the `start_backward_probe` call would
+    /// silently re-regress #292 for the import path; this pin fails CI if
+    /// it does.
+    #[test]
+    fn import_recovery_routes_through_backward_probe() {
+        let src = include_str!("get_response.rs");
+        assert!(
+            src.contains("start_backward_probe(owner_vk)"),
+            "handle_get_response must call start_backward_probe for a current-key \
+             GET that returned no real state — this is the recovery entry point \
+             for imported / migrated rooms stranded under an older room-contract \
+             generation (freenet/river#292)."
+        );
+        assert!(
+            src.contains("is_probe_instance(key.id())"),
+            "handle_get_response must route legacy-key GET responses into the \
+             probe handler via is_probe_instance (freenet/river#292)."
+        );
+    }
 }

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -1,4 +1,10 @@
+use crate::components::app::freenet_api::backward_probe::{
+    advance_backward_probe, start_backward_probe, take_probe,
+};
 use crate::components::app::freenet_api::error::SynchronizerError;
+use crate::components::app::freenet_api::response_handler::update_notification::{
+    clear_upgrade_target, follow_upgrade_pointer_if_needed, upgrade_target_owner,
+};
 use crate::components::app::freenet_api::room_synchronizer::RoomSynchronizer;
 use crate::components::app::notifications::mark_initial_sync_complete;
 use crate::components::app::sync_info::{RoomSyncStatus, SYNC_INFO};
@@ -34,8 +40,24 @@ pub async fn handle_get_response(
 ) -> Result<(), SynchronizerError> {
     info!("Received get response for key {key}");
 
+    // Backward-probe routing (freenet/river#292): a GET response whose
+    // contract id matches an outstanding legacy-key probe is for a
+    // *previous* room-contract generation. It cannot be resolved to an
+    // owner via SYNC_INFO / ROOMS (both keyed by the CURRENT contract
+    // id), so route it into the probe handler before any other lookup.
+    if crate::components::app::freenet_api::backward_probe::is_probe_instance(key.id()) {
+        handle_probe_get_response(key, state).await;
+        return Ok(());
+    }
+
     // First try to find the owner_vk from SYNC_INFO
     let owner_vk = SYNC_INFO.read().get_owner_vk_for_instance_id(key.id());
+
+    // Upgrade-pointer-target fallback (freenet/river#292 multi-hop): a
+    // GET response for a contract reached by following an upgrade
+    // pointer is keyed by a NEWER contract id that isn't in SYNC_INFO or
+    // ROOMS. Resolve it via the upgrade-target side-table.
+    let owner_vk = owner_vk.or_else(|| upgrade_target_owner(key.id()));
 
     // If we couldn't find it in SYNC_INFO, try fallback mechanisms
     let owner_vk = if owner_vk.is_none() {
@@ -86,6 +108,23 @@ pub async fn handle_get_response(
     if let Some(owner_vk) = owner_vk {
         let is_pending_invite = PENDING_INVITES.read().map.contains_key(&owner_vk);
         let is_existing_room = ROOMS.read().map.contains_key(&owner_vk);
+
+        // Multi-hop upgrade chain (freenet/river#292, Task 1): if the
+        // contract whose state we just GET'd carries an `OptionalUpgradeV1`
+        // pointer to a *newer* contract, follow it — and because the GET
+        // response for that newer contract is itself routed back through
+        // here, a pointer→pointer→pointer chain is walked to its end.
+        // `follow_upgrade_pointer_if_needed` carries the cycle / hop-cap
+        // guards. We pass `key.id()` as `delivered_from` so a pointer
+        // that targets the contract that just delivered it is not
+        // chased into an infinite loop.
+        {
+            let probed_state: ChatRoomStateV1 = from_cbor_slice::<ChatRoomStateV1>(&state);
+            follow_upgrade_pointer_if_needed(&probed_state, &owner_vk, Some(*key.id()));
+        }
+        // This GET response consumed any outstanding upgrade-target
+        // side-table entry for this contract id.
+        clear_upgrade_target(key.id());
 
         if is_pending_invite {
             info!("This is a subscription for a pending invitation, adding state");
@@ -524,6 +563,54 @@ pub async fn handle_get_response(
                 }
             }
         } else if is_existing_room {
+            // Backward-probe recovery (freenet/river#292, Task 3).
+            //
+            // The current contract key is always authoritative. If THIS
+            // GET — for the room's CURRENT contract key — came back with
+            // no real state (a default `ChatRoomStateV1` whose
+            // configuration signature does not verify against the
+            // owner), the room may be stranded under an older
+            // room-contract generation. Probe the legacy keys
+            // newest-to-oldest before doing anything else.
+            //
+            // We gate strictly on "current key" so we never probe in
+            // response to a GET that was itself for a legacy/pointer
+            // contract. `is_probe_instance` already short-circuited
+            // legacy-key responses at the top of this function; the
+            // explicit equality check here is defence-in-depth.
+            let retrieved_state: ChatRoomStateV1 = from_cbor_slice::<ChatRoomStateV1>(&state);
+
+            let is_current_key = key.id() == owner_vk_to_contract_key(&owner_vk).id();
+            let retrieved_has_real_state = retrieved_state
+                .configuration
+                .verify_signature(&owner_vk)
+                .is_ok();
+
+            if is_current_key && !retrieved_has_real_state {
+                info!(
+                    "Current contract key for room {:?} returned empty/default state — \
+                     starting backward probe (freenet/river#292)",
+                    MemberId::from(owner_vk)
+                );
+                if start_backward_probe(owner_vk) {
+                    // A probe is in flight. It is responsible for either
+                    // recovering stranded state (CRDT-merge + PUT-forward)
+                    // or, on full exhaustion, seeding the current key with
+                    // the local snapshot. Do NOT seed here — that would
+                    // race the probe and re-introduce the stale state
+                    // this whole mechanism exists to avoid.
+                    return Ok(());
+                }
+                // `false` => no legacy generations exist. There is
+                // nothing to recover, so fall through to the normal
+                // path, which seeds the current key with the local
+                // snapshot (the genuine last resort).
+                info!(
+                    "No legacy generations for room {:?} — falling through to seed current key",
+                    MemberId::from(owner_vk)
+                );
+            }
+
             // Imported rooms use GET-first because their default state has an
             // invalid configuration signature. After merging the retrieved state,
             // we need to PUT+subscribe with the valid state.
@@ -541,7 +628,6 @@ pub async fn handle_get_response(
                 "Processing GET response for existing room (needs_put_subscribe={})",
                 needs_put_subscribe
             );
-            let retrieved_state: ChatRoomStateV1 = from_cbor_slice::<ChatRoomStateV1>(&state);
             let retrieved_state_for_put = retrieved_state.clone();
 
             crate::util::defer(move || {
@@ -730,6 +816,199 @@ pub async fn handle_get_response(
     }
 
     Ok(())
+}
+
+/// Handle a GET response whose contract id matches an outstanding
+/// backward probe (freenet/river#292, Task 3).
+///
+/// The GET was for a *legacy* room-contract generation. Two outcomes:
+///
+/// * **The legacy key holds real state** (its `configuration` signature
+///   verifies against the owner): this is the room's last-active
+///   stranded state. CRDT-merge it into the room's `RoomData` in `ROOMS`
+///   and PUT it forward onto the CURRENT contract key so the room is no
+///   longer stranded. The probe ends here.
+/// * **The legacy key is empty/default**: advance the probe to the next
+///   (older) legacy key. If the probe is now exhausted — every
+///   generation tried, nothing found — seed the CURRENT contract key
+///   with the device's local snapshot as the genuine last resort.
+async fn handle_probe_get_response(key: ContractKey, state: Vec<u8>) {
+    let Some(probe) = take_probe(key.id()) else {
+        // Race: the probe entry was already consumed (e.g. a duplicate
+        // GET response). Nothing to do.
+        warn!(
+            "Probe GET response for {} had no matching probe entry — ignoring",
+            key.id()
+        );
+        return;
+    };
+    let owner_vk = probe.owner_vk;
+
+    let recovered_state: ChatRoomStateV1 = from_cbor_slice::<ChatRoomStateV1>(&state);
+    let recovered_has_real_state = recovered_state
+        .configuration
+        .verify_signature(&owner_vk)
+        .is_ok();
+
+    if recovered_has_real_state {
+        info!(
+            "Backward probe for room {:?} recovered real state from legacy contract {} \
+             — adopting and PUTting forward onto the current key",
+            MemberId::from(owner_vk),
+            key.id()
+        );
+
+        // CRDT-merge the recovered state into the room's RoomData. If the
+        // room is still a placeholder (a fresh import), replace wholesale
+        // — exactly as the normal imported-room GET path does, because
+        // the placeholder's `owner_member_id` differs and `merge` would
+        // reject it.
+        let merged_state = recovered_state.clone();
+        crate::util::defer(move || {
+            ROOMS.with_mut(|rooms| {
+                if let Some(room_data) = rooms.map.get_mut(&owner_vk) {
+                    let params = ChatRoomParametersV1 { owner: owner_vk };
+                    if room_data.is_awaiting_initial_sync() {
+                        room_data.room_state = merged_state;
+                        room_data.capture_self_membership_data(&params);
+                        let _ = room_data.repopulate_secrets_from_state();
+                    } else {
+                        let current_state = room_data.room_state.clone();
+                        match room_data
+                            .room_state
+                            .merge(&current_state, &params, &merged_state)
+                        {
+                            Ok(_) => {
+                                room_data.capture_self_membership_data(&params);
+                                let _ = room_data.repopulate_secrets_from_state();
+                            }
+                            Err(e) => {
+                                error!(
+                                    "Backward probe: failed to merge recovered state \
+                                     for room {:?}: {}",
+                                    MemberId::from(owner_vk),
+                                    e
+                                );
+                            }
+                        }
+                    }
+                } else {
+                    warn!(
+                        "Backward probe recovered state for room {:?} but it is no \
+                         longer in ROOMS — discarding",
+                        MemberId::from(owner_vk)
+                    );
+                }
+            });
+        });
+
+        // PUT the recovered state forward onto the current contract key
+        // so the room is no longer stranded, and subscribe to it.
+        put_state_to_current_key(owner_vk, recovered_state, "recovered (backward probe)").await;
+
+        crate::util::defer(move || {
+            SYNC_INFO.with_mut(|sync_info| {
+                sync_info.register_new_room(owner_vk);
+                sync_info.update_sync_status(&owner_vk, RoomSyncStatus::Subscribing);
+            });
+            // Enable notifications — the room now has real state, exactly
+            // as the normal imported-room GET path does once it has
+            // adopted network state.
+            mark_initial_sync_complete(&owner_vk);
+        });
+        crate::components::app::mark_needs_sync(owner_vk);
+        return;
+    }
+
+    // Legacy key empty — advance to the next older generation.
+    if advance_backward_probe(probe) {
+        info!(
+            "Backward probe for room {:?}: legacy contract {} empty, advancing",
+            MemberId::from(owner_vk),
+            key.id()
+        );
+        return;
+    }
+
+    // Probe exhausted — no legacy generation held real state. Last
+    // resort: seed the current contract key with the device's local
+    // snapshot. This is the ONLY path on which the stale local snapshot
+    // is allowed onto the network (the core design principle of #292).
+    info!(
+        "Backward probe for room {:?} exhausted — seeding current contract key \
+         with the local snapshot (last resort)",
+        MemberId::from(owner_vk)
+    );
+    let local_snapshot = {
+        let Ok(rooms) = ROOMS.try_read() else {
+            warn!(
+                "Backward probe exhausted for {:?} but ROOMS is borrowed — \
+                 cannot seed; the next sync cycle will retry",
+                MemberId::from(owner_vk)
+            );
+            return;
+        };
+        rooms.map.get(&owner_vk).map(|rd| rd.room_state.clone())
+    };
+    if let Some(local_snapshot) = local_snapshot {
+        put_state_to_current_key(owner_vk, local_snapshot, "local snapshot (last resort)").await;
+        crate::util::defer(move || {
+            SYNC_INFO.with_mut(|sync_info| {
+                sync_info.register_new_room(owner_vk);
+                sync_info.update_sync_status(&owner_vk, RoomSyncStatus::Subscribing);
+            });
+        });
+    }
+}
+
+/// PUT `state` onto the room's CURRENT contract key (the key derived
+/// from the owner VK + currently-bundled WASM) with `subscribe: true`.
+///
+/// Used by the backward probe both to push recovered stranded state
+/// forward and to seed the current key with the local snapshot when no
+/// stranded state was found.
+async fn put_state_to_current_key(
+    owner_vk: ed25519_dalek::VerifyingKey,
+    state: ChatRoomStateV1,
+    label: &str,
+) {
+    let contract_code = ContractCode::from(ROOM_CONTRACT_WASM);
+    let parameters = ChatRoomParametersV1 { owner: owner_vk };
+    let params_bytes = to_cbor_vec(&parameters);
+    let contract_container = ContractContainer::from(ContractWasmAPIVersion::V1(
+        WrappedContract::new(Arc::new(contract_code), Parameters::from(params_bytes)),
+    ));
+    let wrapped_state = WrappedState::new(to_cbor_vec(&state));
+
+    let put_request = ContractRequest::Put {
+        contract: contract_container,
+        state: wrapped_state,
+        related_contracts: Default::default(),
+        subscribe: true,
+        blocking_subscribe: false,
+    };
+
+    if let Some(web_api) = WEB_API.write().as_mut() {
+        match web_api.send(ClientRequest::ContractOp(put_request)).await {
+            Ok(_) => info!(
+                "Backward probe: PUT {} state to current contract for room {:?}",
+                label,
+                MemberId::from(owner_vk)
+            ),
+            Err(e) => error!(
+                "Backward probe: failed to PUT {} state for room {:?}: {}",
+                label,
+                MemberId::from(owner_vk),
+                e
+            ),
+        }
+    } else {
+        error!(
+            "Backward probe: WebAPI unavailable, cannot PUT {} state for room {:?}",
+            label,
+            MemberId::from(owner_vk)
+        );
+    }
 }
 
 /// Error returned by [`build_state_for_put`] when the invitation cannot

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -15,6 +15,7 @@ use crate::room_data::RoomData;
 use crate::util::ecies::decrypt_with_symmetric_key;
 use crate::util::{
     from_cbor_slice, get_current_system_time, owner_vk_to_contract_key, to_cbor_vec,
+    try_from_cbor_slice,
 };
 use dioxus::logger::tracing::{error, info, warn};
 use dioxus::prelude::ReadableExt;
@@ -856,7 +857,22 @@ pub(crate) async fn handle_probe_get_response(key: ContractKey, state: Vec<u8>) 
     };
     let owner_vk = probe.owner_vk;
 
-    let recovered_state: ChatRoomStateV1 = from_cbor_slice::<ChatRoomStateV1>(&state);
+    // Deserialize defensively: the probe walks many historical generations,
+    // and a very old one may carry a `ChatRoomStateV1` whose layout the
+    // current type cannot decode. Treat an undeserializable legacy state as
+    // empty (default) so the probe advances to the next generation rather
+    // than panicking — matching the CLI's `try_get_state` (freenet/river#292).
+    let recovered_state: ChatRoomStateV1 = match try_from_cbor_slice::<ChatRoomStateV1>(&state) {
+        Some(s) => s,
+        None => {
+            warn!(
+                "Backward probe: legacy contract {} returned undeserializable state \
+                 (incompatible older generation) — treating as empty",
+                key.id()
+            );
+            ChatRoomStateV1::default()
+        }
+    };
     let recovered_has_real_state = recovered_state
         .configuration
         .verify_signature(&owner_vk)

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -1609,9 +1609,16 @@ mod tests {
     /// it does.
     #[test]
     fn import_recovery_routes_through_backward_probe() {
-        let src = include_str!("get_response.rs");
+        // Search only the PRODUCTION half of the file — slice off `mod tests`
+        // so this pin can't be satisfied by its own assertion-message text
+        // (the failure mode the response_handler.rs pins also guard against).
+        let full = include_str!("get_response.rs");
+        let src = full
+            .split("mod tests {")
+            .next()
+            .expect("get_response.rs must have production code before `mod tests`");
         assert!(
-            src.contains("start_backward_probe(owner_vk)"),
+            src.contains("start_backward_probe(owner_vk,"),
             "handle_get_response must call start_backward_probe for a current-key \
              GET that returned no real state — this is the recovery entry point \
              for imported / migrated rooms stranded under an older room-contract \
@@ -1621,6 +1628,33 @@ mod tests {
             src.contains("is_probe_instance(key.id())"),
             "handle_get_response must route legacy-key GET responses into the \
              probe handler via is_probe_instance (freenet/river#292)."
+        );
+    }
+
+    /// freenet/river#292 — `merge_room_states` CRDT-merges a recovered legacy
+    /// state with the device's local snapshot before the migrating PUT. It
+    /// must preserve the recovered state's owner-signed configuration (so the
+    /// merged state remains valid) and must not panic when the local snapshot
+    /// is an empty default.
+    #[test]
+    fn merge_room_states_preserves_recovered_configuration() {
+        let owner_sk = SigningKey::from_bytes(&[11u8; 32]);
+        let owner_vk = owner_sk.verifying_key();
+        let params = ChatRoomParametersV1 { owner: owner_vk };
+
+        // A recovered legacy state with a real owner-signed configuration.
+        let recovered = ChatRoomStateV1 {
+            configuration: AuthorizedConfigurationV1::new(Configuration::default(), &owner_sk),
+            ..Default::default()
+        };
+
+        // Merging in an empty/default local snapshot (the fresh-import case)
+        // must keep the recovered state usable — its signed configuration
+        // survives the merge.
+        let merged = merge_room_states(recovered, &ChatRoomStateV1::default(), &params);
+        assert!(
+            merged.configuration.verify_signature(&owner_vk).is_ok(),
+            "merge_room_states must preserve the recovered state's owner-signed configuration"
         );
     }
 }

--- a/ui/src/components/app/freenet_api/response_handler/update_notification.rs
+++ b/ui/src/components/app/freenet_api/response_handler/update_notification.rs
@@ -163,7 +163,7 @@ pub(crate) fn follow_upgrade_pointer_if_needed(
         match classify_upgrade_hop(set, delivered_from, new_contract_id) {
             UpgradeHopDecision::Follow => {
                 info!(
-                    "Following upgrade pointer (hop {}): subscribing to new contract for room {:?}",
+                    "Following upgrade pointer (hop {}): discovery GET of new contract for room {:?}",
                     set.len(),
                     river_core::room_state::member::MemberId::from(*room_owner_vk)
                 );

--- a/ui/src/components/app/freenet_api/response_handler/update_notification.rs
+++ b/ui/src/components/app/freenet_api/response_handler/update_notification.rs
@@ -4,51 +4,172 @@ use crate::components::app::sync_info::SYNC_INFO;
 use crate::components::app::WEB_API;
 use crate::util::{from_cbor_slice, owner_vk_to_contract_key};
 use dioxus::logger::tracing::{debug, info, warn};
-use dioxus::prelude::ReadableExt;
+use dioxus::prelude::{Global, GlobalSignal, ReadableExt};
 use ed25519_dalek::VerifyingKey;
 use freenet_stdlib::client_api::{ClientRequest, ContractRequest};
-use freenet_stdlib::prelude::{ContractKey, UpdateData};
+use freenet_stdlib::prelude::{ContractInstanceId, ContractKey, UpdateData};
 use river_core::room_state::{ChatRoomStateV1, ChatRoomStateV1Delta};
+use std::collections::HashMap;
 
-/// If the state contains an upgrade pointer to a different contract,
-/// send a GET+subscribe to the new contract address.
-fn follow_upgrade_pointer_if_needed(state: &ChatRoomStateV1, room_owner_vk: &VerifyingKey) {
-    if let Some(ref authorized_upgrade) = state.upgrade.0 {
-        let new_address = authorized_upgrade.upgrade.new_chatroom_address;
-        info!(
-            "Received upgrade pointer for room {:?}, new address: {}",
-            river_core::room_state::member::MemberId::from(*room_owner_vk),
-            new_address
-        );
+/// Hard cap on the number of upgrade-pointer hops a single chain walk
+/// will follow before giving up. A correctly-formed upgrade chain has at
+/// most one hop per WASM generation; this is a defence-in-depth guard
+/// against a runaway pointer→pointer→pointer chain (a malicious or
+/// corrupt `OptionalUpgradeV1`).
+const MAX_UPGRADE_HOPS: usize = 32;
 
-        let current_key = owner_vk_to_contract_key(room_owner_vk);
-        let current_id_bytes = current_key.id().as_bytes();
-        let mut current_hash = [0u8; 32];
-        current_hash.copy_from_slice(current_id_bytes);
+/// Per-room count of upgrade-pointer hops already followed in the
+/// current chain walk. Keyed by `room_owner_vk`. Incremented each time
+/// `follow_upgrade_pointer_if_needed` follows a pointer; the entry is
+/// removed once the chain terminates (the GET response carries no
+/// further pointer, or it points at the current key).
+static UPGRADE_HOP_COUNTS: GlobalSignal<HashMap<VerifyingKey, usize>> = Global::new(HashMap::new);
 
-        if blake3::Hash::from(current_hash) != new_address {
-            info!(
-                "Following upgrade pointer: subscribing to new contract for room {:?}",
-                river_core::room_state::member::MemberId::from(*room_owner_vk)
-            );
+/// Maps the `ContractInstanceId` of an upgrade-pointer target whose
+/// GET we have outstanding back to the `room_owner_vk` it belongs to.
+///
+/// A GET response for an upgrade-pointer target arrives keyed by a
+/// contract id that is NOT the room's current contract id, so it
+/// cannot be resolved via `SYNC_INFO` or `RoomData::contract_key`. This
+/// side-table lets `handle_get_response` recover the owner so it can
+/// (a) continue walking a multi-hop chain and (b) merge the recovered
+/// state into the right room.
+static UPGRADE_TARGETS: GlobalSignal<HashMap<ContractInstanceId, VerifyingKey>> =
+    Global::new(HashMap::new);
 
-            let new_contract_id =
-                freenet_stdlib::prelude::ContractInstanceId::new(*new_address.as_bytes());
-            wasm_bindgen_futures::spawn_local(async move {
-                let get_request = ContractRequest::Get {
-                    key: new_contract_id,
-                    return_contract_code: true,
-                    subscribe: true,
-                    blocking_subscribe: false,
-                };
-                if let Some(web_api) = WEB_API.write().as_mut() {
-                    if let Err(e) = web_api.send(ClientRequest::ContractOp(get_request)).await {
-                        warn!("Failed to follow upgrade pointer: {}", e);
-                    }
-                }
-            });
-        }
+/// The `room_owner_vk` an outstanding upgrade-pointer GET for
+/// `instance_id` belongs to, if any. Used by `handle_get_response` as an
+/// owner-resolution fallback for pointer-target contracts.
+pub(crate) fn upgrade_target_owner(instance_id: &ContractInstanceId) -> Option<VerifyingKey> {
+    UPGRADE_TARGETS.read().get(instance_id).copied()
+}
+
+/// Remove the upgrade-target side-table entry for `instance_id` — its
+/// GET response has been consumed.
+pub(crate) fn clear_upgrade_target(instance_id: &ContractInstanceId) {
+    let instance_id = *instance_id;
+    crate::util::defer(move || {
+        UPGRADE_TARGETS.with_mut(|targets| {
+            targets.remove(&instance_id);
+        });
+    });
+}
+
+/// If `state` carries an upgrade pointer to a *different* contract,
+/// send a GET+subscribe to the new address.
+///
+/// Multi-hop (freenet/river#292): the GET response for the contract
+/// reached by following a pointer is itself routed back through
+/// `handle_get_response`, which calls this function again — so a
+/// pointer→pointer→pointer chain is walked all the way to the end.
+///
+/// `delivered_from` is the `ContractInstanceId` of the contract whose
+/// GET response (or update notification) carried `state`. It is used as
+/// a cycle guard: a pointer that targets the very contract that just
+/// delivered it is ignored rather than re-fetched forever. The
+/// [`MAX_UPGRADE_HOPS`] counter is a second, total-length guard.
+pub(crate) fn follow_upgrade_pointer_if_needed(
+    state: &ChatRoomStateV1,
+    room_owner_vk: &VerifyingKey,
+    delivered_from: Option<ContractInstanceId>,
+) {
+    let Some(ref authorized_upgrade) = state.upgrade.0 else {
+        // Chain terminates here — drop any hop counter for this room so a
+        // future, unrelated chain walk starts fresh.
+        clear_upgrade_hops(room_owner_vk);
+        return;
+    };
+
+    let new_address = authorized_upgrade.upgrade.new_chatroom_address;
+    let new_contract_id = ContractInstanceId::new(*new_address.as_bytes());
+
+    info!(
+        "Received upgrade pointer for room {:?}, new address: {}",
+        river_core::room_state::member::MemberId::from(*room_owner_vk),
+        new_address
+    );
+
+    // Cycle guard 1: the pointer targets the current bundled contract —
+    // we already know that key, no need to chase it.
+    let current_key = owner_vk_to_contract_key(room_owner_vk);
+    let current_id_bytes = current_key.id().as_bytes();
+    let mut current_hash = [0u8; 32];
+    current_hash.copy_from_slice(current_id_bytes);
+    if blake3::Hash::from(current_hash) == new_address {
+        clear_upgrade_hops(room_owner_vk);
+        return;
     }
+
+    // Cycle guard 2: the pointer targets the contract that just
+    // delivered this state. Following it would loop forever.
+    if delivered_from == Some(new_contract_id) {
+        warn!(
+            "Upgrade pointer for room {:?} targets the delivering contract \
+             {} — refusing to follow (cycle guard)",
+            river_core::room_state::member::MemberId::from(*room_owner_vk),
+            new_contract_id
+        );
+        clear_upgrade_hops(room_owner_vk);
+        return;
+    }
+
+    // Runaway guard: cap total hops across the chain walk.
+    let hops = UPGRADE_HOP_COUNTS
+        .read()
+        .get(room_owner_vk)
+        .copied()
+        .unwrap_or(0);
+    if hops >= MAX_UPGRADE_HOPS {
+        warn!(
+            "Upgrade chain for room {:?} hit MAX_UPGRADE_HOPS ({}) — aborting",
+            river_core::room_state::member::MemberId::from(*room_owner_vk),
+            MAX_UPGRADE_HOPS
+        );
+        clear_upgrade_hops(room_owner_vk);
+        return;
+    }
+
+    info!(
+        "Following upgrade pointer (hop {}): subscribing to new contract for room {:?}",
+        hops + 1,
+        river_core::room_state::member::MemberId::from(*room_owner_vk)
+    );
+
+    let room_owner_vk_copy = *room_owner_vk;
+    crate::util::defer(move || {
+        UPGRADE_HOP_COUNTS.with_mut(|counts| {
+            *counts.entry(room_owner_vk_copy).or_insert(0) += 1;
+        });
+        // Register the target so `handle_get_response` can resolve the
+        // owner when the GET for this pointer hop comes back.
+        UPGRADE_TARGETS.with_mut(|targets| {
+            targets.insert(new_contract_id, room_owner_vk_copy);
+        });
+    });
+
+    crate::util::safe_spawn_local(async move {
+        let get_request = ContractRequest::Get {
+            key: new_contract_id,
+            return_contract_code: true,
+            subscribe: true,
+            blocking_subscribe: false,
+        };
+        if let Some(web_api) = WEB_API.write().as_mut() {
+            if let Err(e) = web_api.send(ClientRequest::ContractOp(get_request)).await {
+                warn!("Failed to follow upgrade pointer: {}", e);
+            }
+        }
+    });
+}
+
+/// Drop the hop counter for `room_owner_vk` — the chain walk has ended.
+fn clear_upgrade_hops(room_owner_vk: &VerifyingKey) {
+    let room_owner_vk = *room_owner_vk;
+    crate::util::defer(move || {
+        UPGRADE_HOP_COUNTS.with_mut(|counts| {
+            counts.remove(&room_owner_vk);
+        });
+    });
 }
 
 pub fn handle_update_notification(
@@ -70,7 +191,7 @@ pub fn handle_update_notification(
     match update {
         UpdateData::State(state) => {
             let new_state: ChatRoomStateV1 = from_cbor_slice::<ChatRoomStateV1>(&state);
-            follow_upgrade_pointer_if_needed(&new_state, &room_owner_vk);
+            follow_upgrade_pointer_if_needed(&new_state, &room_owner_vk, Some(*key.id()));
 
             info!(
                 "UpdateNotification: state ({} messages, {} members)",
@@ -97,7 +218,7 @@ pub fn handle_update_notification(
                 "Received state and delta in UpdateNotification state: {:?} delta: {:?}",
                 state, delta
             );
-            follow_upgrade_pointer_if_needed(&new_state, &room_owner_vk);
+            follow_upgrade_pointer_if_needed(&new_state, &room_owner_vk, Some(*key.id()));
 
             room_synchronizer.update_room_state(&room_owner_vk, &new_state);
         }

--- a/ui/src/components/app/freenet_api/response_handler/update_notification.rs
+++ b/ui/src/components/app/freenet_api/response_handler/update_notification.rs
@@ -71,6 +71,44 @@ fn clear_upgrade_visited(room_owner_vk: &VerifyingKey) {
     upgrade_visited().remove(room_owner_vk);
 }
 
+/// Outcome of classifying one upgrade-pointer hop against a walk's visited-set.
+#[derive(Debug, PartialEq, Eq)]
+enum UpgradeHopDecision {
+    /// Follow the pointer — `new_id` has been recorded in the visited-set.
+    Follow,
+    /// The pointer loops back to a contract already visited in this walk.
+    Cycle,
+    /// The walk has already followed [`MAX_UPGRADE_HOPS`] hops.
+    CapReached,
+}
+
+/// Classify an upgrade-pointer hop and update the per-walk `visited` set.
+///
+/// If `delivered_from` is not itself a visited hop, this response is the root
+/// of a fresh walk and `visited` is reset first — discarding any stale set an
+/// earlier walk left behind if its GET never returned. The cycle guard then
+/// rejects a pointer back to ANY visited contract, and the cap rejects a walk
+/// longer than [`MAX_UPGRADE_HOPS`]. Pure (no I/O, no signals) so the guards
+/// are unit-testable (freenet/river#292).
+fn classify_upgrade_hop(
+    visited: &mut HashSet<ContractInstanceId>,
+    delivered_from: Option<ContractInstanceId>,
+    new_id: ContractInstanceId,
+) -> UpgradeHopDecision {
+    match delivered_from {
+        Some(from) if visited.contains(&from) => {}
+        _ => visited.clear(),
+    }
+    if visited.contains(&new_id) {
+        return UpgradeHopDecision::Cycle;
+    }
+    if visited.len() >= MAX_UPGRADE_HOPS {
+        return UpgradeHopDecision::CapReached;
+    }
+    visited.insert(new_id);
+    UpgradeHopDecision::Follow
+}
+
 /// If `state` carries an upgrade pointer to a *different* contract, send a
 /// GET+subscribe to the new address.
 ///
@@ -122,46 +160,34 @@ pub(crate) fn follow_upgrade_pointer_if_needed(
     {
         let mut visited = upgrade_visited();
         let set = visited.entry(*room_owner_vk).or_default();
-
-        // Fresh-walk reset: a response whose delivering contract was not
-        // itself a followed hop is the root of a new walk. Resetting here
-        // discards any stale set a previous walk left behind if its GET
-        // never returned (so the set cannot leak unboundedly).
-        match delivered_from {
-            Some(from) if set.contains(&from) => {}
-            _ => set.clear(),
+        match classify_upgrade_hop(set, delivered_from, new_contract_id) {
+            UpgradeHopDecision::Follow => {
+                info!(
+                    "Following upgrade pointer (hop {}): subscribing to new contract for room {:?}",
+                    set.len(),
+                    river_core::room_state::member::MemberId::from(*room_owner_vk)
+                );
+            }
+            UpgradeHopDecision::Cycle => {
+                warn!(
+                    "Upgrade pointer for room {:?} targets already-visited contract \
+                     {} — refusing to follow (cycle guard)",
+                    river_core::room_state::member::MemberId::from(*room_owner_vk),
+                    new_contract_id
+                );
+                visited.remove(room_owner_vk);
+                return;
+            }
+            UpgradeHopDecision::CapReached => {
+                warn!(
+                    "Upgrade chain for room {:?} hit MAX_UPGRADE_HOPS ({}) — aborting",
+                    river_core::room_state::member::MemberId::from(*room_owner_vk),
+                    MAX_UPGRADE_HOPS
+                );
+                visited.remove(room_owner_vk);
+                return;
+            }
         }
-
-        // Cycle guard 2: a pointer back to ANY contract already visited in
-        // this walk (not just the immediately-preceding one) is a cycle.
-        if set.contains(&new_contract_id) {
-            warn!(
-                "Upgrade pointer for room {:?} targets already-visited contract \
-                 {} — refusing to follow (cycle guard)",
-                river_core::room_state::member::MemberId::from(*room_owner_vk),
-                new_contract_id
-            );
-            visited.remove(room_owner_vk);
-            return;
-        }
-
-        // Runaway guard: cap total hops across the chain walk.
-        if set.len() >= MAX_UPGRADE_HOPS {
-            warn!(
-                "Upgrade chain for room {:?} hit MAX_UPGRADE_HOPS ({}) — aborting",
-                river_core::room_state::member::MemberId::from(*room_owner_vk),
-                MAX_UPGRADE_HOPS
-            );
-            visited.remove(room_owner_vk);
-            return;
-        }
-
-        set.insert(new_contract_id);
-        info!(
-            "Following upgrade pointer (hop {}): subscribing to new contract for room {:?}",
-            set.len(),
-            river_core::room_state::member::MemberId::from(*room_owner_vk)
-        );
     }
 
     // Register the target so `handle_get_response` can resolve the owner when
@@ -251,4 +277,65 @@ pub fn handle_update_notification(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cid(seed: u8) -> ContractInstanceId {
+        ContractInstanceId::new([seed; 32])
+    }
+
+    /// A response whose delivering contract is not in the visited-set is the
+    /// root of a fresh walk: any stale set is reset and the hop is followed.
+    #[test]
+    fn classify_resets_and_follows_on_fresh_root() {
+        let mut visited = HashSet::new();
+        visited.insert(cid(99)); // stale leftover from an earlier walk
+        let decision = classify_upgrade_hop(&mut visited, Some(cid(1)), cid(2));
+        assert_eq!(decision, UpgradeHopDecision::Follow);
+        assert!(visited.contains(&cid(2)), "followed hop must be recorded");
+        assert!(
+            !visited.contains(&cid(99)),
+            "a fresh walk must discard the stale set"
+        );
+    }
+
+    /// Mid-chain (the delivering contract IS a visited hop), an unvisited
+    /// target is followed without resetting the set.
+    #[test]
+    fn classify_follows_mid_chain_without_reset() {
+        let mut visited = HashSet::new();
+        visited.insert(cid(1));
+        let decision = classify_upgrade_hop(&mut visited, Some(cid(1)), cid(2));
+        assert_eq!(decision, UpgradeHopDecision::Follow);
+        assert!(visited.contains(&cid(1)) && visited.contains(&cid(2)));
+    }
+
+    /// A pointer back to any already-visited contract — not just the
+    /// immediately-preceding one — is a cycle (the A→B→A case).
+    #[test]
+    fn classify_detects_multi_hop_cycle() {
+        let mut visited = HashSet::new();
+        visited.insert(cid(1)); // A
+        visited.insert(cid(2)); // B, delivering this response
+        let decision = classify_upgrade_hop(&mut visited, Some(cid(2)), cid(1));
+        assert_eq!(
+            decision,
+            UpgradeHopDecision::Cycle,
+            "B pointing back to already-visited A must be caught"
+        );
+    }
+
+    /// A walk that has already followed MAX_UPGRADE_HOPS contracts stops.
+    #[test]
+    fn classify_stops_at_hop_cap() {
+        let mut visited: HashSet<ContractInstanceId> =
+            (0..MAX_UPGRADE_HOPS as u16).map(|i| cid(i as u8)).collect();
+        // Deliver from a visited contract so the set is not reset.
+        let from = *visited.iter().next().unwrap();
+        let decision = classify_upgrade_hop(&mut visited, Some(from), cid(250));
+        assert_eq!(decision, UpgradeHopDecision::CapReached);
+    }
 }

--- a/ui/src/components/app/freenet_api/response_handler/update_notification.rs
+++ b/ui/src/components/app/freenet_api/response_handler/update_notification.rs
@@ -110,7 +110,7 @@ fn classify_upgrade_hop(
 }
 
 /// If `state` carries an upgrade pointer to a *different* contract, send a
-/// GET+subscribe to the new address.
+/// (discovery-only, non-subscribing) GET to the new address.
 ///
 /// Multi-hop (freenet/river#292): the GET response for the contract reached by
 /// following a pointer is itself routed back through `handle_get_response`,
@@ -191,14 +191,26 @@ pub(crate) fn follow_upgrade_pointer_if_needed(
     }
 
     // Register the target so `handle_get_response` can resolve the owner when
-    // the GET for this pointer hop comes back.
+    // the GET for this pointer hop comes back. The entry is short-lived —
+    // `clear_upgrade_target` removes it once that GET response is consumed. If
+    // the GET never returns (a garbage-collected intermediate), the entry is a
+    // bounded, harmless leak: at most one per distinct upgrade-pointer target
+    // ever seen (≈ the number of contract generations), and a stale entry
+    // still maps that target id to its correct owner.
     upgrade_targets().insert(new_contract_id, *room_owner_vk);
 
     crate::util::safe_spawn_local(async move {
         let get_request = ContractRequest::Get {
             key: new_contract_id,
             return_contract_code: true,
-            subscribe: true,
+            // Discovery-only: the chain walk GETs each hop to find where the
+            // room's state now lives, but does NOT subscribe to intermediate
+            // (stale) generations. Subscribing to them would register a
+            // contract id that `SYNC_INFO` cannot resolve, so their
+            // `UpdateNotification`s would be silently dropped. Live updates
+            // come from the room's CURRENT contract key, subscribed via the
+            // normal sync path / the backward-probe PUT-forward.
+            subscribe: false,
             blocking_subscribe: false,
         };
         if let Some(web_api) = WEB_API.write().as_mut() {
@@ -326,6 +338,21 @@ mod tests {
             UpgradeHopDecision::Cycle,
             "B pointing back to already-visited A must be caught"
         );
+    }
+
+    /// `delivered_from == None` (a root response with no tracked delivering
+    /// contract) is treated as a fresh walk: the visited-set is reset.
+    #[test]
+    fn classify_with_no_delivered_from_resets() {
+        let mut visited = HashSet::new();
+        visited.insert(cid(50)); // stale leftover
+        let decision = classify_upgrade_hop(&mut visited, None, cid(7));
+        assert_eq!(decision, UpgradeHopDecision::Follow);
+        assert!(
+            !visited.contains(&cid(50)),
+            "None delivered_from must reset the set"
+        );
+        assert!(visited.contains(&cid(7)));
     }
 
     /// A walk that has already followed MAX_UPGRADE_HOPS contracts stops.

--- a/ui/src/components/app/freenet_api/response_handler/update_notification.rs
+++ b/ui/src/components/app/freenet_api/response_handler/update_notification.rs
@@ -4,79 +4,97 @@ use crate::components::app::sync_info::SYNC_INFO;
 use crate::components::app::WEB_API;
 use crate::util::{from_cbor_slice, owner_vk_to_contract_key};
 use dioxus::logger::tracing::{debug, info, warn};
-use dioxus::prelude::{Global, GlobalSignal, ReadableExt};
+use dioxus::prelude::ReadableExt;
 use ed25519_dalek::VerifyingKey;
 use freenet_stdlib::client_api::{ClientRequest, ContractRequest};
 use freenet_stdlib::prelude::{ContractInstanceId, ContractKey, UpdateData};
 use river_core::room_state::{ChatRoomStateV1, ChatRoomStateV1Delta};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::sync::{LazyLock, Mutex, MutexGuard};
 
-/// Hard cap on the number of upgrade-pointer hops a single chain walk
-/// will follow before giving up. A correctly-formed upgrade chain has at
-/// most one hop per WASM generation; this is a defence-in-depth guard
-/// against a runaway pointer→pointer→pointer chain (a malicious or
-/// corrupt `OptionalUpgradeV1`).
+/// Hard cap on the number of upgrade-pointer hops a single chain walk will
+/// follow before giving up. A correctly-formed upgrade chain has at most one
+/// hop per WASM generation; this is a defence-in-depth guard against a runaway
+/// pointer→pointer→pointer chain (a malicious or corrupt `OptionalUpgradeV1`).
 const MAX_UPGRADE_HOPS: usize = 32;
 
-/// Per-room count of upgrade-pointer hops already followed in the
-/// current chain walk. Keyed by `room_owner_vk`. Incremented each time
-/// `follow_upgrade_pointer_if_needed` follows a pointer; the entry is
-/// removed once the chain terminates (the GET response carries no
-/// further pointer, or it points at the current key).
-static UPGRADE_HOP_COUNTS: GlobalSignal<HashMap<VerifyingKey, usize>> = Global::new(HashMap::new);
-
-/// Maps the `ContractInstanceId` of an upgrade-pointer target whose
-/// GET we have outstanding back to the `room_owner_vk` it belongs to.
+/// Per-room set of upgrade-pointer-target contract ids already visited in the
+/// current chain walk, keyed by `room_owner_vk`. The set is BOTH the cycle
+/// guard (a pointer back to any already-visited contract — not just the
+/// immediately-preceding one — is a cycle) AND the hop cap (`len()`).
 ///
-/// A GET response for an upgrade-pointer target arrives keyed by a
-/// contract id that is NOT the room's current contract id, so it
-/// cannot be resolved via `SYNC_INFO` or `RoomData::contract_key`. This
-/// side-table lets `handle_get_response` recover the owner so it can
-/// (a) continue walking a multi-hop chain and (b) merge the recovered
-/// state into the right room.
-static UPGRADE_TARGETS: GlobalSignal<HashMap<ContractInstanceId, VerifyingKey>> =
-    Global::new(HashMap::new);
+/// Plain `Mutex` map, NOT a Dioxus signal — internal bookkeeping with zero UI
+/// reactivity, like `backward_probe::BACKWARD_PROBES`.
+static UPGRADE_CHAIN_VISITED: LazyLock<Mutex<HashMap<VerifyingKey, HashSet<ContractInstanceId>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
-/// The `room_owner_vk` an outstanding upgrade-pointer GET for
-/// `instance_id` belongs to, if any. Used by `handle_get_response` as an
-/// owner-resolution fallback for pointer-target contracts.
+/// Maps the `ContractInstanceId` of an upgrade-pointer target whose GET we
+/// have outstanding back to the `room_owner_vk` it belongs to.
+///
+/// A GET response for an upgrade-pointer target arrives keyed by a contract id
+/// that is NOT the room's current contract id, so it cannot be resolved via
+/// `SYNC_INFO` or `RoomData::contract_key`. This side-table lets
+/// `handle_get_response` recover the owner so it can (a) continue walking a
+/// multi-hop chain and (b) merge the recovered state into the right room.
+///
+/// Plain `Mutex` map, NOT a Dioxus signal — see `UPGRADE_CHAIN_VISITED`.
+static UPGRADE_TARGETS: LazyLock<Mutex<HashMap<ContractInstanceId, VerifyingKey>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn upgrade_visited() -> MutexGuard<'static, HashMap<VerifyingKey, HashSet<ContractInstanceId>>> {
+    UPGRADE_CHAIN_VISITED
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}
+
+fn upgrade_targets() -> MutexGuard<'static, HashMap<ContractInstanceId, VerifyingKey>> {
+    UPGRADE_TARGETS.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// The `room_owner_vk` an outstanding upgrade-pointer GET for `instance_id`
+/// belongs to, if any. Used by `handle_get_response` as an owner-resolution
+/// fallback for pointer-target contracts.
 pub(crate) fn upgrade_target_owner(instance_id: &ContractInstanceId) -> Option<VerifyingKey> {
-    UPGRADE_TARGETS.read().get(instance_id).copied()
+    upgrade_targets().get(instance_id).copied()
 }
 
-/// Remove the upgrade-target side-table entry for `instance_id` — its
-/// GET response has been consumed.
+/// Remove the upgrade-target side-table entry for `instance_id` — its GET
+/// response has been consumed. Synchronous (plain mutex), so a later GET
+/// response for the same id cannot be mis-routed by a not-yet-applied
+/// deferred removal.
 pub(crate) fn clear_upgrade_target(instance_id: &ContractInstanceId) {
-    let instance_id = *instance_id;
-    crate::util::defer(move || {
-        UPGRADE_TARGETS.with_mut(|targets| {
-            targets.remove(&instance_id);
-        });
-    });
+    upgrade_targets().remove(instance_id);
 }
 
-/// If `state` carries an upgrade pointer to a *different* contract,
-/// send a GET+subscribe to the new address.
+/// Drop the visited-set for `room_owner_vk` — the chain walk has ended.
+fn clear_upgrade_visited(room_owner_vk: &VerifyingKey) {
+    upgrade_visited().remove(room_owner_vk);
+}
+
+/// If `state` carries an upgrade pointer to a *different* contract, send a
+/// GET+subscribe to the new address.
 ///
-/// Multi-hop (freenet/river#292): the GET response for the contract
-/// reached by following a pointer is itself routed back through
-/// `handle_get_response`, which calls this function again — so a
-/// pointer→pointer→pointer chain is walked all the way to the end.
+/// Multi-hop (freenet/river#292): the GET response for the contract reached by
+/// following a pointer is itself routed back through `handle_get_response`,
+/// which calls this function again — so a pointer→pointer→pointer chain is
+/// walked all the way to the end.
 ///
-/// `delivered_from` is the `ContractInstanceId` of the contract whose
-/// GET response (or update notification) carried `state`. It is used as
-/// a cycle guard: a pointer that targets the very contract that just
-/// delivered it is ignored rather than re-fetched forever. The
-/// [`MAX_UPGRADE_HOPS`] counter is a second, total-length guard.
+/// `delivered_from` is the `ContractInstanceId` of the contract whose GET
+/// response (or update notification) carried `state`. A response whose
+/// `delivered_from` is not in the visited-set starts a fresh walk (the
+/// visited-set is reset), which both bounds the set's lifetime and discards
+/// any stale set left by an earlier walk that never terminated. The
+/// per-walk visited-set then catches every cycle (not just an immediate
+/// A→A), and its size is capped by [`MAX_UPGRADE_HOPS`].
 pub(crate) fn follow_upgrade_pointer_if_needed(
     state: &ChatRoomStateV1,
     room_owner_vk: &VerifyingKey,
     delivered_from: Option<ContractInstanceId>,
 ) {
     let Some(ref authorized_upgrade) = state.upgrade.0 else {
-        // Chain terminates here — drop any hop counter for this room so a
+        // Chain terminates here — drop the visited-set for this room so a
         // future, unrelated chain walk starts fresh.
-        clear_upgrade_hops(room_owner_vk);
+        clear_upgrade_visited(room_owner_vk);
         return;
     };
 
@@ -89,63 +107,66 @@ pub(crate) fn follow_upgrade_pointer_if_needed(
         new_address
     );
 
-    // Cycle guard 1: the pointer targets the current bundled contract —
-    // we already know that key, no need to chase it.
+    // Cycle guard 1: the pointer targets the current bundled contract — we
+    // already know that key, no need to chase it.
     let current_key = owner_vk_to_contract_key(room_owner_vk);
     let current_id_bytes = current_key.id().as_bytes();
     let mut current_hash = [0u8; 32];
     current_hash.copy_from_slice(current_id_bytes);
     if blake3::Hash::from(current_hash) == new_address {
-        clear_upgrade_hops(room_owner_vk);
+        clear_upgrade_visited(room_owner_vk);
         return;
     }
 
-    // Cycle guard 2: the pointer targets the contract that just
-    // delivered this state. Following it would loop forever.
-    if delivered_from == Some(new_contract_id) {
-        warn!(
-            "Upgrade pointer for room {:?} targets the delivering contract \
-             {} — refusing to follow (cycle guard)",
-            river_core::room_state::member::MemberId::from(*room_owner_vk),
-            new_contract_id
+    // Visited-set bookkeeping + cycle / runaway guards, all under one lock.
+    {
+        let mut visited = upgrade_visited();
+        let set = visited.entry(*room_owner_vk).or_default();
+
+        // Fresh-walk reset: a response whose delivering contract was not
+        // itself a followed hop is the root of a new walk. Resetting here
+        // discards any stale set a previous walk left behind if its GET
+        // never returned (so the set cannot leak unboundedly).
+        match delivered_from {
+            Some(from) if set.contains(&from) => {}
+            _ => set.clear(),
+        }
+
+        // Cycle guard 2: a pointer back to ANY contract already visited in
+        // this walk (not just the immediately-preceding one) is a cycle.
+        if set.contains(&new_contract_id) {
+            warn!(
+                "Upgrade pointer for room {:?} targets already-visited contract \
+                 {} — refusing to follow (cycle guard)",
+                river_core::room_state::member::MemberId::from(*room_owner_vk),
+                new_contract_id
+            );
+            visited.remove(room_owner_vk);
+            return;
+        }
+
+        // Runaway guard: cap total hops across the chain walk.
+        if set.len() >= MAX_UPGRADE_HOPS {
+            warn!(
+                "Upgrade chain for room {:?} hit MAX_UPGRADE_HOPS ({}) — aborting",
+                river_core::room_state::member::MemberId::from(*room_owner_vk),
+                MAX_UPGRADE_HOPS
+            );
+            visited.remove(room_owner_vk);
+            return;
+        }
+
+        set.insert(new_contract_id);
+        info!(
+            "Following upgrade pointer (hop {}): subscribing to new contract for room {:?}",
+            set.len(),
+            river_core::room_state::member::MemberId::from(*room_owner_vk)
         );
-        clear_upgrade_hops(room_owner_vk);
-        return;
     }
 
-    // Runaway guard: cap total hops across the chain walk.
-    let hops = UPGRADE_HOP_COUNTS
-        .read()
-        .get(room_owner_vk)
-        .copied()
-        .unwrap_or(0);
-    if hops >= MAX_UPGRADE_HOPS {
-        warn!(
-            "Upgrade chain for room {:?} hit MAX_UPGRADE_HOPS ({}) — aborting",
-            river_core::room_state::member::MemberId::from(*room_owner_vk),
-            MAX_UPGRADE_HOPS
-        );
-        clear_upgrade_hops(room_owner_vk);
-        return;
-    }
-
-    info!(
-        "Following upgrade pointer (hop {}): subscribing to new contract for room {:?}",
-        hops + 1,
-        river_core::room_state::member::MemberId::from(*room_owner_vk)
-    );
-
-    let room_owner_vk_copy = *room_owner_vk;
-    crate::util::defer(move || {
-        UPGRADE_HOP_COUNTS.with_mut(|counts| {
-            *counts.entry(room_owner_vk_copy).or_insert(0) += 1;
-        });
-        // Register the target so `handle_get_response` can resolve the
-        // owner when the GET for this pointer hop comes back.
-        UPGRADE_TARGETS.with_mut(|targets| {
-            targets.insert(new_contract_id, room_owner_vk_copy);
-        });
-    });
+    // Register the target so `handle_get_response` can resolve the owner when
+    // the GET for this pointer hop comes back.
+    upgrade_targets().insert(new_contract_id, *room_owner_vk);
 
     crate::util::safe_spawn_local(async move {
         let get_request = ContractRequest::Get {
@@ -159,16 +180,6 @@ pub(crate) fn follow_upgrade_pointer_if_needed(
                 warn!("Failed to follow upgrade pointer: {}", e);
             }
         }
-    });
-}
-
-/// Drop the hop counter for `room_owner_vk` — the chain walk has ended.
-fn clear_upgrade_hops(room_owner_vk: &VerifyingKey) {
-    let room_owner_vk = *room_owner_vk;
-    crate::util::defer(move || {
-        UPGRADE_HOP_COUNTS.with_mut(|counts| {
-            counts.remove(&room_owner_vk);
-        });
     });
 }
 

--- a/ui/src/components/app/freenet_api/room_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/room_synchronizer.rs
@@ -623,66 +623,75 @@ impl RoomSynchronizer {
             }
         }
 
-        // Handle migrated rooms: any client can PUT state to the new contract key.
-        // Owner additionally sends an upgrade pointer on the old contract for old-client compat.
+        // Handle migrated rooms (freenet/river#292, Task 2).
+        //
+        // Previously this block force-PUT the device's *local* `room_state`
+        // snapshot onto the new contract key. That re-introduced stale
+        // state — old member IDs, pruned members — whenever the new key
+        // already carried fresher state from the network. Instead we now
+        // route the migrated room through the normal GET+subscribe path:
+        // GET the new contract key, and let `handle_get_response` CRDT-
+        // merge whatever the network has. If the new key turns out to be
+        // empty, `handle_get_response` itself triggers the backward
+        // probe (Task 3), which recovers the room's last-active state
+        // from an older generation and only seeds the new key with the
+        // local snapshot as a genuine last resort.
+        //
+        // The owner still sends the `OptionalUpgradeV1` pointer on the
+        // OLD contract so old clients can find the new key.
         if web_api_available {
             let migrated_rooms: Vec<(VerifyingKey, freenet_stdlib::prelude::ContractKey)> =
                 ROOMS.with_mut(|rooms| std::mem::take(&mut rooms.migrated_rooms));
 
             for (owner_vk, old_contract_key) in &migrated_rooms {
-                let (new_contract_key, room_state_bytes, is_owner) = {
+                let (new_contract_key, is_owner) = {
                     let rooms = ROOMS.read();
                     if let Some(room_data) = rooms.map.get(owner_vk) {
                         let is_owner = room_data.self_sk.verifying_key() == *owner_vk;
-                        (
-                            room_data.contract_key,
-                            to_cbor_vec(&room_data.room_state),
-                            is_owner,
-                        )
+                        (room_data.contract_key, is_owner)
                     } else {
                         continue;
                     }
                 };
 
                 info!(
-                    "Migrating room {:?} from old contract {} to new contract {}",
+                    "Migrating room {:?} from old contract {} to new contract {} \
+                     (GET+subscribe — network state is authoritative)",
                     MemberId::from(*owner_vk),
                     old_contract_key.id(),
                     new_contract_key.id()
                 );
 
-                // Any client: PUT state to new contract key
-                let contract_code = ContractCode::from(ROOM_CONTRACT_WASM);
-                let parameters = ChatRoomParametersV1 { owner: *owner_vk };
-                let params_bytes = to_cbor_vec(&parameters);
-                let contract_container = ContractContainer::from(ContractWasmAPIVersion::V1(
-                    WrappedContract::new(Arc::new(contract_code), Parameters::from(params_bytes)),
-                ));
-                let wrapped_state = WrappedState::new(room_state_bytes);
+                // Register the new contract id so the GET response
+                // resolves back to this owner.
+                SYNC_INFO.with_mut(|sync_info| {
+                    sync_info.register_new_room(*owner_vk);
+                });
 
-                let put_request = ContractRequest::Put {
-                    contract: contract_container,
-                    state: wrapped_state,
-                    related_contracts: Default::default(),
+                // Any client: GET+subscribe the new contract key. The
+                // GET response handler merges network state and, when
+                // the new key is empty, fans out to the backward probe.
+                let get_request = ContractRequest::Get {
+                    key: *new_contract_key.id(),
+                    return_contract_code: true,
                     subscribe: true,
                     blocking_subscribe: false,
                 };
 
                 if let Some(web_api) = WEB_API.write().as_mut() {
-                    match web_api.send(ClientRequest::ContractOp(put_request)).await {
+                    match web_api.send(ClientRequest::ContractOp(get_request)).await {
                         Ok(_) => {
                             info!(
-                                "PUT state to new contract for room {:?}",
+                                "Sent GET+subscribe to new contract for migrated room {:?}",
                                 MemberId::from(*owner_vk)
                             );
-                            // Note: previous_contract_key is NOT cleared here because
-                            // send() only confirms the message was sent to the WebSocket,
-                            // not that the PUT was accepted. It will be cleared when we
-                            // successfully GET the new contract state.
+                            SYNC_INFO.with_mut(|sync_info| {
+                                sync_info.update_sync_status(owner_vk, RoomSyncStatus::Subscribing);
+                            });
                         }
                         Err(e) => {
                             warn!(
-                                "Failed to PUT state to new contract for room {:?}: {}",
+                                "Failed to GET new contract for migrated room {:?}: {}",
                                 MemberId::from(*owner_vk),
                                 e
                             );

--- a/ui/src/components/app/sync_info.rs
+++ b/ui/src/components/app/sync_info.rs
@@ -93,6 +93,21 @@ impl SyncInfo {
         }
     }
 
+    /// Refresh `subscribing_since` for a room that is still `Subscribing`,
+    /// without otherwise changing its status. A backward-probe recovery
+    /// (freenet/river#292) can run longer than `REPUT_DELAY_MS`; calling this
+    /// each probe hop keeps `rooms_awaiting_subscription` from reclaiming the
+    /// room mid-probe. Unlike `update_sync_status(.., Subscribing)` this does
+    /// NOT force the status, so a room that genuinely reached `Subscribed`
+    /// mid-probe is left alone (and is not swept anyway).
+    pub fn touch_subscribing_since(&mut self, owner_key: &VerifyingKey) {
+        if let Some(sync_info) = self.map.get_mut(owner_key) {
+            if sync_info.sync_status == RoomSyncStatus::Subscribing {
+                sync_info.subscribing_since = Some(now_ms());
+            }
+        }
+    }
+
     pub fn update_last_synced_state(&mut self, owner_key: &VerifyingKey, state: &ChatRoomStateV1) {
         if let Some(sync_info) = self.map.get_mut(owner_key) {
             sync_info.last_synced_state = Some(state.clone());
@@ -307,4 +322,49 @@ pub enum RoomSyncStatus {
     Subscribed,
 
     Error(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    fn test_owner(seed: u8) -> VerifyingKey {
+        SigningKey::from_bytes(&[seed; 32]).verifying_key()
+    }
+
+    /// `touch_subscribing_since` refreshes the timestamp for a `Subscribing`
+    /// room — this is what keeps a long backward-probe recovery out of the
+    /// `rooms_awaiting_subscription` timeout sweep (freenet/river#292) — but
+    /// must NOT touch a room in any other status (no spurious status flap,
+    /// and a `Subscribed` room is not swept anyway).
+    #[test]
+    fn touch_subscribing_since_only_restamps_while_subscribing() {
+        let mut si = SyncInfo::new();
+        let owner = test_owner(1);
+        si.register_new_room(owner);
+
+        // Subscribing room with a cleared timestamp → touch re-stamps it.
+        si.update_sync_status(&owner, RoomSyncStatus::Subscribing);
+        si.map.get_mut(&owner).unwrap().subscribing_since = None;
+        si.touch_subscribing_since(&owner);
+        assert!(
+            si.map.get(&owner).unwrap().subscribing_since.is_some(),
+            "touch must re-stamp a Subscribing room"
+        );
+
+        // Subscribed room → touch must NOT re-stamp and must NOT flip status.
+        si.update_sync_status(&owner, RoomSyncStatus::Subscribed);
+        assert!(si.map.get(&owner).unwrap().subscribing_since.is_none());
+        si.touch_subscribing_since(&owner);
+        assert!(
+            si.map.get(&owner).unwrap().subscribing_since.is_none(),
+            "touch must not act on a non-Subscribing room"
+        );
+        assert_eq!(
+            si.map.get(&owner).unwrap().sync_status,
+            RoomSyncStatus::Subscribed,
+            "touch must never change the status"
+        );
+    }
 }

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -2170,7 +2170,14 @@ mod tests {
             ),
             (
                 "ui/src/components/app/freenet_api/response_handler/get_response.rs",
-                3, // pending-invite branch + existing-room (replace) + existing-room (merge)
+                // pending-invite branch + existing-room (replace) + existing-room (merge)
+                // + backward-probe handler (replace) + backward-probe handler (merge).
+                // The last two are the freenet/river#292 recovery path: when a
+                // backward probe recovers stranded state from a legacy contract
+                // generation, the recovered state is adopted into RoomData and
+                // its private-room secrets must be repopulated, exactly like the
+                // normal existing-room GET path.
+                5,
                 include_str!("components/app/freenet_api/response_handler/get_response.rs"),
             ),
         ];

--- a/ui/src/util.rs
+++ b/ui/src/util.rs
@@ -416,6 +416,12 @@ pub fn owner_vk_to_contract_key(owner_vk: &VerifyingKey) -> ContractKey {
     ContractKey::from_params_and_code(parameters, &contract_code)
 }
 
+/// Contract keys for `owner_vk` under every previous room-contract WASM
+/// generation, newest-first (freenet/river#292).
+pub fn owner_vk_to_legacy_contract_keys(owner_vk: &VerifyingKey) -> Vec<ContractKey> {
+    river_core::migration::legacy_contract_keys_for_owner(owner_vk)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -536,6 +542,43 @@ mod tests {
              otherwise the response_handler load-rooms path can subscribe the delegate \
              to a stale contract id after a room-contract WASM rebuild (PR #276 round 2 \
              Codex P1)"
+        );
+    }
+
+    /// freenet/river#292: the `river_core::migration` legacy-key derivation
+    /// (`contract_key_for_code_hash`, used by the backward-probe path) MUST
+    /// agree with the live `owner_vk_to_contract_key` derivation when fed the
+    /// CURRENT bundled WASM's code hash. If they drift, a probe that recovers
+    /// a stranded room would PUT it forward onto a contract id that is NOT the
+    /// one the rest of the UI subscribes to.
+    #[test]
+    fn legacy_derivation_matches_live_key_for_current_wasm() {
+        use ed25519_dalek::SigningKey;
+
+        let owner = SigningKey::from_bytes(&[7u8; 32]).verifying_key();
+        let current_code_hash = blake3::hash(ROOM_CONTRACT_WASM);
+        let derived_via_migration =
+            river_core::migration::contract_key_for_code_hash(&owner, current_code_hash.as_bytes());
+        assert_eq!(
+            derived_via_migration.id(),
+            owner_vk_to_contract_key(&owner).id(),
+            "river_core::migration::contract_key_for_code_hash on the current WASM's \
+             code hash MUST produce the same contract id as owner_vk_to_contract_key \
+             (freenet/river#292)"
+        );
+    }
+
+    /// freenet/river#292: the current bundled WASM's code hash must NOT appear
+    /// in the legacy registry. If it did, the backward probe would re-derive
+    /// the current key as a "legacy" key and GET it redundantly.
+    #[test]
+    fn current_wasm_not_in_legacy_registry() {
+        let current_code_hash = blake3::hash(ROOM_CONTRACT_WASM);
+        assert!(
+            !river_core::migration::LEGACY_ROOM_CONTRACT_CODE_HASHES
+                .contains(current_code_hash.as_bytes()),
+            "the current room-contract WASM's code hash must not be in \
+             LEGACY_ROOM_CONTRACT_CODE_HASHES (freenet/river#292)"
         );
     }
 }

--- a/ui/src/util.rs
+++ b/ui/src/util.rs
@@ -255,6 +255,14 @@ pub fn from_cbor_slice<T: serde::de::DeserializeOwned>(data: &[u8]) -> T {
     ciborium::de::from_reader(data).unwrap()
 }
 
+/// Like [`from_cbor_slice`] but returns `None` instead of panicking when the
+/// bytes do not deserialize. Use this for bytes from a possibly-incompatible
+/// source — e.g. a legacy room-contract generation whose `ChatRoomStateV1`
+/// layout predates the current one (freenet/river#292).
+pub fn try_from_cbor_slice<T: serde::de::DeserializeOwned>(data: &[u8]) -> Option<T> {
+    ciborium::de::from_reader(data).ok()
+}
+
 /// Check if debug overlay is enabled via `?debug=1` query parameter.
 #[cfg(target_arch = "wasm32")]
 fn is_debug_enabled() -> bool {


### PR DESCRIPTION
## Problem

Reported by Ivvor (Matrix, 2026-05-20): restoring/importing a room that has been dormant for a while brings back **stale old member IDs** instead of the room's current state.

The room contract key is `BLAKE3(room_contract.wasm, params)` with `params = {owner}`, so **every room-contract WASM upgrade moves the key**. River had no way to recover a room whose live state sits under an older-generation contract key:

1. **No backward search.** Import/migration only ever derive the *current* contract key. There was no registry of historical room-contract WASM hashes (the chat delegate has `legacy_delegates.toml`; the room contract had no equivalent).
2. **Stale-state resurfacing.** On a WASM upgrade the migration path force-PUT the device's *stale local* `room_state` snapshot to the new key instead of adopting the network's current state, re-introducing old member entries into the live room.
3. `OptionalUpgradeV1` was followed exactly one hop.

## Approach

One principle, the same gating the chat-delegate legacy migration uses (#253): **the current contract key is always authoritative; backward recovery fires only when the current key has no usable state** — so recovery can never resurface stale state over live state.

**Registry (Part 1).** New `common/legacy_room_contracts.toml` records the BLAKE3 code hash of every previous room-contract WASM generation (24 entries, extracted from git history) — the room-contract analogue of `legacy_delegates.toml`. `common/build.rs` generates `LEGACY_ROOM_CONTRACT_CODE_HASHES`; the new `river-core` `migration` module re-derives the contract key any owner's room used under each generation. The module is **feature-gated so the room-contract and chat-delegate WASM builds never compile it** — their WASM bytes and keys stay byte-identical (this PR does not redeploy the contract or delegate).

**CLI (riverctl).** `get_room` GETs the current contract, walks any `OptionalUpgradeV1` chain forward (multi-hop, cycle-guarded), and on an empty current contract probes every previous generation newest-to-oldest, then migrates a recovered room forward. `get_migration_state` probes the full registry for the freshest network state instead of force-PUTting a stale local snapshot. Fixes `riverctl identity import` for a room several generations behind.

**UI.** The migration path no longer force-PUTs the local snapshot — it GET+subscribes the new key so network state is adopted. When the current key returns no real state, a backward probe walks the legacy generations newest-to-oldest; every probe GET is paired with a 12s timeout watchdog so an absent (GC'd) generation cannot stall recovery. The first generation with real state is CRDT-merged with the local snapshot and PUT forward onto the current key. The stale local snapshot is PUT only as a genuine last resort. `follow_upgrade_pointer_if_needed` is multi-hop (discovery-only). Imported rooms flow through this recovery.

## Testing

- `river-core`: new `migration` unit tests (registry key derivation matches the live `from_params_and_code` path; owner-specificity; newest-first order) + `room_contract_migration_test` registry validation — both now gated in CI.
- `riverctl`: 21 lib tests — registry-derivation parity, `next_upgrade_hop` cycle guard — now gated in CI.
- `river-ui`: 189 tests — backward-probe gate classification, probe-table single-shot + epoch guard, `classify_upgrade_hop` cycle/cap/reset, `merge_room_states`, `touch_subscribing_since`, import-path source-grep pin.
- Also fixes a **pre-existing flaky test** (the `ENSURE_SUBSCRIPTION_SENT` dedup tests raced on a global static — now serialized; 0/25 stress failures).
- Full workspace compiles native + `wasm32-unknown-unknown`; no `.wasm` files modified.

## Review

Full multi-model review (4 perspectives + Codex) run across four rounds. Round 1 found a blocking cluster in the UI probe machinery (no timeout → permanent stall; signal-safety violation). Round 2 found a probe-vs-subscription-timeout race and a CLI `return_contract_code` regression. Round 3 found a panic on malformed legacy state. Round 4 came back clean (Mergeable). All findings addressed — see the PR review threads. (Branch merged with `main` to pick up #129/#131.)

## Known limitations / follow-ups

- **Pending-invite branch not probed.** Recovery is wired into the existing-room / import path; accepting an invite *link* to a stranded room does not probe. Follow-up.
- **#292 is preventive, not curative.** It stops future stale-state resurfacing. State already merged into a contract by a pre-#293 client cannot be un-merged here (a CRDT property); the room contract's `post_apply_cleanup` prunes inactive resurfaced members on the next activity.
- A client whose bundled WASM is *older* than the generation a room currently lives on fetches the room once but does not get live push updates until the client itself updates — inherent to running stale client code.

Closes #292

[AI-assisted - Claude]