### PR TITLE
feat(ui): carry private-room secrets in the invitation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ curl -s http://127.0.0.1:7509/v1/contract/web/raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSW
 **Contract ID:** `raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv`
 
 ## Architecture Highlights
-1. `common/`: shared state types (`RoomState`, `Member`, `Message`, `Invitation`) and cryptography helpers.
+1. `common/`: shared state types (`RoomState`, `Member`, `Message`) and cryptography helpers. (`Invitation` is NOT here — it is a `ui/`-only type, with a separate copy in `cli/`; it is not compiled into contract/delegate WASM.)
 2. `contracts/room-contract`: manages room membership, permissions, and message history.
 3. `contracts/web-container-contract`: serves the compiled UI as a Freenet contract asset.
 4. `delegates/chat-delegate`: handles chat-specific workflows and background tasks.
@@ -361,7 +361,12 @@ design.
 
 ## Private Room Support
 - Messages, metadata, and member nicknames are encrypted with AES-256-GCM.
-- Room secrets distributed with ECIES (X25519 + AES-256-GCM).
+- Room secrets distributed two ways: (a) owner-signed `encrypted_secrets`
+  blobs in the room contract, ECIES-wrapped per member (X25519 + AES-256-GCM);
+  (b) for a new invitee, the secrets are also embedded in the `Invitation`
+  artifact so they can read the room immediately on join without waiting for
+  the owner's delegate to back-fill an `encrypted_secrets` blob. The contract
+  blob is authoritative and supersedes the invitation-carried copy.
 - Secret rotation has two converging paths (#228 PR 2 v2):
   - **UI synchronous fast-path** (`RoomData::rotate_secret`): runs while the owner
     is actively driving a state change — banning a member, clicking the manual
@@ -445,6 +450,11 @@ design.
   `[Encrypted message - secret vN not available]` until they
   hard-refresh, because the back-filled blob arrives in a *subsequent*
   state update that the in-memory map never sees.
+  `repopulate_secrets_from_state` also folds in `room_data.invitation_secrets`
+  (secrets carried in the `Invitation` artifact) for versions the contract
+  has not yet provided an owner-signed blob for; the owner-signed blob is
+  authoritative and overwrites an invitation-carried value at the same
+  version (and prunes it from `invitation_secrets`).
 - Key files:
   - `common/src/room_state/privacy.rs`, `secret.rs`, `configuration.rs`
   - `common/src/key_derivation.rs`

--- a/ui/src/components/app/document_title.rs
+++ b/ui/src/components/app/document_title.rs
@@ -528,6 +528,7 @@ mod tests {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
+            invitation_secrets: HashMap::new(),
         }
     }
 

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -153,8 +153,17 @@ pub async fn handle_get_response(
             // and seal their own nickname — immediately, before the owner
             // delegate's `encrypted_secrets` back-fill arrives. Empty for
             // public rooms and pre-feature invitations.
-            let invitation_secrets: std::collections::HashMap<u32, [u8; 32]> =
-                room_secrets.into_iter().collect();
+            //
+            // Drop any entry whose version exceeds the room's current
+            // version — a malicious inviter could otherwise pad the
+            // invitation with unbounded bogus future-version secrets.
+            let invitation_secrets: std::collections::HashMap<u32, [u8; 32]> = {
+                let current_version = retrieved_state.secrets.current_version;
+                room_secrets
+                    .into_iter()
+                    .filter(|(version, _)| *version <= current_version)
+                    .collect()
+            };
 
             // Prepare the member ID for checking
             let member_id: MemberId = authorized_member.member.member_vk.into();

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -28,7 +28,7 @@ use freenet_stdlib::prelude::{
 use river_core::room_state::member::MemberId;
 use river_core::room_state::member_info::{AuthorizedMemberInfo, MemberInfo};
 use river_core::room_state::message::{AuthorizedMessageV1, MessageId, MessageV1, RoomMessageBody};
-use river_core::room_state::privacy::{PrivacyMode, SealedBytes};
+use river_core::room_state::privacy::PrivacyMode;
 use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1, ChatRoomStateV1Delta};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -137,15 +137,24 @@ pub async fn handle_get_response(
             let retrieved_state: ChatRoomStateV1 = from_cbor_slice::<ChatRoomStateV1>(&state);
 
             // Get the pending invite data once to avoid multiple reads
-            let (self_sk, authorized_member, preferred_nickname) = {
+            let (self_sk, authorized_member, preferred_nickname, room_secrets) = {
                 let pending_invites = PENDING_INVITES.read();
                 let invite = &pending_invites.map[&owner_vk];
                 (
                     invite.invitee_signing_key.clone(),
                     invite.authorized_member.clone(),
                     invite.preferred_nickname.clone(),
+                    invite.room_secrets.clone(),
                 )
             };
+
+            // The room secrets the inviter embedded in the invitation
+            // (private rooms only). These let the invitee read the room —
+            // and seal their own nickname — immediately, before the owner
+            // delegate's `encrypted_secrets` back-fill arrives. Empty for
+            // public rooms and pre-feature invitations.
+            let invitation_secrets: std::collections::HashMap<u32, [u8; 32]> =
+                room_secrets.into_iter().collect();
 
             // Prepare the member ID for checking
             let member_id: MemberId = authorized_member.member.member_vk.into();
@@ -189,32 +198,30 @@ pub async fn handle_get_response(
             // invitee's own key; the room contract rejects member_info
             // signed by anyone else.
             //
-            // A PRIVATE room's nickname must be encrypted. If the room
-            // secret is not yet available (the owner's encrypted-secret
-            // back-fill is asynchronous), we deliberately produce NO
-            // member_info rather than fall back to a plaintext
-            // `SealedBytes::public` seal — publishing a cleartext
-            // nickname into a private room is a privacy leak.
-            // `build_member_info_heal` re-publishes it, properly sealed,
-            // on a later GET once the secret has arrived. (The heal runs
-            // only on GET, not on the UPDATE that typically delivers the
-            // secret — tracked as issue #295.)
+            // A PRIVATE room's nickname must be encrypted. The room secret
+            // normally comes from the invitation itself (`room_secrets`),
+            // so the nickname can be sealed right here; `seal_invitee_nickname`
+            // also falls back to a blob the owner has already back-filled
+            // into the contract. Only if NEITHER source has the secret do
+            // we produce NO member_info — rather than fall back to a
+            // plaintext `SealedBytes::public` seal, which would leak a
+            // cleartext nickname into a private room. `build_member_info_heal`
+            // then re-publishes it, properly sealed, on a later GET once the
+            // secret has arrived. (The heal runs only on GET, not on the
+            // UPDATE that typically delivers the secret — tracked as issue
+            // #295.)
             let authorized_member_info: Option<AuthorizedMemberInfo> = {
-                let sealed_nickname = if retrieved_state.configuration.configuration.privacy_mode
-                    == PrivacyMode::Private
-                {
-                    crate::room_data::current_secret_from_state(&retrieved_state, &self_sk).map(
-                        |(secret, version)| {
-                            crate::util::ecies::seal_bytes(
-                                preferred_nickname.as_bytes(),
-                                &secret,
-                                version,
-                            )
-                        },
-                    )
-                } else {
-                    Some(SealedBytes::public(preferred_nickname.as_bytes().to_vec()))
-                };
+                // Seal the invitee's nickname against the room secret —
+                // taken from the contract state if the owner has already
+                // back-filled this member's blob, otherwise from the
+                // invitation-provided secret so the nickname lands in the
+                // join PUT immediately (no "Unknown member" window).
+                let sealed_nickname = crate::room_data::seal_invitee_nickname(
+                    &retrieved_state,
+                    &self_sk,
+                    &invitation_secrets,
+                    &preferred_nickname,
+                );
                 if sealed_nickname.is_none() {
                     warn!(
                         "Private room secret not available yet — deferring invitee \
@@ -302,6 +309,7 @@ pub async fn handle_get_response(
                             self_member_info: None,
                             self_nickname: None,
                             previous_contract_key: None,
+                            invitation_secrets: std::collections::HashMap::new(),
                         }
                     });
 
@@ -332,6 +340,17 @@ pub async fn handle_get_response(
                             .merge(&current_state, &params, &retrieved_state)
                             .expect("Failed to merge room states");
                     }
+
+                    // Seed the secrets recovered from the invitation so a
+                    // brand-new invitee can decrypt the room before the
+                    // owner delegate's `encrypted_secrets` back-fill
+                    // arrives. `extend` covers both the freshly-inserted
+                    // entry and a pre-existing one (a re-accepted invite).
+                    // `repopulate_secrets_from_state` below folds these
+                    // into the in-memory `secrets` map.
+                    room_data
+                        .invitation_secrets
+                        .extend(invitation_secrets.iter().map(|(k, v)| (*k, *v)));
 
                     // Decrypt ALL room secret versions if this is a private room
                     let decrypted = room_data.repopulate_secrets_from_state();
@@ -1385,6 +1404,7 @@ mod tests {
     use ed25519_dalek::SigningKey;
     use river_core::room_state::configuration::{AuthorizedConfigurationV1, Configuration};
     use river_core::room_state::member::{AuthorizedMember, Member};
+    use river_core::room_state::privacy::SealedBytes;
 
     /// Build a public-room `AuthorizedMemberInfo` self-signed by `sk`,
     /// so the `build_state_for_put` tests can supply the member_info

--- a/ui/src/components/direct_messages.rs
+++ b/ui/src/components/direct_messages.rs
@@ -695,6 +695,7 @@ mod tests {
                 self_member_info: None,
                 self_nickname: None,
                 previous_contract_key: None,
+                invitation_secrets: std::collections::HashMap::new(),
             },
         );
         rooms

--- a/ui/src/components/direct_messages/dm_thread_modal.rs
+++ b/ui/src/components/direct_messages/dm_thread_modal.rs
@@ -1501,6 +1501,7 @@ mod tests {
             room: room_owner_vk,
             invitee_signing_key,
             invitee: authorized,
+            room_secrets: Vec::new(),
         }
     }
 

--- a/ui/src/components/direct_messages/invite_via_dm_picker_modal.rs
+++ b/ui/src/components/direct_messages/invite_via_dm_picker_modal.rs
@@ -39,7 +39,7 @@ use crate::components::direct_messages::{
     send_structured_dm, InvitePickInflight, SendDmOutcome, INVITE_VIA_DM_PICKER,
     INVITE_VIA_DM_PICKER_INFLIGHT,
 };
-use crate::components::members::Invitation;
+use crate::components::members::{collect_invitation_secrets, Invitation};
 use crate::util::ecies::unseal_bytes_with_secrets;
 use dioxus::logger::tracing::{error, info, warn};
 use dioxus::prelude::*;
@@ -643,10 +643,19 @@ async fn drive_send(
     let signature =
         crate::signing::sign_member_with_fallback(room_key, member_bytes, &inviter_sk).await;
     let authorized = AuthorizedMember::with_signature(member, signature);
+    // For a private room, embed the room secrets the inviter holds so the
+    // invitee can decrypt the room immediately on join. Empty for a public
+    // room or an empty secrets map.
+    let room_secrets = if candidate_data.is_private() {
+        collect_invitation_secrets(&candidate_data.secrets)
+    } else {
+        Vec::new()
+    };
     let invitation = Invitation {
         room: candidate_data.owner_vk,
         invitee_signing_key,
         invitee: authorized,
+        room_secrets,
     };
 
     // Encode the Invitation as CBOR — same bytes the URL form base58-

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -98,7 +98,7 @@ pub fn collect_invitation_secrets(secrets: &HashMap<u32, [u8; 32]>) -> Vec<(u32,
     out
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub struct Invitation {
     pub room: VerifyingKey,
     pub invitee_signing_key: SigningKey,
@@ -140,6 +140,26 @@ impl Invitation {
             .into_vec()
             .map_err(|e| format!("Base58 decode error: {}", e))?;
         ciborium::de::from_reader(&decoded[..]).map_err(|e| format!("Deserialization error: {}", e))
+    }
+}
+
+/// Hand-written `Debug` that REDACTS `room_secrets`. The derived `Debug`
+/// for `[u8; 32]` is fully transparent, so `{:?}`-logging an `Invitation`
+/// (e.g. `info!("...{:?}", invitation)`) would print every room-secret
+/// byte to the browser console. `room` and `invitee` are non-sensitive;
+/// `SigningKey`'s own `Debug` is already non-exhaustive (it does not print
+/// the secret), so it is safe to delegate to.
+impl std::fmt::Debug for Invitation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Invitation")
+            .field("room", &self.room)
+            .field("invitee_signing_key", &self.invitee_signing_key)
+            .field("invitee", &self.invitee)
+            .field(
+                "room_secrets",
+                &format_args!("<{} room secret(s) redacted>", self.room_secrets.len()),
+            )
+            .finish()
     }
 }
 

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -84,11 +84,46 @@ pub fn ConnectionStatusIndicator() -> Element {
     }
 }
 
+/// Collect the room secrets an inviter holds into the `(version, secret)`
+/// list embedded in an [`Invitation`].
+///
+/// Sorted ascending by version so the invitation has a deterministic CBOR
+/// encoding (the encoded string is fingerprinted for processed-invite
+/// dedup, so it must be stable across decode/re-encode cycles). Returns an
+/// empty `Vec` for an empty input — a public room, or a private room whose
+/// inviting member holds no secret yet.
+pub fn collect_invitation_secrets(secrets: &HashMap<u32, [u8; 32]>) -> Vec<(u32, [u8; 32])> {
+    let mut out: Vec<(u32, [u8; 32])> = secrets.iter().map(|(&v, &s)| (v, s)).collect();
+    out.sort_unstable_by_key(|(v, _)| *v);
+    out
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Invitation {
     pub room: VerifyingKey,
     pub invitee_signing_key: SigningKey,
     pub invitee: AuthorizedMember,
+    /// The room's symmetric secrets, one `(version, secret)` per version
+    /// the inviting member holds. Lets the invitee decrypt a private room
+    /// immediately on join, instead of being stuck on
+    /// `[Encrypted message - secret vN not available]` until the room
+    /// owner's chat-delegate comes online and back-fills an
+    /// `encrypted_secrets` blob (Bug #6 / PR #276). Works even when a
+    /// non-owner issues the invitation — the inviter already holds the
+    /// secret; the room contract is untouched.
+    ///
+    /// Carried in plaintext, NOT ECIES-wrapped. That is not a confidentiality
+    /// regression: the invitation already carries `invitee_signing_key` in
+    /// the clear, so the whole artifact is a bearer credential — anyone who
+    /// can read these bytes can already read everything the room secret
+    /// protects. Plaintext also avoids decrypting attacker-influenced
+    /// ciphertext on the join path (`river_core::ecies::decrypt` panics on a
+    /// malformed blob, and the release build is `panic = "abort"`).
+    ///
+    /// Empty for public rooms and for invitations created before this field
+    /// existed (`#[serde(default)]` keeps old links decodable).
+    #[serde(default)]
+    pub room_secrets: Vec<(u32, [u8; 32])>,
 }
 
 impl Invitation {
@@ -612,6 +647,7 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
                     // nickname. Narrow window; acceptable.
                     self_nickname: None,
                     previous_contract_key: None,
+                    invitation_secrets: std::collections::HashMap::new(),
                 };
 
                 // Migrate the imported signing key to the delegate immediately.
@@ -746,5 +782,119 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use river_core::room_state::member::Member;
+
+    fn authorized_member(owner_sk: &SigningKey, invitee_vk: &VerifyingKey) -> AuthorizedMember {
+        let owner_id = MemberId::from(&owner_sk.verifying_key());
+        let member = Member {
+            owner_member_id: owner_id,
+            invited_by: owner_id,
+            member_vk: *invitee_vk,
+        };
+        AuthorizedMember::new(member, owner_sk)
+    }
+
+    #[test]
+    fn collect_invitation_secrets_is_sorted_by_version() {
+        let mut secrets = HashMap::new();
+        secrets.insert(2u32, [11u8; 32]);
+        secrets.insert(0u32, [7u8; 32]);
+        secrets.insert(1u32, [9u8; 32]);
+
+        let collected = collect_invitation_secrets(&secrets);
+        assert_eq!(
+            collected,
+            vec![(0, [7u8; 32]), (1, [9u8; 32]), (2, [11u8; 32])]
+        );
+    }
+
+    #[test]
+    fn collect_invitation_secrets_empty_input_is_empty() {
+        assert!(collect_invitation_secrets(&HashMap::new()).is_empty());
+    }
+
+    #[test]
+    fn invitation_cbor_round_trip_preserves_room_secrets() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let invitee_vk = invitee_sk.verifying_key();
+
+        let mut secrets = HashMap::new();
+        secrets.insert(0u32, [1u8; 32]);
+        secrets.insert(1u32, [2u8; 32]);
+
+        let invitation = Invitation {
+            room: owner_sk.verifying_key(),
+            invitee_signing_key: invitee_sk.clone(),
+            invitee: authorized_member(&owner_sk, &invitee_vk),
+            room_secrets: collect_invitation_secrets(&secrets),
+        };
+
+        let decoded = Invitation::from_encoded_string(&invitation.to_encoded_string())
+            .expect("invitation should round-trip");
+        assert_eq!(decoded, invitation);
+        assert_eq!(
+            decoded.room_secrets.into_iter().collect::<HashMap<_, _>>(),
+            secrets
+        );
+    }
+
+    #[test]
+    fn invitation_encoding_is_deterministic_with_room_secrets() {
+        // The encoded string is fingerprinted for processed-invite dedup,
+        // so it must be byte-stable across re-encodes.
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+
+        let mut secrets = HashMap::new();
+        secrets.insert(0u32, [5u8; 32]);
+        secrets.insert(7u32, [6u8; 32]);
+        secrets.insert(3u32, [4u8; 32]);
+
+        let invitation = Invitation {
+            room: owner_sk.verifying_key(),
+            invitee_signing_key: invitee_sk.clone(),
+            invitee: authorized_member(&owner_sk, &invitee_sk.verifying_key()),
+            room_secrets: collect_invitation_secrets(&secrets),
+        };
+        assert_eq!(
+            invitation.to_encoded_string(),
+            invitation.to_encoded_string()
+        );
+    }
+
+    #[test]
+    fn legacy_invitation_without_room_secrets_decodes_to_empty() {
+        // Backward-compat: an invitation encoded before `room_secrets`
+        // existed must still decode, with the field defaulting to empty.
+        #[derive(Serialize)]
+        struct LegacyInvitation {
+            room: VerifyingKey,
+            invitee_signing_key: SigningKey,
+            invitee: AuthorizedMember,
+        }
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let legacy = LegacyInvitation {
+            room: owner_sk.verifying_key(),
+            invitee_signing_key: invitee_sk.clone(),
+            invitee: authorized_member(&owner_sk, &invitee_sk.verifying_key()),
+        };
+        let mut bytes = Vec::new();
+        ciborium::ser::into_writer(&legacy, &mut bytes).unwrap();
+        let encoded = bs58::encode(bytes).into_string();
+
+        let decoded =
+            Invitation::from_encoded_string(&encoded).expect("legacy invitation should decode");
+        assert!(decoded.room_secrets.is_empty());
     }
 }

--- a/ui/src/components/members/invite_member_modal.rs
+++ b/ui/src/components/members/invite_member_modal.rs
@@ -1,5 +1,5 @@
 use crate::components::app::{CURRENT_ROOM, ROOMS};
-use crate::components::members::Invitation;
+use crate::components::members::{collect_invitation_secrets, Invitation};
 use crate::room_data::RoomData;
 use crate::util::ecies::unseal_bytes_with_secrets;
 use dioxus::prelude::*;
@@ -92,11 +92,24 @@ pub fn InviteMemberModal(is_active: Signal<bool>) -> Element {
                 // Create authorized member with pre-computed signature
                 let authorized_member = AuthorizedMember::with_signature(member, signature);
 
+                // For a private room, embed the room secrets the inviter
+                // holds so the invitee can decrypt the room immediately on
+                // join, without waiting for the owner delegate's
+                // `encrypted_secrets` back-fill. Empty for a public room,
+                // or if the inviter holds no secret yet (then the invitee
+                // falls back to that wait).
+                let room_secrets = if room_data.is_private() {
+                    collect_invitation_secrets(&room_data.secrets)
+                } else {
+                    Vec::new()
+                };
+
                 // Create invitation
                 let invitation = Invitation {
                     room: room_data.owner_vk,
                     invitee_signing_key,
                     invitee: authorized_member,
+                    room_secrets,
                 };
 
                 Ok::<Invitation, String>(invitation)

--- a/ui/src/components/room_list/receive_invitation_modal.rs
+++ b/ui/src/components/room_list/receive_invitation_modal.rs
@@ -666,6 +666,7 @@ fn accept_invitation(inv: Invitation, nickname: String) {
     let room_owner = inv.room;
     let authorized_member = inv.invitee.clone();
     let invitee_signing_key = inv.invitee_signing_key.clone();
+    let room_secrets = inv.room_secrets.clone();
 
     // Use the user-provided nickname
     let nickname = if nickname.trim().is_empty() {
@@ -691,6 +692,7 @@ fn accept_invitation(inv: Invitation, nickname: String) {
                 status: PendingRoomStatus::PendingSubscription,
                 subscribing_since: None,
                 retry_count: 0,
+                room_secrets: room_secrets.clone(),
             },
         );
     });
@@ -823,6 +825,7 @@ mod tests {
             room: owner_sk.verifying_key(),
             invitee_signing_key: invitee_sk,
             invitee: authorized,
+            room_secrets: Vec::new(),
         };
 
         let first = inv.to_encoded_string();

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -231,6 +231,7 @@ fn create_room(room_name: &String, self_is: SelfIs, description: Option<&str>) -
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
+            invitation_secrets: std::collections::HashMap::new(),
         },
     }
 }

--- a/ui/src/invites.rs
+++ b/ui/src/invites.rs
@@ -52,6 +52,11 @@ pub struct PendingRoomJoin {
     /// On retry_count >= 1, falls back to requesting contract code from the
     /// network in case the local copy is stale.
     pub retry_count: u32,
+    /// Room secrets carried in the invitation, copied here from
+    /// `Invitation::room_secrets` at accept time so the pending-invite
+    /// GET-response handler can seed them into `RoomData`. Empty for
+    /// public rooms and pre-feature invitations.
+    pub room_secrets: Vec<(u32, [u8; 32])>,
 }
 
 /// Status of a pending room join request

--- a/ui/src/invites.rs
+++ b/ui/src/invites.rs
@@ -35,7 +35,7 @@ impl PendingInvites {
 }
 
 /// Information about a pending room join
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct PendingRoomJoin {
     /// The authorized member data for the join
     pub authorized_member: AuthorizedMember,
@@ -57,6 +57,27 @@ pub struct PendingRoomJoin {
     /// GET-response handler can seed them into `RoomData`. Empty for
     /// public rooms and pre-feature invitations.
     pub room_secrets: Vec<(u32, [u8; 32])>,
+}
+
+/// Hand-written `Debug` that REDACTS `room_secrets` — the derived `Debug`
+/// for `[u8; 32]` would print every room-secret byte if a `PendingRoomJoin`
+/// were ever `{:?}`-logged. `SigningKey`'s own `Debug` is already
+/// non-exhaustive, so it is safe to delegate to.
+impl std::fmt::Debug for PendingRoomJoin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PendingRoomJoin")
+            .field("authorized_member", &self.authorized_member)
+            .field("invitee_signing_key", &self.invitee_signing_key)
+            .field("preferred_nickname", &self.preferred_nickname)
+            .field("status", &self.status)
+            .field("subscribing_since", &self.subscribing_since)
+            .field("retry_count", &self.retry_count)
+            .field(
+                "room_secrets",
+                &format_args!("<{} room secret(s) redacted>", self.room_secrets.len()),
+            )
+            .finish()
+    }
 }
 
 /// Status of a pending room join request

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -144,6 +144,11 @@ pub(crate) fn seal_invitee_nickname(
     if state.configuration.configuration.privacy_mode != PrivacyMode::Private {
         return Some(SealedBytes::public(preferred_nickname.as_bytes().to_vec()));
     }
+    // Fallback: the invitation-carried secret for the room's CURRENT
+    // version — the nickname must be sealed at `current_version`. An
+    // invitation created before a rotation has no entry at the new
+    // `current_version`, so this correctly yields `None` and the caller
+    // defers `member_info` to the self-heal path.
     let (secret, version) = current_secret_from_state(state, self_sk).or_else(|| {
         let version = state.secrets.current_version;
         invitation_secrets
@@ -280,6 +285,12 @@ impl RoomData {
     /// `[Encrypted message - secret vN not available]` until they hard-
     /// refreshed.
     ///
+    /// Also folds in [`Self::invitation_secrets`] — secrets carried in the
+    /// invitation artifact — for any version the contract has not provided
+    /// an owner-signed blob for. The owner-signed contract blob is
+    /// authoritative and overwrites an invitation-carried value at the same
+    /// version (and prunes it from `invitation_secrets`).
+    ///
     /// Returns the number of new versions decrypted (for logging).
     pub fn repopulate_secrets_from_state(&mut self) -> usize {
         use dioxus::logger::tracing::warn;
@@ -293,16 +304,22 @@ impl RoomData {
 
         let member_id = MemberId::from(&self.self_sk.verifying_key());
 
-        // Snapshot the encrypted blobs we don't yet have plaintext for,
-        // so we can release the borrow on `room_state` before calling
-        // `set_secret` (which holds `&mut self`).
+        // Snapshot the member's encrypted_secrets blobs so we can release
+        // the borrow on `room_state` before the `&mut self` calls below.
+        //
+        // We deliberately do NOT filter out versions already in `secrets`:
+        // the owner-signed contract blob is authoritative and MUST be able
+        // to overwrite an (unauthenticated) value a prior `invitation_secrets`
+        // fold placed at the same version — otherwise a malicious or buggy
+        // inviter who supplied a wrong secret would permanently shadow the
+        // authentic blob for the rest of the session. Re-decrypting the
+        // handful of own-member blobs on each ingestion is negligible.
         let pending: Vec<PendingBlob> = self
             .room_state
             .secrets
             .encrypted_secrets
             .iter()
             .filter(|s| s.secret.member_id == member_id)
-            .filter(|s| !self.secrets.contains_key(&s.secret.secret_version))
             .map(|s| {
                 (
                     s.secret.secret_version,
@@ -323,8 +340,18 @@ impl RoomData {
                 &self_sk,
             ) {
                 Ok(secret) => {
+                    let is_new = !self.secrets.contains_key(&version);
+                    // `set_secret` inserts/overwrites — the owner-signed
+                    // contract secret is authoritative.
                     self.set_secret(secret, version);
-                    decrypted_count += 1;
+                    // It supersedes any invitation-carried copy at this
+                    // version: drop it so a stale/garbage invitation secret
+                    // cannot resurface and is not re-persisted in
+                    // `rooms_data`.
+                    self.invitation_secrets.remove(&version);
+                    if is_new {
+                        decrypted_count += 1;
+                    }
                 }
                 Err(e) => {
                     warn!(
@@ -336,16 +363,15 @@ impl RoomData {
         }
 
         // Fold in any secrets recovered from the invitation artifact
-        // (carried in `Invitation::room_secrets`, copied into
-        // `invitation_secrets` at accept time). These let an invitee read
-        // a private room before the owner delegate's `encrypted_secrets`
-        // back-fill arrives, and survive a refresh because `secrets` is
-        // `#[serde(skip)]` while `invitation_secrets` is persisted. The
-        // `contains_key` guard
-        // makes a blob already decrypted from the (authoritative)
-        // contract `encrypted_secrets` above win — both derive the same
-        // bytes anyway. Cloned to release the `&self` borrow before the
-        // `&mut self` `set_secret` calls.
+        // (`Invitation::room_secrets`, copied into `invitation_secrets` at
+        // accept time) for versions the contract has NOT yet provided an
+        // owner-signed blob for. This lets an invitee read a private room
+        // before the owner delegate's `encrypted_secrets` back-fill
+        // arrives, and survive a refresh (`secrets` is `#[serde(skip)]`
+        // while `invitation_secrets` is persisted). The contract loop above
+        // runs first and removes from `invitation_secrets` every version it
+        // covers, so the owner-signed value always wins. Cloned to release
+        // the `&self` borrow before the `&mut self` `set_secret` calls.
         let invitation_secrets = self.invitation_secrets.clone();
         for (version, secret) in invitation_secrets {
             if !self.secrets.contains_key(&version) {
@@ -3458,5 +3484,180 @@ mod tests {
         let (_v0_secret, room) = make_private_invitee_room(&owner_sk, &invitee_sk);
         let sealed = seal_invitee_nickname(&room.room_state, &invitee_sk, &HashMap::new(), "Alice");
         assert!(sealed.is_none());
+    }
+
+    /// Regression for the cross-call ordering bug (PR #301 skeptical /
+    /// Codex review): a stale or garbage invitation secret folded BEFORE
+    /// the owner-signed `encrypted_secrets` blob arrives must NOT
+    /// permanently shadow it. A later ingestion carrying the authentic
+    /// blob has to overwrite the in-memory `secrets` value and prune the
+    /// superseded entry from `invitation_secrets`.
+    #[test]
+    fn repopulate_secrets_contract_blob_overwrites_stale_invitation_secret() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let (v0_secret, mut room) = make_private_invitee_room(&owner_sk, &invitee_sk);
+
+        // Call 1: only a (garbage) invitation secret, no contract blob yet.
+        room.invitation_secrets.insert(0, [0x11u8; 32]);
+        room.repopulate_secrets_from_state();
+        assert_eq!(
+            room.secrets.get(&0u32),
+            Some(&[0x11u8; 32]),
+            "invitation secret is folded in while no contract blob exists"
+        );
+
+        // Call 2: the owner delegate back-fills the authentic blob.
+        append_encrypted_secret_for(
+            &mut room.room_state,
+            &owner_sk,
+            &invitee_sk.verifying_key(),
+            &v0_secret,
+            0,
+        );
+        room.repopulate_secrets_from_state();
+        assert_eq!(
+            room.secrets.get(&0u32),
+            Some(&v0_secret),
+            "the authentic contract blob must overwrite the stale invitation secret"
+        );
+        assert!(
+            !room.invitation_secrets.contains_key(&0),
+            "the superseded invitation secret must be pruned from invitation_secrets"
+        );
+    }
+
+    /// Backward-compat: a `rooms_data` blob written before
+    /// `invitation_secrets` (and the other `#[serde(default)]` fields)
+    /// existed must still deserialize as a `RoomData`. Encodes a minimal
+    /// struct carrying only the non-default fields.
+    #[test]
+    fn roomdata_decodes_from_minimal_legacy_blob() {
+        #[derive(Serialize)]
+        struct MinimalRoomData {
+            owner_vk: VerifyingKey,
+            room_state: ChatRoomStateV1,
+            self_sk: SigningKey,
+            contract_key: ContractKey,
+        }
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let (_v0, room) = make_private_invitee_room(&owner_sk, &invitee_sk);
+
+        let minimal = MinimalRoomData {
+            owner_vk: room.owner_vk,
+            room_state: room.room_state.clone(),
+            self_sk: invitee_sk.clone(),
+            contract_key: room.contract_key,
+        };
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&minimal, &mut buf).unwrap();
+        let decoded: RoomData =
+            ciborium::de::from_reader(buf.as_slice()).expect("legacy RoomData blob must decode");
+        assert!(decoded.invitation_secrets.is_empty());
+        assert!(decoded.previous_contract_key.is_none());
+    }
+
+    /// Refresh durability: `invitation_secrets` is persisted while
+    /// `secrets` is `#[serde(skip)]`, so after a serde round-trip
+    /// (simulating a page reload) the in-memory map is empty but
+    /// `repopulate_secrets_from_state` recovers it from the persisted
+    /// `invitation_secrets`.
+    #[test]
+    fn invitation_secrets_survive_roomdata_serde_round_trip() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let (v0_secret, mut room) = make_private_invitee_room(&owner_sk, &invitee_sk);
+        room.invitation_secrets.insert(0, v0_secret);
+        room.set_secret(v0_secret, 0);
+
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&room, &mut buf).unwrap();
+        let mut decoded: RoomData = ciborium::de::from_reader(buf.as_slice()).unwrap();
+
+        assert_eq!(
+            decoded.invitation_secrets.get(&0u32),
+            Some(&v0_secret),
+            "invitation_secrets must persist across the round-trip"
+        );
+        assert!(
+            decoded.secrets.is_empty(),
+            "secrets is #[serde(skip)] — empty after deserialize"
+        );
+
+        let recovered = decoded.repopulate_secrets_from_state();
+        assert_eq!(
+            recovered, 1,
+            "the secret is recovered from invitation_secrets"
+        );
+        assert_eq!(decoded.secrets.get(&0u32), Some(&v0_secret));
+    }
+
+    /// `seal_invitee_nickname` defers (returns `None`) when the invitation
+    /// carries no secret for the room's *current* version — e.g. the room
+    /// rotated after the invitation was created.
+    #[test]
+    fn seal_invitee_nickname_none_when_invitation_lacks_current_version() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let (v0_secret, mut room) = make_private_invitee_room(&owner_sk, &invitee_sk);
+        // Room has rotated to v1; the invitation only carries v0.
+        room.room_state.secrets.current_version = 1;
+        let mut invitation_secrets = HashMap::new();
+        invitation_secrets.insert(0u32, v0_secret);
+        let sealed =
+            seal_invitee_nickname(&room.room_state, &invitee_sk, &invitation_secrets, "Alice");
+        assert!(
+            sealed.is_none(),
+            "no invitation secret at current_version → defer to self-heal"
+        );
+    }
+
+    /// `seal_invitee_nickname` prefers the owner-signed contract secret
+    /// over an invitation-carried secret for the same version.
+    #[test]
+    fn seal_invitee_nickname_prefers_contract_secret() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let (v0_secret, mut room) = make_private_invitee_room(&owner_sk, &invitee_sk);
+        append_encrypted_secret_for(
+            &mut room.room_state,
+            &owner_sk,
+            &invitee_sk.verifying_key(),
+            &v0_secret,
+            0,
+        );
+        // A wrong invitation secret for the same version.
+        let mut invitation_secrets = HashMap::new();
+        invitation_secrets.insert(0u32, [0xCDu8; 32]);
+        let sealed =
+            seal_invitee_nickname(&room.room_state, &invitee_sk, &invitation_secrets, "Bob")
+                .expect("the contract secret should let the nickname seal");
+        // Sealed against the contract secret → unsealing with it succeeds.
+        let mut good = HashMap::new();
+        good.insert(0u32, v0_secret);
+        assert!(
+            crate::util::ecies::unseal_bytes_with_secrets(&sealed, &good).is_ok(),
+            "nickname must be sealed with the authoritative contract secret"
+        );
+    }
+
+    /// Source-grep pin: `seal_invitee_nickname` must remain wired into the
+    /// invitation-accept path. If a refactor drops the call and reverts to
+    /// an inline `SealedBytes::public` seal, a private room would leak a
+    /// plaintext nickname — this fails CI before that can happen.
+    #[test]
+    fn seal_invitee_nickname_call_site_pinned() {
+        let contents = include_str!("components/app/freenet_api/response_handler/get_response.rs");
+        assert_eq!(
+            contents.matches("seal_invitee_nickname(").count(),
+            1,
+            "seal_invitee_nickname must be called exactly once in get_response.rs"
+        );
     }
 }

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -105,6 +105,52 @@ pub struct RoomData {
     /// any client can GET state from the old contract and PUT it to the new one.
     #[serde(default)]
     pub previous_contract_key: Option<ContractKey>,
+    /// Room secrets recovered from the invitation artifact, by version.
+    ///
+    /// Populated once, when an invitation to a private room is accepted,
+    /// from the `room_secrets` the inviting member embedded in the
+    /// `Invitation`. Persisted (rides inside the `rooms_data` delegate
+    /// blob) so an invitee who has not yet received the owner delegate's
+    /// `encrypted_secrets` back-fill can still rebuild the
+    /// `#[serde(skip)]` `secrets` map after a page refresh.
+    ///
+    /// Plaintext, like `self_sk` and `self_nickname` already in this
+    /// struct — not a new exposure class, since the persisted `RoomData`
+    /// already carries `self_sk`. Folded into `secrets` by
+    /// [`RoomData::repopulate_secrets_from_state`]. Empty for public
+    /// rooms, for the room owner, and for rooms joined before this field
+    /// existed.
+    #[serde(default)]
+    pub invitation_secrets: HashMap<u32, [u8; 32]>,
+}
+
+/// Compute the `SealedBytes` for an invitee's chosen nickname at join time.
+///
+/// For a private room, prefer the secret carried in the freshly-fetched
+/// network `state` ([`current_secret_from_state`]); fall back to a secret
+/// supplied out-of-band by the invitation artifact, so a brand-new invitee
+/// can seal their nickname WITHOUT waiting for the owner delegate's
+/// `encrypted_secrets` back-fill. Returns `None` for a private room when no
+/// secret is available from either source — the caller then defers
+/// `member_info` to the self-heal path rather than leaking a plaintext
+/// nickname into a private room. A public room always returns `Some`
+/// (plaintext seal).
+pub(crate) fn seal_invitee_nickname(
+    state: &ChatRoomStateV1,
+    self_sk: &SigningKey,
+    invitation_secrets: &HashMap<u32, [u8; 32]>,
+    preferred_nickname: &str,
+) -> Option<SealedBytes> {
+    if state.configuration.configuration.privacy_mode != PrivacyMode::Private {
+        return Some(SealedBytes::public(preferred_nickname.as_bytes().to_vec()));
+    }
+    let (secret, version) = current_secret_from_state(state, self_sk).or_else(|| {
+        let version = state.secrets.current_version;
+        invitation_secrets
+            .get(&version)
+            .map(|secret| (*secret, version))
+    })?;
+    Some(seal_bytes(preferred_nickname.as_bytes(), &secret, version))
 }
 
 /// Decrypt the room's current-version secret out of a raw network
@@ -286,6 +332,25 @@ impl RoomData {
                         version, member_id, e
                     );
                 }
+            }
+        }
+
+        // Fold in any secrets recovered from the invitation artifact
+        // (carried in `Invitation::room_secrets`, copied into
+        // `invitation_secrets` at accept time). These let an invitee read
+        // a private room before the owner delegate's `encrypted_secrets`
+        // back-fill arrives, and survive a refresh because `secrets` is
+        // `#[serde(skip)]` while `invitation_secrets` is persisted. The
+        // `contains_key` guard
+        // makes a blob already decrypted from the (authoritative)
+        // contract `encrypted_secrets` above win — both derive the same
+        // bytes anyway. Cloned to release the `&self` borrow before the
+        // `&mut self` `set_secret` calls.
+        let invitation_secrets = self.invitation_secrets.clone();
+        for (version, secret) in invitation_secrets {
+            if !self.secrets.contains_key(&version) {
+                self.set_secret(secret, version);
+                decrypted_count += 1;
             }
         }
 
@@ -1263,6 +1328,7 @@ impl Rooms {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
+            invitation_secrets: HashMap::new(),
         };
 
         info!("🟢 Inserting room into map...");
@@ -1395,6 +1461,7 @@ mod tests {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
+            invitation_secrets: HashMap::new(),
         };
 
         // With stale key, user should NOT be recognized as a member
@@ -1467,6 +1534,7 @@ mod tests {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
+            invitation_secrets: HashMap::new(),
         };
 
         // Before capture, self_member_info should be None
@@ -1535,6 +1603,7 @@ mod tests {
                 self_member_info: None,
                 self_nickname: None,
                 previous_contract_key: None,
+                invitation_secrets: HashMap::new(),
             }
         };
 
@@ -1603,6 +1672,7 @@ mod tests {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
+            invitation_secrets: HashMap::new(),
         }
     }
 
@@ -2549,6 +2619,7 @@ mod tests {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
+            invitation_secrets: HashMap::new(),
         }
     }
 
@@ -2670,6 +2741,7 @@ mod tests {
                 self_member_info: None,
                 self_nickname: None,
                 previous_contract_key: None,
+                invitation_secrets: HashMap::new(),
             }
         };
 
@@ -2793,6 +2865,7 @@ mod tests {
                 self_member_info: None,
                 self_nickname: None,
                 previous_contract_key: None,
+                invitation_secrets: HashMap::new(),
             }
         };
 
@@ -2858,6 +2931,7 @@ mod tests {
                 self_member_info: None,
                 self_nickname: None,
                 previous_contract_key: None,
+                invitation_secrets: HashMap::new(),
             }
         };
 
@@ -3084,6 +3158,7 @@ mod tests {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
+            invitation_secrets: HashMap::new(),
         };
 
         (v0_secret, room)
@@ -3289,11 +3364,99 @@ mod tests {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
+            invitation_secrets: HashMap::new(),
         };
 
         let decrypted = room.repopulate_secrets_from_state();
         assert_eq!(decrypted, 0);
         assert!(room.secrets.is_empty());
         assert_eq!(room.current_secret_version, None);
+    }
+
+    /// An invitee whose `encrypted_secrets` blob has not been back-filled
+    /// yet must still get the room secret folded into the in-memory
+    /// `secrets` map from `invitation_secrets` (carried in the
+    /// invitation artifact) — this is what lets them read a private room
+    /// without waiting for the owner delegate.
+    #[test]
+    fn repopulate_secrets_folds_invitation_secrets() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+
+        let (v0_secret, mut room) = make_private_invitee_room(&owner_sk, &invitee_sk);
+        // No encrypted_secrets blob — the secret arrived only via the
+        // invitation artifact.
+        room.invitation_secrets.insert(0, v0_secret);
+
+        let decrypted = room.repopulate_secrets_from_state();
+        assert_eq!(decrypted, 1, "invitation secret v0 must be folded in");
+        assert_eq!(room.secrets.get(&0u32), Some(&v0_secret));
+        assert_eq!(room.current_secret_version, Some(0));
+    }
+
+    /// When both the contract `encrypted_secrets` blob and an invitation
+    /// secret exist for the same version, the contract blob is
+    /// authoritative — it is decrypted first and the `contains_key`
+    /// guard skips the invitation copy.
+    #[test]
+    fn repopulate_secrets_contract_blob_wins_over_invitation_secret() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+
+        let (v0_secret, mut room) = make_private_invitee_room(&owner_sk, &invitee_sk);
+        append_encrypted_secret_for(
+            &mut room.room_state,
+            &owner_sk,
+            &invitee_sk.verifying_key(),
+            &v0_secret,
+            0,
+        );
+        // A deliberately wrong invitation secret for the same version.
+        room.invitation_secrets.insert(0, [0xABu8; 32]);
+
+        room.repopulate_secrets_from_state();
+        assert_eq!(
+            room.secrets.get(&0u32),
+            Some(&v0_secret),
+            "the contract encrypted_secrets blob must win over invitation_secrets"
+        );
+    }
+
+    /// `seal_invitee_nickname` falls back to the invitation-provided
+    /// secret when the contract state carries no blob for this member.
+    #[test]
+    fn seal_invitee_nickname_uses_invitation_secret_as_fallback() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+
+        let (v0_secret, room) = make_private_invitee_room(&owner_sk, &invitee_sk);
+        // No blob -> the contract-state lookup yields nothing.
+        assert!(current_secret_from_state(&room.room_state, &invitee_sk).is_none());
+
+        let mut invitation_secrets = HashMap::new();
+        invitation_secrets.insert(0u32, v0_secret);
+        let sealed =
+            seal_invitee_nickname(&room.room_state, &invitee_sk, &invitation_secrets, "Alice");
+        assert!(
+            sealed.is_some(),
+            "invitation secret should let the nickname seal"
+        );
+    }
+
+    /// `seal_invitee_nickname` returns `None` for a private room when no
+    /// secret is available from either source — the caller defers
+    /// member_info rather than leaking a plaintext nickname.
+    #[test]
+    fn seal_invitee_nickname_none_when_no_secret_available() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+
+        let (_v0_secret, room) = make_private_invitee_room(&owner_sk, &invitee_sk);
+        let sealed = seal_invitee_nickname(&room.room_state, &invitee_sk, &HashMap::new(), "Alice");
+        assert!(sealed.is_none());
     }
 }

--- a/ui/src/util.rs
+++ b/ui/src/util.rs
@@ -540,6 +540,7 @@ mod tests {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
+            invitation_secrets: HashMap::new(),
         };
         room_data.regenerate_contract_key();
 


### PR DESCRIPTION
## Problem

For River **private rooms**, a newly-invited member can *become* a member offline (the invitation pre-signs their `AuthorizedMember`, the contract is permissionless) but cannot **read** the room until an owner-signed `AuthorizedEncryptedSecretForMember` blob appears in the contract's `encrypted_secrets`. Only the room owner's signing key can mint that blob, so the owner's chat-delegate (or owner's open UI) must come online *after* the join to back-fill it. If it never does, the invitee is stuck on `[Encrypted message - secret vN not available]` (Bug #6 / #276, Ivvor 2026-05-17).

This also breaks for **non-owner member invites**: any member can invite (the invitation chain), and the inviting member holds the room secret — but cannot mint an owner-signed blob.

## Approach

Embed the room's symmetric secrets directly in the `Invitation` artifact (`Invitation::room_secrets`). The inviting member — owner *or* not — already holds the secrets; the invitee seeds them into `RoomData` on accept and can decrypt the room (and seal their own nickname for the join PUT) immediately, with **zero realtime involvement from the owner's delegate**.

The room contract and chat-delegate are **untouched** — `encrypted_secrets` stays owner-only and its owner-delegate back-fill becomes pure eventual-consistency durability. This is a **UI-only change**: no contract/delegate WASM change, no migration entry.

**Plaintext, not ECIES-wrapped** — a deliberate change from the originally-planned ECIES wrapping. The invitation already carries `invitee_signing_key` in the clear, so the whole artifact is a bearer credential; ECIES-wrapping the secret to the invitee's key adds *no* confidentiality (the decryption key sits in the same blob). Plaintext also avoids decrypting attacker-influenced ciphertext on the join path: `river_core::ecies::decrypt` panics on a malformed blob, and the release profile is `panic = "abort"`, so a malformed invitation would abort the whole UI. Making that path fallible would require changing `common/` (→ delegate WASM change → migration), which this PR specifically avoids.

**Persistence:** a new `#[serde(default)]` `RoomData::invitation_secrets` field rides inside the existing `rooms_data` delegate blob, so the secret survives a page refresh (`RoomData::secrets` itself is `#[serde(skip)]`). `repopulate_secrets_from_state` folds it into the in-memory `secrets` map on every ingestion. A contract `encrypted_secrets` blob is authoritative and wins on version collision. Plaintext-on-disk is consistent with the existing `self_sk` / `self_nickname` already in the persisted `RoomData`.

**Prune safety** needs no contract change: the invitee's join PUT carries a `join_event` they authored, so `post_apply_cleanup` keeps them as a message-author regardless of any `encrypted_secrets` blob.

## Security note

Embedding the secret means an interceptor of the invitation link can passively decrypt the room without joining. This is a change in *degree* only — the invitation already carries a full signing key, so it was always a bearer credential. Mitigation is unchanged: treat invitations as single-use, short-lived, delivered over a secure channel.

## Out of scope

`riverctl` is not modified. CBOR's tolerance of a missing `#[serde(default)]` field keeps old/new invitations interoperable without touching `cli/`. The CLI cannot decrypt private rooms at all today; full CLI private-room support is a separate follow-up.

## Testing

`cargo test -p river-ui --bins` — 229 pass, including 9 new tests:
- `Invitation` CBOR round-trip preserves `room_secrets`; deterministic encoding; **legacy (pre-field) invitation decodes to empty** (backward compat).
- `collect_invitation_secrets` sorted / empty.
- `repopulate_secrets_from_state` folds `invitation_secrets`; contract blob wins on collision.
- `seal_invitee_nickname` seals from the invitation secret as fallback; returns `None` (defers member_info) when no secret is available.

`cargo clippy -p river-ui --target wasm32-unknown-unknown --features no-sync` — clean (pre-existing warnings only, none in changed files). `cargo fmt` applied.

Recommended pre-merge manual check (not yet run): the AGENTS.md Playwright-MCP flow — a non-owner member invites someone while the owner's node is stopped; the invitee should see decrypted history immediately and survive a refresh.

[AI-assisted - Claude]