### PR TITLE
fix(ui): strip markdown and render @mentions in reply-preview snapshot

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -178,6 +178,19 @@ pub(crate) fn reply_context(
     }
 }
 
+/// Like [`reply_context`], but with `@[name](rv:id)` mention tokens in the
+/// quoted preview resolved to `@name` for terminal display (mirroring
+/// `message_display_text`, so the reply preview and the message body render
+/// mentions the same way). Markdown is left as-is, consistent with how the CLI
+/// renders message bodies.
+pub(crate) fn reply_context_display(
+    room_state: &ChatRoomStateV1,
+    msg: &river_core::room_state::message::AuthorizedMessageV1,
+) -> Option<(String, String)> {
+    reply_context(msg)
+        .map(|(author, preview)| (author, render_mentions_for_terminal(room_state, &preview)))
+}
+
 /// Whether a message seen by a monitor stream is brand new, an edit of one
 /// already emitted, or unchanged since last emitted.
 #[derive(Debug, PartialEq, Eq)]
@@ -3041,7 +3054,7 @@ impl ApiClient {
         let msg_id = msg.id();
         let edited = room_state.recent_messages.is_edited(&msg_id);
         let reactions = room_state.recent_messages.reactions(&msg_id);
-        let reply = reply_context(msg);
+        let reply = reply_context_display(room_state, msg);
 
         match format {
             OutputFormat::Human => {
@@ -4996,5 +5009,35 @@ mod mention_cli_tests {
         let msg = msg_with_text(format!("hi {}", encode_mention(member_id(&alice), "Alice")));
         // The full display path wraps render_mentions_for_terminal.
         assert_eq!(message_display_text(&state, &msg), "hi @Alice");
+    }
+
+    #[test]
+    fn reply_context_display_renders_mention_in_preview() {
+        use river_core::room_state::message::MessageId;
+        let alice = SigningKey::from_bytes(&[1u8; 32]);
+        let state = state_with_members(&[(alice.clone(), SealedBytes::public(b"Alice".to_vec()))]);
+        // A reply whose quoted preview snapshot contains a mention token.
+        let preview = format!("re: {}", encode_mention(member_id(&alice), "Alice"));
+        let sender = SigningKey::from_bytes(&[200u8; 32]);
+        let reply = AuthorizedMessageV1::new(
+            MessageV1 {
+                room_owner: MemberId::from(sender.verifying_key()),
+                author: member_id(&sender),
+                content: RoomMessageBody::reply(
+                    "ok".to_string(),
+                    MessageId(freenet_scaffold::util::FastHash(0)),
+                    "Bob".to_string(),
+                    preview,
+                ),
+                time: SystemTime::UNIX_EPOCH,
+            },
+            &sender,
+        );
+        let (_, rendered) = reply_context_display(&state, &reply).expect("is a reply");
+        assert!(
+            rendered.contains("@Alice"),
+            "mention rendered in preview: {rendered}"
+        );
+        assert!(!rendered.contains("rv:"), "no raw token syntax: {rendered}");
     }
 }

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -183,12 +183,26 @@ pub(crate) fn reply_context(
 /// `message_display_text`, so the reply preview and the message body render
 /// mentions the same way). Markdown is left as-is, consistent with how the CLI
 /// renders message bodies.
+///
+/// Mentions are resolved on the FULL stored preview *before* the display-length
+/// truncation, so a mention token sitting near the cutoff isn't sliced into
+/// raw `@[name](rv:..` syntax.
 pub(crate) fn reply_context_display(
     room_state: &ChatRoomStateV1,
     msg: &river_core::room_state::message::AuthorizedMessageV1,
 ) -> Option<(String, String)> {
-    reply_context(msg)
-        .map(|(author, preview)| (author, render_mentions_for_terminal(room_state, &preview)))
+    use river_core::room_state::content::{DecodedContent, CONTENT_TYPE_REPLY};
+    if msg.message.content.content_type() != CONTENT_TYPE_REPLY {
+        return None;
+    }
+    match msg.message.content.decode_content() {
+        Some(DecodedContent::Reply(reply)) => {
+            let rendered = render_mentions_for_terminal(room_state, &reply.target_content_preview);
+            let preview: String = rendered.chars().take(50).collect();
+            Some((reply.target_author_name, preview))
+        }
+        _ => None,
+    }
 }
 
 /// Whether a message seen by a monitor stream is brand new, an edit of one
@@ -5039,5 +5053,39 @@ mod mention_cli_tests {
             "mention rendered in preview: {rendered}"
         );
         assert!(!rendered.contains("rv:"), "no raw token syntax: {rendered}");
+    }
+
+    #[test]
+    fn reply_context_display_does_not_slice_a_boundary_mention_token() {
+        use river_core::room_state::message::MessageId;
+        let alice = SigningKey::from_bytes(&[1u8; 32]);
+        let state = state_with_members(&[(alice.clone(), SealedBytes::public(b"Alice".to_vec()))]);
+        // Pad so the raw token would straddle the 50-char display cutoff; the
+        // token must be resolved before truncation, never sliced into raw syntax.
+        let preview = format!(
+            "{}{}",
+            "x".repeat(45),
+            encode_mention(member_id(&alice), "Alice")
+        );
+        let sender = SigningKey::from_bytes(&[200u8; 32]);
+        let reply = AuthorizedMessageV1::new(
+            MessageV1 {
+                room_owner: MemberId::from(sender.verifying_key()),
+                author: member_id(&sender),
+                content: RoomMessageBody::reply(
+                    "ok".to_string(),
+                    MessageId(freenet_scaffold::util::FastHash(0)),
+                    "Bob".to_string(),
+                    preview,
+                ),
+                time: SystemTime::UNIX_EPOCH,
+            },
+            &sender,
+        );
+        let (_, rendered) = reply_context_display(&state, &reply).expect("is a reply");
+        assert!(
+            !rendered.contains("rv:") && !rendered.contains("@["),
+            "no raw/partial token in boundary preview: {rendered}"
+        );
     }
 }

--- a/cli/src/commands/message.rs
+++ b/cli/src/commands/message.rs
@@ -241,7 +241,7 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
                             // Check for reply context (shared with the monitor
                             // stream via crate::api::reply_context so the two
                             // renderings can't drift).
-                            let reply_prefix = crate::api::reply_context(msg)
+                            let reply_prefix = crate::api::reply_context_display(&room_state, msg)
                                 .map(|(author, preview)| {
                                     format!("[reply to {}: {}...] ", author, preview)
                                 })
@@ -315,7 +315,7 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
                             // Reply context (null for non-replies) — same shape
                             // as the monitor stream's JSON, so a bridge sees
                             // reply_to on both the backfill and the live feed.
-                            let reply_to = crate::api::reply_context(msg).map(
+                            let reply_to = crate::api::reply_context_display(&room_state, msg).map(
                                 |(author, preview)| json!({ "author": author, "preview": preview }),
                             );
 

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -240,10 +240,23 @@ fn group_messages(
                     .unwrap_or_else(|| {
                         decrypt_message_content(&target_msg.message.content, secrets)
                     });
-                let preview: String = current_text.chars().take(100).collect();
-                reply_to_preview = Some(preview);
+                // Keep the full current text; mention/markdown cleaning and
+                // truncation happen once, below.
+                reply_to_preview = Some(current_text);
             }
         }
+
+        // Clean the reply preview for display: resolve @mention tokens to plain
+        // `@name` (current nickname) and strip markdown, so the quoted snapshot
+        // reads as plain text rather than showing raw `@[name](rv:id)` / `**` /
+        // `[text](url)` syntax. Truncate after cleaning. Applies to both the
+        // refreshed-current-text and the stored-snapshot fallback paths.
+        let reply_to_preview = reply_to_preview.map(|p| {
+            clean_reply_preview(&p, member_names)
+                .chars()
+                .take(100)
+                .collect::<String>()
+        });
 
         // Look up propagation delay (send time → receive time)
         let send_time_ms = raw_time.timestamp_millis();
@@ -404,6 +417,50 @@ pub(crate) fn decrypt_message_content(
                     secret_version
                 )
             }
+        }
+    }
+}
+
+/// Clean a quoted reply-preview snapshot for display: resolve `@[name](rv:id)`
+/// mention tokens to plain `@name` (using each member's *current* nickname, with
+/// the token snapshot as fallback) and strip markdown formatting, so the preview
+/// reads as plain text. Caller truncates the result.
+fn clean_reply_preview(text: &str, member_names: &HashMap<MemberId, String>) -> String {
+    let with_mentions =
+        river_core::mention::render_plaintext(text, |id| member_names.get(&id).cloned());
+    strip_markdown(&with_mentions)
+}
+
+/// Reduce markdown to its plain-text content (emphasis/headings/code-fences
+/// removed, links rendered as their visible text). Used for the single-line
+/// reply-preview snapshot, never for the message body (which renders full
+/// markdown). Falls back to the input unchanged if parsing fails.
+fn strip_markdown(text: &str) -> String {
+    match markdown::to_mdast(text, &markdown::ParseOptions::gfm()) {
+        Ok(node) => {
+            let mut out = String::with_capacity(text.len());
+            collect_mdast_text(&node, &mut out);
+            out
+        }
+        Err(_) => text.to_string(),
+    }
+}
+
+/// Depth-first collection of the visible text from a markdown AST node.
+fn collect_mdast_text(node: &markdown::mdast::Node, out: &mut String) {
+    use markdown::mdast::Node;
+    match node {
+        Node::Text(t) => out.push_str(&t.value),
+        Node::InlineCode(c) => out.push_str(&c.value),
+        Node::Code(c) => out.push_str(&c.value),
+        // A hard/soft break or thematic break becomes a space so words on
+        // separate lines don't run together in the single-line preview.
+        Node::Break(_) | Node::ThematicBreak(_) => out.push(' '),
+        _ => {}
+    }
+    if let Some(children) = node.children() {
+        for child in children {
+            collect_mdast_text(child, out);
         }
     }
 }
@@ -3236,6 +3293,43 @@ mod tests {
 
     fn mid_from(hex: &str) -> MemberId {
         river_core::mention::member_id_from_hex(hex).unwrap()
+    }
+
+    #[test]
+    fn strip_markdown_removes_formatting_and_keeps_link_text() {
+        let s = strip_markdown("**bold** and `code` and [a link](http://x.example) end");
+        assert!(!s.contains('*'), "emphasis markers removed: {s}");
+        assert!(!s.contains('`'), "code fences removed: {s}");
+        assert!(!s.contains("http://x.example"), "link url dropped: {s}");
+        assert!(s.contains("bold") && s.contains("code") && s.contains("end"));
+        assert!(s.contains("a link"), "link visible text kept: {s}");
+    }
+
+    #[test]
+    fn clean_reply_preview_resolves_mention_to_current_name_and_strips_markdown() {
+        let id = mid_from("00000000000000aa");
+        let mut names = HashMap::new();
+        names.insert(id, "Alice".to_string());
+        // Token snapshot is "OldAlice"; the live map says "Alice".
+        let token = river_core::mention::encode_mention(id, "OldAlice");
+        let cleaned = clean_reply_preview(&format!("hey {token}, **see** this"), &names);
+        assert!(
+            cleaned.contains("@Alice"),
+            "current nickname used: {cleaned}"
+        );
+        assert!(
+            !cleaned.contains("OldAlice"),
+            "snapshot overridden: {cleaned}"
+        );
+        assert!(
+            !cleaned.contains("rv:"),
+            "no raw mention token syntax: {cleaned}"
+        );
+        assert!(
+            !cleaned.contains("**") && !cleaned.contains("]("),
+            "markdown stripped: {cleaned}"
+        );
+        assert!(cleaned.contains("see"));
     }
 
     #[test]

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -2441,7 +2441,14 @@ fn MessageGroupComponent(
                                         let msg_id_for_delete = msg.message_id.clone();
                                         let msg_id_for_reply = msg.message_id.clone();
                                         let current_text = msg.content_text.clone();
-                                        let reply_text_preview = msg.content_text.chars().take(100).collect::<String>();
+                                        // Clean the snapshot (mentions -> @name, markdown stripped)
+                                        // BEFORE truncating, so the stored preview is plain text and
+                                        // no consumer (UI, CLI, old client) ever sees a raw token —
+                                        // even one that would have crossed the truncation boundary.
+                                        let reply_text_preview = clean_reply_preview(&msg.content_text, &member_names)
+                                            .chars()
+                                            .take(100)
+                                            .collect::<String>();
                                         let reply_author_name = group.author_name.clone();
                                         rsx! {
                                             div {


### PR DESCRIPTION
## Problem
The reply preview — the quoted original message shown above a reply — is rendered as a plain text node, so when the quoted message contained an `@[name](rv:id)` mention token or markdown, the raw syntax showed instead of clean text. (Follow-up to #340/#342.)

## Approach
Clean the preview snapshot for display: resolve mention tokens to plain `@name` (current nickname via the member map, token snapshot as fallback) and strip markdown to its visible text (links render as their text; emphasis/code/headings removed) using the `markdown` crate's AST. Applied at render time in `group_messages`, so it covers both the refreshed-current-text and stored-snapshot paths and fixes all existing replies. riverctl gets parity via `reply_context_display` (renders the mention token in the terminal reply preview like message bodies already do; markdown left raw, consistent with the CLI).

## Testing
New unit tests: `strip_markdown` (formatting removed, link text kept), `clean_reply_preview` (current-name mention + markdown stripped), and CLI `reply_context_display_renders_mention_in_preview`. river-ui 297 + riverctl 105 pass; wasm compiles.

Note: touches riverctl, so fully shipping the CLI parity needs a riverctl crates.io republish (river-core 0.1.11 with mentions is already published).

[AI-assisted - Claude]