### PR TITLE
fix(ui): preserve private-room edits across optimistic apply_delta (#310)

### DIFF
--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -12,7 +12,6 @@ use crate::components::app::{CURRENT_ROOM, PENDING_INVITES, ROOMS, WEB_API};
 use crate::constants::ROOM_CONTRACT_WASM;
 use crate::invites::PendingRoomStatus;
 use crate::room_data::RoomData;
-use crate::util::ecies::decrypt_with_symmetric_key;
 use crate::util::{
     from_cbor_slice, get_current_system_time, owner_vk_to_contract_key, to_cbor_vec,
     try_from_cbor_slice,
@@ -27,10 +26,8 @@ use freenet_stdlib::prelude::{
 };
 use river_core::room_state::member::MemberId;
 use river_core::room_state::member_info::{AuthorizedMemberInfo, MemberInfo};
-use river_core::room_state::message::{AuthorizedMessageV1, MessageId, MessageV1, RoomMessageBody};
-use river_core::room_state::privacy::PrivacyMode;
+use river_core::room_state::message::{AuthorizedMessageV1, MessageV1, RoomMessageBody};
 use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1, ChatRoomStateV1Delta};
-use std::collections::HashMap;
 use std::sync::Arc;
 
 pub async fn handle_get_response(
@@ -469,46 +466,9 @@ pub async fn handle_get_response(
 
                     // Rebuild actions_state from action messages (edit, delete, reaction)
                     // This is needed because actions_state is #[serde(skip)] and not serialized
-                    let is_private = room_data
-                        .room_state
-                        .configuration
-                        .configuration
-                        .privacy_mode
-                        == PrivacyMode::Private;
-                    if is_private {
-                        // Decrypt all private action messages using version-aware lookup
-                        let decrypted_actions: HashMap<MessageId, Vec<u8>> = room_data
-                            .room_state
-                            .recent_messages
-                            .messages
-                            .iter()
-                            .filter(|msg| msg.message.content.is_action())
-                            .filter_map(|msg| {
-                                if let RoomMessageBody::Private {
-                                    ciphertext,
-                                    nonce,
-                                    secret_version,
-                                    ..
-                                } = &msg.message.content
-                                {
-                                    // Look up the secret for this message's version
-                                    room_data.get_secret_for_version(*secret_version).and_then(
-                                        |secret| {
-                                            decrypt_with_symmetric_key(secret, ciphertext, nonce)
-                                                .ok()
-                                                .map(|plaintext| (msg.id(), plaintext))
-                                        },
-                                    )
-                                } else {
-                                    None
-                                }
-                            })
-                            .collect();
-
-                        room_data
-                            .room_state
-                            .recent_messages
-                            .rebuild_actions_state_with_decrypted(&decrypted_actions);
+                    if room_data.is_private() {
+                        // Re-derive with decrypted private action payloads (#310).
+                        room_data.rebuild_private_actions_state();
                     } else {
                         // Public room - rebuild from public action messages
                         room_data.room_state.recent_messages.rebuild_actions_state();

--- a/ui/src/components/app/freenet_api/room_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/room_synchronizer.rs
@@ -14,7 +14,6 @@ use crate::components::app::sync_info::{now_ms, RoomSyncStatus, SYNC_INFO};
 use crate::components::app::{CURRENT_ROOM, PENDING_INVITES, ROOMS, WEB_API};
 use crate::constants::ROOM_CONTRACT_WASM;
 use crate::invites::PendingRoomStatus;
-use crate::util::ecies::decrypt_with_symmetric_key;
 use crate::util::{owner_vk_to_contract_key, to_cbor_vec};
 use dioxus::logger::tracing::{debug, error, info, warn};
 use dioxus::prelude::*;
@@ -29,7 +28,7 @@ use freenet_stdlib::{
 };
 use river_core::room_state::member::MemberId;
 use river_core::room_state::member_info::{AuthorizedMemberInfo, MemberInfoV1};
-use river_core::room_state::message::{AuthorizedMessageV1, MessageId, RoomMessageBody};
+use river_core::room_state::message::AuthorizedMessageV1;
 use river_core::room_state::privacy::PrivacyMode;
 use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1, ChatRoomStateV1Delta};
 use std::collections::HashMap;
@@ -256,33 +255,9 @@ impl RoomSynchronizer {
                                     room_data.build_member_info_heal(&room_data.room_state);
                             }
 
-                            // Decrypt all private action messages using version-aware lookup
-                            let decrypted_actions: HashMap<MessageId, Vec<u8>> = room_data
-                                .room_state
-                                .recent_messages
-                                .messages
-                                .iter()
-                                .filter(|msg| msg.message.content.is_action())
-                                .filter_map(|msg| {
-                                    if let RoomMessageBody::Private { ciphertext, nonce, secret_version, .. } =
-                                        &msg.message.content
-                                    {
-                                        room_data.get_secret_for_version(*secret_version)
-                                            .and_then(|secret| {
-                                                decrypt_with_symmetric_key(secret, ciphertext, nonce)
-                                                    .ok()
-                                                    .map(|plaintext| (msg.id(), plaintext))
-                                            })
-                                    } else {
-                                        None
-                                    }
-                                })
-                                .collect();
-
-                            room_data
-                                .room_state
-                                .recent_messages
-                                .rebuild_actions_state_with_decrypted(&decrypted_actions);
+                            // Re-derive actions_state with decrypted payloads
+                            // (apply_delta only processes public actions). See #310.
+                            room_data.rebuild_private_actions_state();
                         }
 
                         // Log versions after applying delta
@@ -1189,33 +1164,9 @@ impl RoomSynchronizer {
                                     room_data.build_member_info_heal(&room_data.room_state);
                             }
 
-                            // Decrypt all private action messages using version-aware lookup
-                            let decrypted_actions: HashMap<MessageId, Vec<u8>> = room_data
-                                .room_state
-                                .recent_messages
-                                .messages
-                                .iter()
-                                .filter(|msg| msg.message.content.is_action())
-                                .filter_map(|msg| {
-                                    if let RoomMessageBody::Private { ciphertext, nonce, secret_version, .. } =
-                                        &msg.message.content
-                                    {
-                                        room_data.get_secret_for_version(*secret_version)
-                                            .and_then(|secret| {
-                                                decrypt_with_symmetric_key(secret, ciphertext, nonce)
-                                                    .ok()
-                                                    .map(|plaintext| (msg.id(), plaintext))
-                                            })
-                                    } else {
-                                        None
-                                    }
-                                })
-                                .collect();
-
-                            room_data
-                                .room_state
-                                .recent_messages
-                                .rebuild_actions_state_with_decrypted(&decrypted_actions);
+                            // Re-derive actions_state with decrypted payloads
+                            // (merge only processes public actions). See #310.
+                            room_data.rebuild_private_actions_state();
                         }
 
                         // Log member info versions after merge

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1098,6 +1098,9 @@ pub fn Conversation() -> Element {
                                         error!("Failed to apply reaction delta: {:?}", e);
                                         false
                                     } else {
+                                        // See #310 — keep private actions_state intact
+                                        // across the optimistic apply_delta.
+                                        room_data.rebuild_private_actions_state();
                                         true
                                     }
                                 } else {
@@ -1199,6 +1202,9 @@ pub fn Conversation() -> Element {
                                     error!("Failed to apply delete delta: {:?}", e);
                                     false
                                 } else {
+                                    // See #310 — keep private actions_state intact
+                                    // across the optimistic apply_delta.
+                                    room_data.rebuild_private_actions_state();
                                     true
                                 }
                             } else {
@@ -1305,6 +1311,10 @@ pub fn Conversation() -> Element {
                                     error!("Failed to apply edit delta: {:?}", e);
                                     false
                                 } else {
+                                    // See #310 — re-derive private actions_state so the
+                                    // just-made edit shows immediately instead of waiting
+                                    // for the network echo's decrypt-aware rebuild.
+                                    room_data.rebuild_private_actions_state();
                                     true
                                 }
                             } else {
@@ -1509,6 +1519,12 @@ pub fn Conversation() -> Element {
                                     false
                                 } else {
                                     crate::util::debug_log("[send] delta applied OK");
+                                    // For private rooms, re-derive actions_state with
+                                    // decrypted payloads. apply_delta's built-in rebuild
+                                    // only handles public actions, so without this the
+                                    // optimistic update wipes private edits/deletes/reactions
+                                    // until the network echo re-applies them (#310).
+                                    room_data.rebuild_private_actions_state();
                                     true
                                 }
                             } else {

--- a/ui/src/components/direct_messages.rs
+++ b/ui/src/components/direct_messages.rs
@@ -478,6 +478,10 @@ pub async fn send_structured_dm(
             if !landed {
                 return SendDmOutcome::SilentDrop;
             }
+            // #310: apply_delta's MessagesV1 step re-runs the public-only
+            // rebuild_actions_state, dropping private edits/reactions.
+            // Re-derive them with decryption. No-op on public rooms.
+            rd.rebuild_private_actions_state();
             SendDmOutcome::Sent
         });
 

--- a/ui/src/components/direct_messages/dm_thread_modal.rs
+++ b/ui/src/components/direct_messages/dm_thread_modal.rs
@@ -589,6 +589,12 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                         );
                         return ApplyOutcome::SilentDrop;
                     }
+                    // #310: apply_delta's MessagesV1 step always re-runs the
+                    // public-only rebuild_actions_state, which wipes private
+                    // edits/deletes/reactions. Re-derive them with decryption
+                    // so sending a DM doesn't transiently revert an edited
+                    // message. No-op on public rooms.
+                    rd.rebuild_private_actions_state();
                     ApplyOutcome::Applied
                 });
                 match outcome {
@@ -744,6 +750,9 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                         error!("DM purge apply_delta failed: {:?}", e);
                         false
                     } else {
+                        // #310: preserve private edits/reactions across the
+                        // optimistic apply_delta. No-op on public rooms.
+                        rd.rebuild_private_actions_state();
                         true
                     }
                 });

--- a/ui/src/components/members/member_info_modal/ban_button.rs
+++ b/ui/src/components/members/member_info_modal/ban_button.rs
@@ -145,6 +145,14 @@ pub fn BanButton(member_to_ban: MemberId, is_downstream: bool, nickname: String)
                                         }
                                     }
                                 }
+
+                                // #310: both apply_delta calls above (ban, and
+                                // the post-ban rotation) re-run the public-only
+                                // rebuild_actions_state, wiping private edits/
+                                // reactions. Re-derive them with decryption once
+                                // here, after the (possibly rotated) secret is in
+                                // place. No-op on public rooms.
+                                room_data_mut.rebuild_private_actions_state();
                             }
                         }
                     });

--- a/ui/src/components/members/member_info_modal/nickname_field.rs
+++ b/ui/src/components/members/member_info_modal/nickname_field.rs
@@ -183,6 +183,13 @@ pub fn NicknameField(member_info: AuthorizedMemberInfo) -> Element {
                                         edited_member_info,
                                         nickname_for_self,
                                     );
+                                    // #310: apply_delta's MessagesV1 step re-runs
+                                    // the public-only rebuild_actions_state, which
+                                    // wipes private edits/reactions. Re-derive them
+                                    // with decryption so changing a nickname doesn't
+                                    // transiently revert an edited message. No-op on
+                                    // public rooms.
+                                    room_data.rebuild_private_actions_state();
                                     true
                                 }
                             } else {

--- a/ui/src/components/room_list/edit_room_modal.rs
+++ b/ui/src/components/room_list/edit_room_modal.rs
@@ -230,6 +230,10 @@ pub fn EditRoomModal() -> Element {
                                                                                     error!("Failed to apply manual rotation delta: {:?}", e);
                                                                                 } else {
                                                                                     info!("Manual rotation succeeded");
+                                                                                    // #310: apply_delta re-runs the public-only
+                                                                                    // actions-state rebuild; re-derive private
+                                                                                    // edits/reactions with decryption.
+                                                                                    room_data_mut.rebuild_private_actions_state();
                                                                                     applied = true;
                                                                                 }
                                                                             }
@@ -460,6 +464,11 @@ fn RoomDescriptionField(config: Configuration, is_owner: bool) -> Element {
                         ) {
                             Ok(_) => {
                                 info!("Room description updated successfully");
+                                // #310: apply_delta re-runs the public-only
+                                // actions-state rebuild; re-derive private
+                                // edits/reactions with decryption. No-op on
+                                // public rooms.
+                                room_data.rebuild_private_actions_state();
                                 true
                             }
                             Err(e) => {
@@ -602,6 +611,11 @@ fn NumericConfigField(
                         ) {
                             Ok(_) => {
                                 info!("{label} updated successfully");
+                                // #310: apply_delta re-runs the public-only
+                                // actions-state rebuild; re-derive private
+                                // edits/reactions with decryption. No-op on
+                                // public rooms.
+                                room_data.rebuild_private_actions_state();
                                 true
                             }
                             Err(e) => {
@@ -711,6 +725,11 @@ fn MaxMembersField(
                         ) {
                             Ok(_) => {
                                 info!("max_members updated successfully");
+                                // #310: apply_delta re-runs the public-only
+                                // actions-state rebuild; re-derive private
+                                // edits/reactions with decryption. No-op on
+                                // public rooms.
+                                room_data.rebuild_private_actions_state();
                                 true
                             }
                             Err(e) => {

--- a/ui/src/components/room_list/room_name_field.rs
+++ b/ui/src/components/room_list/room_name_field.rs
@@ -127,6 +127,11 @@ pub fn RoomNameField(config: Configuration, is_owner: bool) -> Element {
                             ) {
                                 Ok(_) => {
                                     info!("Delta applied successfully");
+                                    // #310: apply_delta re-runs the public-only
+                                    // actions-state rebuild; re-derive private
+                                    // edits/reactions with decryption. No-op on
+                                    // public rooms.
+                                    room_data.rebuild_private_actions_state();
                                     true
                                 }
                                 Err(e) => {

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -250,6 +250,70 @@ impl RoomData {
         self.secrets.get(&version)
     }
 
+    /// Rebuild `recent_messages.actions_state` (edits, deletes, reactions)
+    /// from this room's action messages, decrypting private action payloads
+    /// with the in-memory secrets.
+    ///
+    /// `ComposableState::apply_delta` for `MessagesV1` ends every merge with
+    /// the *non-decrypting* `rebuild_actions_state()`, which can only decode
+    /// PUBLIC action messages. For a private room that call clears
+    /// `actions_state` and re-derives it from public actions only — so every
+    /// edit / delete / reaction carried by a PRIVATE action message is wiped
+    /// until a later decrypt-aware rebuild restores it.
+    ///
+    /// The network ingestion paths (`apply_delta_inner`,
+    /// `update_room_state_inner`, the GET handler) already follow their
+    /// `apply_delta`/`merge` with a decrypt-aware rebuild. The local
+    /// optimistic send/edit/delete/react handlers in `conversation.rs` did
+    /// not, which is why an edited private-room message briefly reverted to
+    /// its original text whenever a new message (or any other local action)
+    /// was sent — the optimistic `apply_delta` ran the public-only rebuild
+    /// and dropped the edit until the network echo re-applied it
+    /// (freenet/river#310).
+    ///
+    /// Call this after any local `apply_delta` that mutates a private room's
+    /// `recent_messages`. No-op on public rooms (the public rebuild that
+    /// `apply_delta` already ran is correct and complete).
+    pub fn rebuild_private_actions_state(&mut self) {
+        use crate::util::ecies::decrypt_with_symmetric_key;
+        use river_core::room_state::message::RoomMessageBody;
+
+        if !self.is_private() {
+            return;
+        }
+
+        // Decrypt all private action messages using version-aware lookup.
+        let decrypted_actions: HashMap<MessageId, Vec<u8>> = self
+            .room_state
+            .recent_messages
+            .messages
+            .iter()
+            .filter(|msg| msg.message.content.is_action())
+            .filter_map(|msg| {
+                if let RoomMessageBody::Private {
+                    ciphertext,
+                    nonce,
+                    secret_version,
+                    ..
+                } = &msg.message.content
+                {
+                    self.get_secret_for_version(*secret_version)
+                        .and_then(|secret| {
+                            decrypt_with_symmetric_key(secret, ciphertext, nonce)
+                                .ok()
+                                .map(|plaintext| (msg.id(), plaintext))
+                        })
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        self.room_state
+            .recent_messages
+            .rebuild_actions_state_with_decrypted(&decrypted_actions);
+    }
+
     /// Get a reference to the current secret (convenience method)
     pub fn current_secret(&self) -> Option<&[u8; 32]> {
         self.current_secret_version
@@ -2647,6 +2711,190 @@ mod tests {
             previous_contract_key: None,
             invitation_secrets: HashMap::new(),
         }
+    }
+
+    /// Regression test for freenet/river#310: in a private room, an edited
+    /// message must NOT briefly revert to its original text when a new
+    /// message (or any other local action) is sent.
+    ///
+    /// Root cause: the local optimistic send/edit/delete/react handlers call
+    /// `ChatRoomStateV1::apply_delta`, whose `MessagesV1` impl ends with the
+    /// non-decrypting `rebuild_actions_state()`. For a private room that can
+    /// only decode PUBLIC actions, so it wipes the edit (carried by a private
+    /// action message) from `actions_state.edited_content` until the network
+    /// echo runs the decrypt-aware rebuild. `RoomData::rebuild_private_actions_state`
+    /// restores it synchronously after the optimistic apply.
+    ///
+    /// This test reproduces the bug (asserts `apply_delta` alone drops the
+    /// edit) and verifies the fix (the edit survives once the helper runs).
+    #[test]
+    fn private_edit_survives_new_message_send() {
+        use river_core::room_state::content::{
+            ActionContentV1, TextContentV1, CONTENT_TYPE_TEXT, TEXT_CONTENT_VERSION,
+        };
+        use river_core::room_state::message::{AuthorizedMessageV1, MessageV1, RoomMessageBody};
+        use river_core::room_state::ChatRoomStateV1Delta;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let member_sk = SigningKey::generate(&mut rng);
+        let owner_vk = owner_sk.verifying_key();
+        let owner_id: MemberId = owner_vk.into();
+
+        let mut room = make_private_owner_room(&owner_sk, &member_sk);
+        let params = ChatRoomParametersV1 { owner: owner_vk };
+        let (secret, secret_version) = {
+            let (s, v) = room.get_secret().expect("private room must have a secret");
+            (*s, v)
+        };
+
+        // 1. Author an original message (owner-authored, encrypted).
+        let original_text = "Original content";
+        let (orig_ct, orig_nonce) = crate::util::ecies::encrypt_with_symmetric_key(
+            &secret,
+            &TextContentV1::new(original_text.to_string()).encode(),
+        );
+        let original_msg = MessageV1 {
+            room_owner: owner_id,
+            author: owner_id,
+            time: get_current_system_time(),
+            content: RoomMessageBody::private(
+                CONTENT_TYPE_TEXT,
+                TEXT_CONTENT_VERSION,
+                orig_ct,
+                orig_nonce,
+                secret_version,
+            ),
+        };
+        let auth_original = AuthorizedMessageV1::new(original_msg, &owner_sk);
+        let original_id = auth_original.id();
+
+        // 2. Author an edit action (private, encrypted) for that message.
+        let edited_text = "Edited content";
+        let edit_action = ActionContentV1::edit(original_id.clone(), edited_text.to_string());
+        let (edit_ct, edit_nonce) =
+            crate::util::ecies::encrypt_with_symmetric_key(&secret, &edit_action.encode());
+        let edit_msg = MessageV1 {
+            room_owner: owner_id,
+            author: owner_id,
+            time: get_current_system_time() + std::time::Duration::from_secs(1),
+            content: RoomMessageBody::private_action(edit_ct, edit_nonce, secret_version),
+        };
+        let auth_edit = AuthorizedMessageV1::new(edit_msg, &owner_sk);
+
+        // Apply original + edit, then rebuild with decryption (mirrors the
+        // network ingestion path). The edit must now be visible.
+        room.room_state
+            .apply_delta(
+                &ChatRoomStateV1::default(),
+                &params,
+                &Some(ChatRoomStateV1Delta {
+                    recent_messages: Some(vec![auth_original.clone(), auth_edit]),
+                    ..Default::default()
+                }),
+            )
+            .expect("applying original + edit must succeed");
+        room.rebuild_private_actions_state();
+        assert_eq!(
+            room.room_state
+                .recent_messages
+                .effective_text(&auth_original),
+            Some(edited_text.to_string()),
+            "edit must be applied before the new message is sent"
+        );
+
+        // 3. Send a NEW message — the optimistic path runs apply_delta, whose
+        //    private-room rebuild is public-only.
+        let (new_ct, new_nonce) = crate::util::ecies::encrypt_with_symmetric_key(
+            &secret,
+            &TextContentV1::new("A brand new message".to_string()).encode(),
+        );
+        let new_msg = MessageV1 {
+            room_owner: owner_id,
+            author: owner_id,
+            time: get_current_system_time() + std::time::Duration::from_secs(2),
+            content: RoomMessageBody::private(
+                CONTENT_TYPE_TEXT,
+                TEXT_CONTENT_VERSION,
+                new_ct,
+                new_nonce,
+                secret_version,
+            ),
+        };
+        let auth_new = AuthorizedMessageV1::new(new_msg, &owner_sk);
+        room.room_state
+            .apply_delta(
+                &ChatRoomStateV1::default(),
+                &params,
+                &Some(ChatRoomStateV1Delta {
+                    recent_messages: Some(vec![auth_new]),
+                    ..Default::default()
+                }),
+            )
+            .expect("applying new message must succeed");
+
+        // BUG REPRODUCTION: immediately after apply_delta (before the fix's
+        // helper runs), the private edit has been wiped from actions_state.
+        // The conversation render does
+        //   `effective_text(msg).unwrap_or_else(|| decrypt original ciphertext)`
+        // (see conversation.rs:210-214), so with the edit gone, `effective_text`
+        // returns `None` and the UI falls back to decrypting the ORIGINAL
+        // ciphertext — i.e. the message visibly reverts to its pre-edit text.
+        // That is exactly the transient flicker #310 describes.
+        assert!(
+            !room.room_state.recent_messages.is_edited(&original_id),
+            "sanity: apply_delta's public-only rebuild drops the private edit \
+             (this is the bug being fixed)"
+        );
+        assert_eq!(
+            room.room_state
+                .recent_messages
+                .effective_text(&auth_original),
+            None,
+            "with the edit wiped, effective_text falls through to decrypting \
+             the original ciphertext — the UI shows the pre-edit text"
+        );
+
+        // FIX: re-derive the private actions_state synchronously, as the
+        // optimistic handlers now do. The edit is restored — no flicker.
+        room.rebuild_private_actions_state();
+        assert_eq!(
+            room.room_state
+                .recent_messages
+                .effective_text(&auth_original),
+            Some(edited_text.to_string()),
+            "rebuild_private_actions_state must restore the edit after the \
+             optimistic new-message apply_delta (#310)"
+        );
+
+        // Broader class (#310): the wipe is NOT specific to message deltas.
+        // `MessagesV1::apply_delta` ALWAYS ends with the public-only
+        // rebuild_actions_state, even when the delta carries no
+        // `recent_messages` at all — so sending a DM, editing a nickname,
+        // or banning a member (member/member_info/direct_messages/secrets
+        // deltas) wipes the private edit too. Verify an empty (non-message)
+        // delta reproduces the wipe and that the helper restores it.
+        room.room_state
+            .apply_delta(
+                &ChatRoomStateV1::default(),
+                &params,
+                &Some(ChatRoomStateV1Delta::default()),
+            )
+            .expect("applying an empty delta must succeed");
+        assert!(
+            !room.room_state.recent_messages.is_edited(&original_id),
+            "an apply_delta with no recent_messages still wipes the private \
+             edit — this is why DM/nickname/ban paths also revert (#310)"
+        );
+        room.rebuild_private_actions_state();
+        assert_eq!(
+            room.room_state
+                .recent_messages
+                .effective_text(&auth_original),
+            Some(edited_text.to_string()),
+            "rebuild_private_actions_state must restore the edit after ANY \
+             optimistic apply_delta, not just message sends (#310)"
+        );
     }
 
     /// Fix 1 (#228 PR 2 v2): UI-side `rotate_secret` derives the new


### PR DESCRIPTION
## Problem

In a private room, an edited message briefly reverted to its original text whenever a new message was sent (reported by @Ivvvor in #246). The optimistic send/edit/delete/react handlers call `ChatRoomStateV1::apply_delta`, whose `MessagesV1` impl always ends with the **non-decrypting** `rebuild_actions_state()`. For a private room that can only decode PUBLIC action messages, so it cleared `actions_state` and the edit (carried by a PRIVATE action message) vanished until the network echo ran the decrypt-aware rebuild — a visible flicker back to the pre-edit text.

The wipe is **not** specific to message deltas: `MessagesV1::apply_delta` re-runs the public-only rebuild unconditionally, even when the delta carries no `recent_messages` at all. So sending a DM, changing a nickname, banning a member, editing the room name/description/settings, or rotating the secret all reverted private edits the same way.

## Approach

Extract the decrypt-aware rebuild — previously inlined byte-identically in three network-ingestion paths (`apply_delta_inner`, `update_room_state_inner`, GET handler) — into `RoomData::rebuild_private_actions_state` (a no-op on public rooms), and call it after **every** local optimistic `apply_delta`:

- conversation.rs: send, edit, delete, react
- direct_messages.rs / dm_thread_modal.rs: DM send, DM purge
- member_info_modal: nickname edit, ban (after ban + post-ban rotation)
- room_list: room name, description, settings, max_members, manual secret rotation

The three network paths now delegate to the same helper, removing ~100 lines of duplication.

Pure UI/state-rendering fix — **no** contract/delegate/wire-format/crypto/migration change (only `ui/` source touched).

## Testing

New `private_edit_survives_new_message_send` regression test in `room_data.rs`: authors a private message + encrypted edit, sends a new message, and asserts the edit is wiped by `apply_delta` alone and restored by the helper; also pins the broader empty-delta (DM/nickname/ban/config) class. Verified the test FAILS when the helper is neutralized and PASSES with it. Full `cargo test -p river-ui --bins` green (272 passed); `cargo fmt` clean.

Closes #310

[AI-assisted - Claude]