### PR TITLE
fix(ui): recover rooms stranded by an interrupted delegate migration

### DIFF
--- a/.claude/rules/river-publish.md
+++ b/.claude/rules/river-publish.md
@@ -108,13 +108,31 @@ where stale legacy data overwrites newer state on the current delegate
 2. `LEGACY_DELEGATES` is generated at compile time from `legacy_delegates.toml`
    by `ui/build.rs`.
 3. The current delegate's `ListResponse` is classified by `plan_load_from_keys`:
-   - **Has `room:<vk>` keys** → current is authoritative: `load_rooms_per_room`
-     plain-GETs each slot (+ `rooms_meta`), reconstructs `Rooms`, hydrates, and
-     calls `mark_legacy_migration_done()`. Legacy probes never fire.
+   - **Has `room:<vk>` keys** → `load_rooms_per_room` plain-GETs each slot
+     (+ `rooms_meta`), reconstructs `Rooms`, and hydrates. What it does about
+     legacy migration is gated by `decide_per_room_load_action` on the
+     **interrupted-migration flag** (`is_legacy_migration_in_progress()`):
+     - *Not interrupted* (the common case) → the per-room set is authoritative:
+       call `mark_legacy_migration_done()`; legacy probes never fire (#253).
+     - *Interrupted* (a prior legacy→per-room migration was cut short before it
+       wrote every key — freenet/river#345 follow-up, Nacho's "Freenet Devs"
+       disappeared-after-update) → do NOT mark done; after loading the partial
+       set, re-run `migrate_current_blob_to_per_room()` once (armed via
+       `arm_legacy_migration_recovery()`, which also clears the per-session
+       attempt guard so same-session recovery isn't a no-op) to recover any
+       stranded room. The re-save is per-room CAS read-merge-write, so an
+       already-present room merges rather than being clobbered.
    - **No per-room keys, only a legacy `rooms_data` blob** →
      `migrate_current_blob_to_per_room` reads it and re-saves as per-room keys
      (non-destructive — the blob is left as a rollback fallback).
    - **Nothing** → `fire_legacy_migration_request()`.
+
+   The **interrupted-migration flag** is a per-legacy-set localStorage marker
+   (`river_legacy_migration_in_progress:<fingerprint>`, parallel to the
+   `…_done:` flag): set BEFORE any migration re-save (`hydrate_loaded_rooms`'s
+   legacy branch and the current-blob explosion alike) and cleared ONLY on a
+   FULL successful re-save. A partial/aborted re-save therefore leaves it set,
+   which is what drives the recovery above.
 4. `fire_legacy_migration_request` probes each legacy delegate TWO ways:
    (a) fixed `GetRequest` for `[ROOMS_STORAGE_KEY, OUTBOUND_DMS_STORAGE_KEY]`
    (the pre-#345 single-blob format + DM cache), and (b) a `ListRequest` to

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -974,6 +974,33 @@ mod tests {
         );
     }
 
+    /// Per-room load gating (freenet/river#345 follow-up — interrupted-migration
+    /// recovery). A clean per-room set is authoritative: seal migration, never
+    /// probe legacy. An interrupted one must NOT be sealed and must re-run the
+    /// migration to recover rooms a partial migration failed to write.
+    #[test]
+    fn per_room_load_action_gates_on_interrupted_flag() {
+        let clean = decide_per_room_load_action(false);
+        assert!(
+            clean.mark_done,
+            "a clean per-room set must seal migration (#253)"
+        );
+        assert!(
+            !clean.recover,
+            "a clean per-room set must not re-probe legacy"
+        );
+
+        let interrupted = decide_per_room_load_action(true);
+        assert!(
+            !interrupted.mark_done,
+            "an interrupted migration must NOT be sealed, or stranded rooms are lost forever"
+        );
+        assert!(
+            interrupted.recover,
+            "an interrupted migration must re-run to recover stranded rooms"
+        );
+    }
+
     /// Codex P1 finding on PR #259: the legacy-migration-done
     /// localStorage flag MUST be scoped to the current
     /// `LEGACY_DELEGATES` set, otherwise every WASM bump that adds
@@ -3365,6 +3392,44 @@ pub(crate) fn decide_legacy_migration_action(
     }
 }
 
+/// What a current-delegate `LoadPlan::PerRoom` load should do (freenet/river#345
+/// follow-up). Extracted as a pure value so the gating logic is unit-testable
+/// off-WASM — the load path itself is too coupled to the Dioxus/WebSocket
+/// runtime to drive in a test.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PerRoomLoadAction {
+    /// Seal legacy migration as permanently done (the per-room set is
+    /// authoritative; legacy must never be probed again — freenet/river#253).
+    pub mark_done: bool,
+    /// Re-run the migration to recover any room a prior interrupted migration
+    /// failed to write before it was cut short.
+    pub recover: bool,
+}
+
+/// Decide what a current-delegate per-room load should do, given whether a
+/// prior legacy migration was left in progress (interrupted).
+///
+/// - **Not interrupted** → the per-room set is authoritative: `mark_done` so
+///   legacy is never probed (freenet/river#253 — a stale legacy response could
+///   clobber newer state), and do not `recover`.
+/// - **Interrupted** → the set may be missing rooms a partial migration never
+///   wrote: do NOT seal it (`mark_done == false`) and `recover` (re-run the
+///   migration). The recovery re-save is a per-room CAS read-merge-write, so a
+///   room already present merges rather than being overwritten.
+pub(crate) fn decide_per_room_load_action(migration_interrupted: bool) -> PerRoomLoadAction {
+    if migration_interrupted {
+        PerRoomLoadAction {
+            mark_done: false,
+            recover: true,
+        }
+    } else {
+        PerRoomLoadAction {
+            mark_done: true,
+            recover: false,
+        }
+    }
+}
+
 /// localStorage key PREFIX to track whether legacy migration has been
 /// attempted. The actual key is suffixed with the fingerprint of the
 /// current [`LEGACY_DELEGATES`] set so that adding a new legacy entry
@@ -3515,6 +3580,32 @@ pub fn clear_legacy_migration_in_progress() {
 /// every WebSocket reconnect would re-fire all 3 legacy delegate requests, creating a
 /// tight error spam loop (~9 errors every 3 seconds).
 static LEGACY_MIGRATION_ATTEMPTED: AtomicBool = AtomicBool::new(false);
+
+/// Per-session guard so interrupted-migration recovery re-fires the legacy
+/// probe at most ONCE per session. Without it, every WebSocket reconnect that
+/// re-runs the per-room load would reset [`LEGACY_MIGRATION_ATTEMPTED`] and
+/// re-probe, reintroducing the very error-spam that guard prevents.
+static RECOVERY_REFIRE_DONE: AtomicBool = AtomicBool::new(false);
+
+/// Arm one interrupted-migration recovery probe for this session
+/// (freenet/river#345 follow-up; codex review of #352).
+///
+/// Returns `true` the FIRST time it is called in a session — and, as a side
+/// effect, clears the per-session [`LEGACY_MIGRATION_ATTEMPTED`] guard so the
+/// recovery's `fire_legacy_migration_request` actually fires. Returns `false`
+/// on every subsequent call. This is needed because the initial migration this
+/// session may already have set `LEGACY_MIGRATION_ATTEMPTED`; without clearing
+/// it, a same-session reconnect's recovery probe would be a silent no-op and
+/// stranded rooms wouldn't be recovered until a full page reload. The
+/// once-per-session bound means at most one extra legacy probe, only for users
+/// whose migration was interrupted — never reconnect spam.
+pub(crate) fn arm_legacy_migration_recovery() -> bool {
+    if RECOVERY_REFIRE_DONE.swap(true, Ordering::Relaxed) {
+        return false;
+    }
+    LEGACY_MIGRATION_ATTEMPTED.store(false, Ordering::Relaxed);
+    true
+}
 
 /// Fire requests to load rooms from all known legacy delegates (fire and forget).
 /// If any legacy delegate has room data, the response handler will migrate it.

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -994,6 +994,23 @@ mod tests {
         assert!(key.ends_with(&fp));
     }
 
+    /// The "migration in progress" and "migration done" localStorage keys MUST
+    /// be distinct — they're set/cleared independently, and a shared key would
+    /// make clearing one corrupt the other (freenet/river#345 follow-up: the
+    /// in-progress flag drives interrupted-migration recovery).
+    #[test]
+    fn migration_in_progress_key_distinct_from_done_key() {
+        let fp = legacy_set_fingerprint();
+        let in_progress = legacy_migration_in_progress_key();
+        let done = legacy_migration_flag_key();
+        assert_ne!(in_progress, done);
+        assert!(in_progress.starts_with(LEGACY_MIGRATION_IN_PROGRESS_PREFIX));
+        assert!(
+            in_progress.ends_with(&fp),
+            "in-progress flag must be per-set too"
+        );
+    }
+
     // ===== resolve_hidden_thread_hydration tests (#261 Codex P3) =====
     use freenet_scaffold::util::FastHash;
 
@@ -3417,6 +3434,75 @@ pub fn mark_legacy_migration_done() {
                 } else {
                     info!("Legacy migration marked as done (key={})", key);
                 }
+            }
+        }
+    }
+}
+
+/// localStorage key prefix for the "legacy migration in progress" flag — set
+/// BEFORE a migration's per-room re-save and cleared only on full success. If a
+/// migration is interrupted (a per-room CAS write fails, or the tab is closed
+/// mid-migration), this flag stays set, so the next load's per-room path knows
+/// the per-room key set may be INCOMPLETE and re-runs the legacy fill to recover
+/// any stranded room (freenet/river#345 follow-up — Nacho's "Freenet Devs"
+/// disappeared-after-update report). New users never set it (no legacy data → no
+/// migration), so they incur no extra probing.
+#[allow(dead_code)]
+const LEGACY_MIGRATION_IN_PROGRESS_PREFIX: &str = "river_legacy_migration_in_progress:";
+
+#[allow(dead_code)]
+fn legacy_migration_in_progress_key() -> String {
+    format!(
+        "{}{}",
+        LEGACY_MIGRATION_IN_PROGRESS_PREFIX,
+        legacy_set_fingerprint()
+    )
+}
+
+/// True if a legacy migration was started but not confirmed complete (see
+/// [`LEGACY_MIGRATION_IN_PROGRESS_PREFIX`]).
+pub fn is_legacy_migration_in_progress() -> bool {
+    #[cfg(target_arch = "wasm32")]
+    {
+        if let Some(window) = web_sys::window() {
+            if let Ok(Some(storage)) = window.local_storage() {
+                let key = legacy_migration_in_progress_key();
+                return storage.get_item(&key).ok().flatten().is_some();
+            }
+        }
+        false
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        // Non-WASM (tests): no migration is ever in progress.
+        false
+    }
+}
+
+/// Mark a legacy migration as in progress (call BEFORE the re-save).
+pub fn mark_legacy_migration_in_progress() {
+    #[cfg(target_arch = "wasm32")]
+    {
+        if let Some(window) = web_sys::window() {
+            if let Ok(Some(storage)) = window.local_storage() {
+                let key = legacy_migration_in_progress_key();
+                if let Err(e) = storage.set_item(&key, "true") {
+                    warn!("Failed to set legacy-migration-in-progress flag: {:?}", e);
+                }
+            }
+        }
+    }
+}
+
+/// Clear the "legacy migration in progress" flag (call only after a FULL,
+/// successful re-save — alongside [`mark_legacy_migration_done`]).
+pub fn clear_legacy_migration_in_progress() {
+    #[cfg(target_arch = "wasm32")]
+    {
+        if let Some(window) = web_sys::window() {
+            if let Ok(Some(storage)) = window.local_storage() {
+                let key = legacy_migration_in_progress_key();
+                let _ = storage.remove_item(&key);
             }
         }
     }

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -9,14 +9,14 @@ mod update_response;
 use super::error::SynchronizerError;
 use super::room_synchronizer::RoomSynchronizer;
 use crate::components::app::chat_delegate::{
-    cas_store_correlation_key, clear_legacy_migration_in_progress,
+    arm_legacy_migration_recovery, cas_store_correlation_key, clear_legacy_migration_in_progress,
     complete_pending_public_key_request, complete_pending_request, complete_pending_sign_request,
     complete_pending_signing_key_request, decide_legacy_migration_action,
-    fire_legacy_migration_request, get_versioned_correlation_key, hydrate_hidden_dm_threads,
-    hydrate_outbound_dms_cache, is_legacy_delegate_key, is_legacy_migration_in_progress,
-    legacy_scoped_correlation, mark_legacy_migration_done, mark_legacy_migration_in_progress,
-    parse_room_storage_key, prune_outbound_dms_for_purges, room_storage_key,
-    save_outbound_dms_to_delegate, save_rooms_to_delegate, send_delegate_request,
+    decide_per_room_load_action, fire_legacy_migration_request, get_versioned_correlation_key,
+    hydrate_hidden_dm_threads, hydrate_outbound_dms_cache, is_legacy_delegate_key,
+    is_legacy_migration_in_progress, legacy_scoped_correlation, mark_legacy_migration_done,
+    mark_legacy_migration_in_progress, parse_room_storage_key, prune_outbound_dms_for_purges,
+    room_storage_key, save_outbound_dms_to_delegate, save_rooms_to_delegate, send_delegate_request,
     send_delegate_request_to, LegacyMigrationAction, OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY,
     ROOMS_STORAGE_KEY,
 };
@@ -632,9 +632,11 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
             // migration done — we re-run the legacy fill below to recover them
             // (freenet/river#345 follow-up). Otherwise the per-room set is
             // authoritative: mark done so we never probe legacy (#253 — a stale
-            // legacy response could clobber newer state).
+            // legacy response could clobber newer state). The decision is a pure,
+            // unit-tested function (`decide_per_room_load_action`).
             let migration_interrupted = is_legacy_migration_in_progress();
-            if !migration_interrupted {
+            let action = decide_per_room_load_action(migration_interrupted);
+            if action.mark_done {
                 mark_legacy_migration_done();
             }
 
@@ -703,19 +705,35 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
                 schedule_subscription_timeout_check();
             }
 
-            // Recover from an interrupted migration: re-run the migration to
-            // pick up any room whose per-room key wasn't written before the
-            // previous attempt was cut short. `migrate_current_blob_to_per_room`
+            // Recover from an interrupted migration by re-running it to pick up
+            // any room whose per-room key wasn't written before the previous
+            // attempt was cut short. `migrate_current_blob_to_per_room`
             // dispatches to whichever source applies — a current-delegate
-            // `rooms_data` blob (re-explode) or, if there's none, the legacy
-            // delegates (legacy fill, the common case). Either way the migration
-            // re-save uses CAS read-merge-write, so re-migrating an
-            // already-present room is a no-op and only genuinely-missing rooms
-            // are added; a full re-save then clears the in-progress flag and
-            // marks migration done, so this is a one-shot recovery (guarded by
-            // is_legacy_migration_done + the per-session attempt flag), not a
-            // per-load probe.
-            if migration_interrupted {
+            // `rooms_data` blob (re-explode) or, when there's none (the common
+            // case), the legacy delegates via `fire_legacy_migration_request`.
+            //
+            // Bounds & safety:
+            // - `arm_legacy_migration_recovery()` fires this at most ONCE per
+            //   session AND clears the per-session `LEGACY_MIGRATION_ATTEMPTED`
+            //   guard, so the probe isn't a silent no-op when the initial
+            //   migration this session already set that guard (codex review of
+            //   #352). Without the reset, same-session recovery (a CAS failure
+            //   mid-save, then a reconnect) wouldn't fire until a page reload.
+            // - The re-save is per-room CAS read-merge-write: a room already
+            //   present merges (CRDT union) rather than being overwritten, so
+            //   recovering an already-present, same-identity room neither loses
+            //   messages nor clobbers newer state. (The narrow diverged-identity
+            //   case — same room key under a different signing key — keeps the
+            //   local copy per `reconcile_room_present`; recovery does not widen
+            //   that pre-existing behavior.)
+            // - On a successful full re-save the in-progress flag is cleared and
+            //   migration is marked done, so recovery converges. If the legacy
+            //   delegate is genuinely empty or no longer installed, nothing is
+            //   recovered and the flag persists; the next session re-probes once
+            //   — the SAME bounded, harmless cost the existing empty-legacy path
+            //   already pays (see the `is_legacy_delegate` no-`rooms_data` branch
+            //   above). No data loss, no spam loop.
+            if action.recover && arm_legacy_migration_recovery() {
                 info!("Prior migration was interrupted — re-running to recover any stranded rooms");
                 migrate_current_blob_to_per_room().await;
             }
@@ -837,6 +855,12 @@ async fn migrate_current_blob_to_per_room() {
                     }
                 });
             }
+            // A corrupt current-delegate blob is unparseable; retrying won't
+            // help, so do nothing here. We intentionally do NOT mark migration
+            // done (a corrupt blob is not proof there's nothing to migrate) and
+            // do NOT touch the in-progress flag — if a prior migration left it
+            // set, the next session re-runs recovery, and the already-loaded
+            // per-room keys remain intact regardless.
             Err(e) => error!("Failed to deserialize current-delegate rooms blob: {}", e),
         },
         Ok(_) => {
@@ -1714,16 +1738,30 @@ mod tests {
             "legacy re-save must clear the in-progress flag on success"
         );
 
-        // (2) Per-room load gates mark-done on the in-progress flag and re-runs
-        //     the migration when one was interrupted.
+        // (2) Per-room load routes its gating through the pure, unit-tested
+        //     decision helper (see `decide_per_room_load_action` tests in
+        //     chat_delegate.rs for the truth table), and the recovery call is
+        //     scoped INSIDE the `action.recover` branch. The scoping matters:
+        //     `migrate_current_blob_to_per_room().await;` also appears in the
+        //     unrelated `LoadPlan::MigrateCurrentBlob` arm, so a file-wide
+        //     `contains` would pass even if the recovery call were deleted.
         assert!(
-            production.contains("let migration_interrupted = is_legacy_migration_in_progress();"),
-            "per-room load must check whether a prior migration was interrupted"
+            production.contains("let migration_interrupted = is_legacy_migration_in_progress();")
+                && production.contains("decide_per_room_load_action(migration_interrupted)"),
+            "per-room load must derive its action from the in-progress flag via the helper"
+        );
+        let recover_idx = production
+            .find("if action.recover")
+            .expect("per-room load must have an `if action.recover` recovery branch");
+        let recover_block = &production[recover_idx..recover_idx + 300];
+        assert!(
+            recover_block.contains("migrate_current_blob_to_per_room().await;"),
+            "the recovery branch must re-run the migration to recover stranded rooms"
         );
         assert!(
-            production.contains("if migration_interrupted")
-                && production.contains("migrate_current_blob_to_per_room().await;"),
-            "per-room load must re-run the migration when one was interrupted"
+            recover_block.contains("arm_legacy_migration_recovery()"),
+            "recovery must be armed once-per-session (clears the attempt guard so \
+             same-session recovery isn't a no-op — codex review of #352)"
         );
     }
 

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -1728,7 +1728,7 @@ mod tests {
         let resave_start = production
             .find("Migrating room data from legacy delegate to new delegate")
             .expect("legacy re-save block marker must exist");
-        let resave = &production[resave_start..resave_start + 1200];
+        let resave = &production[resave_start..(resave_start + 1200).min(production.len())];
         assert!(
             resave.contains("mark_legacy_migration_in_progress()"),
             "legacy re-save must mark migration in progress BEFORE saving"
@@ -1753,7 +1753,7 @@ mod tests {
         let recover_idx = production
             .find("if action.recover")
             .expect("per-room load must have an `if action.recover` recovery branch");
-        let recover_block = &production[recover_idx..recover_idx + 300];
+        let recover_block = &production[recover_idx..(recover_idx + 300).min(production.len())];
         assert!(
             recover_block.contains("migrate_current_blob_to_per_room().await;"),
             "the recovery branch must re-run the migration to recover stranded rooms"

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -9,14 +9,16 @@ mod update_response;
 use super::error::SynchronizerError;
 use super::room_synchronizer::RoomSynchronizer;
 use crate::components::app::chat_delegate::{
-    cas_store_correlation_key, complete_pending_public_key_request, complete_pending_request,
-    complete_pending_sign_request, complete_pending_signing_key_request,
-    decide_legacy_migration_action, fire_legacy_migration_request, get_versioned_correlation_key,
-    hydrate_hidden_dm_threads, hydrate_outbound_dms_cache, is_legacy_delegate_key,
-    legacy_scoped_correlation, mark_legacy_migration_done, parse_room_storage_key,
-    prune_outbound_dms_for_purges, room_storage_key, save_outbound_dms_to_delegate,
-    save_rooms_to_delegate, send_delegate_request, send_delegate_request_to, LegacyMigrationAction,
-    OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY, ROOMS_STORAGE_KEY,
+    cas_store_correlation_key, clear_legacy_migration_in_progress,
+    complete_pending_public_key_request, complete_pending_request, complete_pending_sign_request,
+    complete_pending_signing_key_request, decide_legacy_migration_action,
+    fire_legacy_migration_request, get_versioned_correlation_key, hydrate_hidden_dm_threads,
+    hydrate_outbound_dms_cache, is_legacy_delegate_key, is_legacy_migration_in_progress,
+    legacy_scoped_correlation, mark_legacy_migration_done, mark_legacy_migration_in_progress,
+    parse_room_storage_key, prune_outbound_dms_for_purges, room_storage_key,
+    save_outbound_dms_to_delegate, save_rooms_to_delegate, send_delegate_request,
+    send_delegate_request_to, LegacyMigrationAction, OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY,
+    ROOMS_STORAGE_KEY,
 };
 use crate::components::app::document_title::{mark_current_room_as_read, update_document_title};
 use crate::components::app::notifications::mark_initial_sync_complete;
@@ -624,10 +626,17 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
             migrate_current_blob_to_per_room().await;
         }
         LoadPlan::PerRoom { room_vks, has_meta } => {
-            // Current delegate holds authoritative per-room data: never probe
-            // legacy (freenet/river#253 — a legacy response could clobber newer
-            // state).
-            mark_legacy_migration_done();
+            // Was a prior legacy migration interrupted before it finished writing
+            // every per-room key? If so, the set we're about to load may be
+            // missing rooms the legacy delegate still holds, and we must NOT mark
+            // migration done — we re-run the legacy fill below to recover them
+            // (freenet/river#345 follow-up). Otherwise the per-room set is
+            // authoritative: mark done so we never probe legacy (#253 — a stale
+            // legacy response could clobber newer state).
+            let migration_interrupted = is_legacy_migration_in_progress();
+            if !migration_interrupted {
+                mark_legacy_migration_done();
+            }
 
             // Concurrency note: a WebSocket reconnect re-fires `ListRequest`, so
             // two `load_rooms_per_room` tasks can briefly overlap. The per-room
@@ -692,6 +701,23 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
             let loaded = reconstruct_rooms(slots, meta);
             if hydrate_loaded_rooms(loaded, false) {
                 schedule_subscription_timeout_check();
+            }
+
+            // Recover from an interrupted migration: re-run the migration to
+            // pick up any room whose per-room key wasn't written before the
+            // previous attempt was cut short. `migrate_current_blob_to_per_room`
+            // dispatches to whichever source applies — a current-delegate
+            // `rooms_data` blob (re-explode) or, if there's none, the legacy
+            // delegates (legacy fill, the common case). Either way the migration
+            // re-save uses CAS read-merge-write, so re-migrating an
+            // already-present room is a no-op and only genuinely-missing rooms
+            // are added; a full re-save then clears the in-progress flag and
+            // marks migration done, so this is a one-shot recovery (guarded by
+            // is_legacy_migration_done + the per-session attempt flag), not a
+            // per-load probe.
+            if migration_interrupted {
+                info!("Prior migration was interrupted — re-running to recover any stranded rooms");
+                migrate_current_blob_to_per_room().await;
             }
         }
     }
@@ -783,7 +809,11 @@ async fn migrate_current_blob_to_per_room() {
             value: Some(bytes), ..
         }) => match from_reader::<Rooms, _>(&bytes[..]) {
             Ok(loaded) => {
-                mark_legacy_migration_done();
+                // Mark in progress BEFORE the explosion save; only mark done once
+                // it fully succeeds — otherwise a partial explosion would strand
+                // rooms on the next per-room load (freenet/river#345 follow-up,
+                // same hazard as the legacy-delegate path).
+                mark_legacy_migration_in_progress();
                 if hydrate_loaded_rooms(loaded, false) {
                     schedule_subscription_timeout_check();
                 }
@@ -795,8 +825,15 @@ async fn migrate_current_blob_to_per_room() {
                 // AFTER the merge's defer, runs once the merge has populated
                 // ROOMS (FIFO ordering), mirroring the legacy-delegate re-save.
                 crate::util::safe_spawn_local(async {
-                    if let Err(e) = save_rooms_to_delegate().await {
-                        error!("Failed to explode single blob into per-room keys: {}", e);
+                    match save_rooms_to_delegate().await {
+                        Ok(_) => {
+                            clear_legacy_migration_in_progress();
+                            mark_legacy_migration_done();
+                        }
+                        Err(e) => {
+                            error!("Failed to explode single blob into per-room keys: {}", e);
+                            // Leave the in-progress flag set — next load re-runs.
+                        }
                     }
                 });
             }
@@ -1335,15 +1372,24 @@ fn hydrate_loaded_rooms(loaded_rooms: Rooms, is_legacy_delegate: bool) -> bool {
     // If this was from the legacy delegate, save to the new delegate
     if is_legacy_delegate {
         info!("Migrating room data from legacy delegate to new delegate");
+        // Mark the migration in progress BEFORE the re-save. The save writes one
+        // per-room key at a time, so an interrupted migration (a per-room CAS
+        // failure, or the tab closing mid-save) can leave a PARTIAL per-room set.
+        // If we don't record that, the next load takes the per-room path and
+        // never re-probes legacy, stranding any room whose key wasn't written
+        // until the user rejoins (freenet/river#345 follow-up). The flag stays
+        // set until a FULL re-save succeeds, so the next load knows to re-fill.
+        mark_legacy_migration_in_progress();
         crate::util::safe_spawn_local(async {
             match save_rooms_to_delegate().await {
                 Ok(_) => {
                     info!("Successfully migrated room data to new delegate");
+                    clear_legacy_migration_in_progress();
                     mark_legacy_migration_done();
                 }
                 Err(e) => {
                     error!("Failed to migrate room data to new delegate: {}", e);
-                    // Don't mark as done - will retry on next startup
+                    // Leave the in-progress flag set — the next load re-fills.
                 }
             }
         });
@@ -1637,6 +1683,47 @@ mod tests {
             !production[start..end].contains("mark_legacy_migration_done("),
             "the empty-rooms_data legacy branch must NOT mark migration done — \
              per-room keys may still need migrating (code-first/skeptical re-review)"
+        );
+    }
+
+    /// Regression pin (freenet/river#345 follow-up — Nacho's "Freenet Devs"
+    /// disappeared-after-update): an interrupted migration must be recoverable.
+    /// (1) The legacy re-save marks migration IN PROGRESS before saving and only
+    /// clears it on success, so a partial/aborted migration is detectable.
+    /// (2) The per-room load, when a migration was left in progress, must NOT
+    /// blindly mark done and must re-run the migration to recover stranded rooms.
+    #[test]
+    fn interrupted_migration_is_recovered_on_next_load() {
+        let src = include_str!("response_handler.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+
+        // (1) Legacy re-save: in-progress set before save, cleared on success.
+        let resave_start = production
+            .find("Migrating room data from legacy delegate to new delegate")
+            .expect("legacy re-save block marker must exist");
+        let resave = &production[resave_start..resave_start + 1200];
+        assert!(
+            resave.contains("mark_legacy_migration_in_progress()"),
+            "legacy re-save must mark migration in progress BEFORE saving"
+        );
+        assert!(
+            resave.contains("clear_legacy_migration_in_progress()"),
+            "legacy re-save must clear the in-progress flag on success"
+        );
+
+        // (2) Per-room load gates mark-done on the in-progress flag and re-runs
+        //     the migration when one was interrupted.
+        assert!(
+            production.contains("let migration_interrupted = is_legacy_migration_in_progress();"),
+            "per-room load must check whether a prior migration was interrupted"
+        );
+        assert!(
+            production.contains("if migration_interrupted")
+                && production.contains("migrate_current_blob_to_per_room().await;"),
+            "per-room load must re-run the migration when one was interrupted"
         );
     }
 


### PR DESCRIPTION
## Problem

Nacho reported that his **"Freenet Devs"** room disappeared from his room list after the per-room delegate update (#345) and he had to rejoin via a previous invite link. The room came back on its own after a few seconds in some cases, but it should never disappear.

**Root cause:** the legacy→per-room migration re-saves rooms one per-room key at a time. If that re-save is cut short — a per-room CAS write fails, or the tab is closed mid-migration — the current delegate is left with a **partial** per-room key set. On the next load, the code takes the `PerRoom` path, loads only the keys that made it across, calls `mark_legacy_migration_done()`, and never re-probes the legacy delegate. Any room whose key wasn't written is stranded until the user rejoins.

## Approach

A persistent `legacy_migration_in_progress` localStorage flag:

- **Set** before a migration's per-room re-save (both the legacy-delegate re-save in `hydrate_loaded_rooms` and the current-blob explosion in `migrate_current_blob_to_per_room`).
- **Cleared** only on a *full* successful re-save (alongside `mark_legacy_migration_done`). On failure it is left set.

The `PerRoom` load branch now reads the flag:

- Flag **not** set → per-room set is authoritative: `mark_legacy_migration_done()` as before (never probe legacy, per #253).
- Flag **set** (a prior migration was interrupted) → do **not** mark done; after loading + hydrating the existing keys, re-run `migrate_current_blob_to_per_room()`, which re-explodes a current `rooms_data` blob if present, else fires the legacy probe — recovering any stranded room.

Because the migration re-save uses CAS read-merge-write, re-migrating an already-present room is a no-op; only genuinely-missing rooms are added. No data is destroyed (the legacy blob and existing per-room keys are left in place).

### Why this is low-risk

- **Clean users**: migration completed → flag cleared, done flag set → `PerRoom` load marks done as before, no recovery fires. Zero behavioural change.
- **Brand-new users**: never have legacy data, never set the flag. Zero cost.
- **Self-healing across sessions**: the flag is keyed per legacy-set generation (same scoping as the existing done flag), so a later delegate bump re-runs migration cleanly anyway.
- **No probe spam**: recovery's `fire_legacy_migration_request` is bounded by the existing per-session `LEGACY_MIGRATION_ATTEMPTED` guard — at most one probe per page load.

## Testing

Source-pin tests, matching this file's existing convention (the load/migration path is too coupled to the Dioxus signal runtime + WebSocket to drive in a unit test):

- `migration_in_progress_key_distinct_from_done_key` — the in-progress and done localStorage keys must be distinct (and both per-legacy-set).
- `interrupted_migration_is_recovered_on_next_load` — pins that the legacy re-save marks in-progress before saving and clears it on success, and that the per-room load gates `mark_done` on the flag and re-runs the migration when one was interrupted.

`cargo test -p river-ui --bins` → 341 passed. `cargo fmt` clean, `cargo clippy` introduces no new warnings.

UI-only change (no `common/`/`delegates/`/`contracts/` edits) → no delegate migration entry needed.

Follow-up to #345.

[AI-assisted - Claude]