### PR TITLE
test(ui): tighten connection-indicator regression tests (#274)

### DIFF
--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -374,7 +374,14 @@ pub fn MemberList() -> Element {
     }
 
     rsx! {
-        aside { class: "w-full md:w-56 flex-shrink-0 bg-panel border-l border-border flex flex-col",
+        aside {
+            // Stable hook for the connection-indicator regression tests
+            // (freenet/river#274): the members rail is the PRE-FIX location
+            // of the connection pill (Bug #5). Tests assert this rail
+            // carries no indicator, anchoring on the testid instead of the
+            // brittle visible text "Active Members".
+            "data-testid": "members-rail",
+            class: "w-full md:w-56 flex-shrink-0 bg-panel border-l border-border flex flex-col",
             // Header
             div { class: "px-4 py-3 border-b border-border flex-shrink-0",
                 div { class: "flex items-center gap-2",

--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -139,7 +139,14 @@ pub fn RoomList() -> Element {
     let drag_over_end_now: bool = drag_over_end.try_read().map(|g| *g).unwrap_or(false);
 
     rsx! {
-        aside { class: "w-full md:w-64 flex-shrink-0 bg-panel border-r border-border flex flex-col overflow-y-auto",
+        aside {
+            // Stable hook for the connection-indicator regression tests
+            // (freenet/river#274): the rooms rail is the always-rendered
+            // left column that carries the persistent connection pill, so
+            // tests anchor on this testid instead of the brittle visible
+            // text "Rooms".
+            "data-testid": "rooms-rail",
+            class: "w-full md:w-64 flex-shrink-0 bg-panel border-r border-border flex flex-col overflow-y-auto",
             // Mobile back button (hidden on desktop)
             div { class: "md:hidden flex items-center px-3 py-2 border-b border-border flex-shrink-0",
                 button {

--- a/ui/tests/connection-status-indicator.spec.ts
+++ b/ui/tests/connection-status-indicator.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from "@playwright/test";
+import { test, expect, Locator, Page } from "@playwright/test";
 
 // Regression tests for Bug #5 (Ivvor, Matrix 2026-05-17): the WebSocket
 // connection indicator must remain visible when the user has no rooms —
@@ -14,26 +14,106 @@ import { test, expect, Page } from "@playwright/test";
 // Both placements share the `data-testid="connection-status-indicator"`
 // id, so `:visible` is used to pick the one the user actually sees at
 // the current viewport.
-
-async function waitForApp(page: Page) {
-  await page.waitForSelector(".app-root", { timeout: 30_000 });
-  await expect(page.locator("aside, .app-root button")).not.toHaveCount(0);
-}
+//
+// Hardening (freenet/river#274): the earlier version of this spec only
+// asserted `.first()` of the `:visible` set, which silently tolerated a
+// regression where `md:hidden` inverted (or the Tailwind v4
+// `@source "../src/**/*.rs"` directive was dropped — see AGENTS.md),
+// leaving BOTH copies visible or NEITHER. The tests below now assert the
+// EXACT visible count (one, never zero or two) at each viewport, that the
+// DOM carries exactly the two expected placements, and that the visible
+// pill renders a real connection state (matching dot-colour + label)
+// rather than a stuck/blank pill.
 
 const PILL = '[data-testid="connection-status-indicator"]';
 const VISIBLE_PILL = `${PILL}:visible`;
+const ROOMS_RAIL = '[data-testid="rooms-rail"]';
+const MEMBERS_RAIL = '[data-testid="members-rail"]';
+
+// Wait for the app shell AND the always-rendered Rooms rail to mount.
+// (#274 item 3) The previous `"aside, .app-root button"` selector matched
+// any button anywhere in the app, so it could resolve before the rail —
+// which carries the persistent indicator — actually rendered. Anchor on
+// the rail's stable testid instead.
+async function waitForApp(page: Page) {
+  await page.waitForSelector(".app-root", { timeout: 30_000 });
+  await expect(page.locator(ROOMS_RAIL)).toHaveCount(1);
+}
+
+// The component maps each `SynchronizerStatus` to a (dot bg-colour, label)
+// pair (see `ConnectionStatusIndicator` in ui/src/components/members.rs).
+// A genuinely-rendered pill ALWAYS matches one of these rows; a stuck or
+// blank pill (e.g. a regression that replaces the reactive `try_read()`
+// with a non-subscribing `peek()` and renders no real state) would not.
+const STATUS_STATES = [
+  { dot: "bg-green-500", label: "Connected" },
+  { dot: "bg-yellow-500", label: "Connecting..." },
+  { dot: "bg-red-500", label: "Disconnected" },
+  // SynchronizerStatus::Error renders "Error: <msg>" with the red dot; the
+  // label is matched with a prefix below rather than an exact string.
+  { dot: "bg-red-500", label: "Error:" },
+];
+
+// Assert the visible pill renders a coherent connection state: its dot
+// carries exactly one of the known status colours AND the label text is
+// the one paired with that colour. This is the #274 item-2 "detect a
+// stuck-state regression" check — a pill that never picks up a real state
+// (no subscription) cannot satisfy both halves.
+async function expectCoherentState(visiblePill: Locator) {
+  const dot = visiblePill.locator("div").first();
+  await expect(dot).toBeVisible({ timeout: 5_000 });
+
+  const dotClass = (await dot.getAttribute("class")) ?? "";
+  const labelText = ((await visiblePill.textContent()) ?? "").trim();
+
+  // Distinct status colours — `bg-red-500` is shared by Disconnected and
+  // Error, so dedupe before counting how many the dot carries.
+  const colours = [...new Set(STATUS_STATES.map((s) => s.dot))];
+  const present = colours.filter((c) =>
+    new RegExp(`(^|\\s)${c}(\\s|$)`).test(dotClass)
+  );
+  // Exactly one status colour — not zero (blank/stuck dot) and not several
+  // (ambiguous render).
+  expect(
+    present,
+    `dot class "${dotClass}" must carry exactly one status colour`
+  ).toHaveLength(1);
+
+  const colour = present[0];
+  const expectedLabels = STATUS_STATES.filter((s) => s.dot === colour).map(
+    (s) => s.label
+  );
+  const labelMatches = expectedLabels.some((l) =>
+    l.endsWith(":") ? labelText.startsWith(l) : labelText === l
+  );
+  expect(
+    labelMatches,
+    `label "${labelText}" must match dot colour "${colour}" (one of ${JSON.stringify(
+      expectedLabels
+    )})`
+  ).toBeTruthy();
+}
 
 test.describe("Connection status indicator on desktop (Bug #5)", () => {
   test.use({ viewport: { width: 1280, height: 800 } });
 
-  test("a visible indicator is rendered on initial load", async ({ page }) => {
+  test("exactly one indicator is visible on initial load", async ({ page }) => {
     await page.goto("/");
     await waitForApp(page);
 
-    // The pill carries a stable data-testid so renames of the
-    // surrounding panel can't accidentally orphan this assertion.
-    const visiblePill = page.locator(VISIBLE_PILL).first();
-    await expect(visiblePill).toBeVisible({ timeout: 5_000 });
+    // (#274 item 1) Exactly ONE pill is visible at desktop width — the
+    // left-rail copy. The Welcome-screen inline copy is `md:hidden`, so a
+    // count of 2 here would mean `md:hidden` inverted; a count of 0 would
+    // mean the rail copy got hidden. `.first()` masked both.
+    await expect(page.locator(VISIBLE_PILL)).toHaveCount(1);
+
+    // Both placements still exist in the DOM (one shown, one hidden); this
+    // guards against the rail copy being dropped entirely — which would
+    // also yield a visible count of 1 from the Welcome copy alone if it
+    // weren't `md:hidden`.
+    await expect(page.locator(PILL)).toHaveCount(2);
+
+    const visiblePill = page.locator(VISIBLE_PILL);
     await expect(visiblePill).toHaveAttribute(
       "aria-label",
       "WebSocket connection status"
@@ -50,20 +130,33 @@ test.describe("Connection status indicator on desktop (Bug #5)", () => {
     await page.goto("/");
     await waitForApp(page);
 
-    await expect(page.locator(VISIBLE_PILL).first()).toBeVisible({
-      timeout: 5_000,
-    });
+    await expect(page.locator(VISIBLE_PILL)).toHaveCount(1);
 
-    const roomsRail = page.locator("aside").filter({ hasText: "Rooms" });
-    const membersRail = page
-      .locator("aside")
-      .filter({ hasText: "Active Members" });
+    const roomsRail = page.locator(ROOMS_RAIL);
+    const membersRail = page.locator(MEMBERS_RAIL);
 
-    // The visible pill at desktop width must be inside the Rooms rail.
+    // The single visible pill at desktop width must be inside the Rooms
+    // rail, and it must be the rail's only pill.
     await expect(roomsRail.locator(VISIBLE_PILL)).toHaveCount(1);
+    await expect(roomsRail.locator(PILL)).toHaveCount(1);
     // The Members rail must NOT carry an indicator at all (pre-fix
     // location).
     await expect(membersRail.locator(PILL)).toHaveCount(0);
+  });
+
+  test("the visible indicator renders a real connection state", async ({
+    page,
+  }) => {
+    // (#274 item 2) Assert the visible pill's dot colour and label form a
+    // coherent SynchronizerStatus. A regression that leaves the pill stuck
+    // / blank (e.g. swapping the reactive `try_read()` for `peek()`) would
+    // fail to render a matching colour+label pair.
+    await page.goto("/");
+    await waitForApp(page);
+
+    const visiblePill = page.locator(VISIBLE_PILL);
+    await expect(visiblePill).toHaveCount(1);
+    await expectCoherentState(visiblePill);
   });
 
   test("indicator remains visible when no room is selected (Welcome screen)", async ({
@@ -78,9 +171,7 @@ test.describe("Connection status indicator on desktop (Bug #5)", () => {
       timeout: 5_000,
     });
 
-    await expect(page.locator(VISIBLE_PILL).first()).toBeVisible({
-      timeout: 5_000,
-    });
+    await expect(page.locator(VISIBLE_PILL)).toHaveCount(1);
   });
 });
 
@@ -91,7 +182,7 @@ test.describe("Connection status indicator on mobile (Bug #5)", () => {
   // the indicator, Bug #5 would reappear on mobile.
   test.use({ viewport: { width: 375, height: 812 } });
 
-  test("a visible indicator is shown on the mobile Welcome screen", async ({
+  test("exactly one indicator is visible on the mobile Welcome screen", async ({
     page,
   }) => {
     await page.goto("/");
@@ -101,16 +192,40 @@ test.describe("Connection status indicator on mobile (Bug #5)", () => {
       timeout: 5_000,
     });
 
-    // The left-rail copy is hidden at this width, so the visible
-    // indicator must be the inline one inside the Conversation panel.
-    const visiblePill = page.locator(VISIBLE_PILL).first();
-    await expect(visiblePill).toBeVisible({ timeout: 5_000 });
+    // (#274 item 1) Exactly ONE pill is visible at mobile width. The
+    // left-rail copy lives in the `hidden md:flex` rail wrapper (hidden
+    // here), so the single visible pill must be the inline Welcome copy.
+    // A count of 2 would mean the rail wrapper failed to hide; a count of
+    // 0 would mean the inline `md:hidden` copy is hidden at mobile width
+    // too (the original Bug #5 on mobile).
+    await expect(page.locator(VISIBLE_PILL)).toHaveCount(1);
+    // Both placements still exist in the DOM.
+    await expect(page.locator(PILL)).toHaveCount(2);
 
-    // Confirm we're looking at the inline (not left-rail) copy.
+    // Confirm we're looking at the inline (not left-rail) copy: it sits
+    // inside the Welcome-screen heading's container, NOT the Rooms rail.
     const inWelcomeScreen = page
       .locator("h1", { hasText: "Welcome to River" })
       .locator("..")
       .locator(VISIBLE_PILL);
     await expect(inWelcomeScreen).toHaveCount(1);
+    await expect(page.locator(ROOMS_RAIL).locator(VISIBLE_PILL)).toHaveCount(0);
+  });
+
+  test("the mobile indicator renders a real connection state", async ({
+    page,
+  }) => {
+    // (#274 item 2) Same coherent-state check as desktop, against the
+    // inline Welcome-screen copy that mobile users actually see.
+    await page.goto("/");
+    await waitForApp(page);
+
+    await expect(page.getByText("Welcome to River")).toBeVisible({
+      timeout: 5_000,
+    });
+
+    const visiblePill = page.locator(VISIBLE_PILL);
+    await expect(visiblePill).toHaveCount(1);
+    await expectCoherentState(visiblePill);
   });
 });

--- a/ui/tests/connection-status-indicator.spec.ts
+++ b/ui/tests/connection-status-indicator.spec.ts
@@ -62,6 +62,10 @@ const STATUS_STATES = [
 async function expectCoherentState(visiblePill: Locator) {
   const dot = visiblePill.locator("div").first();
   await expect(dot).toBeVisible({ timeout: 5_000 });
+  // The label span always renders some status text; wait for it via a
+  // retrying assertion before the non-retrying getAttribute/textContent
+  // reads below, so a mid-render empty read can't make this flaky.
+  await expect(visiblePill).toContainText(/\S/, { timeout: 5_000 });
 
   const dotClass = (await dot.getAttribute("class")) ?? "";
   const labelText = ((await visiblePill.textContent()) ?? "").trim();
@@ -172,6 +176,32 @@ test.describe("Connection status indicator on desktop (Bug #5)", () => {
     });
 
     await expect(page.locator(VISIBLE_PILL)).toHaveCount(1);
+  });
+
+  test("still exactly one indicator when a room IS selected", async ({
+    page,
+  }) => {
+    // The no-room Welcome screen was Bug #5's trigger, but the
+    // "exactly one pill" invariant must also hold with a room selected —
+    // otherwise re-introducing the indicator into the now-rendered
+    // MemberList (its pre-fix home) would add a SECOND desktop pill and go
+    // unnoticed. Selecting a room mounts the Members rail; assert the pill
+    // count stays at one and stays in the Rooms rail.
+    await page.goto("/");
+    await waitForApp(page);
+
+    await page.getByRole("button", { name: "Team Chat Room" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Team Chat Room" })
+    ).toBeVisible({ timeout: 5_000 });
+
+    // The Members rail is now mounted (it returns empty only when no room
+    // is selected — that was the Bug #5 root cause).
+    await expect(page.locator(MEMBERS_RAIL)).toHaveCount(1);
+
+    await expect(page.locator(VISIBLE_PILL)).toHaveCount(1);
+    await expect(page.locator(ROOMS_RAIL).locator(VISIBLE_PILL)).toHaveCount(1);
+    await expect(page.locator(MEMBERS_RAIL).locator(PILL)).toHaveCount(0);
   });
 });
 


### PR DESCRIPTION
## Problem

The connection-indicator regression suite (`ui/tests/connection-status-indicator.spec.ts`, added in PR #273 for Bug #5 — Ivvor's "no connection indicator on the no-rooms screen") had four review follow-ups (#274) that left it able to silently pass through real regressions:

1. It asserted `.first()` of the `:visible` pill set. Both pill placements share `data-testid="connection-status-indicator"`, so `.first()` tolerated an `md:hidden` inversion (or a dropped Tailwind v4 `@source "../src/**/*.rs"` directive) that left BOTH copies visible — exactly the class of regression that would re-break the new-user experience.
2. All tests only asserted the indicator was present. A regression that left the pill stuck/blank (e.g. swapping the reactive `try_read()` for a non-subscribing `peek()`, per the Dioxus 0.7.x signal-safety rule) would not be caught.
3. `waitForApp` waited on `"aside, .app-root button"`, which matches any button anywhere in the app — it could resolve before the rail that carries the indicator rendered.
4. Rail-membership assertions keyed off the brittle visible text `"Rooms"` / `"Active Members"`.

## Approach

Test-only hardening, plus two `data-testid` attributes on existing UI source for stable hooks:

- **Exact visible count (item 1):** assert `expect(VISIBLE_PILL).toHaveCount(1)` at desktop (1280px) and mobile (375x812), and `expect(PILL).toHaveCount(2)` for the DOM (both placements present, one shown one `md:hidden`). Catches both the "both visible" inversion and the "placement dropped" regression that `.first()` masked.
- **Coherent-state check (item 2):** the visible pill's dot bg-colour and label text must form a valid `SynchronizerStatus` pair (green↔Connected, yellow↔Connecting, red↔Disconnected/Error). A stuck/blank pill fails. Chosen over driving a state transition because the `no-sync` build exposes no state-injection fixture; this still detects the stuck-state regression the issue names.
- **Tighter `waitForApp` (item 3):** anchor on the new `rooms-rail` testid.
- **Cross-browser (item 4):** the spec already runs across all five Playwright projects (chromium, firefox, webkit, mobile-chrome, mobile-safari) via `testMatch: "*.spec.ts"` with no per-project filtering — confirmed by running the suite (30 tests = 6 × 5 projects, all green). No config change needed.
- **Stable testids (item 5):** add `data-testid="rooms-rail"` to the `RoomList` `aside` and `data-testid="members-rail"` to the `MemberList` `aside`; rail assertions now anchor on these instead of visible text. These are UI-WASM-only source attributes — no contract/delegate WASM is affected, so no migration is involved.

## Testing

- Built locally: `cargo make build-tailwind` + `cargo make build-ui-example-no-sync`, served the built static dir with `python3 -m http.server 8082`.
- `npx playwright test connection-status-indicator`: **30 passed** (6 tests × chromium/firefox/webkit/mobile-chrome/mobile-safari).
- Full suite (`npx playwright test`): **251 passed, 3 skipped** — the testid additions don't disturb any existing layout test. (One pre-existing `message-layout.spec.ts` mobile-safari test was flaky on a loaded machine and passed on retry; it uses the old loose `waitForApp` selector and is untouched here.)
- **Non-vacuity proof:** injected a CSS override forcing both pills visible (simulating the `md:hidden` inversion). The old `.first()` assertion still passed (the masked bug) while the new `toHaveCount(1)` assertion correctly failed — confirming the tightened assertion catches the regression class #274 describes.
- Empirically confirmed the rendered DOM: desktop/mobile each have 2 pills in the DOM, exactly 1 visible; in the `no-sync` build the state is `Error: WebSocket error...` with a `bg-red-500` dot, which the coherent-state check validates.

Closes #274

[AI-assisted - Claude]