### PR TITLE
feat(cli): add `riverctl dm accept` for invitations received via DM

### DIFF
--- a/.claude/rules/direct-messages.md
+++ b/.claude/rules/direct-messages.md
@@ -63,6 +63,18 @@ co-member" entry and the cross-room "is target already a member" filter
 are deferred (per-room identities make the filter structurally
 infeasible without a global-identity layer).
 
+**Accepting an invite DM.** The UI's invitation card Accept button decodes
+the embedded `Invitation` and routes through `present_invitation`. The CLI
+counterpart is `riverctl dm accept <carrier_room_id> [--from <sender>]
+[--room <target>]` (`cli/src/commands/dm.rs::execute_accept`): it decrypts
+the carrier room's inbound DMs, keeps the `Invite` bodies, validates each
+embedded `Invitation`'s target against its advertised `room_owner_vk`
+(`decode_invitation_from_payload`), selects a single valid invitation
+(`select_invite_to_accept` — malformed candidates are skipped, not fatal),
+and joins via the shared `ApiClient::accept_invitation_struct` — the same
+core the base58 `invite accept` path uses, so the #308 re-accept guard and
+`room_secrets` persistence are identical across both entry points.
+
 ## Placeholder render
 
 `BodyKind::{Plaintext, Placeholder}` in `dm_thread_modal.rs` routes

--- a/cli/README.md
+++ b/cli/README.md
@@ -73,6 +73,7 @@ riverctl member ban          <room-owner-vk> <member-vk>   # Owner only.
 | `message`  | `send`, `list`, `stream`, `edit`, `delete`, `react`, `unreact`, `reply` |
 | `member`   | `list`, `set-nickname`, `ban`                                           |
 | `invite`   | `create`, `accept`                                                      |
+| `dm`       | `send`, `list`, `purge`, `accept`                                       |
 | `identity` | `export`, `import`                                                      |
 | `debug`    | troubleshooting utilities                                               |
 

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -1132,14 +1132,32 @@ impl ApiClient {
         invitation_code: &str,
         nickname: &str,
     ) -> Result<(VerifyingKey, ContractKey)> {
-        info!("Accepting invitation with nickname: {}", nickname);
-
-        // Decode the invitation
+        // Decode the base58 invitation code, then defer to the struct-based
+        // path shared with `dm accept` (which already holds a decoded
+        // `Invitation` extracted from an invite DM's CBOR payload).
         let decoded = bs58::decode(invitation_code)
             .into_vec()
             .map_err(|e| anyhow!("Failed to decode invitation: {}", e))?;
         let invitation: Invitation = ciborium::de::from_reader(&decoded[..])
             .map_err(|e| anyhow!("Failed to deserialize invitation: {}", e))?;
+
+        self.accept_invitation_struct(invitation, nickname).await
+    }
+
+    /// Accept a pre-decoded [`Invitation`]. This is the shared core of
+    /// invitation acceptance, called both by [`Self::accept_invitation`]
+    /// (which decodes the base58 `?invitation=…` code first) and by the
+    /// `dm accept` command (which decodes the CBOR `Invitation` carried
+    /// inside a [`river_core::room_state::dm_body::DirectMessageBody::Invite`]
+    /// DM). Keeping a single body means the re-accept guard, room GET,
+    /// invite-chain walk, secret persistence, and join-delta publish stay
+    /// byte-identical across both entry points.
+    pub async fn accept_invitation_struct(
+        &self,
+        invitation: Invitation,
+        nickname: &str,
+    ) -> Result<(VerifyingKey, ContractKey)> {
+        info!("Accepting invitation with nickname: {}", nickname);
 
         let room_owner_vk = invitation.room;
         let contract_key = self.owner_vk_to_contract_key(&room_owner_vk);
@@ -4257,19 +4275,22 @@ mod reaccept_guard_tests {
         );
     }
 
-    /// Source-grep pin: `accept_invitation` MUST consult `get_room` and bail
-    /// via `reaccept_refusal_error` BEFORE doing the network GET that rebuilds
-    /// the `StoredRoomInfo`. A refactor that drops this guard would silently
-    /// reintroduce the #308 clobber, which no pure unit test can catch because
-    /// `accept_invitation` requires a live Freenet node end-to-end.
+    /// Source-grep pin: the shared `accept_invitation_struct` core MUST
+    /// consult `get_room` and bail via `reaccept_refusal_error` BEFORE doing
+    /// the network GET that rebuilds the `StoredRoomInfo`. A refactor that
+    /// drops this guard would silently reintroduce the #308 clobber, which no
+    /// pure unit test can catch because the accept path requires a live
+    /// Freenet node end-to-end. The guard lives in `accept_invitation_struct`
+    /// (shared by the base58 `invite accept` path and the `dm accept` path),
+    /// so pinning it there protects BOTH entry points at once.
     #[test]
     fn accept_invitation_has_reaccept_guard() {
         let api_src = include_str!("api.rs");
-        // Pin the guard within the accept_invitation body: find the function,
+        // Pin the guard within the shared accept body: find the function,
         // then assert the guard appears before the network GET request.
         let accept_idx = api_src
-            .find("pub async fn accept_invitation(")
-            .expect("accept_invitation must exist");
+            .find("pub async fn accept_invitation_struct(")
+            .expect("accept_invitation_struct must exist");
         let body = &api_src[accept_idx..];
         let guard_idx = body
             .find("if self.storage.get_room(&room_owner_vk)?.is_some() {")

--- a/cli/src/commands/dm.rs
+++ b/cli/src/commands/dm.rs
@@ -90,10 +90,16 @@ pub enum DmCommands {
         /// thread contains the invitation.
         room_id: String,
         /// Only consider invite DMs sent by this member (short MemberId
-        /// prefix accepted). Use this to disambiguate when you have invite
-        /// DMs to several rooms.
+        /// prefix accepted). Narrows by *sender*; if a single sender invited
+        /// you to several rooms, disambiguate with `--room` instead.
         #[arg(long)]
         from: Option<String>,
+        /// Only consider invitations to this *target* room (base58 prefix of
+        /// the target room's owner key — e.g. the 8-char prefix shown by
+        /// `dm list`). Use this to pick one when invitations to several rooms
+        /// are present, including several from the same sender.
+        #[arg(long)]
+        room: Option<String>,
         /// Your nickname in the room you are joining.
         #[arg(short = 'N', long)]
         nickname: Option<String>,
@@ -117,8 +123,19 @@ pub async fn execute(command: DmCommands, api: ApiClient, format: OutputFormat) 
         DmCommands::Accept {
             room_id,
             from,
+            room,
             nickname,
-        } => execute_accept(api, format, &room_id, from.as_deref(), nickname).await,
+        } => {
+            execute_accept(
+                api,
+                format,
+                &room_id,
+                from.as_deref(),
+                room.as_deref(),
+                nickname,
+            )
+            .await
+        }
     }
 }
 
@@ -456,6 +473,12 @@ async fn execute_list(
             .then(a.timestamp.cmp(&b.timestamp))
     });
 
+    // Whether any inbound invite DM exists — computed BEFORE the per-thread
+    // cap below so a `dm accept`able invite that scrolled off a chatty thread
+    // still surfaces the discoverability tip (`dm accept` scans the full,
+    // uncapped state regardless of what `dm list` chose to print).
+    let any_invite = decrypted.iter().any(|dm| dm.is_invite);
+
     // Group + cap per counterparty.
     let mut by_peer: HashMap<MemberId, Vec<DecryptedDm>> = HashMap::new();
     for dm in decrypted {
@@ -497,10 +520,11 @@ async fn execute_list(
             // Discoverability: invite-via-DM (#252) bodies render as
             // `[Invitation to room …]` but aren't actionable until the user
             // knows the accept command. Point them at it when any is present.
-            if by_peer.values().flatten().any(|dm| dm.is_invite) {
+            if any_invite {
                 println!(
                     "Tip: accept an invitation that arrived as a DM with \
-                     `riverctl dm accept {room_id}` (add `--from <sender>` if several appear above)."
+                     `riverctl dm accept {room_id}` (narrow with `--from <sender>` or \
+                     `--room <target>` if you have several)."
                 );
             }
         }
@@ -641,16 +665,21 @@ async fn execute_purge(
 /// `DirectMessageBody::Invite` whose ECIES envelope only the recipient can
 /// open, so the invitation never appears as a base58 `?invitation=…` code the
 /// user could paste into `invite accept`. We decrypt every inbound DM in the
-/// carrier room, keep the ones that decode to an `Invite`, optionally filter
-/// by sender (`--from`), then accept the (single) target room through the same
+/// carrier room, keep the ones that decode to an `Invite`, narrow by sender
+/// (`--from`) and/or target room (`--room`), then pick a single valid
+/// invitation via [`select_invite_to_accept`] and join through the same
 /// `accept_invitation_struct` core the base58 `invite accept` path uses — so
 /// the re-accept guard, room GET, secret persistence and join publish are all
-/// byte-identical regardless of how the invitation arrived.
+/// byte-identical regardless of how the invitation arrived. (In particular the
+/// invitation's `room_secrets` flow through `accept_invitation_struct`
+/// unchanged, so a DM-borne private-room invite persists its secrets exactly
+/// like the URL path.)
 async fn execute_accept(
     api: ApiClient,
     format: OutputFormat,
     room_id: &str,
     from: Option<&str>,
+    room: Option<&str>,
     nickname: Option<String>,
 ) -> Result<()> {
     let room_owner_key = parse_room_id(room_id)?;
@@ -677,24 +706,106 @@ async fn execute_accept(
         });
     }
 
-    // Disambiguate to a single TARGET room. Multiple invites to the SAME
-    // target are fine — accepting any one joins that room — so collapse by
-    // target owner key and only refuse when distinct targets remain. The
-    // `room_owner_vk` field is the cheap-to-inspect copy of the target key;
-    // `decode_invitation_from_payload` later verifies it against the signed
-    // invitation before we act on it.
-    let distinct_targets: HashSet<[u8; 32]> = invites
-        .iter()
-        .map(|i| i.payload.room_owner_vk.to_bytes())
-        .collect();
+    let chosen = select_invite_to_accept(invites, room)?;
+    let nickname = resolve_nickname(nickname)?;
+
+    if !matches!(format, OutputFormat::Json) {
+        eprintln!(
+            "Accepting invitation to room {} (from {})...",
+            short_room_key(&chosen.target),
+            short_member_id(&chosen.sender)
+        );
+    }
+
+    let (room_owner_vk, contract_key) = api
+        .accept_invitation_struct(chosen.invitation, &nickname)
+        .await?;
+    print_invitation_accepted(format, &room_owner_vk, &contract_key);
+    Ok(())
+}
+
+/// A decoded, room-matched invite candidate — an [`InboundInvite`] whose
+/// embedded `Invitation` decoded cleanly and targets the room its payload
+/// advertised.
+#[derive(Debug)]
+struct ValidInvite {
+    sender: MemberId,
+    timestamp: u64,
+    target: VerifyingKey,
+    invitation: Invitation,
+}
+
+/// Choose the single invitation `dm accept` should act on, or explain why it
+/// can't. Pure (no I/O) so the selection rules are unit-testable.
+///
+/// Steps, in order:
+/// 1. **Target filter.** When `room_filter` is set, drop invites whose target
+///    room's base58 key doesn't start with the given prefix.
+/// 2. **Decode + validate.** Decode each remaining invite's embedded
+///    `Invitation` and keep only the well-formed, room-matched ones
+///    (`decode_invitation_from_payload`). Malformed invites — undecodable CBOR
+///    or a target-room mismatch — are dropped, NOT fatal: a later corrupt or
+///    malicious invite to a room must not block accepting an earlier valid one
+///    (Codex review of #343). If every candidate is malformed we say so, with
+///    a count.
+/// 3. **Disambiguate.** If the surviving valid invites target more than one
+///    distinct room, refuse and list them, pointing at `--room` / `--from`.
+/// 4. **Pick newest.** For the single surviving target, take the highest
+///    `timestamp`. Several valid invites to one room are interchangeable
+///    bearer credentials, so the choice only needs to be deterministic.
+fn select_invite_to_accept(
+    invites: Vec<InboundInvite>,
+    room_filter: Option<&str>,
+) -> Result<ValidInvite> {
+    let filtered: Vec<InboundInvite> = match room_filter {
+        Some(prefix) => invites
+            .into_iter()
+            .filter(|i| {
+                bs58::encode(i.payload.room_owner_vk.as_bytes())
+                    .into_string()
+                    .starts_with(prefix)
+            })
+            .collect(),
+        None => invites,
+    };
+    if filtered.is_empty() {
+        return Err(anyhow!(
+            "No invitation DMs target a room matching '{}'. Drop or widen `--room`.",
+            room_filter.unwrap_or_default()
+        ));
+    }
+
+    // Decode + validate; drop (don't fail on) malformed invites.
+    let total = filtered.len();
+    let mut valid: Vec<ValidInvite> = Vec::new();
+    for inv in &filtered {
+        if let Ok(invitation) = decode_invitation_from_payload(&inv.payload) {
+            valid.push(ValidInvite {
+                sender: inv.sender,
+                timestamp: inv.timestamp,
+                target: inv.payload.room_owner_vk,
+                invitation,
+            });
+        }
+    }
+    if valid.is_empty() {
+        return Err(anyhow!(
+            "All {} matching invitation DM(s) were malformed (undecodable, or targeting a \
+             mismatched room) and were skipped. Nothing to accept.",
+            total
+        ));
+    }
+
+    // Disambiguate to a single target room among the VALID invites.
+    let distinct_targets: HashSet<[u8; 32]> = valid.iter().map(|v| v.target.to_bytes()).collect();
     if distinct_targets.len() > 1 {
-        let mut lines: Vec<String> = invites
+        let mut lines: Vec<String> = valid
             .iter()
-            .map(|i| {
+            .map(|v| {
                 format!(
                     "  - room {} (from {})",
-                    short_room_key(&i.payload.room_owner_vk),
-                    short_member_id(&i.sender)
+                    short_room_key(&v.target),
+                    short_member_id(&v.sender)
                 )
             })
             .collect();
@@ -702,34 +813,18 @@ async fn execute_accept(
         lines.dedup();
         return Err(anyhow!(
             "Found invitations to {} different rooms in this DM thread:\n{}\n\
-             Re-run with `--from <sender prefix>` to choose which one to accept.",
+             Re-run with `--room <target room prefix>` (or `--from <sender prefix>`) to pick one.",
             distinct_targets.len(),
             lines.join("\n")
         ));
     }
 
-    // Single target room: accept the most recent invite to it. Each invite
-    // carries its own invitee signing key, so picking the newest is arbitrary
-    // but deterministic — any valid invitation to the room joins it.
-    let chosen = invites
-        .iter()
-        .max_by_key(|i| i.timestamp)
-        .expect("invites is non-empty (checked above)");
-
-    let invitation = decode_invitation_from_payload(&chosen.payload)?;
-    let nickname = resolve_nickname(nickname)?;
-
-    if !matches!(format, OutputFormat::Json) {
-        eprintln!(
-            "Accepting invitation to room {} (from {})...",
-            short_room_key(&chosen.payload.room_owner_vk),
-            short_member_id(&chosen.sender)
-        );
-    }
-
-    let (room_owner_vk, contract_key) = api.accept_invitation_struct(invitation, &nickname).await?;
-    print_invitation_accepted(format, &room_owner_vk, &contract_key);
-    Ok(())
+    // Single target: newest valid invite. `max_by_key` returns the last
+    // maximal element on ties, which is fine — interchangeable credentials.
+    Ok(valid
+        .into_iter()
+        .max_by_key(|v| v.timestamp)
+        .expect("valid is non-empty (checked above)"))
 }
 
 // ---------------------------------------------------------------------------
@@ -759,11 +854,14 @@ struct InboundInvite {
 /// Decrypt every inbound DM in `state` addressed to the local member and
 /// return those that decode to a `DirectMessageBody::Invite`. `from_filter`,
 /// when set, keeps only invites whose sender's MemberId string starts with
-/// the given prefix (same prefix-matching convention as `dm list --with`).
-/// Pure (no I/O) so `dm accept`'s selection logic is unit-testable against a
-/// hand-built room state. Undecryptable or undecodable DMs are skipped rather
-/// than failing the whole command — a single corrupt entry shouldn't block
-/// accepting a valid invitation.
+/// the given prefix. This is a plain `starts_with` on the MemberId — unlike
+/// `dm list --with` (which routes through `resolve_recipient_vk`) it does NOT
+/// consult the member list or error on an ambiguous prefix; over-broad
+/// filters simply fall through to the target-room disambiguation in
+/// [`select_invite_to_accept`]. Pure (no I/O) so `dm accept`'s selection
+/// logic is unit-testable against a hand-built room state. Undecryptable or
+/// undecodable DMs are skipped rather than failing the whole command — a
+/// single corrupt entry shouldn't block accepting a valid invitation.
 fn collect_inbound_invites(
     state: &ChatRoomStateV1,
     signing_key: &SigningKey,
@@ -797,12 +895,15 @@ fn collect_inbound_invites(
     out
 }
 
-/// Decode the CBOR `Invitation` embedded in an [`InvitePayload`] and verify it
-/// targets the room the payload advertises. The target room key is carried
-/// twice — once in the cheap-to-inspect `room_owner_vk` field and once inside
-/// the signed `Invitation` — and the `dm_body` docs say a client SHOULD reject
-/// a mismatch as malformed (the cleartext "which room" hint disagreeing with
-/// the credential we'd actually act on).
+/// Decode the CBOR `Invitation` embedded in an [`InvitePayload`] and
+/// cross-check that it targets the room the payload advertises. The target
+/// room key is carried twice — once in the cheap-to-inspect `room_owner_vk`
+/// field and once inside the `Invitation` — and the `dm_body` docs say a
+/// client SHOULD reject a mismatch as malformed (the cleartext "which room"
+/// hint disagreeing with the credential we'd act on). This is a field-equality
+/// check, NOT cryptographic verification: authorization is enforced by the
+/// room contract when the join delta is published (same as `invite accept`),
+/// so this only stops us acting on a self-inconsistent / spoofed-hint DM.
 fn decode_invitation_from_payload(payload: &InvitePayload) -> Result<Invitation> {
     let invitation: Invitation = ciborium::de::from_reader(&payload.invitation_payload[..])
         .map_err(|e| anyhow!("Invite DM carried an undecodable invitation: {}", e))?;
@@ -1490,5 +1591,131 @@ mod tests {
             personal_message: None,
         };
         assert!(decode_invitation_from_payload(&garbage).is_err());
+    }
+
+    /// Build an `InboundInvite` for `select_invite_to_accept` tests. A `valid`
+    /// invite carries a well-formed, room-matched `Invitation`; otherwise the
+    /// payload is garbage CBOR that fails to decode.
+    fn inbound(sender: &SigningKey, target: &SigningKey, ts: u64, valid: bool) -> InboundInvite {
+        let payload_bytes = if valid {
+            encode_invitation(target)
+        } else {
+            vec![0xde, 0xad, 0xbe, 0xef]
+        };
+        InboundInvite {
+            sender: MemberId::from(&sender.verifying_key()),
+            timestamp: ts,
+            payload: InvitePayload {
+                room_owner_vk: target.verifying_key(),
+                invitation_payload: payload_bytes,
+                personal_message: None,
+            },
+        }
+    }
+
+    /// Several valid invites to ONE target collapse to that target, and the
+    /// newest (highest timestamp) is chosen.
+    #[test]
+    fn select_picks_newest_valid_for_single_target() {
+        let alice = key(2);
+        let target_a = key(20);
+        let chosen = select_invite_to_accept(
+            vec![
+                inbound(&alice, &target_a, 100, true),
+                inbound(&alice, &target_a, 200, true),
+            ],
+            None,
+        )
+        .expect("single target should select");
+        assert_eq!(chosen.target, target_a.verifying_key());
+        assert_eq!(chosen.timestamp, 200, "newest valid invite wins");
+    }
+
+    /// Codex #343 P2: a malformed NEWER invite to a target must not block
+    /// accepting an older VALID invite to the same target.
+    #[test]
+    fn select_skips_malformed_newest_falls_back_to_valid() {
+        let alice = key(2);
+        let target_a = key(20);
+        let chosen = select_invite_to_accept(
+            vec![
+                inbound(&alice, &target_a, 100, true),  // valid, older
+                inbound(&alice, &target_a, 200, false), // malformed, newer
+            ],
+            None,
+        )
+        .expect("should fall back to the older valid invite");
+        assert_eq!(chosen.target, target_a.verifying_key());
+        assert_eq!(chosen.timestamp, 100, "the valid invite is selected");
+    }
+
+    /// When every candidate is malformed, selection fails with a clear message
+    /// rather than picking one and aborting deep in the accept path.
+    #[test]
+    fn select_errors_when_all_malformed() {
+        let alice = key(2);
+        let target_a = key(20);
+        let err = select_invite_to_accept(vec![inbound(&alice, &target_a, 100, false)], None)
+            .expect_err("all-malformed must error");
+        assert!(err.to_string().contains("malformed"), "got: {err}");
+    }
+
+    /// Valid invites to DISTINCT target rooms are ambiguous and refused with a
+    /// listing pointing at the disambiguating flags.
+    #[test]
+    fn select_errors_on_distinct_targets() {
+        let alice = key(2);
+        let bob = key(3);
+        let target_a = key(20);
+        let target_b = key(21);
+        let err = select_invite_to_accept(
+            vec![
+                inbound(&alice, &target_a, 100, true),
+                inbound(&bob, &target_b, 100, true),
+            ],
+            None,
+        )
+        .expect_err("distinct targets must be ambiguous");
+        assert!(err.to_string().contains("different rooms"), "got: {err}");
+    }
+
+    /// Codex #343 P2: `--room` resolves the same-sender-multiple-rooms case
+    /// that `--from` cannot.
+    #[test]
+    fn select_room_filter_disambiguates_same_sender_two_rooms() {
+        let alice = key(2);
+        let target_a = key(20);
+        let target_b = key(21);
+        let invites = || {
+            vec![
+                inbound(&alice, &target_a, 100, true),
+                inbound(&alice, &target_b, 100, true),
+            ]
+        };
+
+        // No room filter → ambiguous even though it's one sender.
+        assert!(select_invite_to_accept(invites(), None).is_err());
+
+        // `--room <prefix of B>` → unambiguously picks room B.
+        let b_prefix: String = bs58::encode(target_b.verifying_key().as_bytes())
+            .into_string()
+            .chars()
+            .take(12)
+            .collect();
+        let chosen = select_invite_to_accept(invites(), Some(&b_prefix))
+            .expect("room filter should disambiguate");
+        assert_eq!(chosen.target, target_b.verifying_key());
+    }
+
+    /// A `--room` prefix matching no invite errors rather than silently
+    /// selecting an unrelated invitation.
+    #[test]
+    fn select_room_filter_no_match_errors() {
+        let alice = key(2);
+        let target_a = key(20);
+        let err =
+            select_invite_to_accept(vec![inbound(&alice, &target_a, 100, true)], Some("zzzz"))
+                .expect_err("no-match room filter must error");
+        assert!(err.to_string().contains("matching"), "got: {err}");
     }
 }

--- a/cli/src/commands/dm.rs
+++ b/cli/src/commands/dm.rs
@@ -8,20 +8,21 @@
 //! the sender + recipient signatures, both produced from helpers that live
 //! in the `river-core` crate.
 
-use crate::api::ApiClient;
+use crate::api::{ApiClient, Invitation};
+use crate::commands::invite::{print_invitation_accepted, resolve_nickname};
 use crate::output::OutputFormat;
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Local, Utc};
 use clap::Subcommand;
-use ed25519_dalek::VerifyingKey;
+use ed25519_dalek::{SigningKey, VerifyingKey};
 use river_core::chat_delegate::OutboundDmEntry;
 use river_core::room_state::direct_messages::{
     advance_recipient_purges, compose_direct_message, open_direct_message, pair_message_count,
     PurgeToken, MAX_DM_MESSAGES_PER_PAIR,
 };
-use river_core::room_state::dm_body::{decode_body, DirectMessageBody};
+use river_core::room_state::dm_body::{decode_body, DirectMessageBody, InvitePayload};
 use river_core::room_state::member::MemberId;
-use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1Delta};
+use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1, ChatRoomStateV1Delta};
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -72,6 +73,31 @@ pub enum DmCommands {
         /// `dm list` output.
         token: String,
     },
+    /// Accept a room invitation that arrived as a direct message.
+    ///
+    /// The River UI can "share an invite via DM" (#252): the invitation is
+    /// embedded in a DM rather than handed over as an `?invitation=…` link.
+    /// Such DMs show up in `dm list <room_id>` as `[Invitation to room …]`.
+    /// This command finds that invite DM, decodes the embedded invitation,
+    /// and joins the target room — the CLI counterpart of the UI's "Accept"
+    /// button on the invitation card.
+    ///
+    /// `room_id` is the room the invite DM was *received in* (the carrier
+    /// room), NOT the room you are joining. If you have invite DMs to more
+    /// than one room, narrow the selection with `--from`.
+    Accept {
+        /// Carrier room ID (base58 room owner key) — the room whose DM
+        /// thread contains the invitation.
+        room_id: String,
+        /// Only consider invite DMs sent by this member (short MemberId
+        /// prefix accepted). Use this to disambiguate when you have invite
+        /// DMs to several rooms.
+        #[arg(long)]
+        from: Option<String>,
+        /// Your nickname in the room you are joining.
+        #[arg(short = 'N', long)]
+        nickname: Option<String>,
+    },
 }
 
 pub async fn execute(command: DmCommands, api: ApiClient, format: OutputFormat) -> Result<()> {
@@ -88,6 +114,11 @@ pub async fn execute(command: DmCommands, api: ApiClient, format: OutputFormat) 
             since_minutes,
         } => execute_list(api, format, &room_id, with.as_deref(), limit, since_minutes).await,
         DmCommands::Purge { room_id, token } => execute_purge(api, format, &room_id, &token).await,
+        DmCommands::Accept {
+            room_id,
+            from,
+            nickname,
+        } => execute_accept(api, format, &room_id, from.as_deref(), nickname).await,
     }
 }
 
@@ -381,19 +412,23 @@ async fn execute_list(
         // peers). Outbound DMs go through the local plaintext cache as
         // before — the cache stores the user-facing string regardless of
         // wire shape.
-        let body_str = if is_self_recipient {
+        let (body_str, is_invite) = if is_self_recipient {
             match open_direct_message(&signing_key, msg) {
                 Ok(bytes) => match decode_body(&bytes) {
-                    Ok(body) => format_dm_body_for_cli(&body, &nicknames),
-                    Err(_) => "<unable to decode body>".to_string(),
+                    Ok(body) => {
+                        let invite = matches!(body, DirectMessageBody::Invite(_));
+                        (format_dm_body_for_cli(&body, &nicknames), invite)
+                    }
+                    Err(_) => ("<unable to decode body>".to_string(), false),
                 },
-                Err(_) => "<unable to decrypt>".to_string(),
+                Err(_) => ("<unable to decrypt>".to_string(), false),
             }
         } else {
-            match outbound_lookup.get(&(msg.message.recipient, msg.purge_token())) {
+            let plaintext = match outbound_lookup.get(&(msg.message.recipient, msg.purge_token())) {
                 Some(plaintext) => plaintext.clone(),
                 None => "<sent: ciphertext only>".to_string(),
-            }
+            };
+            (plaintext, false)
         };
 
         decrypted.push(DecryptedDm {
@@ -402,6 +437,7 @@ async fn execute_list(
             timestamp: msg.message.timestamp,
             body: body_str,
             token: msg.purge_token(),
+            is_invite,
         });
     }
 
@@ -458,6 +494,15 @@ async fn execute_list(
                 }
                 println!();
             }
+            // Discoverability: invite-via-DM (#252) bodies render as
+            // `[Invitation to room …]` but aren't actionable until the user
+            // knows the accept command. Point them at it when any is present.
+            if by_peer.values().flatten().any(|dm| dm.is_invite) {
+                println!(
+                    "Tip: accept an invitation that arrived as a DM with \
+                     `riverctl dm accept {room_id}` (add `--from <sender>` if several appear above)."
+                );
+            }
         }
         OutputFormat::Json => {
             let threads: Vec<_> = by_peer
@@ -480,6 +525,7 @@ async fn execute_list(
                                     "timestamp_unix": dm.timestamp,
                                     "body": dm.body,
                                     "purge_token": hex_token(&dm.token),
+                                    "is_invitation": dm.is_invite,
                                 })
                             })
                             .collect::<Vec<_>>(),
@@ -589,6 +635,103 @@ async fn execute_purge(
     Ok(())
 }
 
+/// `dm accept` — join a room from an invitation that arrived as a DM.
+///
+/// The invite-via-DM flow (#252) embeds a CBOR `Invitation` inside a
+/// `DirectMessageBody::Invite` whose ECIES envelope only the recipient can
+/// open, so the invitation never appears as a base58 `?invitation=…` code the
+/// user could paste into `invite accept`. We decrypt every inbound DM in the
+/// carrier room, keep the ones that decode to an `Invite`, optionally filter
+/// by sender (`--from`), then accept the (single) target room through the same
+/// `accept_invitation_struct` core the base58 `invite accept` path uses — so
+/// the re-accept guard, room GET, secret persistence and join publish are all
+/// byte-identical regardless of how the invitation arrived.
+async fn execute_accept(
+    api: ApiClient,
+    format: OutputFormat,
+    room_id: &str,
+    from: Option<&str>,
+    nickname: Option<String>,
+) -> Result<()> {
+    let room_owner_key = parse_room_id(room_id)?;
+    let (signing_key, _, _) = api.storage().get_room(&room_owner_key)?.ok_or_else(|| {
+        anyhow!("Room not found. You must be a member of the carrier room to read its invite DMs.")
+    })?;
+
+    let room_state = api.get_room(&room_owner_key, false).await?;
+
+    let invites = collect_inbound_invites(&room_state, &signing_key, from);
+    if invites.is_empty() {
+        return Err(match from {
+            Some(f) => anyhow!(
+                "No invitation DMs from a sender matching '{}' were found in this room. \
+                 Run `riverctl dm list {}` to see who sent you invitations.",
+                f,
+                room_id
+            ),
+            None => anyhow!(
+                "No invitation DMs found in this room. An invitation sent via DM appears in \
+                 `riverctl dm list {}` as `[Invitation to room …]`.",
+                room_id
+            ),
+        });
+    }
+
+    // Disambiguate to a single TARGET room. Multiple invites to the SAME
+    // target are fine — accepting any one joins that room — so collapse by
+    // target owner key and only refuse when distinct targets remain. The
+    // `room_owner_vk` field is the cheap-to-inspect copy of the target key;
+    // `decode_invitation_from_payload` later verifies it against the signed
+    // invitation before we act on it.
+    let distinct_targets: HashSet<[u8; 32]> = invites
+        .iter()
+        .map(|i| i.payload.room_owner_vk.to_bytes())
+        .collect();
+    if distinct_targets.len() > 1 {
+        let mut lines: Vec<String> = invites
+            .iter()
+            .map(|i| {
+                format!(
+                    "  - room {} (from {})",
+                    short_room_key(&i.payload.room_owner_vk),
+                    short_member_id(&i.sender)
+                )
+            })
+            .collect();
+        lines.sort();
+        lines.dedup();
+        return Err(anyhow!(
+            "Found invitations to {} different rooms in this DM thread:\n{}\n\
+             Re-run with `--from <sender prefix>` to choose which one to accept.",
+            distinct_targets.len(),
+            lines.join("\n")
+        ));
+    }
+
+    // Single target room: accept the most recent invite to it. Each invite
+    // carries its own invitee signing key, so picking the newest is arbitrary
+    // but deterministic — any valid invitation to the room joins it.
+    let chosen = invites
+        .iter()
+        .max_by_key(|i| i.timestamp)
+        .expect("invites is non-empty (checked above)");
+
+    let invitation = decode_invitation_from_payload(&chosen.payload)?;
+    let nickname = resolve_nickname(nickname)?;
+
+    if !matches!(format, OutputFormat::Json) {
+        eprintln!(
+            "Accepting invitation to room {} (from {})...",
+            short_room_key(&chosen.payload.room_owner_vk),
+            short_member_id(&chosen.sender)
+        );
+    }
+
+    let (room_owner_vk, contract_key) = api.accept_invitation_struct(invitation, &nickname).await?;
+    print_invitation_accepted(format, &room_owner_vk, &contract_key);
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -599,6 +742,77 @@ struct DecryptedDm {
     timestamp: u64,
     body: String,
     token: PurgeToken,
+    /// True when the decrypted body decoded to a
+    /// `DirectMessageBody::Invite` — drives the `dm list` "accept with…"
+    /// footer tip and the `is_invitation` JSON field.
+    is_invite: bool,
+}
+
+/// One inbound DM that decoded to a `DirectMessageBody::Invite`, surfaced by
+/// [`collect_inbound_invites`] for `dm accept`.
+struct InboundInvite {
+    sender: MemberId,
+    timestamp: u64,
+    payload: InvitePayload,
+}
+
+/// Decrypt every inbound DM in `state` addressed to the local member and
+/// return those that decode to a `DirectMessageBody::Invite`. `from_filter`,
+/// when set, keeps only invites whose sender's MemberId string starts with
+/// the given prefix (same prefix-matching convention as `dm list --with`).
+/// Pure (no I/O) so `dm accept`'s selection logic is unit-testable against a
+/// hand-built room state. Undecryptable or undecodable DMs are skipped rather
+/// than failing the whole command — a single corrupt entry shouldn't block
+/// accepting a valid invitation.
+fn collect_inbound_invites(
+    state: &ChatRoomStateV1,
+    signing_key: &SigningKey,
+    from_filter: Option<&str>,
+) -> Vec<InboundInvite> {
+    let self_id = MemberId::from(&signing_key.verifying_key());
+    let mut out = Vec::new();
+    for msg in &state.direct_messages.messages {
+        if msg.message.recipient != self_id {
+            continue;
+        }
+        if let Some(prefix) = from_filter {
+            if !msg.message.sender.to_string().starts_with(prefix) {
+                continue;
+            }
+        }
+        let Ok(bytes) = open_direct_message(signing_key, msg) else {
+            continue;
+        };
+        let Ok(body) = decode_body(&bytes) else {
+            continue;
+        };
+        if let DirectMessageBody::Invite(payload) = body {
+            out.push(InboundInvite {
+                sender: msg.message.sender,
+                timestamp: msg.message.timestamp,
+                payload: *payload,
+            });
+        }
+    }
+    out
+}
+
+/// Decode the CBOR `Invitation` embedded in an [`InvitePayload`] and verify it
+/// targets the room the payload advertises. The target room key is carried
+/// twice — once in the cheap-to-inspect `room_owner_vk` field and once inside
+/// the signed `Invitation` — and the `dm_body` docs say a client SHOULD reject
+/// a mismatch as malformed (the cleartext "which room" hint disagreeing with
+/// the credential we'd actually act on).
+fn decode_invitation_from_payload(payload: &InvitePayload) -> Result<Invitation> {
+    let invitation: Invitation = ciborium::de::from_reader(&payload.invitation_payload[..])
+        .map_err(|e| anyhow!("Invite DM carried an undecodable invitation: {}", e))?;
+    if invitation.room != payload.room_owner_vk {
+        return Err(anyhow!(
+            "Malformed invite DM: the embedded invitation targets a different room than the \
+             DM's advertised target. Refusing to act on it."
+        ));
+    }
+    Ok(invitation)
 }
 
 fn parse_room_id(room_id: &str) -> Result<VerifyingKey> {
@@ -696,6 +910,16 @@ fn hex_token(t: &PurgeToken) -> String {
 fn short_member_id(id: &MemberId) -> String {
     let s = id.to_string();
     s.chars().take(8).collect()
+}
+
+/// 8-char prefix of a room owner key's base58 form — the same abbreviation
+/// `dm list` shows for invite DMs, reused by `dm accept` diagnostics.
+fn short_room_key(vk: &VerifyingKey) -> String {
+    bs58::encode(vk.as_bytes())
+        .into_string()
+        .chars()
+        .take(8)
+        .collect()
 }
 
 /// Append a new outbound DM entry to the local cache, enforcing the
@@ -818,10 +1042,12 @@ fn unix_now() -> Result<u64> {
 /// * `Text` → the text itself.
 /// * `Invite` → a compact one-line summary so an inbound invite DM is
 ///   labelled distinctly from prose. The on-wire `invitation_payload`
-///   isn't decoded here — we just surface the room owner key (8-char
-///   prefix) so the recipient can `riverctl room accept` against the
-///   right target if they want to. Personal message (when present) is
-///   appended.
+///   isn't decoded here — we just surface the target room owner key (8-char
+///   prefix) so the recipient knows which room it's for. To actually join,
+///   run `riverctl dm accept <carrier room id>` (see [`execute_accept`]),
+///   which decodes the embedded invitation; `dm list` prints a tip pointing
+///   there whenever an invite DM is present. Personal message (when present)
+///   is appended.
 fn format_dm_body_for_cli(
     body: &DirectMessageBody,
     _nicknames: &HashMap<MemberId, String>,
@@ -829,11 +1055,7 @@ fn format_dm_body_for_cli(
     match body {
         DirectMessageBody::Text { text } => text.clone(),
         DirectMessageBody::Invite(payload) => {
-            let room_short: String = bs58::encode(payload.room_owner_vk.as_bytes())
-                .into_string()
-                .chars()
-                .take(8)
-                .collect();
+            let room_short = short_room_key(&payload.room_owner_vk);
             match &payload.personal_message {
                 Some(msg) if !msg.trim().is_empty() => {
                     format!("[Invitation to room {}…] {}", room_short, msg.trim())
@@ -1113,5 +1335,160 @@ mod tests {
         let bob_count = store.entries.iter().filter(|e| e.recipient == bob).count();
         assert_eq!(alice_count, MAX_DM_MESSAGES_PER_PAIR);
         assert_eq!(bob_count, 1);
+    }
+
+    // -----------------------------------------------------------------
+    // `dm accept` selection logic (#252 CLI parity)
+    // -----------------------------------------------------------------
+
+    use ed25519_dalek::SigningKey;
+    use river_core::room_state::dm_body::encode_body;
+    use river_core::room_state::member::{AuthorizedMember, Member};
+
+    fn key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    /// Build a structurally-valid CBOR `Invitation` for `target_owner`,
+    /// signed by `target_owner` as the inviter. Content beyond `room` is
+    /// inert for these tests — we only exercise decode + room-match.
+    fn encode_invitation(target_owner: &SigningKey) -> Vec<u8> {
+        let target_vk = target_owner.verifying_key();
+        let owner_id = MemberId::from(&target_vk);
+        let invitee_sk = key(200);
+        let member = Member {
+            owner_member_id: owner_id,
+            member_vk: invitee_sk.verifying_key(),
+            invited_by: owner_id,
+        };
+        let invitation = Invitation {
+            room: target_vk,
+            invitee_signing_key: invitee_sk,
+            invitee: AuthorizedMember::new(member, target_owner),
+            room_secrets: vec![],
+        };
+        let mut bytes = Vec::new();
+        ciborium::ser::into_writer(&invitation, &mut bytes).unwrap();
+        bytes
+    }
+
+    /// Compose an inbound DM addressed to `me` from `sender` carrying the
+    /// given body bytes, anchored in carrier room `carrier_owner`.
+    fn dm_to_me(
+        sender: &SigningKey,
+        me: &SigningKey,
+        carrier_owner: &VerifyingKey,
+        body: &[u8],
+        ts: u64,
+    ) -> river_core::room_state::direct_messages::AuthorizedDirectMessage {
+        compose_direct_message(sender, &me.verifying_key(), carrier_owner, ts, ts, body).unwrap()
+    }
+
+    fn invite_body(target_owner_vk: VerifyingKey, payload_bytes: Vec<u8>) -> Vec<u8> {
+        encode_body(&DirectMessageBody::Invite(Box::new(InvitePayload {
+            room_owner_vk: target_owner_vk,
+            invitation_payload: payload_bytes,
+            personal_message: None,
+        })))
+        .unwrap()
+    }
+
+    /// `collect_inbound_invites` returns only inbound `Invite` DMs: it skips
+    /// plain text DMs, DMs addressed to someone else, and honours the
+    /// `--from` sender prefix filter.
+    #[test]
+    fn collect_inbound_invites_filters_correctly() {
+        let me = key(1);
+        let alice = key(2);
+        let bob = key(3);
+        let other = key(4);
+        let carrier = key(10).verifying_key();
+        let target_a = key(20).verifying_key();
+        let target_b = key(21).verifying_key();
+        let ts = unix_now().unwrap();
+
+        let mut state = ChatRoomStateV1::default();
+        // Invite DM to me from Alice (target room A).
+        state.direct_messages.messages.push(dm_to_me(
+            &alice,
+            &me,
+            &carrier,
+            &invite_body(target_a, vec![1, 2, 3]),
+            ts,
+        ));
+        // Plain text DM to me from Alice — must be ignored.
+        state
+            .direct_messages
+            .messages
+            .push(dm_to_me(&alice, &me, &carrier, b"just chatting", ts));
+        // Invite DM to me from Bob (target room B).
+        state.direct_messages.messages.push(dm_to_me(
+            &bob,
+            &me,
+            &carrier,
+            &invite_body(target_b, vec![4, 5, 6]),
+            ts,
+        ));
+        // Invite DM addressed to someone ELSE — must be ignored.
+        state.direct_messages.messages.push(dm_to_me(
+            &alice,
+            &other,
+            &carrier,
+            &invite_body(target_a, vec![7, 8, 9]),
+            ts,
+        ));
+
+        // No filter: both invites addressed to me, none of the noise.
+        let all = collect_inbound_invites(&state, &me, None);
+        assert_eq!(all.len(), 2, "should find Alice's and Bob's invites only");
+
+        // `--from` Alice's MemberId prefix: just her invite.
+        let alice_id = MemberId::from(&alice.verifying_key()).to_string();
+        let from_alice = collect_inbound_invites(&state, &me, Some(&alice_id[..8]));
+        assert_eq!(from_alice.len(), 1);
+        assert_eq!(
+            from_alice[0].payload.room_owner_vk, target_a,
+            "Alice's invite targets room A"
+        );
+
+        // `--from` a prefix matching nobody: empty.
+        assert!(collect_inbound_invites(&state, &me, Some("zzzzzzzz")).is_empty());
+    }
+
+    /// `decode_invitation_from_payload` round-trips a matching invitation and
+    /// rejects one whose embedded `room` disagrees with the payload's
+    /// advertised `room_owner_vk` (malformed / spoofed invite DM).
+    #[test]
+    fn decode_invitation_from_payload_validates_room_match() {
+        let target = key(30);
+        let target_vk = target.verifying_key();
+        let bytes = encode_invitation(&target);
+
+        // Matching room_owner_vk → decodes to an invitation for that room.
+        let good = InvitePayload {
+            room_owner_vk: target_vk,
+            invitation_payload: bytes.clone(),
+            personal_message: None,
+        };
+        let inv = decode_invitation_from_payload(&good).expect("matching invite should decode");
+        assert_eq!(inv.room, target_vk);
+
+        // Mismatched room_owner_vk → rejected as malformed.
+        let mismatched = InvitePayload {
+            room_owner_vk: key(31).verifying_key(),
+            invitation_payload: bytes,
+            personal_message: None,
+        };
+        let err = decode_invitation_from_payload(&mismatched)
+            .expect_err("room mismatch must be rejected");
+        assert!(err.to_string().contains("different room"), "got: {err}");
+
+        // Garbage payload → decode error, not a panic.
+        let garbage = InvitePayload {
+            room_owner_vk: target_vk,
+            invitation_payload: vec![0xff, 0x00, 0x13, 0x37],
+            personal_message: None,
+        };
+        assert!(decode_invitation_from_payload(&garbage).is_err());
     }
 }

--- a/cli/src/commands/dm.rs
+++ b/cli/src/commands/dm.rs
@@ -84,7 +84,8 @@ pub enum DmCommands {
     ///
     /// `room_id` is the room the invite DM was *received in* (the carrier
     /// room), NOT the room you are joining. If you have invite DMs to more
-    /// than one room, narrow the selection with `--from`.
+    /// than one room, narrow the selection with `--from` (by sender) or
+    /// `--room` (by target room).
     Accept {
         /// Carrier room ID (base58 room owner key) — the room whose DM
         /// thread contains the invitation.
@@ -811,11 +812,21 @@ fn select_invite_to_accept(
             .collect();
         lines.sort();
         lines.dedup();
+        // Tailor the hint: if the user already passed `--room` and it still
+        // matched several rooms (a too-short prefix / prefix collision),
+        // telling them to "use --room" again is a dead-end — ask for a longer
+        // prefix instead.
+        let hint = if room_filter.is_some() {
+            "That `--room` prefix matches more than one room — pass a longer prefix \
+             (or add `--from <sender prefix>`) to pick one."
+        } else {
+            "Re-run with `--room <target room prefix>` (or `--from <sender prefix>`) to pick one."
+        };
         return Err(anyhow!(
-            "Found invitations to {} different rooms in this DM thread:\n{}\n\
-             Re-run with `--room <target room prefix>` (or `--from <sender prefix>`) to pick one.",
+            "Found invitations to {} different rooms in this DM thread:\n{}\n{}",
             distinct_targets.len(),
-            lines.join("\n")
+            lines.join("\n"),
+            hint
         ));
     }
 
@@ -1717,5 +1728,49 @@ mod tests {
             select_invite_to_accept(vec![inbound(&alice, &target_a, 100, true)], Some("zzzz"))
                 .expect_err("no-match room filter must error");
         assert!(err.to_string().contains("matching"), "got: {err}");
+    }
+
+    /// A too-broad `--room` that still matches several distinct targets must
+    /// fall through to the ambiguity error — never silently pick one. (The
+    /// empty prefix matches every target via `starts_with("")`, modelling a
+    /// prefix collision.)
+    #[test]
+    fn select_room_filter_too_broad_still_errors() {
+        let alice = key(2);
+        let bob = key(3);
+        let target_a = key(20);
+        let target_b = key(21);
+        let err = select_invite_to_accept(
+            vec![
+                inbound(&alice, &target_a, 100, true),
+                inbound(&bob, &target_b, 100, true),
+            ],
+            Some(""),
+        )
+        .expect_err("an over-broad --room must still error, not pick");
+        let msg = err.to_string();
+        assert!(msg.contains("different rooms"), "got: {msg}");
+        // The hint adapts: since `--room` was supplied, ask for a longer prefix.
+        assert!(msg.contains("longer prefix"), "got: {msg}");
+    }
+
+    /// A malformed invite to a DIFFERENT room must be dropped, not counted as a
+    /// second distinct target — otherwise it would spuriously block accepting
+    /// the one valid invite.
+    #[test]
+    fn select_drops_malformed_across_targets() {
+        let alice = key(2);
+        let bob = key(3);
+        let target_a = key(20);
+        let target_b = key(21);
+        let chosen = select_invite_to_accept(
+            vec![
+                inbound(&alice, &target_a, 100, true), // valid → room A
+                inbound(&bob, &target_b, 200, false),  // malformed → room B, dropped
+            ],
+            None,
+        )
+        .expect("the lone valid invite should be selected");
+        assert_eq!(chosen.target, target_a.verifying_key());
     }
 }

--- a/cli/src/commands/invite.rs
+++ b/cli/src/commands/invite.rs
@@ -4,6 +4,7 @@ use anyhow::{anyhow, Result};
 use clap::Subcommand;
 use colored::Colorize;
 use ed25519_dalek::VerifyingKey;
+use freenet_stdlib::prelude::ContractKey;
 
 #[derive(Subcommand)]
 pub enum InviteCommands {
@@ -77,20 +78,7 @@ pub async fn execute(command: InviteCommands, api: ApiClient, format: OutputForm
             invitation_code,
             nickname,
         } => {
-            // Ask for nickname if not provided
-            let nickname = match nickname {
-                Some(n) => n,
-                None => {
-                    if atty::is(atty::Stream::Stdin) {
-                        dialoguer::Input::<String>::new()
-                            .with_prompt("Enter your nickname")
-                            .default("Anonymous".to_string())
-                            .interact_text()?
-                    } else {
-                        "Anonymous".to_string()
-                    }
-                }
-            };
+            let nickname = resolve_nickname(nickname)?;
 
             if !matches!(format, OutputFormat::Json) {
                 eprintln!("Accepting invitation...");
@@ -98,28 +86,7 @@ pub async fn execute(command: InviteCommands, api: ApiClient, format: OutputForm
 
             match api.accept_invitation(&invitation_code, &nickname).await {
                 Ok((room_owner_vk, contract_key)) => {
-                    let owner_key_str = bs58::encode(room_owner_vk.as_bytes()).into_string();
-
-                    match format {
-                        OutputFormat::Human => {
-                            println!("{}", "Invitation accepted successfully!".green());
-                            println!("Room owner key: {}", owner_key_str);
-                            println!("Contract key: {}", contract_key.id());
-                            println!("\nYou can now:");
-                            println!(
-                                "  - Send messages: riverctl message send {} \"Hello!\"",
-                                owner_key_str
-                            );
-                            println!("  - List members: riverctl member list {}", owner_key_str);
-                        }
-                        OutputFormat::Json => {
-                            println!(
-                                r#"{{"status": "success", "room_owner_key": "{}", "contract_key": "{}"}}"#,
-                                owner_key_str,
-                                contract_key.id()
-                            );
-                        }
-                    }
+                    print_invitation_accepted(format, &room_owner_vk, &contract_key);
                     Ok(())
                 }
                 Err(e) => {
@@ -127,6 +94,57 @@ pub async fn execute(command: InviteCommands, api: ApiClient, format: OutputForm
                     Err(e)
                 }
             }
+        }
+    }
+}
+
+/// Resolve the invitee nickname: use the value the user passed, else prompt
+/// interactively on a TTY, else fall back to "Anonymous". Shared by
+/// `invite accept` and `dm accept` so both entry points behave identically.
+pub fn resolve_nickname(nickname: Option<String>) -> Result<String> {
+    match nickname {
+        Some(n) => Ok(n),
+        None => {
+            if atty::is(atty::Stream::Stdin) {
+                Ok(dialoguer::Input::<String>::new()
+                    .with_prompt("Enter your nickname")
+                    .default("Anonymous".to_string())
+                    .interact_text()?)
+            } else {
+                Ok("Anonymous".to_string())
+            }
+        }
+    }
+}
+
+/// Print the success report after an invitation is accepted. Shared by
+/// `invite accept` and `dm accept` so the post-accept guidance stays
+/// identical regardless of how the invitation reached the user.
+pub fn print_invitation_accepted(
+    format: OutputFormat,
+    room_owner_vk: &VerifyingKey,
+    contract_key: &ContractKey,
+) {
+    let owner_key_str = bs58::encode(room_owner_vk.as_bytes()).into_string();
+
+    match format {
+        OutputFormat::Human => {
+            println!("{}", "Invitation accepted successfully!".green());
+            println!("Room owner key: {}", owner_key_str);
+            println!("Contract key: {}", contract_key.id());
+            println!("\nYou can now:");
+            println!(
+                "  - Send messages: riverctl message send {} \"Hello!\"",
+                owner_key_str
+            );
+            println!("  - List members: riverctl member list {}", owner_key_str);
+        }
+        OutputFormat::Json => {
+            println!(
+                r#"{{"status": "success", "room_owner_key": "{}", "contract_key": "{}"}}"#,
+                owner_key_str,
+                contract_key.id()
+            );
         }
     }
 }


### PR DESCRIPTION
## Problem

River's "share an invite via DM" flow (#252) embeds a CBOR `Invitation` inside a `DirectMessageBody::Invite` DM. The UI renders it as an invitation card with an **Accept** button, but **riverctl had no way to accept such an invite**:

- `dm list` only showed `[Invitation to room <8-char prefix>…]` — never the payload.
- `invite accept` requires a base58 `?invitation=…` code the recipient never receives (the invitation lives as CBOR bytes inside the encrypted DM body).
- There was no `dm accept`, and a stale comment in `format_dm_body_for_cli` even pointed users at a **non-existent** `riverctl room accept`.

Reported by Ivvor on Matrix ("doesn't look like it's possible to accept a DM room invite via riverctl").

## Approach

Add `riverctl dm accept <carrier_room_id> [--from <sender>] [--room <target>] [--nickname <n>]` — the CLI counterpart of the UI's Accept button:

1. Decrypt the inbound DMs in the carrier room, keep the `Invite` bodies (`collect_inbound_invites`, pure/testable).
2. Narrow by sender (`--from <MemberId prefix>`) and/or target room (`--room <target room prefix>`).
3. Decode + room-match **every** candidate, dropping malformed ones (`select_invite_to_accept`); disambiguate to a single target room; pick the newest **valid** invite. If invitations to several rooms remain, error with a listing and ask the user to narrow.
4. Cross-check that the embedded `Invitation` targets the room its payload advertises (`decode_invitation_from_payload`) — a field-equality guard against a self-inconsistent / spoofed-hint DM. This is **not** cryptographic verification: authorization is enforced by the room contract when the join delta is published (same as `invite accept`).
5. Join via the existing accept core.

To keep the accept logic identical across both entry points, `ApiClient::accept_invitation` is refactored into a thin base58 decoder over a new shared **`accept_invitation_struct`**. The #308 re-accept guard, room GET, invitation-secret persistence and join publish are therefore byte-identical whether the invitation arrived as a URL or a DM. The re-accept guard source-pin test now anchors on the shared core (protecting both paths at once). Shared `resolve_nickname` / `print_invitation_accepted` helpers in `invite.rs` are reused so both paths prompt and report the same way.

Discoverability: `dm list` prints an accept tip when any invite DM is present (computed before the per-thread cap, so an invite that scrolled off still surfaces it), and exposes `is_invitation` in its JSON output. Fixed the misleading `room accept` comment.

## Testing

Pure, fast unit tests for the selection seams:
- `collect_inbound_invites_filters_correctly` — inbound `Invite` DMs only; ignores text DMs and DMs to others; honours `--from`.
- `decode_invitation_from_payload_validates_room_match` — round-trip, room-mismatch rejection, garbage payload (no panic).
- `select_*` (8 tests) — newest-valid pick, **malformed-newest fallback** (regression for the validate-before-select fix), all-malformed error, distinct-target error, `--room` same-sender disambiguation, `--room` no-match, over-broad `--room` still errors, malformed-drop across distinct targets.

Full `riverctl` lib suite green (104 tests). `cargo fmt` + `cargo clippy` clean.

## Scope / migration

Confined to `cli/` (riverctl). No `common/` / delegate / contract WASM change, so **no migration entry is required** (both migration CI checks confirm the WASM is byte-identical).

Closes the gap reported by Ivvor.

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)