### PR TITLE
fix(build): retarget test-publish webapp via base_path, not length-unsafe WASM sed

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -390,37 +390,102 @@ echo "Run 'cargo make sign-webapp-test' to sign with test keys"
 '''
 
 [tasks.compress-webapp-test]
-description = "Retarget and compress webapp for test contract"
-dependencies = ["build-ui-with-cleanup", "build-web-container"]
+description = "Build (retargeted to the test contract) and compress the webapp"
+# NOTE: deliberately does NOT depend on build-ui-with-cleanup. That task bakes
+# the PRODUCTION base_path into the build. For the test contract we must bake
+# the TEST contract ID as the base_path BEFORE building, so we run the build
+# ourselves here. build-chat-delegate + build-tailwind are the same UI build
+# prerequisites build-ui depends on.
+dependencies = [
+    "build-chat-delegate",
+    "build-tailwind",
+    "build-web-container",
+    "build-web-container-tool",
+    "clean-stale-assets",
+]
 script = '''
+set -e
 PROD_ID="raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv"
+TOOL="target/native/x86_64-unknown-linux-gnu/${BUILD_PROFILE}/web-container-tool"
+DIOXUS_TOML="ui/Dioxus.toml"
 
-# Compute test contract ID from test parameters
-if [ -f "target/webapp/webapp-test.parameters" ]; then
-    TEST_ID=$(fdev get-contract-id \
-        --code target/wasm32-unknown-unknown/release/web_container_contract.wasm \
-        --parameters target/webapp/webapp-test.parameters 2>/dev/null)
-elif [ -f "test-contract/contract-id.txt" ]; then
-    TEST_ID=$(cat test-contract/contract-id.txt)
-else
+if [ ! -f "test-contract/test-keys.toml" ]; then
+    echo "No test keys found. Run 'cargo make generate-test-keys' first"
+    exit 1
+fi
+
+# The test contract ID is derive(web_container_contract.wasm, parameters),
+# and parameters are just the test signing identity's verifying-key bytes.
+# We need the ID BEFORE building the UI so the correct base_path is baked into
+# the WASM as DIOXUS_ASSET_ROOT (release web builds resolve asset!() URLs from
+# the compile-time-baked base_path, NOT from window.location). Generate the
+# parameters from the test keys directly so we don't depend on a prior sign.
+mkdir -p target/webapp
+"$TOOL" export-parameters \
+    --parameters target/webapp/webapp-test.parameters \
+    --key-file test-contract/test-keys.toml
+
+TEST_ID=$(fdev get-contract-id \
+    --code target/wasm32-unknown-unknown/release/web_container_contract.wasm \
+    --parameters target/webapp/webapp-test.parameters)
+if [ -z "$TEST_ID" ]; then
     echo "ERROR: Cannot determine test contract ID"
     exit 1
 fi
 
-echo "Retargeting webapp: $PROD_ID → $TEST_ID"
+echo "Building webapp retargeted to test contract: $PROD_ID -> $TEST_ID"
 
-# Copy build output to temp dir
-TEMP_DIR=$(mktemp -d)
-cp -r target/dx/river-ui/${BUILD_PROFILE}/web/public/* "$TEMP_DIR/"
+# Set base_path to the TEST contract ID for this build, then restore the
+# committed (commented, production) value afterwards. This is the same
+# approach scripts/local-republish.sh uses and is the ONLY length-safe way to
+# retarget the contract ID — rewriting the built WASM with a different-length
+# base58 ID corrupts the module (freenet/river#257).
+restore_dioxus() {
+    perl -pi -e "s|^\\s*#?\\s*base_path\\s*=\\s*\".*\"|#base_path = \"v1/contract/web/${PROD_ID}\"|" "$DIOXUS_TOML"
+}
+trap restore_dioxus EXIT
 
-# Replace contract ID in all files (HTML, JS, WASM - all same byte length)
-find "$TEMP_DIR" -type f \( -name "*.html" -o -name "*.js" -o -name "*.wasm" \) \
-    -exec sed -i "s|$PROD_ID|$TEST_ID|g" {} +
+if grep -q "^#\\?base_path" "$DIOXUS_TOML"; then
+    perl -pi -e "s|^\\s*#?\\s*base_path\\s*=\\s*\".*\"|base_path = \"v1/contract/web/${TEST_ID}\"|" "$DIOXUS_TOML"
+else
+    echo "ERROR: no base_path line found in $DIOXUS_TOML"
+    exit 1
+fi
+
+# Force the UI to recompile so the new base_path is actually baked in. dx keys
+# its incremental build off source mtimes and does NOT treat a Dioxus.toml
+# base_path edit as a source change, so without this a rerun after regenerating
+# test keys (new TEST_ID) could reuse artifacts carrying the PREVIOUS test ID.
+# (build-ui-with-cleanup gets this via its touch-ui-files dep; we replicate it.)
+touch ui/src/main.rs
+
+(cd ui && dx build --${BUILD_PROFILE} --features "${UI_FEATURES}")
+
+restore_dioxus
+trap - EXIT
+
+# Sanity-check the freshly built output BEFORE packaging, so we never sign and
+# publish a mis-targeted webapp:
+#   1. POSITIVE: the loaders must reference THIS run's TEST_ID. This catches a
+#      stale build that still carries a previous test contract's ID (dx artifact
+#      reuse) — the production-ID check below would not.
+#   2. NEGATIVE: the production contract ID must not appear anywhere
+#      (HTML/JS/WASM), i.e. the base_path retarget took full effect.
+PUBLIC_DIR="target/dx/river-ui/${BUILD_PROFILE}/web/public"
+if ! grep -rqF "$TEST_ID" "$PUBLIC_DIR/index.html"; then
+    echo "ERROR: built test webapp does not reference this run's test contract ID."
+    echo "       Expected $TEST_ID in $PUBLIC_DIR/index.html (stale build?)."
+    exit 1
+fi
+if grep -rqF "$PROD_ID" "$PUBLIC_DIR"; then
+    echo "ERROR: built test webapp still references the production contract ID."
+    echo "       The base_path retarget did not take effect; refusing to publish."
+    grep -rlF "$PROD_ID" "$PUBLIC_DIR" || true
+    exit 1
+fi
 
 # Compress
-mkdir -p target/webapp
-(cd "$TEMP_DIR" && tar -cJf "$OLDPWD/target/webapp/webapp-test.tar.xz" *)
-rm -rf "$TEMP_DIR"
+(cd "$PUBLIC_DIR" && tar -cJf "$OLDPWD/target/webapp/webapp-test.tar.xz" *)
 echo "Test webapp: target/webapp/webapp-test.tar.xz"
 '''
 

--- a/contracts/web-container-contract/web-container-tool/src/main.rs
+++ b/contracts/web-container-contract/web-container-tool/src/main.rs
@@ -4,6 +4,8 @@ use river_core::crypto_values::CryptoValue;
 use river_core::web_container::WebContainerMetadata;
 use std::fs;
 use std::io::Write;
+#[cfg(test)]
+use std::path::Path;
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -36,6 +38,23 @@ enum Commands {
         /// Version number for the webapp
         #[arg(long, short)]
         version: u32,
+        /// Key file to use (default: ~/.config/river/web-container-keys.toml)
+        #[arg(long, short)]
+        key_file: Option<String>,
+    },
+    /// Write the web-container contract parameters (the signing identity's
+    /// verifying-key bytes) without needing a webapp archive to sign.
+    ///
+    /// The contract parameters are exactly the 32-byte verifying key, and the
+    /// contract ID is derived from `(web_container_contract.wasm, parameters)`.
+    /// `compress-webapp-test` needs the test contract ID *before* it builds the
+    /// UI (to bake the correct `base_path`/`DIOXUS_ASSET_ROOT` into the WASM),
+    /// which is a chicken-and-egg with `sign` (sign needs the built archive).
+    /// This command breaks that cycle. See freenet/river#257.
+    ExportParameters {
+        /// Output file for contract parameters
+        #[arg(long)]
+        parameters: String,
         /// Key file to use (default: ~/.config/river/web-container-keys.toml)
         #[arg(long, short)]
         key_file: Option<String>,
@@ -247,12 +266,37 @@ fn sign_webapp(
     println!("Metadata written to: {}", output);
 
     // Write parameters file containing verifying key bytes
-    let verifying_key = signing_key.verifying_key();
-    fs::write(&parameters, verifying_key.to_bytes())
-        .map_err(|e| format!("Failed to write parameters to '{}': {}", parameters, e))?;
-    println!("Parameters written to: {}", parameters);
+    write_parameters(&signing_key, &parameters)?;
 
     Ok(())
+}
+
+/// Write the contract parameters file: the raw 32-byte verifying key.
+///
+/// This is the single source of truth for what the parameters file contains.
+/// The web-container contract ID is `derive(web_container_contract.wasm,
+/// parameters)`, so the parameters must be byte-identical regardless of which
+/// command produced them (`sign` or `export-parameters`).
+fn write_parameters(
+    signing_key: &SigningKey,
+    parameters: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let verifying_key = signing_key.verifying_key();
+    fs::write(parameters, verifying_key.to_bytes())
+        .map_err(|e| format!("Failed to write parameters to '{}': {}", parameters, e))?;
+    println!("Parameters written to: {}", parameters);
+    Ok(())
+}
+
+/// Export the contract parameters (verifying-key bytes) from a key file,
+/// without signing a webapp archive.
+fn export_parameters(
+    parameters: String,
+    key_file: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let signing_key = read_signing_key(key_file.as_deref())
+        .map_err(|e| format!("Failed to read signing key: {}", e))?;
+    write_parameters(&signing_key, &parameters)
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -267,5 +311,91 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             version,
             key_file,
         } => sign_webapp(input, output, parameters, version, key_file),
+        Commands::ExportParameters {
+            parameters,
+            key_file,
+        } => export_parameters(parameters, key_file),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmpdir(name: &str) -> PathBuf {
+        let mut dir = std::env::temp_dir();
+        dir.push(format!(
+            "river-web-container-tool-{}-{}-{}",
+            name,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_key_file(dir: &Path, signing_key: &SigningKey) -> PathBuf {
+        let signing_key_str = CryptoValue::SigningKey(signing_key.clone()).to_encoded_string();
+        let verifying_key_str =
+            CryptoValue::VerifyingKey(signing_key.verifying_key()).to_encoded_string();
+        let config = toml::toml! {
+            [keys]
+            signing_key = signing_key_str
+            verifying_key = verifying_key_str
+        };
+        let path = dir.join("keys.toml");
+        fs::write(&path, toml::to_string(&config).unwrap()).unwrap();
+        path
+    }
+
+    /// The contract ID is `derive(wasm, parameters)`, and `compress-webapp-test`
+    /// derives the test ID from parameters written by `export-parameters` while
+    /// `sign-webapp-test` later writes them via `sign`. If the two ever produced
+    /// different parameter bytes, the baked base_path would target a different
+    /// contract than the one actually published — exactly the class of bug #257
+    /// is about. Pin that they are byte-identical (both are the verifying key).
+    #[test]
+    fn export_parameters_matches_sign_parameters() {
+        let dir = tmpdir("export-params");
+        let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+        let key_file = write_key_file(&dir, &signing_key);
+
+        // export-parameters path
+        let export_path = dir.join("export.parameters");
+        export_parameters(
+            export_path.to_str().unwrap().to_string(),
+            Some(key_file.to_str().unwrap().to_string()),
+        )
+        .unwrap();
+
+        // sign path (needs an archive to sign; contents are irrelevant to params)
+        let archive = dir.join("webapp.tar.xz");
+        fs::write(&archive, b"not a real archive, irrelevant to parameters").unwrap();
+        let sign_params = dir.join("sign.parameters");
+        sign_webapp(
+            archive.to_str().unwrap().to_string(),
+            dir.join("metadata").to_str().unwrap().to_string(),
+            sign_params.to_str().unwrap().to_string(),
+            1,
+            Some(key_file.to_str().unwrap().to_string()),
+        )
+        .unwrap();
+
+        let exported = fs::read(&export_path).unwrap();
+        let signed = fs::read(&sign_params).unwrap();
+        assert_eq!(
+            exported,
+            signing_key.verifying_key().to_bytes().to_vec(),
+            "export-parameters must write the raw verifying key"
+        );
+        assert_eq!(
+            exported, signed,
+            "export-parameters and sign must produce byte-identical parameters"
+        );
+
+        fs::remove_dir_all(&dir).ok();
     }
 }

--- a/ui/src/components/members/invite_member_modal.rs
+++ b/ui/src/components/members/invite_member_modal.rs
@@ -9,9 +9,16 @@ use ed25519_dalek::SigningKey;
 use river_core::room_state::member::{AuthorizedMember, Member};
 use std::rc::Rc;
 
-/// Fallback URL for non-browser environments or when window.location is unavailable
-const FALLBACK_BASE_URL: &str =
-    "http://127.0.0.1:7509/v1/contract/web/raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv/";
+/// Fallback URL for non-browser environments or when `window.location` is
+/// unavailable. This is ONLY reached off the browser (native/test builds) or
+/// if `web_sys::window()` returns `None` — i.e. never on a real gateway, where
+/// the URL is always derived from `window.location`. It deliberately does NOT
+/// embed the production contract ID: doing so baked that ID into the UI WASM,
+/// and the test-publish flow then either had to corrupt the WASM to retarget it
+/// (freenet/river#257) or shipped a test webapp whose invitation fallback
+/// pointed at the production contract. The `CONTRACT_ID` placeholder makes the
+/// non-functional fallback obvious and keeps the WASM contract-ID-agnostic.
+const FALLBACK_BASE_URL: &str = "http://127.0.0.1:7509/v1/contract/web/CONTRACT_ID/";
 
 /// Get the base URL for invitation links.
 /// Derives from the current window.location so invitations work on any host/port.


### PR DESCRIPTION
## Problem

`cargo make compress-webapp-test` (the `publish-river-test` path) retargeted a built webapp from the production contract ID (`raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv`, 43 chars) to a freshly-generated test contract ID with a byte-for-byte `sed` over HTML, JS, **and the WASM binary** — assuming all IDs are the same byte length.

They aren't. Base58 of a 32-byte key is 43, 44, or occasionally 45 chars depending on leading zero bytes. Production is 43; a fresh test key has a ~1/256 chance per generation of also being 43. When the test ID differs in length, the `sed` over the `.wasm` shifts every byte after the first match while the module's own length-prefix / section-length fields keep their old values, corrupting it. The browser then fails with `WebAssembly.instantiateStreaming(): illegal flag value …`. Hit twice in the #244 cycle; the workaround was looping `generate-test-keys` (~256 attempts mean). P3 — only the test-publish path is affected; production publishes use committed parameters and never run this task.

## Approach

The contract ID is baked into the UI WASM **at compile time**, in two places, and a text substitution can't preserve the WASM's length fields:
1. **`DIOXUS_ASSET_ROOT`** (the `base_path` from `Dioxus.toml`) — release web builds resolve `asset!()` URLs (stylesheets, logo) from this compile-time value, **not** from `window.location` (confirmed in `dioxus-cli-config::web_base_path`, which uses `option_env!("DIOXUS_ASSET_ROOT")` in release). So it MUST be the test ID for a test deploy, or assets load from the production contract.
2. **`FALLBACK_BASE_URL`** in `invite_member_modal.rs` — a hardcoded production contract URL.

Fix (the issue's recommended Option #1, plus the proven `scripts/local-republish.sh` mechanism):
- **Build the test webapp with the test contract ID as `base_path` from the start**, so the WASM's `DIOXUS_ASSET_ROOT` and all HTML/JS loaders bake the test ID. No post-build `sed` of any file. `compress-webapp-test` no longer depends on the prod-base_path `build-ui-with-cleanup`; it runs the UI build itself with the test base_path and restores `Dioxus.toml` afterward (via an EXIT trap).
- **Drop the hardcoded production contract ID from `FALLBACK_BASE_URL`** (now a `CONTRACT_ID` placeholder). The fallback is only reached off-browser, where the contract URL is meaningless; this just removes a baked-in prod ID and doesn't change browser behavior (invite URLs come from `window.location`).
- **Add a `web-container-tool export-parameters` subcommand** to write the contract parameters (verifying-key bytes) from the test keys without a webapp archive, breaking the chicken-and-egg where the test ID is needed before the build but `sign` needs the built archive.
- **Force a rebuild** (`touch ui/src/main.rs`) so a new test key's base_path actually takes effect, and **assert the built output contains this run's test ID and no production ID anywhere** (HTML/JS/WASM) before packaging — so a base_path that fails to take effect, or a stale dx artifact carrying a previous test ID, fails the build instead of silently shipping a mis-targeted webapp.

## Testing

- Unit test (`web-container-tool`): pins that `export-parameters` and `sign` produce byte-identical parameters (both are the verifying key) — if they diverged, the baked base_path would target a different contract than the one published.
- **End-to-end, length-mismatch case:** ran `cargo make compress-webapp-test` with a freshly-generated test key whose ID is 44/45 chars (length-mismatched vs the 43-char prod ID — the exact case that corrupted the WASM before). Verified the packaged `webapp-test.tar.xz` references the test ID in HTML/JS, contains no production ID anywhere, and the UI WASM passes `wasm-validate`.
- **End-to-end, stale-build case:** built once, regenerated test keys (new ID), rebuilt — verified the new build references the NEW test ID with zero stale-ID and zero prod-ID, WASM valid.
- `cargo test -p river-ui --bins` (265 tests) and `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync` pass. `cargo fmt`/`clippy` clean.

No live publish performed. No contract/delegate WASM changes; the only WASM affected is the (non-committed, build-generated) UI app WASM, so no migration entry is needed.

Closes #257

[AI-assisted - Claude]