### PR TITLE
fix(ui): preserve paragraph breaks in chat messages

### DIFF
--- a/ui/assets/tailwind.css
+++ b/ui/assets/tailwind.css
@@ -91,6 +91,22 @@ html, body {
   color: var(--color-text);
 }
 
+/* Paragraph spacing in prose (Markdown messages).
+   Tailwind v4's Preflight reset zeroes margins on every element, so the
+   <p> blocks the Markdown renderer emits for blank-line-separated
+   paragraphs collapse into a single wall of text (freenet/river#158).
+   Re-add vertical spacing between paragraphs, but trim the outer edges
+   so a message bubble has no dangling gap above its first paragraph or
+   below its last. Single newlines are already preserved as <br> by
+   message_to_html, so this rule only affects true paragraph breaks. */
+.prose p {
+  margin: 0 0 0.5rem;
+}
+
+.prose p:last-child {
+  margin-bottom: 0;
+}
+
 /* Link styling for prose content (Markdown messages) */
 .prose a {
   color: var(--color-accent);

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -2483,6 +2483,41 @@ mod tests {
         );
     }
 
+    /// Issue #158: a blank line between two blocks of text is a paragraph
+    /// break, and the Markdown renderer must emit a separate `<p>` for each
+    /// so the stylesheet can space them apart. This is the HTML-structure
+    /// half of the fix; the CSS half is pinned by
+    /// `prose_paragraph_spacing_css_present` below.
+    #[test]
+    fn blank_line_produces_separate_paragraphs() {
+        let html = message_to_html("First paragraph.\n\nSecond paragraph.");
+        let paragraphs = html.matches("<p>").count();
+        assert_eq!(
+            paragraphs, 2,
+            "blank-line-separated text should render as two <p> blocks: {html}"
+        );
+    }
+
+    /// Issue #158 root cause: Tailwind v4's Preflight reset zeroes the
+    /// margin on every element, so the `<p>` blocks above collapse into a
+    /// single wall of text unless the stylesheet re-adds paragraph spacing.
+    /// The message body is rendered inside a `.prose` container, so the
+    /// `.prose p` margin rule is what actually makes paragraph breaks
+    /// visible. Pin its presence in the source stylesheet so a future
+    /// Tailwind bump or CSS refactor that silently drops it fails CI rather
+    /// than regressing the rendering. `styles.css` (the compiled output) is
+    /// a gitignored build artifact, so we assert against the tracked source.
+    #[test]
+    fn prose_paragraph_spacing_css_present() {
+        const TAILWIND_CSS: &str = include_str!("../../assets/tailwind.css");
+        assert!(
+            TAILWIND_CSS.contains(".prose p {"),
+            "tailwind.css must keep a `.prose p` rule so Markdown paragraph \
+             breaks are visible (issue #158); the Tailwind reset zeroes <p> \
+             margins otherwise"
+        );
+    }
+
     const SAMPLE_ID: &str = "UDzGbcWrKN748tYbhvbPCCCQrZc9r9xkN3tUuun5Rts";
     /// Real-shape 44-char base58 ID for tests that need a second distinct ID.
     const SAMPLE_ID_2: &str = "EqJ5YpEEV3XLqEvKWLQHFhGAac2qXzSUoE6k2zbdnXBr";


### PR DESCRIPTION
## Problem

Multi-paragraph messages rendered as a single wall of text. The Markdown renderer (`message_to_html`) emits a `<p>` per blank-line-separated paragraph, but Tailwind v4's Preflight reset (`@import "tailwindcss"`) zeroes the margin on every element. So the paragraphs collapsed with no visible gap between them — the "wall of text" reported in #158.

Single newlines were already fine (`message_to_html` converts `\n` to `  \n`, which becomes a `<br>`). Only true blank-line paragraph breaks were broken.

## Approach

The message body is rendered inside a `.prose` container, and `ui/assets/tailwind.css` already re-adds spacing the global reset strips for lists, code blocks, and blockquotes — it was simply missing the equivalent rule for paragraphs. Add:

```css
.prose p { margin: 0 0 0.5rem; }
.prose p:last-child { margin-bottom: 0; }
```

The `0.5rem` matches the existing `.prose ul/ol` spacing (chat density), and trimming the last paragraph's bottom margin keeps the bubble from having a dangling gap.

This keeps the existing Markdown + linkify pipeline intact. The issue suggested rewriting the render to plain `textContent`, but that would have discarded URL linkification and the `target="_blank"` / `rel` handling, so it isn't a drop-in fix. A scoped CSS rule restores the paragraph spacing with no logic change.

The room-description prose (`[&>p]:m-0 [&>p]:inline`, line 1572) is unaffected: its inline arbitrary-variant overrides have higher specificity and use a direct-child selector, so it keeps its single-line truncated rendering.

`ui/assets/styles.css` (the compiled, minified output) is a gitignored build artifact regenerated by `cargo make build` → `build-tailwind` in CI, so only the source `tailwind.css` is committed.

## Testing

- `blank_line_produces_separate_paragraphs` — pins the HTML structure (two paragraphs → two `<p>` blocks).
- `prose_paragraph_spacing_css_present` — pins the `.prose p` rule in the source stylesheet so a future Tailwind bump or CSS refactor that silently drops it fails CI. **Verified this test FAILS with the rule removed and PASSES with it restored.**
- `cargo fmt --check`, `cargo clippy -p river-ui` (no new warnings), and `cargo test -p river-ui --bins` all clean.

Closes #158

[AI-assisted - Claude]