### PR TITLE
feat(ui): auto-resume subscription on reload mid-invitation-flow

### DIFF
--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -18,8 +18,8 @@ use crate::components::room_list::edit_room_modal::EditRoomModal;
 use crate::components::room_list::receive_invitation_modal::{
     accept_invitation, clear_invitation_from_storage, decide_recovered_invitation,
     is_invitation_processed, load_invitation_from_storage, load_invitation_nickname_from_storage,
-    save_invitation_to_storage, ReceiveInvitationModal, RecoveredInvitationAction,
-    PRESENT_INVITATION_REQUEST,
+    save_invitation_to_storage, take_resume_once, ReceiveInvitationModal,
+    RecoveredInvitationAction, PRESENT_INVITATION_REQUEST,
 };
 use crate::invites::PendingInvites;
 use crate::room_data::{CurrentRoom, Rooms};
@@ -104,6 +104,19 @@ pub fn App() -> Element {
     crate::components::invite_click_interceptor::install_invite_click_interceptor();
 
     let mut receive_invitation = use_signal(|| None::<Invitation>);
+
+    // One-shot guard for the localStorage auto-resume path (#218). The
+    // recovery block below runs in the `App` component BODY, which re-executes
+    // on every render. The `Resume` branch has side effects (re-sends
+    // `AcceptInvitation` and resets `PENDING_INVITES` to `PendingSubscription`)
+    // and the persisted nickname stays in localStorage until the join
+    // completes — so without this guard, every re-render while the
+    // subscription is in flight would re-fire `accept_invitation`, resetting
+    // the status and looping. We resume at most once per page load; that
+    // single resume re-populates `PENDING_INVITES` and the synchronizer drives
+    // the rest. Uses the same `use_hook(Rc<Cell>)` one-shot idiom as
+    // `dm_thread_modal.rs`.
+    let invitation_resume_fired = use_hook(|| std::rc::Rc::new(std::cell::Cell::new(false)));
 
     // Bridge the click interceptor's `INTERCEPTED_INVITATION_CODE` global
     // into the local `receive_invitation` signal that drives
@@ -317,15 +330,22 @@ pub fn App() -> Element {
             );
             match action {
                 RecoveredInvitationAction::Resume { nickname } => {
-                    // Mount the modal first, then defer the accept so the
-                    // `PENDING_INVITES` mutation and channel send happen in a
-                    // clean execution context (per the Dioxus signal-safety
-                    // rules) rather than mid-render of the `App` component body.
-                    info!("Recovered pending invitation with saved nickname; auto-resuming subscription");
-                    receive_invitation.set(Some(invitation.clone()));
-                    crate::util::defer(move || {
-                        accept_invitation(invitation, nickname);
-                    });
+                    // Resume at most once per page load (see
+                    // `invitation_resume_fired` above). Re-running on every
+                    // render would re-send `AcceptInvitation` and reset the
+                    // pending status, looping.
+                    if take_resume_once(&invitation_resume_fired) {
+                        // Mount the modal first, then defer the accept so the
+                        // `PENDING_INVITES` mutation and channel send happen in
+                        // a clean execution context (per the Dioxus signal-
+                        // safety rules) rather than mid-render of the `App`
+                        // component body.
+                        info!("Recovered pending invitation with saved nickname; auto-resuming subscription");
+                        receive_invitation.set(Some(invitation.clone()));
+                        crate::util::defer(move || {
+                            accept_invitation(invitation, nickname);
+                        });
+                    }
                 }
                 RecoveredInvitationAction::Discard => {
                     debug!("Discarding recovered invitation: already processed");

--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -16,8 +16,10 @@ use crate::components::members::Invitation;
 use crate::components::room_list::create_room_modal::CreateRoomModal;
 use crate::components::room_list::edit_room_modal::EditRoomModal;
 use crate::components::room_list::receive_invitation_modal::{
-    clear_invitation_from_storage, is_invitation_processed, load_invitation_from_storage,
-    save_invitation_to_storage, ReceiveInvitationModal, PRESENT_INVITATION_REQUEST,
+    accept_invitation, clear_invitation_from_storage, decide_recovered_invitation,
+    is_invitation_processed, load_invitation_from_storage, load_invitation_nickname_from_storage,
+    save_invitation_to_storage, ReceiveInvitationModal, RecoveredInvitationAction,
+    PRESENT_INVITATION_REQUEST,
 };
 use crate::invites::PendingInvites;
 use crate::room_data::{CurrentRoom, Rooms};
@@ -289,19 +291,50 @@ pub fn App() -> Element {
     });
 
     // Recover invitation from localStorage if not found in URL (e.g. after
-    // page reload before subscription completed). Skip if the user has
-    // already acted on this invitation in a previous session. Without this
-    // check, a reload mid-subscription re-opens the modal with a nickname
-    // prompt even though the user already accepted, because PENDING_INVITES
-    // is in-memory only.
+    // page reload before subscription completed). The invitation artifact
+    // stays in storage from the moment it is seen until the room is
+    // subscribed OR the user dismisses it (`clear_invitation_from_storage`).
+    //
+    // Three cases, in priority order:
+    //   1. A nickname is ALSO saved → the user already clicked Accept and the
+    //      subscription was still in flight at reload. Auto-resume with that
+    //      nickname (#218) so the "Subscribing…" indicator returns instead of
+    //      a blank UI / re-prompt. This MUST take precedence over the
+    //      processed-fingerprint check below, because `accept_invitation`
+    //      marks the invitation processed up front — so a mid-flight reload
+    //      always sees `is_invitation_processed == true`. Storage-still-present
+    //      + nickname-present is the authoritative "join not yet finished"
+    //      signal here.
+    //   2. No nickname, but the invitation was already acted on in this
+    //      browser → discard (the user accepted-then-left, or dismissed).
+    //   3. No nickname, not yet processed → the user reloaded before deciding;
+    //      re-open the modal at the nickname prompt.
     if !found_invitation {
         if let Some(invitation) = load_invitation_from_storage() {
-            if is_invitation_processed(&invitation.to_encoded_string()) {
-                debug!("Discarding recovered invitation: already processed");
-                clear_invitation_from_storage();
-            } else {
-                info!("Recovered pending invitation from localStorage");
-                receive_invitation.set(Some(invitation));
+            let action = decide_recovered_invitation(
+                load_invitation_nickname_from_storage(),
+                is_invitation_processed(&invitation.to_encoded_string()),
+            );
+            match action {
+                RecoveredInvitationAction::Resume { nickname } => {
+                    // Mount the modal first, then defer the accept so the
+                    // `PENDING_INVITES` mutation and channel send happen in a
+                    // clean execution context (per the Dioxus signal-safety
+                    // rules) rather than mid-render of the `App` component body.
+                    info!("Recovered pending invitation with saved nickname; auto-resuming subscription");
+                    receive_invitation.set(Some(invitation.clone()));
+                    crate::util::defer(move || {
+                        accept_invitation(invitation, nickname);
+                    });
+                }
+                RecoveredInvitationAction::Discard => {
+                    debug!("Discarding recovered invitation: already processed");
+                    clear_invitation_from_storage();
+                }
+                RecoveredInvitationAction::Prompt => {
+                    info!("Recovered pending invitation from localStorage");
+                    receive_invitation.set(Some(invitation));
+                }
             }
         }
     }

--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -324,9 +324,10 @@ pub fn App() -> Element {
     //      re-open the modal at the nickname prompt.
     if !found_invitation {
         if let Some(invitation) = load_invitation_from_storage() {
+            let encoded = invitation.to_encoded_string();
             let action = decide_recovered_invitation(
-                load_invitation_nickname_from_storage(),
-                is_invitation_processed(&invitation.to_encoded_string()),
+                load_invitation_nickname_from_storage(&encoded),
+                is_invitation_processed(&encoded),
             );
             match action {
                 RecoveredInvitationAction::Resume { nickname } => {

--- a/ui/src/components/room_list/receive_invitation_modal.rs
+++ b/ui/src/components/room_list/receive_invitation_modal.rs
@@ -37,6 +37,14 @@ const INVITATION_STORAGE_KEY: &str = "river_pending_invitation";
 /// prompt, matching the fingerprint guard's "mark only on definitive action"
 /// rule.
 const INVITATION_NICKNAME_STORAGE_KEY: &str = "river_pending_invitation_nickname";
+/// Fingerprint of the invitation the saved nickname belongs to. Without this
+/// binding, a stale nickname from a previously-accepted invitation A could be
+/// applied to a *different* invitation B that was opened (but not accepted)
+/// and overwrote `INVITATION_STORAGE_KEY` before A's subscription cleared
+/// storage — auto-accepting B with A's nickname (Codex review, PR #333). The
+/// nickname is only returned when this fingerprint matches the recovered
+/// invitation's fingerprint.
+const INVITATION_NICKNAME_FP_STORAGE_KEY: &str = "river_pending_invitation_nickname_fp";
 /// Prefix that identifies River's processed-invitation list inside the
 /// top-level URL hash. Format: `#river-processed=fp1,fp2,fp3`.
 ///
@@ -90,8 +98,19 @@ pub fn present_invitation(inv: Invitation) {
     });
 }
 
-/// Save invitation to localStorage so it survives page reloads
+/// Save invitation to localStorage so it survives page reloads.
+///
+/// Clears any previously-saved nickname binding first: this is the single
+/// chokepoint every fresh-invitation save path (URL bar, click interceptor,
+/// DM-card present, and `accept_invitation` itself) goes through, so a stale
+/// nickname from a previously-accepted invitation can never linger to be
+/// applied to a different invitation that overwrites the invitation key. The
+/// fingerprint binding in `load_invitation_nickname_from_storage` is the
+/// authoritative guard; this clear is defense-in-depth that keeps storage
+/// honest. `accept_invitation` re-saves the nickname immediately after, so its
+/// own binding survives. (Codex review, PR #333.)
 pub fn save_invitation_to_storage(invitation: &Invitation) {
+    clear_invitation_nickname_from_storage();
     if let Some(window) = web_sys::window() {
         if let Ok(Some(storage)) = window.local_storage() {
             let encoded = invitation.to_encoded_string();
@@ -110,19 +129,38 @@ pub fn load_invitation_from_storage() -> Option<Invitation> {
     Invitation::from_encoded_string(&encoded).ok()
 }
 
-/// Clear saved invitation (and any saved nickname) from localStorage.
+/// Clear saved invitation (and any saved nickname + its fingerprint binding)
+/// from localStorage.
 pub fn clear_invitation_from_storage() {
     if let Some(window) = web_sys::window() {
         if let Ok(Some(storage)) = window.local_storage() {
             let _ = storage.remove_item(INVITATION_STORAGE_KEY);
             let _ = storage.remove_item(INVITATION_NICKNAME_STORAGE_KEY);
+            let _ = storage.remove_item(INVITATION_NICKNAME_FP_STORAGE_KEY);
+        }
+    }
+}
+
+/// Remove only the saved nickname binding, leaving the invitation artifact in
+/// place. Called from `save_invitation_to_storage` so a stale nickname from a
+/// previously accepted invitation can never auto-accept a different,
+/// not-yet-accepted invitation that overwrote `INVITATION_STORAGE_KEY` (Codex
+/// review, PR #333).
+fn clear_invitation_nickname_from_storage() {
+    if let Some(window) = web_sys::window() {
+        if let Ok(Some(storage)) = window.local_storage() {
+            let _ = storage.remove_item(INVITATION_NICKNAME_STORAGE_KEY);
+            let _ = storage.remove_item(INVITATION_NICKNAME_FP_STORAGE_KEY);
         }
     }
 }
 
 /// Save the accepted nickname alongside the pending invitation so a reload
 /// mid-subscription can auto-resume the join without re-prompting (#218).
-pub fn save_invitation_nickname_to_storage(nickname: &str) {
+/// `invitation_encoded` is the canonical `Invitation::to_encoded_string()`;
+/// its fingerprint is stored too so the nickname is only ever applied back to
+/// the same invitation it was chosen for.
+pub fn save_invitation_nickname_to_storage(invitation_encoded: &str, nickname: &str) {
     if let Some(window) = web_sys::window() {
         if let Ok(Some(storage)) = window.local_storage() {
             if let Err(e) = storage.set_item(INVITATION_NICKNAME_STORAGE_KEY, nickname) {
@@ -130,6 +168,18 @@ pub fn save_invitation_nickname_to_storage(nickname: &str) {
                     "Failed to save invitation nickname to localStorage: {:?}",
                     e
                 );
+                return;
+            }
+            let fp = invitation_fingerprint(invitation_encoded);
+            if let Err(e) = storage.set_item(INVITATION_NICKNAME_FP_STORAGE_KEY, &fp) {
+                warn!(
+                    "Failed to save invitation nickname fingerprint to localStorage: {:?}",
+                    e
+                );
+                // Leave no half-written binding: drop the nickname too so the
+                // resume path falls back to prompting rather than applying an
+                // unbound nickname.
+                let _ = storage.remove_item(INVITATION_NICKNAME_STORAGE_KEY);
             }
         }
     }
@@ -172,6 +222,12 @@ pub fn decide_recovered_invitation(
     }
 }
 
+/// Whether a stored nickname-binding fingerprint belongs to `invitation_encoded`.
+/// Extracted so the binding check is host-testable without a browser.
+fn nickname_belongs_to_invitation(stored_fp: &str, invitation_encoded: &str) -> bool {
+    stored_fp == invitation_fingerprint(invitation_encoded)
+}
+
 /// Check-and-set a one-shot flag: returns `true` exactly once (the first call),
 /// `false` on every subsequent call. Used by the `App` body to fire the #218
 /// auto-resume at most once per page load — the recovery block runs on every
@@ -186,13 +242,26 @@ pub fn take_resume_once(fired: &std::cell::Cell<bool>) -> bool {
     }
 }
 
-/// Load the saved nickname for a pending invitation, if the user already
-/// accepted (i.e. clicked Accept) before reloading. `None` means the user
-/// has not yet chosen a nickname, so the modal should prompt for one.
-pub fn load_invitation_nickname_from_storage() -> Option<String> {
+/// Load the saved nickname for `invitation_encoded`, if the user already
+/// accepted (i.e. clicked Accept) *this* invitation before reloading. Returns
+/// `None` — meaning "prompt for a nickname" — when no nickname is stored, the
+/// stored nickname is blank, or the stored fingerprint does not match this
+/// invitation (a stale nickname from a different invitation; Codex review,
+/// PR #333).
+pub fn load_invitation_nickname_from_storage(invitation_encoded: &str) -> Option<String> {
     let window = web_sys::window()?;
     let storage = window.local_storage().ok()??;
     let nickname = storage.get_item(INVITATION_NICKNAME_STORAGE_KEY).ok()??;
+    let stored_fp = storage
+        .get_item(INVITATION_NICKNAME_FP_STORAGE_KEY)
+        .ok()??;
+    // The nickname must belong to THIS invitation. Without the match, a
+    // nickname saved for invitation A would be applied to a different
+    // invitation B that overwrote the invitation key before A's join cleared
+    // storage.
+    if !nickname_belongs_to_invitation(&stored_fp, invitation_encoded) {
+        return None;
+    }
     // Treat an empty/whitespace-only stored value as "no nickname" so we fall
     // back to the prompt rather than auto-resuming with a blank nickname.
     if nickname.trim().is_empty() {
@@ -775,11 +844,14 @@ pub(crate) fn accept_invitation(inv: Invitation, nickname: String) {
     // Persist the chosen nickname alongside the pending invitation so a reload
     // before the room arrives auto-resumes the subscription with this nickname
     // instead of re-prompting (#218). `clear_invitation_from_storage` removes
-    // both keys together once the room is subscribed or the invitation is
+    // all three keys together once the room is subscribed or the invitation is
     // dismissed. We keep the raw invitation in storage too — the resume path
-    // needs both the invitation artifact and the nickname.
+    // needs both the invitation artifact and the nickname. The nickname is
+    // fingerprint-bound to THIS invitation so it can't be applied to a
+    // different one that later overwrites the invitation key.
+    let encoded = inv.to_encoded_string();
     save_invitation_to_storage(&inv);
-    save_invitation_nickname_to_storage(&nickname);
+    save_invitation_nickname_to_storage(&encoded, &nickname);
 
     info!(
         "Adding room to pending invites: {:?}",
@@ -1073,6 +1145,26 @@ mod tests {
         // Re-open the modal at the nickname prompt (pre-#218 behaviour).
         let action = decide_recovered_invitation(None, false);
         assert_eq!(action, RecoveredInvitationAction::Prompt);
+    }
+
+    #[test]
+    fn nickname_binding_matches_only_its_own_invitation() {
+        // Regression for the Codex-review P2: a nickname saved for invitation A
+        // must NOT be applied to a different invitation B that overwrote the
+        // invitation key. The binding stores fp(A); recovering B compares
+        // against fp(B) and rejects.
+        let inv_a = "encoded-invitation-A";
+        let inv_b = "encoded-invitation-B";
+        let stored_fp_for_a = invitation_fingerprint(inv_a);
+
+        assert!(
+            nickname_belongs_to_invitation(&stored_fp_for_a, inv_a),
+            "nickname saved for A must match A"
+        );
+        assert!(
+            !nickname_belongs_to_invitation(&stored_fp_for_a, inv_b),
+            "nickname saved for A must NOT match a different invitation B"
+        );
     }
 
     #[test]

--- a/ui/src/components/room_list/receive_invitation_modal.rs
+++ b/ui/src/components/room_list/receive_invitation_modal.rs
@@ -172,6 +172,20 @@ pub fn decide_recovered_invitation(
     }
 }
 
+/// Check-and-set a one-shot flag: returns `true` exactly once (the first call),
+/// `false` on every subsequent call. Used by the `App` body to fire the #218
+/// auto-resume at most once per page load — the recovery block runs on every
+/// re-render and the resume's side effects (re-send `AcceptInvitation`, reset
+/// `PENDING_INVITES`) must NOT repeat, or they loop (Codex review, PR #333).
+pub fn take_resume_once(fired: &std::cell::Cell<bool>) -> bool {
+    if fired.get() {
+        false
+    } else {
+        fired.set(true);
+        true
+    }
+}
+
 /// Load the saved nickname for a pending invitation, if the user already
 /// accepted (i.e. clicked Accept) before reloading. `None` means the user
 /// has not yet chosen a nickname, so the modal should prompt for one.
@@ -1059,6 +1073,33 @@ mod tests {
         // Re-open the modal at the nickname prompt (pre-#218 behaviour).
         let action = decide_recovered_invitation(None, false);
         assert_eq!(action, RecoveredInvitationAction::Prompt);
+    }
+
+    #[test]
+    fn resume_fires_at_most_once_across_many_renders() {
+        // Regression for the Codex-review P1: the recovery block runs in the
+        // `App` body on EVERY render, and the persisted nickname stays until
+        // the join completes. Without the one-shot guard, each render would
+        // re-fire the resume (re-send AcceptInvitation, reset PENDING_INVITES),
+        // looping. Simulate many renders and assert the side effect fires once.
+        let fired = std::cell::Cell::new(false);
+        let mut side_effects = 0;
+        for _ in 0..100 {
+            // Each iteration is a render where the Resume action is selected.
+            assert_eq!(
+                decide_recovered_invitation(Some("Alice".to_string()), true),
+                RecoveredInvitationAction::Resume {
+                    nickname: "Alice".to_string()
+                }
+            );
+            if take_resume_once(&fired) {
+                side_effects += 1;
+            }
+        }
+        assert_eq!(
+            side_effects, 1,
+            "auto-resume must fire exactly once across many renders"
+        );
     }
 
     #[test]

--- a/ui/src/components/room_list/receive_invitation_modal.rs
+++ b/ui/src/components/room_list/receive_invitation_modal.rs
@@ -28,6 +28,15 @@ thread_local! {
 }
 
 const INVITATION_STORAGE_KEY: &str = "river_pending_invitation";
+/// Sibling key to [`INVITATION_STORAGE_KEY`] holding the nickname the user
+/// chose when they accepted the pending invitation. Persisting it lets a
+/// reload mid-subscription auto-resume `accept_invitation` (re-populating the
+/// in-memory `PENDING_INVITES` so the "Subscribing…" indicator returns)
+/// instead of re-prompting for a nickname (#218). Only written once the user
+/// has clicked Accept — a reload *before* Accept still shows the nickname
+/// prompt, matching the fingerprint guard's "mark only on definitive action"
+/// rule.
+const INVITATION_NICKNAME_STORAGE_KEY: &str = "river_pending_invitation_nickname";
 /// Prefix that identifies River's processed-invitation list inside the
 /// top-level URL hash. Format: `#river-processed=fp1,fp2,fp3`.
 ///
@@ -101,12 +110,81 @@ pub fn load_invitation_from_storage() -> Option<Invitation> {
     Invitation::from_encoded_string(&encoded).ok()
 }
 
-/// Clear saved invitation from localStorage
+/// Clear saved invitation (and any saved nickname) from localStorage.
 pub fn clear_invitation_from_storage() {
     if let Some(window) = web_sys::window() {
         if let Ok(Some(storage)) = window.local_storage() {
             let _ = storage.remove_item(INVITATION_STORAGE_KEY);
+            let _ = storage.remove_item(INVITATION_NICKNAME_STORAGE_KEY);
         }
+    }
+}
+
+/// Save the accepted nickname alongside the pending invitation so a reload
+/// mid-subscription can auto-resume the join without re-prompting (#218).
+pub fn save_invitation_nickname_to_storage(nickname: &str) {
+    if let Some(window) = web_sys::window() {
+        if let Ok(Some(storage)) = window.local_storage() {
+            if let Err(e) = storage.set_item(INVITATION_NICKNAME_STORAGE_KEY, nickname) {
+                warn!(
+                    "Failed to save invitation nickname to localStorage: {:?}",
+                    e
+                );
+            }
+        }
+    }
+}
+
+/// What the app should do with an invitation recovered from localStorage on
+/// page load. Pure decision so the three-way branch is testable on the host
+/// without a browser (the storage reads that feed it are wasm-only).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecoveredInvitationAction {
+    /// User had clicked Accept (a nickname was saved); re-run `accept_invitation`
+    /// with this nickname to resume the in-flight subscription (#218).
+    Resume { nickname: String },
+    /// User already acted on this invitation in this browser and there is no
+    /// in-flight join to resume; drop it and clear storage.
+    Discard,
+    /// User reloaded before deciding; re-open the modal at the nickname prompt.
+    Prompt,
+}
+
+/// Decide what to do with a recovered invitation given the two persisted
+/// signals: whether a nickname was saved alongside it (meaning the user had
+/// clicked Accept), and whether the invitation's fingerprint is already in the
+/// processed set.
+///
+/// A saved nickname takes precedence over the processed flag, because
+/// `accept_invitation` marks the invitation processed *up front* — so a reload
+/// mid-subscription always sees `already_processed == true`. The invitation
+/// artifact only stays in storage until the room subscribes or the user
+/// dismisses (both clear the nickname too), so "nickname present" is the
+/// authoritative "join not yet finished, resume it" signal.
+pub fn decide_recovered_invitation(
+    saved_nickname: Option<String>,
+    already_processed: bool,
+) -> RecoveredInvitationAction {
+    match saved_nickname {
+        Some(nickname) => RecoveredInvitationAction::Resume { nickname },
+        None if already_processed => RecoveredInvitationAction::Discard,
+        None => RecoveredInvitationAction::Prompt,
+    }
+}
+
+/// Load the saved nickname for a pending invitation, if the user already
+/// accepted (i.e. clicked Accept) before reloading. `None` means the user
+/// has not yet chosen a nickname, so the modal should prompt for one.
+pub fn load_invitation_nickname_from_storage() -> Option<String> {
+    let window = web_sys::window()?;
+    let storage = window.local_storage().ok()??;
+    let nickname = storage.get_item(INVITATION_NICKNAME_STORAGE_KEY).ok()??;
+    // Treat an empty/whitespace-only stored value as "no nickname" so we fall
+    // back to the prompt rather than auto-resuming with a blank nickname.
+    if nickname.trim().is_empty() {
+        None
+    } else {
+        Some(nickname)
     }
 }
 
@@ -655,8 +733,12 @@ fn render_new_invitation(inv: Invitation, invitation: Signal<Option<Invitation>>
     }
 }
 
-/// Handles the invitation acceptance process
-fn accept_invitation(inv: Invitation, nickname: String) {
+/// Handles the invitation acceptance process.
+///
+/// `pub(crate)` so the reload-recovery path in `app.rs` can auto-resume a
+/// subscription that was in flight when the page was reloaded (#218), reusing
+/// the exact same accept flow the Accept button uses.
+pub(crate) fn accept_invitation(inv: Invitation, nickname: String) {
     // Mark this invitation processed up front. The user has now made a choice
     // for this URL parameter; even if subscription fails or the page is
     // reloaded mid-flow, we should not re-prompt for a nickname on every
@@ -675,6 +757,15 @@ fn accept_invitation(inv: Invitation, nickname: String) {
     } else {
         nickname
     };
+
+    // Persist the chosen nickname alongside the pending invitation so a reload
+    // before the room arrives auto-resumes the subscription with this nickname
+    // instead of re-prompting (#218). `clear_invitation_from_storage` removes
+    // both keys together once the room is subscribed or the invitation is
+    // dismissed. We keep the raw invitation in storage too — the resume path
+    // needs both the invitation artifact and the nickname.
+    save_invitation_to_storage(&inv);
+    save_invitation_nickname_to_storage(&nickname);
 
     info!(
         "Adding room to pending invites: {:?}",
@@ -917,6 +1008,57 @@ mod tests {
         assert!(after[1..].iter().all(|fp| fp.len() == 32));
 
         PROCESSED_CACHE.with(|c| *c.borrow_mut() = None);
+    }
+
+    // ---- #218: auto-resume subscription on reload mid-invitation-flow ----
+
+    #[test]
+    fn recovered_invitation_with_nickname_resumes() {
+        // The user clicked Accept (nickname saved) and reloaded before the
+        // room arrived. Even though `accept_invitation` already marked the
+        // invitation processed, we must RESUME (not Discard) — otherwise the
+        // user is dropped with no "Subscribing…" feedback, which is exactly
+        // the bug #218 fixes.
+        let action = decide_recovered_invitation(
+            Some("Alice".to_string()),
+            /* already_processed */ true,
+        );
+        assert_eq!(
+            action,
+            RecoveredInvitationAction::Resume {
+                nickname: "Alice".to_string()
+            },
+            "saved nickname must take precedence over the processed flag"
+        );
+    }
+
+    #[test]
+    fn recovered_invitation_with_nickname_resumes_even_when_not_processed() {
+        // Defensive: a nickname present but processed-flag somehow absent
+        // (e.g. the top-level hash was lost) must still resume, never prompt.
+        let action = decide_recovered_invitation(Some("Bob".to_string()), false);
+        assert_eq!(
+            action,
+            RecoveredInvitationAction::Resume {
+                nickname: "Bob".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn recovered_invitation_processed_without_nickname_discards() {
+        // No nickname → the user accepted-then-left or dismissed in a prior
+        // session; there is no in-flight join to resume. Discard.
+        let action = decide_recovered_invitation(None, true);
+        assert_eq!(action, RecoveredInvitationAction::Discard);
+    }
+
+    #[test]
+    fn recovered_invitation_not_processed_without_nickname_prompts() {
+        // The user reloaded before deciding: no nickname, not yet acted on.
+        // Re-open the modal at the nickname prompt (pre-#218 behaviour).
+        let action = decide_recovered_invitation(None, false);
+        assert_eq!(action, RecoveredInvitationAction::Prompt);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Follow-up from #216. After #216, a reload *mid-subscription* (user opened `?invitation=`, picked a nickname, clicked Accept, then reloaded before the room arrived) leaves the user with no feedback:

- The fingerprint guard correctly suppresses the nickname-prompt modal, but
- `PENDING_INVITES` is in-memory only, so it is empty on reload — no "Subscribing…" indicator either.
- If the original `AcceptInvitation` send never reached a running synchronizer, there was previously no recovery path short of re-opening the original URL.

## Approach

Persist the chosen nickname alongside the pending invitation, and auto-resume on reload.

- On Accept, save the nickname under a **sibling** localStorage key `river_pending_invitation_nickname` (no change to the existing `river_pending_invitation` format — the stored value is a raw encoded invitation, not a struct, so a sibling key avoids any stored-data migration).
- On the localStorage-recovery path in `App`, when both the invitation artifact and a saved nickname are present, **auto-resume** by re-calling `accept_invitation` with that nickname. That re-populates the in-memory `PENDING_INVITES` (status `PendingSubscription`) and re-sends `AcceptInvitation` to the synchronizer, so the modal re-renders the "Subscribing…" / "Preparing to subscribe…" progress state. This also recovers the failed-initial-send case (the unbounded synchronizer channel queues the message even if the loop is not yet up).
- The saved-nickname signal **takes precedence over** the processed-fingerprint guard from #216, because `accept_invitation` marks the invitation processed *up front* — so a mid-flight reload always sees it as processed. The invitation artifact only stays in storage until the room subscribes or the user dismisses (both now clear the nickname key too), so "nickname present" is the authoritative "join not yet finished, resume it" signal. No resume loop: completion (`render_subscribed_state`) and dismiss (`dismiss_invitation_persistently`) both clear storage.
- A reload **before** clicking Accept still shows the nickname prompt (no nickname saved), matching pre-PR behaviour and #216's "mark only on definitive action" rule.

The three-way recovery decision (Resume / Discard / Prompt) is extracted into a pure `decide_recovered_invitation` helper so it is host-testable — the localStorage reads that feed it are wasm-only.

UI-only change: no `common/`, `delegates/`, `contracts/`, or Cargo-manifest changes, so **no delegate/contract migration is required**.

## Testing

Four new host unit tests in `receive_invitation_modal.rs` pin the decision matrix:

- `recovered_invitation_with_nickname_resumes` — nickname present + already-processed ⇒ **Resume** (the #218 regression: with the naive processed-first ordering this would Discard, dropping the user). Verified this test FAILS against the buggy ordering and PASSES with the fix.
- `recovered_invitation_with_nickname_resumes_even_when_not_processed` — defensive precedence check.
- `recovered_invitation_processed_without_nickname_discards` — accepted-then-left / dismissed ⇒ Discard.
- `recovered_invitation_not_processed_without_nickname_prompts` — reloaded before deciding ⇒ Prompt.

Full `cargo test -p river-ui --bins` green (269 tests). `cargo fmt --check` clean; `cargo clippy` and `cargo check` on `wasm32-unknown-unknown` clean (no new warnings).

### Manual test plan (local Freenet node)

1. Owner publishes an invite link; joiner opens it, enters a nickname, clicks Accept.
2. Reload before the room arrives. **Expected:** modal shows "Subscribing…/Preparing to subscribe…" (auto-resumed), not a nickname re-prompt or blank UI.
3. After the room loads, reload again. **Expected:** no modal (storage cleared on subscribe).
4. Open a fresh invite link, reload **without** clicking Accept. **Expected:** nickname prompt re-appears.

Closes #218

[AI-assisted - Claude]