### PR TITLE
feat(ui): drag-and-drop room reordering; move private-room lock to the right

### DIFF
--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -502,6 +502,7 @@ fn initial_rooms() -> Rooms {
         removed_rooms: std::collections::HashSet::new(),
         notification_modes: Default::default(),
         migrated_rooms: Vec::new(),
+        room_order: Vec::new(),
     }
 }
 

--- a/ui/src/components/direct_messages.rs
+++ b/ui/src/components/direct_messages.rs
@@ -639,6 +639,7 @@ mod tests {
             notification_modes: Default::default(),
             migrated_rooms: Vec::new(),
             removed_rooms: std::collections::HashSet::new(),
+            room_order: Vec::new(),
         }
     }
 

--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -25,6 +25,10 @@ use river_core::room_state::privacy::PrivacyMode;
 // Access the build timestamp (ISO 8601 format) environment variable set by build.rs
 const BUILD_TIMESTAMP_ISO: &str = env!("BUILD_TIMESTAMP_ISO", "Build timestamp not set");
 
+// Stable Dioxus key for the reorder tail drop zone (keys must be unique and
+// distinct from any room's `{room_key:?}`).
+const TAIL_DROP_ZONE_KEY: &str = "room-reorder-tail-drop-zone";
+
 /// Convert UTC ISO timestamp to local time string
 fn format_build_time_local() -> String {
     #[cfg(target_arch = "wasm32")]
@@ -67,9 +71,13 @@ pub fn RoomList() -> Element {
 
     // Drag-and-drop reorder state (a local view preference). `dragged_room`
     // is the row currently being dragged; `drag_over_room` is the row the
-    // cursor is hovering over, used only to draw the insertion indicator.
+    // cursor is hovering over, used to draw the insertion indicator;
+    // `drag_over_end` is the same for the tail (move-to-end) drop zone.
+    // All mutations to these are routed through `crate::util::defer()` per the
+    // Dioxus signal-safety rules (this component reads them during render).
     let mut dragged_room = use_signal(|| None::<VerifyingKey>);
     let mut drag_over_room = use_signal(|| None::<VerifyingKey>);
+    let mut drag_over_end = use_signal(|| false);
 
     // Memoize the room list to avoid reading signals during render.
     // Rooms render in the user's drag-chosen order first, then any
@@ -188,15 +196,20 @@ pub fn RoomList() -> Element {
                                 if is_drag_over && !is_dragged { "border-accent" } else { "border-transparent" },
                             ),
                             ondragstart: move |_| {
-                                dragged_room.set(Some(room_key));
+                                // Defer every drag-state mutation per the
+                                // signal-safety rules (this component reads
+                                // these signals during render).
+                                crate::util::defer(move || dragged_room.set(Some(room_key)));
                             },
                             ondragenter: move |_| {
                                 // Fires on entering a new row (unlike ondragover,
                                 // which fires continuously), so this won't churn
                                 // re-renders on every mouse move.
-                                if drag_over_room() != Some(room_key) {
-                                    drag_over_room.set(Some(room_key));
-                                }
+                                crate::util::defer(move || {
+                                    if *drag_over_room.peek() != Some(room_key) {
+                                        drag_over_room.set(Some(room_key));
+                                    }
+                                });
                             },
                             ondragover: move |evt| {
                                 // Required for the browser to treat this row as a
@@ -205,27 +218,32 @@ pub fn RoomList() -> Element {
                             },
                             ondrop: move |evt| {
                                 evt.prevent_default();
-                                drag_over_room.set(None);
-                                let Some(src) = dragged_room() else { return; };
-                                dragged_room.set(None);
-                                if src == room_key {
-                                    return;
-                                }
-                                // Defer the ROOMS mutation to a clean execution
-                                // context (re-entrant borrow safety), then persist
-                                // the new order to the delegate.
+                                // Read the dragged key up front (peek: no
+                                // subscription), then do all signal mutations
+                                // and the persisted reorder inside one deferred,
+                                // re-entrancy-safe closure.
+                                let src = *dragged_room.peek();
                                 crate::util::defer(move || {
-                                    ROOMS.with_mut(|rooms| rooms.move_room(src, room_key));
-                                    spawn(async move {
-                                        if let Err(e) = save_rooms_to_delegate().await {
-                                            error!("Failed to save room order: {}", e);
+                                    drag_over_room.set(None);
+                                    dragged_room.set(None);
+                                    if let Some(src) = src {
+                                        if src != room_key {
+                                            ROOMS.with_mut(|rooms| rooms.move_room(src, room_key));
+                                            spawn(async move {
+                                                if let Err(e) = save_rooms_to_delegate().await {
+                                                    error!("Failed to save room order: {}", e);
+                                                }
+                                            });
                                         }
-                                    });
+                                    }
                                 });
                             },
                             ondragend: move |_| {
-                                dragged_room.set(None);
-                                drag_over_room.set(None);
+                                crate::util::defer(move || {
+                                    dragged_room.set(None);
+                                    drag_over_room.set(None);
+                                    drag_over_end.set(false);
+                                });
                             },
                             button {
                                 class: format!(
@@ -286,6 +304,52 @@ pub fn RoomList() -> Element {
                         }
                     }
                 }).collect::<Vec<_>>().into_iter()}
+
+                // Tail drop zone: only present mid-drag. Every row drop inserts
+                // the dragged room BEFORE its target, so the final slot would be
+                // unreachable without a dedicated end target. Shown only while a
+                // drag is in progress so it never adds layout when idle.
+                if dragged_room().is_some() {
+                    li {
+                        key: "{TAIL_DROP_ZONE_KEY}",
+                        class: format!(
+                            "h-8 rounded-lg border-2 border-dashed transition-colors flex items-center justify-center text-xs text-text-muted {}",
+                            if drag_over_end() { "border-accent bg-accent/10" } else { "border-border/40" },
+                        ),
+                        "aria-label": "Move to end",
+                        ondragenter: move |_| {
+                            crate::util::defer(move || {
+                                if !*drag_over_end.peek() {
+                                    drag_over_end.set(true);
+                                }
+                            });
+                        },
+                        ondragover: move |evt| {
+                            evt.prevent_default();
+                        },
+                        ondragleave: move |_| {
+                            crate::util::defer(move || drag_over_end.set(false));
+                        },
+                        ondrop: move |evt| {
+                            evt.prevent_default();
+                            let src = *dragged_room.peek();
+                            crate::util::defer(move || {
+                                drag_over_end.set(false);
+                                drag_over_room.set(None);
+                                dragged_room.set(None);
+                                if let Some(src) = src {
+                                    ROOMS.with_mut(|rooms| rooms.move_room_to_end(src));
+                                    spawn(async move {
+                                        if let Err(e) = save_rooms_to_delegate().await {
+                                            error!("Failed to save room order: {}", e);
+                                        }
+                                    });
+                                }
+                            });
+                        },
+                        "Drop here to move to end"
+                    }
+                }
             }
 
             // Direct Messages section under the room list — surfaces DM

--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -19,6 +19,7 @@ use dioxus_free_icons::{
     icons::fa_solid_icons::{FaArrowLeft, FaComments, FaFileImport, FaLock, FaPlus},
     Icon,
 };
+use ed25519_dalek::VerifyingKey;
 use river_core::room_state::privacy::PrivacyMode;
 
 // Access the build timestamp (ISO 8601 format) environment variable set by build.rs
@@ -64,7 +65,16 @@ fn format_build_time_local() -> String {
 pub fn RoomList() -> Element {
     let mut import_modal_active = use_signal(|| false);
 
-    // Memoize the room list to avoid reading signals during render
+    // Drag-and-drop reorder state (a local view preference). `dragged_room`
+    // is the row currently being dragged; `drag_over_room` is the row the
+    // cursor is hovering over, used only to draw the insertion indicator.
+    let mut dragged_room = use_signal(|| None::<VerifyingKey>);
+    let mut drag_over_room = use_signal(|| None::<VerifyingKey>);
+
+    // Memoize the room list to avoid reading signals during render.
+    // Rooms render in the user's drag-chosen order first, then any
+    // not-yet-positioned rooms in a deterministic order — see
+    // `Rooms::ordered_room_keys` (raw `HashMap` order is unstable).
     let room_items = use_memo(move || {
         let Ok(rooms) = ROOMS.try_read() else {
             return Vec::new();
@@ -72,10 +82,10 @@ pub fn RoomList() -> Element {
         let current_room_key = CURRENT_ROOM.read().owner_key;
 
         rooms
-            .map
-            .iter()
-            .map(|(room_key, room_data)| {
-                let room_key = *room_key;
+            .ordered_room_keys()
+            .into_iter()
+            .filter_map(|room_key| {
+                let room_data = rooms.map.get(&room_key)?;
                 let awaiting_sync = room_data.is_awaiting_initial_sync();
                 // Decrypt room name if room is private and we have the secret
                 let sealed_name = &room_data
@@ -100,14 +110,14 @@ pub fn RoomList() -> Element {
                 // notifications (e.g. not on a localhost node) can still see
                 // which rooms have new messages.
                 let unread = count_unread_in_room_data(room_data);
-                (
+                Some((
                     room_key,
                     room_name,
                     is_current,
                     awaiting_sync,
                     is_private,
                     unread,
-                )
+                ))
             })
             .collect::<Vec<_>>()
     });
@@ -156,8 +166,67 @@ pub fn RoomList() -> Element {
                     let awaiting_sync = *awaiting_sync;
                     let is_private = *is_private;
                     let unread = *unread;
+                    // Drag feedback: dim the row being dragged, and draw a top
+                    // border on the row the cursor is over (drop lands the
+                    // dragged room immediately before it — see `move_room`).
+                    // The 2px top border is always reserved (transparent →
+                    // accent) so highlighting it on drag-over causes no layout
+                    // shift.
+                    let is_dragged = dragged_room() == Some(room_key);
+                    let is_drag_over = drag_over_room() == Some(room_key);
                     rsx! {
-                        li { key: "{room_key:?}",
+                        li {
+                            key: "{room_key:?}",
+                            // Rooms are reorderable by drag-and-drop. The whole
+                            // row is the drag handle; the inner button still
+                            // handles click-to-open (a click is distinct from a
+                            // drag gesture).
+                            draggable: "true",
+                            class: format!(
+                                "rounded-lg cursor-grab active:cursor-grabbing select-none transition-opacity border-t-2 {} {}",
+                                if is_dragged { "opacity-50" } else { "" },
+                                if is_drag_over && !is_dragged { "border-accent" } else { "border-transparent" },
+                            ),
+                            ondragstart: move |_| {
+                                dragged_room.set(Some(room_key));
+                            },
+                            ondragenter: move |_| {
+                                // Fires on entering a new row (unlike ondragover,
+                                // which fires continuously), so this won't churn
+                                // re-renders on every mouse move.
+                                if drag_over_room() != Some(room_key) {
+                                    drag_over_room.set(Some(room_key));
+                                }
+                            },
+                            ondragover: move |evt| {
+                                // Required for the browser to treat this row as a
+                                // valid drop target.
+                                evt.prevent_default();
+                            },
+                            ondrop: move |evt| {
+                                evt.prevent_default();
+                                drag_over_room.set(None);
+                                let Some(src) = dragged_room() else { return; };
+                                dragged_room.set(None);
+                                if src == room_key {
+                                    return;
+                                }
+                                // Defer the ROOMS mutation to a clean execution
+                                // context (re-entrant borrow safety), then persist
+                                // the new order to the delegate.
+                                crate::util::defer(move || {
+                                    ROOMS.with_mut(|rooms| rooms.move_room(src, room_key));
+                                    spawn(async move {
+                                        if let Err(e) = save_rooms_to_delegate().await {
+                                            error!("Failed to save room order: {}", e);
+                                        }
+                                    });
+                                });
+                            },
+                            ondragend: move |_| {
+                                dragged_room.set(None);
+                                drag_over_room.set(None);
+                            },
                             button {
                                 class: format!(
                                     "w-full text-left px-3 py-2 rounded-lg text-sm transition-colors {}",
@@ -183,6 +252,9 @@ pub fn RoomList() -> Element {
                                     });
                                 },
                                 div { class: "flex items-center gap-2",
+                                    span { class: "block truncate flex-1", "{room_name}" }
+                                    // Private-room lock — sits to the RIGHT of the
+                                    // room name (after it in the flex row).
                                     if is_private {
                                         span {
                                             class: "flex-shrink-0 text-text-muted",
@@ -191,7 +263,6 @@ pub fn RoomList() -> Element {
                                             Icon { width: 12, height: 12, icon: FaLock }
                                         }
                                     }
-                                    span { class: "block truncate flex-1", "{room_name}" }
                                     // Unread badge — hidden for the current
                                     // room (its messages are marked read on
                                     // open, so a badge there would only

--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -130,6 +130,14 @@ pub fn RoomList() -> Element {
             .collect::<Vec<_>>()
     });
 
+    // Snapshot the drag-state signals once per render via `try_read` (fallible,
+    // per the Dioxus signal-safety rules — a concurrent write borrow returns
+    // Err here instead of panicking with "RefCell already borrowed" on
+    // Firefox). Reused for the per-row highlight and the tail-zone visibility.
+    let dragged_now: Option<VerifyingKey> = dragged_room.try_read().ok().and_then(|g| *g);
+    let drag_over_now: Option<VerifyingKey> = drag_over_room.try_read().ok().and_then(|g| *g);
+    let drag_over_end_now: bool = drag_over_end.try_read().map(|g| *g).unwrap_or(false);
+
     rsx! {
         aside { class: "w-full md:w-64 flex-shrink-0 bg-panel border-r border-border flex flex-col overflow-y-auto",
             // Mobile back button (hidden on desktop)
@@ -180,8 +188,8 @@ pub fn RoomList() -> Element {
                     // The 2px top border is always reserved (transparent →
                     // accent) so highlighting it on drag-over causes no layout
                     // shift.
-                    let is_dragged = dragged_room() == Some(room_key);
-                    let is_drag_over = drag_over_room() == Some(room_key);
+                    let is_dragged = dragged_now == Some(room_key);
+                    let is_drag_over = drag_over_now == Some(room_key);
                     rsx! {
                         li {
                             key: "{room_key:?}",
@@ -309,12 +317,12 @@ pub fn RoomList() -> Element {
                 // the dragged room BEFORE its target, so the final slot would be
                 // unreachable without a dedicated end target. Shown only while a
                 // drag is in progress so it never adds layout when idle.
-                if dragged_room().is_some() {
+                if dragged_now.is_some() {
                     li {
                         key: "{TAIL_DROP_ZONE_KEY}",
                         class: format!(
                             "h-8 rounded-lg border-2 border-dashed transition-colors flex items-center justify-center text-xs text-text-muted {}",
-                            if drag_over_end() { "border-accent bg-accent/10" } else { "border-border/40" },
+                            if drag_over_end_now { "border-accent bg-accent/10" } else { "border-border/40" },
                         ),
                         "aria-label": "Move to end",
                         ondragenter: move |_| {

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -49,6 +49,7 @@ pub fn create_example_rooms() -> Rooms {
         removed_rooms: std::collections::HashSet::new(),
         notification_modes: Default::default(),
         migrated_rooms: Vec::new(),
+        room_order: Vec::new(),
     }
 }
 

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -1280,6 +1280,24 @@ pub struct Rooms {
     /// below is local-wins and never overwrites a kept value).
     #[serde(default)]
     pub notification_modes: HashMap<VerifyingKey, NotificationMode>,
+    /// User-chosen display order for the room rail, keyed by room owner key
+    /// (a local user setting, same persistence model as `notification_modes`
+    /// and `removed_rooms`: stored inside the `rooms_data` delegate blob with
+    /// `#[serde(default)]`, so it survives reloads and delegate migration and
+    /// needs no new delegate storage key).
+    ///
+    /// Invariants / semantics:
+    /// * Only rooms the user has explicitly dragged appear here. Rooms not in
+    ///   this list are appended after the ordered ones in a deterministic
+    ///   (key-byte) order — see [`Rooms::ordered_room_keys`]. So an absent
+    ///   entry just means "not yet manually positioned", never "hidden".
+    /// * Entries are pruned to keys present in `map` on `merge` and on
+    ///   `leave_room`, so the list never grows without bound.
+    /// * On `merge`, this device's order is authoritative; keys seen only in
+    ///   the incoming order are appended (same local-wins rule as
+    ///   `notification_modes`).
+    #[serde(default)]
+    pub room_order: Vec<VerifyingKey>,
     /// Rooms whose contract key changed due to WASM update.
     /// Each entry is (owner_vk, old_contract_key) for rooms where the owner
     /// should send an upgrade pointer to the old contract.
@@ -1292,6 +1310,7 @@ impl PartialEq for Rooms {
         self.map == other.map
             && self.removed_rooms == other.removed_rooms
             && self.notification_modes == other.notification_modes
+            && self.room_order == other.room_order
     }
 }
 
@@ -1513,6 +1532,18 @@ impl Rooms {
                 )?;
             }
         }
+
+        // Room display order: this device's order is authoritative (a local
+        // user setting, same rule as `notification_modes`). Adopt any keys the
+        // incoming order has that we don't, then prune to rooms actually in
+        // `map` so the list can't accumulate stale entries across merges.
+        for vk in other.room_order {
+            if !self.room_order.contains(&vk) {
+                self.room_order.push(vk);
+            }
+        }
+        self.room_order.retain(|vk| self.map.contains_key(vk));
+
         Ok(())
     }
 
@@ -1525,6 +1556,62 @@ impl Rooms {
         self.map.remove(&room_vk);
         self.migrated_rooms.retain(|(vk, _)| vk != &room_vk);
         self.removed_rooms.insert(room_vk);
+        // Drop the room from the manual order so the list never carries a
+        // stale entry for a room that's gone.
+        self.room_order.retain(|vk| vk != &room_vk);
+    }
+
+    /// Room owner keys in display order: manually-positioned rooms first (in
+    /// `room_order`, filtered to rooms still present in `map`), then any
+    /// not-yet-positioned rooms appended in a deterministic key-byte order.
+    ///
+    /// The deterministic tail matters because `map` is a `HashMap`: iterating
+    /// it directly would render rooms in an arbitrary, render-to-render
+    /// unstable order. Sorting the remainder gives a stable baseline before
+    /// the user has dragged anything.
+    pub fn ordered_room_keys(&self) -> Vec<VerifyingKey> {
+        let mut result: Vec<VerifyingKey> = self
+            .room_order
+            .iter()
+            .filter(|k| self.map.contains_key(k))
+            .copied()
+            .collect();
+        let mut remainder: Vec<VerifyingKey> = self
+            .map
+            .keys()
+            .filter(|k| !self.room_order.contains(k))
+            .copied()
+            .collect();
+        remainder.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
+        result.extend(remainder);
+        result
+    }
+
+    /// Move `dragged` so it sits immediately before `target` in the display
+    /// order, persisting the resulting full order into `room_order`.
+    ///
+    /// Operates on the current effective order (`ordered_room_keys`), so the
+    /// first drag of an as-yet-unordered list materialises the full order
+    /// rather than just the two rooms involved. No-ops if either key is not a
+    /// current room or if they're equal. After this call `room_order` contains
+    /// exactly the current `map` keys (no stale entries).
+    pub fn move_room(&mut self, dragged: VerifyingKey, target: VerifyingKey) {
+        if dragged == target {
+            return;
+        }
+        let mut order = self.ordered_room_keys();
+        let Some(from) = order.iter().position(|k| k == &dragged) else {
+            return;
+        };
+        let item = order.remove(from);
+        // Recompute the target index AFTER removing `dragged` — if `dragged`
+        // sat above `target`, removing it shifts `target` down by one.
+        let insert_at = match order.iter().position(|k| k == &target) {
+            Some(to) => to,
+            None => order.len(),
+        };
+        order.insert(insert_at, item);
+        self.room_order = order;
     }
 }
 
@@ -1551,6 +1638,7 @@ mod tests {
             removed_rooms: std::collections::HashSet::new(),
             notification_modes: HashMap::new(),
             migrated_rooms: Vec::new(),
+            room_order: Vec::new(),
         };
         local
             .notification_modes
@@ -1562,6 +1650,7 @@ mod tests {
             removed_rooms: std::collections::HashSet::new(),
             notification_modes: HashMap::new(),
             migrated_rooms: Vec::new(),
+            room_order: Vec::new(),
         };
         incoming
             .notification_modes
@@ -3109,6 +3198,7 @@ mod tests {
             removed_rooms: std::collections::HashSet::new(),
             notification_modes: Default::default(),
             migrated_rooms: Vec::new(),
+            room_order: Vec::new(),
         };
         current.map.insert(owner_vk, room_data.clone());
 
@@ -3124,6 +3214,7 @@ mod tests {
             removed_rooms: std::collections::HashSet::new(),
             notification_modes: Default::default(),
             migrated_rooms: Vec::new(),
+            room_order: Vec::new(),
         };
         legacy.map.insert(owner_vk, room_data);
 
@@ -3137,6 +3228,175 @@ mod tests {
             current.removed_rooms.contains(&owner_vk),
             "tombstone must survive the merge"
         );
+    }
+
+    // ---- Room display-order (drag-and-drop reorder) helpers ----
+
+    fn vk_from_seed(seed: u8) -> VerifyingKey {
+        SigningKey::from_bytes(&[seed; 32]).verifying_key()
+    }
+
+    fn minimal_room_data(owner_vk: VerifyingKey) -> RoomData {
+        let params = ChatRoomParametersV1 { owner: owner_vk };
+        let params_bytes = to_cbor_vec(&params);
+        let contract_key = ContractKey::from_params_and_code(
+            Parameters::from(params_bytes),
+            &ContractCode::from(ROOM_CONTRACT_WASM),
+        );
+        RoomData {
+            owner_vk,
+            room_state: ChatRoomStateV1::default(),
+            self_sk: SigningKey::from_bytes(&[1u8; 32]),
+            contract_key,
+            last_read_message_id: None,
+            secrets: HashMap::new(),
+            current_secret_version: None,
+            last_secret_rotation: None,
+            key_migrated_to_delegate: false,
+            self_authorized_member: None,
+            invite_chain: vec![],
+            self_member_info: None,
+            self_nickname: None,
+            previous_contract_key: None,
+            invitation_secrets: HashMap::new(),
+        }
+    }
+
+    fn rooms_with_keys(keys: &[VerifyingKey]) -> Rooms {
+        let mut rooms = Rooms {
+            map: HashMap::new(),
+            current_room_key: None,
+            removed_rooms: std::collections::HashSet::new(),
+            notification_modes: Default::default(),
+            migrated_rooms: Vec::new(),
+            room_order: Vec::new(),
+        };
+        for vk in keys {
+            rooms.map.insert(*vk, minimal_room_data(*vk));
+        }
+        rooms
+    }
+
+    /// With no manual order, rooms render in a deterministic (key-byte) order
+    /// rather than arbitrary `HashMap` order — and a manually-positioned room
+    /// leads, with the rest following in the deterministic tail.
+    #[test]
+    fn ordered_room_keys_is_deterministic_with_positioned_lead() {
+        let keys: Vec<VerifyingKey> = (1..=3).map(vk_from_seed).collect();
+        let mut rooms = rooms_with_keys(&keys);
+
+        // No manual order: pure deterministic key-byte sort.
+        let mut expected_sorted = keys.clone();
+        expected_sorted.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
+        assert_eq!(rooms.ordered_room_keys(), expected_sorted);
+
+        // Position the third key first; the other two follow sorted.
+        rooms.room_order = vec![keys[2]];
+        let ordered = rooms.ordered_room_keys();
+        assert_eq!(ordered[0], keys[2]);
+        let mut rest = vec![keys[0], keys[1]];
+        rest.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
+        assert_eq!(&ordered[1..], &rest[..]);
+    }
+
+    /// A stale `room_order` entry for a room no longer in `map` is ignored,
+    /// not rendered as a phantom row.
+    #[test]
+    fn ordered_room_keys_ignores_stale_order_entries() {
+        let keys: Vec<VerifyingKey> = (1..=2).map(vk_from_seed).collect();
+        let mut rooms = rooms_with_keys(&keys);
+        let ghost = vk_from_seed(99);
+        rooms.room_order = vec![ghost, keys[0]];
+        let ordered = rooms.ordered_room_keys();
+        assert!(!ordered.contains(&ghost));
+        assert_eq!(ordered.len(), 2);
+        assert_eq!(ordered[0], keys[0]);
+    }
+
+    /// Dragging the last room onto the first lands it immediately before the
+    /// first, materialising the full order, with the others' relative order
+    /// preserved.
+    #[test]
+    fn move_room_drops_before_target() {
+        let keys: Vec<VerifyingKey> = (1..=4).map(vk_from_seed).collect();
+        let mut rooms = rooms_with_keys(&keys);
+        let base = rooms.ordered_room_keys();
+
+        rooms.move_room(base[3], base[0]);
+        let after = rooms.ordered_room_keys();
+        assert_eq!(after, vec![base[3], base[0], base[1], base[2]]);
+        // The full order is now persisted (every current room, no stale keys).
+        assert_eq!(rooms.room_order, after);
+    }
+
+    /// Dragging a room downward (above→below its target) also lands it
+    /// immediately before the target, accounting for the index shift caused
+    /// by removing the dragged item first.
+    #[test]
+    fn move_room_downward_inserts_before_target() {
+        let keys: Vec<VerifyingKey> = (1..=4).map(vk_from_seed).collect();
+        let mut rooms = rooms_with_keys(&keys);
+        let base = rooms.ordered_room_keys();
+
+        // Move base[0] so it sits just before base[2].
+        rooms.move_room(base[0], base[2]);
+        let after = rooms.ordered_room_keys();
+        assert_eq!(after, vec![base[1], base[0], base[2], base[3]]);
+    }
+
+    /// `move_room` no-ops on a self-drop or an unknown key rather than
+    /// corrupting the order.
+    #[test]
+    fn move_room_noops_on_self_or_unknown() {
+        let keys: Vec<VerifyingKey> = (1..=3).map(vk_from_seed).collect();
+        let mut rooms = rooms_with_keys(&keys);
+
+        rooms.move_room(keys[0], keys[0]);
+        assert!(rooms.room_order.is_empty(), "self-drop must not reorder");
+
+        let ghost = vk_from_seed(99);
+        rooms.move_room(ghost, keys[0]);
+        assert!(
+            rooms.room_order.is_empty(),
+            "unknown dragged key is a no-op"
+        );
+
+        rooms.move_room(keys[0], ghost);
+        // Unknown target falls back to appending dragged at the end; the order
+        // still contains exactly the live rooms.
+        assert_eq!(rooms.room_order.len(), keys.len());
+        for k in &keys {
+            assert!(rooms.room_order.contains(k));
+        }
+    }
+
+    /// Leaving a room drops it from the manual order.
+    #[test]
+    fn leave_room_prunes_room_order() {
+        let keys: Vec<VerifyingKey> = (1..=3).map(vk_from_seed).collect();
+        let mut rooms = rooms_with_keys(&keys);
+        rooms.room_order = vec![keys[0], keys[1], keys[2]];
+        rooms.leave_room(keys[1]);
+        assert_eq!(rooms.room_order, vec![keys[0], keys[2]]);
+    }
+
+    /// Merge keeps this device's order authoritative, adopts incoming-only
+    /// keys, and prunes any order entry not backed by a live room.
+    #[test]
+    fn merge_unions_and_prunes_room_order() {
+        let keys: Vec<VerifyingKey> = (1..=3).map(vk_from_seed).collect();
+        // Local has all three rooms, ordered [k3, k1] (k2 unpositioned).
+        let mut local = rooms_with_keys(&keys);
+        local.room_order = vec![keys[2], keys[0]];
+
+        // Incoming order references k2 (live) and a ghost (not in any map).
+        let ghost = vk_from_seed(99);
+        let mut incoming = rooms_with_keys(&keys);
+        incoming.room_order = vec![keys[1], ghost];
+
+        local.merge(incoming).expect("merge");
+        // k3,k1 from local; k2 adopted from incoming; ghost pruned.
+        assert_eq!(local.room_order, vec![keys[2], keys[0], keys[1]]);
     }
 
     /// Backward-compat: a `rooms_data` blob serialised before this PR
@@ -3164,6 +3424,8 @@ mod tests {
         assert!(decoded.removed_rooms.is_empty());
         assert!(decoded.map.is_empty());
         assert!(decoded.current_room_key.is_none());
+        // The new drag-order field must also default cleanly for old blobs.
+        assert!(decoded.room_order.is_empty());
     }
 
     /// Round-trip: serialise a `Rooms` containing a tombstone, deserialise,
@@ -3180,6 +3442,7 @@ mod tests {
             removed_rooms: std::collections::HashSet::new(),
             notification_modes: Default::default(),
             migrated_rooms: Vec::new(),
+            room_order: Vec::new(),
         };
         original.removed_rooms.insert(vk);
 
@@ -3236,6 +3499,7 @@ mod tests {
             removed_rooms: std::collections::HashSet::new(),
             notification_modes: Default::default(),
             migrated_rooms: Vec::new(),
+            room_order: Vec::new(),
         };
         // Step 1: leave the room.
         current.leave_room(owner_vk);
@@ -3249,6 +3513,7 @@ mod tests {
             removed_rooms: std::collections::HashSet::new(),
             notification_modes: Default::default(),
             migrated_rooms: Vec::new(),
+            room_order: Vec::new(),
         };
         incoming.map.insert(owner_vk, room_data);
         current.merge(incoming).expect("merge");
@@ -3306,6 +3571,7 @@ mod tests {
             removed_rooms: std::collections::HashSet::new(),
             notification_modes: Default::default(),
             migrated_rooms: Vec::new(),
+            room_order: Vec::new(),
         };
         receiver.map.insert(owner_vk, room_data);
         let mut sender = Rooms {
@@ -3314,6 +3580,7 @@ mod tests {
             removed_rooms: std::collections::HashSet::new(),
             notification_modes: Default::default(),
             migrated_rooms: Vec::new(),
+            room_order: Vec::new(),
         };
         sender.removed_rooms.insert(owner_vk);
 

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -1295,7 +1295,11 @@ pub struct Rooms {
     ///   `leave_room`, so the list never grows without bound.
     /// * On `merge`, this device's order is authoritative; keys seen only in
     ///   the incoming order are appended (same local-wins rule as
-    ///   `notification_modes`).
+    ///   `notification_modes`). Cross-device consequence: reordering rooms on
+    ///   one device does NOT reorder the rooms another device already has —
+    ///   each device keeps its own arrangement and only adopts the *positions*
+    ///   of rooms it had not yet placed. This is intended for a local view
+    ///   preference; it is not a sync bug.
     #[serde(default)]
     pub room_order: Vec<VerifyingKey>,
     /// Rooms whose contract key changed due to WASM update.
@@ -1592,9 +1596,11 @@ impl Rooms {
     ///
     /// Operates on the current effective order (`ordered_room_keys`), so the
     /// first drag of an as-yet-unordered list materialises the full order
-    /// rather than just the two rooms involved. No-ops if either key is not a
-    /// current room or if they're equal. After this call `room_order` contains
-    /// exactly the current `map` keys (no stale entries).
+    /// rather than just the two rooms involved. No-ops if `dragged` is not a
+    /// current room or if the two keys are equal. If `target` is not a current
+    /// room (unreachable from the UI, where the target is always a rendered
+    /// row) the dragged room falls back to the end. After this call
+    /// `room_order` contains exactly the current `map` keys (no stale entries).
     pub fn move_room(&mut self, dragged: VerifyingKey, target: VerifyingKey) {
         if dragged == target {
             return;
@@ -1611,6 +1617,20 @@ impl Rooms {
             None => order.len(),
         };
         order.insert(insert_at, item);
+        self.room_order = order;
+    }
+
+    /// Move `dragged` to the very end of the display order, persisting the
+    /// resulting full order. Backs the rail's tail drop zone — every row drop
+    /// inserts *before* its target, so without this the last slot would be
+    /// unreachable. No-ops if `dragged` is not a current room.
+    pub fn move_room_to_end(&mut self, dragged: VerifyingKey) {
+        let mut order = self.ordered_room_keys();
+        let Some(from) = order.iter().position(|k| k == &dragged) else {
+            return;
+        };
+        let item = order.remove(from);
+        order.push(item);
         self.room_order = order;
     }
 }
@@ -3397,6 +3417,46 @@ mod tests {
         local.merge(incoming).expect("merge");
         // k3,k1 from local; k2 adopted from incoming; ghost pruned.
         assert_eq!(local.room_order, vec![keys[2], keys[0], keys[1]]);
+    }
+
+    /// The tail drop zone path: `move_room_to_end` puts a room last regardless
+    /// of where it started, materialising the full order.
+    #[test]
+    fn move_room_to_end_appends() {
+        let keys: Vec<VerifyingKey> = (1..=4).map(vk_from_seed).collect();
+        let mut rooms = rooms_with_keys(&keys);
+        let base = rooms.ordered_room_keys();
+
+        rooms.move_room_to_end(base[0]);
+        let after = rooms.ordered_room_keys();
+        assert_eq!(after, vec![base[1], base[2], base[3], base[0]]);
+        assert_eq!(rooms.room_order, after);
+
+        // Already-last stays last; unknown key is a no-op.
+        rooms.move_room_to_end(base[0]);
+        assert_eq!(rooms.ordered_room_keys(), after);
+        rooms.move_room_to_end(vk_from_seed(99));
+        assert_eq!(rooms.ordered_room_keys(), after);
+    }
+
+    /// Persistence round-trip: a populated `room_order` must survive the same
+    /// ciborium encode/decode the delegate save/load path uses. `room_order`
+    /// is a `Vec<VerifyingKey>`, a serde shape this blob hadn't exercised
+    /// before — pin it so a future `VerifyingKey` serde change can't silently
+    /// drop the user's drag order.
+    #[test]
+    fn rooms_round_trip_preserves_room_order() {
+        let keys: Vec<VerifyingKey> = (1..=3).map(vk_from_seed).collect();
+        let mut rooms = rooms_with_keys(&keys);
+        // A non-trivial order (not the deterministic default).
+        rooms.room_order = vec![keys[2], keys[0], keys[1]];
+
+        let mut buf: Vec<u8> = Vec::new();
+        ciborium::ser::into_writer(&rooms, &mut buf).unwrap();
+        let decoded: Rooms = ciborium::de::from_reader(buf.as_slice()).unwrap();
+
+        assert_eq!(decoded.room_order, vec![keys[2], keys[0], keys[1]]);
+        assert_eq!(decoded.ordered_room_keys(), vec![keys[2], keys[0], keys[1]]);
     }
 
     /// Backward-compat: a `rooms_data` blob serialised before this PR


### PR DESCRIPTION
## Problem

Two small Rooms-list UX requests:

1. **No way to reorder rooms.** The rail rendered rooms in raw `HashMap`
   iteration order, which is arbitrary and unstable across renders. Users
   couldn't put their most-used rooms at the top.
2. **Private-room lock icon sat to the left of the room name.** Requested move
   to the right.

## Approach

**Reorder (drag-and-drop):**
- Added `Rooms::room_order: Vec<VerifyingKey>` — a local, per-device display
  order persisted in the existing `rooms_data` delegate blob via
  `#[serde(default)]`, the same persistence model as `notification_modes` and
  `removed_rooms`. **No delegate migration needed:** `Rooms` is a `ui/`-only
  type, not compiled into delegate/contract WASM, and the field is additive +
  `serde(default)` so old blobs deserialise cleanly.
- `ordered_room_keys()` returns manually-positioned rooms first, then any
  not-yet-positioned rooms in a deterministic key-byte order. This also fixes
  the pre-existing arbitrary/unstable render order.
- `move_room(dragged, target)` drops the dragged room immediately before the
  target; `move_room_to_end(dragged)` backs a tail drop zone so the final slot
  is reachable (every row drop inserts *before* its target). `merge` keeps this
  device's order authoritative (adopts incoming-only keys, prunes to live
  rooms); `leave_room` prunes the left room.
- Each room row is `draggable`; all drag-state signal mutations route through
  `crate::util::defer()` (Dioxus WASM signal-safety), and the drag-over border
  space is reserved up front (transparent → accent) so there is **no layout
  shift**.

**Lock icon:** moved after the room-name span in the flex row (now right of the name).

## Testing

- `river-ui` native unit tests (`cargo test -p river-ui --bins`, all green):
  `ordered_room_keys` determinism + stale-entry filtering; `move_room`
  up/down/self-drop/unknown-key; `move_room_to_end`; `leave_room` pruning;
  `merge` union+prune; a populated `room_order` ciborium round-trip
  (`rooms_round_trip_preserves_room_order`); and the pre-247 backward-compat
  blob test extended to assert `room_order` defaults empty.
- `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync` — clean.
- `cargo clippy` — no new warnings in the touched files.

## Notes / limitations

- HTML5 drag-and-drop is desktop/pointer only; touch devices won't reorder
  (rooms still render and click-to-open still works). Acceptable for v1.
- Reordering is a local, per-device view preference (last-write-wins on the
  shared `rooms_data` blob, identical to the existing `removed_rooms` /
  `notification_modes` fields). A future `rooms_data` persistence rework (CAS /
  per-room-key split) would protect `room_order` for free since it rides the
  same blob — additive, low conflict risk.

[AI-assisted - Claude]