### PR TITLE
fix(cli): carry invitation_secrets through IdentityExport for private-room imports

### DIFF
--- a/cli/src/commands/identity.rs
+++ b/cli/src/commands/identity.rs
@@ -154,6 +154,11 @@ async fn export_identity(
         // the private-room join-heal sealed `member_info` doesn't lose it on
         // re-import (freenet/river#298).
         self_nickname: room_info.self_nickname.clone(),
+        // Carry the invitation-carried room secrets so a non-owner of a
+        // private room can still forward useful `room_secrets` via
+        // `invitation create` after re-importing on another device
+        // (freenet/river#306). Empty for public rooms and for owners.
+        invitation_secrets: room_info.invitation_secrets.clone(),
     };
 
     let armored = export.to_armored_string();
@@ -224,13 +229,18 @@ async fn import_identity(
             )
         })?;
 
-    // Store the room with the imported identity
+    // Store the room with the imported identity, seeding the persisted
+    // `invitation_secrets` from the export so a non-owner of a private room
+    // keeps the secret across a device migration (freenet/river#306). For a
+    // public room or an export taken before this field existed, the map is
+    // empty and this behaves exactly like the previous `add_room` call.
     let contract_key = api_client.owner_vk_to_contract_key(&export.room_owner);
-    api_client.storage().add_room(
+    api_client.storage().add_room_with_invitation_secrets(
         &export.room_owner,
         &export.signing_key,
         room_state,
         &contract_key,
+        export.invitation_secrets.clone(),
     )?;
 
     // Store the authorized member and invite chain for rejoin support
@@ -358,10 +368,142 @@ fn check_export_coherence(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::compute_contract_key;
+    use crate::storage::Storage;
+    use river_core::room_state::configuration::{AuthorizedConfigurationV1, Configuration};
     use river_core::room_state::member::{Member, MemberId};
+    use river_core::room_state::ChatRoomStateV1;
+    use std::collections::HashMap;
+    use tempfile::TempDir;
 
     fn signing_key_from_seed(seed: u8) -> SigningKey {
         SigningKey::from_bytes(&[seed; 32])
+    }
+
+    /// Minimal valid room state owned by `owner_sk` (matches the helper in
+    /// `storage.rs` tests).
+    fn create_test_state(owner_sk: &SigningKey) -> ChatRoomStateV1 {
+        let owner_vk = owner_sk.verifying_key();
+        let mut state = ChatRoomStateV1::default();
+        let config = Configuration {
+            owner_member_id: owner_vk.into(),
+            ..Default::default()
+        };
+        state.configuration = AuthorizedConfigurationV1::new(config, owner_sk);
+        state
+    }
+
+    /// End-to-end round-trip for freenet/river#306: a non-owner export that
+    /// carries `invitation_secrets` must, after armor → decode → the
+    /// storage-seeding step `import_identity` performs, leave the secrets
+    /// retrievable via `get_invitation_secrets`. This is the exact wiring the
+    /// issue asks for (export populates the field, import seeds storage via
+    /// `add_room_with_invitation_secrets`), exercised without a live node by
+    /// driving the same `Storage` call the import path uses.
+    #[test]
+    fn invitation_secrets_survive_export_armor_import_persist() {
+        let owner_sk = signing_key_from_seed(7);
+        let owner_vk = owner_sk.verifying_key();
+        let owner_id = MemberId::from(&owner_vk);
+
+        // A non-owner member invited by the owner.
+        let member_sk = signing_key_from_seed(8);
+        let member = Member {
+            owner_member_id: owner_id,
+            invited_by: owner_id,
+            member_vk: member_sk.verifying_key(),
+        };
+        let authorized_member = AuthorizedMember::new(member, &owner_sk);
+
+        let mut invitation_secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+        invitation_secrets.insert(0, [0xABu8; 32]);
+        invitation_secrets.insert(2, [0xCDu8; 32]);
+
+        let export = IdentityExport {
+            room_owner: owner_vk,
+            signing_key: member_sk.clone(),
+            authorized_member,
+            invite_chain: vec![],
+            member_info: None,
+            room_name: None,
+            self_nickname: None,
+            invitation_secrets: invitation_secrets.clone(),
+        };
+
+        // Export → armor → wipe → decode, exactly as a device migration would.
+        let armored = export.to_armored_string();
+        let decoded = IdentityExport::from_armored_string(&armored).unwrap();
+
+        // Import-persist step: a fresh storage (the "new device") seeds the
+        // room from the decoded export, mirroring `import_identity`.
+        let temp_dir = TempDir::new().unwrap();
+        let storage = Storage::new(Some(temp_dir.path().to_str().unwrap())).unwrap();
+        let contract_key = compute_contract_key(&decoded.room_owner);
+        storage
+            .add_room_with_invitation_secrets(
+                &decoded.room_owner,
+                &decoded.signing_key,
+                create_test_state(&owner_sk),
+                &contract_key,
+                decoded.invitation_secrets.clone(),
+            )
+            .unwrap();
+
+        // The persisted secrets must match the originals byte-for-byte. Before
+        // the #306 fix the export dropped the field and this returned empty.
+        let retrieved = storage.get_invitation_secrets(&owner_vk).unwrap();
+        assert_eq!(
+            retrieved, invitation_secrets,
+            "invitation_secrets must survive export → import → persist"
+        );
+    }
+
+    /// A public-room (or pre-#306) export carries no secrets; the import path
+    /// must persist an empty map, not panic or invent entries.
+    #[test]
+    fn empty_invitation_secrets_round_trip_to_empty() {
+        let owner_sk = signing_key_from_seed(9);
+        let owner_vk = owner_sk.verifying_key();
+        let owner_id = MemberId::from(&owner_vk);
+        let member = Member {
+            owner_member_id: owner_id,
+            invited_by: owner_id,
+            member_vk: owner_vk,
+        };
+        let authorized_member = AuthorizedMember::new(member, &owner_sk);
+
+        let export = IdentityExport {
+            room_owner: owner_vk,
+            signing_key: owner_sk.clone(),
+            authorized_member,
+            invite_chain: vec![],
+            member_info: None,
+            room_name: None,
+            self_nickname: None,
+            invitation_secrets: HashMap::new(),
+        };
+
+        let armored = export.to_armored_string();
+        let decoded = IdentityExport::from_armored_string(&armored).unwrap();
+        assert!(decoded.invitation_secrets.is_empty());
+
+        let temp_dir = TempDir::new().unwrap();
+        let storage = Storage::new(Some(temp_dir.path().to_str().unwrap())).unwrap();
+        let contract_key = compute_contract_key(&decoded.room_owner);
+        storage
+            .add_room_with_invitation_secrets(
+                &decoded.room_owner,
+                &decoded.signing_key,
+                create_test_state(&owner_sk),
+                &contract_key,
+                decoded.invitation_secrets.clone(),
+            )
+            .unwrap();
+
+        assert!(storage
+            .get_invitation_secrets(&owner_vk)
+            .unwrap()
+            .is_empty());
     }
 
     /// Build an `AuthorizedMember` signed by `key` (the member is `key`'s own

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -605,6 +605,40 @@ mod tests {
         );
     }
 
+    /// Source-grep pin for the #306 import wiring, in storage.rs so the pinned
+    /// strings aren't self-satisfied by the scanned file (commands/identity.rs).
+    /// Guards the exact regression #306 fixed: `import_identity` calling the
+    /// no-secrets `add_room`, which silently drops a private-room invitee's
+    /// invitation-carried secrets on a device migration (making their later
+    /// `invitation create` emit `room_secrets: []`).
+    #[test]
+    fn import_identity_seeds_invitation_secrets_wiring_pinned() {
+        // NOTE: these two pinned substrings appear ONLY in the production
+        // export/import paths, never in `commands/identity.rs`'s own test
+        // module — so the assertions can't be self-satisfied by test code in
+        // the scanned file. (A bare `add_room_with_invitation_secrets(` would
+        // be, since that module's tests also call it; we deliberately don't
+        // pin that.)
+        let identity_src = include_str!("commands/identity.rs");
+        // The export side must populate the field from the stored room info,
+        // not leave it empty.
+        assert!(
+            identity_src.contains("invitation_secrets: room_info.invitation_secrets.clone()"),
+            "export_identity must populate IdentityExport.invitation_secrets from \
+             the room's StoredRoomInfo.invitation_secrets (freenet/river#306)."
+        );
+        // The import side must seed storage with the export's carried secrets
+        // (via add_room_with_invitation_secrets), NOT the no-secrets add_room —
+        // otherwise a private-room invitee loses their secret on a device
+        // migration, making their later `invitation create` emit
+        // `room_secrets: []`.
+        assert!(
+            identity_src.contains("export.invitation_secrets.clone()"),
+            "import_identity must pass export.invitation_secrets into \
+             Storage::add_room_with_invitation_secrets (freenet/river#306)."
+        );
+    }
+
     /// Source-grep pins for the monitor edit/reply wiring (PR #322), in
     /// storage.rs so the pinned strings aren't self-satisfied by the scanned
     /// file (api.rs). Guards the exact regressions the PR fixed: a refactor

--- a/common/src/room_state/identity.rs
+++ b/common/src/room_state/identity.rs
@@ -1,5 +1,6 @@
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 use super::member::{AuthorizedMember, MemberId};
 use super::member_info::AuthorizedMemberInfo;
@@ -41,6 +42,30 @@ pub struct IdentityExport {
     /// more sensitive secret.
     #[serde(default)]
     pub self_nickname: Option<String>,
+    /// Invitation-carried room secrets, keyed by `secret_version`
+    /// (32-byte symmetric key per version). See freenet/river#306.
+    ///
+    /// For a non-owner of a PRIVATE room, the only copy of the room
+    /// secret a CLI invitee holds may be the one carried in their
+    /// `Invitation` artifact and persisted in
+    /// `cli::storage::StoredRoomInfo::invitation_secrets`. Without
+    /// carrying it through the export, importing the identity on another
+    /// device loses that secret: `riverctl invitation create` would emit
+    /// an invitation with `room_secrets: []` (replicating the #303 bug
+    /// for any downstream invitee) whenever the network state does not
+    /// yet contain an owner-signed `encrypted_secrets` blob for the
+    /// imported member.
+    ///
+    /// Empty for public rooms and for owners (the owner's secret is in
+    /// the owner-addressed contract blob, confirmed at
+    /// `common/src/room_state/secret.rs:450-451`).
+    ///
+    /// `#[serde(default)]` keeps old tokens (which lack the field)
+    /// decoding cleanly as an empty map. Plaintext here adds no new
+    /// exposure class: the export already carries the private signing
+    /// key, a far more sensitive secret.
+    #[serde(default)]
+    pub invitation_secrets: HashMap<u32, [u8; 32]>,
 }
 
 impl IdentityExport {
@@ -164,6 +189,7 @@ mod tests {
             member_info: None,
             room_name: None,
             self_nickname: None,
+            invitation_secrets: HashMap::new(),
         };
 
         let armored = export.to_armored_string();
@@ -218,6 +244,7 @@ mod tests {
             member_info: None,
             room_name: None,
             self_nickname: None,
+            invitation_secrets: HashMap::new(),
         };
 
         let armored = export.to_armored_string();
@@ -265,6 +292,7 @@ mod tests {
             member_info: Some(auth_member_info.clone()),
             room_name: Some("Test Room".to_string()),
             self_nickname: Some("TestUser".to_string()),
+            invitation_secrets: HashMap::new(),
         };
 
         let armored = export.to_armored_string();
@@ -310,6 +338,7 @@ mod tests {
             member_info: None,
             room_name: None,
             self_nickname: None,
+            invitation_secrets: HashMap::new(),
         };
 
         let armored = export.to_armored_string();
@@ -353,6 +382,7 @@ mod tests {
             member_info: None,
             room_name: None,
             self_nickname: None,
+            invitation_secrets: HashMap::new(),
         };
 
         let armored = export.to_armored_string();
@@ -383,6 +413,7 @@ mod tests {
             member_info: None,
             room_name: None,
             self_nickname: None,
+            invitation_secrets: HashMap::new(),
         };
 
         let armored = export.to_armored_string();
@@ -434,6 +465,7 @@ mod tests {
             member_info: None,
             room_name: None,
             self_nickname: None,
+            invitation_secrets: HashMap::new(),
         };
 
         let armored = export.to_armored_string();
@@ -489,6 +521,9 @@ mod tests {
         // The same old token also predates `self_nickname`; it must decode
         // cleanly with the field defaulting to `None`.
         assert!(decoded.self_nickname.is_none());
+        // It also predates `invitation_secrets` (freenet/river#306); that
+        // field must default to an empty map, not fail to decode.
+        assert!(decoded.invitation_secrets.is_empty());
     }
 
     #[test]
@@ -518,6 +553,7 @@ mod tests {
             member_info: None,
             room_name: None,
             self_nickname: Some("ChosenName".to_string()),
+            invitation_secrets: HashMap::new(),
         };
 
         let armored = export.to_armored_string();
@@ -553,6 +589,7 @@ mod tests {
             member_info: None,
             room_name: Some("My Room".to_string()),
             self_nickname: None,
+            invitation_secrets: HashMap::new(),
         };
 
         let armored = export.to_armored_string();
@@ -573,5 +610,48 @@ mod tests {
             .member_vk
             .verify_strict(message, &signature)
             .is_ok());
+    }
+
+    #[test]
+    fn test_invitation_secrets_survive_roundtrip() {
+        // Regression for freenet/river#306: a non-owner of a PRIVATE room
+        // may hold the room secret only via the secrets carried in their
+        // `Invitation` artifact. The export must carry that map so importing
+        // on another device does not silently drop it (which would make
+        // `riverctl invitation create` emit `room_secrets: []`).
+        let owner_sk = SigningKey::generate(&mut OsRng);
+        let owner_vk = owner_sk.verifying_key();
+        let owner_id = MemberId::from(&owner_vk);
+
+        let member_sk = SigningKey::generate(&mut OsRng);
+        let member = Member {
+            owner_member_id: owner_id,
+            invited_by: owner_id,
+            member_vk: member_sk.verifying_key(),
+        };
+        let authorized_member = AuthorizedMember::new(member, &owner_sk);
+
+        let mut invitation_secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+        invitation_secrets.insert(0, [0x11u8; 32]);
+        invitation_secrets.insert(3, [0x22u8; 32]);
+
+        let export = IdentityExport {
+            room_owner: owner_vk,
+            signing_key: member_sk,
+            authorized_member,
+            invite_chain: vec![],
+            member_info: None,
+            room_name: None,
+            self_nickname: None,
+            invitation_secrets: invitation_secrets.clone(),
+        };
+
+        let armored = export.to_armored_string();
+        let decoded = IdentityExport::from_armored_string(&armored).unwrap();
+
+        assert_eq!(
+            decoded.invitation_secrets, invitation_secrets,
+            "invitation_secrets must survive the armored round-trip byte-for-byte"
+        );
     }
 }

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -553,6 +553,13 @@ fn ExportIdentityModal(is_active: Signal<bool>) -> Element {
                             // sealed `member_info` doesn't lose it on
                             // re-import (freenet/river#298).
                             self_nickname: room_data.self_nickname.clone(),
+                            // Carry the invitation-carried room secrets so a
+                            // non-owner of a private room keeps the secret
+                            // across a device migration and can still forward
+                            // useful `room_secrets` via new invitations
+                            // (freenet/river#306). Empty for public rooms and
+                            // for owners.
+                            invitation_secrets: room_data.invitation_secrets.clone(),
                         };
                         token_text.set(export.to_armored_string());
                     } else {
@@ -684,7 +691,13 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
                     // instead of minting a generated default (freenet/river#298).
                     self_nickname: export.self_nickname,
                     previous_contract_key: None,
-                    invitation_secrets: std::collections::HashMap::new(),
+                    // Restore the invitation-carried room secrets so a
+                    // non-owner of a private room keeps the secret across a
+                    // device migration (freenet/river#306). Folded into the
+                    // `#[serde(skip)]` `secrets` map by
+                    // `repopulate_secrets_from_state` on the next sync. Empty
+                    // for public rooms, owners, and pre-#306 exports.
+                    invitation_secrets: export.invitation_secrets,
                 };
 
                 // Migrate the imported signing key to the delegate immediately.


### PR DESCRIPTION
## Problem

`riverctl identity import` reconstitutes a room from an `IdentityExport` bundle. For a non-owner of a PRIVATE room it called `Storage::add_room` (the no-secrets variant), so `StoredRoomInfo.invitation_secrets` was left empty after import.

If the imported network state does not yet contain an owner-signed `encrypted_secrets` blob addressed to the imported member (delegate back-fill lag, or back-fill via a different delegate generation), the imported user has no copy of the room secret. The concrete new harm: their `riverctl invitation create` produces an invitation with `room_secrets: []`, silently replicating the bug PR #303 fixed for the normal accept-invitation path. This is a silent secret-loss vector on device migration / backup-restore for private rooms.

The owner case was already fine — the owner's secret is in the owner-addressed contract blob (`common/src/room_state/secret.rs:450-451`), so the gap was specifically non-owner identities.

## Approach

Add a `#[serde(default)] invitation_secrets: HashMap<u32, [u8; 32]>` field to `IdentityExport`:

1. `export_identity` populates it from `StoredRoomInfo.invitation_secrets`.
2. `import_identity` seeds storage via the existing `Storage::add_room_with_invitation_secrets` (added for #302/#303) instead of `add_room`.
3. `#[serde(default)]` keeps old tokens decoding cleanly as an empty map — the same backward-compat shape as the `self_nickname` field (#331).

Empty for public rooms and for owners, so those paths behave exactly as before.

**No delegate/contract migration required.** `IdentityExport` is never referenced by the room-contract or chat-delegate crates, so it is dead-code-eliminated from their WASM (same as the #331 precedent that added `self_nickname`). CI's `check-delegate-migration` / `check-room-contract-migration` confirm the WASM is byte-identical.

## Testing

- `test_invitation_secrets_survive_roundtrip` (common): armored export → decode preserves the secrets map byte-for-byte.
- `test_backward_compat_no_room_name` extended: a pre-#306 token (no `invitation_secrets` key in the CBOR map) decodes with the field defaulting to an empty map.
- `invitation_secrets_survive_export_armor_import_persist` (cli): full export → armor → wipe → decode → storage-seed loop, then `get_invitation_secrets` returns the originals.
- `empty_invitation_secrets_round_trip_to_empty` (cli): public/pre-#306 export persists an empty map (no panic, no invented entries).
- `import_identity_seeds_invitation_secrets_wiring_pinned` (storage): source-grep pin (placed in `storage.rs` so it can't be self-satisfied by test code in the scanned file) guarding the export-population and import-seeding call sites against a future revert to no-secrets `add_room`.

Failing-first verified: removing the export population is a compile error (the new field is a mandatory struct field, not `Option`); reverting import to `add_room` trips the pin's `export.invitation_secrets.clone()` assertion.

Local runs (all green): `cargo test -p river-core --lib` (181), `--features ecies-randomized,migration,mentions` (211), `cargo test -p riverctl --lib` (117), `cargo fmt`, `cargo clippy -p river-core -p riverctl` clean on the changed code.

Closes #306

[AI-assisted - Claude]