### PR TITLE
fix(ui): restore member_info on join + self-heal "Unknown" members

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -410,6 +410,28 @@ design.
   `test_stale_secret_recipient_is_pruned_after_rotation`, and
   `test_ban_race_with_encrypted_secret_converges_to_pruned` in
   `common/src/room_state.rs`.
+- **`member_info` must accompany every membership change** (PR #294,
+  "Unknown member" regression): whenever a member is added to
+  `room_state.members` on a path that goes to the network, their
+  `AuthorizedMemberInfo` MUST be written to `room_state.member_info` in
+  the same wire payload. A member present in `members` but absent from
+  `member_info` is valid contract state (member_info entries are
+  optional per `MemberInfoV1::verify`) but renders as **"Unknown"** to
+  every other peer. `build_state_for_put` (invitation-accept PUT) is the
+  canonical example: it must inject the invitee's `member_info`
+  byte-identically to the deferred local-state copy — the same
+  build-once-reuse discipline the synthesised join_event follows. PR
+  #272 added the member injection but omitted `member_info`, which is
+  the regression #294 fixed. The remediation for already-stranded
+  members is `RoomData::build_member_info_heal`: on every GET of an
+  existing room it detects "self in `members`, absent from
+  `member_info`" and re-publishes a self-signed `member_info` (folded
+  into the PUT for imported rooms, sent as a standalone UPDATE for
+  already-subscribed rooms). A non-owner's `member_info` is only valid
+  when self-signed by that member's own key, so this heal can ONLY run
+  client-side, by the affected member — never owner-side. For a private
+  room the heal defers (publishes nothing) until the room secret is
+  available, so it never leaks a plaintext nickname.
 - **In-memory secret repopulation** (#251): `room_data.secrets:
   HashMap<u32, [u8; 32]>` is `#[serde(skip)]` and must be rebuilt from
   `room_state.secrets.encrypted_secrets` after EVERY network state

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -706,6 +706,11 @@ pub async fn handle_get_response(
             // the entry is already synced when the network never received
             // it. The delta is self-signed and idempotent, so re-sending
             // it is harmless if it raced another heal.
+            //
+            // The heal is NOT written into the local `room_state` here,
+            // so self renders as "Unknown" locally until the subscription
+            // notification echoes this UPDATE back — the same benign,
+            // self-resolving transient as the imported-room path above.
             if !needs_put_subscribe {
                 if let Some(heal_info) = member_info_heal {
                     let heal_delta = ChatRoomStateV1Delta {
@@ -968,6 +973,12 @@ pub(crate) fn build_state_for_put(
         .iter()
         .any(|m| m.member.member_vk == self_vk);
     if already_member {
+        // The invitee is already in `members`. If they are also missing
+        // from `member_info` (a retry of a partially-completed accept, or
+        // a legacy stranding) this PUT does not heal them — but the room
+        // is now an existing room, so the GET-path `build_member_info_heal`
+        // self-heal covers it on the next GET. Same delayed-heal class as
+        // issue #295.
         return Ok((state, None));
     }
 

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -15,14 +15,14 @@ use dioxus::prelude::ReadableExt;
 use freenet_scaffold::ComposableState;
 use freenet_stdlib::client_api::{ClientRequest, ContractRequest};
 use freenet_stdlib::prelude::{
-    ContractCode, ContractContainer, ContractKey, ContractWasmAPIVersion, Parameters,
+    ContractCode, ContractContainer, ContractKey, ContractWasmAPIVersion, Parameters, UpdateData,
     WrappedContract, WrappedState,
 };
 use river_core::room_state::member::MemberId;
 use river_core::room_state::member_info::{AuthorizedMemberInfo, MemberInfo};
 use river_core::room_state::message::{AuthorizedMessageV1, MessageId, MessageV1, RoomMessageBody};
 use river_core::room_state::privacy::{PrivacyMode, SealedBytes};
-use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1};
+use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1, ChatRoomStateV1Delta};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -134,11 +134,49 @@ pub async fn handle_get_response(
             // but the network never sees the join, and the next
             // sync from the owner silently strips them with no
             // surfaced reason. See HIGH-1 finding on PR #272.
+            // Build the invitee's member_info ONCE, before the PUT and
+            // before the deferred ROOMS mutation, so both carry a
+            // byte-identical entry (the same reuse discipline the
+            // synthesised join_event follows). A member who lands in the
+            // contract's `members` list with no `member_info` entry
+            // renders as "Unknown" to every other peer — the PR #272
+            // regression. The entry MUST be self-signed with the
+            // invitee's own key; the room contract rejects member_info
+            // signed by anyone else.
+            let preferred_nickname_sealed =
+                if retrieved_state.configuration.configuration.privacy_mode == PrivacyMode::Private
+                {
+                    match current_secret_from_state(&retrieved_state, &self_sk) {
+                        Some((secret, version)) => crate::util::ecies::seal_bytes(
+                            preferred_nickname.as_bytes(),
+                            &secret,
+                            version,
+                        ),
+                        None => {
+                            warn!(
+                            "Private room but no secret available to seal nickname, using public"
+                        );
+                            SealedBytes::public(preferred_nickname.as_bytes().to_vec())
+                        }
+                    }
+                } else {
+                    SealedBytes::public(preferred_nickname.as_bytes().to_vec())
+                };
+            let authorized_member_info = AuthorizedMemberInfo::new_with_member_key(
+                MemberInfo {
+                    member_id,
+                    version: 0,
+                    preferred_nickname: preferred_nickname_sealed,
+                },
+                &self_sk,
+            );
+
             let (retrieved_state_for_put, synthesised_join_event) = match build_state_for_put(
                 retrieved_state.clone(),
                 owner_vk,
                 &self_sk,
                 &authorized_member,
+                &authorized_member_info,
                 get_current_system_time(),
             ) {
                 Ok(v) => v,
@@ -181,7 +219,8 @@ pub async fn handle_get_response(
                 let entry = rooms.map.entry(owner_vk);
 
                 // Check if this is a new entry before inserting
-                let is_new_entry = matches!(entry, std::collections::hash_map::Entry::Vacant(_));
+                let is_new_entry =
+                    matches!(entry, std::collections::hash_map::Entry::Vacant(_));
 
                 // Insert or get the existing room data
                 let room_data = entry.or_insert_with(|| {
@@ -240,35 +279,14 @@ pub async fn handle_get_response(
                     );
                 }
 
-                // Set the member's nickname in member_info regardless of whether they were already in the room
-                // This ensures the member has corresponding MemberInfo even if they were already a member
-                let preferred_nickname_sealed = if room_data.room_state.configuration.configuration.privacy_mode == PrivacyMode::Private {
-                    // For private rooms, encrypt the nickname with the room secret
-                    if let Some((secret, version)) = room_data.get_secret() {
-                        use crate::util::ecies::encrypt_with_symmetric_key;
-                        let (ciphertext, nonce) = encrypt_with_symmetric_key(secret, preferred_nickname.as_bytes());
-                        SealedBytes::Private {
-                            ciphertext,
-                            nonce,
-                            secret_version: version,
-                            declared_len_bytes: preferred_nickname.len() as u32,
-                        }
-                    } else {
-                        warn!("Private room but no secret available for encrypting nickname, using public");
-                        SealedBytes::public(preferred_nickname.clone().into_bytes())
-                    }
-                } else {
-                    SealedBytes::public(preferred_nickname.clone().into_bytes())
-                };
-
-                let member_info = MemberInfo {
-                    member_id,
-                    version: 0,
-                    preferred_nickname: preferred_nickname_sealed,
-                };
-
-                let authorized_member_info =
-                    AuthorizedMemberInfo::new_with_member_key(member_info.clone(), &self_sk);
+                // The invitee's `authorized_member_info` was built once
+                // above, before `build_state_for_put`, and moved into this
+                // closure. Reusing the SAME value here keeps the local
+                // ROOMS state and the PUT payload byte-identical — the
+                // same reuse discipline the synthesised join_event
+                // follows. (Re-sealing here would also be wrong for
+                // private rooms: each seal uses a fresh random nonce, so
+                // a re-built entry would not match the PUT's.)
 
                 // Store membership credentials for future rejoin after
                 // inactivity pruning.
@@ -347,7 +365,11 @@ pub async fn handle_get_response(
 
                 // Rebuild actions_state from action messages (edit, delete, reaction)
                 // This is needed because actions_state is #[serde(skip)] and not serialized
-                let is_private = room_data.room_state.configuration.configuration.privacy_mode
+                let is_private = room_data
+                    .room_state
+                    .configuration
+                    .configuration
+                    .privacy_mode
                     == PrivacyMode::Private;
                 if is_private {
                     // Decrypt all private action messages using version-aware lookup
@@ -358,16 +380,21 @@ pub async fn handle_get_response(
                         .iter()
                         .filter(|msg| msg.message.content.is_action())
                         .filter_map(|msg| {
-                            if let RoomMessageBody::Private { ciphertext, nonce, secret_version, .. } =
-                                &msg.message.content
+                            if let RoomMessageBody::Private {
+                                ciphertext,
+                                nonce,
+                                secret_version,
+                                ..
+                            } = &msg.message.content
                             {
                                 // Look up the secret for this message's version
-                                room_data.get_secret_for_version(*secret_version)
-                                    .and_then(|secret| {
+                                room_data.get_secret_for_version(*secret_version).and_then(
+                                    |secret| {
                                         decrypt_with_symmetric_key(secret, ciphertext, nonce)
                                             .ok()
                                             .map(|plaintext| (msg.id(), plaintext))
-                                    })
+                                    },
+                                )
                             } else {
                                 None
                             }
@@ -380,12 +407,9 @@ pub async fn handle_get_response(
                         .rebuild_actions_state_with_decrypted(&decrypted_actions);
                 } else {
                     // Public room - rebuild from public action messages
-                    room_data
-                        .room_state
-                        .recent_messages
-                        .rebuild_actions_state();
+                    room_data.room_state.recent_messages.rebuild_actions_state();
                 }
-            });
+                });
             });
 
             // Make sure SYNC_INFO is properly set up for this room
@@ -544,6 +568,19 @@ pub async fn handle_get_response(
             let retrieved_state: ChatRoomStateV1 = from_cbor_slice::<ChatRoomStateV1>(&state);
             let retrieved_state_for_put = retrieved_state.clone();
 
+            // Member-info self-heal — remediation for the PR #272 stranding.
+            // If the freshly-GET'd canonical state shows us in `members`
+            // with no matching `member_info` entry, every other peer
+            // renders us as "Unknown". Detect it from the raw network
+            // state and re-publish our own self-signed member_info below.
+            // Idempotent: once the entry lands, later GETs no longer see
+            // the stranding and the heal stops firing.
+            let member_info_heal: Option<AuthorizedMemberInfo> = ROOMS
+                .read()
+                .map
+                .get(&owner_vk)
+                .and_then(|rd| rd.build_member_info_heal(&retrieved_state));
+
             crate::util::defer(move || {
                 ROOMS.with_mut(|rooms| {
                     if let Some(room_data) = rooms.map.get_mut(&owner_vk) {
@@ -612,6 +649,39 @@ pub async fn handle_get_response(
                     }
                 });
             });
+
+            // Send the member-info self-heal UPDATE (see the detection
+            // above). A dedicated member_info-only delta — independent of
+            // the normal last_synced_state diff path, which can believe
+            // the entry is already synced when the network never received
+            // it. The delta is self-signed and idempotent, so re-sending
+            // it is harmless if it raced another heal.
+            if let Some(heal_info) = member_info_heal {
+                let heal_delta = ChatRoomStateV1Delta {
+                    member_info: Some(vec![heal_info]),
+                    ..Default::default()
+                };
+                let update_request = ContractRequest::Update {
+                    key,
+                    data: UpdateData::Delta(to_cbor_vec(&heal_delta).into()),
+                };
+                if let Some(web_api) = WEB_API.write().as_mut() {
+                    match web_api
+                        .send(ClientRequest::ContractOp(update_request))
+                        .await
+                    {
+                        Ok(_) => info!(
+                            "Sent member_info self-heal UPDATE for room {:?}",
+                            MemberId::from(owner_vk)
+                        ),
+                        Err(e) => warn!(
+                            "Failed to send member_info self-heal for room {:?}: {}",
+                            MemberId::from(owner_vk),
+                            e
+                        ),
+                    }
+                }
+            }
 
             if needs_put_subscribe {
                 // This is an imported room that just received its first real state via
@@ -771,6 +841,37 @@ impl std::fmt::Display for BuildStateForPutError {
     }
 }
 
+/// Decrypt the room's current-version secret out of a raw network
+/// `ChatRoomStateV1`, for a member who holds `self_sk`.
+///
+/// Mirrors the per-blob decrypt loop in
+/// `RoomData::repopulate_secrets_from_state`, but for the single
+/// current version and without needing a constructed `RoomData` — the
+/// invitation-accept PUT path must seal the joiner's nickname before
+/// any `RoomData` exists. Returns `None` on public rooms (no secret),
+/// when the blob for the current version hasn't been issued for this
+/// member yet, or when decryption fails.
+fn current_secret_from_state(
+    state: &ChatRoomStateV1,
+    self_sk: &ed25519_dalek::SigningKey,
+) -> Option<([u8; 32], u32)> {
+    let member_id = MemberId::from(&self_sk.verifying_key());
+    let version = state.secrets.current_version;
+    let blob = state
+        .secrets
+        .encrypted_secrets
+        .iter()
+        .find(|s| s.secret.member_id == member_id && s.secret.secret_version == version)?;
+    let secret = crate::util::ecies::decrypt_secret_from_member_blob_raw(
+        &blob.secret.ciphertext,
+        &blob.secret.nonce,
+        &blob.secret.sender_ephemeral_public_key,
+        self_sk,
+    )
+    .ok()?;
+    Some((secret, version))
+}
+
 /// Build the state payload to PUT after accepting an invitation.
 ///
 /// The PUT must include the invitee's join_event message so the
@@ -786,6 +887,13 @@ impl std::fmt::Display for BuildStateForPutError {
 /// invitee's join_event — the underlying cause of the
 /// "newly-invited member silently dropped" symptom (Bug #3, issue
 /// #110, Ivvor 2026-05-17).
+///
+/// The PUT must ALSO include the invitee's `member_info` entry — passed
+/// in by the caller, who builds it once and reuses the identical value
+/// for the deferred local ROOMS mutation. A member present in `members`
+/// but absent from `member_info` renders as "Unknown" to every other
+/// peer. PR #272 added the join_event injection but omitted member_info,
+/// which is the regression this restores.
 ///
 /// Returns the new state plus, when a join_event was synthesised, the
 /// `AuthorizedMessageV1` itself. The deferred ROOMS mutation MUST
@@ -813,6 +921,7 @@ pub(crate) fn build_state_for_put(
     owner_vk: ed25519_dalek::VerifyingKey,
     invitee_sk: &ed25519_dalek::SigningKey,
     authorized_member: &river_core::room_state::member::AuthorizedMember,
+    member_info: &AuthorizedMemberInfo,
     time: std::time::SystemTime,
 ) -> Result<(ChatRoomStateV1, Option<AuthorizedMessageV1>), BuildStateForPutError> {
     let self_vk = invitee_sk.verifying_key();
@@ -857,6 +966,16 @@ pub(crate) fn build_state_for_put(
 
     state.members.members.push(authorized_member.clone());
 
+    // Inject the invitee's member_info alongside the member entry. Without
+    // this, the invitee lands in the contract's `members` list with no
+    // `member_info`, so every other peer renders them as "Unknown" (the
+    // PR #272 regression). The caller builds `member_info` once and reuses
+    // the SAME value for the deferred local ROOMS mutation, keeping the
+    // PUT state and local state byte-identical. The entry is self-signed
+    // by the invitee — the room contract rejects member_info signed by
+    // any other key.
+    state.member_info.member_info.push(member_info.clone());
+
     let join_msg = MessageV1 {
         room_owner: MemberId::from(owner_vk),
         author: MemberId::from(&self_vk),
@@ -875,6 +994,20 @@ mod tests {
     use ed25519_dalek::SigningKey;
     use river_core::room_state::configuration::{AuthorizedConfigurationV1, Configuration};
     use river_core::room_state::member::{AuthorizedMember, Member};
+
+    /// Build a public-room `AuthorizedMemberInfo` self-signed by `sk`,
+    /// so the `build_state_for_put` tests can supply the member_info
+    /// parameter the production caller builds before the PUT.
+    fn test_member_info(sk: &SigningKey) -> AuthorizedMemberInfo {
+        AuthorizedMemberInfo::new_with_member_key(
+            MemberInfo {
+                member_id: MemberId::from(&sk.verifying_key()),
+                version: 0,
+                preferred_nickname: SealedBytes::public(b"Tester".to_vec()),
+            },
+            sk,
+        )
+    }
 
     /// Regression test for Bug #3 PR B (issue #110, Ivvor 2026-05-17):
     /// the state PUT to the network after accepting an invitation must
@@ -911,9 +1044,15 @@ mod tests {
         // Use a fixed timestamp so the test is deterministic — the
         // production code passes `get_current_system_time()`.
         let fixed_time = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
-        let (put_state, synthesised_join_event) =
-            build_state_for_put(state, owner_vk, &invitee_sk, &authorized_member, fixed_time)
-                .expect("non-capacity invitee path must succeed");
+        let (put_state, synthesised_join_event) = build_state_for_put(
+            state,
+            owner_vk,
+            &invitee_sk,
+            &authorized_member,
+            &test_member_info(&invitee_sk),
+            fixed_time,
+        )
+        .expect("non-capacity invitee path must succeed");
 
         // Member is in the state.
         assert!(
@@ -977,6 +1116,78 @@ mod tests {
         );
     }
 
+    /// Regression test for the PR #272 "Unknown member" bug: the state
+    /// PUT after accepting an invitation must also include the invitee's
+    /// `member_info` entry. Without it the invitee is in `members` on the
+    /// contract but absent from `member_info`, so every other peer
+    /// renders them as "Unknown".
+    #[test]
+    fn build_state_for_put_includes_member_info() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let owner_vk = owner_sk.verifying_key();
+        let invitee_vk = invitee_sk.verifying_key();
+
+        let config = AuthorizedConfigurationV1::new(Configuration::default(), &owner_sk);
+        let state = ChatRoomStateV1 {
+            configuration: config,
+            ..Default::default()
+        };
+        let authorized_member = AuthorizedMember::new(
+            Member {
+                owner_member_id: owner_vk.into(),
+                invited_by: owner_vk.into(),
+                member_vk: invitee_vk,
+            },
+            &owner_sk,
+        );
+        let member_info = test_member_info(&invitee_sk);
+        let fixed_time = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+
+        let (put_state, _) = build_state_for_put(
+            state,
+            owner_vk,
+            &invitee_sk,
+            &authorized_member,
+            &member_info,
+            fixed_time,
+        )
+        .expect("non-capacity invitee path must succeed");
+
+        // The invitee's member_info must be in the PUT state.
+        let invitee_id = MemberId::from(&invitee_vk);
+        assert!(
+            put_state
+                .member_info
+                .member_info
+                .iter()
+                .any(|i| i.member_info.member_id == invitee_id),
+            "PUT state must include the invitee's member_info — without it \
+             every other peer renders the invitee as \"Unknown\" (PR #272 bug)"
+        );
+
+        // It must survive the owner-side post_apply_cleanup and the
+        // contract's verify() — proving it is a well-formed, self-signed
+        // entry the room contract accepts.
+        let params = ChatRoomParametersV1 { owner: owner_vk };
+        let mut after_cleanup = put_state;
+        after_cleanup
+            .post_apply_cleanup(&params)
+            .expect("post_apply_cleanup must succeed");
+        assert!(
+            after_cleanup
+                .member_info
+                .member_info
+                .iter()
+                .any(|i| i.member_info.member_id == invitee_id),
+            "invitee member_info must survive post_apply_cleanup"
+        );
+        after_cleanup
+            .verify(&after_cleanup, &params)
+            .expect("PUT state with injected member_info must verify");
+    }
+
     /// Owner PUTting their own state must NOT have anything synthesised
     /// — they're not joining their own room.
     #[test]
@@ -1008,6 +1219,7 @@ mod tests {
             owner_vk,
             &owner_sk,
             &authorized_member,
+            &test_member_info(&owner_sk),
             fixed_time,
         )
         .expect("owner path must succeed");
@@ -1091,6 +1303,7 @@ mod tests {
             owner_vk,
             &invitee_sk,
             &authorized_member,
+            &test_member_info(&invitee_sk),
             fixed_time,
         );
 
@@ -1159,7 +1372,14 @@ mod tests {
 
         let snapshot = state.clone();
         let fixed_time = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
-        let _ = build_state_for_put(state, owner_vk, &invitee_sk, &authorized_member, fixed_time);
+        let _ = build_state_for_put(
+            state,
+            owner_vk,
+            &invitee_sk,
+            &authorized_member,
+            &test_member_info(&invitee_sk),
+            fixed_time,
+        );
 
         // The snapshot is what we passed in. The function consumes
         // `state` by value, so direct equality is the assertion that
@@ -1213,17 +1433,25 @@ mod tests {
         );
 
         let fixed_time = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+        let member_info = test_member_info(&invitee_sk);
         let (_, j1) = build_state_for_put(
             state.clone(),
             owner_vk,
             &invitee_sk,
             &authorized_member,
+            &member_info,
             fixed_time,
         )
         .expect("must succeed");
-        let (_, j2) =
-            build_state_for_put(state, owner_vk, &invitee_sk, &authorized_member, fixed_time)
-                .expect("must succeed");
+        let (_, j2) = build_state_for_put(
+            state,
+            owner_vk,
+            &invitee_sk,
+            &authorized_member,
+            &member_info,
+            fixed_time,
+        )
+        .expect("must succeed");
 
         let j1 = j1.expect("first synthesised join_event");
         let j2 = j2.expect("second synthesised join_event");

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -151,12 +151,14 @@ pub async fn handle_get_response(
             // `SealedBytes::public` seal — publishing a cleartext
             // nickname into a private room is a privacy leak.
             // `build_member_info_heal` re-publishes it, properly sealed,
-            // on a later GET once the secret has arrived.
+            // on a later GET once the secret has arrived. (The heal runs
+            // only on GET, not on the UPDATE that typically delivers the
+            // secret — tracked as issue #295.)
             let authorized_member_info: Option<AuthorizedMemberInfo> = {
                 let sealed_nickname = if retrieved_state.configuration.configuration.privacy_mode
                     == PrivacyMode::Private
                 {
-                    current_secret_from_state(&retrieved_state, &self_sk).map(
+                    crate::room_data::current_secret_from_state(&retrieved_state, &self_sk).map(
                         |(secret, version)| {
                             crate::util::ecies::seal_bytes(
                                 preferred_nickname.as_bytes(),
@@ -640,6 +642,13 @@ pub async fn handle_get_response(
                                 "Replacing placeholder state for imported room {:?} with network state",
                                 MemberId::from(owner_vk)
                             );
+                            // Note: for an imported room the member-info heal
+                            // entry was folded into `retrieved_state_for_put`
+                            // (the PUT payload), NOT into `retrieved_state`.
+                            // So this local `room_state` briefly lacks the
+                            // heal entry — self renders as "Unknown" locally
+                            // until the post-PUT subscription delivers the
+                            // network state back. Transient and self-healing.
                             room_data.room_state = retrieved_state;
                             room_data.capture_self_membership_data(&params);
                             // #251: a refresh/suspension GET on an imported room
@@ -722,6 +731,15 @@ pub async fn handle_get_response(
                                 e
                             ),
                         }
+                    } else {
+                        // No socket — the heal is dropped. Harmless: it is
+                        // idempotent and re-evaluated on the next GET, but
+                        // log it so a stranded user isn't a silent mystery.
+                        warn!(
+                            "WebAPI not available — member_info self-heal for room \
+                             {:?} skipped, will retry on the next GET",
+                            MemberId::from(owner_vk)
+                        );
                     }
                 }
             }
@@ -882,37 +900,6 @@ impl std::fmt::Display for BuildStateForPutError {
             ),
         }
     }
-}
-
-/// Decrypt the room's current-version secret out of a raw network
-/// `ChatRoomStateV1`, for a member who holds `self_sk`.
-///
-/// Mirrors the per-blob decrypt loop in
-/// `RoomData::repopulate_secrets_from_state`, but for the single
-/// current version and without needing a constructed `RoomData` — the
-/// invitation-accept PUT path must seal the joiner's nickname before
-/// any `RoomData` exists. Returns `None` on public rooms (no secret),
-/// when the blob for the current version hasn't been issued for this
-/// member yet, or when decryption fails.
-fn current_secret_from_state(
-    state: &ChatRoomStateV1,
-    self_sk: &ed25519_dalek::SigningKey,
-) -> Option<([u8; 32], u32)> {
-    let member_id = MemberId::from(&self_sk.verifying_key());
-    let version = state.secrets.current_version;
-    let blob = state
-        .secrets
-        .encrypted_secrets
-        .iter()
-        .find(|s| s.secret.member_id == member_id && s.secret.secret_version == version)?;
-    let secret = crate::util::ecies::decrypt_secret_from_member_blob_raw(
-        &blob.secret.ciphertext,
-        &blob.secret.nonce,
-        &blob.secret.sender_ephemeral_public_key,
-        self_sk,
-    )
-    .ok()?;
-    Some((secret, version))
 }
 
 /// Build the state payload to PUT after accepting an invitation.
@@ -1238,24 +1225,62 @@ mod tests {
             .expect("PUT state with injected member_info must verify");
     }
 
-    /// `current_secret_from_state` returns `None` for a room with no
-    /// encrypted secret for the member — a public room carries none, so
-    /// the invitation-accept PUT path public-seals the nickname (correct
-    /// for a public room, not a leak). This is the branch the official
-    /// (public) room's join path exercises.
+    /// `build_state_for_put` with `member_info: None` — the private-room
+    /// path where the room secret was unavailable to seal the nickname.
+    /// The member + join_event are still injected, but NO `member_info`
+    /// entry is added; the self-heal restores it (properly sealed) on a
+    /// later GET. A regression that re-added an unconditional
+    /// `member_info` push — the PR #272 mistake — would fail this test.
     #[test]
-    fn current_secret_from_state_none_without_blob() {
+    fn build_state_for_put_omits_member_info_when_none() {
         let mut rng = rand::thread_rng();
         let owner_sk = SigningKey::generate(&mut rng);
-        let member_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let owner_vk = owner_sk.verifying_key();
+        let invitee_vk = invitee_sk.verifying_key();
+
         let config = AuthorizedConfigurationV1::new(Configuration::default(), &owner_sk);
         let state = ChatRoomStateV1 {
             configuration: config,
             ..Default::default()
         };
+        let authorized_member = AuthorizedMember::new(
+            Member {
+                owner_member_id: owner_vk.into(),
+                invited_by: owner_vk.into(),
+                member_vk: invitee_vk,
+            },
+            &owner_sk,
+        );
+        let fixed_time = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+
+        let (put_state, join) = build_state_for_put(
+            state,
+            owner_vk,
+            &invitee_sk,
+            &authorized_member,
+            None,
+            fixed_time,
+        )
+        .expect("non-capacity invitee path must succeed");
+
+        let invitee_id = MemberId::from(&invitee_vk);
         assert!(
-            current_secret_from_state(&state, &member_sk).is_none(),
-            "no encrypted_secrets blob for the member → None"
+            put_state
+                .members
+                .members
+                .iter()
+                .any(|m| m.member.member_vk == invitee_vk),
+            "member is still injected even when member_info is None"
+        );
+        assert!(join.is_some(), "join_event is still synthesised");
+        assert!(
+            !put_state
+                .member_info
+                .member_info
+                .iter()
+                .any(|i| i.member_info.member_id == invitee_id),
+            "member_info must be omitted when None is passed"
         );
     }
 

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -209,206 +209,206 @@ pub async fn handle_get_response(
             // Update the room data
             crate::util::defer(move || {
                 ROOMS.with_mut(|rooms| {
-                // Accepting an invitation is an explicit rejoin — clear any
-                // prior leave tombstone for this room so the merge path
-                // doesn't silently filter the room out again later. See
-                // freenet/river#247.
-                rooms.removed_rooms.remove(&owner_vk);
+                    // Accepting an invitation is an explicit rejoin — clear any
+                    // prior leave tombstone for this room so the merge path
+                    // doesn't silently filter the room out again later. See
+                    // freenet/river#247.
+                    rooms.removed_rooms.remove(&owner_vk);
 
-                // Get the entry for this room
-                let entry = rooms.map.entry(owner_vk);
+                    // Get the entry for this room
+                    let entry = rooms.map.entry(owner_vk);
 
-                // Check if this is a new entry before inserting
-                let is_new_entry =
-                    matches!(entry, std::collections::hash_map::Entry::Vacant(_));
+                    // Check if this is a new entry before inserting
+                    let is_new_entry =
+                        matches!(entry, std::collections::hash_map::Entry::Vacant(_));
 
-                // Insert or get the existing room data
-                let room_data = entry.or_insert_with(|| {
-                    // Create new room data if it doesn't exist
-                    RoomData {
-                        owner_vk,
-                        room_state: retrieved_state.clone(),
-                        self_sk: self_sk.clone(),
-                        contract_key: key,
-                        last_read_message_id: None,
-                        secrets: std::collections::HashMap::new(),
-                        current_secret_version: None,
-                        last_secret_rotation: None,
-                        key_migrated_to_delegate: false, // Will be checked/migrated on startup
-                        self_authorized_member: None,
-                        invite_chain: vec![],
-                        self_member_info: None,
-                        previous_contract_key: None,
-                    }
-                });
+                    // Insert or get the existing room data
+                    let room_data = entry.or_insert_with(|| {
+                        // Create new room data if it doesn't exist
+                        RoomData {
+                            owner_vk,
+                            room_state: retrieved_state.clone(),
+                            self_sk: self_sk.clone(),
+                            contract_key: key,
+                            last_read_message_id: None,
+                            secrets: std::collections::HashMap::new(),
+                            current_secret_version: None,
+                            last_secret_rotation: None,
+                            key_migrated_to_delegate: false, // Will be checked/migrated on startup
+                            self_authorized_member: None,
+                            invite_chain: vec![],
+                            self_member_info: None,
+                            previous_contract_key: None,
+                        }
+                    });
 
-                // Clear previous_contract_key on successful GET — proves migration worked
-                if room_data.previous_contract_key.is_some() {
-                    room_data.previous_contract_key = None;
-                }
-
-                // If the room already existed, update self_sk and merge state
-                if !is_new_entry {
-                    // Only update self_sk if the user is NOT the room owner,
-                    // to avoid stripping owner privileges
-                    if room_data.self_sk.verifying_key() != owner_vk {
-                        room_data.self_sk = self_sk.clone();
-                        // Reset migration flag so the new key gets migrated
-                        room_data.key_migrated_to_delegate = false;
+                    // Clear previous_contract_key on successful GET — proves migration worked
+                    if room_data.previous_contract_key.is_some() {
+                        room_data.previous_contract_key = None;
                     }
 
-                    // Create parameters for merge
-                    let params = ChatRoomParametersV1 { owner: owner_vk };
+                    // If the room already existed, update self_sk and merge state
+                    if !is_new_entry {
+                        // Only update self_sk if the user is NOT the room owner,
+                        // to avoid stripping owner privileges
+                        if room_data.self_sk.verifying_key() != owner_vk {
+                            room_data.self_sk = self_sk.clone();
+                            // Reset migration flag so the new key gets migrated
+                            room_data.key_migrated_to_delegate = false;
+                        }
 
-                    // Clone current state to avoid borrow issues during merge
-                    let current_state = room_data.room_state.clone();
+                        // Create parameters for merge
+                        let params = ChatRoomParametersV1 { owner: owner_vk };
 
-                    // Merge the retrieved state into the existing state
-                    room_data
-                        .room_state
-                        .merge(&current_state, &params, &retrieved_state)
-                        .expect("Failed to merge room states");
-                }
+                        // Clone current state to avoid borrow issues during merge
+                        let current_state = room_data.room_state.clone();
 
-                // Decrypt ALL room secret versions if this is a private room
-                let decrypted = room_data.repopulate_secrets_from_state();
-                if room_data.is_private() {
-                    info!(
-                        "GET response: decrypted {} room secret(s) for member {:?}",
-                        decrypted, member_id
-                    );
-                }
+                        // Merge the retrieved state into the existing state
+                        room_data
+                            .room_state
+                            .merge(&current_state, &params, &retrieved_state)
+                            .expect("Failed to merge room states");
+                    }
 
-                // The invitee's `authorized_member_info` was built once
-                // above, before `build_state_for_put`, and moved into this
-                // closure. Reusing the SAME value here keeps the local
-                // ROOMS state and the PUT payload byte-identical — the
-                // same reuse discipline the synthesised join_event
-                // follows. (Re-sealing here would also be wrong for
-                // private rooms: each seal uses a fresh random nonce, so
-                // a re-built entry would not match the PUT's.)
+                    // Decrypt ALL room secret versions if this is a private room
+                    let decrypted = room_data.repopulate_secrets_from_state();
+                    if room_data.is_private() {
+                        info!(
+                            "GET response: decrypted {} room secret(s) for member {:?}",
+                            decrypted, member_id
+                        );
+                    }
 
-                // Store membership credentials for future rejoin after
-                // inactivity pruning.
-                room_data.self_authorized_member = Some(authorized_member.clone());
-                room_data.self_member_info = Some(authorized_member_info.clone());
-                // Capture invite chain from current state
-                if let Ok(chain) = room_data.room_state.members.get_invite_chain(
-                    &authorized_member,
-                    &ChatRoomParametersV1 { owner: owner_vk },
-                ) {
-                    room_data.invite_chain = chain;
-                }
+                    // The invitee's `authorized_member_info` was built once
+                    // above, before `build_state_for_put`, and moved into this
+                    // closure. Reusing the SAME value here keeps the local
+                    // ROOMS state and the PUT payload byte-identical — the
+                    // same reuse discipline the synthesised join_event
+                    // follows. (Re-sealing here would also be wrong for
+                    // private rooms: each seal uses a fresh random nonce, so
+                    // a re-built entry would not match the PUT's.)
 
-                // Apply membership immediately on invitation acceptance so
-                // that other room members see "X joined the room" right away
-                // (not deferred until the user's first message).
-                let self_vk = room_data.self_sk.verifying_key();
-                let already_member = self_vk == owner_vk
-                    || room_data
-                        .room_state
-                        .members
-                        .members
-                        .iter()
-                        .any(|m| m.member.member_vk == self_vk);
+                    // Store membership credentials for future rejoin after
+                    // inactivity pruning.
+                    room_data.self_authorized_member = Some(authorized_member.clone());
+                    room_data.self_member_info = Some(authorized_member_info.clone());
+                    // Capture invite chain from current state
+                    if let Ok(chain) = room_data.room_state.members.get_invite_chain(
+                        &authorized_member,
+                        &ChatRoomParametersV1 { owner: owner_vk },
+                    ) {
+                        room_data.invite_chain = chain;
+                    }
 
-                if !already_member {
-                    // Add member + any missing invite chain members
-                    let current_member_ids: std::collections::HashSet<_> = room_data
-                        .room_state
-                        .members
-                        .members
-                        .iter()
-                        .map(|m| m.member.id())
-                        .collect();
+                    // Apply membership immediately on invitation acceptance so
+                    // that other room members see "X joined the room" right away
+                    // (not deferred until the user's first message).
+                    let self_vk = room_data.self_sk.verifying_key();
+                    let already_member = self_vk == owner_vk
+                        || room_data
+                            .room_state
+                            .members
+                            .members
+                            .iter()
+                            .any(|m| m.member.member_vk == self_vk);
 
-                    room_data
-                        .room_state
-                        .members
-                        .members
-                        .push(authorized_member.clone());
-                    for chain_member in &room_data.invite_chain {
-                        if !current_member_ids.contains(&chain_member.member.id()) {
+                    if !already_member {
+                        // Add member + any missing invite chain members
+                        let current_member_ids: std::collections::HashSet<_> = room_data
+                            .room_state
+                            .members
+                            .members
+                            .iter()
+                            .map(|m| m.member.id())
+                            .collect();
+
+                        room_data
+                            .room_state
+                            .members
+                            .members
+                            .push(authorized_member.clone());
+                        for chain_member in &room_data.invite_chain {
+                            if !current_member_ids.contains(&chain_member.member.id()) {
+                                room_data
+                                    .room_state
+                                    .members
+                                    .members
+                                    .push(chain_member.clone());
+                            }
+                        }
+
+                        // Add member info
+                        room_data
+                            .room_state
+                            .member_info
+                            .member_info
+                            .push(authorized_member_info);
+
+                        // Append the same join_event we already injected into
+                        // the PUT payload (see `build_state_for_put`). Reusing
+                        // the exact `AuthorizedMessageV1` — same timestamp,
+                        // same signature, same MessageId — is critical: if we
+                        // signed a NEW join_event here with a fresh timestamp,
+                        // the local state and the PUT state would each carry a
+                        // separately-IDed "joined" entry, and the room would
+                        // surface two join events for a single acceptance once
+                        // the network state syncs back. See Codex review of
+                        // PR #272.
+                        if let Some(auth_join) = synthesised_join_event.clone() {
                             room_data
                                 .room_state
-                                .members
-                                .members
-                                .push(chain_member.clone());
+                                .recent_messages
+                                .messages
+                                .push(auth_join);
                         }
                     }
 
-                    // Add member info
-                    room_data
+                    // Rebuild actions_state from action messages (edit, delete, reaction)
+                    // This is needed because actions_state is #[serde(skip)] and not serialized
+                    let is_private = room_data
                         .room_state
-                        .member_info
-                        .member_info
-                        .push(authorized_member_info);
-
-                    // Append the same join_event we already injected into
-                    // the PUT payload (see `build_state_for_put`). Reusing
-                    // the exact `AuthorizedMessageV1` — same timestamp,
-                    // same signature, same MessageId — is critical: if we
-                    // signed a NEW join_event here with a fresh timestamp,
-                    // the local state and the PUT state would each carry a
-                    // separately-IDed "joined" entry, and the room would
-                    // surface two join events for a single acceptance once
-                    // the network state syncs back. See Codex review of
-                    // PR #272.
-                    if let Some(auth_join) = synthesised_join_event.clone() {
-                        room_data
+                        .configuration
+                        .configuration
+                        .privacy_mode
+                        == PrivacyMode::Private;
+                    if is_private {
+                        // Decrypt all private action messages using version-aware lookup
+                        let decrypted_actions: HashMap<MessageId, Vec<u8>> = room_data
                             .room_state
                             .recent_messages
                             .messages
-                            .push(auth_join);
+                            .iter()
+                            .filter(|msg| msg.message.content.is_action())
+                            .filter_map(|msg| {
+                                if let RoomMessageBody::Private {
+                                    ciphertext,
+                                    nonce,
+                                    secret_version,
+                                    ..
+                                } = &msg.message.content
+                                {
+                                    // Look up the secret for this message's version
+                                    room_data.get_secret_for_version(*secret_version).and_then(
+                                        |secret| {
+                                            decrypt_with_symmetric_key(secret, ciphertext, nonce)
+                                                .ok()
+                                                .map(|plaintext| (msg.id(), plaintext))
+                                        },
+                                    )
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect();
+
+                        room_data
+                            .room_state
+                            .recent_messages
+                            .rebuild_actions_state_with_decrypted(&decrypted_actions);
+                    } else {
+                        // Public room - rebuild from public action messages
+                        room_data.room_state.recent_messages.rebuild_actions_state();
                     }
-                }
-
-                // Rebuild actions_state from action messages (edit, delete, reaction)
-                // This is needed because actions_state is #[serde(skip)] and not serialized
-                let is_private = room_data
-                    .room_state
-                    .configuration
-                    .configuration
-                    .privacy_mode
-                    == PrivacyMode::Private;
-                if is_private {
-                    // Decrypt all private action messages using version-aware lookup
-                    let decrypted_actions: HashMap<MessageId, Vec<u8>> = room_data
-                        .room_state
-                        .recent_messages
-                        .messages
-                        .iter()
-                        .filter(|msg| msg.message.content.is_action())
-                        .filter_map(|msg| {
-                            if let RoomMessageBody::Private {
-                                ciphertext,
-                                nonce,
-                                secret_version,
-                                ..
-                            } = &msg.message.content
-                            {
-                                // Look up the secret for this message's version
-                                room_data.get_secret_for_version(*secret_version).and_then(
-                                    |secret| {
-                                        decrypt_with_symmetric_key(secret, ciphertext, nonce)
-                                            .ok()
-                                            .map(|plaintext| (msg.id(), plaintext))
-                                    },
-                                )
-                            } else {
-                                None
-                            }
-                        })
-                        .collect();
-
-                    room_data
-                        .room_state
-                        .recent_messages
-                        .rebuild_actions_state_with_decrypted(&decrypted_actions);
-                } else {
-                    // Public room - rebuild from public action messages
-                    room_data.room_state.recent_messages.rebuild_actions_state();
-                }
                 });
             });
 

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -143,40 +143,55 @@ pub async fn handle_get_response(
             // regression. The entry MUST be self-signed with the
             // invitee's own key; the room contract rejects member_info
             // signed by anyone else.
-            let preferred_nickname_sealed =
-                if retrieved_state.configuration.configuration.privacy_mode == PrivacyMode::Private
+            //
+            // A PRIVATE room's nickname must be encrypted. If the room
+            // secret is not yet available (the owner's encrypted-secret
+            // back-fill is asynchronous), we deliberately produce NO
+            // member_info rather than fall back to a plaintext
+            // `SealedBytes::public` seal — publishing a cleartext
+            // nickname into a private room is a privacy leak.
+            // `build_member_info_heal` re-publishes it, properly sealed,
+            // on a later GET once the secret has arrived.
+            let authorized_member_info: Option<AuthorizedMemberInfo> = {
+                let sealed_nickname = if retrieved_state.configuration.configuration.privacy_mode
+                    == PrivacyMode::Private
                 {
-                    match current_secret_from_state(&retrieved_state, &self_sk) {
-                        Some((secret, version)) => crate::util::ecies::seal_bytes(
-                            preferred_nickname.as_bytes(),
-                            &secret,
-                            version,
-                        ),
-                        None => {
-                            warn!(
-                            "Private room but no secret available to seal nickname, using public"
-                        );
-                            SealedBytes::public(preferred_nickname.as_bytes().to_vec())
-                        }
-                    }
+                    current_secret_from_state(&retrieved_state, &self_sk).map(
+                        |(secret, version)| {
+                            crate::util::ecies::seal_bytes(
+                                preferred_nickname.as_bytes(),
+                                &secret,
+                                version,
+                            )
+                        },
+                    )
                 } else {
-                    SealedBytes::public(preferred_nickname.as_bytes().to_vec())
+                    Some(SealedBytes::public(preferred_nickname.as_bytes().to_vec()))
                 };
-            let authorized_member_info = AuthorizedMemberInfo::new_with_member_key(
-                MemberInfo {
-                    member_id,
-                    version: 0,
-                    preferred_nickname: preferred_nickname_sealed,
-                },
-                &self_sk,
-            );
+                if sealed_nickname.is_none() {
+                    warn!(
+                        "Private room secret not available yet — deferring invitee \
+                         member_info to the self-heal path"
+                    );
+                }
+                sealed_nickname.map(|preferred_nickname| {
+                    AuthorizedMemberInfo::new_with_member_key(
+                        MemberInfo {
+                            member_id,
+                            version: 0,
+                            preferred_nickname,
+                        },
+                        &self_sk,
+                    )
+                })
+            };
 
             let (retrieved_state_for_put, synthesised_join_event) = match build_state_for_put(
                 retrieved_state.clone(),
                 owner_vk,
                 &self_sk,
                 &authorized_member,
-                &authorized_member_info,
+                authorized_member_info.as_ref(),
                 get_current_system_time(),
             ) {
                 Ok(v) => v,
@@ -289,9 +304,11 @@ pub async fn handle_get_response(
                     // a re-built entry would not match the PUT's.)
 
                     // Store membership credentials for future rejoin after
-                    // inactivity pruning.
+                    // inactivity pruning. `authorized_member_info` is `None`
+                    // only when a private room's secret was not yet available
+                    // to seal the nickname — see the build above.
                     room_data.self_authorized_member = Some(authorized_member.clone());
-                    room_data.self_member_info = Some(authorized_member_info.clone());
+                    room_data.self_member_info = authorized_member_info.clone();
                     // Capture invite chain from current state
                     if let Ok(chain) = room_data.room_state.members.get_invite_chain(
                         &authorized_member,
@@ -337,12 +354,17 @@ pub async fn handle_get_response(
                             }
                         }
 
-                        // Add member info
-                        room_data
-                            .room_state
-                            .member_info
-                            .member_info
-                            .push(authorized_member_info);
+                        // Add member info. Skipped only when the private-room
+                        // secret was unavailable to seal the nickname (see the
+                        // build above); the self-heal restores it, properly
+                        // sealed, once the secret arrives.
+                        if let Some(member_info) = authorized_member_info {
+                            room_data
+                                .room_state
+                                .member_info
+                                .member_info
+                                .push(member_info);
+                        }
 
                         // Append the same join_event we already injected into
                         // the PUT payload (see `build_state_for_put`). Reusing
@@ -566,13 +588,12 @@ pub async fn handle_get_response(
                 needs_put_subscribe
             );
             let retrieved_state: ChatRoomStateV1 = from_cbor_slice::<ChatRoomStateV1>(&state);
-            let retrieved_state_for_put = retrieved_state.clone();
 
             // Member-info self-heal — remediation for the PR #272 stranding.
             // If the freshly-GET'd canonical state shows us in `members`
             // with no matching `member_info` entry, every other peer
             // renders us as "Unknown". Detect it from the raw network
-            // state and re-publish our own self-signed member_info below.
+            // state and re-publish our own self-signed member_info.
             // Idempotent: once the entry lands, later GETs no longer see
             // the stranding and the heal stops firing.
             let member_info_heal: Option<AuthorizedMemberInfo> = ROOMS
@@ -580,6 +601,22 @@ pub async fn handle_get_response(
                 .map
                 .get(&owner_vk)
                 .and_then(|rd| rd.build_member_info_heal(&retrieved_state));
+
+            // For an imported room the heal must ride along in the PUT
+            // below: a standalone UPDATE sent before that PUT registers
+            // the contract code with the local node would be rejected
+            // ("missing contract parameters"). An already-subscribed room
+            // has no PUT, so its heal goes out as a standalone UPDATE
+            // further down.
+            let mut retrieved_state_for_put = retrieved_state.clone();
+            if needs_put_subscribe {
+                if let Some(heal) = &member_info_heal {
+                    retrieved_state_for_put
+                        .member_info
+                        .member_info
+                        .push(heal.clone());
+                }
+            }
 
             crate::util::defer(move || {
                 ROOMS.with_mut(|rooms| {
@@ -650,35 +687,41 @@ pub async fn handle_get_response(
                 });
             });
 
-            // Send the member-info self-heal UPDATE (see the detection
-            // above). A dedicated member_info-only delta — independent of
+            // Send the member-info self-heal as a standalone UPDATE — but
+            // ONLY for an already-subscribed room. For an imported room
+            // (`needs_put_subscribe`) the heal was folded into the PUT
+            // payload above instead; sending an UPDATE before that PUT
+            // registers the contract code locally would drop it. A
+            // dedicated member_info-only delta is used here rather than
             // the normal last_synced_state diff path, which can believe
             // the entry is already synced when the network never received
             // it. The delta is self-signed and idempotent, so re-sending
             // it is harmless if it raced another heal.
-            if let Some(heal_info) = member_info_heal {
-                let heal_delta = ChatRoomStateV1Delta {
-                    member_info: Some(vec![heal_info]),
-                    ..Default::default()
-                };
-                let update_request = ContractRequest::Update {
-                    key,
-                    data: UpdateData::Delta(to_cbor_vec(&heal_delta).into()),
-                };
-                if let Some(web_api) = WEB_API.write().as_mut() {
-                    match web_api
-                        .send(ClientRequest::ContractOp(update_request))
-                        .await
-                    {
-                        Ok(_) => info!(
-                            "Sent member_info self-heal UPDATE for room {:?}",
-                            MemberId::from(owner_vk)
-                        ),
-                        Err(e) => warn!(
-                            "Failed to send member_info self-heal for room {:?}: {}",
-                            MemberId::from(owner_vk),
-                            e
-                        ),
+            if !needs_put_subscribe {
+                if let Some(heal_info) = member_info_heal {
+                    let heal_delta = ChatRoomStateV1Delta {
+                        member_info: Some(vec![heal_info]),
+                        ..Default::default()
+                    };
+                    let update_request = ContractRequest::Update {
+                        key,
+                        data: UpdateData::Delta(to_cbor_vec(&heal_delta).into()),
+                    };
+                    if let Some(web_api) = WEB_API.write().as_mut() {
+                        match web_api
+                            .send(ClientRequest::ContractOp(update_request))
+                            .await
+                        {
+                            Ok(_) => info!(
+                                "Sent member_info self-heal UPDATE for room {:?}",
+                                MemberId::from(owner_vk)
+                            ),
+                            Err(e) => warn!(
+                                "Failed to send member_info self-heal for room {:?}: {}",
+                                MemberId::from(owner_vk),
+                                e
+                            ),
+                        }
                     }
                 }
             }
@@ -921,7 +964,7 @@ pub(crate) fn build_state_for_put(
     owner_vk: ed25519_dalek::VerifyingKey,
     invitee_sk: &ed25519_dalek::SigningKey,
     authorized_member: &river_core::room_state::member::AuthorizedMember,
-    member_info: &AuthorizedMemberInfo,
+    member_info: Option<&AuthorizedMemberInfo>,
     time: std::time::SystemTime,
 ) -> Result<(ChatRoomStateV1, Option<AuthorizedMessageV1>), BuildStateForPutError> {
     let self_vk = invitee_sk.verifying_key();
@@ -974,7 +1017,14 @@ pub(crate) fn build_state_for_put(
     // PUT state and local state byte-identical. The entry is self-signed
     // by the invitee — the room contract rejects member_info signed by
     // any other key.
-    state.member_info.member_info.push(member_info.clone());
+    //
+    // `member_info` is `None` only when the room is private and its
+    // secret was not yet available to seal the nickname: we publish no
+    // member_info rather than leak a plaintext nickname, and the
+    // self-heal (`build_member_info_heal`) restores it on a later GET.
+    if let Some(member_info) = member_info {
+        state.member_info.member_info.push(member_info.clone());
+    }
 
     let join_msg = MessageV1 {
         room_owner: MemberId::from(owner_vk),
@@ -1049,7 +1099,7 @@ mod tests {
             owner_vk,
             &invitee_sk,
             &authorized_member,
-            &test_member_info(&invitee_sk),
+            Some(&test_member_info(&invitee_sk)),
             fixed_time,
         )
         .expect("non-capacity invitee path must succeed");
@@ -1150,7 +1200,7 @@ mod tests {
             owner_vk,
             &invitee_sk,
             &authorized_member,
-            &member_info,
+            Some(&member_info),
             fixed_time,
         )
         .expect("non-capacity invitee path must succeed");
@@ -1188,6 +1238,27 @@ mod tests {
             .expect("PUT state with injected member_info must verify");
     }
 
+    /// `current_secret_from_state` returns `None` for a room with no
+    /// encrypted secret for the member — a public room carries none, so
+    /// the invitation-accept PUT path public-seals the nickname (correct
+    /// for a public room, not a leak). This is the branch the official
+    /// (public) room's join path exercises.
+    #[test]
+    fn current_secret_from_state_none_without_blob() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let member_sk = SigningKey::generate(&mut rng);
+        let config = AuthorizedConfigurationV1::new(Configuration::default(), &owner_sk);
+        let state = ChatRoomStateV1 {
+            configuration: config,
+            ..Default::default()
+        };
+        assert!(
+            current_secret_from_state(&state, &member_sk).is_none(),
+            "no encrypted_secrets blob for the member → None"
+        );
+    }
+
     /// Owner PUTting their own state must NOT have anything synthesised
     /// — they're not joining their own room.
     #[test]
@@ -1219,7 +1290,7 @@ mod tests {
             owner_vk,
             &owner_sk,
             &authorized_member,
-            &test_member_info(&owner_sk),
+            Some(&test_member_info(&owner_sk)),
             fixed_time,
         )
         .expect("owner path must succeed");
@@ -1303,7 +1374,7 @@ mod tests {
             owner_vk,
             &invitee_sk,
             &authorized_member,
-            &test_member_info(&invitee_sk),
+            Some(&test_member_info(&invitee_sk)),
             fixed_time,
         );
 
@@ -1377,7 +1448,7 @@ mod tests {
             owner_vk,
             &invitee_sk,
             &authorized_member,
-            &test_member_info(&invitee_sk),
+            Some(&test_member_info(&invitee_sk)),
             fixed_time,
         );
 
@@ -1439,7 +1510,7 @@ mod tests {
             owner_vk,
             &invitee_sk,
             &authorized_member,
-            &member_info,
+            Some(&member_info),
             fixed_time,
         )
         .expect("must succeed");
@@ -1448,7 +1519,7 @@ mod tests {
             owner_vk,
             &invitee_sk,
             &authorized_member,
-            &member_info,
+            Some(&member_info),
             fixed_time,
         )
         .expect("must succeed");

--- a/ui/src/components/room_list/receive_invitation_modal.rs
+++ b/ui/src/components/room_list/receive_invitation_modal.rs
@@ -596,10 +596,10 @@ fn render_new_invitation(inv: Invitation, invitation: Signal<Option<Invitation>>
     let inv_for_accept = inv.clone();
     let inv_for_enter = inv.clone();
 
-    // Generate a default nickname from the member's key
-    let encoded = bs58::encode(inv.invitee.member.member_vk.as_bytes()).into_string();
-    let shortened = encoded.chars().take(6).collect::<String>();
-    let default_nickname = format!("User-{}", shortened);
+    // Generate a default handle from the member's key (deterministic —
+    // same key always yields the same handle).
+    let default_nickname =
+        crate::nickname::generate_default_nickname(&inv.invitee.member.member_vk);
 
     // Create a signal for the nickname
     let mut nickname = use_signal(|| default_nickname);
@@ -669,10 +669,8 @@ fn accept_invitation(inv: Invitation, nickname: String) {
 
     // Use the user-provided nickname
     let nickname = if nickname.trim().is_empty() {
-        // Fallback to generated nickname if somehow empty
-        let encoded = bs58::encode(authorized_member.member.member_vk.as_bytes()).into_string();
-        let shortened = encoded.chars().take(6).collect::<String>();
-        format!("User-{}", shortened)
+        // Fallback to generated handle if somehow empty
+        crate::nickname::generate_default_nickname(&authorized_member.member.member_vk)
     } else {
         nickname
     };

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -7,6 +7,7 @@ mod constants;
 #[cfg(feature = "example-data")]
 mod example_data;
 mod invites;
+mod nickname;
 #[allow(dead_code)]
 mod pending_invites;
 mod room_data;

--- a/ui/src/nickname.rs
+++ b/ui/src/nickname.rs
@@ -1,0 +1,138 @@
+//! Default nickname generation.
+//!
+//! When a member joins a room without typing a nickname, River assigns one
+//! automatically. The old scheme produced `User-<6 base58 chars>` (e.g.
+//! `User-a3F9bX`), which reads like a spam account or an error.
+//!
+//! Instead we deterministically derive a 90s-hacker-culture handle (think
+//! *Hackers*, *The Matrix*, *Sneakers*) from the member's verifying key:
+//! one word from [`FIRST_NAMES`], one from [`LAST_NAMES`], e.g. "Cipher
+//! Daylight". The derivation is a pure function of the key, so — exactly
+//! like the old `User-XYZ` scheme — the same member always gets the same
+//! handle, with no stored state and no RNG. That property matters: the
+//! member-info self-heal path regenerates this name and must land on the
+//! same value every time.
+
+use ed25519_dalek::VerifyingKey;
+
+/// First half of the handle. Exactly 30 entries — see `pools_are_30` test.
+pub const FIRST_NAMES: [&str; 30] = [
+    "Acid", "Zero", "Crash", "Cyber", "Ghost", "Neon", "Razor", "Static", "Phantom", "Chrome",
+    "Glitch", "Cipher", "Daemon", "Null", "Hex", "Rogue", "Vapor", "Plasma", "Volt", "Frost",
+    "Quantum", "Binary", "Proxy", "Logic", "Echo", "Pixel", "Neural", "Photon", "Onyx", "Cobalt",
+];
+
+/// Second half of the handle. Exactly 30 entries — see `pools_are_30` test.
+pub const LAST_NAMES: [&str; 30] = [
+    "Override",
+    "Phreak",
+    "Wraith",
+    "Surge",
+    "Spike",
+    "Pulse",
+    "Breaker",
+    "Worm",
+    "Drift",
+    "Storm",
+    "Specter",
+    "Cascade",
+    "Cortex",
+    "Reaper",
+    "Circuit",
+    "Modem",
+    "Kernel",
+    "Daylight",
+    "Vector",
+    "Falcon",
+    "Raven",
+    "Socket",
+    "Glider",
+    "Nomad",
+    "Sentinel",
+    "Havoc",
+    "Relay",
+    "Vertex",
+    "Payload",
+    "Mainframe",
+];
+
+/// Fold a byte slice into a stable index seed (simple polynomial hash).
+fn fold(bytes: &[u8]) -> usize {
+    bytes.iter().fold(0usize, |acc, &b| {
+        acc.wrapping_mul(31).wrapping_add(b as usize)
+    })
+}
+
+/// Derive a deterministic default handle (e.g. "Cipher Daylight") from a
+/// member's verifying key. Pure function of the key — same key in, same
+/// handle out, every time.
+pub fn generate_default_nickname(vk: &VerifyingKey) -> String {
+    let bytes = vk.as_bytes();
+    // Use disjoint key halves for the two indices so the first and last
+    // word vary independently.
+    let first = FIRST_NAMES[fold(&bytes[0..16]) % FIRST_NAMES.len()];
+    let last = LAST_NAMES[fold(&bytes[16..32]) % LAST_NAMES.len()];
+    format!("{first} {last}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    #[test]
+    fn pools_are_30() {
+        // The doc-comments and the deterministic-distribution reasoning
+        // both assume 30x30 = 900 combinations.
+        assert_eq!(FIRST_NAMES.len(), 30);
+        assert_eq!(LAST_NAMES.len(), 30);
+    }
+
+    #[test]
+    fn is_deterministic() {
+        let mut rng = rand::thread_rng();
+        let sk = SigningKey::generate(&mut rng);
+        let vk = sk.verifying_key();
+        // Same key must always produce the same handle — the self-heal
+        // path relies on this.
+        assert_eq!(
+            generate_default_nickname(&vk),
+            generate_default_nickname(&vk)
+        );
+    }
+
+    #[test]
+    fn handle_is_two_words_from_the_pools() {
+        let mut rng = rand::thread_rng();
+        for _ in 0..200 {
+            let sk = SigningKey::generate(&mut rng);
+            let name = generate_default_nickname(&sk.verifying_key());
+            let (first, last) = name
+                .split_once(' ')
+                .expect("handle is two space-separated words");
+            assert!(
+                FIRST_NAMES.contains(&first),
+                "unexpected first word: {first}"
+            );
+            assert!(LAST_NAMES.contains(&last), "unexpected last word: {last}");
+        }
+    }
+
+    #[test]
+    fn distinct_keys_mostly_distinct_handles() {
+        // Not a guarantee (900 combos, birthday paradox), but a sanity
+        // check that the fold actually spreads keys around.
+        let mut rng = rand::thread_rng();
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..50 {
+            let sk = SigningKey::generate(&mut rng);
+            seen.insert(generate_default_nickname(&sk.verifying_key()));
+        }
+        // 50 keys into 900 buckets: expect well over half unique.
+        assert!(
+            seen.len() > 30,
+            "fold barely spread keys: {} unique",
+            seen.len()
+        );
+    }
+}

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -521,10 +521,16 @@ impl RoomData {
     /// produces — using `self_sk`. It cannot be done owner-side or for
     /// any other member.
     ///
-    /// The nickname is taken, in priority order, from the stored
-    /// `self_member_info`, then any local `member_info` entry, then a
-    /// freshly-generated deterministic default handle — so a user who
-    /// already picked a nickname keeps it.
+    /// For a **public** room the nickname is taken, in priority order,
+    /// from the stored `self_member_info`, then any local `member_info`
+    /// entry, then a freshly-generated deterministic default handle — so
+    /// a user who already picked a nickname keeps it.
+    ///
+    /// For a **private** room the nickname must be encrypted: a stored
+    /// entry is reused only if already `Private`-sealed, otherwise a
+    /// fresh `Private`-sealed default handle is minted. If the room
+    /// secret is not yet available this returns `None` (deferring the
+    /// heal) rather than publish a plaintext nickname.
     pub fn build_member_info_heal(&self, state: &ChatRoomStateV1) -> Option<AuthorizedMemberInfo> {
         let self_vk = self.self_sk.verifying_key();
         if self_vk == self.owner_vk {
@@ -549,7 +555,43 @@ impl RoomData {
             return None; // already present — not stranded
         }
 
-        // Stranded. Re-publish our own member_info, preferring an
+        // Stranded — re-publish our own member_info.
+        //
+        // A PRIVATE room's nickname must be encrypted. We must never
+        // publish a `SealedBytes::Public` (plaintext) nickname into one,
+        // so: a stored entry is reusable only if it is already
+        // Private-sealed; otherwise we mint a fresh Private-sealed
+        // default handle, and if the room secret is not yet available we
+        // defer the heal entirely (return `None`) rather than leak a
+        // plaintext nickname — the member stays "Unknown" until a later
+        // GET when the secret has arrived.
+        if self.is_private() {
+            if let Some(stored) = &self.self_member_info {
+                if matches!(
+                    stored.member_info.preferred_nickname,
+                    SealedBytes::Private { .. }
+                ) {
+                    return Some(stored.clone());
+                }
+            }
+            let (secret, version) = self.get_secret()?;
+            let nickname = crate::nickname::generate_default_nickname(&self_vk);
+            // version: 0 is safe — the heal only fires when no member_info
+            // entry exists on the network (the `has_member_info` check
+            // above), so this is never version-compared against an
+            // existing entry.
+            let info = MemberInfo {
+                member_id,
+                version: 0,
+                preferred_nickname: seal_bytes(nickname.as_bytes(), secret, version),
+            };
+            return Some(AuthorizedMemberInfo::new_with_member_key(
+                info,
+                &self.self_sk,
+            ));
+        }
+
+        // Public room — a public nickname is not sensitive. Prefer an
         // already-known entry so the user keeps their chosen nickname.
         if let Some(stored) = &self.self_member_info {
             return Some(stored.clone());
@@ -566,15 +608,12 @@ impl RoomData {
         }
 
         // No nickname on record — assign a deterministic default handle.
+        // version: 0 is safe for the reason noted in the private branch.
         let nickname = crate::nickname::generate_default_nickname(&self_vk);
-        let preferred_nickname = match (self.is_private(), self.get_secret()) {
-            (true, Some((secret, version))) => seal_bytes(nickname.as_bytes(), secret, version),
-            _ => SealedBytes::public(nickname.into_bytes()),
-        };
         let info = MemberInfo {
             member_id,
             version: 0,
-            preferred_nickname,
+            preferred_nickname: SealedBytes::public(nickname.into_bytes()),
         };
         Some(AuthorizedMemberInfo::new_with_member_key(
             info,
@@ -1524,6 +1563,12 @@ mod tests {
             .expect("stranded member must produce a heal entry");
         assert_eq!(heal.member_info.member_id, MemberId::from(&invitee_vk));
         assert_eq!(heal.member_info.version, 0);
+        // The healed entry must be a valid self-signed AuthorizedMemberInfo
+        // — the room contract only accepts member_info self-signed by the
+        // member's own key. A heal signed with the wrong key would be
+        // silently rejected by the contract.
+        heal.verify_signature_with_key(&invitee_vk)
+            .expect("healed entry must be self-signed by the member");
     }
 
     #[test]
@@ -1595,6 +1640,59 @@ mod tests {
             .build_member_info_heal(&network_state)
             .expect("stranded member must produce a heal entry");
         assert_eq!(heal.member_info.version, 7);
+    }
+
+    #[test]
+    fn build_member_info_heal_private_room_seals_when_secret_available() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let member_sk = SigningKey::generate(&mut rng);
+
+        // Private room; `member_sk` is in `members` with no member_info
+        // (stranded) and the v0 secret is available. self is the member.
+        let mut room = make_private_owner_room(&owner_sk, &member_sk);
+        room.self_sk = member_sk.clone();
+        assert!(room.is_private());
+        assert!(room.get_secret().is_some());
+
+        let network_state = room.room_state.clone();
+        let heal = room
+            .build_member_info_heal(&network_state)
+            .expect("stranded private-room member with a secret must heal");
+        // The nickname MUST be encrypted — never a plaintext Public seal.
+        assert!(
+            matches!(
+                heal.member_info.preferred_nickname,
+                SealedBytes::Private { .. }
+            ),
+            "private-room heal must produce a Private-sealed nickname"
+        );
+        heal.verify_signature_with_key(&member_sk.verifying_key())
+            .expect("healed entry must be self-signed by the member");
+    }
+
+    #[test]
+    fn build_member_info_heal_private_room_defers_without_secret() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let member_sk = SigningKey::generate(&mut rng);
+
+        let mut room = make_private_owner_room(&owner_sk, &member_sk);
+        room.self_sk = member_sk.clone();
+        // Drop the secret — simulates the owner's encrypted-secret
+        // back-fill not having arrived yet.
+        room.secrets.clear();
+        room.current_secret_version = None;
+        assert!(room.get_secret().is_none());
+
+        let network_state = room.room_state.clone();
+        // No secret to seal the nickname → the heal must defer (return
+        // None) rather than publish a plaintext nickname into a private
+        // room. The member stays "Unknown" until a later GET.
+        assert!(
+            room.build_member_info_heal(&network_state).is_none(),
+            "private-room heal must defer when the room secret is unavailable"
+        );
     }
 
     /// Builds a private owner-mode room with one invited member, populated

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -1808,6 +1808,43 @@ mod tests {
     }
 
     #[test]
+    fn build_member_info_heal_reads_secret_from_state_not_self() {
+        // Pins the secret-SOURCE half of the round-3 fix: the heal must
+        // derive the room secret from the network `state`, NOT from
+        // `self.get_secret()`. For an imported room `self.secrets` is
+        // empty at heal-build time (it is repopulated later in a deferred
+        // closure) while the secret blob lives in the fetched `state`.
+        // Reverting the heal to `self.get_secret()` makes this test fail.
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let member_sk = SigningKey::generate(&mut rng);
+        let mut room = make_private_owner_room(&owner_sk, &member_sk);
+        room.self_sk = member_sk.clone();
+        let v0_secret = *room.secrets.get(&0).expect("v0 secret seeded");
+        append_encrypted_secret_for(
+            &mut room.room_state,
+            &owner_sk,
+            &member_sk.verifying_key(),
+            &v0_secret,
+            0,
+        );
+        let network_state = room.room_state.clone();
+        // Imported-room reality: self.secrets is empty; the secret lives
+        // only in the network `state`.
+        room.secrets.clear();
+        room.current_secret_version = None;
+        assert!(room.get_secret().is_none());
+
+        let heal = room
+            .build_member_info_heal(&network_state)
+            .expect("heal must seal using the secret from the network state");
+        assert!(matches!(
+            heal.member_info.preferred_nickname,
+            SealedBytes::Private { .. }
+        ));
+    }
+
+    #[test]
     fn current_secret_from_state_none_without_blob() {
         let mut rng = rand::thread_rng();
         let owner_sk = SigningKey::generate(&mut rng);

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -84,6 +84,38 @@ pub struct RoomData {
     pub previous_contract_key: Option<ContractKey>,
 }
 
+/// Decrypt the room's current-version secret out of a raw network
+/// `ChatRoomStateV1`, for the member who holds `self_sk`.
+///
+/// Mirrors the per-blob decrypt loop in
+/// [`RoomData::repopulate_secrets_from_state`], but for the single
+/// current version and reading straight from the supplied `state` —
+/// callers (the invitation-accept PUT path, `build_member_info_heal`)
+/// need the secret derived from the freshly-fetched NETWORK state, not
+/// from a possibly-stale `RoomData`. Returns `None` for a public room
+/// (no secret), when the blob for the current version has not been
+/// issued for this member yet, or when decryption fails.
+pub(crate) fn current_secret_from_state(
+    state: &ChatRoomStateV1,
+    self_sk: &SigningKey,
+) -> Option<([u8; 32], u32)> {
+    let member_id = MemberId::from(&self_sk.verifying_key());
+    let version = state.secrets.current_version;
+    let blob = state
+        .secrets
+        .encrypted_secrets
+        .iter()
+        .find(|s| s.secret.member_id == member_id && s.secret.secret_version == version)?;
+    let secret = decrypt_secret_from_member_blob_raw(
+        &blob.secret.ciphertext,
+        &blob.secret.nonce,
+        &blob.secret.sender_ephemeral_public_key,
+        self_sk,
+    )
+    .ok()?;
+    Some((secret, version))
+}
+
 impl RoomData {
     /// Regenerate the contract_key from the owner_vk using the current WASM.
     /// This ensures the contract_key always matches the bundled WASM, which may
@@ -521,16 +553,20 @@ impl RoomData {
     /// produces — using `self_sk`. It cannot be done owner-side or for
     /// any other member.
     ///
-    /// For a **public** room the nickname is taken, in priority order,
-    /// from the stored `self_member_info`, then any local `member_info`
-    /// entry, then a freshly-generated deterministic default handle — so
-    /// a user who already picked a nickname keeps it.
+    /// Privacy mode and the room secret are read from the supplied
+    /// network `state`, never from `self` — for an imported room `self`'s
+    /// `room_state`/`secrets` are a stale public placeholder at the time
+    /// this runs, and trusting them would mis-seal a private nickname.
+    ///
+    /// For a **public** room the nickname is taken from the stored
+    /// `self_member_info` if present (so a user who already picked a
+    /// nickname keeps it), else a freshly-generated default handle.
     ///
     /// For a **private** room the nickname must be encrypted: a stored
     /// entry is reused only if already `Private`-sealed, otherwise a
     /// fresh `Private`-sealed default handle is minted. If the room
-    /// secret is not yet available this returns `None` (deferring the
-    /// heal) rather than publish a plaintext nickname.
+    /// secret is not yet present in `state` this returns `None`
+    /// (deferring the heal) rather than publish a plaintext nickname.
     pub fn build_member_info_heal(&self, state: &ChatRoomStateV1) -> Option<AuthorizedMemberInfo> {
         let self_vk = self.self_sk.verifying_key();
         if self_vk == self.owner_vk {
@@ -557,15 +593,22 @@ impl RoomData {
 
         // Stranded — re-publish our own member_info.
         //
-        // A PRIVATE room's nickname must be encrypted. We must never
-        // publish a `SealedBytes::Public` (plaintext) nickname into one,
-        // so: a stored entry is reusable only if it is already
-        // Private-sealed; otherwise we mint a fresh Private-sealed
-        // default handle, and if the room secret is not yet available we
-        // defer the heal entirely (return `None`) rather than leak a
-        // plaintext nickname — the member stays "Unknown" until a later
-        // GET when the secret has arrived.
-        if self.is_private() {
+        // Privacy mode and the room secret are read from the freshly-
+        // fetched network `state`, NOT from `self.room_state` /
+        // `self.secrets` / `self.get_secret()`. For an imported room
+        // those reflect a stale public placeholder and an empty secret
+        // map at heal-build time (the merge runs later, in a deferred
+        // closure), so trusting `self` would misclassify a private room
+        // as public and seal the nickname in plaintext.
+        let is_private = state.configuration.configuration.privacy_mode == PrivacyMode::Private;
+
+        // A PRIVATE room's nickname must be encrypted. A stored entry is
+        // reusable only if it is already Private-sealed; otherwise mint a
+        // fresh Private-sealed default handle, and if the room secret is
+        // not yet present in `state` defer the heal entirely (return
+        // `None`) rather than leak a plaintext nickname — the member
+        // stays "Unknown" until a later GET once the secret has arrived.
+        if is_private {
             if let Some(stored) = &self.self_member_info {
                 if matches!(
                     stored.member_info.preferred_nickname,
@@ -574,16 +617,16 @@ impl RoomData {
                     return Some(stored.clone());
                 }
             }
-            let (secret, version) = self.get_secret()?;
+            let (secret, version) = current_secret_from_state(state, &self.self_sk)?;
             let nickname = crate::nickname::generate_default_nickname(&self_vk);
             // version: 0 is safe — the heal only fires when no member_info
-            // entry exists on the network (the `has_member_info` check
+            // entry exists in `state` (the `has_member_info` check
             // above), so this is never version-compared against an
             // existing entry.
             let info = MemberInfo {
                 member_id,
                 version: 0,
-                preferred_nickname: seal_bytes(nickname.as_bytes(), secret, version),
+                preferred_nickname: seal_bytes(nickname.as_bytes(), &secret, version),
             };
             return Some(AuthorizedMemberInfo::new_with_member_key(
                 info,
@@ -595,16 +638,6 @@ impl RoomData {
         // already-known entry so the user keeps their chosen nickname.
         if let Some(stored) = &self.self_member_info {
             return Some(stored.clone());
-        }
-        if let Some(local) = self
-            .room_state
-            .member_info
-            .member_info
-            .iter()
-            .filter(|i| i.member_info.member_id == member_id)
-            .max_by_key(|i| i.member_info.version)
-        {
-            return Some(local.clone());
         }
 
         // No nickname on record — assign a deterministic default handle.
@@ -1649,11 +1682,20 @@ mod tests {
         let member_sk = SigningKey::generate(&mut rng);
 
         // Private room; `member_sk` is in `members` with no member_info
-        // (stranded) and the v0 secret is available. self is the member.
+        // (stranded). self is the member.
         let mut room = make_private_owner_room(&owner_sk, &member_sk);
         room.self_sk = member_sk.clone();
-        assert!(room.is_private());
-        assert!(room.get_secret().is_some());
+        // The heal reads the secret from the network `state` it is given,
+        // so that state must carry an encrypted-secret blob for the
+        // member (the heal does NOT trust `self.secrets`).
+        let v0_secret = *room.secrets.get(&0).expect("v0 secret seeded");
+        append_encrypted_secret_for(
+            &mut room.room_state,
+            &owner_sk,
+            &member_sk.verifying_key(),
+            &v0_secret,
+            0,
+        );
 
         let network_state = room.room_state.clone();
         let heal = room
@@ -1677,22 +1719,134 @@ mod tests {
         let owner_sk = SigningKey::generate(&mut rng);
         let member_sk = SigningKey::generate(&mut rng);
 
+        // Private room, member stranded — but the network state carries
+        // NO encrypted-secret blob for the member (the owner's back-fill
+        // has not arrived yet). make_private_owner_room seeds only
+        // `secrets.versions`, not `encrypted_secrets`.
         let mut room = make_private_owner_room(&owner_sk, &member_sk);
         room.self_sk = member_sk.clone();
-        // Drop the secret — simulates the owner's encrypted-secret
-        // back-fill not having arrived yet.
-        room.secrets.clear();
-        room.current_secret_version = None;
-        assert!(room.get_secret().is_none());
 
         let network_state = room.room_state.clone();
-        // No secret to seal the nickname → the heal must defer (return
-        // None) rather than publish a plaintext nickname into a private
-        // room. The member stays "Unknown" until a later GET.
+        // No secret in `state` to seal the nickname → the heal must defer
+        // (return None) rather than publish a plaintext nickname into a
+        // private room. The member stays "Unknown" until a later GET.
         assert!(
             room.build_member_info_heal(&network_state).is_none(),
             "private-room heal must defer when the room secret is unavailable"
         );
+    }
+
+    #[test]
+    fn build_member_info_heal_private_room_uses_network_privacy_not_local_placeholder() {
+        // Regression for the round-2 review (Codex P1 / skeptical H1):
+        // an imported room's LOCAL room_state is a public placeholder, so
+        // the heal must read privacy mode from the network `state`, not
+        // from `self`. With a public local placeholder but a PRIVATE
+        // network state and no secret blob, the heal must DEFER — never
+        // mint a plaintext Public-sealed nickname.
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let member_sk = SigningKey::generate(&mut rng);
+
+        // `self` carries a public placeholder room_state...
+        let mut room = make_rejoin_test_room(&owner_sk, &member_sk, true);
+        assert!(!room.is_private(), "local placeholder is public");
+        room.self_member_info = None;
+
+        // ...but the network state is a PRIVATE room with the member
+        // stranded and no secret blob.
+        let private_state = make_private_owner_room(&owner_sk, &member_sk).room_state;
+
+        assert!(
+            room.build_member_info_heal(&private_state).is_none(),
+            "heal must read privacy from the network state and defer — \
+             trusting the local public placeholder would leak a plaintext \
+             nickname into a private room"
+        );
+    }
+
+    #[test]
+    fn build_member_info_heal_private_room_ignores_public_sealed_stored_entry() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let member_sk = SigningKey::generate(&mut rng);
+
+        let mut room = make_private_owner_room(&owner_sk, &member_sk);
+        room.self_sk = member_sk.clone();
+        let v0_secret = *room.secrets.get(&0).expect("v0 secret seeded");
+        append_encrypted_secret_for(
+            &mut room.room_state,
+            &owner_sk,
+            &member_sk.verifying_key(),
+            &v0_secret,
+            0,
+        );
+
+        // A stored entry whose nickname is PUBLIC-sealed must NOT be
+        // reused in a private room — reusing it would publish plaintext.
+        let public_entry = MemberInfo {
+            member_id: MemberId::from(&member_sk.verifying_key()),
+            version: 3,
+            preferred_nickname: SealedBytes::public(b"PlainName".to_vec()),
+        };
+        room.self_member_info = Some(AuthorizedMemberInfo::new_with_member_key(
+            public_entry,
+            &member_sk,
+        ));
+
+        let network_state = room.room_state.clone();
+        let heal = room
+            .build_member_info_heal(&network_state)
+            .expect("private-room member with a secret must heal");
+        assert!(
+            matches!(
+                heal.member_info.preferred_nickname,
+                SealedBytes::Private { .. }
+            ),
+            "a Public-sealed stored entry must not be reused in a private room"
+        );
+    }
+
+    #[test]
+    fn current_secret_from_state_none_without_blob() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let member_sk = SigningKey::generate(&mut rng);
+        // A public room (default config) carries no encrypted_secrets, so
+        // the helper returns None and the invitation-accept path
+        // public-seals the nickname (correct for a public room).
+        let config = AuthorizedConfigurationV1::new(Configuration::default(), &owner_sk);
+        let state = ChatRoomStateV1 {
+            configuration: config,
+            ..Default::default()
+        };
+        assert!(
+            current_secret_from_state(&state, &member_sk).is_none(),
+            "no encrypted_secrets blob for the member → None"
+        );
+    }
+
+    #[test]
+    fn current_secret_from_state_decrypts_blob() {
+        // Success path: a private room state carrying an encrypted-secret
+        // blob for the member yields the decrypted secret + version.
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let member_sk = SigningKey::generate(&mut rng);
+        let mut room = make_private_owner_room(&owner_sk, &member_sk);
+        let v0_secret = *room.secrets.get(&0).expect("v0 secret seeded");
+        append_encrypted_secret_for(
+            &mut room.room_state,
+            &owner_sk,
+            &member_sk.verifying_key(),
+            &v0_secret,
+            0,
+        );
+
+        let (secret, version) = current_secret_from_state(&room.room_state, &member_sk)
+            .expect("blob present for the member → decrypts");
+        assert_eq!(version, 0);
+        assert_eq!(secret, v0_secret);
     }
 
     /// Builds a private owner-mode room with one invited member, populated

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
-use crate::util::ecies::{decrypt_secret_from_member_blob_raw, encrypt_secret_for_member};
+use crate::util::ecies::{
+    decrypt_secret_from_member_blob_raw, encrypt_secret_for_member, seal_bytes,
+};
 use crate::util::get_current_system_time;
 use crate::{constants::ROOM_CONTRACT_WASM, util::to_cbor_vec};
 use ed25519_dalek::{SigningKey, VerifyingKey};
@@ -501,6 +503,83 @@ impl RoomData {
             )),
             Some(vec![authorized_info]),
         )
+    }
+
+    /// Self-heal for the PR #272 "Unknown member" regression.
+    ///
+    /// If the network's canonical `state` shows this user in `members`
+    /// but with no matching `member_info` entry, they render as
+    /// "Unknown" to every other peer. Returns a self-signed
+    /// `AuthorizedMemberInfo` to re-publish so the entry is restored;
+    /// returns `None` when there is nothing to heal — the user is the
+    /// owner, is not a member of `state`, or already has a `member_info`
+    /// entry.
+    ///
+    /// The room contract only accepts a non-owner's `member_info` when
+    /// it is self-signed by that member's own key, so a stranded member
+    /// can only be healed by their own client. That is exactly what this
+    /// produces — using `self_sk`. It cannot be done owner-side or for
+    /// any other member.
+    ///
+    /// The nickname is taken, in priority order, from the stored
+    /// `self_member_info`, then any local `member_info` entry, then a
+    /// freshly-generated deterministic default handle — so a user who
+    /// already picked a nickname keeps it.
+    pub fn build_member_info_heal(&self, state: &ChatRoomStateV1) -> Option<AuthorizedMemberInfo> {
+        let self_vk = self.self_sk.verifying_key();
+        if self_vk == self.owner_vk {
+            return None; // the owner's member_info is managed separately
+        }
+        let member_id = MemberId::from(&self_vk);
+
+        let in_members = state
+            .members
+            .members
+            .iter()
+            .any(|m| m.member.member_vk == self_vk);
+        if !in_members {
+            return None; // not a member on the network — nothing to heal
+        }
+        let has_member_info = state
+            .member_info
+            .member_info
+            .iter()
+            .any(|i| i.member_info.member_id == member_id);
+        if has_member_info {
+            return None; // already present — not stranded
+        }
+
+        // Stranded. Re-publish our own member_info, preferring an
+        // already-known entry so the user keeps their chosen nickname.
+        if let Some(stored) = &self.self_member_info {
+            return Some(stored.clone());
+        }
+        if let Some(local) = self
+            .room_state
+            .member_info
+            .member_info
+            .iter()
+            .filter(|i| i.member_info.member_id == member_id)
+            .max_by_key(|i| i.member_info.version)
+        {
+            return Some(local.clone());
+        }
+
+        // No nickname on record — assign a deterministic default handle.
+        let nickname = crate::nickname::generate_default_nickname(&self_vk);
+        let preferred_nickname = match (self.is_private(), self.get_secret()) {
+            (true, Some((secret, version))) => seal_bytes(nickname.as_bytes(), secret, version),
+            _ => SealedBytes::public(nickname.into_bytes()),
+        };
+        let info = MemberInfo {
+            member_id,
+            version: 0,
+            preferred_nickname,
+        };
+        Some(AuthorizedMemberInfo::new_with_member_key(
+            info,
+            &self.self_sk,
+        ))
     }
 
     pub fn owner_id(&self) -> MemberId {
@@ -1425,6 +1504,97 @@ mod tests {
         let members = members.expect("should have members delta");
         // Should include both self and the missing chain member
         assert_eq!(members.added().len(), 2);
+    }
+
+    // --- build_member_info_heal: PR #272 "Unknown member" remediation ---
+
+    #[test]
+    fn build_member_info_heal_returns_some_when_stranded() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let invitee_vk = invitee_sk.verifying_key();
+
+        // Network state: invitee is in `members` but has no member_info.
+        let room = make_rejoin_test_room(&owner_sk, &invitee_sk, true);
+        let network_state = room.room_state.clone();
+
+        let heal = room
+            .build_member_info_heal(&network_state)
+            .expect("stranded member must produce a heal entry");
+        assert_eq!(heal.member_info.member_id, MemberId::from(&invitee_vk));
+        assert_eq!(heal.member_info.version, 0);
+    }
+
+    #[test]
+    fn build_member_info_heal_returns_none_when_member_info_present() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let invitee_vk = invitee_sk.verifying_key();
+
+        let room = make_rejoin_test_room(&owner_sk, &invitee_sk, true);
+        let mut network_state = room.room_state.clone();
+        // Network already carries the invitee's member_info — not stranded.
+        let info = MemberInfo {
+            member_id: MemberId::from(&invitee_vk),
+            version: 0,
+            preferred_nickname: SealedBytes::public(b"Present".to_vec()),
+        };
+        network_state
+            .member_info
+            .member_info
+            .push(AuthorizedMemberInfo::new_with_member_key(info, &invitee_sk));
+
+        assert!(room.build_member_info_heal(&network_state).is_none());
+    }
+
+    #[test]
+    fn build_member_info_heal_returns_none_for_owner() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        // self_sk == owner_sk — the owner's member_info is managed separately.
+        let room = make_rejoin_test_room(&owner_sk, &owner_sk, false);
+        let network_state = room.room_state.clone();
+        assert!(room.build_member_info_heal(&network_state).is_none());
+    }
+
+    #[test]
+    fn build_member_info_heal_returns_none_when_not_a_member() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        // include_member = false — invitee is absent from the network state.
+        let room = make_rejoin_test_room(&owner_sk, &invitee_sk, false);
+        let network_state = room.room_state.clone();
+        assert!(room.build_member_info_heal(&network_state).is_none());
+    }
+
+    #[test]
+    fn build_member_info_heal_prefers_stored_self_member_info() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let member_id = MemberId::from(&invitee_sk.verifying_key());
+
+        let mut room = make_rejoin_test_room(&owner_sk, &invitee_sk, true);
+        // The user already picked a nickname — the heal must preserve it
+        // rather than minting a fresh default handle.
+        let stored = MemberInfo {
+            member_id,
+            version: 7,
+            preferred_nickname: SealedBytes::public(b"ChosenName".to_vec()),
+        };
+        room.self_member_info = Some(AuthorizedMemberInfo::new_with_member_key(
+            stored,
+            &invitee_sk,
+        ));
+
+        let network_state = room.room_state.clone();
+        let heal = room
+            .build_member_info_heal(&network_state)
+            .expect("stranded member must produce a heal entry");
+        assert_eq!(heal.member_info.version, 7);
     }
 
     /// Builds a private owner-mode room with one invited member, populated


### PR DESCRIPTION
## Problem

PR #272's `build_state_for_put` PUTs a newly-joined member into the room
contract's `members` list but **never into `member_info`**. The contract
accepts this (member_info entries are optional per `MemberInfoV1::verify`),
so the member-info-less state becomes canonical, and every other peer
renders the member as **"Unknown"** instead of their nickname.

In the official Freenet room, **10 of 33 members** are stranded this way.
(`riverctl member list` iterates `member_info`, so it only showed 23 — the
gap is the bug.)

## Approach

**Fix the root cause** — `build_state_for_put` now also injects the
invitee's self-signed `AuthorizedMemberInfo` into the PUT state. The
caller builds it once (before the PUT and before the deferred local ROOMS
mutation) and reuses the identical value for both, so the PUT payload and
local state stay byte-identical — the same reuse discipline the
synthesised join_event already follows.

**Remediate already-stranded members** — new `RoomData::build_member_info_heal`:
on every GET of an existing room, if the network's canonical state shows
us in `members` with no `member_info` entry, we re-publish our own
self-signed `member_info` via a dedicated UPDATE. Idempotent — once the
entry lands, later GETs no longer see the stranding. This heals each of
the 10 stranded members the next time they open River.

**Themed default nicknames** (folded in per request) — members who join
without typing a nickname previously got `User-a3F9bX`, which reads like a
spam account. They now get a deterministic 90s-hacker-culture handle
(e.g. "Cipher Daylight"), derived by hashing the verifying key — a pure
function of the key, like the old scheme but friendlier.

## Why the remediation must be client-side

`MemberInfoV1::verify` requires a non-owner's `member_info` to be signed
by **that member's own key**. The room owner's key cannot sign a heal
entry for someone else — the contract would reject it. So an owner-side or
server-side back-fill is impossible; each stranded member can only be
healed by their own client. That is exactly what `build_member_info_heal`
does, using `self_sk`.

## Scope

UI-only (`ui/`). No `common/`, room-contract, or delegate WASM changes —
the room contract key is unchanged, no migration needed, riverctl
unaffected.

## Commits

- `feat(ui)`: themed default nicknames (new `ui/src/nickname.rs`).
- `fix(ui)`: the member_info injection + self-heal — **the commit to review**.
- `style(ui)`: isolated `cargo fmt` of `get_response.rs` (pre-existing
  under-indented closure; `git diff -w` against its parent is empty).

## Testing

- `build_state_for_put_includes_member_info` — pins the PUT-state
  injection; asserts it survives `post_apply_cleanup` + `verify`.
- 5 × `build_member_info_heal_*` — stranded / healthy / owner /
  not-a-member, and that a stored nickname is preferred over a fresh
  default.
- 4 × `nickname::*` — determinism, pool sizes, two-word format,
  distribution.
- All 185 river-ui native unit tests pass; native + `wasm32` builds clean.

[AI-assisted - Claude]
