### PR TITLE
feat: @mentions (UI + riverctl) with per-room notification preference

### DIFF
--- a/.claude/rules/river-publish.md
+++ b/.claude/rules/river-publish.md
@@ -23,6 +23,16 @@ git diff HEAD~1 --name-only | grep -E '(common/|delegates/|contracts/|Cargo\.(to
 
 If ANY match, migration is needed. If ONLY `ui/` changed, skip to Step 4.
 
+**Exception — feature-gated client-only `common/` modules.** A change confined to
+a `common/` module gated behind a client-only Cargo feature (one enabled by
+`river-ui`/`riverctl` but NOT by the room-contract or chat-delegate crates —
+e.g. `migration`, `mentions`) does **not** enter the delegate/contract WASM, so
+it needs no migration entry. This holds only because those WASMs are built with
+`-p <crate>` scoping (never `--workspace`, which would unify the feature in).
+Don't add a migration entry for such a change — CI's `check-delegate-migration`
+and `check-room-contract-migration` confirm the WASM is byte-identical and will
+fail loudly if it isn't.
+
 ### Step 2: Add Migration Entry
 
 ```bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,13 +152,16 @@ jobs:
       # See freenet/river#241 — these tests pin the wire format and catch
       # silent drift in the ECIES derivation. The `migration` feature also
       # gates the `migration` module's unit tests (legacy room-contract key
-      # derivation, newest-first ordering — freenet/river#292).
+      # derivation, newest-first ordering — freenet/river#292). The `mentions`
+      # feature gates the `mention` module's codec tests (token encode/parse,
+      # lossless id hex, sanitization, typed-mention resolution) — without it
+      # those 12 tests are compiled out and never gate.
       #
       # `--features` takes ONE comma-separated value; passing space-separated
       # feature names makes cargo treat the extras as positional test-name
       # filters (and a second one is a hard "unexpected argument" error).
       # `ecies-randomized` enables `ecies` transitively.
-      run: cargo test -p river-core --lib --features ecies-randomized,migration
+      run: cargo test -p river-core --lib --features ecies-randomized,migration,mentions
 
     - name: Test river-ui (UI crate unit tests)
       env:

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -50,7 +50,7 @@ dialoguer = "0.11"
 atty = "0.2"
 
 # Internal dependencies
-river-core = { version = "0.1.6", path = "../common", features = ["ecies", "ecies-randomized", "migration"] }
+river-core = { version = "0.1.6", path = "../common", features = ["ecies", "ecies-randomized", "migration", "mentions"] }
 freenet-stdlib = { workspace = true, features = ["net"] }
 freenet-scaffold = "0.2.2"
 

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -4857,3 +4857,123 @@ mod monitor_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod mention_cli_tests {
+    use super::*;
+    use river_core::mention::encode_mention;
+    use river_core::room_state::message::{AuthorizedMessageV1, MessageV1, RoomMessageBody};
+    use std::time::SystemTime;
+
+    fn member_id(sk: &SigningKey) -> MemberId {
+        MemberId::from(&sk.verifying_key())
+    }
+
+    /// Build a room state whose `member_info` carries the given (key, nickname)
+    /// entries.
+    fn state_with_members(members: &[(SigningKey, SealedBytes)]) -> ChatRoomStateV1 {
+        let mut state = ChatRoomStateV1::default();
+        for (i, (sk, nickname)) in members.iter().enumerate() {
+            let info = MemberInfo {
+                member_id: member_id(sk),
+                version: i as u32,
+                preferred_nickname: nickname.clone(),
+            };
+            state
+                .member_info
+                .member_info
+                .push(AuthorizedMemberInfo::new_with_member_key(info, sk));
+        }
+        state
+    }
+
+    fn msg_with_text(text: String) -> AuthorizedMessageV1 {
+        let author = SigningKey::from_bytes(&[200u8; 32]);
+        let m = MessageV1 {
+            room_owner: MemberId::from(author.verifying_key()),
+            author: member_id(&author),
+            content: RoomMessageBody::public(text),
+            time: SystemTime::UNIX_EPOCH,
+        };
+        AuthorizedMessageV1::new(m, &author)
+    }
+
+    // --- resolve_outgoing_mentions (send path) ---
+
+    #[test]
+    fn resolves_unambiguous_public_nickname() {
+        let alice = SigningKey::from_bytes(&[1u8; 32]);
+        let state = state_with_members(&[(alice.clone(), SealedBytes::public(b"alice".to_vec()))]);
+        let out = resolve_outgoing_mentions(&state, "hi @alice!");
+        assert_eq!(
+            out,
+            format!("hi {}!", encode_mention(member_id(&alice), "alice"))
+        );
+    }
+
+    #[test]
+    fn leaves_ambiguous_nickname_as_plain_text() {
+        // Two members share the nickname "alice" → cannot disambiguate.
+        let a = SigningKey::from_bytes(&[1u8; 32]);
+        let b = SigningKey::from_bytes(&[2u8; 32]);
+        let state = state_with_members(&[
+            (a, SealedBytes::public(b"alice".to_vec())),
+            (b, SealedBytes::public(b"alice".to_vec())),
+        ]);
+        assert_eq!(resolve_outgoing_mentions(&state, "hi @alice"), "hi @alice");
+    }
+
+    #[test]
+    fn leaves_unknown_name_as_plain_text() {
+        let alice = SigningKey::from_bytes(&[1u8; 32]);
+        let state = state_with_members(&[(alice, SealedBytes::public(b"alice".to_vec()))]);
+        assert_eq!(resolve_outgoing_mentions(&state, "hi @bob"), "hi @bob");
+    }
+
+    #[test]
+    fn does_not_match_private_nickname() {
+        // A private (encrypted) nickname has no public bytes → cannot match.
+        let alice = SigningKey::from_bytes(&[1u8; 32]);
+        let state = state_with_members(&[(
+            alice,
+            SealedBytes::private(vec![0xDE, 0xAD], [0u8; 12], 0, 5),
+        )]);
+        assert_eq!(resolve_outgoing_mentions(&state, "hi @alice"), "hi @alice");
+    }
+
+    #[test]
+    fn leaves_already_encoded_token_untouched() {
+        let alice = SigningKey::from_bytes(&[1u8; 32]);
+        let state = state_with_members(&[(alice.clone(), SealedBytes::public(b"alice".to_vec()))]);
+        let token = encode_mention(member_id(&alice), "alice");
+        assert_eq!(resolve_outgoing_mentions(&state, &token), token);
+    }
+
+    // --- render_mentions_for_terminal (display path) ---
+
+    #[test]
+    fn render_uses_current_nickname_over_snapshot() {
+        let alice = SigningKey::from_bytes(&[1u8; 32]);
+        let state =
+            state_with_members(&[(alice.clone(), SealedBytes::public(b"NewName".to_vec()))]);
+        let text = format!("hey {}", encode_mention(member_id(&alice), "OldName"));
+        assert_eq!(render_mentions_for_terminal(&state, &text), "hey @NewName");
+    }
+
+    #[test]
+    fn render_falls_back_to_snapshot_for_unknown_member() {
+        let ghost = SigningKey::from_bytes(&[9u8; 32]);
+        let state = state_with_members(&[]); // ghost not present
+        let text = format!("hey {}", encode_mention(member_id(&ghost), "Ghost"));
+        assert_eq!(render_mentions_for_terminal(&state, &text), "hey @Ghost");
+    }
+
+    #[test]
+    fn message_display_text_renders_mentions() {
+        let alice = SigningKey::from_bytes(&[1u8; 32]);
+        let state = state_with_members(&[(alice.clone(), SealedBytes::public(b"Alice".to_vec()))]);
+        let msg = msg_with_text(format!("hi {}", encode_mention(member_id(&alice), "Alice")));
+        // The full display path wraps render_mentions_for_terminal.
+        assert_eq!(message_display_text(&state, &msg), "hi @Alice");
+    }
+}

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -92,7 +92,7 @@ pub(crate) fn message_display_text(
     room_state: &ChatRoomStateV1,
     msg: &river_core::room_state::message::AuthorizedMessageV1,
 ) -> String {
-    room_state
+    let raw = room_state
         .recent_messages
         .effective_text(msg)
         .unwrap_or_else(|| {
@@ -101,7 +101,57 @@ pub(crate) fn message_display_text(
                 .decode_content()
                 .map(|decoded| decoded.to_display_string())
                 .unwrap_or_else(|| "<encrypted>".to_string())
-        })
+        });
+    render_mentions_for_terminal(room_state, &raw)
+}
+
+/// Replace `@[name](rv:id)` mention tokens with `@<name>` for terminal display.
+/// Prefers each member's *current* public nickname (so the rendered name
+/// follows renames); falls back to the token's snapshot name when the member is
+/// unknown or their nickname is encrypted (riverctl does not decrypt
+/// private-room nicknames). Plain text without tokens is returned unchanged.
+pub(crate) fn render_mentions_for_terminal(room_state: &ChatRoomStateV1, text: &str) -> String {
+    river_core::mention::render_plaintext(text, |id| {
+        room_state
+            .member_info
+            .member_info
+            .iter()
+            .find(|info| info.member_info.member_id == id)
+            .and_then(|info| info.member_info.preferred_nickname.as_public_bytes())
+            .map(|bytes| String::from_utf8_lossy(bytes).to_string())
+    })
+}
+
+/// Convert bare `@nickname` mentions in an outgoing message into full mention
+/// tokens, resolving each against the room's current members. Only **public**
+/// nicknames are matched (riverctl does not decrypt private-room nicknames) and
+/// only an **unambiguous** exact (case-insensitive) match is linked — a name
+/// shared by two members, an unknown `@word`, or a private-room nickname is
+/// left as plain text. Already-encoded tokens pass through untouched. This is
+/// the CLI counterpart to the UI's `@` autocomplete picker.
+pub(crate) fn resolve_outgoing_mentions(room_state: &ChatRoomStateV1, text: &str) -> String {
+    use std::collections::HashMap;
+    // Lowercased nickname -> Some((id, canonical name)) if unique, None if shared.
+    let mut by_name: HashMap<String, Option<(MemberId, String)>> = HashMap::new();
+    for info in &room_state.member_info.member_info {
+        if let Some(bytes) = info.member_info.preferred_nickname.as_public_bytes() {
+            let name = String::from_utf8_lossy(bytes).to_string();
+            let id = info.member_info.member_id;
+            by_name
+                .entry(name.to_lowercase())
+                .and_modify(|e| {
+                    if let Some((eid, _)) = e {
+                        if *eid != id {
+                            *e = None; // two members share this nickname → ambiguous
+                        }
+                    }
+                })
+                .or_insert(Some((id, name)));
+        }
+    }
+    river_core::mention::resolve_typed_mentions(text, |name| {
+        by_name.get(&name.to_lowercase()).cloned().flatten()
+    })
 }
 
 /// If `msg` is a reply, return `(target_author_name, truncated_preview)` for
@@ -1916,6 +1966,9 @@ impl ApiClient {
         let sender_vk = signing_key.verifying_key();
         let sender_member_id: MemberId = (&sender_vk).into();
 
+        // Resolve any bare @nickname mentions to full mention tokens.
+        let message_content = resolve_outgoing_mentions(&room_state, &message_content);
+
         // Create the message
         let message = river_core::room_state::message::MessageV1 {
             room_owner: MemberId::from(*room_owner_key),
@@ -2022,6 +2075,9 @@ impl ApiClient {
 
         // Fetch fresh state from network so build_rejoin_delta can detect pruning
         let mut room_state = self.get_room(room_owner_key, false).await?;
+
+        // Resolve any bare @nickname mentions to full mention tokens.
+        let message_content = resolve_outgoing_mentions(&room_state, &message_content);
 
         // Create the message
         let message = river_core::room_state::message::MessageV1 {
@@ -2443,6 +2499,9 @@ impl ApiClient {
             .chars()
             .take(100)
             .collect();
+
+        // Resolve any bare @nickname mentions in the reply body.
+        let reply_text = resolve_outgoing_mentions(&room_state, &reply_text);
 
         // Create the reply message
         let message = river_core::room_state::message::MessageV1 {

--- a/cli/src/commands/message.rs
+++ b/cli/src/commands/message.rs
@@ -10,11 +10,18 @@ use serde_json::json;
 
 #[derive(Subcommand)]
 pub enum MessageCommands {
-    /// Send a message to a room
+    /// Send a message to a room.
+    ///
+    /// Mentions: a bare `@nickname` that unambiguously (case-insensitively)
+    /// matches a current member's public nickname is converted into a mention
+    /// that links to that member by id and follows their later renames. An
+    /// unknown, ambiguous, or private-room `@word` is sent as plain text
+    /// (riverctl cannot decrypt private-room nicknames). The desktop UI offers
+    /// an @-autocomplete picker for the same result.
     Send {
         /// Room ID (base58-encoded room owner verifying key)
         room_id: String,
-        /// Message content
+        /// Message content. Write `@nickname` to mention a member.
         message: String,
         /// Signing key (base64-encoded 32-byte Ed25519 signing key).
         /// If provided, sends without requiring local room storage.
@@ -87,13 +94,15 @@ pub enum MessageCommands {
         /// Emoji to remove
         emoji: String,
     },
-    /// Reply to a message
+    /// Reply to a message.
+    ///
+    /// `@nickname` mentions in the reply text are resolved exactly as in `send`.
     Reply {
         /// Room ID
         room_id: String,
         /// Message ID of the message to reply to
         message_id: String,
-        /// Reply text
+        /// Reply text. Write `@nickname` to mention a member.
         message: String,
     },
 }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -63,6 +63,13 @@ ecies-randomized = ["ecies", "dep:rand"]
 # contract/delegate keys) byte-identical. The recovery logic is a pure client
 # concern; the contract itself never derives legacy keys.
 migration = []
+# @mention codec: parse/encode the inline `@[name](rv:id)` mention token that
+# rides inside the plaintext message `text` field. Enabled ONLY by the client
+# crates (river-ui, riverctl), exactly like `migration` above — deliberately
+# OFF for the room-contract and chat-delegate WASM so their bytes (and keys)
+# stay byte-identical. The contract treats message content as opaque bytes and
+# never parses mentions, so this is a pure client concern.
+mentions = []
 
 [build-dependencies]
 # Used by build.rs to parse legacy_room_contracts.toml and generate the

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -8,6 +8,12 @@ pub mod key_derivation;
 /// do not enable it) keep byte-identical WASM and stable keys.
 #[cfg(feature = "migration")]
 pub mod migration;
+/// `@mention` codec (freenet/river @mentions feature). Gated on the `mentions`
+/// feature so the room-contract / chat-delegate WASM builds (which do not
+/// enable it) keep byte-identical WASM and stable keys. Pure client concern:
+/// the contract treats message content as opaque bytes and never parses it.
+#[cfg(feature = "mentions")]
+pub mod mention;
 pub mod room_state;
 pub mod util;
 pub mod web_container;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -3,17 +3,17 @@ pub mod crypto_values;
 #[cfg(feature = "ecies")]
 pub mod ecies;
 pub mod key_derivation;
-/// Legacy room-contract migration registry (freenet/river#292). Gated on the
-/// `migration` feature so the room-contract / chat-delegate WASM builds (which
-/// do not enable it) keep byte-identical WASM and stable keys.
-#[cfg(feature = "migration")]
-pub mod migration;
 /// `@mention` codec (freenet/river @mentions feature). Gated on the `mentions`
 /// feature so the room-contract / chat-delegate WASM builds (which do not
 /// enable it) keep byte-identical WASM and stable keys. Pure client concern:
 /// the contract treats message content as opaque bytes and never parses it.
 #[cfg(feature = "mentions")]
 pub mod mention;
+/// Legacy room-contract migration registry (freenet/river#292). Gated on the
+/// `migration` feature so the room-contract / chat-delegate WASM builds (which
+/// do not enable it) keep byte-identical WASM and stable keys.
+#[cfg(feature = "migration")]
+pub mod migration;
 pub mod room_state;
 pub mod util;
 pub mod web_container;

--- a/common/src/mention.rs
+++ b/common/src/mention.rs
@@ -233,7 +233,7 @@ mod tests {
         assert_eq!(member_id_from_hex(""), None);
         assert_eq!(member_id_from_hex("zz"), None);
         assert_eq!(member_id_from_hex("00000000000000000"), None); // 17 digits
-        // Uppercase is accepted on parse even though we always emit lowercase.
+                                                                   // Uppercase is accepted on parse even though we always emit lowercase.
         assert_eq!(member_id_from_hex("FF"), Some(mid(0xff)));
     }
 
@@ -269,15 +269,25 @@ mod tests {
     fn parses_multiple_mentions_interleaved_with_text() {
         let a = mid(1);
         let b = mid(2);
-        let text = format!("hi {} and {}!", encode_mention(a, "Ann"), encode_mention(b, "Bob"));
+        let text = format!(
+            "hi {} and {}!",
+            encode_mention(a, "Ann"),
+            encode_mention(b, "Bob")
+        );
         let segs = parse_segments(&text);
         assert_eq!(
             segs,
             vec![
                 MentionSegment::Text("hi ".to_string()),
-                MentionSegment::Mention(Mention { member_id: a, display_name: "Ann".to_string() }),
+                MentionSegment::Mention(Mention {
+                    member_id: a,
+                    display_name: "Ann".to_string()
+                }),
                 MentionSegment::Text(" and ".to_string()),
-                MentionSegment::Mention(Mention { member_id: b, display_name: "Bob".to_string() }),
+                MentionSegment::Mention(Mention {
+                    member_id: b,
+                    display_name: "Bob".to_string()
+                }),
                 MentionSegment::Text("!".to_string()),
             ]
         );
@@ -288,7 +298,13 @@ mod tests {
         let id = mid(42);
         let token = format!("@[](rv:{})", member_id_to_hex(id));
         let mentions = parse_mentions(&token);
-        assert_eq!(mentions, vec![Mention { member_id: id, display_name: String::new() }]);
+        assert_eq!(
+            mentions,
+            vec![Mention {
+                member_id: id,
+                display_name: String::new()
+            }]
+        );
     }
 
     #[test]
@@ -304,7 +320,11 @@ mod tests {
             "@[name](rv:zz)", // non-hex id
             "@[name](xx:01)", // wrong scheme
         ] {
-            assert_eq!(parse_mentions(s), vec![], "should not parse a mention from: {s:?}");
+            assert_eq!(
+                parse_mentions(s),
+                vec![],
+                "should not parse a mention from: {s:?}"
+            );
             // And the full text survives a segment round-trip.
             let rebuilt: String = parse_segments(s)
                 .into_iter()
@@ -323,7 +343,11 @@ mod tests {
         let other = mid(200);
         let text = format!("ping {}", encode_mention(other, "Other"));
         assert!(!contains_mention_of(&text, me));
-        let text2 = format!("ping {} and {}", encode_mention(other, "Other"), encode_mention(me, "Me"));
+        let text2 = format!(
+            "ping {} and {}",
+            encode_mention(other, "Other"),
+            encode_mention(me, "Me")
+        );
         assert!(contains_mention_of(&text2, me));
     }
 

--- a/common/src/mention.rs
+++ b/common/src/mention.rs
@@ -210,6 +210,65 @@ where
     out
 }
 
+/// Trailing characters that are punctuation rather than part of a typed name.
+const TRAILING_PUNCT: &[char] = &['.', ',', '!', '?', ';', ':', ')', ']', '}', '"', '\''];
+
+/// Convert bare `@name` mentions typed in free text into full `@[name](rv:id)`
+/// wire tokens. Used by surfaces without an autocomplete picker (riverctl).
+///
+/// A `@name` is a `@` at a word boundary (start of text or after whitespace)
+/// followed by a run of non-whitespace characters; trailing punctuation is not
+/// part of the name. `resolve(name)` maps the typed name to the member to link
+/// (its id and canonical display name), or returns `None` to leave the text
+/// untouched — so an unmatched `@word`, an email-like `a@b`, and an
+/// already-encoded `@[Name](rv:..)` token are all left exactly as-is (the
+/// bracketed token never matches a plain name lookup).
+pub fn resolve_typed_mentions<F>(text: &str, mut resolve: F) -> String
+where
+    F: FnMut(&str) -> Option<(MemberId, String)>,
+{
+    let bytes = text.as_bytes();
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0usize;
+    let mut prev_was_ws = true; // start-of-text counts as a boundary
+    while i < bytes.len() {
+        let ch = text[i..].chars().next().unwrap();
+        let ch_len = ch.len_utf8();
+        if ch == '@' && prev_was_ws {
+            // Take the run of non-whitespace characters after '@'.
+            let run_start = i + 1;
+            let mut j = run_start;
+            while j < bytes.len() {
+                let c = text[j..].chars().next().unwrap();
+                if c.is_whitespace() {
+                    break;
+                }
+                j += c.len_utf8();
+            }
+            let run = &text[run_start..j];
+            let candidate = run.trim_end_matches(TRAILING_PUNCT);
+            if !candidate.is_empty() {
+                if let Some((id, name)) = resolve(candidate) {
+                    out.push_str(&encode_mention(id, &name));
+                    out.push_str(&run[candidate.len()..]); // re-append stripped punctuation
+                    i = j;
+                    prev_was_ws = false;
+                    continue;
+                }
+            }
+            // No match: emit '@' literally and keep scanning the run as text.
+            out.push('@');
+            i = run_start;
+            prev_was_ws = false;
+            continue;
+        }
+        out.push(ch);
+        prev_was_ws = ch.is_whitespace();
+        i += ch_len;
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -368,6 +427,51 @@ mod tests {
             }
         });
         assert_eq!(rendered, "hey @NewName and @Ghost");
+    }
+
+    #[test]
+    fn resolve_typed_mentions_links_known_names_only() {
+        let alice = mid(0xa11ce);
+        let resolve = |name: &str| -> Option<(MemberId, String)> {
+            match name.to_lowercase().as_str() {
+                "alice" => Some((alice, "Alice".to_string())),
+                _ => None,
+            }
+        };
+        // Known name (with trailing punctuation) becomes a token; the comma is
+        // preserved after it. Unknown @name and an email are left untouched.
+        let out = resolve_typed_mentions("hi @alice, ping @bob and a@b.com", resolve);
+        assert_eq!(
+            out,
+            format!(
+                "hi {}, ping @bob and a@b.com",
+                encode_mention(alice, "Alice")
+            )
+        );
+        // The produced token parses back to the right member.
+        assert_eq!(
+            parse_mentions(&out),
+            vec![Mention {
+                member_id: alice,
+                display_name: "Alice".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn resolve_typed_mentions_leaves_existing_tokens_untouched() {
+        let alice = mid(0xa11ce);
+        // Resolver that would match "Alice" — but the bracketed token's run is
+        // "[Alice](rv:..)" which never equals "Alice", so it is left as-is.
+        let resolve = |name: &str| -> Option<(MemberId, String)> {
+            if name.eq_ignore_ascii_case("alice") {
+                Some((alice, "Alice".to_string()))
+            } else {
+                None
+            }
+        };
+        let already = encode_mention(alice, "Alice");
+        assert_eq!(resolve_typed_mentions(&already, resolve), already);
     }
 
     #[test]

--- a/common/src/mention.rs
+++ b/common/src/mention.rs
@@ -1,0 +1,356 @@
+//! `@mention` codec — the inline wire token that references a member by their
+//! stable [`MemberId`] while displaying their *current* nickname.
+//!
+//! ## Wire format
+//!
+//! A mention is stored inline in the plaintext message `text` field as:
+//!
+//! ```text
+//! @[Display Name](rv:8f3a2b1c0000d4e5)
+//! ```
+//!
+//! - `rv:<hex>` is the **authoritative** reference: 16 lowercase hex digits
+//!   encoding the member's [`MemberId`] (a 64-bit value). Clients re-resolve
+//!   the member's *current* nickname from `member_info` by this id, so the
+//!   rendered chip follows renames.
+//! - `Display Name` is a **fallback snapshot** captured at send time, used only
+//!   when re-resolution is impossible (member not in `member_info`, an
+//!   undecryptable private-room nickname, or a client too old to parse the
+//!   token). Old clients render the raw token via markdown as a plain
+//!   `@Display Name` link — acceptable graceful degradation.
+//!
+//! The token rides inside the existing `text` field, so it needs **no** change
+//! to `RoomMessageBody` / the contract, works in both public and private rooms
+//! (it sits inside the encrypted text), and applies equally to plain text and
+//! replies (both carry a `text` field).
+//!
+//! ## Why a hand-rolled parser (no regex)
+//!
+//! This module is gated on the `mentions` feature and compiled into the client
+//! crates only; a regex dependency would be heavier than the few lines below
+//! and the grammar is trivial. The parser also never has to be valid markdown —
+//! clients extract mentions *before* markdown runs over the text.
+
+use crate::room_state::member::MemberId;
+use freenet_scaffold::util::FastHash;
+
+/// Scheme prefix inside the mention token's reference, e.g. `rv:8f3a…`.
+pub const REF_SCHEME: &str = "rv:";
+
+/// Maximum number of characters retained from the snapshot display name. The
+/// snapshot is only a fallback, so a hard cap keeps a hostile/huge nickname
+/// from bloating the token. Authoritative resolution uses the id, not this.
+pub const MAX_SNAPSHOT_NAME_LEN: usize = 64;
+
+/// A parsed mention: the authoritative member reference plus the snapshot name
+/// carried in the token (which may be empty, or stale relative to the member's
+/// current nickname — callers should prefer a fresh lookup by `member_id`).
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Mention {
+    pub member_id: MemberId,
+    pub display_name: String,
+}
+
+/// One piece of a message body: either a run of plain text or a mention token.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum MentionSegment {
+    Text(String),
+    Mention(Mention),
+}
+
+/// Encode a [`MemberId`] as the 16-char lowercase-hex reference body (no scheme
+/// prefix). Lossless — unlike `MemberId`'s `Display`, which is *truncated*.
+pub fn member_id_to_hex(id: MemberId) -> String {
+    // MemberId(FastHash(i64)); encode the raw 64 bits.
+    format!("{:016x}", id.0 .0 as u64)
+}
+
+/// Parse a 1..=16 digit hex reference body back into a [`MemberId`]. Returns
+/// `None` for empty input, over-long input, or non-hex characters.
+pub fn member_id_from_hex(s: &str) -> Option<MemberId> {
+    if s.is_empty() || s.len() > 16 || !s.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let raw = u64::from_str_radix(s, 16).ok()?;
+    Some(MemberId(FastHash(raw as i64)))
+}
+
+/// Strip characters that would break token parsing (the bracket/paren
+/// delimiters and control chars), trim, and cap the length. Applied to the
+/// snapshot name at encode time so a name can never break the wire token.
+pub fn sanitize_name(name: &str) -> String {
+    let cleaned: String = name
+        .chars()
+        .filter(|c| !matches!(c, '[' | ']' | '(' | ')') && !c.is_control())
+        .collect();
+    cleaned.trim().chars().take(MAX_SNAPSHOT_NAME_LEN).collect()
+}
+
+/// Build the wire token `@[name](rv:hex)` for a mention. The name is sanitized.
+pub fn encode_mention(id: MemberId, display_name: &str) -> String {
+    format!(
+        "@[{}]({}{})",
+        sanitize_name(display_name),
+        REF_SCHEME,
+        member_id_to_hex(id)
+    )
+}
+
+/// Split message text into ordered plain-text / mention segments. This is the
+/// core parser; the other helpers are thin wrappers over it.
+pub fn parse_segments(text: &str) -> Vec<MentionSegment> {
+    let bytes = text.as_bytes();
+    let mut segments = Vec::new();
+    // Byte index where the current run of plain text began.
+    let mut text_start = 0usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if bytes[i] == b'@' {
+            if let Some((mention, end)) = try_parse_token_at(text, i) {
+                if text_start < i {
+                    segments.push(MentionSegment::Text(text[text_start..i].to_string()));
+                }
+                segments.push(MentionSegment::Mention(mention));
+                i = end;
+                text_start = end;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    if text_start < bytes.len() {
+        segments.push(MentionSegment::Text(text[text_start..].to_string()));
+    }
+    segments
+}
+
+/// Try to parse a complete mention token starting at byte index `at` (which
+/// must point at `@`). On success returns the parsed mention and the byte index
+/// just past the closing `)`. All delimiters (`[ ] ( ) :`) are ASCII, so byte
+/// scanning never lands mid-codepoint.
+fn try_parse_token_at(text: &str, at: usize) -> Option<(Mention, usize)> {
+    let bytes = text.as_bytes();
+    if bytes.get(at) != Some(&b'@') || bytes.get(at + 1) != Some(&b'[') {
+        return None;
+    }
+    // Name runs from just after `[` to the first `]`.
+    let name_start = at + 2;
+    let mut j = name_start;
+    while j < bytes.len() && bytes[j] != b']' {
+        j += 1;
+    }
+    if j >= bytes.len() {
+        return None; // unterminated `[`
+    }
+    let name = &text[name_start..j];
+    // `](rv:` must immediately follow the name.
+    let after = j + 1;
+    let open: &[u8] = b"(";
+    let scheme = REF_SCHEME.as_bytes();
+    let prefix_len = open.len() + scheme.len();
+    if bytes.len() < after + prefix_len
+        || &bytes[after..after + open.len()] != open
+        || &bytes[after + open.len()..after + prefix_len] != scheme
+    {
+        return None;
+    }
+    // Hex id runs to the closing `)`.
+    let id_start = after + prefix_len;
+    let mut k = id_start;
+    while k < bytes.len() && bytes[k] != b')' {
+        k += 1;
+    }
+    if k >= bytes.len() {
+        return None; // unterminated `(`
+    }
+    let member_id = member_id_from_hex(&text[id_start..k])?;
+    Some((
+        Mention {
+            member_id,
+            display_name: name.to_string(),
+        },
+        k + 1,
+    ))
+}
+
+/// All mentions in the text, in order of appearance.
+pub fn parse_mentions(text: &str) -> Vec<Mention> {
+    parse_segments(text)
+        .into_iter()
+        .filter_map(|s| match s {
+            MentionSegment::Mention(m) => Some(m),
+            MentionSegment::Text(_) => None,
+        })
+        .collect()
+}
+
+/// Whether `text` mentions the member with the given id.
+pub fn contains_mention_of(text: &str, id: MemberId) -> bool {
+    parse_mentions(text).iter().any(|m| m.member_id == id)
+}
+
+/// Render the text for a plain-text surface (e.g. the CLI), replacing each
+/// mention token with `@<name>`. `resolve` supplies the member's *current*
+/// display name; when it returns `None` the snapshot name in the token is used.
+pub fn render_plaintext<F>(text: &str, mut resolve: F) -> String
+where
+    F: FnMut(MemberId) -> Option<String>,
+{
+    let mut out = String::with_capacity(text.len());
+    for seg in parse_segments(text) {
+        match seg {
+            MentionSegment::Text(t) => out.push_str(&t),
+            MentionSegment::Mention(m) => {
+                let name = resolve(m.member_id).unwrap_or(m.display_name);
+                out.push('@');
+                out.push_str(&name);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mid(raw: i64) -> MemberId {
+        MemberId(FastHash(raw))
+    }
+
+    #[test]
+    fn member_id_hex_round_trips_including_high_bit() {
+        for raw in [0i64, 1, -1, i64::MAX, i64::MIN, 0x0123_4567_89ab_cdef] {
+            let id = mid(raw);
+            let hex = member_id_to_hex(id);
+            assert_eq!(hex.len(), 16, "hex must be zero-padded to 16: {hex}");
+            assert_eq!(member_id_from_hex(&hex), Some(id), "round trip raw={raw}");
+        }
+    }
+
+    #[test]
+    fn member_id_from_hex_rejects_garbage() {
+        assert_eq!(member_id_from_hex(""), None);
+        assert_eq!(member_id_from_hex("zz"), None);
+        assert_eq!(member_id_from_hex("00000000000000000"), None); // 17 digits
+        // Uppercase is accepted on parse even though we always emit lowercase.
+        assert_eq!(member_id_from_hex("FF"), Some(mid(0xff)));
+    }
+
+    #[test]
+    fn encode_parse_round_trip() {
+        let id = mid(0x8f3a_2b1c_0000_d4e5u64 as i64);
+        let token = encode_mention(id, "Alice");
+        assert_eq!(token, "@[Alice](rv:8f3a2b1c0000d4e5)");
+        let mentions = parse_mentions(&token);
+        assert_eq!(mentions.len(), 1);
+        assert_eq!(mentions[0].member_id, id);
+        assert_eq!(mentions[0].display_name, "Alice");
+    }
+
+    #[test]
+    fn sanitize_strips_delimiters_and_caps_length() {
+        assert_eq!(sanitize_name("a]b)c(d[e"), "abcde");
+        assert_eq!(sanitize_name("  spaced  "), "spaced");
+        let long: String = "x".repeat(100);
+        assert_eq!(sanitize_name(&long).chars().count(), MAX_SNAPSHOT_NAME_LEN);
+        // A name laden with the token's own delimiters can't inject a second
+        // (fake) mention: stripping `] ( )` removes the `](rv:` sequence needed
+        // to break out, so exactly one mention parses and it points at `id`.
+        let id = mid(7);
+        let token = encode_mention(id, "ev)il](rv:dead)");
+        let parsed = parse_mentions(&token);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].member_id, id);
+        assert!(!parsed[0].display_name.contains([']', '(', ')']));
+    }
+
+    #[test]
+    fn parses_multiple_mentions_interleaved_with_text() {
+        let a = mid(1);
+        let b = mid(2);
+        let text = format!("hi {} and {}!", encode_mention(a, "Ann"), encode_mention(b, "Bob"));
+        let segs = parse_segments(&text);
+        assert_eq!(
+            segs,
+            vec![
+                MentionSegment::Text("hi ".to_string()),
+                MentionSegment::Mention(Mention { member_id: a, display_name: "Ann".to_string() }),
+                MentionSegment::Text(" and ".to_string()),
+                MentionSegment::Mention(Mention { member_id: b, display_name: "Bob".to_string() }),
+                MentionSegment::Text("!".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_snapshot_name_is_valid() {
+        let id = mid(42);
+        let token = format!("@[](rv:{})", member_id_to_hex(id));
+        let mentions = parse_mentions(&token);
+        assert_eq!(mentions, vec![Mention { member_id: id, display_name: String::new() }]);
+    }
+
+    #[test]
+    fn non_tokens_are_left_as_text() {
+        // Bare `@`, a markdown-ish `[link]` with the wrong scheme, an email-like
+        // `a@[b].c`, and unterminated tokens must all stay plain text.
+        for s in [
+            "just @ a mention symbol",
+            "see @[docs](http:01) for details",
+            "mail a@[b].c please",
+            "@[unterminated",
+            "@[name](rv:)",   // empty id
+            "@[name](rv:zz)", // non-hex id
+            "@[name](xx:01)", // wrong scheme
+        ] {
+            assert_eq!(parse_mentions(s), vec![], "should not parse a mention from: {s:?}");
+            // And the full text survives a segment round-trip.
+            let rebuilt: String = parse_segments(s)
+                .into_iter()
+                .map(|seg| match seg {
+                    MentionSegment::Text(t) => t,
+                    MentionSegment::Mention(_) => unreachable!(),
+                })
+                .collect();
+            assert_eq!(rebuilt, s);
+        }
+    }
+
+    #[test]
+    fn contains_mention_of_matches_only_the_right_id() {
+        let me = mid(100);
+        let other = mid(200);
+        let text = format!("ping {}", encode_mention(other, "Other"));
+        assert!(!contains_mention_of(&text, me));
+        let text2 = format!("ping {} and {}", encode_mention(other, "Other"), encode_mention(me, "Me"));
+        assert!(contains_mention_of(&text2, me));
+    }
+
+    #[test]
+    fn render_plaintext_uses_resolver_then_falls_back_to_snapshot() {
+        let known = mid(1);
+        let unknown = mid(2);
+        let text = format!(
+            "hey {} and {}",
+            encode_mention(known, "OldName"),
+            encode_mention(unknown, "Ghost")
+        );
+        let rendered = render_plaintext(&text, |id| {
+            if id == known {
+                Some("NewName".to_string()) // current nickname overrides snapshot
+            } else {
+                None // unknown member -> fall back to snapshot
+            }
+        });
+        assert_eq!(rendered, "hey @NewName and @Ghost");
+    }
+
+    #[test]
+    fn token_preserves_surrounding_text_exactly() {
+        let id = mid(0xdead_beef);
+        let text = format!("(see {}, thanks)", encode_mention(id, "Cat"));
+        let rendered = render_plaintext(&text, |_| Some("Cat".to_string()));
+        assert_eq!(rendered, "(see @Cat, thanks)");
+    }
+}

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -76,7 +76,7 @@ log = "0.4" # Add log crate
 tracing = { version = "0.1", default-features = false, features = ["std", "release_max_level_info"] }
 
 # Internal dependencies
-river-core = { workspace = true, features = ["ecies", "ecies-randomized", "migration"] }
+river-core = { workspace = true, features = ["ecies", "ecies-randomized", "migration", "mentions"] }
 
 # Freenet dependencies
 freenet-scaffold.workspace = true

--- a/ui/assets/main.css
+++ b/ui/assets/main.css
@@ -21,6 +21,35 @@
     opacity: 0.4;
 }
 
+/* @mention chips. Rendered as raw <span class="river-mention"> inside message
+ * bodies (see conversation::message_to_html_with_mentions). The pill uses the
+ * brand accent at low alpha; `river-mention-self` (a mention of the local user)
+ * is stronger so you can spot at a glance that you were tagged. Clickable via
+ * the document-level mention click interceptor. */
+.river-mention {
+    display: inline;
+    padding: 0 0.2rem;
+    border-radius: 0.3rem;
+    font-weight: 500;
+    white-space: nowrap;
+    cursor: pointer;
+    color: var(--color-accent, #0265e7);
+    background-color: var(--color-accent-soft, rgba(2, 101, 231, 0.12));
+}
+
+.river-mention:hover {
+    text-decoration: underline;
+}
+
+.river-mention-self {
+    background-color: rgba(2, 101, 231, 0.28);
+}
+
+.river-mention:focus-visible {
+    outline: 2px solid var(--color-accent, #0265e7);
+    outline-offset: 1px;
+}
+
 /* Reply highlight animation (when clicking "scroll to original") */
 .reply-highlight {
     animation: replyHighlight 2s ease-out;

--- a/ui/src/components.rs
+++ b/ui/src/components.rs
@@ -3,4 +3,5 @@ pub mod conversation;
 pub mod direct_messages;
 pub mod invite_click_interceptor;
 pub mod members;
+pub mod mention_click_interceptor;
 pub mod room_list;

--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -103,6 +103,11 @@ pub fn App() -> Element {
     // 2026-05-16). Safe to call on every re-render — idempotent.
     crate::components::invite_click_interceptor::install_invite_click_interceptor();
 
+    // Document-level click delegation for @mention chips (rendered as raw HTML
+    // inside message bodies, so they can't carry a Dioxus onclick directly).
+    // Clicking a chip opens the member-info modal. Idempotent.
+    crate::components::mention_click_interceptor::install_mention_click_interceptor();
+
     let mut receive_invitation = use_signal(|| None::<Invitation>);
 
     // One-shot guard for the localStorage auto-resume path (#218). The

--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -500,6 +500,7 @@ fn initial_rooms() -> Rooms {
         map: std::collections::HashMap::new(),
         current_room_key: None,
         removed_rooms: std::collections::HashSet::new(),
+        notification_modes: Default::default(),
         migrated_rooms: Vec::new(),
     }
 }

--- a/ui/src/components/app/notifications.rs
+++ b/ui/src/components/app/notifications.rs
@@ -287,6 +287,43 @@ fn create_notification_internal(
     }
 }
 
+/// Whether `msg` should notify the local user under
+/// [`crate::room_data::NotificationMode::MentionsAndReplies`]: it either
+/// @mentions them or is a reply to one of their own messages.
+fn message_notifies_self(
+    msg: &AuthorizedMessageV1,
+    self_member_id: MemberId,
+    room_key: &VerifyingKey,
+    room_secrets: &std::collections::HashMap<u32, [u8; 32]>,
+) -> bool {
+    use crate::components::conversation::{decrypt_message_content, extract_reply_context};
+
+    // (a) An @mention of self anywhere in the (decrypted) message text.
+    let text = decrypt_message_content(&msg.message.content, room_secrets);
+    if river_core::mention::contains_mention_of(&text, self_member_id) {
+        return true;
+    }
+
+    // (b) A reply to a message authored by self. The reply carries the target
+    // message id; resolve it against the room's recent messages and compare the
+    // target's author to self. If the target has scrolled out of the recent
+    // window we cannot confirm authorship, so we conservatively do not notify.
+    let (_, _, target_id) = extract_reply_context(&msg.message.content, room_secrets);
+    if let Some(target_id) = target_id {
+        if let Ok(rooms) = ROOMS.try_read() {
+            if let Some(rd) = rooms.map.get(room_key) {
+                return rd
+                    .room_state
+                    .recent_messages
+                    .messages
+                    .iter()
+                    .any(|m| m.id() == target_id && m.message.author == self_member_id);
+            }
+        }
+    }
+    false
+}
+
 /// Process new messages and show notifications if appropriate
 /// Called from apply_delta when new messages are received
 ///
@@ -362,6 +399,32 @@ pub fn notify_new_messages(
 
     if external_messages.is_empty() {
         info!("No external messages to notify about");
+        return;
+    }
+
+    // Apply the per-room notification preference (a local user setting).
+    let mode = ROOMS
+        .read()
+        .notification_modes
+        .get(room_key)
+        .copied()
+        .unwrap_or_default();
+    let external_messages: Vec<_> = match mode {
+        crate::room_data::NotificationMode::All => external_messages,
+        crate::room_data::NotificationMode::Muted => {
+            info!(
+                "Room {:?} is muted, skipping notification",
+                MemberId::from(*room_key)
+            );
+            return;
+        }
+        crate::room_data::NotificationMode::MentionsAndReplies => external_messages
+            .into_iter()
+            .filter(|msg| message_notifies_self(msg, self_member_id, room_key, room_secrets))
+            .collect(),
+    };
+    if external_messages.is_empty() {
+        info!("No messages match the room's mentions-and-replies filter");
         return;
     }
 

--- a/ui/src/components/app/notifications.rs
+++ b/ui/src/components/app/notifications.rs
@@ -287,14 +287,19 @@ fn create_notification_internal(
     }
 }
 
-/// Whether `msg` should notify the local user under
-/// [`crate::room_data::NotificationMode::MentionsAndReplies`]: it either
-/// @mentions them or is a reply to one of their own messages.
-fn message_notifies_self(
+/// Pure decision for [`crate::room_data::NotificationMode::MentionsAndReplies`]:
+/// does `msg` @mention `self_member_id`, OR is it a reply to a message that
+/// `self_member_id` authored among `recent`? No globals, so it is unit-testable.
+///
+/// The reply check resolves the reply's target id against `recent` and compares
+/// that message's author to self. If the target has scrolled out of `recent` we
+/// cannot confirm authorship, so we conservatively return `false` (miss rather
+/// than spuriously notify).
+fn mentions_or_replies_to_self(
     msg: &AuthorizedMessageV1,
     self_member_id: MemberId,
-    room_key: &VerifyingKey,
     room_secrets: &std::collections::HashMap<u32, [u8; 32]>,
+    recent: &[AuthorizedMessageV1],
 ) -> bool {
     use crate::components::conversation::{decrypt_message_content, extract_reply_context};
 
@@ -304,24 +309,41 @@ fn message_notifies_self(
         return true;
     }
 
-    // (b) A reply to a message authored by self. The reply carries the target
-    // message id; resolve it against the room's recent messages and compare the
-    // target's author to self. If the target has scrolled out of the recent
-    // window we cannot confirm authorship, so we conservatively do not notify.
+    // (b) A reply to a message authored by self.
     let (_, _, target_id) = extract_reply_context(&msg.message.content, room_secrets);
     if let Some(target_id) = target_id {
-        if let Ok(rooms) = ROOMS.try_read() {
-            if let Some(rd) = rooms.map.get(room_key) {
-                return rd
-                    .room_state
-                    .recent_messages
-                    .messages
-                    .iter()
-                    .any(|m| m.id() == target_id && m.message.author == self_member_id);
-            }
-        }
+        return recent
+            .iter()
+            .any(|m| m.id() == target_id && m.message.author == self_member_id);
     }
     false
+}
+
+/// Whether `msg` should notify the local user under
+/// [`crate::room_data::NotificationMode::MentionsAndReplies`]: it either
+/// @mentions them or is a reply to one of their own messages.
+///
+/// Reads `recent_messages` from `ROOMS` (needed for reply-authorship) and
+/// delegates the decision to the pure [`mentions_or_replies_to_self`] helper.
+fn message_notifies_self(
+    msg: &AuthorizedMessageV1,
+    self_member_id: MemberId,
+    room_key: &VerifyingKey,
+    room_secrets: &std::collections::HashMap<u32, [u8; 32]>,
+) -> bool {
+    if let Ok(rooms) = ROOMS.try_read() {
+        if let Some(rd) = rooms.map.get(room_key) {
+            return mentions_or_replies_to_self(
+                msg,
+                self_member_id,
+                room_secrets,
+                &rd.room_state.recent_messages.messages,
+            );
+        }
+    }
+    // ROOMS unreadable / room missing: the @mention check needs no room
+    // context, so still honour it with an empty recent-message window.
+    mentions_or_replies_to_self(msg, self_member_id, room_secrets, &[])
 }
 
 /// Process new messages and show notifications if appropriate
@@ -566,4 +588,150 @@ pub fn mark_initial_sync_complete(room_key: &VerifyingKey) {
         "Marked initial sync complete for room: {:?}",
         MemberId::from(*room_key)
     );
+}
+
+#[cfg(test)]
+mod notify_gate_tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use river_core::room_state::message::MessageV1;
+    use std::collections::HashMap;
+    use std::time::SystemTime;
+
+    fn key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    fn id_of(sk: &SigningKey) -> MemberId {
+        MemberId::from(&sk.verifying_key())
+    }
+
+    fn public_msg(author_sk: &SigningKey, content: RoomMessageBody) -> AuthorizedMessageV1 {
+        let author = id_of(author_sk);
+        AuthorizedMessageV1::new(
+            MessageV1 {
+                room_owner: author,
+                author,
+                content,
+                time: SystemTime::UNIX_EPOCH,
+            },
+            author_sk,
+        )
+    }
+
+    #[test]
+    fn notifies_on_mention_of_self() {
+        let me = key(1);
+        let other = key(2);
+        let secrets = HashMap::new();
+        let text = format!(
+            "hey {}!",
+            river_core::mention::encode_mention(id_of(&me), "Me")
+        );
+        let msg = public_msg(&other, RoomMessageBody::public(text));
+        assert!(mentions_or_replies_to_self(&msg, id_of(&me), &secrets, &[]));
+    }
+
+    #[test]
+    fn does_not_notify_on_mention_of_someone_else() {
+        let me = key(1);
+        let other = key(2);
+        let secrets = HashMap::new();
+        let text = format!(
+            "hey {}!",
+            river_core::mention::encode_mention(id_of(&other), "Other")
+        );
+        let msg = public_msg(&other, RoomMessageBody::public(text));
+        assert!(!mentions_or_replies_to_self(
+            &msg,
+            id_of(&me),
+            &secrets,
+            &[]
+        ));
+    }
+
+    #[test]
+    fn notifies_on_reply_to_own_message() {
+        let me = key(1);
+        let other = key(2);
+        let secrets = HashMap::new();
+        let target = public_msg(&me, RoomMessageBody::public("my message".to_string()));
+        let reply = public_msg(
+            &other,
+            RoomMessageBody::reply(
+                "agreed".to_string(),
+                target.id(),
+                "Me".to_string(),
+                "my message".to_string(),
+            ),
+        );
+        assert!(mentions_or_replies_to_self(
+            &reply,
+            id_of(&me),
+            &secrets,
+            &[target]
+        ));
+    }
+
+    #[test]
+    fn does_not_notify_on_reply_to_other_message() {
+        let me = key(1);
+        let other = key(2);
+        let secrets = HashMap::new();
+        // Target authored by `other`, not by `me`.
+        let target = public_msg(&other, RoomMessageBody::public("their message".to_string()));
+        let reply = public_msg(
+            &me,
+            RoomMessageBody::reply(
+                "ok".to_string(),
+                target.id(),
+                "Other".to_string(),
+                "their message".to_string(),
+            ),
+        );
+        assert!(!mentions_or_replies_to_self(
+            &reply,
+            id_of(&me),
+            &secrets,
+            &[target]
+        ));
+    }
+
+    #[test]
+    fn does_not_notify_when_reply_target_scrolled_out() {
+        let me = key(1);
+        let other = key(2);
+        let secrets = HashMap::new();
+        let target = public_msg(&me, RoomMessageBody::public("old message".to_string()));
+        let reply = public_msg(
+            &other,
+            RoomMessageBody::reply(
+                "re".to_string(),
+                target.id(),
+                "Me".to_string(),
+                "old message".to_string(),
+            ),
+        );
+        // Target not in the recent window → conservatively no notification.
+        assert!(!mentions_or_replies_to_self(
+            &reply,
+            id_of(&me),
+            &secrets,
+            &[]
+        ));
+    }
+
+    #[test]
+    fn plain_message_does_not_notify() {
+        let me = key(1);
+        let other = key(2);
+        let secrets = HashMap::new();
+        let msg = public_msg(&other, RoomMessageBody::public("just chatting".to_string()));
+        assert!(!mentions_or_replies_to_self(
+            &msg,
+            id_of(&me),
+            &secrets,
+            &[]
+        ));
+    }
 }

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -308,7 +308,10 @@ fn format_event_summary(names: &[String]) -> String {
     }
 }
 
-fn decrypt_message_content(content: &RoomMessageBody, secrets: &HashMap<u32, [u8; 32]>) -> String {
+pub(crate) fn decrypt_message_content(
+    content: &RoomMessageBody,
+    secrets: &HashMap<u32, [u8; 32]>,
+) -> String {
     use river_core::room_state::content::{
         ReplyContentV1, TextContentV1, CONTENT_TYPE_ACTION, CONTENT_TYPE_REPLY, CONTENT_TYPE_TEXT,
     };
@@ -407,7 +410,7 @@ fn decrypt_message_content(content: &RoomMessageBody, secrets: &HashMap<u32, [u8
 
 /// Extract reply context from a message body, if it is a reply.
 /// Returns (author_name, content_preview, target_message_id) or (None, None, None).
-fn extract_reply_context(
+pub(crate) fn extract_reply_context(
     content: &RoomMessageBody,
     secrets: &HashMap<u32, [u8; 32]>,
 ) -> (Option<String>, Option<String>, Option<MessageId>) {

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1908,6 +1908,29 @@ pub fn Conversation() -> Element {
                         match room_data.can_participate() {
                             Ok(()) => {
                                 let max_msg_size = room_data.room_state.configuration.configuration.max_message_size;
+                                // Mentionable members for the @ autocomplete: every member
+                                // with a (decrypted) nickname except self, sorted by name.
+                                let self_id = MemberId::from(&room_data.self_sk.verifying_key());
+                                let mut mention_members: Vec<(MemberId, String)> = room_data
+                                    .room_state
+                                    .member_info
+                                    .member_info
+                                    .iter()
+                                    .filter(|ami| ami.member_info.member_id != self_id)
+                                    .map(|ami| {
+                                        let name = match unseal_bytes_with_secrets(
+                                            &ami.member_info.preferred_nickname,
+                                            &room_data.secrets,
+                                        ) {
+                                            Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
+                                            Err(_) => ami.member_info.preferred_nickname.to_string_lossy(),
+                                        };
+                                        (ami.member_info.member_id, name)
+                                    })
+                                    .filter(|(_, name)| !name.is_empty())
+                                    .collect();
+                                mention_members
+                                    .sort_by(|a, b| a.1.to_lowercase().cmp(&b.1.to_lowercase()));
                                 rsx! {
                                     MessageInput {
                                         handle_send_message: move |msg: (String, Option<ReplyContext>)| {
@@ -1917,6 +1940,7 @@ pub fn Conversation() -> Element {
                                         replying_to: replying_to,
                                         on_request_edit_last: request_edit_last,
                                         max_message_size: max_msg_size,
+                                        members: mention_members,
                                     }
                                 }
                             },

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1930,7 +1930,7 @@ pub fn Conversation() -> Element {
                                         };
                                         (ami.member_info.member_id, name)
                                     })
-                                    .filter(|(_, name)| !name.is_empty())
+                                    .filter(|(_, name)| !name.trim().is_empty())
                                     .collect();
                                 mention_members
                                     .sort_by(|a, b| a.1.to_lowercase().cmp(&b.1.to_lowercase()));

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -159,6 +159,7 @@ fn group_messages(
     member_info: &MemberInfoV1,
     self_member_id: MemberId,
     secrets: &HashMap<u32, [u8; 32]>,
+    member_names: &HashMap<MemberId, String>,
 ) -> Vec<DisplayItem> {
     let mut items: Vec<DisplayItem> = Vec::new();
     let group_threshold = Duration::from_secs(5 * 60); // 5 minutes
@@ -212,7 +213,8 @@ fn group_messages(
         let content_text = messages_state
             .effective_text(message)
             .unwrap_or_else(|| decrypt_message_content(&message.message.content, secrets));
-        let content_html = message_to_html(&content_text);
+        let content_html =
+            message_to_html_with_mentions(&content_text, member_names, self_member_id);
         let is_self = author_id == self_member_id;
 
         // Get edited status and reactions
@@ -476,6 +478,126 @@ fn markdown_to_html(text: &str, behind_gateway: bool) -> String {
         .unwrap_or_else(|_| markdown::to_html(text));
 
     finalize_anchors(&html, behind_gateway)
+}
+
+/// Render message text to HTML, turning `@[name](rv:id)` mention tokens into
+/// styled, clickable chips that show each member's *current* nickname.
+///
+/// Mentions are extracted *before* markdown runs — each is replaced by an inert
+/// private-use sentinel, markdown + anchor finalization run over the sentinel'd
+/// text, then the sentinels are swapped for chip HTML. This keeps mention
+/// rendering independent of markdown's link grammar (so a token can never be
+/// mangled by adjacent markdown, and a malicious `[..](javascript:..)` payload
+/// can't masquerade as a mention).
+///
+/// `member_names` maps each member id to their decrypted current nickname (the
+/// `[name]` snapshot in the token is only used as a fallback when the id is not
+/// in the map). `self_member_id` gets a distinct highlight (a mention of you).
+pub(crate) fn message_to_html_with_mentions(
+    text: &str,
+    member_names: &HashMap<MemberId, String>,
+    self_member_id: MemberId,
+) -> String {
+    use river_core::mention::{parse_segments, MentionSegment};
+
+    let segments = parse_segments(text);
+    // Fast path: no mentions -> byte-identical to the plain renderer.
+    if !segments
+        .iter()
+        .any(|s| matches!(s, MentionSegment::Mention(_)))
+    {
+        return message_to_html(text);
+    }
+
+    // Private-use sentinels that markdown passes through verbatim and that
+    // never legitimately appear in chat text. Strip any pre-existing
+    // occurrences from plain-text runs so a crafted message can't smuggle a
+    // sentinel and hijack the post-markdown substitution.
+    const OPEN: char = '\u{E000}';
+    const CLOSE: char = '\u{E001}';
+
+    let mut working = String::with_capacity(text.len());
+    let mut chips: Vec<String> = Vec::new();
+    for seg in segments {
+        match seg {
+            MentionSegment::Text(t) => {
+                working.extend(t.chars().filter(|c| *c != OPEN && *c != CLOSE));
+            }
+            MentionSegment::Mention(m) => {
+                let idx = chips.len();
+                let name = member_names
+                    .get(&m.member_id)
+                    .cloned()
+                    .unwrap_or(m.display_name);
+                chips.push(render_mention_chip_html(
+                    m.member_id,
+                    &name,
+                    m.member_id == self_member_id,
+                ));
+                working.push(OPEN);
+                working.push_str(&idx.to_string());
+                working.push(CLOSE);
+            }
+        }
+    }
+
+    let mut html = message_to_html(&working);
+    // The CLOSE delimiter bounds each index, so `…0␁` never matches inside
+    // `…10␁` — replacement is unambiguous regardless of order.
+    for (idx, chip) in chips.iter().enumerate() {
+        html = html.replace(&format!("{OPEN}{idx}{CLOSE}"), chip);
+    }
+    html
+}
+
+/// Build the inline chip markup for one mention. `name` is the resolved current
+/// nickname (or snapshot fallback) and is HTML-escaped — nicknames are
+/// attacker-controlled and this string goes through `dangerous_inner_html`
+/// (freenet/river#227). The `data-member-id` carries the lossless hex id so the
+/// document-level click interceptor can open the member-info modal.
+fn render_mention_chip_html(id: MemberId, name: &str, is_self: bool) -> String {
+    let class = if is_self {
+        "river-mention river-mention-self"
+    } else {
+        "river-mention"
+    };
+    format!(
+        "<span class=\"{class}\" data-river-mention=\"1\" data-member-id=\"{hex}\" \
+         role=\"button\" tabindex=\"0\" title=\"@{title}\">@{label}</span>",
+        hex = river_core::mention::member_id_to_hex(id),
+        title = escape_html_attr(name),
+        label = escape_html(name),
+    )
+}
+
+/// Escape `&<>` for HTML text content.
+fn escape_html(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Escape `&<>"'` for an HTML attribute value (double-quoted).
+fn escape_html_attr(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(c),
+        }
+    }
+    out
 }
 
 /// True when River is currently being served from a path under
@@ -790,13 +912,7 @@ pub fn Conversation() -> Element {
                     .is_some()
                 {
                     let self_member_id = MemberId::from(&room_data.self_sk.verifying_key());
-                    let groups = group_messages(
-                        &room_state.recent_messages,
-                        &room_state.member_info,
-                        self_member_id,
-                        &room_data.secrets,
-                    );
-                    // Build member name lookup for reaction tooltips
+                    // Build member name lookup (reaction tooltips, @mention chips).
                     let member_names: HashMap<MemberId, String> = room_state
                         .member_info
                         .member_info
@@ -812,6 +928,13 @@ pub fn Conversation() -> Element {
                             (ami.member_info.member_id, name)
                         })
                         .collect();
+                    let groups = group_messages(
+                        &room_state.recent_messages,
+                        &room_state.member_info,
+                        self_member_id,
+                        &room_data.secrets,
+                        &member_names,
+                    );
                     return Some((groups, self_member_id, member_names));
                 }
             }
@@ -3079,6 +3202,118 @@ mod tests {
             rendered.contains("v5"),
             "the rotated-past placeholder should surface the missing \
              version number, got: {rendered}"
+        );
+    }
+
+    // --- @mention rendering ---------------------------------------------
+
+    fn mid_from(hex: &str) -> MemberId {
+        river_core::mention::member_id_from_hex(hex).unwrap()
+    }
+
+    #[test]
+    fn mention_chip_uses_current_name_not_snapshot() {
+        let id = mid_from("00000000000000aa");
+        let mut names = HashMap::new();
+        names.insert(id, "CurrentName".to_string());
+        let token = river_core::mention::encode_mention(id, "OldName");
+        let html = message_to_html_with_mentions(
+            &format!("hi {token}!"),
+            &names,
+            mid_from("00000000000000ff"),
+        );
+        assert!(
+            html.contains("data-member-id=\"00000000000000aa\""),
+            "chip must carry the lossless member id: {html}"
+        );
+        assert!(
+            html.contains(">@CurrentName</span>"),
+            "chip must show the CURRENT name, following renames: {html}"
+        );
+        assert!(
+            !html.contains("OldName"),
+            "stale snapshot name must be overridden: {html}"
+        );
+    }
+
+    #[test]
+    fn mention_chip_falls_back_to_snapshot_for_unknown_member() {
+        let id = mid_from("0000000000000abc");
+        let names = HashMap::new(); // member not resolvable
+        let token = river_core::mention::encode_mention(id, "Ghost");
+        let html = message_to_html_with_mentions(&token, &names, mid_from("0000000000000001"));
+        assert!(
+            html.contains(">@Ghost</span>"),
+            "unknown member falls back to the token's snapshot name: {html}"
+        );
+    }
+
+    #[test]
+    fn mention_chip_escapes_attacker_controlled_nickname() {
+        // Nicknames are attacker-controlled and the chip enters the DOM via
+        // dangerous_inner_html (freenet/river#227) — must be escaped.
+        let id = mid_from("0000000000000001");
+        let mut names = HashMap::new();
+        names.insert(id, "<img src=x onerror=alert(1)>".to_string());
+        let token = river_core::mention::encode_mention(id, "snap");
+        let html = message_to_html_with_mentions(&token, &names, mid_from("0000000000000002"));
+        assert!(
+            !html.contains("<img"),
+            "raw markup must not survive: {html}"
+        );
+        assert!(
+            html.contains("&lt;img"),
+            "nickname must be HTML-escaped: {html}"
+        );
+    }
+
+    #[test]
+    fn mention_of_self_gets_distinct_highlight_class() {
+        let me = mid_from("0000000000000007");
+        let mut names = HashMap::new();
+        names.insert(me, "Me".to_string());
+        let token = river_core::mention::encode_mention(me, "Me");
+        let html = message_to_html_with_mentions(&token, &names, me);
+        assert!(
+            html.contains("river-mention-self"),
+            "a mention of the local user must get the self class: {html}"
+        );
+    }
+
+    #[test]
+    fn text_without_mentions_renders_identically_to_plain() {
+        let names = HashMap::new();
+        let text = "a normal *markdown* msg with a https://example.com link";
+        let any = mid_from("0000000000000001");
+        assert_eq!(
+            message_to_html_with_mentions(text, &names, any),
+            message_to_html(text),
+            "the no-mention fast path must match the plain renderer byte-for-byte"
+        );
+    }
+
+    #[test]
+    fn multiple_mentions_each_resolve_independently() {
+        let a = mid_from("000000000000000a");
+        let b = mid_from("000000000000000b");
+        let mut names = HashMap::new();
+        names.insert(a, "Ann".to_string());
+        names.insert(b, "Bob".to_string());
+        let text = format!(
+            "{} and {}",
+            river_core::mention::encode_mention(a, "x"),
+            river_core::mention::encode_mention(b, "y")
+        );
+        let html = message_to_html_with_mentions(&text, &names, mid_from("00000000000000ff"));
+        assert!(html.contains(">@Ann</span>"), "{html}");
+        assert!(html.contains(">@Bob</span>"), "{html}");
+        assert!(
+            html.contains("data-member-id=\"000000000000000a\""),
+            "{html}"
+        );
+        assert!(
+            html.contains("data-member-id=\"000000000000000b\""),
+            "{html}"
         );
     }
 }

--- a/ui/src/components/conversation/message_input.rs
+++ b/ui/src/components/conversation/message_input.rs
@@ -1,20 +1,29 @@
 use dioxus::prelude::*;
+use river_core::room_state::member::MemberId;
 use wasm_bindgen::JsCast;
 
 use super::emoji_picker::EmojiPicker;
 use super::ReplyContext;
 
+/// Maximum number of members shown in the @mention autocomplete dropdown.
+const MENTION_CANDIDATE_LIMIT: usize = 8;
+
+/// In-flight @mention autocomplete state, set while the caret sits inside an
+/// `@query` token in the composer.
+#[derive(Clone, PartialEq)]
+struct MentionAutocomplete {
+    /// Byte offset of the `@` in the current message text.
+    anchor: usize,
+    /// Byte offset just past the typed query (i.e. the caret).
+    query_end: usize,
+    /// Members matching the query, already truncated to the display limit.
+    candidates: Vec<(MemberId, String)>,
+    /// Index into `candidates` currently highlighted for keyboard selection.
+    selected: usize,
+}
+
 fn auto_resize_message_input() {
-    let Some(window) = web_sys::window() else {
-        return;
-    };
-    let Some(doc) = window.document() else {
-        return;
-    };
-    let Some(el) = doc.get_element_by_id("message-input") else {
-        return;
-    };
-    let Ok(el) = el.dyn_into::<web_sys::HtmlElement>() else {
+    let Some(el) = get_message_textarea() else {
         return;
     };
     // Reset height to auto to measure scrollHeight correctly, then clamp to ~7 lines.
@@ -23,6 +32,149 @@ fn auto_resize_message_input() {
     el.style()
         .set_property("height", &format!("{}px", new_height))
         .ok();
+}
+
+fn get_message_textarea() -> Option<web_sys::HtmlTextAreaElement> {
+    web_sys::window()?
+        .document()?
+        .get_element_by_id("message-input")?
+        .dyn_into::<web_sys::HtmlTextAreaElement>()
+        .ok()
+}
+
+/// Read the textarea caret as a *byte* offset into `value`. `selection_start`
+/// is a UTF-16 code-unit index (DOMString semantics), so it must be converted.
+fn read_caret_byte(value: &str) -> Option<usize> {
+    let el = get_message_textarea()?;
+    let caret_u16 = el.selection_start().ok().flatten()? as usize;
+    Some(utf16_to_byte_offset(value, caret_u16))
+}
+
+/// Focus the textarea and place the caret at byte offset `byte_off` in `value`.
+fn set_caret(value: &str, byte_off: usize) {
+    let Some(el) = get_message_textarea() else {
+        return;
+    };
+    let _ = el.focus();
+    let off = byte_to_utf16_offset(value, byte_off);
+    let _ = el.set_selection_range(off, off);
+}
+
+fn utf16_to_byte_offset(s: &str, utf16_off: usize) -> usize {
+    let mut u16count = 0usize;
+    for (byte_idx, ch) in s.char_indices() {
+        if u16count >= utf16_off {
+            return byte_idx;
+        }
+        u16count += ch.len_utf16();
+    }
+    s.len()
+}
+
+fn byte_to_utf16_offset(s: &str, byte_off: usize) -> u32 {
+    let mut u16count = 0u32;
+    for (byte_idx, ch) in s.char_indices() {
+        if byte_idx >= byte_off {
+            break;
+        }
+        u16count += ch.len_utf16() as u32;
+    }
+    u16count
+}
+
+/// If the caret sits inside an `@query` token (a `@` at a word boundary with no
+/// whitespace between it and the caret), return `(byte offset of '@', query)`.
+fn detect_mention_query(value: &str, byte_caret: usize) -> Option<(usize, String)> {
+    if byte_caret > value.len() || !value.is_char_boundary(byte_caret) {
+        return None;
+    }
+    let prefix = &value[..byte_caret];
+    // Walk back from the caret: the first `@` (with no intervening whitespace)
+    // starts the query; any whitespace first means we're not in a token.
+    let mut at = None;
+    for (idx, ch) in prefix.char_indices().rev() {
+        if ch == '@' {
+            at = Some(idx);
+            break;
+        }
+        if ch.is_whitespace() {
+            return None;
+        }
+    }
+    let at = at?;
+    // The `@` must begin a word: at start-of-text or after whitespace. This
+    // skips email-like `name@host` (the char before `@` is not whitespace).
+    if at > 0 {
+        let before = prefix[..at].chars().next_back()?;
+        if !before.is_whitespace() {
+            return None;
+        }
+    }
+    Some((at, prefix[at + 1..].to_string()))
+}
+
+/// Rank members against a query: case-insensitive prefix matches first, then
+/// substring matches, preserving the input order (caller pre-sorts by name).
+/// An empty query lists everyone (up to `limit`).
+fn filter_mention_candidates(
+    members: &[(MemberId, String)],
+    query: &str,
+    limit: usize,
+) -> Vec<(MemberId, String)> {
+    let q = query.to_lowercase();
+    let mut prefix = Vec::new();
+    let mut substr = Vec::new();
+    for (id, name) in members {
+        let lname = name.to_lowercase();
+        if q.is_empty() || lname.starts_with(&q) {
+            prefix.push((*id, name.clone()));
+        } else if lname.contains(&q) {
+            substr.push((*id, name.clone()));
+        }
+    }
+    prefix.extend(substr);
+    prefix.truncate(limit);
+    prefix
+}
+
+/// Replace the `@query` span with the chosen member's wire token and a trailing
+/// space, then reposition the caret after the inserted token.
+fn apply_mention_selection(
+    mut message_text: Signal<String>,
+    mut mention: Signal<Option<MentionAutocomplete>>,
+    idx: usize,
+) {
+    let Some(m) = mention.peek().clone() else {
+        return;
+    };
+    let Some((id, name)) = m.candidates.get(idx).cloned() else {
+        return;
+    };
+    let value = message_text.peek().to_string();
+    // Guard the stored offsets against a value that changed out from under us
+    // (they are only valid for the value captured at the last keystroke).
+    if m.anchor > m.query_end
+        || m.query_end > value.len()
+        || !value.is_char_boundary(m.anchor)
+        || !value.is_char_boundary(m.query_end)
+    {
+        mention.set(None);
+        return;
+    }
+    let token = river_core::mention::encode_mention(id, &name);
+    let mut new_value = String::with_capacity(value.len() + token.len() + 1);
+    new_value.push_str(&value[..m.anchor]);
+    new_value.push_str(&token);
+    new_value.push(' ');
+    new_value.push_str(&value[m.query_end..]);
+    let caret_byte = m.anchor + token.len() + 1;
+    message_text.set(new_value.clone());
+    mention.set(None);
+    // The caret must be set after Dioxus flushes the new value to the DOM.
+    crate::util::defer(move || {
+        set_caret(&new_value, caret_byte);
+        auto_resize_message_input();
+    });
 }
 
 /// Message input component that owns its own state.
@@ -35,10 +187,15 @@ pub fn MessageInput(
     on_request_edit_last: EventHandler<()>,
     /// Maximum message content size in bytes (from room configuration).
     max_message_size: usize,
+    /// Mentionable members (id, current nickname), excluding self, sorted by
+    /// name. Drives the `@` autocomplete. Changes only when membership changes,
+    /// so it does not affect keystroke-level re-rendering.
+    members: Vec<(MemberId, String)>,
 ) -> Element {
     // Own the message state locally - keystrokes only re-render this component
     let mut message_text = use_signal(String::new);
     let mut show_emoji_picker = use_signal(|| false);
+    let mut mention = use_signal(|| None as Option<MentionAutocomplete>);
 
     let mut send_message = move || {
         let text = message_text.peek().to_string();
@@ -46,6 +203,7 @@ pub fn MessageInput(
             let reply_ctx = replying_to.peek().clone();
             message_text.set(String::new());
             replying_to.set(None);
+            mention.set(None);
             handle_send_message.call((text, reply_ctx));
             // Defer resize so it runs after Dioxus flushes the cleared value to the DOM;
             // measuring scrollHeight synchronously here still sees the pre-send content.
@@ -58,6 +216,12 @@ pub fn MessageInput(
         let current = message_text.peek().to_string();
         message_text.set(format!("{}{}", current, emoji));
     };
+
+    // Snapshot dropdown state for rendering (drops the read guard before rsx).
+    let mention_view = mention
+        .read()
+        .as_ref()
+        .map(|m| (m.candidates.clone(), m.selected));
 
     rsx! {
         // Backdrop for emoji picker - outside the message bar to avoid z-index issues
@@ -123,8 +287,36 @@ pub fn MessageInput(
                             }
                         }
                     }
-                    // Textarea with optional byte counter
-                    div { class: "flex-1 flex flex-col",
+                    // Textarea with optional byte counter. `relative` anchors the
+                    // @mention autocomplete dropdown.
+                    div { class: "flex-1 flex flex-col relative",
+                        // @mention autocomplete dropdown (floats above the textarea)
+                        if let Some((candidates, selected)) = mention_view {
+                            div {
+                                class: "absolute bottom-full left-0 mb-1 w-64 max-h-56 overflow-y-auto bg-panel border border-border rounded-xl shadow-lg z-50",
+                                role: "listbox",
+                                "aria-label": "Mention a member",
+                                for (i, (id, name)) in candidates.into_iter().enumerate() {
+                                    button {
+                                        key: "{river_core::mention::member_id_to_hex(id)}",
+                                        r#type: "button",
+                                        role: "option",
+                                        "aria-selected": if i == selected { "true" } else { "false" },
+                                        class: format!(
+                                            "w-full text-left px-3 py-2 text-sm truncate {}",
+                                            if i == selected { "bg-accent/15 text-accent" } else { "text-text hover:bg-surface" }
+                                        ),
+                                        // Use mousedown + preventDefault so the textarea
+                                        // doesn't blur before the selection is applied.
+                                        onmousedown: move |evt| {
+                                            evt.prevent_default();
+                                            apply_mention_selection(message_text, mention, i);
+                                        },
+                                        span { class: "font-medium", "@{name}" }
+                                    }
+                                }
+                            }
+                        }
                         textarea {
                             id: "message-input",
                             class: "w-full px-4 py-2.5 bg-surface border border-border rounded-xl text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors resize-none min-h-[44px] overflow-y-auto",
@@ -133,18 +325,72 @@ pub fn MessageInput(
                             value: "{message_text}",
                             rows: "1",
                             oninput: move |evt| {
-                                message_text.set(evt.value().to_string());
+                                let value = evt.value().to_string();
+                                message_text.set(value.clone());
                                 auto_resize_message_input();
+                                // Detect / update the @mention autocomplete.
+                                match read_caret_byte(&value)
+                                    .and_then(|caret| detect_mention_query(&value, caret))
+                                {
+                                    Some((at, query)) => {
+                                        let candidates = filter_mention_candidates(
+                                            &members, &query, MENTION_CANDIDATE_LIMIT,
+                                        );
+                                        if candidates.is_empty() {
+                                            mention.set(None);
+                                        } else {
+                                            mention.set(Some(MentionAutocomplete {
+                                                anchor: at,
+                                                query_end: at + 1 + query.len(),
+                                                candidates,
+                                                selected: 0,
+                                            }));
+                                        }
+                                    }
+                                    None => mention.set(None),
+                                }
                             },
                             onkeydown: move |evt| {
+                                let key = evt.key();
+                                // @mention navigation takes precedence while the dropdown is open.
+                                if mention.peek().is_some() {
+                                    if key == Key::ArrowDown || key == Key::ArrowUp {
+                                        evt.prevent_default();
+                                        let down = key == Key::ArrowDown;
+                                        mention.with_mut(|opt| {
+                                            if let Some(m) = opt.as_mut() {
+                                                let n = m.candidates.len();
+                                                if n > 0 {
+                                                    m.selected = if down {
+                                                        (m.selected + 1) % n
+                                                    } else {
+                                                        (m.selected + n - 1) % n
+                                                    };
+                                                }
+                                            }
+                                        });
+                                        return;
+                                    }
+                                    if key == Key::Escape {
+                                        evt.prevent_default();
+                                        mention.set(None);
+                                        return;
+                                    }
+                                    if (key == Key::Enter || key == Key::Tab) && !evt.modifiers().shift() {
+                                        evt.prevent_default();
+                                        let idx = mention.peek().as_ref().map(|m| m.selected).unwrap_or(0);
+                                        apply_mention_selection(message_text, mention, idx);
+                                        return;
+                                    }
+                                }
                                 // Enter without Shift sends the message
                                 // Shift+Enter creates a new line (default textarea behavior)
-                                if evt.key() == Key::Enter && !evt.modifiers().shift() {
+                                if key == Key::Enter && !evt.modifiers().shift() {
                                     evt.prevent_default();
                                     send_message();
                                 }
                                 // Up arrow in empty input: edit last sent message
-                                if evt.key() == Key::ArrowUp && message_text.peek().is_empty() {
+                                if key == Key::ArrowUp && message_text.peek().is_empty() {
                                     evt.prevent_default();
                                     on_request_edit_last.call(());
                                 }
@@ -205,5 +451,86 @@ pub fn MessageInput(
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn members() -> Vec<(MemberId, String)> {
+        vec![
+            (
+                MemberId(freenet_scaffold::util::FastHash(1)),
+                "Alice".to_string(),
+            ),
+            (
+                MemberId(freenet_scaffold::util::FastHash(2)),
+                "Albert".to_string(),
+            ),
+            (
+                MemberId(freenet_scaffold::util::FastHash(3)),
+                "Bob".to_string(),
+            ),
+        ]
+    }
+
+    #[test]
+    fn detects_query_at_caret() {
+        assert_eq!(
+            detect_mention_query("hi @al", 6),
+            Some((3, "al".to_string()))
+        );
+        // Caret at the bare '@'
+        assert_eq!(detect_mention_query("@", 1), Some((0, String::new())));
+        // '@' at start of text
+        assert_eq!(detect_mention_query("@bo", 3), Some((0, "bo".to_string())));
+    }
+
+    #[test]
+    fn no_query_when_not_in_token() {
+        assert_eq!(detect_mention_query("hello world", 11), None);
+        // whitespace between '@' and caret
+        assert_eq!(detect_mention_query("@al bob", 7), None);
+        // email-like: '@' not at a word boundary
+        assert_eq!(detect_mention_query("name@host", 9), None);
+    }
+
+    #[test]
+    fn filter_prefers_prefix_then_substring() {
+        // "al" → Albert and Alice by prefix (input order preserved)
+        let r = filter_mention_candidates(&members(), "al", 8);
+        let names: Vec<_> = r.iter().map(|(_, n)| n.as_str()).collect();
+        assert_eq!(names, vec!["Alice", "Albert"]);
+        // substring-only match
+        let r = filter_mention_candidates(&members(), "ob", 8);
+        assert_eq!(
+            r.iter().map(|(_, n)| n.as_str()).collect::<Vec<_>>(),
+            vec!["Bob"]
+        );
+        // empty query lists everyone
+        assert_eq!(filter_mention_candidates(&members(), "", 8).len(), 3);
+        // limit is honoured
+        assert_eq!(filter_mention_candidates(&members(), "", 1).len(), 1);
+    }
+
+    #[test]
+    fn utf16_byte_offset_round_trips_with_multibyte() {
+        // "é" is 2 bytes / 1 utf16 unit; "𝄞" is 4 bytes / 2 utf16 units.
+        let s = "aé𝄞b";
+        for (byte_off, _) in s.char_indices().chain(std::iter::once((s.len(), ' '))) {
+            let u16 = byte_to_utf16_offset(s, byte_off);
+            assert_eq!(utf16_to_byte_offset(s, u16 as usize), byte_off);
+        }
+    }
+
+    #[test]
+    fn detect_handles_multibyte_before_at() {
+        // "é @bo" — the '@' is preceded by a space, query is "bo".
+        let s = "é @bo";
+        let caret = s.len();
+        let (at, q) = detect_mention_query(s, caret).unwrap();
+        assert_eq!(&s[at..at + 1], "@");
+        assert_eq!(q, "bo");
     }
 }

--- a/ui/src/components/direct_messages.rs
+++ b/ui/src/components/direct_messages.rs
@@ -636,6 +636,7 @@ mod tests {
         Rooms {
             map: std::collections::HashMap::new(),
             current_room_key: None,
+            notification_modes: Default::default(),
             migrated_rooms: Vec::new(),
             removed_rooms: std::collections::HashSet::new(),
         }

--- a/ui/src/components/mention_click_interceptor.rs
+++ b/ui/src/components/mention_click_interceptor.rs
@@ -1,0 +1,78 @@
+//! Document-level click interceptor for `@mention` chips.
+//!
+//! Mention chips are rendered as `<span class="river-mention"
+//! data-member-id="<hex>">@Name</span>` inside message bodies that are injected
+//! via `dangerous_inner_html` (see `conversation::message_to_html_with_mentions`).
+//! Because that markup is raw HTML, Dioxus can't attach an `onclick` to the
+//! chip directly. Instead we install one document-level `click` listener that
+//! walks up from the click target to the nearest `[data-member-id]` element and
+//! opens the member-info modal — the same delegation pattern used by
+//! [`crate::components::invite_click_interceptor`] for invite anchors.
+
+use crate::components::app::MEMBER_INFO_MODAL;
+use dioxus::logger::tracing::warn;
+use std::sync::atomic::{AtomicBool, Ordering};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+
+static HANDLER_INSTALLED: AtomicBool = AtomicBool::new(false);
+
+/// Install a document-level `click` listener that opens the member-info modal
+/// when a mention chip is clicked. Safe to call multiple times — installed once
+/// per page load and ignored thereafter.
+pub fn install_mention_click_interceptor() {
+    if HANDLER_INSTALLED
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return;
+    }
+
+    let cb = Closure::wrap(Box::new(move |evt: web_sys::Event| {
+        // Only plain left-clicks. Leave modifier clicks alone (consistent with
+        // the invite interceptor); a chip has no navigation behaviour to
+        // preserve, but we still don't want to hijack e.g. Ctrl-click.
+        if let Some(me) = evt.dyn_ref::<web_sys::MouseEvent>() {
+            if me.button() != 0 || me.ctrl_key() || me.meta_key() || me.shift_key() || me.alt_key()
+            {
+                return;
+            }
+        }
+
+        let Some(target) = evt.target() else { return };
+        // The click target may be a text node inside the span; walk up.
+        let mut node = target.dyn_into::<web_sys::Element>().ok();
+        while let Some(el) = node {
+            if let Some(hex) = el.get_attribute("data-member-id") {
+                if let Some(member_id) = river_core::mention::member_id_from_hex(&hex) {
+                    evt.prevent_default();
+                    evt.stop_propagation();
+                    // Defer the signal write off the JS event tick — same
+                    // pattern the rest of the UI uses for signal mutations
+                    // from JS callbacks (see `defer()` in `util.rs`).
+                    crate::util::defer(move || {
+                        MEMBER_INFO_MODAL.with_mut(|signal| {
+                            signal.member = Some(member_id);
+                        });
+                    });
+                }
+                return;
+            }
+            node = el.parent_element();
+        }
+    }) as Box<dyn FnMut(web_sys::Event)>);
+
+    if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
+        if let Err(e) = doc.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref()) {
+            warn!(
+                "mention click interceptor: addEventListener failed: {:?}",
+                e
+            );
+            HANDLER_INSTALLED.store(false, Ordering::SeqCst);
+            return;
+        }
+        // Leak the closure intentionally — the listener lives for the lifetime
+        // of the page.
+        cb.forget();
+    }
+}

--- a/ui/src/components/room_list/edit_room_modal.rs
+++ b/ui/src/components/room_list/edit_room_modal.rs
@@ -1,9 +1,11 @@
 use super::room_name_field::RoomNameField;
 use crate::components::app::chat_delegate::save_rooms_to_delegate;
 use crate::components::app::{CURRENT_ROOM, EDIT_ROOM_MODAL, ROOMS};
+use crate::room_data::NotificationMode;
 use crate::util::ecies::{seal_for_room, unseal_bytes_with_secrets};
 use dioxus::logger::tracing::{error, info, warn};
 use dioxus::prelude::*;
+use ed25519_dalek::VerifyingKey;
 use freenet_scaffold::ComposableState;
 use river_core::room_state::configuration::{AuthorizedConfigurationV1, Configuration};
 use river_core::room_state::privacy::{PrivacyMode, RoomDisplayMetadata};
@@ -97,6 +99,12 @@ pub fn EditRoomModal() -> Element {
                                     }
                                 }
                             }
+                        }
+
+                        // Per-room notification preference (local setting, all
+                        // users — not owner-gated).
+                        if let Some(room_vk) = EDIT_ROOM_MODAL.read().room {
+                            NotificationModeField { room_vk }
                         }
 
                         // Numeric configuration fields (owner-only)
@@ -345,6 +353,61 @@ pub fn EditRoomModal() -> Element {
         }
     } else {
         rsx! {}
+    }
+}
+
+/// Per-room notification preference selector. Local-only setting (persisted in
+/// the `rooms_data` delegate blob, applies on this device), so it is shown to
+/// every member, not just the owner. Reads the current mode from `ROOMS` each
+/// render (no cached hook state) so reopening the modal for a different room
+/// always reflects that room's value.
+#[component]
+fn NotificationModeField(room_vk: VerifyingKey) -> Element {
+    let current = ROOMS
+        .read()
+        .notification_modes
+        .get(&room_vk)
+        .copied()
+        .unwrap_or_default();
+    let current_str = match current {
+        NotificationMode::All => "all",
+        NotificationMode::MentionsAndReplies => "mentions",
+        NotificationMode::Muted => "muted",
+    };
+
+    rsx! {
+        div { class: "mb-4",
+            label { class: "block text-sm font-medium text-text-muted mb-2", "Notifications" }
+            select {
+                class: "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent",
+                value: "{current_str}",
+                onchange: move |evt| {
+                    let mode = match evt.value().as_str() {
+                        "mentions" => NotificationMode::MentionsAndReplies,
+                        "muted" => NotificationMode::Muted,
+                        _ => NotificationMode::All,
+                    };
+                    // Defer the signal mutation (RefCell re-entrancy rule), then
+                    // persist to the delegate so the choice survives reloads.
+                    crate::util::defer(move || {
+                        ROOMS.with_mut(|rooms| {
+                            rooms.notification_modes.insert(room_vk, mode);
+                        });
+                        spawn(async move {
+                            if let Err(e) = save_rooms_to_delegate().await {
+                                error!("Failed to save notification mode: {}", e);
+                            }
+                        });
+                    });
+                },
+                option { value: "all", "All messages" }
+                option { value: "mentions", "Mentions & replies only" }
+                option { value: "muted", "Muted" }
+            }
+            p { class: "text-xs text-text-muted mt-1",
+                "When to notify for this room. Applies on this device only."
+            }
+        }
     }
 }
 

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -324,6 +324,25 @@ fn add_example_messages(
         current_time_ms += (rand::random::<u64>() % 870 + 30) * 1000;
     }
 
+    // A message exercising @mention chips. The snapshot name in the token is
+    // intentionally generic ("member") to prove the rendered chip re-resolves
+    // to the member's CURRENT nickname from member_info rather than the
+    // snapshot. Mentions the first non-owner member.
+    if let Some(mentioned_id) = member_keys.keys().find(|id| **id != *owner_id).copied() {
+        let token = river_core::mention::encode_mention(mentioned_id, "member");
+        let msg = AuthorizedMessageV1::new(
+            MessageV1 {
+                room_owner: *owner_id,
+                author: *owner_id,
+                time: get_time_from_millis(current_time_ms),
+                content: RoomMessageBody::public(format!("welcome {token} \u{1F44B}")),
+            },
+            owner_key,
+        );
+        messages.messages.push(msg);
+        current_time_ms += 60_000;
+    }
+
     // Add a reply to the first message so example data exercises the reply
     // bubble layout (needed for Playwright coverage of #205/#206/#207).
     if !messages.messages.is_empty() {

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -47,6 +47,7 @@ pub fn create_example_rooms() -> Rooms {
         map,
         current_room_key: None,
         removed_rooms: std::collections::HashSet::new(),
+        notification_modes: Default::default(),
         migrated_rooms: Vec::new(),
     }
 }

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -1223,6 +1223,20 @@ impl PartialEq for CurrentRoom {
     }
 }
 
+/// Per-room notification preference (local user setting). Controls when a
+/// browser notification fires for new messages in a room.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]
+pub enum NotificationMode {
+    /// Notify for every message from another member (the historical default).
+    #[default]
+    All,
+    /// Notify only for messages that @mention the local user or reply to one
+    /// of their messages.
+    MentionsAndReplies,
+    /// Never notify for this room.
+    Muted,
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Rooms {
     pub map: HashMap<VerifyingKey, RoomData>,
@@ -1255,6 +1269,14 @@ pub struct Rooms {
     /// should NOT clear the tombstone — the user explicitly left.
     #[serde(default)]
     pub removed_rooms: std::collections::HashSet<VerifyingKey>,
+    /// Per-room notification preference (a local user setting), keyed by room
+    /// owner key. An absent entry means [`NotificationMode::All`]. Persisted
+    /// alongside `map` inside the `rooms_data` delegate blob — the same
+    /// local-per-room-state pattern as `removed_rooms`, so it needs no new
+    /// delegate storage key and survives delegate migration. A stale entry for
+    /// a room no longer in `map` is harmless (never consulted).
+    #[serde(default)]
+    pub notification_modes: HashMap<VerifyingKey, NotificationMode>,
     /// Rooms whose contract key changed due to WASM update.
     /// Each entry is (owner_vk, old_contract_key) for rooms where the owner
     /// should send an upgrade pointer to the old contract.
@@ -1264,7 +1286,9 @@ pub struct Rooms {
 
 impl PartialEq for Rooms {
     fn eq(&self, other: &Self) -> bool {
-        self.map == other.map && self.removed_rooms == other.removed_rooms
+        self.map == other.map
+            && self.removed_rooms == other.removed_rooms
+            && self.notification_modes == other.notification_modes
     }
 }
 
@@ -1445,6 +1469,13 @@ impl Rooms {
         // map atomically), the tombstone wins.
         self.map.retain(|vk, _| !self.removed_rooms.contains(vk));
 
+        // Notification preferences: keep this device's choice on conflict (a
+        // local user setting), only adopting another source's value where this
+        // device has none.
+        for (vk, mode) in other.notification_modes {
+            self.notification_modes.entry(vk).or_insert(mode);
+        }
+
         for (vk, mut room_data) in other.map {
             // Honour tombstones — never re-add a room the user has left.
             if self.removed_rooms.contains(&vk) {
@@ -1499,6 +1530,56 @@ mod tests {
     use super::*;
     use river_core::room_state::configuration::{AuthorizedConfigurationV1, Configuration};
     use river_core::room_state::member::{AuthorizedMember, Member};
+
+    #[test]
+    fn notification_mode_defaults_to_all() {
+        assert_eq!(NotificationMode::default(), NotificationMode::All);
+    }
+
+    #[test]
+    fn merge_notification_modes_keeps_local_and_adopts_new() {
+        let mut rng = rand::thread_rng();
+        let shared = SigningKey::generate(&mut rng).verifying_key();
+        let only_incoming = SigningKey::generate(&mut rng).verifying_key();
+
+        let mut local = Rooms {
+            map: HashMap::new(),
+            current_room_key: None,
+            removed_rooms: std::collections::HashSet::new(),
+            notification_modes: HashMap::new(),
+            migrated_rooms: Vec::new(),
+        };
+        local
+            .notification_modes
+            .insert(shared, NotificationMode::Muted);
+
+        let mut incoming = Rooms {
+            map: HashMap::new(),
+            current_room_key: None,
+            removed_rooms: std::collections::HashSet::new(),
+            notification_modes: HashMap::new(),
+            migrated_rooms: Vec::new(),
+        };
+        incoming
+            .notification_modes
+            .insert(shared, NotificationMode::All);
+        incoming
+            .notification_modes
+            .insert(only_incoming, NotificationMode::MentionsAndReplies);
+
+        local.merge(incoming).unwrap();
+
+        // The local device's choice wins on conflict; a key present only in the
+        // incoming set is adopted.
+        assert_eq!(
+            local.notification_modes.get(&shared),
+            Some(&NotificationMode::Muted)
+        );
+        assert_eq!(
+            local.notification_modes.get(&only_incoming),
+            Some(&NotificationMode::MentionsAndReplies)
+        );
+    }
 
     /// Regression test for #85: accepting an invitation for a room that already
     /// exists in the ROOMS map must update self_sk so can_send_message() passes.
@@ -3023,6 +3104,7 @@ mod tests {
             map: HashMap::new(),
             current_room_key: None,
             removed_rooms: std::collections::HashSet::new(),
+            notification_modes: Default::default(),
             migrated_rooms: Vec::new(),
         };
         current.map.insert(owner_vk, room_data.clone());
@@ -3037,6 +3119,7 @@ mod tests {
             map: HashMap::new(),
             current_room_key: None,
             removed_rooms: std::collections::HashSet::new(),
+            notification_modes: Default::default(),
             migrated_rooms: Vec::new(),
         };
         legacy.map.insert(owner_vk, room_data);
@@ -3092,6 +3175,7 @@ mod tests {
             map: HashMap::new(),
             current_room_key: None,
             removed_rooms: std::collections::HashSet::new(),
+            notification_modes: Default::default(),
             migrated_rooms: Vec::new(),
         };
         original.removed_rooms.insert(vk);
@@ -3147,6 +3231,7 @@ mod tests {
             map: HashMap::new(),
             current_room_key: None,
             removed_rooms: std::collections::HashSet::new(),
+            notification_modes: Default::default(),
             migrated_rooms: Vec::new(),
         };
         // Step 1: leave the room.
@@ -3159,6 +3244,7 @@ mod tests {
             map: HashMap::new(),
             current_room_key: None,
             removed_rooms: std::collections::HashSet::new(),
+            notification_modes: Default::default(),
             migrated_rooms: Vec::new(),
         };
         incoming.map.insert(owner_vk, room_data);
@@ -3215,6 +3301,7 @@ mod tests {
             map: HashMap::new(),
             current_room_key: None,
             removed_rooms: std::collections::HashSet::new(),
+            notification_modes: Default::default(),
             migrated_rooms: Vec::new(),
         };
         receiver.map.insert(owner_vk, room_data);
@@ -3222,6 +3309,7 @@ mod tests {
             map: HashMap::new(),
             current_room_key: None,
             removed_rooms: std::collections::HashSet::new(),
+            notification_modes: Default::default(),
             migrated_rooms: Vec::new(),
         };
         sender.removed_rooms.insert(owner_vk);

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -1274,7 +1274,10 @@ pub struct Rooms {
     /// alongside `map` inside the `rooms_data` delegate blob — the same
     /// local-per-room-state pattern as `removed_rooms`, so it needs no new
     /// delegate storage key and survives delegate migration. A stale entry for
-    /// a room no longer in `map` is harmless (never consulted).
+    /// a room no longer in `map` is harmless (never consulted) — but note a
+    /// consequence: leaving a room does NOT clear its entry, so re-joining the
+    /// same room later inherits the preference set before leaving (the merge
+    /// below is local-wins and never overwrites a kept value).
     #[serde(default)]
     pub notification_modes: HashMap<VerifyingKey, NotificationMode>,
     /// Rooms whose contract key changed due to WASM update.


### PR DESCRIPTION
## Problem

River had no way to mention a specific member. Plain `@name` text doesn't link to anyone and breaks when the member renames. There was also no way to tune notifications per room — every external message in any non-active room fired a desktop notification.

## Approach

**Inline wire token, no contract change.** A mention is stored inside the existing message `text` field as `@[Display Name](rv:<lossless-hex-member-id>)`. The `rv:` reference (the member's stable `MemberId`) is authoritative; the name is a fallback snapshot. Clients re-resolve the member's *current* nickname from `member_info` by id, so a rendered chip follows renames. The codec lives in `river-core` behind a new client-only `mentions` feature (mirrors the existing `migration` feature) so it is **never compiled into the room-contract / chat-delegate WASM** — their bytes and keys are unchanged, **no delegate/contract migration**. This was verified by rebuilding both WASMs from origin/main's `common` vs this branch's `common` on the same machine: byte-identical.

- **Rendering** (`conversation.rs`): mentions are extracted *before* markdown (swapped for inert private-use sentinels, then substituted with chip HTML after markdown + anchor finalization), so rendering is independent of markdown's link grammar. The chip shows the current nickname, is HTML-escaped (freenet/river#227), highlights mentions of the local user, and opens the member-info modal on click (document-level delegation, mirroring `invite_click_interceptor`).
- **Composer** (`message_input.rs`): typing `@` opens a keyboard-navigable dropdown of room members (minus self), filtered prefix-first then substring. ↑/↓ move, Enter/Tab insert the wire token at the caret, Esc closes. Caret handling converts between UTF-16 (DOM `selectionStart`) and UTF-8 byte offsets. The candidate list is a prop computed by the parent, so keystroke isolation is preserved.
- **Per-room notifications** (`room_data.rs`, `notifications.rs`, `edit_room_modal.rs`): a `NotificationMode` (All / MentionsAndReplies / Muted) stored as a sidecar map on `Rooms` — rides the existing `rooms_data` delegate blob like `removed_rooms`, no new storage key, survives migration. `notify_new_messages` gates on the mode: Muted suppresses all; MentionsAndReplies fires only when a new message @mentions the local user or replies to one of their messages (resolved by target message id). Default `All` is unchanged behaviour. A non-owner-gated selector in Room Details sets it.
- **riverctl parity**: `message list`/`stream` render tokens as `@name` (current public nickname, snapshot fallback — the CLI cannot decrypt private-room nicknames). `send`/`reply` resolve a bare `@nickname` to a token when it unambiguously, case-insensitively matches a current member's public nickname (the CLI counterpart to the autocomplete picker). Documented in `--help`.

## Testing

- New unit tests: codec (encode/parse/round-trip, id hex, sanitization, multi-mention, non-token text, typed-mention resolution); rendering (rename-following, snapshot fallback, XSS escaping, self-highlight, no-mention fast path, multi-mention); composer helpers (caret detection, candidate filtering, UTF-16↔byte round-trip); notification-mode merge/default.
- All suites green: `river-core` + full common suite, `river-ui` native (288), `riverctl` (83).
- Contract/delegate WASM proven byte-identical (no migration).
- Verified end-to-end in a real browser (Playwright against example-data): chip renders with the resolved current name, autocomplete dropdown lists members with self excluded, keyboard select inserts the correct token.

## Design decisions (from discussion with the maintainer)

- Composer inserts the **raw token** (visible while typing) rather than a rendered pill — simplest, unambiguous, plain `<textarea>` (no contenteditable risk).
- Token carries a **name snapshot overridden on display** by the current nickname.
- Three notification modes including **Muted**.

[AI-assisted - Claude]
