### PR TITLE
fix(cli): refuse re-accept of invitation to prevent identity clobber

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -239,6 +239,32 @@ fn rejoin_preferred_nickname(
         .unwrap_or_else(|| SealedBytes::public("Member".to_string().into_bytes()))
 }
 
+/// Error returned when `accept_invitation` is asked to join a room the CLI
+/// already has stored credentials for (issue freenet/river#308).
+///
+/// Re-accepting an invitation used to rebuild the `StoredRoomInfo` from
+/// scratch and `insert` it, wholesale-clobbering the existing room's
+/// `signing_key_bytes`, `self_authorized_member`, `invite_chain`,
+/// `previous_contract_key`, and `self_nickname`. The most severe case is a
+/// silent identity flip: re-accepting a *different* invitation for the same
+/// room replaced the stored signing key, so every subsequent CLI command
+/// authenticated with the wrong key. We refuse the re-accept instead — the
+/// same posture `commands::identity::import_identity` already takes — and
+/// point the user at `riverctl room leave` to opt into a deliberate replace.
+///
+/// Kept as a free function so the user-facing message is unit-testable
+/// without a live Freenet node (the rest of `accept_invitation` requires
+/// one). Mirrors the `rejoin_preferred_nickname` extraction discipline above.
+fn reaccept_refusal_error(room_owner_vk: &VerifyingKey) -> anyhow::Error {
+    let owner_key_str = bs58::encode(room_owner_vk.as_bytes()).into_string();
+    anyhow!(
+        "You already have an identity for room {owner_key_str}. Accepting this \
+         invitation would overwrite your stored signing key, membership, and \
+         nickname for that room. Leave it first with `riverctl room leave \
+         {owner_key_str}` if you want to replace it."
+    )
+}
+
 /// On-wire invitation artifact. **MUST stay byte-identical to the UI's
 /// `ui::components::members::Invitation`** — both clients exchange these via
 /// base58+CBOR and the encoded string is fingerprinted for processed-invite
@@ -986,6 +1012,17 @@ impl ApiClient {
 
         let room_owner_vk = invitation.room;
         let contract_key = self.owner_vk_to_contract_key(&room_owner_vk);
+
+        // Refuse to re-accept an invitation for a room we already have stored
+        // credentials for (issue freenet/river#308). Re-accepting rebuilds the
+        // `StoredRoomInfo` from scratch, silently clobbering the existing
+        // `signing_key_bytes`, `self_authorized_member`, `invite_chain`,
+        // `previous_contract_key`, and `self_nickname`. Bail out *before* the
+        // network GET — same posture as `import_identity`. The user can opt
+        // into a deliberate replace via `riverctl room leave <owner>`.
+        if self.storage.get_room(&room_owner_vk)?.is_some() {
+            return Err(reaccept_refusal_error(&room_owner_vk));
+        }
 
         info!(
             "Invitation is for room owned by: {}",
@@ -3773,6 +3810,76 @@ mod rejoin_nickname_tests {
             out.to_string_lossy(),
             "Alice",
             "real nickname must never be published as plaintext in a private room"
+        );
+    }
+}
+
+/// Regression tests for the re-accept guard (issue freenet/river#308).
+///
+/// `accept_invitation` must refuse to re-accept an invitation for a room the
+/// CLI already has stored credentials for — re-accepting used to rebuild the
+/// `StoredRoomInfo` and `insert` it, wholesale-clobbering the existing
+/// `signing_key_bytes` / `self_authorized_member` / `invite_chain` /
+/// `previous_contract_key` / `self_nickname`. The substantive
+/// "clobber is actually prevented" assertion lives in `storage.rs`
+/// (`reaccept_guard_prevents_clobber`, which can run without a live node);
+/// here we pin the guard's wiring and its user-facing error.
+#[cfg(test)]
+mod reaccept_guard_tests {
+    use super::*;
+
+    /// The refusal error names the room and points at `riverctl room leave`,
+    /// mirroring `import_identity`'s message so the recovery path is the same
+    /// across both entry points.
+    #[test]
+    fn refusal_error_names_room_and_points_to_leave() {
+        let owner_vk = SigningKey::from_bytes(&[9u8; 32]).verifying_key();
+        let owner_key_str = bs58::encode(owner_vk.as_bytes()).into_string();
+        let msg = reaccept_refusal_error(&owner_vk).to_string();
+        assert!(
+            msg.contains(&owner_key_str),
+            "refusal must name the room owner key so the user knows which room: {msg}"
+        );
+        assert!(
+            msg.contains(&format!("riverctl room leave {owner_key_str}")),
+            "refusal must point the user at `riverctl room leave <owner>`: {msg}"
+        );
+    }
+
+    /// Source-grep pin: `accept_invitation` MUST consult `get_room` and bail
+    /// via `reaccept_refusal_error` BEFORE doing the network GET that rebuilds
+    /// the `StoredRoomInfo`. A refactor that drops this guard would silently
+    /// reintroduce the #308 clobber, which no pure unit test can catch because
+    /// `accept_invitation` requires a live Freenet node end-to-end.
+    #[test]
+    fn accept_invitation_has_reaccept_guard() {
+        let api_src = include_str!("api.rs");
+        // Pin the guard within the accept_invitation body: find the function,
+        // then assert the guard appears before the network GET request.
+        let accept_idx = api_src
+            .find("pub async fn accept_invitation(")
+            .expect("accept_invitation must exist");
+        let body = &api_src[accept_idx..];
+        let guard_idx = body
+            .find("if self.storage.get_room(&room_owner_vk)?.is_some() {")
+            .expect(
+                "accept_invitation must guard on `get_room(&room_owner_vk)` to refuse re-accept \
+                 (issue #308) — if you refactored the guard, update this pin",
+            );
+        assert!(
+            body[guard_idx..].contains("return Err(reaccept_refusal_error(&room_owner_vk));"),
+            "the re-accept guard must return `reaccept_refusal_error` so the user gets the \
+             `riverctl room leave` recovery path"
+        );
+        // The guard must precede the GET that rebuilds StoredRoomInfo, so we
+        // never touch the network (or local storage) on a refused re-accept.
+        let get_idx = body
+            .find("let get_request = ContractRequest::Get {")
+            .expect("accept_invitation must perform a GET");
+        assert!(
+            guard_idx < get_idx,
+            "the re-accept guard must run BEFORE the network GET so a refused re-accept \
+             does no network or storage work"
         );
     }
 }

--- a/cli/src/commands/room.rs
+++ b/cli/src/commands/room.rs
@@ -189,10 +189,45 @@ pub async fn execute(command: RoomCommands, api: ApiClient, format: OutputFormat
             Ok(())
         }
         RoomCommands::Leave { room_id } => {
-            if !matches!(format, OutputFormat::Json) {
-                eprintln!("Leaving room: {}", room_id);
+            // Parse the room owner key (base58) into a verifying key.
+            let owner_bytes = bs58::decode(&room_id)
+                .into_vec()
+                .map_err(|e| anyhow::anyhow!("Invalid room ID: {}", e))?;
+            let owner_key = ed25519_dalek::VerifyingKey::from_bytes(
+                owner_bytes
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| anyhow::anyhow!("Invalid room ID length"))?,
+            )
+            .map_err(|e| anyhow::anyhow!("Invalid room owner key: {}", e))?;
+
+            // Forget the locally-stored credentials for this room. This is the
+            // deliberate-replace escape hatch for the re-accept guard
+            // (freenet/river#308): once removed, `riverctl invite accept` can
+            // store a fresh identity for the same room. Local-only — the room
+            // contract and on-chain membership are untouched.
+            let removed = api.storage().remove_room(&owner_key)?;
+
+            match (format, removed) {
+                (OutputFormat::Human, true) => {
+                    println!("{}", "Left room (local credentials removed).".green());
+                    println!("To rejoin, accept a fresh invitation:");
+                    println!("  riverctl invite accept <invitation-code>");
+                }
+                (OutputFormat::Human, false) => {
+                    println!("No locally-stored room found for: {}", room_id);
+                }
+                (OutputFormat::Json, _) => {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "status": "success",
+                            "room_id": room_id,
+                            "removed": removed,
+                        })
+                    );
+                }
             }
-            // TODO: Implement room leaving
             Ok(())
         }
         RoomCommands::Config {

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -888,4 +888,106 @@ mod tests {
             .unwrap()
             .is_empty());
     }
+
+    /// Regression for issue freenet/river#308.
+    ///
+    /// `accept_invitation` used to call `add_room_with_invitation_secrets`
+    /// unconditionally, which rebuilds the `StoredRoomInfo` and `insert`s it,
+    /// wholesale-clobbering an existing room's `signing_key_bytes`,
+    /// `self_authorized_member`, `invite_chain`, and `self_nickname`. This
+    /// test pins BOTH halves of the fix:
+    ///
+    /// 1. The destructive behavior is real — a second
+    ///    `add_room_with_invitation_secrets` for the same owner wipes the
+    ///    previously-stored fields. This is exactly what the #308 guard must
+    ///    prevent; if this assertion ever stops holding, the guard's reason to
+    ///    exist has changed and the test should be revisited.
+    /// 2. `get_room(...).is_some()` — the condition the guard checks in
+    ///    `accept_invitation` — is true after the first accept, so the guard
+    ///    fires on the re-accept path.
+    #[test]
+    fn reaccept_guard_prevents_clobber() {
+        let (storage, _temp_dir) = create_test_storage();
+        let owner_sk = create_test_signing_key();
+        let owner_vk = owner_sk.verifying_key();
+        let state = create_test_state(&owner_sk);
+        let key = expected_contract_key(&owner_vk);
+        let owner_key_str = bs58::encode(owner_vk.as_bytes()).into_string();
+
+        // First accept: store the room under the invitee's identity, plus the
+        // ancillary fields a real accept populates (authorized member, invite
+        // chain, nickname).
+        let first_identity = create_test_signing_key();
+        storage
+            .add_room(&owner_vk, &first_identity, state.clone(), &key)
+            .unwrap();
+        let authorized_member = AuthorizedMember::new(
+            river_core::room_state::member::Member {
+                owner_member_id: owner_vk.into(),
+                invited_by: owner_vk.into(),
+                member_vk: first_identity.verifying_key(),
+            },
+            &owner_sk,
+        );
+        storage
+            .store_authorized_member(
+                &owner_vk,
+                &authorized_member,
+                std::slice::from_ref(&authorized_member),
+            )
+            .unwrap();
+        storage.update_self_nickname(&owner_vk, "Alice").unwrap();
+
+        // Sanity: the guard's trigger condition is now true.
+        assert!(
+            storage.get_room(&owner_vk).unwrap().is_some(),
+            "after first accept the room exists, so accept_invitation's \
+             `get_room(...).is_some()` guard must fire on re-accept"
+        );
+
+        // Snapshot the populated fields.
+        let before = storage.load_rooms().unwrap().rooms[&owner_key_str].clone();
+        assert_eq!(before.signing_key_bytes, first_identity.to_bytes());
+        assert!(before.self_authorized_member.is_some());
+        assert!(!before.invite_chain.is_empty());
+        assert_eq!(before.self_nickname.as_deref(), Some("Alice"));
+
+        // Re-accept with a DIFFERENT identity, calling the same storage path
+        // `accept_invitation` would have called pre-fix. Without the guard
+        // this silently clobbers the stored identity and ancillary fields.
+        let second_identity = create_test_signing_key();
+        assert_ne!(first_identity.to_bytes(), second_identity.to_bytes());
+        storage
+            .add_room_with_invitation_secrets(
+                &owner_vk,
+                &second_identity,
+                state,
+                &key,
+                HashMap::new(),
+            )
+            .unwrap();
+
+        let after = storage.load_rooms().unwrap().rooms[&owner_key_str].clone();
+        // These assertions DOCUMENT the destructive behavior the guard exists
+        // to prevent: the storage primitive is intentionally a full replace.
+        assert_eq!(
+            after.signing_key_bytes,
+            second_identity.to_bytes(),
+            "add_room_with_invitation_secrets is a full replace — the stored \
+             identity flips. The #308 guard in accept_invitation is what stops \
+             this from happening silently on re-accept."
+        );
+        assert!(
+            after.self_authorized_member.is_none(),
+            "self_authorized_member is wiped by the full replace"
+        );
+        assert!(
+            after.invite_chain.is_empty(),
+            "invite_chain is wiped by the full replace"
+        );
+        assert_eq!(
+            after.self_nickname, None,
+            "self_nickname is wiped by the full replace"
+        );
+    }
 }

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -361,8 +361,10 @@ impl Storage {
 
     /// Forget all locally-stored credentials for a room: its
     /// `StoredRoomInfo` entry in `rooms.json` (signing key, state, membership,
-    /// nickname, invitation secrets). Returns `true` if a room was removed,
-    /// `false` if no room was stored for `owner_vk`.
+    /// nickname, invitation secrets) AND any cached outbound-DM plaintext /
+    /// archived-thread entries for that room in `outbound_dms.json`. Returns
+    /// `true` if a room was removed, `false` if no room was stored for
+    /// `owner_vk`.
     ///
     /// This is the deliberate-replace escape hatch for the re-accept guard
     /// (issue freenet/river#308): after `riverctl room leave <owner>` the
@@ -370,14 +372,44 @@ impl Storage {
     /// fresh invitation. It does NOT touch the network — the room contract and
     /// the user's on-chain membership are unaffected; this only drops the
     /// local client's copy.
+    ///
+    /// The outbound-DM cache is pruned too so leaving a room does not leave
+    /// orphaned plaintext DM bodies on disk (Gemini review on PR #327). The
+    /// prune is best-effort: a failure to rewrite `outbound_dms.json` does not
+    /// fail the leave, since the authoritative `rooms.json` removal has already
+    /// succeeded.
     pub fn remove_room(&self, owner_vk: &VerifyingKey) -> Result<bool> {
         let mut storage = self.load_rooms()?;
         let owner_key_str = bs58::encode(owner_vk.as_bytes()).into_string();
         let removed = storage.rooms.remove(&owner_key_str).is_some();
         if removed {
             self.save_rooms(&storage)?;
+            if let Err(e) = self.prune_outbound_dms_for_room(owner_vk) {
+                // Non-fatal: the room is already removed from rooms.json. Warn
+                // so the orphaned plaintext is visible, but don't fail leave.
+                tracing::warn!(
+                    "room leave: failed to prune outbound-DM cache for {owner_key_str}: {e}"
+                );
+            }
         }
         Ok(removed)
+    }
+
+    /// Drop every cached outbound-DM plaintext entry and archived-thread entry
+    /// for `owner_vk`'s room from `outbound_dms.json`. No-op if the cache file
+    /// holds nothing for that room. Called by [`Self::remove_room`].
+    fn prune_outbound_dms_for_room(&self, owner_vk: &VerifyingKey) -> Result<()> {
+        let mut store = self.load_outbound_dms()?;
+        let room_bytes = owner_vk.to_bytes();
+        let before = store.entries.len() + store.hidden_threads.len();
+        store.entries.retain(|e| e.room_owner_vk != room_bytes);
+        store
+            .hidden_threads
+            .retain(|h| h.room_owner_vk != room_bytes);
+        if store.entries.len() + store.hidden_threads.len() != before {
+            self.save_outbound_dms(&store)?;
+        }
+        Ok(())
     }
 
     pub fn store_authorized_member(
@@ -1046,5 +1078,82 @@ mod tests {
             "after `room leave` the guard's `get_room(...).is_some()` must be false \
              so a fresh accept succeeds"
         );
+    }
+
+    /// Leaving a room must also drop that room's cached outbound-DM plaintext
+    /// and archived-thread entries from `outbound_dms.json`, so leaving does
+    /// not leave orphaned plaintext on disk (Gemini review on PR #327). Other
+    /// rooms' DM entries must survive.
+    #[test]
+    fn remove_room_prunes_outbound_dm_cache() {
+        use freenet_scaffold::util::FastHash;
+        use river_core::chat_delegate::{HiddenDmThreadEntry, OutboundDmEntry, OutboundDmStore};
+        use river_core::room_state::direct_messages::PurgeToken;
+        use river_core::room_state::member::MemberId;
+
+        let (storage, _temp_dir) = create_test_storage();
+        let left_sk = create_test_signing_key();
+        let left_vk = left_sk.verifying_key();
+        let kept_sk = create_test_signing_key();
+        let kept_vk = kept_sk.verifying_key();
+
+        // Store the room we will leave.
+        let state = create_test_state(&left_sk);
+        let key = expected_contract_key(&left_vk);
+        storage
+            .add_room(&left_vk, &create_test_signing_key(), state, &key)
+            .unwrap();
+
+        // Seed the outbound-DM cache with entries for BOTH rooms.
+        let peer = MemberId(FastHash(42));
+        let store = OutboundDmStore {
+            entries: vec![
+                OutboundDmEntry {
+                    room_owner_vk: left_vk.to_bytes(),
+                    sender: peer,
+                    recipient: peer,
+                    purge_token: PurgeToken([1u8; 16]),
+                    timestamp: 1,
+                    plaintext: "left-room secret".to_string(),
+                },
+                OutboundDmEntry {
+                    room_owner_vk: kept_vk.to_bytes(),
+                    sender: peer,
+                    recipient: peer,
+                    purge_token: PurgeToken([2u8; 16]),
+                    timestamp: 2,
+                    plaintext: "kept-room secret".to_string(),
+                },
+            ],
+            hidden_threads: vec![
+                HiddenDmThreadEntry {
+                    room_owner_vk: left_vk.to_bytes(),
+                    peer,
+                    hidden_at_ts: 1,
+                },
+                HiddenDmThreadEntry {
+                    room_owner_vk: kept_vk.to_bytes(),
+                    peer,
+                    hidden_at_ts: 2,
+                },
+            ],
+        };
+        storage.save_outbound_dms(&store).unwrap();
+
+        assert!(storage.remove_room(&left_vk).unwrap());
+
+        let after = storage.load_outbound_dms().unwrap();
+        assert_eq!(
+            after.entries.len(),
+            1,
+            "the left room's outbound-DM plaintext must be pruned"
+        );
+        assert_eq!(after.entries[0].room_owner_vk, kept_vk.to_bytes());
+        assert_eq!(
+            after.hidden_threads.len(),
+            1,
+            "the left room's archived-thread entry must be pruned"
+        );
+        assert_eq!(after.hidden_threads[0].room_owner_vk, kept_vk.to_bytes());
     }
 }

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -359,6 +359,27 @@ impl Storage {
         }
     }
 
+    /// Forget all locally-stored credentials for a room: its
+    /// `StoredRoomInfo` entry in `rooms.json` (signing key, state, membership,
+    /// nickname, invitation secrets). Returns `true` if a room was removed,
+    /// `false` if no room was stored for `owner_vk`.
+    ///
+    /// This is the deliberate-replace escape hatch for the re-accept guard
+    /// (issue freenet/river#308): after `riverctl room leave <owner>` the
+    /// `accept_invitation` guard no longer fires, so the user can accept a
+    /// fresh invitation. It does NOT touch the network — the room contract and
+    /// the user's on-chain membership are unaffected; this only drops the
+    /// local client's copy.
+    pub fn remove_room(&self, owner_vk: &VerifyingKey) -> Result<bool> {
+        let mut storage = self.load_rooms()?;
+        let owner_key_str = bs58::encode(owner_vk.as_bytes()).into_string();
+        let removed = storage.rooms.remove(&owner_key_str).is_some();
+        if removed {
+            self.save_rooms(&storage)?;
+        }
+        Ok(removed)
+    }
+
     pub fn store_authorized_member(
         &self,
         owner_vk: &VerifyingKey,
@@ -988,6 +1009,42 @@ mod tests {
         assert_eq!(
             after.self_nickname, None,
             "self_nickname is wiped by the full replace"
+        );
+    }
+
+    /// `remove_room` is the recovery path the #308 re-accept guard points
+    /// users at (`riverctl room leave <owner>`). It must actually drop the
+    /// stored entry so a subsequent `accept_invitation` no longer trips the
+    /// guard — otherwise the guard would be a dead end (Codex review P2 on
+    /// PR #327). Returns `true` only when something was removed.
+    #[test]
+    fn remove_room_clears_stored_entry() {
+        let (storage, _temp_dir) = create_test_storage();
+        let owner_sk = create_test_signing_key();
+        let owner_vk = owner_sk.verifying_key();
+        let state = create_test_state(&owner_sk);
+        let key = expected_contract_key(&owner_vk);
+        let identity = create_test_signing_key();
+
+        // Removing a room that was never stored is a no-op returning false.
+        assert!(
+            !storage.remove_room(&owner_vk).unwrap(),
+            "removing a non-existent room must return false"
+        );
+
+        storage.add_room(&owner_vk, &identity, state, &key).unwrap();
+        assert!(storage.get_room(&owner_vk).unwrap().is_some());
+
+        // Removing the stored room returns true and clears it, so the #308
+        // guard (`get_room(...).is_some()`) no longer fires.
+        assert!(
+            storage.remove_room(&owner_vk).unwrap(),
+            "removing a stored room must return true"
+        );
+        assert!(
+            storage.get_room(&owner_vk).unwrap().is_none(),
+            "after `room leave` the guard's `get_room(...).is_some()` must be false \
+             so a fresh accept succeeds"
         );
     }
 }


### PR DESCRIPTION
## Problem

`accept_invitation` (`cli/src/api.rs`) called `Storage::add_room_with_invitation_secrets`, which builds a fresh `StoredRoomInfo` and `insert`s it into the rooms map, overwriting whatever was there. PR #303 fixed the most user-visible field (`invitation_secrets`, now merged), but every other field was still wholesale-replaced on re-accept:

- **`signing_key_bytes`** — silently replaced with `invitation.invitee_signing_key`. Re-accepting a *different* invitation for a room the user already belonged to flipped their stored identity, so every subsequent CLI command authenticated with the wrong key (auth failures that look like server-side problems).
- **`self_authorized_member` / `invite_chain`** — cleared, then restored by the next `store_authorized_member` call; a crash between the two leaves a half-state on disk.
- **`previous_contract_key`** — cleared.
- **`self_nickname`** — cleared.

`commands::identity::import_identity` already guards against exactly this with a `get_room().is_some() -> Err` check; `accept_invitation` did not.

## Approach

**Option A** from the issue (recommended there): refuse the re-accept by default. `accept_invitation` now checks `self.storage.get_room(&room_owner_vk)?.is_some()` *before* the network GET and, if the room already exists, returns an error directing the user to `riverctl room leave <owner>` first. This mirrors `import_identity`'s posture and avoids silent data loss for all fields with no per-field merge semantics to get wrong.

The refusal message is built by a small free function `reaccept_refusal_error` so it is unit-testable without a live Freenet node (the rest of `accept_invitation` needs one) — mirroring the existing `rejoin_preferred_nickname` extraction discipline.

No `--force` flag was added: `import_identity` has none either, and a `--force` would reintroduce the silent-overwrite footgun this fixes. The deliberate-replace path is `riverctl room leave`, consistent across both entry points.

## Testing

- `storage::tests::reaccept_guard_prevents_clobber` — the substantive regression. Populates a room (identity + authorized member + invite chain + nickname), asserts the guard's trigger (`get_room(...).is_some()`) is true, then exercises the exact storage path the old `accept_invitation` used and asserts it is a full replace (documents the destructive behavior the guard prevents).
- `api::reaccept_guard_tests::accept_invitation_has_reaccept_guard` — source-grep pin that the guard exists in the `accept_invitation` body **and runs before** the network GET. Verified it FAILS when the guard is removed and PASSES with it.
- `api::reaccept_guard_tests::refusal_error_names_room_and_points_to_leave` — pins the user-facing message names the room and points at `riverctl room leave`.

Full `cargo test -p riverctl` (67 lib + integration tests) green; `cargo fmt` / `cargo clippy -p riverctl --all-targets` clean. No WASM / contract / delegate changes (CLI logic only), so no migration entry needed.

Closes #308

[AI-assisted - Claude]