### PR TITLE
feat(ui): add Freenet Official invite link to welcome screen

### DIFF
--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1817,6 +1817,19 @@ pub fn Conversation() -> Element {
                             p { class: "text-text-muted",
                                 "Create a new room, or get invited to an existing one."
                             }
+                            // Issue #159: new users (especially on mobile) need a
+                            // concrete next step. Link to the Freenet quickstart
+                            // invite form so they can get into the "Freenet
+                            // Official" room.
+                            p { class: "text-text-muted mt-3",
+                                a {
+                                    class: "text-accent hover:underline",
+                                    href: "https://freenet.org/quickstart#invite-form",
+                                    target: "_blank",
+                                    rel: "noopener noreferrer",
+                                    "Click here to get an invitation to channel \"Freenet Official\""
+                                }
+                            }
                             // Bug #5 (Ivvor, Matrix 2026-05-17): on mobile,
                             // the default MOBILE_VIEW is Chat, so a brand-new
                             // user with no rooms lands here without ever

--- a/ui/tests/welcome-invite-link.spec.ts
+++ b/ui/tests/welcome-invite-link.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect, Page } from "@playwright/test";
+
+// Regression test for issue #159: the Welcome screen (shown when no room
+// is selected) must offer a concrete next step for new users — a link to
+// the Freenet quickstart invite form so they can get into the "Freenet
+// Official" room. The issue specifically called out that, especially on
+// mobile, a brand-new user has no idea what to do after "Create a new
+// room, or get invited to an existing one."
+
+async function waitForApp(page: Page) {
+  await page.waitForSelector(".app-root", { timeout: 30_000 });
+  await expect(page.locator("aside, .app-root button")).not.toHaveCount(0);
+}
+
+const INVITE_HREF = "https://freenet.org/quickstart#invite-form";
+
+async function expectInviteLink(page: Page) {
+  await page.goto("/");
+  await waitForApp(page);
+
+  // Confirm we're on the Welcome screen (no room selected on first load).
+  await expect(page.getByText("Welcome to River")).toBeVisible({
+    timeout: 5_000,
+  });
+
+  const link = page.locator(`a[href="${INVITE_HREF}"]`);
+  await expect(link).toBeVisible({ timeout: 5_000 });
+  await expect(link).toHaveText(
+    /Click here to get an invitation to channel "Freenet Official"/
+  );
+  // External link must open in a new tab and be safe against tabnabbing.
+  await expect(link).toHaveAttribute("target", "_blank");
+  await expect(link).toHaveAttribute("rel", /noopener/);
+}
+
+test.describe("Welcome screen invite link (issue #159)", () => {
+  test("desktop: invite link is shown on the Welcome screen", async ({
+    page,
+  }) => {
+    await expectInviteLink(page);
+  });
+
+  test.describe("mobile viewport", () => {
+    test.use({ viewport: { width: 375, height: 812 } });
+
+    test("mobile: invite link is shown on the Welcome screen", async ({
+      page,
+    }) => {
+      await expectInviteLink(page);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

The River welcome screen (shown when no room is selected) only says:

> Welcome to River. Create a new room, or get invited to an existing one.

New users — especially on mobile — have no concrete next step. There's no path to actually getting an invitation.

## Approach

Add a link directly below the welcome message pointing to the Freenet quickstart invite form:

- URL: `https://freenet.org/quickstart#invite-form` (verified: the page has `<div id=invite-form>` with "Get your invite to **Freenet Official**")
- Text: `Click here to get an invitation to channel "Freenet Official"`

Implementation notes:
- Static rsx markup in the no-room (`None`) arm of the conversation panel, so it renders on both desktop and mobile (no `md:` viewport gating). No signals are read/written, so the Dioxus signal-safety rules don't apply.
- External link uses `target="_blank"` + `rel="noopener noreferrer"`, matching the existing external-link convention in `message_to_html`.
- Styling (`text-accent hover:underline`, `mt-3`) matches Tailwind classes already used in the UI.
- UI-only change — no contract/delegate/common/WASM touched, so no migration entry needed.

## Testing

- New Playwright spec `ui/tests/welcome-invite-link.spec.ts` asserts the link is present and visible on both desktop and mobile viewports, with the correct `href`, link text, `target=_blank`, and `rel~=noopener`.
- Verified both directions: GREEN with the fix; with the fix reverted and the app rebuilt, the spec fails cleanly at the link locator (`element(s) not found`) while the app still boots and renders "Welcome to River" — proving the test guards the link's presence, not app load.
- `cargo fmt --check` clean; `cargo test -p river-ui --bins` passes (271 tests); `cargo clippy -p river-ui --bins` introduces no new warnings.
- External Codex review: no findings.

Closes #159

[AI-assisted - Claude]