### PR TITLE
ci: authenticate and cache dioxus-cli install to fix binstall rate-limit flake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,30 @@ jobs:
     - name: Install cargo-binstall
       uses: taiki-e/install-action@cargo-binstall
 
+    - name: Cache Dioxus CLI
+      id: cache-dioxus-cli
+      uses: actions/cache@v3
+      with:
+        path: ~/.cargo/bin/dx
+        # Re-key on ui/Cargo.toml so a dioxus version bump invalidates the
+        # cached `dx` rather than pinning it to a stale CLI version forever.
+        key: ${{ runner.os }}-dioxus-cli-${{ hashFiles('ui/Cargo.toml') }}
+
     - name: Install Dioxus CLI
-      run: cargo binstall -y dioxus-cli
+      # Gate on the cache *result*, not on whether the file exists:
+      # freenet-default-runner is self-hosted, so a stale ~/.cargo/bin/dx can
+      # persist from an earlier job even when this key misses (e.g. after a
+      # dioxus bump). A file-existence check would then skip the install and
+      # use the stale CLI; a cache-key miss must always (re)install.
+      #
+      # Pass GITHUB_TOKEN so binstall makes authenticated GitHub API requests
+      # (5000/hr) instead of unauthenticated ones (60/hr). The unauthenticated
+      # limit was getting hit, returning 403, forcing a from-source build that
+      # then failed on a broken transitive dep (freenet/river#316).
+      if: steps.cache-dioxus-cli.outputs.cache-hit != 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: cargo binstall -y --force dioxus-cli
 
     - name: Setup Node.js
       uses: actions/setup-node@v4
@@ -187,8 +209,30 @@ jobs:
     - name: Install cargo-binstall
       uses: taiki-e/install-action@cargo-binstall
 
+    - name: Cache Dioxus CLI
+      id: cache-dioxus-cli
+      uses: actions/cache@v3
+      with:
+        path: ~/.cargo/bin/dx
+        # Re-key on ui/Cargo.toml so a dioxus version bump invalidates the
+        # cached `dx` rather than pinning it to a stale CLI version forever.
+        key: ${{ runner.os }}-dioxus-cli-${{ hashFiles('ui/Cargo.toml') }}
+
     - name: Install Dioxus CLI
-      run: cargo binstall -y dioxus-cli
+      # Gate on the cache *result*, not on whether the file exists:
+      # freenet-default-runner is self-hosted, so a stale ~/.cargo/bin/dx can
+      # persist from an earlier job even when this key misses (e.g. after a
+      # dioxus bump). A file-existence check would then skip the install and
+      # use the stale CLI; a cache-key miss must always (re)install.
+      #
+      # Pass GITHUB_TOKEN so binstall makes authenticated GitHub API requests
+      # (5000/hr) instead of unauthenticated ones (60/hr). The unauthenticated
+      # limit was getting hit, returning 403, forcing a from-source build that
+      # then failed on a broken transitive dep (freenet/river#316).
+      if: steps.cache-dioxus-cli.outputs.cache-hit != 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: cargo binstall -y --force dioxus-cli
 
     - name: Setup Node.js
       uses: actions/setup-node@v4


### PR DESCRIPTION
## Problem

`build` and `ui-playwright-tests` install dioxus-cli with `cargo binstall -y dioxus-cli`. binstall first queries the GitHub Releases API for the prebuilt binary. **Unauthenticated** that call is capped at **60 requests/hr**, and it was hitting **403 Forbidden** (rate limit). binstall then falls back to a from-source build, which fails because a transitive dep (`auth-git2 v0.5.8` → `git2`) uses an API removed in newer git2 — so the whole job dies intermittently.

The rate-limit is the trigger; the broken source build just removes the safety net. (See #316 for the failing run on #314.)

## Approach

Fix both `Install Dioxus CLI` steps:

- **Pass `GITHUB_TOKEN`** so binstall makes **authenticated** requests (5000/hr ceiling instead of 60/hr). This directly removes the 403 trigger. `secrets.GITHUB_TOKEN` is auto-provided to every run — no repo config needed.
- **Cache `~/.cargo/bin/dx`** keyed on `hashFiles('ui/Cargo.toml')` (so a dioxus version bump invalidates it rather than pinning a stale CLI forever), and **gate the install on the cache step's `cache-hit` output**. A warm cache skips the install and the API call entirely; a miss always (re)installs with `--force`.

Gating on the cache result (not file existence) matters because `freenet-default-runner` is **self-hosted**: a stale `dx` can linger across a cache-key change, and a file-existence check would wrongly skip the reinstall and use the stale CLI. On a cache hit, `actions/cache` restores the correct cached binary, overwriting any stale one.

I deliberately did **not** pin the dioxus-cli version (a third option floated in the issue) to avoid a CLI/library version-mismatch risk — the token + cache fully address the documented rate-limit trigger.

## Testing

- This is a CI-workflow-only change; verification is the CI run itself (no unit test applies to a `.yml`).
- Validated with `actionlint` (incl. its shellcheck + expression checks): no new findings — only the repo's pre-existing `freenet-default-runner` self-hosted-label and old-action-version warnings remain.
- YAML parses cleanly; the `steps.cache-dioxus-cli.outputs.cache-hit` expression and the new `id` references validate.
- External review: `codex review --base main` — first pass flagged the file-existence vs. cache-result gap (now fixed by gating on `cache-hit`); re-review on the fixed content found no issues.

Closes #316

[AI-assisted - Claude]