### PR TITLE
fix: carry plaintext nickname in IdentityExport so a join-window export keeps it (#298)

### DIFF
--- a/cli/src/commands/identity.rs
+++ b/cli/src/commands/identity.rs
@@ -163,6 +163,10 @@ async fn export_identity(
         invite_chain,
         member_info,
         room_name,
+        // Carry the chosen nickname in plaintext so an export taken before
+        // the private-room join-heal sealed `member_info` doesn't lose it on
+        // re-import (freenet/river#298).
+        self_nickname: room_info.self_nickname.clone(),
     };
 
     let armored = export.to_armored_string();
@@ -250,23 +254,46 @@ async fn import_identity(
     )?;
 
     // Persist the imported nickname so a later rejoin (after an inactivity
-    // prune) restores it instead of "Member" — but ONLY when it's public
-    // plaintext. A private room's exported nickname is sealed, so
+    // prune) restores it instead of "Member".
+    //
+    // Prefer the public-plaintext nickname carried in `member_info`. A
+    // private room's exported `member_info` nickname is sealed, so
     // `to_string_lossy` yields an "[Encrypted: …]" placeholder, not the real
     // name; persisting that would be worse than the generic fallback.
-    if let Some(info) = export.member_info.as_ref() {
-        if info.member_info.preferred_nickname.is_public() {
-            let imported_nickname = info.member_info.preferred_nickname.to_string_lossy();
-            api_client
-                .storage()
-                .update_self_nickname(&export.room_owner, &imported_nickname)?;
-        }
+    //
+    // When `member_info` carries no usable public nickname (it is absent —
+    // e.g. an export taken before the private-room join-heal sealed it,
+    // freenet/river#298 — or sealed), fall back to the plaintext
+    // `self_nickname` the export now carries. This is the chosen nickname,
+    // not an "[Encrypted: …]" placeholder, so it is safe to persist.
+    let public_member_info_nickname = export.member_info.as_ref().and_then(|info| {
+        info.member_info
+            .preferred_nickname
+            .is_public()
+            .then(|| info.member_info.preferred_nickname.to_string_lossy())
+    });
+    let nickname_to_persist = public_member_info_nickname
+        .clone()
+        .or_else(|| export.self_nickname.clone());
+    if let Some(nick) = nickname_to_persist {
+        api_client
+            .storage()
+            .update_self_nickname(&export.room_owner, &nick)?;
     }
 
-    let nickname = export
-        .member_info
-        .as_ref()
-        .map(|i| i.member_info.preferred_nickname.to_string_lossy())
+    // For the human/JSON summary, show the real nickname: prefer the
+    // public-plaintext `member_info` nickname, then the carried plaintext
+    // `self_nickname`, then "unknown". (A sealed private `member_info`
+    // nickname renders as an "[Encrypted: …]" placeholder via
+    // `to_string_lossy`, so the `self_nickname` fallback is more useful.)
+    let nickname = public_member_info_nickname
+        .or_else(|| export.self_nickname.clone())
+        .or_else(|| {
+            export
+                .member_info
+                .as_ref()
+                .map(|i| i.member_info.preferred_nickname.to_string_lossy())
+        })
         .unwrap_or_else(|| "unknown".to_string());
 
     match format {

--- a/common/src/room_state/identity.rs
+++ b/common/src/room_state/identity.rs
@@ -26,6 +26,21 @@ pub struct IdentityExport {
     /// Room display name (shown immediately on import before sync completes)
     #[serde(default)]
     pub room_name: Option<String>,
+    /// The user's chosen nickname in plaintext.
+    ///
+    /// Carried in addition to `member_info` so that a private-room
+    /// identity exported in the window between joining and the
+    /// member-info self-heal sealing the nickname (when `member_info` is
+    /// still `None`) does not lose the chosen nickname on re-import. The
+    /// heal on the re-imported room restores it from this field instead of
+    /// minting a generated default handle. See freenet/river#298.
+    ///
+    /// `#[serde(default)]` keeps old tokens (which lack the field)
+    /// decoding cleanly as `None`. Plaintext here adds no new exposure
+    /// class: the export already carries the private signing key, a far
+    /// more sensitive secret.
+    #[serde(default)]
+    pub self_nickname: Option<String>,
 }
 
 impl IdentityExport {
@@ -148,6 +163,7 @@ mod tests {
             invite_chain: vec![],
             member_info: None,
             room_name: None,
+            self_nickname: None,
         };
 
         let armored = export.to_armored_string();
@@ -201,6 +217,7 @@ mod tests {
             invite_chain: vec![],
             member_info: None,
             room_name: None,
+            self_nickname: None,
         };
 
         let armored = export.to_armored_string();
@@ -247,6 +264,7 @@ mod tests {
             invite_chain: vec![auth_member_a.clone()],
             member_info: Some(auth_member_info.clone()),
             room_name: Some("Test Room".to_string()),
+            self_nickname: Some("TestUser".to_string()),
         };
 
         let armored = export.to_armored_string();
@@ -267,6 +285,7 @@ mod tests {
             "TestUser"
         );
         assert_eq!(decoded.room_name.as_deref(), Some("Test Room"));
+        assert_eq!(decoded.self_nickname.as_deref(), Some("TestUser"));
     }
 
     #[test]
@@ -290,6 +309,7 @@ mod tests {
             invite_chain: vec![],
             member_info: None,
             room_name: None,
+            self_nickname: None,
         };
 
         let armored = export.to_armored_string();
@@ -332,6 +352,7 @@ mod tests {
             invite_chain: vec![],
             member_info: None,
             room_name: None,
+            self_nickname: None,
         };
 
         let armored = export.to_armored_string();
@@ -361,6 +382,7 @@ mod tests {
             invite_chain: vec![],
             member_info: None,
             room_name: None,
+            self_nickname: None,
         };
 
         let armored = export.to_armored_string();
@@ -411,6 +433,7 @@ mod tests {
             invite_chain: vec![],
             member_info: None,
             room_name: None,
+            self_nickname: None,
         };
 
         let armored = export.to_armored_string();
@@ -463,6 +486,47 @@ mod tests {
 
         let decoded = IdentityExport::from_armored_string(&armored).unwrap();
         assert!(decoded.room_name.is_none());
+        // The same old token also predates `self_nickname`; it must decode
+        // cleanly with the field defaulting to `None`.
+        assert!(decoded.self_nickname.is_none());
+    }
+
+    #[test]
+    fn test_self_nickname_survives_roundtrip_without_member_info() {
+        // Regression for freenet/river#298: a private-room identity exported
+        // in the window between joining and the member-info self-heal has
+        // `member_info: None`, but the chosen nickname must still survive a
+        // round-trip via `self_nickname` so the heal on the re-imported room
+        // can restore it instead of minting a generated default.
+        let owner_sk = SigningKey::generate(&mut OsRng);
+        let owner_vk = owner_sk.verifying_key();
+        let owner_id = MemberId::from(&owner_vk);
+
+        let member_sk = SigningKey::generate(&mut OsRng);
+        let member = Member {
+            owner_member_id: owner_id,
+            invited_by: owner_id,
+            member_vk: member_sk.verifying_key(),
+        };
+        let authorized_member = AuthorizedMember::new(member, &owner_sk);
+
+        let export = IdentityExport {
+            room_owner: owner_vk,
+            signing_key: member_sk,
+            authorized_member,
+            invite_chain: vec![],
+            member_info: None,
+            room_name: None,
+            self_nickname: Some("ChosenName".to_string()),
+        };
+
+        let armored = export.to_armored_string();
+        let decoded = IdentityExport::from_armored_string(&armored).unwrap();
+
+        // The export carried no sealed member_info, but the plaintext
+        // nickname survived so the import-side heal has something to restore.
+        assert!(decoded.member_info.is_none());
+        assert_eq!(decoded.self_nickname.as_deref(), Some("ChosenName"));
     }
 
     #[test]
@@ -488,6 +552,7 @@ mod tests {
             invite_chain: vec![],
             member_info: None,
             room_name: Some("My Room".to_string()),
+            self_nickname: None,
         };
 
         let armored = export.to_armored_string();

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -548,6 +548,11 @@ fn ExportIdentityModal(is_active: Signal<bool>) -> Element {
                             invite_chain,
                             member_info,
                             room_name,
+                            // Carry the chosen nickname in plaintext so an
+                            // export taken before the private-room join-heal
+                            // sealed `member_info` doesn't lose it on
+                            // re-import (freenet/river#298).
+                            self_nickname: room_data.self_nickname.clone(),
                         };
                         token_text.set(export.to_armored_string());
                     } else {
@@ -670,14 +675,14 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
                     self_authorized_member: Some(export.authorized_member),
                     invite_chain: export.invite_chain,
                     self_member_info: export.member_info,
-                    // Imported room: the heal uses `self_member_info` from the
-                    // export when present. If the export pre-dates the
+                    // Imported room: the heal prefers `self_member_info` from
+                    // the export when present. If the export pre-dates the
                     // member_info seal (a private-room identity exported
                     // before the join's self-heal ran) `export.member_info`
-                    // is `None` and the heal falls back to a generated
-                    // default — `IdentityExport` does not carry the plaintext
-                    // nickname. Narrow window; acceptable.
-                    self_nickname: None,
+                    // is `None`, but the export still carries the chosen
+                    // nickname in `self_nickname`, so the heal restores it
+                    // instead of minting a generated default (freenet/river#298).
+                    self_nickname: export.self_nickname,
                     previous_contract_key: None,
                     invitation_secrets: std::collections::HashMap::new(),
                 };


### PR DESCRIPTION
## Problem

`IdentityExport` carries the sealed `member_info` but not the plaintext nickname. In the narrow window between accepting a private-room invite and the member-info self-heal sealing the nickname, `member_info` is `None`. If the user exports their identity in that window:

1. The export's `member_info` is `None`.
2. On re-import, both `self_member_info` and `self_nickname` were set to `None`.
3. `build_member_info_heal` then mints a generated default handle — the user's chosen nickname is lost.

PR #329 made the heal fire reliably on the UPDATE path (not just GET), but that did not fix #298: the heal still had no nickname to restore because `IdentityExport` never carried one. The heal's nickname source order is `self_member_info` → `self_nickname` → generated default; with both `None`, it falls through to the default.

## Approach

Add a plaintext `self_nickname: Option<String>` field to `IdentityExport` with `#[serde(default)]` (the export is an armored CBOR blob; the attribute keeps old tokens decoding cleanly as `None`).

- **Export** (UI `members.rs`, CLI `identity.rs`): populate `self_nickname` from the existing `self_nickname` already tracked in `RoomData` / `StoredRoomInfo`.
- **Import** (UI `members.rs`): set `self_nickname: export.self_nickname` instead of hardcoded `None`, so the heal restores the chosen nickname.
- **Import** (CLI `identity.rs`): when `member_info` has no usable public nickname (absent or sealed), fall back to persisting the carried plaintext `self_nickname`, and use it for the import summary line.

Plaintext here adds no new exposure class: the export already carries the private signing key, a far more sensitive secret. The private-room heal still defers (publishes nothing) until the room secret arrives, so no plaintext nickname is ever leaked to the network.

This is a client-side armored blob exchanged between a user's own devices; `IdentityExport` is never referenced by the room-contract or chat-delegate WASM, so no migration entry is required (the committed WASMs are untouched; the CI migration check keys on committed-WASM bytes).

## Testing

- New `test_self_nickname_survives_roundtrip_without_member_info` in `common/src/room_state/identity.rs` reproduces #298: an export with `member_info: None` but `self_nickname: Some(...)` round-trips and preserves the nickname. Verified it FAILS before the fix (temporarily marking the field `#[serde(skip)]` yields `left: None, right: Some("ChosenName")`) and PASSES after.
- Strengthened `test_backward_compat_no_room_name` to assert an old token (no `self_nickname` field) decodes with `self_nickname: None`.
- Strengthened `test_roundtrip_with_invite_chain_and_member_info` to assert `self_nickname` round-trips.
- `cargo test -p river-core` (174 lib tests), `cargo test -p riverctl --lib` (69 tests, incl. the `update_self_nickname` source-grep pin), `cargo test -p river-ui --bins` (265 tests) all green.
- `cargo fmt`, `cargo clippy -p river-core -p riverctl`, and `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync` all clean.

Closes #298

[AI-assisted - Claude]