### PR TITLE
fix(cli): restore real nickname on rejoin instead of "Member"

### DIFF
--- a/.claude/rules/private-rooms.md
+++ b/.claude/rules/private-rooms.md
@@ -150,6 +150,30 @@ indefinitely (filed as freenet/river#304). The CLI also does NOT prune
 superseded `invitation_secrets` entries the way the UI does — storage
 waste only; the heal path is the natural place to hook the prune.
 
+### Rejoin nickname restoration (`StoredRoomInfo.self_nickname`)
+
+The CLI persists the member's own nickname in
+`StoredRoomInfo.self_nickname` (set on `accept_invitation`,
+`set_nickname`, and public-room `import_identity`). When a member is
+pruned for inactivity and later reposts, `ApiClient::build_rejoin_delta`
+re-adds them AND restores this nickname via the free helper
+`rejoin_preferred_nickname` instead of the generic `"Member"`
+placeholder. The helper routes the nickname through
+`seal_invitee_nickname` (public bytes for a public room, sealed for a
+private room) and falls back to public `"Member"` when no nickname is
+stored, a private room has no secret (so the plaintext is never leaked),
+OR the stored nickname exceeds the room's current `max_nickname_size`
+(which would otherwise make the contract reject the whole rejoin delta).
+
+This is a PARTIAL analog of the UI's `build_member_info_heal`, NOT the
+full #304 heal: it only restores the nickname on the rejoin/send path,
+and it diverges from the UI in the private-room-no-secret case — the UI
+*defers* `member_info` (member shows "Unknown"), whereas the CLI
+publishes a public `"Member"` placeholder (pre-existing CLI behavior;
+safe — no plaintext leak). The call site is pinned by
+`rejoin_nickname_wiring_pinned` in `cli/src/storage.rs` and the
+selection matrix by `rejoin_nickname_tests` in `cli/src/api.rs`.
+
 ## Key files
 
 - `common/src/room_state/privacy.rs`, `secret.rs`, `configuration.rs`

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -960,6 +960,11 @@ impl ApiClient {
                             &invite_chain,
                         )?;
 
+                        // Persist our chosen nickname so a later rejoin (after
+                        // an inactivity prune) restores it instead of "Member".
+                        self.storage
+                            .update_self_nickname(&room_owner_vk, nickname)?;
+
                         // Immediately publish membership + join event atomically.
                         // The join event counts as a message, preventing
                         // post_apply_cleanup from pruning the new member.
@@ -1574,13 +1579,19 @@ impl ApiClient {
             Err(_) => return (None, None),
         };
         let key_str = bs58::encode(room_owner_key.as_bytes()).into_string();
-        let (authorized_member, invite_chain) = match storage.rooms.get(&key_str) {
-            Some(info) => match &info.self_authorized_member {
-                Some(am) => (am.clone(), info.invite_chain.clone()),
+        let (authorized_member, invite_chain, self_nickname, invitation_secrets) =
+            match storage.rooms.get(&key_str) {
+                Some(info) => match &info.self_authorized_member {
+                    Some(am) => (
+                        am.clone(),
+                        info.invite_chain.clone(),
+                        info.self_nickname.clone(),
+                        info.invitation_secrets.clone(),
+                    ),
+                    None => return (None, None),
+                },
                 None => return (None, None),
-            },
-            None => return (None, None),
-        };
+            };
 
         // Build members delta - include self and any missing chain members
         let current_member_ids: HashSet<MemberId> = room_state
@@ -1606,10 +1617,30 @@ impl ApiClient {
             .map(|i| i.member_info.version)
             .unwrap_or(0);
 
+        // Restore the member's real nickname (persisted on join / set-nickname)
+        // rather than the generic "Member" placeholder. `seal_invitee_nickname`
+        // returns public bytes for a public room and sealed bytes for a private
+        // room; it returns `None` for a private room when no secret is available
+        // (so we must NOT publish the plaintext nickname). In that case — and
+        // when no nickname was persisted (rooms joined before this field, or an
+        // older `rooms.json`) — fall back to the generic "Member" placeholder,
+        // which is safe to publish publicly and preserves prior behavior.
+        let preferred_nickname = self_nickname
+            .as_deref()
+            .and_then(|nick| {
+                crate::private_room::seal_invitee_nickname(
+                    room_state,
+                    signing_key,
+                    &invitation_secrets,
+                    nick,
+                )
+            })
+            .unwrap_or_else(|| SealedBytes::public("Member".to_string().into_bytes()));
+
         let member_info = MemberInfo {
             member_id: self_id,
             version: existing_version,
-            preferred_nickname: SealedBytes::public("Member".to_string().into_bytes()),
+            preferred_nickname,
         };
         let authorized_info = AuthorizedMemberInfo::new_with_member_key(member_info, signing_key);
 
@@ -2504,7 +2535,7 @@ impl ApiClient {
         let new_member_info = MemberInfo {
             member_id: my_member_id,
             version: current_version + 1,
-            preferred_nickname: SealedBytes::public(new_nickname.into_bytes()),
+            preferred_nickname: SealedBytes::public(new_nickname.clone().into_bytes()),
         };
 
         // Sign with our member key
@@ -2529,6 +2560,11 @@ impl ApiClient {
         // Save the updated state locally
         self.storage
             .update_room_state(room_owner_key, room_state.clone())?;
+
+        // Persist our chosen nickname so a later rejoin (after an inactivity
+        // prune) restores it instead of "Member".
+        self.storage
+            .update_self_nickname(room_owner_key, &new_nickname)?;
 
         // Check if we need to re-add ourselves (pruned for inactivity)
         let (members_delta, _) = self.build_rejoin_delta(&room_state, room_owner_key, &signing_key);

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -21,7 +21,7 @@ use river_core::room_state::ChatRoomStateV1Delta;
 use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::sync::Arc;
 use std::time::Duration;
@@ -102,6 +102,45 @@ pub(crate) fn message_display_text(
                 .map(|decoded| decoded.to_display_string())
                 .unwrap_or_else(|| "<encrypted>".to_string())
         })
+}
+
+/// Choose the `member_info` nickname to publish when re-adding a member who
+/// was pruned for inactivity (see [`ApiClient::build_rejoin_delta`]).
+///
+/// Restores the member's persisted nickname — sealed for a private room via
+/// [`crate::private_room::seal_invitee_nickname`] — falling back to the generic
+/// public `"Member"` placeholder when any of these hold:
+/// - no nickname was persisted (rooms joined before the `self_nickname` field,
+///   or an older `rooms.json`);
+/// - a private room has no secret available, so sealing returns `None` (we must
+///   never publish a plaintext nickname into a private room);
+/// - the stored nickname's byte length exceeds the room's current
+///   `max_nickname_size`. The contract's `MemberInfoV1::apply_delta` rejects the
+///   ENTIRE rejoin delta (members + member_info together) when
+///   `declared_len() > max_nickname_size`, so an over-long restored nickname
+///   would block the member from rejoining at all. `declared_len()` is the
+///   plaintext byte length for both public and sealed values, so comparing
+///   `nick.len()` here matches the contract check exactly. The 6-byte `"Member"`
+///   placeholder keeps the rejoin working (regression guard — Codex/skeptical
+///   review of PR #321).
+fn rejoin_preferred_nickname(
+    room_state: &ChatRoomStateV1,
+    signing_key: &SigningKey,
+    invitation_secrets: &HashMap<u32, [u8; 32]>,
+    self_nickname: Option<&str>,
+) -> SealedBytes {
+    let max_nickname_size = room_state.configuration.configuration.max_nickname_size;
+    self_nickname
+        .filter(|nick| nick.len() <= max_nickname_size)
+        .and_then(|nick| {
+            crate::private_room::seal_invitee_nickname(
+                room_state,
+                signing_key,
+                invitation_secrets,
+                nick,
+            )
+        })
+        .unwrap_or_else(|| SealedBytes::public("Member".to_string().into_bytes()))
 }
 
 /// On-wire invitation artifact. **MUST stay byte-identical to the UI's
@@ -1617,25 +1656,17 @@ impl ApiClient {
             .map(|i| i.member_info.version)
             .unwrap_or(0);
 
-        // Restore the member's real nickname (persisted on join / set-nickname)
-        // rather than the generic "Member" placeholder. `seal_invitee_nickname`
-        // returns public bytes for a public room and sealed bytes for a private
-        // room; it returns `None` for a private room when no secret is available
-        // (so we must NOT publish the plaintext nickname). In that case — and
-        // when no nickname was persisted (rooms joined before this field, or an
-        // older `rooms.json`) — fall back to the generic "Member" placeholder,
-        // which is safe to publish publicly and preserves prior behavior.
-        let preferred_nickname = self_nickname
-            .as_deref()
-            .and_then(|nick| {
-                crate::private_room::seal_invitee_nickname(
-                    room_state,
-                    signing_key,
-                    &invitation_secrets,
-                    nick,
-                )
-            })
-            .unwrap_or_else(|| SealedBytes::public("Member".to_string().into_bytes()));
+        // Restore the member's real nickname (persisted on join / set-nickname /
+        // import) rather than the generic "Member" placeholder. The selection —
+        // public vs sealed, the no-secret fallback, and the max_nickname_size
+        // clamp — lives in `rejoin_preferred_nickname` so it is unit-testable
+        // without a node connection.
+        let preferred_nickname = rejoin_preferred_nickname(
+            room_state,
+            signing_key,
+            &invitation_secrets,
+            self_nickname.as_deref(),
+        );
 
         let member_info = MemberInfo {
             member_id: self_id,
@@ -3403,6 +3434,102 @@ mod display_text_tests {
         assert_eq!(
             message_display_text(&state, &msg),
             "[Unsupported message type 99.1 - please upgrade]"
+        );
+    }
+}
+
+#[cfg(test)]
+mod rejoin_nickname_tests {
+    use super::*;
+    use river_core::room_state::configuration::{AuthorizedConfigurationV1, Configuration};
+    use river_core::room_state::privacy::PrivacyMode;
+
+    fn member_key() -> SigningKey {
+        SigningKey::from_bytes(&[11u8; 32])
+    }
+
+    /// Build a `ChatRoomStateV1` with the given privacy mode, nickname-size
+    /// limit, and current secret version.
+    fn state_with(
+        privacy: PrivacyMode,
+        max_nickname_size: usize,
+        current_version: u32,
+    ) -> ChatRoomStateV1 {
+        let owner_sk = SigningKey::from_bytes(&[3u8; 32]);
+        let config = Configuration {
+            owner_member_id: owner_sk.verifying_key().into(),
+            privacy_mode: privacy,
+            max_nickname_size,
+            ..Default::default()
+        };
+        let mut state = ChatRoomStateV1 {
+            configuration: AuthorizedConfigurationV1::new(config, &owner_sk),
+            ..Default::default()
+        };
+        state.secrets.current_version = current_version;
+        state
+    }
+
+    /// Public room → the real nickname is restored as public plaintext.
+    #[test]
+    fn public_room_restores_real_nickname() {
+        let state = state_with(PrivacyMode::Public, 50, 0);
+        let out = rejoin_preferred_nickname(&state, &member_key(), &HashMap::new(), Some("Alice"));
+        assert!(out.is_public());
+        assert_eq!(out.to_string_lossy(), "Alice");
+    }
+
+    /// No persisted nickname → generic "Member" placeholder.
+    #[test]
+    fn no_stored_nickname_falls_back_to_member() {
+        let state = state_with(PrivacyMode::Public, 50, 0);
+        let out = rejoin_preferred_nickname(&state, &member_key(), &HashMap::new(), None);
+        assert!(out.is_public());
+        assert_eq!(out.to_string_lossy(), "Member");
+    }
+
+    /// A nickname longer than the room's current `max_nickname_size` must NOT
+    /// be published (the contract would reject the whole rejoin delta) — fall
+    /// back to "Member" so the member can still rejoin. Regression guard for the
+    /// PR #321 Codex/skeptical finding.
+    #[test]
+    fn over_long_nickname_falls_back_to_member() {
+        // max 8: "Member" (6) fits, but the stored nickname (20) does not.
+        let state = state_with(PrivacyMode::Public, 8, 0);
+        let out = rejoin_preferred_nickname(
+            &state,
+            &member_key(),
+            &HashMap::new(),
+            Some("this_is_way_too_long"),
+        );
+        assert_eq!(out.to_string_lossy(), "Member");
+    }
+
+    /// Private room with a secret available → the nickname is SEALED
+    /// (ciphertext), never published as plaintext.
+    #[test]
+    fn private_room_with_secret_seals_nickname() {
+        let state = state_with(PrivacyMode::Private, 50, 1);
+        let mut secrets = HashMap::new();
+        secrets.insert(1u32, [7u8; 32]);
+        let out = rejoin_preferred_nickname(&state, &member_key(), &secrets, Some("Alice"));
+        assert!(out.is_private(), "private-room nickname must be sealed");
+        // Declared plaintext length is preserved even though the bytes are sealed.
+        assert_eq!(out.declared_len(), "Alice".len());
+    }
+
+    /// Private room with NO secret available → must fall back to the generic
+    /// public "Member" placeholder, NEVER leak the real nickname as plaintext.
+    #[test]
+    fn private_room_without_secret_does_not_leak_real_nickname() {
+        let state = state_with(PrivacyMode::Private, 50, 1);
+        let out = rejoin_preferred_nickname(&state, &member_key(), &HashMap::new(), Some("Alice"));
+        assert!(out.is_public());
+        assert_eq!(out.to_string_lossy(), "Member");
+        assert_ne!(
+            out.to_string_lossy(),
+            "Alice",
+            "real nickname must never be published as plaintext in a private room"
         );
     }
 }

--- a/cli/src/commands/identity.rs
+++ b/cli/src/commands/identity.rs
@@ -249,6 +249,20 @@ async fn import_identity(
         &export.invite_chain,
     )?;
 
+    // Persist the imported nickname so a later rejoin (after an inactivity
+    // prune) restores it instead of "Member" — but ONLY when it's public
+    // plaintext. A private room's exported nickname is sealed, so
+    // `to_string_lossy` yields an "[Encrypted: …]" placeholder, not the real
+    // name; persisting that would be worse than the generic fallback.
+    if let Some(info) = export.member_info.as_ref() {
+        if info.member_info.preferred_nickname.is_public() {
+            let imported_nickname = info.member_info.preferred_nickname.to_string_lossy();
+            api_client
+                .storage()
+                .update_self_nickname(&export.room_owner, &imported_nickname)?;
+        }
+    }
+
     let nickname = export
         .member_info
         .as_ref()

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -62,6 +62,15 @@ pub struct StoredRoomInfo {
     /// whatever full-disk encryption the user has configured.
     #[serde(default)]
     pub invitation_secrets: HashMap<u32, [u8; 32]>,
+    /// The member's own chosen nickname for this room, persisted so
+    /// `ApiClient::build_rejoin_delta` can restore it (sealed for private
+    /// rooms) when re-adding the member after an inactivity prune — instead
+    /// of the generic "Member" placeholder. Set on `accept_invitation` and
+    /// `set_nickname`. `None` for rooms joined before this field existed
+    /// (`#[serde(default)]` keeps old `rooms.json` files readable) and for
+    /// the room owner (who is never pruned, so never rejoins).
+    #[serde(default)]
+    pub self_nickname: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -260,11 +269,25 @@ impl Storage {
             invite_chain: Vec::new(),
             previous_contract_key: None,
             invitation_secrets,
+            self_nickname: None,
         };
 
         storage.rooms.insert(owner_key_str, room_info);
         self.save_rooms(&storage)?;
 
+        Ok(())
+    }
+
+    /// Persist the member's own nickname for `owner_vk`'s room, so a later
+    /// rejoin (`ApiClient::build_rejoin_delta`) can restore it instead of the
+    /// generic "Member" placeholder. No-op if the room isn't stored yet.
+    pub fn update_self_nickname(&self, owner_vk: &VerifyingKey, nickname: &str) -> Result<()> {
+        let mut storage = self.load_rooms()?;
+        let owner_key_str = bs58::encode(owner_vk.as_bytes()).into_string();
+        if let Some(info) = storage.rooms.get_mut(&owner_key_str) {
+            info.self_nickname = Some(nickname.to_string());
+            self.save_rooms(&storage)?;
+        }
         Ok(())
     }
 
@@ -459,6 +482,68 @@ mod tests {
         let result = storage.update_contract_key(&owner_vk, &new_key);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Room not found"));
+    }
+
+    #[test]
+    fn test_update_self_nickname_round_trips() {
+        let (storage, _temp_dir) = create_test_storage();
+        let owner_sk = create_test_signing_key();
+        let owner_vk = owner_sk.verifying_key();
+        let state = create_test_state(&owner_sk);
+        let key = expected_contract_key(&owner_vk);
+        storage.add_room(&owner_vk, &owner_sk, state, &key).unwrap();
+
+        let key_str = bs58::encode(owner_vk.as_bytes()).into_string();
+        // Freshly-added rooms carry no nickname until one is set.
+        assert_eq!(
+            storage.load_rooms().unwrap().rooms[&key_str].self_nickname,
+            None
+        );
+
+        storage.update_self_nickname(&owner_vk, "Alice").unwrap();
+        assert_eq!(
+            storage.load_rooms().unwrap().rooms[&key_str]
+                .self_nickname
+                .as_deref(),
+            Some("Alice"),
+            "nickname must persist across a load_rooms reload"
+        );
+    }
+
+    #[test]
+    fn test_update_self_nickname_missing_room_is_noop() {
+        let (storage, _temp_dir) = create_test_storage();
+        let owner_sk = create_test_signing_key();
+        // No room stored for this key — must be a no-op, not an error.
+        storage
+            .update_self_nickname(&owner_sk.verifying_key(), "Ghost")
+            .expect("updating a nickname for an unknown room should be a no-op");
+    }
+
+    #[test]
+    fn test_stored_room_info_without_self_nickname_field_defaults_none() {
+        // An old `rooms.json` written before the `self_nickname` field existed
+        // must still deserialize, with `self_nickname` defaulting to `None`
+        // (the `#[serde(default)]` backward-compat invariant).
+        let owner_sk = create_test_signing_key();
+        let info = StoredRoomInfo {
+            signing_key_bytes: owner_sk.to_bytes(),
+            state: create_test_state(&owner_sk),
+            contract_key: "test".to_string(),
+            self_authorized_member: None,
+            invite_chain: Vec::new(),
+            previous_contract_key: None,
+            invitation_secrets: HashMap::new(),
+            self_nickname: Some("Alice".to_string()),
+        };
+        let mut value = serde_json::to_value(&info).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .remove("self_nickname")
+            .expect("serialized form should contain self_nickname");
+        let parsed: StoredRoomInfo = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed.self_nickname, None);
     }
 
     #[test]

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -510,6 +510,40 @@ mod tests {
         );
     }
 
+    /// Source-grep pins guarding the rejoin-nickname wiring against silent
+    /// refactor regressions (testing-reviewer findings on PR #321). These live
+    /// in storage.rs — NOT api.rs/identity.rs — so the pinned strings are not
+    /// self-satisfied by the test's own source (the same discipline as
+    /// `accept_invitation_calls_seal_invitee_nickname` in private_room.rs).
+    #[test]
+    fn rejoin_nickname_wiring_pinned() {
+        let api_src = include_str!("api.rs");
+        assert!(
+            api_src.contains("rejoin_preferred_nickname("),
+            "build_rejoin_delta must route the rejoin nickname through \
+             `rejoin_preferred_nickname` (which seals for private rooms and \
+             clamps to max_nickname_size). Do NOT inline an unconditional \
+             public placeholder, or a private-room nickname could leak / an \
+             over-long nickname could block rejoin."
+        );
+        assert!(
+            api_src.contains("update_self_nickname(&room_owner_vk, nickname)"),
+            "accept_invitation must persist the chosen nickname via \
+             Storage::update_self_nickname."
+        );
+        assert!(
+            api_src.contains("update_self_nickname(room_owner_key, &new_nickname)"),
+            "set_nickname must persist the new nickname via \
+             Storage::update_self_nickname."
+        );
+        let identity_src = include_str!("commands/identity.rs");
+        assert!(
+            identity_src.contains("update_self_nickname("),
+            "import_identity must persist the imported (public-room) nickname \
+             via Storage::update_self_nickname."
+        );
+    }
+
     #[test]
     fn test_update_self_nickname_missing_room_is_noop() {
         let (storage, _temp_dir) = create_test_storage();


### PR DESCRIPTION
## Problem

When a riverctl member is pruned for inactivity and later posts a message, `build_rejoin_delta` correctly re-adds them to the members list — but re-published their `member_info` with a **hardcoded "Member"** nickname. So a user who joined as "Bob", went quiet long enough to be pruned, then spoke again, reappeared to every peer as **"Member"** instead of "Bob".

Root cause: the member's real nickname lived only in the room's `member_info`, which is pruned alongside the member, and riverctl never persisted it locally. With nothing to restore from, the rejoin path fell back to a placeholder.

(Found while investigating, at the user's request, whether riverctl re-adds a member on post — it does; this is the one rough edge in that path.)

## Approach

- Persist the member's own nickname in a new `StoredRoomInfo.self_nickname: Option<String>` field (`#[serde(default)]`, so old `rooms.json` files still load), set on `accept_invitation` and `set_nickname`.
- On rejoin, `build_rejoin_delta` now seals the stored nickname via the existing `private_room::seal_invitee_nickname` helper: **public** bytes for a public room, **sealed** bytes for a private room.
- Falls back to the generic "Member" placeholder only when (a) no nickname was persisted (rooms joined before this field) or (b) a private room has no secret available — so we **never leak a plaintext nickname** into a private room (mirrors the UI's heal behavior).
- The room owner is exempt from rejoin (`build_rejoin_delta` returns early for the owner), so the owner's nickname is intentionally not persisted.

CLI-only — no `common/`/contract/delegate/WASM change, **no migration, no UI republish**.

## Testing

**Unit** (`cli/src/storage.rs`):
- `test_update_self_nickname_round_trips` — persists and survives a `load_rooms` reload
- `test_update_self_nickname_missing_room_is_noop` — no error when the room isn't stored
- `test_stored_room_info_without_self_nickname_field_defaults_none` — backward-compat: old rooms.json without the field deserializes with `None`

**End-to-end** on a local node: created a room, "Bob" joined (confirmed `self_nickname = "Bob"` persisted), aged his join-event out of a 2-message window to prune him (members → just Owner), then had Bob repost. Before this change he came back as "Member"; with it he rejoins as **"Bob"**.

`cargo fmt`, `cargo clippy -p riverctl --all-targets` (clean), and all 49 CLI lib tests pass.

[AI-assisted - Claude]