### PR TITLE
fix(ui): show @mention autocomplete when editing a message

### DIFF
--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -2270,6 +2270,28 @@ fn MessageGroupComponent(
                                                             let _ = el.scroll_to(ScrollBehavior::Smooth).await;
                                                         });
                                                     },
+                                                    // Global key bindings on the container (#94): Esc cancels,
+                                                    // Enter saves. Kept here (not solely on the textarea) so the
+                                                    // "(Esc)"/"(Enter)" button shortcuts work when keyboard focus
+                                                    // is on a button. The textarea's @mention handler calls
+                                                    // stop_propagation when it consumes a key, so these never
+                                                    // double-fire with mention navigation.
+                                                    onkeydown: {
+                                                        let msg_id = msg_id_for_save.clone();
+                                                        let original = original_text.clone();
+                                                        move |e: KeyboardEvent| {
+                                                            if e.key() == Key::Escape {
+                                                                editing_message.set(None);
+                                                            } else if e.key() == Key::Enter && !e.modifiers().shift() {
+                                                                e.prevent_default();
+                                                                let new_text = edit_text.read().clone();
+                                                                if !new_text.is_empty() && new_text != original {
+                                                                    on_edit.call((msg_id.clone(), new_text));
+                                                                }
+                                                                editing_message.set(None);
+                                                            }
+                                                        }
+                                                    },
                                                     // `relative` anchors the @mention autocomplete
                                                     // dropdown to the textarea.
                                                     div { class: "relative",
@@ -2306,27 +2328,16 @@ fn MessageGroupComponent(
                                                                 );
                                                             },
                                                             // @mention navigation (Arrow/Enter/Tab/Esc) takes
-                                                            // precedence while the dropdown is open; otherwise
-                                                            // Esc cancels the edit and Enter saves it (#94).
-                                                            onkeydown: {
-                                                                let msg_id = msg_id_for_save.clone();
-                                                                let original = original_text.clone();
-                                                                move |e: KeyboardEvent| {
-                                                                    if mention::handle_mention_keydown(
-                                                                        &kd_id, &e, edit_text, edit_mention, || {},
-                                                                    ) {
-                                                                        return;
-                                                                    }
-                                                                    if e.key() == Key::Escape {
-                                                                        editing_message.set(None);
-                                                                    } else if e.key() == Key::Enter && !e.modifiers().shift() {
-                                                                        e.prevent_default();
-                                                                        let new_text = edit_text.read().clone();
-                                                                        if !new_text.is_empty() && new_text != original {
-                                                                            on_edit.call((msg_id.clone(), new_text));
-                                                                        }
-                                                                        editing_message.set(None);
-                                                                    }
+                                                            // precedence while the dropdown is open. When it
+                                                            // consumes the key, stop_propagation keeps the
+                                                            // container's Esc-cancel / Enter-save (above) from
+                                                            // also firing for that same key. Non-mention keys
+                                                            // bubble up to the container handler unchanged.
+                                                            onkeydown: move |e: KeyboardEvent| {
+                                                                if mention::handle_mention_keydown(
+                                                                    &kd_id, &e, edit_text, edit_mention, || {},
+                                                                ) {
+                                                                    e.stop_propagation();
                                                                 }
                                                             },
                                                             // Dismiss the dropdown when focus leaves the textarea

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -11,6 +11,7 @@ use crate::util::{
     get_current_system_time, local_message_date, local_today,
 };
 mod emoji_picker;
+mod mention;
 mod message_actions;
 mod message_input;
 mod not_member_notification;
@@ -2145,6 +2146,24 @@ fn MessageGroupComponent(
     // Track which message is being edited and its current text
     let mut editing_message: Signal<Option<String>> = use_signal(|| None);
     let mut edit_text: Signal<String> = use_signal(String::new);
+    // @mention autocomplete state for the inline edit form (mirrors the
+    // composer in message_input.rs). One signal suffices: at most one message
+    // in this group is edited at a time.
+    let mut edit_mention = use_signal(|| None as Option<mention::MentionAutocomplete>);
+
+    // Mentionable members for the edit form's @ autocomplete: every member with
+    // a (decrypted) nickname except self, sorted by name — the same shape the
+    // composer receives, derived from `member_names` so no extra prop plumbing.
+    let edit_mention_members: Vec<(MemberId, String)> = {
+        let mut v: Vec<(MemberId, String)> = member_names
+            .iter()
+            .filter(|(id, _)| **id != self_member_id)
+            .filter(|(_, name)| !name.trim().is_empty())
+            .map(|(id, name)| (*id, name.clone()))
+            .collect();
+        v.sort_by(|a, b| a.1.to_lowercase().cmp(&b.1.to_lowercase()));
+        v
+    };
 
     // Watch for external edit requests (e.g. up-arrow in empty input)
     let message_ids: Vec<String> = group.messages.iter().map(|m| m.id.clone()).collect();
@@ -2229,6 +2248,13 @@ fn MessageGroupComponent(
                                         if is_editing {
                                             let save_msg_id = msg_id_for_save.clone();
                                             let save_original = original_text.clone();
+                                            // Unique DOM id so the @mention caret math targets THIS
+                                            // edit textarea (multiple groups can theoretically edit).
+                                            let edit_id = format!("edit-msg-{}", msg.id);
+                                            let pick_id = edit_id.clone();
+                                            let kd_id = edit_id.clone();
+                                            let input_id = edit_id.clone();
+                                            let input_members = edit_mention_members.clone();
                                             rsx! {
                                                 div {
                                                     class: format!(
@@ -2244,36 +2270,72 @@ fn MessageGroupComponent(
                                                             let _ = el.scroll_to(ScrollBehavior::Smooth).await;
                                                         });
                                                     },
-                                                    // Global key bindings on the container (#94)
-                                                    onkeydown: {
-                                                        let msg_id = msg_id_for_save.clone();
-                                                        let original = original_text.clone();
-                                                        move |e: KeyboardEvent| {
-                                                            if e.key() == Key::Escape {
-                                                                editing_message.set(None);
-                                                            } else if e.key() == Key::Enter && !e.modifiers().shift() {
-                                                                e.prevent_default();
-                                                                let new_text = edit_text.read().clone();
-                                                                if !new_text.is_empty() && new_text != original {
-                                                                    on_edit.call((msg_id.clone(), new_text));
-                                                                }
-                                                                editing_message.set(None);
-                                                            }
+                                                    // `relative` anchors the @mention autocomplete
+                                                    // dropdown to the textarea.
+                                                    div { class: "relative",
+                                                        // @mention autocomplete dropdown (floats above the textarea)
+                                                        mention::MentionDropdown {
+                                                            mention: edit_mention,
+                                                            on_pick: move |i| mention::apply_mention_selection(
+                                                                pick_id.clone(),
+                                                                edit_text,
+                                                                edit_mention,
+                                                                i,
+                                                                || {},
+                                                            ),
                                                         }
-                                                    },
-                                                    textarea {
-                                                        class: format!(
-                                                            "w-full min-h-[240px] p-2 rounded-lg text-sm resize-y focus:outline-none {}",
-                                                            if is_self { "bg-white/10 text-white placeholder-white/50 border border-white/20" } else { "bg-bg text-text border border-border" }
-                                                        ),
-                                                        value: "{edit_text}",
-                                                        onmounted: move |cx| {
-                                                            let element = cx.data();
-                                                            wasm_bindgen_futures::spawn_local(async move {
-                                                                let _ = element.set_focus(true).await;
-                                                            });
-                                                        },
-                                                        oninput: move |e| edit_text.set(e.value().clone()),
+                                                        textarea {
+                                                            id: "{edit_id}",
+                                                            class: format!(
+                                                                "w-full min-h-[240px] p-2 rounded-lg text-sm resize-y focus:outline-none {}",
+                                                                if is_self { "bg-white/10 text-white placeholder-white/50 border border-white/20" } else { "bg-bg text-text border border-border" }
+                                                            ),
+                                                            value: "{edit_text}",
+                                                            onmounted: move |cx| {
+                                                                let element = cx.data();
+                                                                wasm_bindgen_futures::spawn_local(async move {
+                                                                    let _ = element.set_focus(true).await;
+                                                                });
+                                                            },
+                                                            oninput: move |e| {
+                                                                let value = e.value().to_string();
+                                                                edit_text.set(value.clone());
+                                                                // Detect / update the @mention autocomplete.
+                                                                mention::update_mention_from_input(
+                                                                    &input_id, &value, &input_members, edit_mention,
+                                                                );
+                                                            },
+                                                            // @mention navigation (Arrow/Enter/Tab/Esc) takes
+                                                            // precedence while the dropdown is open; otherwise
+                                                            // Esc cancels the edit and Enter saves it (#94).
+                                                            onkeydown: {
+                                                                let msg_id = msg_id_for_save.clone();
+                                                                let original = original_text.clone();
+                                                                move |e: KeyboardEvent| {
+                                                                    if mention::handle_mention_keydown(
+                                                                        &kd_id, &e, edit_text, edit_mention, || {},
+                                                                    ) {
+                                                                        return;
+                                                                    }
+                                                                    if e.key() == Key::Escape {
+                                                                        editing_message.set(None);
+                                                                    } else if e.key() == Key::Enter && !e.modifiers().shift() {
+                                                                        e.prevent_default();
+                                                                        let new_text = edit_text.read().clone();
+                                                                        if !new_text.is_empty() && new_text != original {
+                                                                            on_edit.call((msg_id.clone(), new_text));
+                                                                        }
+                                                                        editing_message.set(None);
+                                                                    }
+                                                                }
+                                                            },
+                                                            // Dismiss the dropdown when focus leaves the textarea
+                                                            // (click elsewhere). Dropdown rows use mousedown +
+                                                            // preventDefault, so picking one does not blur first.
+                                                            onfocusout: move |_| {
+                                                                crate::util::defer(move || edit_mention.set(None));
+                                                            },
+                                                        }
                                                     }
                                                     div { class: "flex justify-end gap-3 mt-3",
                                                         style: "overflow: visible;",

--- a/ui/src/components/conversation/mention.rs
+++ b/ui/src/components/conversation/mention.rs
@@ -1,0 +1,429 @@
+//! Reusable `@mention` autocomplete machinery shared by the new-message
+//! composer (`message_input.rs`) and the inline message-edit form
+//! (`conversation.rs::MessageGroupComponent`).
+//!
+//! Everything here is parameterised by the DOM `id` of the target
+//! `<textarea>` so the same caret math, query detection, candidate filtering,
+//! and dropdown rendering drive both call sites without duplication.
+
+use dioxus::prelude::*;
+use river_core::room_state::member::MemberId;
+use wasm_bindgen::JsCast;
+
+/// Maximum number of members shown in the @mention autocomplete dropdown.
+pub const MENTION_CANDIDATE_LIMIT: usize = 8;
+
+/// In-flight @mention autocomplete state, set while the caret sits inside an
+/// `@query` token in a textarea.
+#[derive(Clone, PartialEq)]
+pub struct MentionAutocomplete {
+    /// Byte offset of the `@` in the current text.
+    pub anchor: usize,
+    /// Byte offset just past the typed query (i.e. the caret).
+    pub query_end: usize,
+    /// Members matching the query, already truncated to the display limit.
+    pub candidates: Vec<(MemberId, String)>,
+    /// Index into `candidates` currently highlighted for keyboard selection.
+    pub selected: usize,
+}
+
+/// Look up a `<textarea>` by its DOM `id`.
+fn get_textarea(id: &str) -> Option<web_sys::HtmlTextAreaElement> {
+    web_sys::window()?
+        .document()?
+        .get_element_by_id(id)?
+        .dyn_into::<web_sys::HtmlTextAreaElement>()
+        .ok()
+}
+
+/// Read the textarea caret as a *byte* offset into `value`. `selection_start`
+/// is a UTF-16 code-unit index (DOMString semantics), so it must be converted.
+fn read_caret_byte(id: &str, value: &str) -> Option<usize> {
+    let el = get_textarea(id)?;
+    let caret_u16 = el.selection_start().ok().flatten()? as usize;
+    Some(utf16_to_byte_offset(value, caret_u16))
+}
+
+/// Focus the textarea and place the caret at byte offset `byte_off` in `value`.
+fn set_caret(id: &str, value: &str, byte_off: usize) {
+    let Some(el) = get_textarea(id) else {
+        return;
+    };
+    let _ = el.focus();
+    let off = byte_to_utf16_offset(value, byte_off);
+    let _ = el.set_selection_range(off, off);
+}
+
+fn utf16_to_byte_offset(s: &str, utf16_off: usize) -> usize {
+    let mut u16count = 0usize;
+    for (byte_idx, ch) in s.char_indices() {
+        if u16count >= utf16_off {
+            return byte_idx;
+        }
+        u16count += ch.len_utf16();
+    }
+    s.len()
+}
+
+fn byte_to_utf16_offset(s: &str, byte_off: usize) -> u32 {
+    let mut u16count = 0u32;
+    for (byte_idx, ch) in s.char_indices() {
+        if byte_idx >= byte_off {
+            break;
+        }
+        u16count += ch.len_utf16() as u32;
+    }
+    u16count
+}
+
+/// If the caret sits inside an `@query` token (a `@` at a word boundary with no
+/// whitespace between it and the caret), return `(byte offset of '@', query)`.
+fn detect_mention_query(value: &str, byte_caret: usize) -> Option<(usize, String)> {
+    if byte_caret > value.len() || !value.is_char_boundary(byte_caret) {
+        return None;
+    }
+    let prefix = &value[..byte_caret];
+    // Walk back from the caret: the first `@` (with no intervening whitespace)
+    // starts the query; any whitespace first means we're not in a token.
+    let mut at = None;
+    for (idx, ch) in prefix.char_indices().rev() {
+        if ch == '@' {
+            at = Some(idx);
+            break;
+        }
+        if ch.is_whitespace() {
+            return None;
+        }
+    }
+    let at = at?;
+    // The `@` must begin a word: at start-of-text or after whitespace. This
+    // skips email-like `name@host` (the char before `@` is not whitespace).
+    if at > 0 {
+        let before = prefix[..at].chars().next_back()?;
+        if !before.is_whitespace() {
+            return None;
+        }
+    }
+    Some((at, prefix[at + 1..].to_string()))
+}
+
+/// Rank members against a query: case-insensitive prefix matches first, then
+/// substring matches, preserving the input order (caller pre-sorts by name).
+/// An empty query lists everyone (up to `limit`).
+fn filter_mention_candidates(
+    members: &[(MemberId, String)],
+    query: &str,
+    limit: usize,
+) -> Vec<(MemberId, String)> {
+    let q = query.to_lowercase();
+    let mut prefix = Vec::new();
+    let mut substr = Vec::new();
+    for (id, name) in members {
+        let lname = name.to_lowercase();
+        if q.is_empty() || lname.starts_with(&q) {
+            prefix.push((*id, name.clone()));
+        } else if lname.contains(&q) {
+            substr.push((*id, name.clone()));
+        }
+    }
+    prefix.extend(substr);
+    prefix.truncate(limit);
+    prefix
+}
+
+/// Lowercased nicknames that appear on more than one of the shown candidates.
+/// Those rows look identical, so the dropdown shows a disambiguating member id
+/// beside them. Case-insensitive, matching the resolver's ambiguity key (so the
+/// picker and riverctl's send-time `@name` resolution agree on what "ambiguous"
+/// means). Near-but-distinct names (e.g. "Alice"/"Alicia") are intentionally
+/// NOT treated as collisions — they are already distinguishable by sight.
+fn duplicate_candidate_names(
+    candidates: &[(MemberId, String)],
+) -> std::collections::HashSet<String> {
+    let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    for (_, name) in candidates {
+        *counts.entry(name.to_lowercase()).or_default() += 1;
+    }
+    counts
+        .into_iter()
+        .filter(|(_, n)| *n > 1)
+        .map(|(name, _)| name)
+        .collect()
+}
+
+/// Recompute the `@mention` dropdown state for textarea `id` from an `oninput`
+/// event's new `value`. Sets `mention` to the matching candidates (or clears it
+/// when the caret isn't inside an `@query` or nothing matches).
+pub fn update_mention_from_input(
+    id: &str,
+    value: &str,
+    members: &[(MemberId, String)],
+    mut mention: Signal<Option<MentionAutocomplete>>,
+) {
+    match read_caret_byte(id, value).and_then(|caret| detect_mention_query(value, caret)) {
+        Some((at, query)) => {
+            let candidates = filter_mention_candidates(members, &query, MENTION_CANDIDATE_LIMIT);
+            if candidates.is_empty() {
+                mention.set(None);
+            } else {
+                mention.set(Some(MentionAutocomplete {
+                    anchor: at,
+                    query_end: at + 1 + query.len(),
+                    candidates,
+                    selected: 0,
+                }));
+            }
+        }
+        None => mention.set(None),
+    }
+}
+
+/// Replace the `@query` span in textarea `id` with the chosen member's wire
+/// token and a trailing space, then reposition the caret after the inserted
+/// token. `after` runs in the same deferred tick as the caret reposition (used
+/// e.g. to auto-resize the composer textarea); pass `|| {}` when nothing else
+/// is needed.
+pub fn apply_mention_selection(
+    id: String,
+    mut text: Signal<String>,
+    mut mention: Signal<Option<MentionAutocomplete>>,
+    idx: usize,
+    after: impl FnOnce() + 'static,
+) {
+    let Some(m) = mention.peek().clone() else {
+        return;
+    };
+    let Some((member_id, name)) = m.candidates.get(idx).cloned() else {
+        return;
+    };
+    let value = text.peek().to_string();
+    // Guard the stored offsets against a value that changed out from under us
+    // (they are only valid for the value captured at the last keystroke).
+    if m.anchor > m.query_end
+        || m.query_end > value.len()
+        || !value.is_char_boundary(m.anchor)
+        || !value.is_char_boundary(m.query_end)
+    {
+        mention.set(None);
+        return;
+    }
+    let token = river_core::mention::encode_mention(member_id, &name);
+    let mut new_value = String::with_capacity(value.len() + token.len() + 1);
+    new_value.push_str(&value[..m.anchor]);
+    new_value.push_str(&token);
+    new_value.push(' ');
+    new_value.push_str(&value[m.query_end..]);
+    let caret_byte = m.anchor + token.len() + 1;
+    text.set(new_value.clone());
+    mention.set(None);
+    // The caret must be set after Dioxus flushes the new value to the DOM.
+    crate::util::defer(move || {
+        set_caret(&id, &new_value, caret_byte);
+        after();
+    });
+}
+
+/// Handle a textarea `onkeydown` event for `@mention` navigation in textarea
+/// `id`. Returns `true` when the dropdown consumed the key (Arrow Up/Down to
+/// move, Escape to dismiss, Enter/Tab to accept) so the caller can `return`
+/// before its own Enter/Escape handling. Returns `false` (a no-op) when the
+/// dropdown isn't open or the key isn't one it handles. `after` runs after an
+/// accept, like `apply_mention_selection`.
+pub fn handle_mention_keydown(
+    id: &str,
+    evt: &KeyboardEvent,
+    text: Signal<String>,
+    mut mention: Signal<Option<MentionAutocomplete>>,
+    after: impl FnOnce() + 'static,
+) -> bool {
+    if mention.peek().is_none() {
+        return false;
+    }
+    let key = evt.key();
+    if key == Key::ArrowDown || key == Key::ArrowUp {
+        evt.prevent_default();
+        let down = key == Key::ArrowDown;
+        mention.with_mut(|opt| {
+            if let Some(m) = opt.as_mut() {
+                let n = m.candidates.len();
+                if n > 0 {
+                    m.selected = if down {
+                        (m.selected + 1) % n
+                    } else {
+                        (m.selected + n - 1) % n
+                    };
+                }
+            }
+        });
+        return true;
+    }
+    if key == Key::Escape {
+        evt.prevent_default();
+        mention.set(None);
+        return true;
+    }
+    if (key == Key::Enter || key == Key::Tab) && !evt.modifiers().shift() {
+        evt.prevent_default();
+        let idx = mention.peek().as_ref().map(|m| m.selected).unwrap_or(0);
+        apply_mention_selection(id.to_string(), text, mention, idx, after);
+        return true;
+    }
+    false
+}
+
+/// The `@mention` autocomplete dropdown. Renders nothing when `mention` is
+/// `None`. Anchored `absolute bottom-full` so the caller must place it inside a
+/// `position: relative` container that also holds the textarea. `on_pick` is
+/// invoked with the chosen candidate index (use `apply_mention_selection`).
+#[component]
+pub fn MentionDropdown(
+    mention: Signal<Option<MentionAutocomplete>>,
+    on_pick: EventHandler<usize>,
+) -> Element {
+    // Snapshot dropdown state for rendering (drops the read guard before rsx).
+    let view = mention.read().as_ref().map(|m| {
+        // Lowercased nicknames shared by more than one shown candidate need a
+        // disambiguating id, since the rows otherwise look identical.
+        let dups = duplicate_candidate_names(&m.candidates);
+        (m.candidates.clone(), m.selected, dups)
+    });
+    let Some((candidates, selected, dups)) = view else {
+        return rsx! {};
+    };
+    rsx! {
+        div {
+            class: "absolute bottom-full left-0 mb-1 w-64 max-h-56 overflow-y-auto bg-panel border border-border rounded-xl shadow-lg z-50",
+            role: "listbox",
+            "aria-label": "Mention a member",
+            for (i, (id, name)) in candidates.into_iter().enumerate() {
+                button {
+                    key: "{river_core::mention::member_id_to_hex(id)}",
+                    r#type: "button",
+                    role: "option",
+                    "aria-selected": if i == selected { "true" } else { "false" },
+                    class: format!(
+                        "w-full text-left px-3 py-2 text-sm flex items-baseline justify-between gap-2 {}",
+                        if i == selected { "bg-accent/15 text-accent" } else { "text-text hover:bg-surface" }
+                    ),
+                    // Use mousedown + preventDefault so the textarea
+                    // doesn't blur before the selection is applied.
+                    onmousedown: move |evt| {
+                        evt.prevent_default();
+                        on_pick.call(i);
+                    },
+                    span { class: "font-medium truncate min-w-0 flex-1", "@{name}" }
+                    // Show the member id only when another shown candidate shares
+                    // this nickname (case-insensitive), so identical-looking rows
+                    // can be told apart.
+                    if dups.contains(&name.to_lowercase()) {
+                        span {
+                            class: "text-xs text-text-muted font-mono shrink-0",
+                            title: "Member ID (shown because another member shares this name)",
+                            "{id}"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mid(n: i64) -> MemberId {
+        MemberId(freenet_scaffold::util::FastHash(n))
+    }
+
+    #[test]
+    fn duplicate_candidate_names_flags_only_case_insensitive_collisions() {
+        let cands = vec![
+            (mid(1), "Alice".to_string()),
+            (mid(2), "alice".to_string()), // collides with "Alice" (case-insensitive)
+            (mid(3), "Alicia".to_string()), // near but distinct — NOT a collision
+            (mid(4), "Bob".to_string()),   // unique
+        ];
+        let dups = duplicate_candidate_names(&cands);
+        assert!(dups.contains("alice"), "case-insensitive duplicate flagged");
+        assert!(!dups.contains("alicia"), "near-name must not be flagged");
+        assert!(!dups.contains("bob"));
+        assert_eq!(dups.len(), 1);
+    }
+
+    fn members() -> Vec<(MemberId, String)> {
+        vec![
+            (
+                MemberId(freenet_scaffold::util::FastHash(1)),
+                "Alice".to_string(),
+            ),
+            (
+                MemberId(freenet_scaffold::util::FastHash(2)),
+                "Albert".to_string(),
+            ),
+            (
+                MemberId(freenet_scaffold::util::FastHash(3)),
+                "Bob".to_string(),
+            ),
+        ]
+    }
+
+    #[test]
+    fn detects_query_at_caret() {
+        assert_eq!(
+            detect_mention_query("hi @al", 6),
+            Some((3, "al".to_string()))
+        );
+        // Caret at the bare '@'
+        assert_eq!(detect_mention_query("@", 1), Some((0, String::new())));
+        // '@' at start of text
+        assert_eq!(detect_mention_query("@bo", 3), Some((0, "bo".to_string())));
+    }
+
+    #[test]
+    fn no_query_when_not_in_token() {
+        assert_eq!(detect_mention_query("hello world", 11), None);
+        // whitespace between '@' and caret
+        assert_eq!(detect_mention_query("@al bob", 7), None);
+        // email-like: '@' not at a word boundary
+        assert_eq!(detect_mention_query("name@host", 9), None);
+    }
+
+    #[test]
+    fn filter_prefers_prefix_then_substring() {
+        // "al" → Albert and Alice by prefix (input order preserved)
+        let r = filter_mention_candidates(&members(), "al", 8);
+        let names: Vec<_> = r.iter().map(|(_, n)| n.as_str()).collect();
+        assert_eq!(names, vec!["Alice", "Albert"]);
+        // substring-only match
+        let r = filter_mention_candidates(&members(), "ob", 8);
+        assert_eq!(
+            r.iter().map(|(_, n)| n.as_str()).collect::<Vec<_>>(),
+            vec!["Bob"]
+        );
+        // empty query lists everyone
+        assert_eq!(filter_mention_candidates(&members(), "", 8).len(), 3);
+        // limit is honoured
+        assert_eq!(filter_mention_candidates(&members(), "", 1).len(), 1);
+    }
+
+    #[test]
+    fn utf16_byte_offset_round_trips_with_multibyte() {
+        // "é" is 2 bytes / 1 utf16 unit; "𝄞" is 4 bytes / 2 utf16 units.
+        let s = "aé𝄞b";
+        for (byte_off, _) in s.char_indices().chain(std::iter::once((s.len(), ' '))) {
+            let u16 = byte_to_utf16_offset(s, byte_off);
+            assert_eq!(utf16_to_byte_offset(s, u16 as usize), byte_off);
+        }
+    }
+
+    #[test]
+    fn detect_handles_multibyte_before_at() {
+        // "é @bo" — the '@' is preceded by a space, query is "bo".
+        let s = "é @bo";
+        let caret = s.len();
+        let (at, q) = detect_mention_query(s, caret).unwrap();
+        assert_eq!(&s[at..at + 1], "@");
+        assert_eq!(q, "bo");
+    }
+}

--- a/ui/src/components/conversation/message_input.rs
+++ b/ui/src/components/conversation/message_input.rs
@@ -1,26 +1,13 @@
 use dioxus::prelude::*;
-use river_core::room_state::member::MemberId;
 use wasm_bindgen::JsCast;
 
 use super::emoji_picker::EmojiPicker;
+use super::mention::{
+    apply_mention_selection, handle_mention_keydown, update_mention_from_input,
+    MentionAutocomplete, MentionDropdown,
+};
 use super::ReplyContext;
-
-/// Maximum number of members shown in the @mention autocomplete dropdown.
-const MENTION_CANDIDATE_LIMIT: usize = 8;
-
-/// In-flight @mention autocomplete state, set while the caret sits inside an
-/// `@query` token in the composer.
-#[derive(Clone, PartialEq)]
-struct MentionAutocomplete {
-    /// Byte offset of the `@` in the current message text.
-    anchor: usize,
-    /// Byte offset just past the typed query (i.e. the caret).
-    query_end: usize,
-    /// Members matching the query, already truncated to the display limit.
-    candidates: Vec<(MemberId, String)>,
-    /// Index into `candidates` currently highlighted for keyboard selection.
-    selected: usize,
-}
+use river_core::room_state::member::MemberId;
 
 fn auto_resize_message_input() {
     let Some(el) = get_message_textarea() else {
@@ -40,161 +27,6 @@ fn get_message_textarea() -> Option<web_sys::HtmlTextAreaElement> {
         .get_element_by_id("message-input")?
         .dyn_into::<web_sys::HtmlTextAreaElement>()
         .ok()
-}
-
-/// Read the textarea caret as a *byte* offset into `value`. `selection_start`
-/// is a UTF-16 code-unit index (DOMString semantics), so it must be converted.
-fn read_caret_byte(value: &str) -> Option<usize> {
-    let el = get_message_textarea()?;
-    let caret_u16 = el.selection_start().ok().flatten()? as usize;
-    Some(utf16_to_byte_offset(value, caret_u16))
-}
-
-/// Focus the textarea and place the caret at byte offset `byte_off` in `value`.
-fn set_caret(value: &str, byte_off: usize) {
-    let Some(el) = get_message_textarea() else {
-        return;
-    };
-    let _ = el.focus();
-    let off = byte_to_utf16_offset(value, byte_off);
-    let _ = el.set_selection_range(off, off);
-}
-
-fn utf16_to_byte_offset(s: &str, utf16_off: usize) -> usize {
-    let mut u16count = 0usize;
-    for (byte_idx, ch) in s.char_indices() {
-        if u16count >= utf16_off {
-            return byte_idx;
-        }
-        u16count += ch.len_utf16();
-    }
-    s.len()
-}
-
-fn byte_to_utf16_offset(s: &str, byte_off: usize) -> u32 {
-    let mut u16count = 0u32;
-    for (byte_idx, ch) in s.char_indices() {
-        if byte_idx >= byte_off {
-            break;
-        }
-        u16count += ch.len_utf16() as u32;
-    }
-    u16count
-}
-
-/// If the caret sits inside an `@query` token (a `@` at a word boundary with no
-/// whitespace between it and the caret), return `(byte offset of '@', query)`.
-fn detect_mention_query(value: &str, byte_caret: usize) -> Option<(usize, String)> {
-    if byte_caret > value.len() || !value.is_char_boundary(byte_caret) {
-        return None;
-    }
-    let prefix = &value[..byte_caret];
-    // Walk back from the caret: the first `@` (with no intervening whitespace)
-    // starts the query; any whitespace first means we're not in a token.
-    let mut at = None;
-    for (idx, ch) in prefix.char_indices().rev() {
-        if ch == '@' {
-            at = Some(idx);
-            break;
-        }
-        if ch.is_whitespace() {
-            return None;
-        }
-    }
-    let at = at?;
-    // The `@` must begin a word: at start-of-text or after whitespace. This
-    // skips email-like `name@host` (the char before `@` is not whitespace).
-    if at > 0 {
-        let before = prefix[..at].chars().next_back()?;
-        if !before.is_whitespace() {
-            return None;
-        }
-    }
-    Some((at, prefix[at + 1..].to_string()))
-}
-
-/// Rank members against a query: case-insensitive prefix matches first, then
-/// substring matches, preserving the input order (caller pre-sorts by name).
-/// An empty query lists everyone (up to `limit`).
-fn filter_mention_candidates(
-    members: &[(MemberId, String)],
-    query: &str,
-    limit: usize,
-) -> Vec<(MemberId, String)> {
-    let q = query.to_lowercase();
-    let mut prefix = Vec::new();
-    let mut substr = Vec::new();
-    for (id, name) in members {
-        let lname = name.to_lowercase();
-        if q.is_empty() || lname.starts_with(&q) {
-            prefix.push((*id, name.clone()));
-        } else if lname.contains(&q) {
-            substr.push((*id, name.clone()));
-        }
-    }
-    prefix.extend(substr);
-    prefix.truncate(limit);
-    prefix
-}
-
-/// Lowercased nicknames that appear on more than one of the shown candidates.
-/// Those rows look identical, so the dropdown shows a disambiguating member id
-/// beside them. Case-insensitive, matching the resolver's ambiguity key (so the
-/// picker and riverctl's send-time `@name` resolution agree on what "ambiguous"
-/// means). Near-but-distinct names (e.g. "Alice"/"Alicia") are intentionally
-/// NOT treated as collisions — they are already distinguishable by sight.
-fn duplicate_candidate_names(
-    candidates: &[(MemberId, String)],
-) -> std::collections::HashSet<String> {
-    let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
-    for (_, name) in candidates {
-        *counts.entry(name.to_lowercase()).or_default() += 1;
-    }
-    counts
-        .into_iter()
-        .filter(|(_, n)| *n > 1)
-        .map(|(name, _)| name)
-        .collect()
-}
-
-/// Replace the `@query` span with the chosen member's wire token and a trailing
-/// space, then reposition the caret after the inserted token.
-fn apply_mention_selection(
-    mut message_text: Signal<String>,
-    mut mention: Signal<Option<MentionAutocomplete>>,
-    idx: usize,
-) {
-    let Some(m) = mention.peek().clone() else {
-        return;
-    };
-    let Some((id, name)) = m.candidates.get(idx).cloned() else {
-        return;
-    };
-    let value = message_text.peek().to_string();
-    // Guard the stored offsets against a value that changed out from under us
-    // (they are only valid for the value captured at the last keystroke).
-    if m.anchor > m.query_end
-        || m.query_end > value.len()
-        || !value.is_char_boundary(m.anchor)
-        || !value.is_char_boundary(m.query_end)
-    {
-        mention.set(None);
-        return;
-    }
-    let token = river_core::mention::encode_mention(id, &name);
-    let mut new_value = String::with_capacity(value.len() + token.len() + 1);
-    new_value.push_str(&value[..m.anchor]);
-    new_value.push_str(&token);
-    new_value.push(' ');
-    new_value.push_str(&value[m.query_end..]);
-    let caret_byte = m.anchor + token.len() + 1;
-    message_text.set(new_value.clone());
-    mention.set(None);
-    // The caret must be set after Dioxus flushes the new value to the DOM.
-    crate::util::defer(move || {
-        set_caret(&new_value, caret_byte);
-        auto_resize_message_input();
-    });
 }
 
 /// Message input component that owns its own state.
@@ -236,14 +68,6 @@ pub fn MessageInput(
         let current = message_text.peek().to_string();
         message_text.set(format!("{}{}", current, emoji));
     };
-
-    // Snapshot dropdown state for rendering (drops the read guard before rsx).
-    let mention_view = mention.read().as_ref().map(|m| {
-        // Lowercased nicknames shared by more than one shown candidate need a
-        // disambiguating id, since the rows otherwise look identical.
-        let dups = duplicate_candidate_names(&m.candidates);
-        (m.candidates.clone(), m.selected, dups)
-    });
 
     rsx! {
         // Backdrop for emoji picker - outside the message bar to avoid z-index issues
@@ -324,41 +148,15 @@ pub fn MessageInput(
                     // @mention autocomplete dropdown.
                     div { class: "flex-1 flex flex-col relative",
                         // @mention autocomplete dropdown (floats above the textarea)
-                        if let Some((candidates, selected, dups)) = mention_view {
-                            div {
-                                class: "absolute bottom-full left-0 mb-1 w-64 max-h-56 overflow-y-auto bg-panel border border-border rounded-xl shadow-lg z-50",
-                                role: "listbox",
-                                "aria-label": "Mention a member",
-                                for (i, (id, name)) in candidates.into_iter().enumerate() {
-                                    button {
-                                        key: "{river_core::mention::member_id_to_hex(id)}",
-                                        r#type: "button",
-                                        role: "option",
-                                        "aria-selected": if i == selected { "true" } else { "false" },
-                                        class: format!(
-                                            "w-full text-left px-3 py-2 text-sm flex items-baseline justify-between gap-2 {}",
-                                            if i == selected { "bg-accent/15 text-accent" } else { "text-text hover:bg-surface" }
-                                        ),
-                                        // Use mousedown + preventDefault so the textarea
-                                        // doesn't blur before the selection is applied.
-                                        onmousedown: move |evt| {
-                                            evt.prevent_default();
-                                            apply_mention_selection(message_text, mention, i);
-                                        },
-                                        span { class: "font-medium truncate min-w-0 flex-1", "@{name}" }
-                                        // Show the member id only when another shown
-                                        // candidate shares this nickname (case-insensitive),
-                                        // so identical-looking rows can be told apart.
-                                        if dups.contains(&name.to_lowercase()) {
-                                            span {
-                                                class: "text-xs text-text-muted font-mono shrink-0",
-                                                title: "Member ID (shown because another member shares this name)",
-                                                "{id}"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
+                        MentionDropdown {
+                            mention,
+                            on_pick: move |i| apply_mention_selection(
+                                "message-input".to_string(),
+                                message_text,
+                                mention,
+                                i,
+                                auto_resize_message_input,
+                            ),
                         }
                         textarea {
                             id: "message-input",
@@ -372,59 +170,19 @@ pub fn MessageInput(
                                 message_text.set(value.clone());
                                 auto_resize_message_input();
                                 // Detect / update the @mention autocomplete.
-                                match read_caret_byte(&value)
-                                    .and_then(|caret| detect_mention_query(&value, caret))
-                                {
-                                    Some((at, query)) => {
-                                        let candidates = filter_mention_candidates(
-                                            &members, &query, MENTION_CANDIDATE_LIMIT,
-                                        );
-                                        if candidates.is_empty() {
-                                            mention.set(None);
-                                        } else {
-                                            mention.set(Some(MentionAutocomplete {
-                                                anchor: at,
-                                                query_end: at + 1 + query.len(),
-                                                candidates,
-                                                selected: 0,
-                                            }));
-                                        }
-                                    }
-                                    None => mention.set(None),
-                                }
+                                update_mention_from_input("message-input", &value, &members, mention);
                             },
                             onkeydown: move |evt| {
                                 let key = evt.key();
                                 // @mention navigation takes precedence while the dropdown is open.
-                                if mention.peek().is_some() {
-                                    if key == Key::ArrowDown || key == Key::ArrowUp {
-                                        evt.prevent_default();
-                                        let down = key == Key::ArrowDown;
-                                        mention.with_mut(|opt| {
-                                            if let Some(m) = opt.as_mut() {
-                                                let n = m.candidates.len();
-                                                if n > 0 {
-                                                    m.selected = if down {
-                                                        (m.selected + 1) % n
-                                                    } else {
-                                                        (m.selected + n - 1) % n
-                                                    };
-                                                }
-                                            }
-                                        });
-                                        return;
-                                    }
-                                    if key == Key::Escape {
-                                        evt.prevent_default();
-                                        mention.set(None);
-                                        return;
-                                    }
-                                    if (key == Key::Enter || key == Key::Tab) && !evt.modifiers().shift() {
-                                        evt.prevent_default();
-                                        let idx = mention.peek().as_ref().map(|m| m.selected).unwrap_or(0);
-                                        apply_mention_selection(message_text, mention, idx);
-                                        return;
-                                    }
+                                if handle_mention_keydown(
+                                    "message-input",
+                                    &evt,
+                                    message_text,
+                                    mention,
+                                    auto_resize_message_input,
+                                ) {
+                                    return;
                                 }
                                 // Enter without Shift sends the message
                                 // Shift+Enter creates a new line (default textarea behavior)
@@ -494,105 +252,5 @@ pub fn MessageInput(
                 }
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn mid(n: i64) -> MemberId {
-        MemberId(freenet_scaffold::util::FastHash(n))
-    }
-
-    #[test]
-    fn duplicate_candidate_names_flags_only_case_insensitive_collisions() {
-        let cands = vec![
-            (mid(1), "Alice".to_string()),
-            (mid(2), "alice".to_string()), // collides with "Alice" (case-insensitive)
-            (mid(3), "Alicia".to_string()), // near but distinct — NOT a collision
-            (mid(4), "Bob".to_string()),   // unique
-        ];
-        let dups = duplicate_candidate_names(&cands);
-        assert!(dups.contains("alice"), "case-insensitive duplicate flagged");
-        assert!(!dups.contains("alicia"), "near-name must not be flagged");
-        assert!(!dups.contains("bob"));
-        assert_eq!(dups.len(), 1);
-    }
-
-    fn members() -> Vec<(MemberId, String)> {
-        vec![
-            (
-                MemberId(freenet_scaffold::util::FastHash(1)),
-                "Alice".to_string(),
-            ),
-            (
-                MemberId(freenet_scaffold::util::FastHash(2)),
-                "Albert".to_string(),
-            ),
-            (
-                MemberId(freenet_scaffold::util::FastHash(3)),
-                "Bob".to_string(),
-            ),
-        ]
-    }
-
-    #[test]
-    fn detects_query_at_caret() {
-        assert_eq!(
-            detect_mention_query("hi @al", 6),
-            Some((3, "al".to_string()))
-        );
-        // Caret at the bare '@'
-        assert_eq!(detect_mention_query("@", 1), Some((0, String::new())));
-        // '@' at start of text
-        assert_eq!(detect_mention_query("@bo", 3), Some((0, "bo".to_string())));
-    }
-
-    #[test]
-    fn no_query_when_not_in_token() {
-        assert_eq!(detect_mention_query("hello world", 11), None);
-        // whitespace between '@' and caret
-        assert_eq!(detect_mention_query("@al bob", 7), None);
-        // email-like: '@' not at a word boundary
-        assert_eq!(detect_mention_query("name@host", 9), None);
-    }
-
-    #[test]
-    fn filter_prefers_prefix_then_substring() {
-        // "al" → Albert and Alice by prefix (input order preserved)
-        let r = filter_mention_candidates(&members(), "al", 8);
-        let names: Vec<_> = r.iter().map(|(_, n)| n.as_str()).collect();
-        assert_eq!(names, vec!["Alice", "Albert"]);
-        // substring-only match
-        let r = filter_mention_candidates(&members(), "ob", 8);
-        assert_eq!(
-            r.iter().map(|(_, n)| n.as_str()).collect::<Vec<_>>(),
-            vec!["Bob"]
-        );
-        // empty query lists everyone
-        assert_eq!(filter_mention_candidates(&members(), "", 8).len(), 3);
-        // limit is honoured
-        assert_eq!(filter_mention_candidates(&members(), "", 1).len(), 1);
-    }
-
-    #[test]
-    fn utf16_byte_offset_round_trips_with_multibyte() {
-        // "é" is 2 bytes / 1 utf16 unit; "𝄞" is 4 bytes / 2 utf16 units.
-        let s = "aé𝄞b";
-        for (byte_off, _) in s.char_indices().chain(std::iter::once((s.len(), ' '))) {
-            let u16 = byte_to_utf16_offset(s, byte_off);
-            assert_eq!(utf16_to_byte_offset(s, u16 as usize), byte_off);
-        }
-    }
-
-    #[test]
-    fn detect_handles_multibyte_before_at() {
-        // "é @bo" — the '@' is preceded by a space, query is "bo".
-        let s = "é @bo";
-        let caret = s.len();
-        let (at, q) = detect_mention_query(s, caret).unwrap();
-        assert_eq!(&s[at..at + 1], "@");
-        assert_eq!(q, "bo");
     }
 }


### PR DESCRIPTION
## Problem

The `@mention` autocomplete popup worked in the new-message composer but **not** when editing an existing message. The mention machinery (query detection, candidate filtering, caret math, dropdown rendering) lived entirely inside `MessageInput` and was hardcoded to the composer's `#message-input` textarea, so the inline edit form in `MessageGroupComponent` had none of it — typing `@` while editing did nothing.

## Approach

Extract the mention machinery into a shared `components/conversation/mention.rs` module, parameterised by the target textarea's DOM `id` so the same code drives both call sites instead of being duplicated (which would drift):

- `detect_mention_query`, `filter_mention_candidates`, `duplicate_candidate_names`, UTF‑16↔byte caret helpers — moved verbatim (logic unchanged), with their unit tests.
- `update_mention_from_input`, `handle_mention_keydown`, `apply_mention_selection` — thin wrappers that take a textarea `id`.
- `MentionDropdown` component — the dropdown markup, single‑sourced.

The composer is rewired to call the shared module; its rendered DOM is unchanged (verified — composer popup still works). The edit textarea in `MessageGroupComponent` is wrapped in a `relative` container, given a unique `edit-msg-<id>` id, and wired to the same oninput/onkeydown/dropdown path. Its mentionable‑member list is derived from the `member_names` map the component already receives (self excluded, sorted by name), so no new prop plumbing.

Keyboard parity with the composer: Escape closes the dropdown first (a second Escape cancels the edit); Enter/Tab accept a candidate **without** saving; clicking elsewhere dismisses via `onfocusout`.

**UI‑only change** — no delegate/contract/common WASM touched, so no migration entry is required.

## Testing

- Relocated mention unit tests pass (`cargo test -p river-ui --bins` → 348 passed).
- Headless Playwright run against the `example-data` build confirms:
  - composer popup still shows (**regression check**);
  - edit popup now shows, with candidates, on‑screen and unclipped (the fix);
  - mouse‑pick and keyboard (ArrowDown+Enter) both insert the correct mention token and close the dropdown;
  - Enter‑accept of a candidate does **not** save the edit;
  - Escape closes the dropdown without cancelling the edit.

Screenshot (editing a message, dropdown open above the edit box):

`@Alice Williams (Owner)` / `@Ben Martin (Member)` candidates render above the edit textarea.

[AI-assisted - Claude]