### PR TITLE
feat(cli): send encrypted messages to private rooms

### DIFF
--- a/.claude/rules/private-rooms.md
+++ b/.claude/rules/private-rooms.md
@@ -147,10 +147,28 @@ version (and prunes it from `invitation_secrets`).
 
 riverctl carries the same `Invitation::room_secrets` wire shape as the UI,
 with `cli::private_room::{collect_secrets_for_room, collect_invitation_secrets,
-seal_invitee_nickname, current_secret_from_state}` as the byte-identical
-CLI counterparts. `StoredRoomInfo::invitation_secrets` (a
+seal_invitee_nickname, current_secret_from_state, build_message_body}` as the
+byte-identical CLI counterparts. `StoredRoomInfo::invitation_secrets` (a
 `HashMap<u32, [u8; 32]>` in `rooms.json`) persists the invitation-carried
 secrets across CLI invocations.
+
+**Sending (issue #350).** `cli::private_room::build_message_body` is the CLI
+analog of the UI's text-send path in `ui/src/components/conversation.rs`:
+for a private room it CBOR-encodes the text, seals it under the
+current-version secret with `encrypt_with_symmetric_key`, and emits
+`RoomMessageBody::private_text`. Wired into both `ApiClient::send_message`
+(storage identity) and `send_message_with_key` (explicit `--signing-key`,
+the stateless CI-runner path), so `riverctl message send` now works in a
+private room. **Deliberate divergence from the UI:** when no secret is
+available for the current version the UI logs a warning and falls back to a
+**public** body (`conversation.rs`, which the contract then rejects);
+`build_message_body` instead **errors** — never sending a public body into a
+private room, and never sealing under a stale (non-current) version. It also
+errors on an over-`max_message_size` body, which the contract would otherwise
+silently drop. Only plain `message send` is sealed; `message reply` / `edit`
+/ `delete` / reactions still emit public bodies and therefore still fail in a
+private room (they were never functional there — tracked separately for
+sealed action/reply bodies).
 
 **Critical**: `collect_secrets_for_room` does NOT derive owner secrets via
 `derive_room_secret` — the initial random v0 from `generate_room_secret()`

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -2036,11 +2036,27 @@ impl ApiClient {
         // Resolve any bare @nickname mentions to full mention tokens.
         let message_content = resolve_outgoing_mentions(&room_state, &message_content);
 
+        // Build the body — plaintext for a public room, AES-256-GCM sealed
+        // for a private room. Any persisted invitation-carried secrets (when
+        // a config dir holds this room) supplement the contract's per-member
+        // `encrypted_secrets` blob.
+        let invitation_secrets = self
+            .storage
+            .get_invitation_secrets(room_owner_key)
+            .unwrap_or_default();
+        let content = crate::private_room::build_message_body(
+            &room_state,
+            signing_key,
+            &invitation_secrets,
+            message_content,
+        )
+        .map_err(|e| anyhow!(e))?;
+
         // Create the message
         let message = river_core::room_state::message::MessageV1 {
             room_owner: MemberId::from(*room_owner_key),
             author: sender_member_id,
-            content: river_core::room_state::message::RoomMessageBody::public(message_content),
+            content,
             time: std::time::SystemTime::now(),
         };
 
@@ -2146,11 +2162,27 @@ impl ApiClient {
         // Resolve any bare @nickname mentions to full mention tokens.
         let message_content = resolve_outgoing_mentions(&room_state, &message_content);
 
+        // Build the body — plaintext for a public room, AES-256-GCM sealed for
+        // a private room (secret resolved from the contract's per-member
+        // `encrypted_secrets` blob, or this room's persisted invitation
+        // secrets).
+        let invitation_secrets = self
+            .storage
+            .get_invitation_secrets(room_owner_key)
+            .unwrap_or_default();
+        let content = crate::private_room::build_message_body(
+            &room_state,
+            &signing_key,
+            &invitation_secrets,
+            message_content,
+        )
+        .map_err(|e| anyhow!(e))?;
+
         // Create the message
         let message = river_core::room_state::message::MessageV1 {
             room_owner: river_core::room_state::member::MemberId::from(*room_owner_key),
             author: river_core::room_state::member::MemberId::from(&signing_key.verifying_key()),
-            content: river_core::room_state::message::RoomMessageBody::public(message_content),
+            content,
             time: std::time::SystemTime::now(),
         };
 

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -2040,7 +2040,18 @@ impl ApiClient {
         // for a private room. Any persisted invitation-carried secrets (when
         // a config dir holds this room) supplement the contract's per-member
         // `encrypted_secrets` blob.
-        let invitation_secrets = self.storage.get_invitation_secrets(room_owner_key)?;
+        //
+        // This is the explicit-key / stateless path (bots, CI/CD), documented
+        // as NOT requiring local storage, so a missing/corrupt/read-only
+        // `rooms.json` must NOT fail the send: `.unwrap_or_default()` degrades
+        // to "no invitation secrets", and `build_message_body` then relies on
+        // the contract `encrypted_secrets` blob (public sends need no secret at
+        // all). Only erroring if NO secret is available anywhere — never on a
+        // storage hiccup the send doesn't depend on.
+        let invitation_secrets = self
+            .storage
+            .get_invitation_secrets(room_owner_key)
+            .unwrap_or_default();
         let content = crate::private_room::build_message_body(
             &room_state,
             signing_key,
@@ -2162,7 +2173,10 @@ impl ApiClient {
         // Build the body — plaintext for a public room, AES-256-GCM sealed for
         // a private room (secret resolved from the contract's per-member
         // `encrypted_secrets` blob, or this room's persisted invitation
-        // secrets).
+        // secrets). Unlike `send_message_with_key`, this path already requires
+        // local storage (it loaded the signing key from `rooms.json` above), so
+        // a `?` here surfaces a corrupt store as a clear error rather than a
+        // misleading "no secret available".
         let invitation_secrets = self.storage.get_invitation_secrets(room_owner_key)?;
         let content = crate::private_room::build_message_body(
             &room_state,

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -2040,10 +2040,7 @@ impl ApiClient {
         // for a private room. Any persisted invitation-carried secrets (when
         // a config dir holds this room) supplement the contract's per-member
         // `encrypted_secrets` blob.
-        let invitation_secrets = self
-            .storage
-            .get_invitation_secrets(room_owner_key)
-            .unwrap_or_default();
+        let invitation_secrets = self.storage.get_invitation_secrets(room_owner_key)?;
         let content = crate::private_room::build_message_body(
             &room_state,
             signing_key,
@@ -2166,10 +2163,7 @@ impl ApiClient {
         // a private room (secret resolved from the contract's per-member
         // `encrypted_secrets` blob, or this room's persisted invitation
         // secrets).
-        let invitation_secrets = self
-            .storage
-            .get_invitation_secrets(room_owner_key)
-            .unwrap_or_default();
+        let invitation_secrets = self.storage.get_invitation_secrets(room_owner_key)?;
         let content = crate::private_room::build_message_body(
             &room_state,
             &signing_key,

--- a/cli/src/private_room.rs
+++ b/cli/src/private_room.rs
@@ -8,8 +8,12 @@
 //! invitation are wire-interchangeable.
 
 use ed25519_dalek::SigningKey;
-use river_core::ecies::{decrypt_secret_from_member_blob_raw, seal_bytes};
+use river_core::ecies::{
+    decrypt_secret_from_member_blob_raw, encrypt_with_symmetric_key, seal_bytes,
+};
+use river_core::room_state::content::TextContentV1;
 use river_core::room_state::member::MemberId;
+use river_core::room_state::message::RoomMessageBody;
 use river_core::room_state::privacy::{PrivacyMode, SealedBytes};
 use river_core::room_state::ChatRoomStateV1;
 use std::collections::HashMap;
@@ -177,11 +181,58 @@ fn current_secret_from_state(
     Some((secret, version))
 }
 
+/// Build the `RoomMessageBody` for an outgoing chat message.
+///
+/// For a **public** room this is the plaintext body (unchanged behaviour).
+/// For a **private** room the plaintext is encrypted under the room's
+/// current-version secret with AES-256-GCM, mirroring the UI's send path in
+/// `ui/src/components/conversation.rs` (`TextContentV1::encode` →
+/// `encrypt_with_symmetric_key` → `RoomMessageBody::private`). The secret is
+/// resolved exactly like [`seal_invitee_nickname`]: from the member's own
+/// owner-signed `encrypted_secrets` blob in contract state, falling back to
+/// the secret carried in the `Invitation` this member joined with
+/// (`invitation_secrets`). [`collect_secrets_for_room`] folds both sources.
+///
+/// Returns an error (rather than silently falling back to a public body,
+/// which the contract rejects in a private room with "Cannot send public
+/// messages in private room") when no secret is available for the current
+/// version — the room owner must re-provision this member's secret, or the
+/// member must rejoin via a fresh invitation that carries the current version.
+pub fn build_message_body(
+    state: &ChatRoomStateV1,
+    self_sk: &SigningKey,
+    invitation_secrets: &HashMap<u32, [u8; 32]>,
+    text: String,
+) -> Result<RoomMessageBody, String> {
+    if state.configuration.configuration.privacy_mode != PrivacyMode::Private {
+        return Ok(RoomMessageBody::public(text));
+    }
+
+    let version = state.secrets.current_version;
+    let secrets = collect_secrets_for_room(state, self_sk, invitation_secrets);
+    let secret = secrets.get(&version).ok_or_else(|| {
+        format!(
+            "private room: no secret available for the current version (v{version}). \
+             Sealing the message would be impossible. The room owner must share the \
+             current room secret with this member (re-key / re-provision), or this \
+             member must rejoin via a fresh invitation carrying v{version}."
+        )
+    })?;
+
+    // Mirror the UI: CBOR-encode the text content, then AES-256-GCM seal it
+    // under the current room secret with a fresh random nonce.
+    let content_bytes = TextContentV1::new(text).encode();
+    let (ciphertext, nonce) = encrypt_with_symmetric_key(secret, &content_bytes);
+    Ok(RoomMessageBody::private_text(ciphertext, nonce, version))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use ed25519_dalek::SigningKey;
-    use river_core::ecies::{encrypt_secret_for_member, generate_room_secret};
+    use river_core::ecies::{
+        decrypt_with_symmetric_key, encrypt_secret_for_member, generate_room_secret,
+    };
     use river_core::room_state::configuration::{AuthorizedConfigurationV1, Configuration};
     use river_core::room_state::privacy::PrivacyMode;
     use river_core::room_state::secret::{
@@ -397,6 +448,118 @@ mod tests {
             sealed.is_none(),
             "must defer when invitation_secrets lacks current_version — \
              sealing under v0 when room is at v1 yields a SealedBytes nobody can unseal"
+        );
+    }
+
+    #[test]
+    fn build_message_body_public_room_is_plaintext() {
+        let owner = fresh_signing_key();
+        let state = state_with_privacy(&owner, PrivacyMode::Public);
+        let body = build_message_body(&state, &owner, &HashMap::new(), "hello".to_string())
+            .expect("public room always builds a body");
+        match body {
+            RoomMessageBody::Public { data, .. } => {
+                let decoded = TextContentV1::decode(&data).expect("valid text content");
+                assert_eq!(decoded.text, "hello");
+            }
+            RoomMessageBody::Private { .. } => panic!("public room must not seal the body"),
+        }
+    }
+
+    #[test]
+    fn build_message_body_private_room_seals_and_roundtrips_via_invitation_secret() {
+        let owner = fresh_signing_key();
+        let state = state_with_privacy(&owner, PrivacyMode::Private); // current_version = 0
+        let secret = [0x42u8; 32];
+        let mut inv = HashMap::new();
+        inv.insert(0u32, secret);
+
+        let body = build_message_body(&state, &owner, &inv, "secret hi".to_string())
+            .expect("invitation-carried secret seals the body");
+
+        match body {
+            RoomMessageBody::Private {
+                ciphertext,
+                nonce,
+                secret_version,
+                ..
+            } => {
+                assert_eq!(secret_version, 0, "must seal under the current version");
+                let plaintext = decrypt_with_symmetric_key(&secret, &ciphertext, &nonce)
+                    .expect("the sealed body decrypts under the room secret");
+                let decoded = TextContentV1::decode(&plaintext).expect("valid text content");
+                assert_eq!(decoded.text, "secret hi");
+            }
+            RoomMessageBody::Public { .. } => panic!("private room must seal the body"),
+        }
+    }
+
+    #[test]
+    fn build_message_body_private_room_seals_via_contract_blob() {
+        // The member's secret lives only in an owner-signed contract blob
+        // (the steady-state path, once the owner has provisioned the member).
+        let owner = fresh_signing_key();
+        let mut state = state_with_privacy(&owner, PrivacyMode::Private);
+        let secret = [0x7eu8; 32];
+        state
+            .secrets
+            .encrypted_secrets
+            .push(owner_blob(&owner, &owner.verifying_key(), 0, secret));
+
+        let body = build_message_body(&state, &owner, &HashMap::new(), "from blob".to_string())
+            .expect("contract-blob secret seals the body");
+
+        match body {
+            RoomMessageBody::Private {
+                ciphertext,
+                nonce,
+                secret_version,
+                ..
+            } => {
+                assert_eq!(secret_version, 0);
+                let plaintext = decrypt_with_symmetric_key(&secret, &ciphertext, &nonce)
+                    .expect("decrypts under the blob-carried secret");
+                assert_eq!(TextContentV1::decode(&plaintext).unwrap().text, "from blob");
+            }
+            RoomMessageBody::Public { .. } => panic!("private room must seal the body"),
+        }
+    }
+
+    #[test]
+    fn build_message_body_private_room_errors_without_secret() {
+        let owner = fresh_signing_key();
+        let state = state_with_privacy(&owner, PrivacyMode::Private);
+        // A member with neither a contract blob nor an invitation secret for
+        // the current version must error — never silently send a public body
+        // that the contract would reject ("Cannot send public messages...").
+        let err = build_message_body(
+            &state,
+            &fresh_signing_key(),
+            &HashMap::new(),
+            "nope".to_string(),
+        )
+        .expect_err("must refuse to send when no secret is available");
+        assert!(
+            err.contains("no secret available"),
+            "error should explain the missing secret, got: {err}"
+        );
+    }
+
+    #[test]
+    fn build_message_body_private_room_errors_when_secret_lacks_current_version() {
+        // Room rotated to v1 but the member only holds v0 — sealing under v0
+        // would be unreadable by members at v1, so refuse (mirrors the
+        // nickname-sealing guard).
+        let owner = fresh_signing_key();
+        let mut state = state_with_privacy(&owner, PrivacyMode::Private);
+        state.secrets.current_version = 1;
+        let mut inv = HashMap::new();
+        inv.insert(0u32, [0x42u8; 32]);
+        let err = build_message_body(&state, &fresh_signing_key(), &inv, "stale".to_string())
+            .expect_err("must refuse to seal under a non-current version");
+        assert!(
+            err.contains("v1"),
+            "error should name the current version: {err}"
         );
     }
 

--- a/cli/src/private_room.rs
+++ b/cli/src/private_room.rs
@@ -198,32 +198,62 @@ fn current_secret_from_state(
 /// messages in private room") when no secret is available for the current
 /// version — the room owner must re-provision this member's secret, or the
 /// member must rejoin via a fresh invitation that carries the current version.
+///
+/// Also errors if the resulting body exceeds the room's `max_message_size`.
+/// The contract enforces that limit by *silently dropping* the message in
+/// `MessagesV1::apply_delta` (a `retain`, not an `Err`), so without this
+/// guard a too-long message would report success while never being
+/// delivered. The limit is measured against the body's `content_len()` —
+/// for a private room that is the AES-256-GCM **ciphertext** length (raw
+/// text + a 16-byte authentication tag + CBOR framing), so a message that
+/// fits as public can exceed the limit once sealed. Mirrors the UI's
+/// pre-send guard in `ui/src/components/conversation.rs`.
 pub fn build_message_body(
     state: &ChatRoomStateV1,
     self_sk: &SigningKey,
     invitation_secrets: &HashMap<u32, [u8; 32]>,
     text: String,
 ) -> Result<RoomMessageBody, String> {
-    if state.configuration.configuration.privacy_mode != PrivacyMode::Private {
-        return Ok(RoomMessageBody::public(text));
+    let content = if state.configuration.configuration.privacy_mode != PrivacyMode::Private {
+        RoomMessageBody::public(text)
+    } else {
+        let version = state.secrets.current_version;
+        let secrets = collect_secrets_for_room(state, self_sk, invitation_secrets);
+        let secret = secrets.get(&version).ok_or_else(|| {
+            format!(
+                "private room: no secret available for the current version (v{version}). \
+                 Sealing the message would be impossible. The room owner must share the \
+                 current room secret with this member (re-key / re-provision), or this \
+                 member must rejoin via a fresh invitation carrying v{version}."
+            )
+        })?;
+
+        // Mirror the UI: CBOR-encode the text content, then AES-256-GCM seal
+        // it under the current room secret with a fresh random nonce.
+        let content_bytes = TextContentV1::new(text).encode();
+        let (ciphertext, nonce) = encrypt_with_symmetric_key(secret, &content_bytes);
+        RoomMessageBody::private_text(ciphertext, nonce, version)
+    };
+
+    // Fail loudly on an over-size body instead of letting the contract drop it
+    // silently (see the doc comment above). Covers both public and private
+    // bodies via the same `content_len()` the contract checks.
+    let max = state.configuration.configuration.max_message_size;
+    let len = content.content_len();
+    if len > max {
+        return Err(format!(
+            "message too large: {len} encoded bytes exceeds the room's \
+             max_message_size of {max} bytes.{}",
+            if content.is_private() {
+                " Private-room messages are AES-256-GCM sealed, which adds a \
+                 16-byte authentication tag plus CBOR framing over the raw text."
+            } else {
+                ""
+            }
+        ));
     }
 
-    let version = state.secrets.current_version;
-    let secrets = collect_secrets_for_room(state, self_sk, invitation_secrets);
-    let secret = secrets.get(&version).ok_or_else(|| {
-        format!(
-            "private room: no secret available for the current version (v{version}). \
-             Sealing the message would be impossible. The room owner must share the \
-             current room secret with this member (re-key / re-provision), or this \
-             member must rejoin via a fresh invitation carrying v{version}."
-        )
-    })?;
-
-    // Mirror the UI: CBOR-encode the text content, then AES-256-GCM seal it
-    // under the current room secret with a fresh random nonce.
-    let content_bytes = TextContentV1::new(text).encode();
-    let (ciphertext, nonce) = encrypt_with_symmetric_key(secret, &content_bytes);
-    Ok(RoomMessageBody::private_text(ciphertext, nonce, version))
+    Ok(content)
 }
 
 #[cfg(test)]
@@ -560,6 +590,106 @@ mod tests {
         assert!(
             err.contains("v1"),
             "error should name the current version: {err}"
+        );
+    }
+
+    #[test]
+    fn build_message_body_errors_when_body_exceeds_max_message_size() {
+        // The contract silently DROPS an over-size message (a `retain` in
+        // `MessagesV1::apply_delta`), so the helper must refuse loudly rather
+        // than let a send report success while delivering nothing.
+        let owner = fresh_signing_key();
+        let mut state = state_with_privacy(&owner, PrivacyMode::Private);
+        // Tiny limit so a normal-length message overflows once sealed.
+        let mut config = state.configuration.configuration.clone();
+        config.max_message_size = 4;
+        state.configuration = AuthorizedConfigurationV1::new(config, &owner);
+        let mut inv = HashMap::new();
+        inv.insert(0u32, [0x42u8; 32]);
+
+        let err = build_message_body(
+            &state,
+            &owner,
+            &inv,
+            "this is definitely longer than four bytes".to_string(),
+        )
+        .expect_err("over-size body must be rejected, not silently dropped");
+        assert!(
+            err.contains("too large") && err.contains("max_message_size"),
+            "error should explain the size limit, got: {err}"
+        );
+    }
+
+    /// End-to-end contract acceptance: a body produced by `build_message_body`
+    /// must be accepted by the room contract's own `apply_delta` — the same
+    /// validation `send_message` runs locally before transmitting. This closes
+    /// the gap the unit tests above leave open (they only check the sealing
+    /// math against a state whose `secrets.versions` is empty, which the
+    /// contract would reject). Requires no node.
+    #[test]
+    fn build_message_body_output_is_accepted_by_contract_apply_delta() {
+        use freenet_scaffold::ComposableState;
+        use river_core::room_state::message::{AuthorizedMessageV1, MessageV1};
+        use river_core::room_state::privacy::RoomCipherSpec;
+        use river_core::room_state::secret::{
+            AuthorizedSecretVersionRecord, RoomSecretsV1, SecretVersionRecordV1,
+        };
+        use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1Delta};
+
+        let owner = fresh_signing_key();
+        let owner_vk = owner.verifying_key();
+        let owner_id = MemberId::from(&owner_vk);
+        let mut state = state_with_privacy(&owner, PrivacyMode::Private);
+
+        // Provision a genuine v0 secret: an owner-signed version record (so the
+        // contract's `secret_version ∈ versions` check passes) plus the
+        // owner's own owner-signed `encrypted_secrets` blob.
+        let secret = [0x33u8; 32];
+        state.secrets = RoomSecretsV1 {
+            current_version: 0,
+            versions: vec![AuthorizedSecretVersionRecord::new(
+                SecretVersionRecordV1 {
+                    version: 0,
+                    cipher_spec: RoomCipherSpec::Aes256Gcm,
+                    created_at: std::time::SystemTime::now(),
+                },
+                &owner,
+            )],
+            encrypted_secrets: vec![owner_blob(&owner, &owner_vk, 0, secret)],
+        };
+
+        let content = build_message_body(&state, &owner, &HashMap::new(), "ci ping".to_string())
+            .expect("seals under v0");
+
+        // The owner is always an accepted author, so no member entry is needed.
+        let message = MessageV1 {
+            room_owner: owner_id,
+            author: owner_id,
+            content,
+            time: std::time::SystemTime::now(),
+        };
+        let auth = AuthorizedMessageV1::new(message, &owner);
+        let delta = ChatRoomStateV1Delta {
+            recent_messages: Some(vec![auth]),
+            ..Default::default()
+        };
+        let params = ChatRoomParametersV1 { owner: owner_vk };
+
+        let mut applied = state.clone();
+        applied
+            .apply_delta(&state, &params, &Some(delta))
+            .expect("the contract accepts the sealed private message");
+        assert_eq!(
+            applied.recent_messages.messages.len(),
+            1,
+            "the sealed message must be retained, not silently dropped"
+        );
+        assert!(
+            applied.recent_messages.messages[0]
+                .message
+                .content
+                .is_private(),
+            "the accepted body must be the sealed (private) form"
         );
     }
 


### PR DESCRIPTION
## Problem

riverctl's `message send` always built a **public** `RoomMessageBody`, so posting to a **private** room is rejected by the room contract:

```
Error: Failed to apply message delta: "Cannot send public messages in private room"
```

This makes riverctl unusable for any private room. Concretely, it blocks setting up a CI/notification bot in the new private `freenet-dev` room (Nacho's request: CI-failure / nightly / PR-merge announcements, like the old Matrix bot).

## Approach

Mirror the UI's proven send path (`ui/src/components/conversation.rs`): for a private room, CBOR-encode the text content, seal it under the room's **current-version** secret with AES-256-GCM, and emit `RoomMessageBody::private`.

The room secret is resolved by the **same** logic riverctl already uses to seal invitee nicknames (`seal_invitee_nickname`):

1. the member's own owner-signed `encrypted_secrets` blob in contract state (authoritative), else
2. the secret carried in the `Invitation` this member joined with (`invitation_secrets`).

`collect_secrets_for_room` already folds both sources; the new `build_message_body` helper picks `current_version` from it. If no secret is available for the current version, it **errors** rather than silently sending a public body the contract would reject (and rather than sealing under a stale version other members can't read).

Wired into both send paths: `send_message` (storage identity) and `send_message_with_key` (explicit `--signing-key`, which is how a stateless CI runner posts).

**Out of scope (unchanged):** `edit` / `delete` / reactions / `reply` still emit public bodies — they use different content types and aren't needed here. They were already non-functional in private rooms (riverctl never supported private-room sending at all); a follow-up issue will track adding sealed action/reply bodies.

## Testing

New unit tests in `cli/src/private_room.rs`:
- public room → plaintext body (unchanged)
- private room, invitation-carried secret → sealed body; AES-GCM **roundtrip** decodes back to the original text
- private room, contract-blob secret → sealed body; roundtrip
- private room, no secret → error (never falls back to a public body)
- private room rotated past the held version → error (won't seal under a non-current version)

`cargo test -p riverctl --lib private_room` — 22 passed. `cargo fmt` + `cargo clippy` clean.

> Note: a final on-network confirmation (the contract accepting the sealed `Private` message end-to-end) is pending a reachable local node — nova's gateway is down for maintenance as of this writing. The send path's own pre-send `apply_delta` runs the identical contract validation locally, and the sealing is byte-for-byte the UI's production path, so the risk is low; I'll confirm against the live network before the riverctl release that the CI workflows depend on.

[AI-assisted - Claude]