### PR TITLE
feat(ui): add day-change date separators to chat messages

### DIFF
--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -115,6 +115,15 @@ struct EventSummary {
 
 /// The representative timestamp (ms since epoch) for a display item, used to
 /// decide which local calendar day it belongs to for the date separators.
+///
+/// A single item is attributed to one day, so a group whose messages straddle
+/// local midnight (same author within the 5-minute group window, or events
+/// within the 1-hour merge window) is placed entirely under its first/last
+/// message's day — no divider is rendered mid-group. This is an accepted,
+/// self-correcting limitation: the next group on the new day still gets its
+/// own divider and each message keeps its own `HH:MM`. Splitting groups at the
+/// local-day boundary would push timezone logic into the otherwise
+/// timezone-independent `group_messages`, so it is intentionally not done here.
 fn display_item_time_ms(item: &DisplayItem) -> i64 {
     match item {
         DisplayItem::Messages(group) => group.first_time.timestamp_millis(),

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -6,7 +6,10 @@ use crate::components::app::{
 };
 use crate::room_data::SendMessageError;
 use crate::util::ecies::{encrypt_with_symmetric_key, unseal_bytes_with_secrets};
-use crate::util::{format_utc_as_full_datetime, format_utc_as_local_time, get_current_system_time};
+use crate::util::{
+    date_separator_labels, format_utc_as_full_datetime, format_utc_as_local_time,
+    get_current_system_time, local_message_date, local_today,
+};
 mod emoji_picker;
 mod message_actions;
 mod message_input;
@@ -108,6 +111,15 @@ struct EventSummary {
     names: Vec<String>,
     id: String,
     last_time: DateTime<Utc>,
+}
+
+/// The representative timestamp (ms since epoch) for a display item, used to
+/// decide which local calendar day it belongs to for the date separators.
+fn display_item_time_ms(item: &DisplayItem) -> i64 {
+    match item {
+        DisplayItem::Messages(group) => group.first_time.timestamp_millis(),
+        DisplayItem::Event(summary) => summary.last_time.timestamp_millis(),
+    }
 }
 
 /// Group consecutive messages from the same sender within 5 minutes,
@@ -1563,17 +1575,44 @@ pub fn Conversation() -> Element {
                                     let self_member_id = *self_member_id;
                                     let member_names = member_names.clone();
                                     let groups_len = groups.len();
+                                    // Precompute a day-change separator label for each item.
+                                    // A label is emitted only when the local calendar day
+                                    // differs from the previous item's, so a run of messages
+                                    // on the same day shows a single "Today" / "Monday, June 3"
+                                    // divider above it. Computed at render time so relative
+                                    // "Today"/"Yesterday" labels stay fresh across re-renders.
+                                    let separators: Vec<Option<String>> = {
+                                        let item_dates: Vec<chrono::NaiveDate> = groups
+                                            .iter()
+                                            .map(|item| {
+                                                local_message_date(display_item_time_ms(item))
+                                            })
+                                            .collect();
+                                        date_separator_labels(&item_dates, local_today())
+                                    };
                                     Some(rsx! {
                                         div { class: "space-y-4",
                                             {groups.into_iter().enumerate().map({
                                                 let handle_toggle_reaction = handle_toggle_reaction.clone();
                                                 let member_names = member_names.clone();
+                                                let separators = separators.clone();
                                                 move |(group_idx, item)| {
                                                 let is_last_group = group_idx == groups_len - 1;
                                                 let handle_toggle_reaction = handle_toggle_reaction.clone();
                                                 let handle_edit_message = handle_edit_message.clone();
                                                 let member_names = member_names.clone();
-                                                match item {
+                                                let date_separator = separators.get(group_idx).cloned().flatten();
+                                                let separator_rsx = date_separator.map(|label| rsx! {
+                                                    div {
+                                                        key: "date-sep-{group_idx}",
+                                                        class: "flex justify-center py-2",
+                                                        span {
+                                                            class: "text-xs font-medium text-text-muted bg-surface px-3 py-1 rounded-full",
+                                                            "{label}"
+                                                        }
+                                                    }
+                                                });
+                                                let item_rsx = match item {
                                                     DisplayItem::Event(summary) => {
                                                         let text = format_event_summary(&summary.names);
                                                         let key = summary.id.clone();
@@ -1630,6 +1669,10 @@ pub fn Conversation() -> Element {
                                                             }
                                                         }
                                                     }
+                                                };
+                                                rsx! {
+                                                    {separator_rsx}
+                                                    {item_rsx}
                                                 }
                                             }})}
                                         }

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -122,6 +122,27 @@ fn display_item_time_ms(item: &DisplayItem) -> i64 {
     }
 }
 
+/// The stable per-item key used on the item's rendered root, reused to derive
+/// a unique key for the date separator that precedes it.
+fn display_item_key(item: &DisplayItem) -> String {
+    match item {
+        DisplayItem::Messages(group) => group.messages[0].id.clone(),
+        DisplayItem::Event(summary) => summary.id.clone(),
+    }
+}
+
+/// A rendered conversation row: either a day-change date separator or a
+/// message/event display item. Separators are flattened into their own rows
+/// (rather than emitted as a second root alongside the item) so every row
+/// renders as a SINGLE keyed node — otherwise Dioxus takes the list key from
+/// the fragment's first root, which would be the keyless separator expression,
+/// silently dropping the whole group list to positional diffing and leaking
+/// per-group component state on mid-list edits (freenet/river#326 review).
+enum DisplayRow {
+    DateSeparator { key: String, label: String },
+    Item(DisplayItem),
+}
+
 /// Group consecutive messages from the same sender within 5 minutes,
 /// and summarize consecutive event messages (e.g. joins).
 fn group_messages(
@@ -1574,46 +1595,58 @@ pub fn Conversation() -> Element {
                                     let groups = groups.clone();
                                     let self_member_id = *self_member_id;
                                     let member_names = member_names.clone();
-                                    let groups_len = groups.len();
-                                    // Precompute a day-change separator label for each item.
-                                    // A label is emitted only when the local calendar day
-                                    // differs from the previous item's, so a run of messages
-                                    // on the same day shows a single "Today" / "Monday, June 3"
-                                    // divider above it. Computed at render time so relative
+                                    // Flatten the message/event groups into render rows,
+                                    // inserting a day-change separator row above the first
+                                    // item of each local calendar day (a run of messages on
+                                    // the same day shows a single "Today" / "Monday, June 3"
+                                    // divider). Each row renders as a single keyed root so the
+                                    // list keeps diffing by key — see DisplayRow. The separator
+                                    // labels are computed at render time so relative
                                     // "Today"/"Yesterday" labels stay fresh across re-renders.
-                                    let separators: Vec<Option<String>> = {
+                                    let rows: Vec<DisplayRow> = {
                                         let item_dates: Vec<chrono::NaiveDate> = groups
                                             .iter()
                                             .map(|item| {
                                                 local_message_date(display_item_time_ms(item))
                                             })
                                             .collect();
-                                        date_separator_labels(&item_dates, local_today())
+                                        let labels =
+                                            date_separator_labels(&item_dates, local_today());
+                                        let mut rows = Vec::with_capacity(groups.len());
+                                        for (item, label) in groups.into_iter().zip(labels) {
+                                            if let Some(label) = label {
+                                                rows.push(DisplayRow::DateSeparator {
+                                                    key: format!("date-sep-{}", display_item_key(&item)),
+                                                    label,
+                                                });
+                                            }
+                                            rows.push(DisplayRow::Item(item));
+                                        }
+                                        rows
                                     };
+                                    let rows_len = rows.len();
                                     Some(rsx! {
                                         div { class: "space-y-4",
-                                            {groups.into_iter().enumerate().map({
+                                            {rows.into_iter().enumerate().map({
                                                 let handle_toggle_reaction = handle_toggle_reaction.clone();
                                                 let member_names = member_names.clone();
-                                                let separators = separators.clone();
-                                                move |(group_idx, item)| {
-                                                let is_last_group = group_idx == groups_len - 1;
+                                                move |(row_idx, row)| {
+                                                let is_last_group = row_idx == rows_len - 1;
                                                 let handle_toggle_reaction = handle_toggle_reaction.clone();
                                                 let handle_edit_message = handle_edit_message.clone();
                                                 let member_names = member_names.clone();
-                                                let date_separator = separators.get(group_idx).cloned().flatten();
-                                                let separator_rsx = date_separator.map(|label| rsx! {
-                                                    div {
-                                                        key: "date-sep-{group_idx}",
-                                                        class: "flex justify-center py-2",
-                                                        span {
-                                                            class: "text-xs font-medium text-text-muted bg-surface px-3 py-1 rounded-full",
-                                                            "{label}"
+                                                match row {
+                                                    DisplayRow::DateSeparator { key, label } => rsx! {
+                                                        div {
+                                                            key: "{key}",
+                                                            class: "flex justify-center py-2",
+                                                            span {
+                                                                class: "text-xs font-medium text-text-muted bg-surface px-3 py-1 rounded-full",
+                                                                "{label}"
+                                                            }
                                                         }
-                                                    }
-                                                });
-                                                let item_rsx = match item {
-                                                    DisplayItem::Event(summary) => {
+                                                    },
+                                                    DisplayRow::Item(DisplayItem::Event(summary)) => {
                                                         let text = format_event_summary(&summary.names);
                                                         let key = summary.id.clone();
                                                         let mut last_el = last_chat_element;
@@ -1635,7 +1668,7 @@ pub fn Conversation() -> Element {
                                                             }
                                                         }
                                                     }
-                                                    DisplayItem::Messages(group) => {
+                                                    DisplayRow::Item(DisplayItem::Messages(group)) => {
                                                         let key = group.messages[0].id.clone();
                                                         rsx! {
                                                             MessageGroupComponent {
@@ -1669,10 +1702,6 @@ pub fn Conversation() -> Element {
                                                             }
                                                         }
                                                     }
-                                                };
-                                                rsx! {
-                                                    {separator_rsx}
-                                                    {item_rsx}
                                                 }
                                             }})}
                                         }

--- a/ui/src/util.rs
+++ b/ui/src/util.rs
@@ -115,6 +115,15 @@ export function format_full_datetime_local(timestamp_ms) {
         hour12: false
     });
 }
+export function local_date_key(timestamp_ms) {
+    // Local calendar date (viewer's timezone) as a zero-padded YYYY-MM-DD
+    // string. Used to detect day boundaries for chat date separators.
+    const date = new Date(timestamp_ms);
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return y + '-' + m + '-' + d;
+}
 export function js_copy_to_clipboard(text) {
     // execCommand('copy') works in sandboxed iframes without allow-clipboard-write
     const ta = document.createElement('textarea');
@@ -131,6 +140,7 @@ extern "C" {
     fn get_current_time() -> f64;
     fn format_time_local(timestamp_ms: f64) -> String;
     fn format_full_datetime_local(timestamp_ms: f64) -> String;
+    fn local_date_key(timestamp_ms: f64) -> String;
     fn js_copy_to_clipboard(text: &str);
 }
 
@@ -204,6 +214,89 @@ pub fn format_utc_as_full_datetime(timestamp_ms: i64) -> String {
             .format("%a, %b %d, %Y %H:%M:%S")
             .to_string()
     }
+}
+
+/// The local calendar date (viewer's timezone) on which a UTC timestamp
+/// falls. Used to insert day-change separators into the message list.
+///
+/// On wasm the local-date computation MUST go through JS (`Date`), because
+/// chrono's `Local` needs timezone data that isn't present in the wasm build
+/// and would panic — the same reason `format_utc_as_local_time` routes through
+/// the JS shim. The day boundary is the viewer's local midnight, so two
+/// timestamps a minute apart across midnight correctly land on different days.
+pub fn local_message_date(timestamp_ms: i64) -> chrono::NaiveDate {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let key = local_date_key(timestamp_ms as f64);
+        chrono::NaiveDate::parse_from_str(&key, "%Y-%m-%d")
+            .unwrap_or_else(|_| chrono::NaiveDate::from_ymd_opt(1970, 1, 1).unwrap())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        use chrono::{Local, TimeZone, Utc};
+        let utc_time = Utc.timestamp_millis_opt(timestamp_ms).unwrap();
+        utc_time.with_timezone(&Local).date_naive()
+    }
+}
+
+/// Today's local calendar date in the viewer's timezone.
+pub fn local_today() -> chrono::NaiveDate {
+    #[cfg(target_arch = "wasm32")]
+    {
+        local_message_date(get_current_time() as i64)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        chrono::Local::now().date_naive()
+    }
+}
+
+/// Human-readable day-separator label for `that_day` relative to `today`:
+/// `"Today"`, `"Yesterday"`, `"Monday, June 3"` (same year) or
+/// `"Monday, June 3, 2025"` (different year). Pure and deterministic so it can
+/// be unit-tested on all targets; the timezone-dependent part lives in
+/// [`local_message_date`]. Older-than-yesterday and any future-dated day both
+/// fall through to the full weekday+date label.
+pub fn format_date_separator_label(
+    that_day: chrono::NaiveDate,
+    today: chrono::NaiveDate,
+) -> String {
+    use chrono::Datelike;
+    let diff = (today - that_day).num_days();
+    if diff == 0 {
+        "Today".to_string()
+    } else if diff == 1 {
+        "Yesterday".to_string()
+    } else if that_day.year() == today.year() {
+        that_day.format("%A, %B %-d").to_string()
+    } else {
+        that_day.format("%A, %B %-d, %Y").to_string()
+    }
+}
+
+/// Given the local dates of consecutive chat display items (in display order)
+/// and today's local date, return the day-change separator to render above
+/// each item: `Some(label)` when that item's day differs from the previous
+/// item's (the first item always gets one), `None` otherwise. Pure so the
+/// "one divider per day, deduped across same-day groups" behaviour can be
+/// unit-tested deterministically without a browser.
+pub fn date_separator_labels(
+    item_dates: &[chrono::NaiveDate],
+    today: chrono::NaiveDate,
+) -> Vec<Option<String>> {
+    let mut out = Vec::with_capacity(item_dates.len());
+    let mut prev: Option<chrono::NaiveDate> = None;
+    for &date in item_dates {
+        if prev != Some(date) {
+            out.push(Some(format_date_separator_label(date, today)));
+        } else {
+            out.push(None);
+        }
+        prev = Some(date);
+    }
+    out
 }
 
 // Helper function to create a Duration from seconds
@@ -433,6 +526,117 @@ pub fn owner_vk_to_legacy_contract_keys(owner_vk: &VerifyingKey) -> Vec<Contract
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::NaiveDate;
+
+    fn ymd(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).unwrap()
+    }
+
+    #[test]
+    fn date_separator_today() {
+        let today = ymd(2026, 6, 1);
+        assert_eq!(format_date_separator_label(today, today), "Today");
+    }
+
+    #[test]
+    fn date_separator_yesterday() {
+        let today = ymd(2026, 6, 1);
+        assert_eq!(
+            format_date_separator_label(ymd(2026, 5, 31), today),
+            "Yesterday"
+        );
+    }
+
+    #[test]
+    fn date_separator_same_year_uses_weekday_and_date() {
+        let today = ymd(2026, 6, 1);
+        assert_eq!(
+            format_date_separator_label(ymd(2026, 5, 25), today),
+            "Monday, May 25"
+        );
+    }
+
+    #[test]
+    fn date_separator_different_year_includes_year() {
+        let today = ymd(2026, 1, 2);
+        assert_eq!(
+            format_date_separator_label(ymd(2025, 12, 30), today),
+            "Tuesday, December 30, 2025"
+        );
+    }
+
+    #[test]
+    fn date_separator_future_date_falls_through_to_full_label() {
+        // A day "after" today (diff < 0) is not Today/Yesterday — it should
+        // render the full weekday+date label, never "Tomorrow".
+        let today = ymd(2026, 6, 1);
+        assert_eq!(
+            format_date_separator_label(ymd(2026, 6, 3), today),
+            "Wednesday, June 3"
+        );
+    }
+
+    #[test]
+    fn date_separator_single_digit_day_not_zero_padded() {
+        let today = ymd(2026, 6, 20);
+        assert_eq!(
+            format_date_separator_label(ymd(2026, 6, 3), today),
+            "Wednesday, June 3"
+        );
+    }
+
+    #[test]
+    fn date_separator_labels_emits_once_per_day_and_dedupes_within_a_day() {
+        let today = ymd(2026, 6, 1);
+        let yesterday = ymd(2026, 5, 31);
+        // Display order: 3 groups yesterday, then 2 groups today.
+        let dates = vec![yesterday, yesterday, yesterday, today, today];
+        let labels = date_separator_labels(&dates, today);
+        assert_eq!(
+            labels,
+            vec![
+                Some("Yesterday".to_string()),
+                None,
+                None,
+                Some("Today".to_string()),
+                None,
+            ]
+        );
+    }
+
+    #[test]
+    fn date_separator_labels_first_item_always_labeled() {
+        let today = ymd(2026, 6, 1);
+        assert_eq!(
+            date_separator_labels(&[today], today),
+            vec![Some("Today".to_string())]
+        );
+    }
+
+    #[test]
+    fn date_separator_labels_empty_input() {
+        let today = ymd(2026, 6, 1);
+        assert!(date_separator_labels(&[], today).is_empty());
+    }
+
+    #[test]
+    fn date_separator_labels_relabels_when_day_recurs() {
+        // A later item that lands back on an earlier day still gets its own
+        // separator (the comparison is against the immediately preceding
+        // item's day, not a set of seen days).
+        let today = ymd(2026, 6, 2);
+        let d1 = ymd(2026, 5, 31);
+        let d2 = ymd(2026, 6, 1);
+        let labels = date_separator_labels(&[d1, d2, d1], today);
+        assert_eq!(
+            labels,
+            vec![
+                Some("Sunday, May 31".to_string()),
+                Some("Yesterday".to_string()),
+                Some("Sunday, May 31".to_string()),
+            ]
+        );
+    }
 
     #[test]
     fn truncate_str_ascii_shorter_than_max() {


### PR DESCRIPTION
## Problem

A River user (Cobalt Falcon) asked for weekday labels above messages: once a conversation spans more than a day, you can't tell which day a message was sent. Messages only show local `HH:MM` time. The weekday + full date *do* exist, but only in the hover tooltip (`format_utc_as_full_datetime`) — which is invisible on touch devices, exactly where the request came from.

## Approach

Rather than put a weekday on *every* message (cluttered, redundant within a day), insert a centered **date separator** above the first message group of each local calendar day — the standard chat-app pattern (Slack/Discord/Signal):

- `Today`
- `Yesterday`
- `Monday, June 3` (same year) / `Monday, June 3, 2025` (different year)

A run of messages on the same day shows a single divider (deduped against the previous item's day).

### Timezone

The day boundary is computed in the **viewer's local timezone**. On wasm that must go through the JS `Date` shim (a new `local_date_key` export), because chrono's `Local` needs tz data that isn't in the wasm build and would panic — same reason `format_utc_as_local_time` already routes through JS. Since the displayed times are already local, the separators and the per-message times always agree on the day.

The relative-label + per-item dedup logic lives in a pure `date_separator_labels(item_dates, today)` helper so it's deterministically unit-testable on native. Labels are computed at **render time** so `Today`/`Yesterday` stay fresh across re-renders.

## Scope / risk

- **UI-only.** No `common/`, `contracts/`, or `delegates/` changes → no contract/delegate WASM change, no migration, no riverctl republish.
- New code: 2 small JS-shim helpers + a pure label helper in `ui/src/util.rs`, and a render-time interleave in `conversation.rs`.

## Testing

- **10 native unit tests** (`cargo test -p river-ui --bins date_separator`): label formatting (Today/Yesterday/same-year/cross-year/single-digit-day/future), and `date_separator_labels` emission — one divider per day, deduped within a day, first item always labeled, relabel when a day recurs, empty input.
- `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync` clean.
- `cargo clippy` clean (no new warnings).
- **Visual** (example-data build, dev-browser): `Yesterday` divider renders correctly at desktop (1280px) and mobile (390px); no console errors / WASM panics. The example dataset spans a single day, so the cross-midnight case (two dividers) is covered by the deterministic unit test rather than visually.


[AI-assisted - Claude]
