### PR TITLE
fix(cli): render room join events instead of "<encrypted>"

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -3356,4 +3356,17 @@ mod display_text_tests {
         let (state, msg) = state_with_message(RoomMessageBody::public("hello world".to_string()));
         assert_eq!(message_display_text(&state, &msg), "hello world");
     }
+
+    /// An unrecognized *public* content type (a future content_type this CLI
+    /// doesn't understand) is not encrypted, so it renders the "please upgrade"
+    /// placeholder rather than "<encrypted>". Pins that the fallback narrowing
+    /// applies to all public content, not just join events.
+    #[test]
+    fn unknown_public_content_renders_upgrade_placeholder() {
+        let (state, msg) = state_with_message(RoomMessageBody::public_raw(99, 1, vec![0x01, 0x02]));
+        assert_eq!(
+            message_display_text(&state, &msg),
+            "[Unsupported message type 99.1 - please upgrade]"
+        );
+    }
 }

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -75,6 +75,35 @@ pub fn compute_contract_key(owner_vk: &VerifyingKey) -> ContractKey {
     ContractKey::from_params_and_code(Parameters::from(params_bytes), &contract_code)
 }
 
+/// Resolve a message's human-readable body for display.
+///
+/// `effective_text` only yields text for `Text`/`Reply` bodies (and any edited
+/// content). Other *public* content — notably join events (`content_type = 4`,
+/// `EventContentV1`) — is not encrypted but carries no "text" field, so
+/// `effective_text` returns `None`. Such content is decoded to its own display
+/// string ("joined the room" for a join event) instead of being mislabeled as
+/// `<encrypted>`. Only genuinely private (encrypted) bodies fall back to
+/// `<encrypted>`.
+///
+/// Before this helper, riverctl rendered join events as
+/// `[nickname]: <encrypted>` because the display path conflated "no text
+/// content" with "encrypted".
+pub(crate) fn message_display_text(
+    room_state: &ChatRoomStateV1,
+    msg: &river_core::room_state::message::AuthorizedMessageV1,
+) -> String {
+    room_state
+        .recent_messages
+        .effective_text(msg)
+        .unwrap_or_else(|| {
+            msg.message
+                .content
+                .decode_content()
+                .map(|decoded| decoded.to_display_string())
+                .unwrap_or_else(|| "<encrypted>".to_string())
+        })
+}
+
 /// On-wire invitation artifact. **MUST stay byte-identical to the UI's
 /// `ui::components::members::Invitation`** — both clients exchange these via
 /// base58+CBOR and the encoded string is fingerprinted for processed-invite
@@ -2134,10 +2163,7 @@ impl ApiClient {
             .map(|info| info.member_info.preferred_nickname.to_string_lossy())
             .unwrap_or_else(|| target_msg.message.author.to_string());
 
-        let target_content_preview: String = room_state
-            .recent_messages
-            .effective_text(target_msg)
-            .unwrap_or_else(|| "<encrypted>".to_string())
+        let target_content_preview: String = message_display_text(&room_state, target_msg)
             .chars()
             .take(100)
             .collect();
@@ -2352,11 +2378,9 @@ impl ApiClient {
         room_owner_key: &VerifyingKey,
         format: &OutputFormat,
     ) -> Result<()> {
-        // Get effective content (handles edits)
-        let content = room_state
-            .recent_messages
-            .effective_text(msg)
-            .unwrap_or_else(|| "<encrypted>".to_string());
+        // Get display content (handles edits and non-text public content like
+        // join events; only genuinely encrypted bodies render as "<encrypted>")
+        let content = message_display_text(room_state, msg);
 
         // Get message ID for checking edited status and reactions
         let msg_id = msg.id();
@@ -3280,5 +3304,56 @@ mod migration_recovery_tests {
             next_upgrade_hop(&state_pointing_at(target), &mut visited).is_none(),
             "a pointer back to an already-visited contract must stop the walk"
         );
+    }
+}
+
+#[cfg(test)]
+mod display_text_tests {
+    use super::*;
+    use river_core::room_state::message::{AuthorizedMessageV1, MessageV1, RoomMessageBody};
+    use std::time::SystemTime;
+
+    /// Build a `ChatRoomStateV1` whose `recent_messages` holds a single
+    /// authored message with `body`.
+    fn state_with_message(body: RoomMessageBody) -> (ChatRoomStateV1, AuthorizedMessageV1) {
+        let author_sk = SigningKey::from_bytes(&[11u8; 32]);
+        let owner_vk = SigningKey::from_bytes(&[12u8; 32]).verifying_key();
+        let message = MessageV1 {
+            room_owner: MemberId::from(owner_vk),
+            author: MemberId::from(&author_sk.verifying_key()),
+            content: body,
+            time: SystemTime::UNIX_EPOCH,
+        };
+        let authored = AuthorizedMessageV1::new(message, &author_sk);
+        let mut state = ChatRoomStateV1::default();
+        state.recent_messages.messages.push(authored.clone());
+        (state, authored)
+    }
+
+    /// Regression: a join event is a *public* `content_type = 4` message, not
+    /// encrypted. riverctl previously rendered it as "<encrypted>" because the
+    /// display path fell back to that literal whenever `effective_text` (which
+    /// only yields text/reply bodies) returned `None`. It must now read
+    /// "joined the room".
+    #[test]
+    fn join_event_renders_as_joined_not_encrypted() {
+        let (state, msg) = state_with_message(RoomMessageBody::join_event());
+        assert_eq!(message_display_text(&state, &msg), "joined the room");
+    }
+
+    /// A genuinely private (encrypted) body still renders as "<encrypted>" —
+    /// the fix must not leak ciphertext details or mislabel real encryption.
+    #[test]
+    fn private_body_still_renders_as_encrypted() {
+        let body = RoomMessageBody::private(1, 1, vec![0xDE, 0xAD, 0xBE, 0xEF], [0u8; 12], 0);
+        let (state, msg) = state_with_message(body);
+        assert_eq!(message_display_text(&state, &msg), "<encrypted>");
+    }
+
+    /// A public text message is unaffected — it renders its plaintext.
+    #[test]
+    fn public_text_renders_plaintext() {
+        let (state, msg) = state_with_message(RoomMessageBody::public("hello world".to_string()));
+        assert_eq!(message_display_text(&state, &msg), "hello world");
     }
 }

--- a/cli/src/commands/message.rs
+++ b/cli/src/commands/message.rs
@@ -219,11 +219,10 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
                             let datetime: DateTime<Utc> = msg.message.time.into();
                             let local_time: DateTime<Local> = datetime.into();
 
-                            // Get effective content (handles edits)
-                            let content = room_state
-                                .recent_messages
-                                .effective_text(msg)
-                                .unwrap_or_else(|| "<encrypted>".to_string());
+                            // Get display content (handles edits and non-text
+                            // public content like join events; only genuinely
+                            // encrypted bodies render as "<encrypted>")
+                            let content = crate::api::message_display_text(&room_state, msg);
 
                             // Check if message is edited
                             let msg_id = msg.id();
@@ -301,11 +300,10 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
 
                             let datetime: DateTime<Utc> = msg.message.time.into();
 
-                            // Get effective content
-                            let content = room_state
-                                .recent_messages
-                                .effective_text(msg)
-                                .unwrap_or_else(|| "<encrypted>".to_string());
+                            // Get display content (handles edits and non-text
+                            // public content like join events; only genuinely
+                            // encrypted bodies render as "<encrypted>")
+                            let content = crate::api::message_display_text(&room_state, msg);
 
                             // Check edited status
                             let edited = room_state.recent_messages.is_edited(&msg_id);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -186,6 +186,41 @@ fn parse_signing_key_bytes(bytes: &[u8]) -> std::result::Result<SigningKey, Stri
     Ok(SigningKey::from_bytes(&buf))
 }
 
+fn init_logging(debug: bool, log_path: Option<&Path>) -> Result<Option<WorkerGuard>> {
+    use std::fs::OpenOptions;
+    use tracing_subscriber::{fmt, layer::SubscriberExt, Registry};
+
+    let filter = if debug {
+        EnvFilter::new("debug")
+    } else {
+        EnvFilter::from_default_env()
+    };
+
+    let stderr_layer = fmt::layer()
+        .with_writer(std::io::stderr)
+        .with_ansi(atty::is(atty::Stream::Stderr));
+
+    let registry = Registry::default().with(filter).with(stderr_layer);
+
+    if let Some(path) = log_path {
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .with_context(|| format!("failed to open log file {}", path.display()))?;
+        let (writer, guard) = tracing_appender::non_blocking(file);
+        let file_layer = fmt::layer().with_ansi(false).with_writer(writer);
+        let subscriber = registry.with(file_layer);
+        tracing::subscriber::set_global_default(subscriber)
+            .context("failed to install tracing subscriber")?;
+        Ok(Some(guard))
+    } else {
+        tracing::subscriber::set_global_default(registry)
+            .context("failed to install tracing subscriber")?;
+        Ok(None)
+    }
+}
+
 #[cfg(test)]
 mod cli_tests {
     use super::*;
@@ -222,40 +257,5 @@ mod cli_tests {
         let raw: [u8; 0] = [];
         let err = parse_signing_key_bytes(&raw).expect_err("must reject empty input");
         assert!(err.contains("0 bytes"), "msg: {}", err);
-    }
-}
-
-fn init_logging(debug: bool, log_path: Option<&Path>) -> Result<Option<WorkerGuard>> {
-    use std::fs::OpenOptions;
-    use tracing_subscriber::{fmt, layer::SubscriberExt, Registry};
-
-    let filter = if debug {
-        EnvFilter::new("debug")
-    } else {
-        EnvFilter::from_default_env()
-    };
-
-    let stderr_layer = fmt::layer()
-        .with_writer(std::io::stderr)
-        .with_ansi(atty::is(atty::Stream::Stderr));
-
-    let registry = Registry::default().with(filter).with(stderr_layer);
-
-    if let Some(path) = log_path {
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)
-            .with_context(|| format!("failed to open log file {}", path.display()))?;
-        let (writer, guard) = tracing_appender::non_blocking(file);
-        let file_layer = fmt::layer().with_ansi(false).with_writer(writer);
-        let subscriber = registry.with(file_layer);
-        tracing::subscriber::set_global_default(subscriber)
-            .context("failed to install tracing subscriber")?;
-        Ok(Some(guard))
-    } else {
-        tracing::subscriber::set_global_default(registry)
-            .context("failed to install tracing subscriber")?;
-        Ok(None)
     }
 }


### PR DESCRIPTION
## Problem

riverctl renders room **join events** as `[nickname]: <encrypted>` (e.g. `[Proxy Glider.ESOGQNDH]: <encrypted>`). Reported by a user running an XMPP bridge over riverctl. It happens in **public** rooms too — it is unrelated to private-room encryption.

Join events are stored as **public** `content_type=4` (`EventContentV1`) messages — they are never encrypted. The display path calls `effective_text()`, which only returns text for `Text`/`Reply` bodies (`as_text()` returns `None` for events). For a join event it returns `None`, and the CLI blindly fell back to the literal string `"<encrypted>"`, mislabeling a perfectly-decodable public event.

## Approach

Add a `message_display_text()` helper in `cli/src/api.rs`: when `effective_text()` is empty, decode the content and use its own display string (`"joined the room"` for a join event, the `[Unsupported message type …]` placeholder for unknown public types). Only genuinely **private** (encrypted) bodies — where `decode_content()` returns `None` — fall back to `"<encrypted>"`.

Wired into all four display sites: `message list` (human + JSON), the `monitor` stream (`output_message`), and reply previews.

The web UI already special-cases `is_event()` in `conversation.rs` (renders "Alice joined the room"), so this is a **CLI-only** fix — no `common/`/contract/delegate/WASM change, hence **no migration and no UI republish** required.

Also moves a pre-existing trailing fn before the `cli_tests` module in `main.rs` to clear a `clippy::items_after_test_module` warning.

## Testing

New `display_text_tests` module in `cli/src/api.rs`:
- `join_event_renders_as_joined_not_encrypted` — the regression: asserts `"joined the room"`, not `"<encrypted>"`
- `private_body_still_renders_as_encrypted` — encrypted bodies still show `"<encrypted>"`
- `public_text_renders_plaintext` — control

`cargo fmt`, `cargo clippy -p riverctl --all-targets` (clean), and the new tests all pass locally.

[AI-assisted - Claude]