### PR TITLE
fix(cli): finish stubbed riverctl room-join and debug-contract-get JSON

### DIFF
--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -91,6 +91,14 @@ fn contract_get_summary_json(
     })
 }
 
+/// Build the `{"status":"error", ...}` JSON emitted by debug subcommands on
+/// failure. Routing the message through serde keeps the output valid JSON even
+/// when the error text contains a quote, backslash, or newline — the old
+/// hand-rolled `format!` interpolation could emit malformed JSON.
+fn status_error_json(message: &str) -> serde_json::Value {
+    serde_json::json!({ "status": "error", "message": message })
+}
+
 pub async fn execute(command: DebugCommands, api: ApiClient, format: OutputFormat) -> Result<()> {
     match command {
         DebugCommands::ContractGet { room_owner_key } => {
@@ -160,7 +168,10 @@ pub async fn execute(command: DebugCommands, api: ApiClient, format: OutputForma
                     match format {
                         OutputFormat::Human => eprintln!("✗ Contract GET failed: {}", e),
                         OutputFormat::Json => {
-                            println!(r#"{{"status": "error", "message": "{}"}}"#, e);
+                            println!(
+                                "{}",
+                                serde_json::to_string_pretty(&status_error_json(&e.to_string()))?
+                            );
                         }
                     }
                     Err(e)
@@ -188,7 +199,10 @@ pub async fn execute(command: DebugCommands, api: ApiClient, format: OutputForma
                     match format {
                         OutputFormat::Human => eprintln!("✗ WebSocket connection failed: {}", e),
                         OutputFormat::Json => {
-                            println!(r#"{{"status": "error", "message": "{}"}}"#, e);
+                            println!(
+                                "{}",
+                                serde_json::to_string_pretty(&status_error_json(&e.to_string()))?
+                            );
                         }
                     }
                     Err(e)
@@ -393,5 +407,19 @@ mod tests {
         assert_eq!(json["room_name"], "My Room");
         assert_eq!(json["member_count"], 3);
         assert_eq!(json["message_count"], 42);
+    }
+
+    #[test]
+    fn status_error_json_stays_valid_with_special_chars() {
+        // Regression guard: the JSON error arms used to hand-roll output via
+        // `format!`, producing invalid JSON when the error text contained a
+        // quote, backslash, or newline. serde must escape it so the payload
+        // round-trips through a strict parser.
+        let raw = "decode failed for \"weird\\input\"\nsecond line";
+        let value = status_error_json(raw);
+        let serialized = serde_json::to_string(&value).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(parsed["status"], "error");
+        assert_eq!(parsed["message"], raw);
     }
 }

--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -69,6 +69,28 @@ struct RoomConfig {
     max_room_description: usize,
 }
 
+/// Build the JSON summary emitted by `debug contract-get --format json`.
+///
+/// Mirrors the fields the human-readable branch prints, so a scripted
+/// consumer gets the same information instead of the previous bare
+/// `{"status":"success","contract_key":...}` stub.
+fn contract_get_summary_json(
+    contract_key: &str,
+    configuration_version: u32,
+    room_name: &str,
+    member_count: usize,
+    message_count: usize,
+) -> serde_json::Value {
+    serde_json::json!({
+        "status": "success",
+        "contract_key": contract_key,
+        "configuration_version": configuration_version,
+        "room_name": room_name,
+        "member_count": member_count,
+        "message_count": message_count,
+    })
+}
+
 pub async fn execute(command: DebugCommands, api: ApiClient, format: OutputFormat) -> Result<()> {
     match command {
         DebugCommands::ContractGet { room_owner_key } => {
@@ -121,11 +143,15 @@ pub async fn execute(command: DebugCommands, api: ApiClient, format: OutputForma
                             println!("Messages: {}", room_state.recent_messages.messages.len());
                         }
                         OutputFormat::Json => {
-                            // TODO: Implement proper JSON serialization of room state
-                            println!(
-                                r#"{{"status": "success", "contract_key": "{}"}}"#,
-                                contract_key.id()
+                            let cfg = &room_state.configuration.configuration;
+                            let json = contract_get_summary_json(
+                                &contract_key.id().to_string(),
+                                cfg.configuration_version,
+                                &cfg.display.name.to_string_lossy(),
+                                room_state.members.members.len(),
+                                room_state.recent_messages.messages.len(),
                             );
+                            println!("{}", serde_json::to_string_pretty(&json)?);
                         }
                     }
                     Ok(())
@@ -348,4 +374,24 @@ fn parse_owner_key(room_owner_key: &str) -> Result<VerifyingKey> {
     let mut key_bytes = [0u8; 32];
     key_bytes.copy_from_slice(&decoded);
     VerifyingKey::from_bytes(&key_bytes).map_err(|e| anyhow!("Invalid verifying key: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contract_get_summary_json_includes_room_fields() {
+        // Regression guard: the JSON branch of `debug contract-get` used to
+        // emit only `{"status":"success","contract_key":...}` (a TODO stub),
+        // dropping every field the human branch prints. Ensure the summary
+        // now carries them.
+        let json = contract_get_summary_json("CONTRACTKEY123", 7, "My Room", 3, 42);
+        assert_eq!(json["status"], "success");
+        assert_eq!(json["contract_key"], "CONTRACTKEY123");
+        assert_eq!(json["configuration_version"], 7);
+        assert_eq!(json["room_name"], "My Room");
+        assert_eq!(json["member_count"], 3);
+        assert_eq!(json["message_count"], 42);
+    }
 }

--- a/cli/src/commands/room.rs
+++ b/cli/src/commands/room.rs
@@ -81,6 +81,20 @@ pub enum RoomCommands {
     },
 }
 
+/// Build the JSON payload emitted by `room join --format json`.
+///
+/// `room join` cannot make the caller a member (River requires an
+/// invitation chain back to the owner), so it reports an `unsupported`
+/// status plus the actionable next step rather than emitting nothing.
+fn join_requires_invitation_json(room_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "status": "unsupported",
+        "room_id": room_id,
+        "reason": "joining a room requires an invitation",
+        "hint": "riverctl invite accept <invitation-code>",
+    })
+}
+
 pub async fn execute(command: RoomCommands, api: ApiClient, format: OutputFormat) -> Result<()> {
     match command {
         RoomCommands::Create { name, nickname } => {
@@ -182,9 +196,24 @@ pub async fn execute(command: RoomCommands, api: ApiClient, format: OutputFormat
             }
         }
         RoomCommands::Join { room_id } => {
-            if !matches!(format, OutputFormat::Json) {
-                eprintln!("Joining room: {}", room_id);
-                eprintln!("To join a room, you need an invitation. Use 'riverctl invite accept <invitation-code>'");
+            // River has no "open join": membership requires an invitation
+            // chain back to the room owner (see the State Authorization Rule),
+            // so there is nothing for this command to execute. Make that
+            // explicit in both output modes instead of printing a misleading
+            // "Joining room" line (and, in JSON mode, instead of emitting
+            // nothing at all).
+            match format {
+                OutputFormat::Human => {
+                    println!("{}", "Joining a room requires an invitation.".yellow());
+                    println!("Ask an existing member for an invitation code, then run:");
+                    println!("  riverctl invite accept <invitation-code>");
+                }
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&join_requires_invitation_json(&room_id))?
+                    );
+                }
             }
             Ok(())
         }
@@ -430,4 +459,21 @@ struct CreateRoomResult {
     room_name: String,
     owner_key: String,
     contract_key: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn join_json_reports_unsupported_with_invitation_hint() {
+        // Regression guard: `room join --format json` used to emit nothing
+        // (silent exit 0). It must now return a structured, actionable
+        // payload naming the room and pointing at `invite accept`.
+        let json = join_requires_invitation_json("ROOMOWNERKEY");
+        assert_eq!(json["status"], "unsupported");
+        assert_eq!(json["room_id"], "ROOMOWNERKEY");
+        assert!(json["reason"].as_str().unwrap().contains("invitation"));
+        assert_eq!(json["hint"], "riverctl invite accept <invitation-code>");
+    }
 }


### PR DESCRIPTION
## Problem

A River user reported that `riverctl room leave` "isn't yet implemented." It actually *is* implemented in `main` (#327) but hasn't shipped to crates.io yet (published 0.1.65 predates #327). While confirming that, I swept the rest of the CLI for the same class of gap — commands that look like they do something but are silent no-ops.

Two genuine stubs remained:

1. **`room join`** — printed a misleading `Joining room: <id>` line, and in `--format json` mode emitted **nothing** while exiting 0. River has no open-join: membership requires an invitation chain back to the owner (State Authorization Rule), so the command cannot make you a member.
2. **`debug contract-get --format json`** — emitted only `{"status":"success","contract_key":...}` (a `// TODO: Implement proper JSON serialization` stub), dropping the configuration version, room name, member count, and message count that the human branch already prints.

(Considered and deliberately left alone: `config.rs::Config::load()` is a TODO too, but `Config` is `#[allow(dead_code)]` and never read — implementing a config-file loader would add a feature nothing consumes.)

## Approach

- `room join`: state honestly, in both output modes, that joining needs an invitation; JSON now returns a structured `unsupported` payload naming the room and pointing at `invite accept` (no more silent empty output).
- `debug contract-get` JSON: emit the same summary fields as the human branch.
- Each fix extracts a small pure JSON helper so the output shape is unit-testable without a live node.

These are UX/output-completeness fixes only — no protocol, wire-format, contract, or delegate WASM changes; no version bump (a separate release is being prepared).

## Testing

- `contract_get_summary_json_includes_room_fields` — pins the debug JSON now carries all summary fields.
- `join_json_reports_unsupported_with_invitation_hint` — pins `room join --format json` returns the actionable payload instead of nothing.
- `cargo test -p riverctl --lib` green (87 tests); `cargo clippy -p riverctl --all-targets` clean; `cargo fmt` applied.

[AI-assisted - Claude]