### PR TITLE
feat(cli): implement member_info heal counterpart to UI's build_member_info_heal

### DIFF
--- a/.claude/rules/private-rooms.md
+++ b/.claude/rules/private-rooms.md
@@ -183,12 +183,22 @@ cannot be re-derived, so the owner-as-inviter path always decrypts the
 owner-addressed contract blob from `state.secrets.encrypted_secrets` like
 any other member.
 
-The CLI does NOT currently have a `build_member_info_heal` counterpart: a
-private-room invitee whose invitation lacks `current_version`'s secret
-will defer `member_info` and surface as **"Unknown"** to other peers
-indefinitely (filed as freenet/river#304). The CLI also does NOT prune
-superseded `invitation_secrets` entries the way the UI does — storage
-waste only; the heal path is the natural place to hook the prune.
+The CLI has a `build_member_info_heal` counterpart (issue freenet/river#304),
+in `cli/src/private_room.rs`, mirroring the UI's `RoomData::build_member_info_heal`:
+it detects "self in `members`, absent from `member_info`" and returns a
+self-signed `AuthorizedMemberInfo` to re-publish. A private-room heal seals
+the nickname under the current secret and **defers** (returns `None`) when no
+current-version secret is available, so it never leaks a plaintext nickname.
+`ApiClient::heal_member_info` drives it from the central GET path
+(`get_room`) — every read/send command re-attempts the heal once a secret
+arrives — and emits a standalone `member_info`-only UPDATE delta. The heal is
+skipped under a `--signing-key` override that selects an identity other than
+the room's stored one (the persisted nickname/secrets are not that identity's).
+Wiring is pinned by `member_info_heal_wiring_pinned` in `cli/src/storage.rs`;
+behaviour by the `heal_*` tests in `cli/src/private_room.rs`.
+
+The CLI still does NOT prune superseded `invitation_secrets` entries the way
+the UI does — storage waste only.
 
 ### Rejoin nickname restoration (`StoredRoomInfo.self_nickname`)
 

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -840,7 +840,88 @@ impl ApiClient {
             self.subscribe_to_contract(found_id).await?;
         }
 
+        // Self-heal the "Unknown member" condition (issue freenet/river#304):
+        // if this member is in `members` but absent from `member_info`, they
+        // render as "Unknown" to every other peer. This is the CLI counterpart
+        // of the UI's GET-path `build_member_info_heal` trigger. Best-effort —
+        // a heal failure must not fail the read/send command that fetched the
+        // state, so we only warn.
+        if let Err(e) = self.heal_member_info(room_owner_key, &room_state).await {
+            warn!("member_info self-heal (issue #304) did not complete: {e}");
+        }
+
         Ok(room_state)
+    }
+
+    /// Detect and remediate the "Unknown member" condition for the current
+    /// member (issue freenet/river#304): self present in `state.members` but
+    /// absent from `state.member_info`. When detected, publish a standalone
+    /// `member_info`-only UPDATE so other peers stop rendering this member as
+    /// "Unknown", and fold the same entry into the locally-stored state.
+    ///
+    /// The CLI counterpart of the UI's `RoomData::build_member_info_heal`
+    /// (`ui/src/room_data.rs`), driven from the same place: every GET of an
+    /// existing room (see [`Self::get_room`]). The heal-decision logic lives in
+    /// the pure [`crate::private_room::build_member_info_heal`] so it is
+    /// unit-testable without a node; this method owns the storage lookup and
+    /// the network publish.
+    ///
+    /// No-op (returns `Ok(())` without sending anything) when there is nothing
+    /// to heal — the member is the owner, is not in `members`, already has a
+    /// `member_info` entry, or is a private-room member with no secret yet
+    /// available to seal their nickname (in which case the heal defers rather
+    /// than leak a plaintext nickname; a later GET retries once the secret has
+    /// arrived). Also a no-op when the room has no local credentials (a
+    /// stateless `--signing-key`-only path can't know its own nickname).
+    async fn heal_member_info(
+        &self,
+        room_owner_key: &VerifyingKey,
+        state: &ChatRoomStateV1,
+    ) -> Result<()> {
+        // Load this room's stored identity + nickname + invitation secrets.
+        // If the room isn't stored locally we have nothing to heal with.
+        let storage = self.storage.load_rooms()?;
+        let key_str = bs58::encode(room_owner_key.as_bytes()).into_string();
+        let Some(info) = storage.rooms.get(&key_str) else {
+            return Ok(());
+        };
+        let signing_key = self.storage.resolve_signing_key(&info.signing_key_bytes);
+        let self_nickname = info.self_nickname.clone();
+        let invitation_secrets = info.invitation_secrets.clone();
+
+        let Some(authorized_info) = crate::private_room::build_member_info_heal(
+            state,
+            &signing_key,
+            room_owner_key,
+            &invitation_secrets,
+            self_nickname.as_deref(),
+        ) else {
+            return Ok(());
+        };
+
+        info!(
+            "member_info self-heal (issue #304): republishing member_info for self in room {key_str} \
+             (was in members but absent from member_info — rendered as \"Unknown\" to peers)"
+        );
+
+        let delta = ChatRoomStateV1Delta {
+            member_info: Some(vec![authorized_info]),
+            ..Default::default()
+        };
+
+        // Apply locally first (validates the delta and keeps the stored copy
+        // consistent with what we publish), then send to the network.
+        let params = ChatRoomParametersV1 {
+            owner: *room_owner_key,
+        };
+        let mut local_state = state.clone();
+        local_state
+            .apply_delta(state, &params, &Some(delta.clone()))
+            .map_err(|e| anyhow!("Failed to apply member_info heal delta: {:?}", e))?;
+        self.storage
+            .update_room_state(room_owner_key, local_state)?;
+
+        self.send_delta(room_owner_key, delta).await
     }
 
     /// Fetch a room's state, recovering it across contract-WASM generations.

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -889,6 +889,23 @@ impl ApiClient {
         let self_nickname = info.self_nickname.clone();
         let invitation_secrets = info.invitation_secrets.clone();
 
+        // The persisted `self_nickname` and `invitation_secrets` belong to the
+        // room's STORED identity (`info.signing_key_bytes`). When a
+        // `--signing-key-file` / `RIVER_SIGNING_KEY_FILE` override selects a
+        // DIFFERENT identity, those fields are not this member's — healing with
+        // them would republish another member's nickname / private metadata
+        // under the override key (Codex review on PR #358). We have no nickname
+        // or secrets for the override identity, so skip the heal in that case.
+        // (No override, or an override that matches the stored key, is fine.)
+        if signing_key.to_bytes() != info.signing_key_bytes {
+            debug!(
+                "member_info self-heal (issue #304): skipping for room {key_str} — \
+                 active signing-key override does not match the stored identity, so \
+                 the persisted nickname/secrets are not this member's"
+            );
+            return Ok(());
+        }
+
         let Some(authorized_info) = crate::private_room::build_member_info_heal(
             state,
             &signing_key,

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -845,10 +845,20 @@ impl ApiClient {
         // render as "Unknown" to every other peer. This is the CLI counterpart
         // of the UI's GET-path `build_member_info_heal` trigger. Best-effort —
         // a heal failure must not fail the read/send command that fetched the
-        // state, so we only warn.
-        if let Err(e) = self.heal_member_info(room_owner_key, &room_state).await {
-            warn!("member_info self-heal (issue #304) did not complete: {e}");
-        }
+        // state, so on error we warn and fall back to the un-healed state.
+        //
+        // CRUCIAL: we REBIND `room_state` to the healed state the heal returns,
+        // so callers (`send_message`, read commands, etc.) operate on the
+        // repaired state. Otherwise a follow-up delta would be applied to the
+        // pre-heal state and written back, dropping the just-healed entry
+        // locally (Codex review on PR #358).
+        let room_state = match self.heal_member_info(room_owner_key, room_state).await {
+            Ok(healed) => healed,
+            Err((unhealed, e)) => {
+                warn!("member_info self-heal (issue #304) did not complete: {e}");
+                unhealed
+            }
+        };
 
         Ok(room_state)
     }
@@ -857,7 +867,8 @@ impl ApiClient {
     /// member (issue freenet/river#304): self present in `state.members` but
     /// absent from `state.member_info`. When detected, publish a standalone
     /// `member_info`-only UPDATE so other peers stop rendering this member as
-    /// "Unknown", and fold the same entry into the locally-stored state.
+    /// "Unknown", fold the same entry into the locally-stored state, AND return
+    /// the healed state so the caller operates on the repaired copy.
     ///
     /// The CLI counterpart of the UI's `RoomData::build_member_info_heal`
     /// (`ui/src/room_data.rs`), driven from the same place: every GET of an
@@ -866,24 +877,34 @@ impl ApiClient {
     /// unit-testable without a node; this method owns the storage lookup and
     /// the network publish.
     ///
-    /// No-op (returns `Ok(())` without sending anything) when there is nothing
-    /// to heal — the member is the owner, is not in `members`, already has a
-    /// `member_info` entry, or is a private-room member with no secret yet
-    /// available to seal their nickname (in which case the heal defers rather
-    /// than leak a plaintext nickname; a later GET retries once the secret has
-    /// arrived). Also a no-op when the room has no local credentials (a
-    /// stateless `--signing-key`-only path can't know its own nickname).
+    /// Takes `state` by value and returns it (possibly healed). Returns the
+    /// state UNCHANGED when there is nothing to heal — the member is the owner,
+    /// is not in `members`, already has a `member_info` entry, is a private-room
+    /// member with no secret yet available to seal their nickname (in which case
+    /// the heal defers rather than leak a plaintext nickname; a later GET retries
+    /// once the secret has arrived), the room has no local credentials, or an
+    /// active signing-key override selects a different identity than the stored
+    /// one. On the success path the returned state already carries the healed
+    /// `member_info` entry.
+    ///
+    /// On error returns `Err((state, error))` — handing the original state back
+    /// so the caller can still use it (the heal is best-effort). A network-send
+    /// failure is NOT an error here: the local state was already repaired and
+    /// stored, so it is logged and the healed state is returned as `Ok`.
     async fn heal_member_info(
         &self,
         room_owner_key: &VerifyingKey,
-        state: &ChatRoomStateV1,
-    ) -> Result<()> {
+        state: ChatRoomStateV1,
+    ) -> std::result::Result<ChatRoomStateV1, (ChatRoomStateV1, anyhow::Error)> {
         // Load this room's stored identity + nickname + invitation secrets.
         // If the room isn't stored locally we have nothing to heal with.
-        let storage = self.storage.load_rooms()?;
+        let storage = match self.storage.load_rooms() {
+            Ok(s) => s,
+            Err(e) => return Err((state, e)),
+        };
         let key_str = bs58::encode(room_owner_key.as_bytes()).into_string();
         let Some(info) = storage.rooms.get(&key_str) else {
-            return Ok(());
+            return Ok(state);
         };
         let signing_key = self.storage.resolve_signing_key(&info.signing_key_bytes);
         let self_nickname = info.self_nickname.clone();
@@ -903,17 +924,17 @@ impl ApiClient {
                  active signing-key override does not match the stored identity, so \
                  the persisted nickname/secrets are not this member's"
             );
-            return Ok(());
+            return Ok(state);
         }
 
         let Some(authorized_info) = crate::private_room::build_member_info_heal(
-            state,
+            &state,
             &signing_key,
             room_owner_key,
             &invitation_secrets,
             self_nickname.as_deref(),
         ) else {
-            return Ok(());
+            return Ok(state);
         };
 
         info!(
@@ -926,19 +947,36 @@ impl ApiClient {
             ..Default::default()
         };
 
-        // Apply locally first (validates the delta and keeps the stored copy
-        // consistent with what we publish), then send to the network.
+        // Apply locally first (validates the delta and produces the healed
+        // state we both store and return), then publish to the network.
         let params = ChatRoomParametersV1 {
             owner: *room_owner_key,
         };
-        let mut local_state = state.clone();
-        local_state
-            .apply_delta(state, &params, &Some(delta.clone()))
-            .map_err(|e| anyhow!("Failed to apply member_info heal delta: {:?}", e))?;
-        self.storage
-            .update_room_state(room_owner_key, local_state)?;
+        let mut healed_state = state.clone();
+        if let Err(e) = healed_state.apply_delta(&state, &params, &Some(delta.clone())) {
+            return Err((
+                state,
+                anyhow!("Failed to apply member_info heal delta: {:?}", e),
+            ));
+        }
+        if let Err(e) = self
+            .storage
+            .update_room_state(room_owner_key, healed_state.clone())
+        {
+            return Err((state, e));
+        }
 
-        self.send_delta(room_owner_key, delta).await
+        // The network publish is best-effort: the local state is already
+        // repaired and stored, so a send failure must not discard the healed
+        // state the caller will operate on. Log and return the healed state.
+        if let Err(e) = self.send_delta(room_owner_key, delta).await {
+            warn!(
+                "member_info self-heal (issue #304): local state repaired and stored, \
+                 but publishing the member_info UPDATE failed (a later GET will retry): {e}"
+            );
+        }
+
+        Ok(healed_state)
     }
 
     /// Fetch a room's state, recovering it across contract-WASM generations.

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -942,23 +942,37 @@ impl ApiClient {
              (was in members but absent from member_info — rendered as \"Unknown\" to peers)"
         );
 
-        let delta = ChatRoomStateV1Delta {
-            member_info: Some(vec![authorized_info]),
-            ..Default::default()
-        };
-
-        // Apply locally first (validates the delta and produces the healed
-        // state we both store and return), then publish to the network.
-        let params = ChatRoomParametersV1 {
-            owner: *room_owner_key,
-        };
+        // Produce the locally-healed state by folding ONLY the new member_info
+        // entry in — deliberately NOT via `ChatRoomStateV1::apply_delta`.
+        //
+        // A full-state `apply_delta` runs `post_apply_cleanup`, which inactivity-
+        // prunes any member not anchored by a recent message / active DM /
+        // current-version secret blob — and the heal adds NO message. If our
+        // local `state` has aged the member's join event out of
+        // `recent_messages`, cleanup would prune the very member we are healing
+        // AND drop the member_info we just added, turning "in members but
+        // Unknown" into "not a member" locally (Codex review on PR #358).
+        //
+        // That destructive cleanup is purely a LOCAL concern: the standalone
+        // `member_info`-only UPDATE we publish carries no `MembersDelta`, so it
+        // never removes the member from the network — and on the network the
+        // member is anchored by the join event that put them in `state.members`
+        // (the heal precondition), so the network's own cleanup keeps them.
+        //
+        // The entry is already validated (self-signed, length-clamped; the
+        // contract's `MemberInfoV1::apply_delta` acceptance is pinned by
+        // `heal_output_is_accepted_by_member_info_apply_delta`), so inserting it
+        // directly into the `member_info` sub-state is correct and avoids the
+        // cleanup that the heal-only delta must not trigger.
         let mut healed_state = state.clone();
-        if let Err(e) = healed_state.apply_delta(&state, &params, &Some(delta.clone())) {
-            return Err((
-                state,
-                anyhow!("Failed to apply member_info heal delta: {:?}", e),
-            ));
-        }
+        healed_state
+            .member_info
+            .member_info
+            .push(authorized_info.clone());
+        healed_state
+            .member_info
+            .member_info
+            .sort_by_key(|i| i.member_info.member_id);
         if let Err(e) = self
             .storage
             .update_room_state(room_owner_key, healed_state.clone())
@@ -969,6 +983,10 @@ impl ApiClient {
         // The network publish is best-effort: the local state is already
         // repaired and stored, so a send failure must not discard the healed
         // state the caller will operate on. Log and return the healed state.
+        let delta = ChatRoomStateV1Delta {
+            member_info: Some(vec![authorized_info]),
+            ..Default::default()
+        };
         if let Err(e) = self.send_delta(room_owner_key, delta).await {
             warn!(
                 "member_info self-heal (issue #304): local state repaired and stored, \

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -942,28 +942,20 @@ impl ApiClient {
              (was in members but absent from member_info — rendered as \"Unknown\" to peers)"
         );
 
-        // Produce the locally-healed state by folding ONLY the new member_info
-        // entry in — deliberately NOT via `ChatRoomStateV1::apply_delta`.
+        // `build_member_info_heal` only returns `Some` for a member who SURVIVES
+        // `post_apply_cleanup` (it simulates the cleanup and defers otherwise),
+        // so both the network publish and the local fold below are safe from the
+        // "heal prunes the member it is repairing" trap (Codex review on PR
+        // #358): the standalone `member_info`-only UPDATE carries no
+        // `MembersDelta`, and the member is anchored, so neither the network's
+        // nor a local cleanup would drop them.
         //
-        // A full-state `apply_delta` runs `post_apply_cleanup`, which inactivity-
-        // prunes any member not anchored by a recent message / active DM /
-        // current-version secret blob — and the heal adds NO message. If our
-        // local `state` has aged the member's join event out of
-        // `recent_messages`, cleanup would prune the very member we are healing
-        // AND drop the member_info we just added, turning "in members but
-        // Unknown" into "not a member" locally (Codex review on PR #358).
-        //
-        // That destructive cleanup is purely a LOCAL concern: the standalone
-        // `member_info`-only UPDATE we publish carries no `MembersDelta`, so it
-        // never removes the member from the network — and on the network the
-        // member is anchored by the join event that put them in `state.members`
-        // (the heal precondition), so the network's own cleanup keeps them.
-        //
-        // The entry is already validated (self-signed, length-clamped; the
-        // contract's `MemberInfoV1::apply_delta` acceptance is pinned by
-        // `heal_output_is_accepted_by_member_info_apply_delta`), so inserting it
-        // directly into the `member_info` sub-state is correct and avoids the
-        // cleanup that the heal-only delta must not trigger.
+        // We still fold the entry into the local `member_info` sub-state DIRECTLY
+        // rather than via a full-state `ChatRoomStateV1::apply_delta`: the entry
+        // is already validated (self-signed, length-clamped; contract acceptance
+        // pinned by `heal_output_is_accepted_by_member_info_apply_delta`), so a
+        // direct insert is correct and avoids re-running cleanup locally for no
+        // reason.
         let mut healed_state = state.clone();
         healed_state
             .member_info

--- a/cli/src/private_room.rs
+++ b/cli/src/private_room.rs
@@ -18,7 +18,7 @@ use river_core::room_state::member::MemberId;
 use river_core::room_state::member_info::{AuthorizedMemberInfo, MemberInfo};
 use river_core::room_state::message::{MessageId, RoomMessageBody};
 use river_core::room_state::privacy::{PrivacyMode, SealedBytes};
-use river_core::room_state::ChatRoomStateV1;
+use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1};
 use std::collections::HashMap;
 use tracing::warn;
 
@@ -168,13 +168,21 @@ pub fn seal_invitee_nickname(
 /// re-publish so the entry is restored; the caller emits it as a standalone
 /// `member_info`-only UPDATE delta.
 ///
-/// Returns `None` when there is nothing to heal:
+/// Returns `None` when there is nothing to heal (or healing would do harm):
 /// - the member is the room **owner** (their `member_info` is managed
 ///   separately, exactly as the UI skips the owner);
 /// - the member is **not in `state.members`** (not stranded — nothing to
 ///   re-publish; `ApiClient::build_rejoin_delta` handles the pruned-member
 ///   case where they need re-adding to `members`);
-/// - the member **already has a `member_info` entry** (not stranded).
+/// - the member **already has a `member_info` entry** (not stranded);
+/// - the member would **not survive `post_apply_cleanup`** (not anchored by a
+///   recent message / active DM / current-version secret). Publishing a
+///   `member_info`-only UPDATE for such a member makes the contract run its
+///   cleanup and PRUNE them from `members` — removing rather than healing. The
+///   check simulates the contract's own `post_apply_cleanup` so it can't drift.
+///   Such a member becomes anchored once they author a message (a normal
+///   `riverctl message send` re-adds + anchors them via `build_rejoin_delta`),
+///   and a later GET then heals.
 ///
 /// A non-owner's `member_info` is only valid on the contract when self-signed
 /// by that member's own key, so this heal can ONLY be produced client-side by
@@ -230,6 +238,34 @@ pub fn build_member_info_heal(
         .any(|i| i.member_info.member_id == member_id);
     if has_member_info {
         return None; // already present — not stranded
+    }
+
+    // Defer if this member is NOT anchored against inactivity-prune.
+    //
+    // A `member_info`-only UPDATE carries no `MembersDelta`, but the contract
+    // runs `ChatRoomStateV1::post_apply_cleanup` on every apply. That prunes any
+    // member not anchored by a recent message / active DM / current-version
+    // `encrypted_secrets` recipient (or an ancestor of one in the invite chain).
+    // If we publish a heal for an UNanchored member, the cleanup the UPDATE
+    // triggers would prune that very member from `members` and drop the new
+    // `member_info` — turning "in members but Unknown" into "removed" (Codex
+    // review on PR #358). Healing is also futile in that case: the next cleanup
+    // would prune them regardless. So: simulate the cleanup on a clone and only
+    // heal if self survives it. Using the contract's own `post_apply_cleanup`
+    // (rather than re-deriving the anchor set) keeps this faithful and drift-
+    // proof. The member becomes anchored once they author a message (a normal
+    // `riverctl message send` already re-adds + anchors via `build_rejoin_delta`),
+    // and a later GET then heals.
+    let params = ChatRoomParametersV1 { owner: *owner_vk };
+    let mut after_cleanup = state.clone();
+    if after_cleanup.post_apply_cleanup(&params).is_err()
+        || !after_cleanup
+            .members
+            .members
+            .iter()
+            .any(|m| m.member.member_vk == self_vk)
+    {
+        return None; // unanchored — a heal UPDATE would prune, not repair
     }
 
     // Stranded — re-publish our own member_info. The nickname the member
@@ -725,10 +761,36 @@ mod tests {
 
     use river_core::room_state::member::{AuthorizedMember, Member};
     use river_core::room_state::member_info::AuthorizedMemberInfo as AuthInfo;
+    use river_core::room_state::message::{AuthorizedMessageV1, MessageV1, RoomMessageBody};
 
-    /// Push `member_sk` into `state.members`, invited directly by the owner
-    /// (so the member is a valid, authorized entry the heal recognises).
+    /// Push `member_sk` into `state.members` (invited directly by the owner) AND
+    /// anchor them with a join-event message, so they survive
+    /// `post_apply_cleanup` — mirroring the real accept flow, which always
+    /// publishes a join event alongside the membership. This is the realistic
+    /// "stranded member who has a join event but no member_info" the heal
+    /// targets. Use [`add_member_no_anchor`] for the unanchored case.
     fn add_member(state: &mut ChatRoomStateV1, owner_sk: &SigningKey, member_sk: &SigningKey) {
+        add_member_no_anchor(state, owner_sk, member_sk);
+        let join = MessageV1 {
+            room_owner: owner_sk.verifying_key().into(),
+            author: MemberId::from(&member_sk.verifying_key()),
+            content: RoomMessageBody::join_event(),
+            time: std::time::SystemTime::now(),
+        };
+        state
+            .recent_messages
+            .messages
+            .push(AuthorizedMessageV1::new(join, member_sk));
+    }
+
+    /// Push `member_sk` into `state.members` WITHOUT anchoring them — no
+    /// message, no DM, no current-version secret blob. Such a member is pruned
+    /// by `post_apply_cleanup`, so the heal must defer for them.
+    fn add_member_no_anchor(
+        state: &mut ChatRoomStateV1,
+        owner_sk: &SigningKey,
+        member_sk: &SigningKey,
+    ) {
         let member = Member {
             owner_member_id: owner_sk.verifying_key().into(),
             invited_by: owner_sk.verifying_key().into(),
@@ -1086,91 +1148,67 @@ mod tests {
         );
     }
 
-    /// Regression for Codex review round 3 on PR #358: the local heal MUST NOT
-    /// be folded into state via a full-state `ChatRoomStateV1::apply_delta`.
+    /// Regression for Codex review on PR #358 (rounds 3 & 5): an UNanchored
+    /// stranded member must NOT be healed.
     ///
-    /// This documents the trap. A stranded member (in `members`, no
-    /// `member_info`) who has authored no message and has no current-version
-    /// secret blob is NOT anchored against `post_apply_cleanup`. Running a
-    /// `member_info`-only delta through full-state `apply_delta` therefore
-    /// PRUNES that member from `members` AND drops the just-added member_info —
-    /// turning "in members but Unknown" into "not a member" locally. That is
-    /// exactly why `ApiClient::heal_member_info` folds the entry into the
-    /// `member_info` sub-state directly instead. (The standalone network UPDATE
-    /// is safe: it carries no MembersDelta and the member is anchored on the
-    /// network by their join event.)
+    /// A member in `members` with no `member_info`, who has authored no
+    /// message and holds no current-version secret blob, is not anchored
+    /// against `post_apply_cleanup`. Publishing a `member_info`-only UPDATE for
+    /// them makes the contract run `post_apply_cleanup`, which PRUNES that very
+    /// member from `members` and drops the new `member_info` — turning "in
+    /// members but Unknown" into "removed" instead of healing. Healing is also
+    /// futile (the next cleanup prunes them regardless). So the heal must defer
+    /// for an unanchored member.
     #[test]
-    fn full_state_apply_delta_would_prune_unanchored_healed_member() {
-        use freenet_scaffold::ComposableState;
-        use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1Delta};
+    fn heal_defers_for_unanchored_member() {
+        use river_core::room_state::ChatRoomParametersV1;
 
         let owner = fresh_signing_key();
         let owner_vk = owner.verifying_key();
         let member = fresh_signing_key();
-        let member_id = MemberId::from(&member.verifying_key());
 
-        // Public room, member in `members`, no member_info, no message authored,
-        // no secret blob → unanchored against post_apply_cleanup.
+        // Public room, member in `members`, no member_info, NO anchoring
+        // message/DM/secret → unanchored against post_apply_cleanup.
         let mut state = state_with_privacy(&owner, PrivacyMode::Public);
-        add_member(&mut state, &owner, &member);
+        add_member_no_anchor(&mut state, &owner, &member);
 
-        let healed =
-            build_member_info_heal(&state, &member, &owner_vk, &HashMap::new(), Some("Alice"))
-                .expect("self in members, no member_info → heal");
-
-        // The TRAP: full-state apply_delta runs post_apply_cleanup and prunes
-        // the unanchored member, dropping the heal. We assert this is what would
-        // happen, so the direct-insert in heal_member_info is justified and a
-        // future refactor back to apply_delta is caught.
+        // Sanity: the member really is unanchored — post_apply_cleanup prunes
+        // them. (This is the "trap" the deferral avoids triggering on-network.)
         let params = ChatRoomParametersV1 { owner: owner_vk };
-        let mut via_apply_delta = state.clone();
-        via_apply_delta
-            .apply_delta(
-                &state,
-                &params,
-                &Some(ChatRoomStateV1Delta {
-                    member_info: Some(vec![healed.clone()]),
-                    ..Default::default()
-                }),
-            )
-            .expect("apply_delta itself succeeds — it just prunes");
+        let mut after_cleanup = state.clone();
+        after_cleanup.post_apply_cleanup(&params).unwrap();
         assert!(
-            !via_apply_delta
+            !after_cleanup
                 .members
                 .members
                 .iter()
                 .any(|m| m.member.member_vk == member.verifying_key()),
-            "full-state apply_delta prunes the unanchored member (the trap) — \
-             heal_member_info must NOT use it"
-        );
-        assert!(
-            !via_apply_delta
-                .member_info
-                .member_info
-                .iter()
-                .any(|i| i.member_info.member_id == member_id),
-            "and drops the member_info too (cleanup removes info for pruned members)"
+            "test premise: an unanchored member is pruned by post_apply_cleanup"
         );
 
-        // The direct insert that heal_member_info actually performs PRESERVES
-        // both the member and the healed entry.
-        let mut via_direct_insert = state.clone();
-        via_direct_insert.member_info.member_info.push(healed);
+        // The heal MUST defer for this member rather than publish an UPDATE that
+        // would prune them.
         assert!(
-            via_direct_insert
-                .members
-                .members
-                .iter()
-                .any(|m| m.member.member_vk == member.verifying_key()),
-            "direct insert keeps the member"
+            build_member_info_heal(&state, &member, &owner_vk, &HashMap::new(), Some("Alice"))
+                .is_none(),
+            "heal must defer for an unanchored member — a heal UPDATE would prune, \
+             not repair"
         );
+
+        // And once the member is anchored (e.g. a join event, as the real accept
+        // flow always sends), the heal fires.
+        let mut anchored = state_with_privacy(&owner, PrivacyMode::Public);
+        add_member(&mut anchored, &owner, &member); // adds the join-event anchor
         assert!(
-            via_direct_insert
-                .member_info
-                .member_info
-                .iter()
-                .any(|i| i.member_info.member_id == member_id),
-            "direct insert keeps the healed member_info entry"
+            build_member_info_heal(
+                &anchored,
+                &member,
+                &owner_vk,
+                &HashMap::new(),
+                Some("Alice")
+            )
+            .is_some(),
+            "an anchored stranded member is healed"
         );
     }
 

--- a/cli/src/private_room.rs
+++ b/cli/src/private_room.rs
@@ -1023,6 +1023,94 @@ mod tests {
         );
     }
 
+    /// Regression for Codex review round 3 on PR #358: the local heal MUST NOT
+    /// be folded into state via a full-state `ChatRoomStateV1::apply_delta`.
+    ///
+    /// This documents the trap. A stranded member (in `members`, no
+    /// `member_info`) who has authored no message and has no current-version
+    /// secret blob is NOT anchored against `post_apply_cleanup`. Running a
+    /// `member_info`-only delta through full-state `apply_delta` therefore
+    /// PRUNES that member from `members` AND drops the just-added member_info —
+    /// turning "in members but Unknown" into "not a member" locally. That is
+    /// exactly why `ApiClient::heal_member_info` folds the entry into the
+    /// `member_info` sub-state directly instead. (The standalone network UPDATE
+    /// is safe: it carries no MembersDelta and the member is anchored on the
+    /// network by their join event.)
+    #[test]
+    fn full_state_apply_delta_would_prune_unanchored_healed_member() {
+        use freenet_scaffold::ComposableState;
+        use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1Delta};
+
+        let owner = fresh_signing_key();
+        let owner_vk = owner.verifying_key();
+        let member = fresh_signing_key();
+        let member_id = MemberId::from(&member.verifying_key());
+
+        // Public room, member in `members`, no member_info, no message authored,
+        // no secret blob → unanchored against post_apply_cleanup.
+        let mut state = state_with_privacy(&owner, PrivacyMode::Public);
+        add_member(&mut state, &owner, &member);
+
+        let healed =
+            build_member_info_heal(&state, &member, &owner_vk, &HashMap::new(), Some("Alice"))
+                .expect("self in members, no member_info → heal");
+
+        // The TRAP: full-state apply_delta runs post_apply_cleanup and prunes
+        // the unanchored member, dropping the heal. We assert this is what would
+        // happen, so the direct-insert in heal_member_info is justified and a
+        // future refactor back to apply_delta is caught.
+        let params = ChatRoomParametersV1 { owner: owner_vk };
+        let mut via_apply_delta = state.clone();
+        via_apply_delta
+            .apply_delta(
+                &state,
+                &params,
+                &Some(ChatRoomStateV1Delta {
+                    member_info: Some(vec![healed.clone()]),
+                    ..Default::default()
+                }),
+            )
+            .expect("apply_delta itself succeeds — it just prunes");
+        assert!(
+            !via_apply_delta
+                .members
+                .members
+                .iter()
+                .any(|m| m.member.member_vk == member.verifying_key()),
+            "full-state apply_delta prunes the unanchored member (the trap) — \
+             heal_member_info must NOT use it"
+        );
+        assert!(
+            !via_apply_delta
+                .member_info
+                .member_info
+                .iter()
+                .any(|i| i.member_info.member_id == member_id),
+            "and drops the member_info too (cleanup removes info for pruned members)"
+        );
+
+        // The direct insert that heal_member_info actually performs PRESERVES
+        // both the member and the healed entry.
+        let mut via_direct_insert = state.clone();
+        via_direct_insert.member_info.member_info.push(healed);
+        assert!(
+            via_direct_insert
+                .members
+                .members
+                .iter()
+                .any(|m| m.member.member_vk == member.verifying_key()),
+            "direct insert keeps the member"
+        );
+        assert!(
+            via_direct_insert
+                .member_info
+                .member_info
+                .iter()
+                .any(|i| i.member_info.member_id == member_id),
+            "direct insert keeps the healed member_info entry"
+        );
+    }
+
     #[test]
     fn build_message_body_public_room_is_plaintext() {
         let owner = fresh_signing_key();

--- a/cli/src/private_room.rs
+++ b/cli/src/private_room.rs
@@ -233,25 +233,32 @@ pub fn build_member_info_heal(
     }
 
     // Stranded — re-publish our own member_info. The nickname the member
-    // chose at join time (kept in `self_nickname`) if we still have it, else
-    // the generic "Member" placeholder (the same fallback build_rejoin_delta
-    // uses). A stored nickname longer than the room's current
-    // `max_nickname_size` is dropped to the placeholder: the contract's
-    // `MemberInfoV1::apply_delta` rejects an entry whose `declared_len()`
-    // exceeds the limit, which would make the whole heal UPDATE fail — same
-    // clamp `rejoin_preferred_nickname` applies. `declared_len()` is the
-    // plaintext byte length for both public and sealed values, so comparing
-    // `nick.len()` here matches the contract check exactly.
+    // chose at join time (kept in `self_nickname`) if we still have it AND it
+    // fits the room's current `max_nickname_size`, else the generic "Member"
+    // placeholder.
+    //
+    // Both candidates must satisfy the contract: `MemberInfoV1::apply_delta`
+    // rejects an entry whose `declared_len()` exceeds `max_nickname_size`,
+    // which would make the whole heal UPDATE fail — and `heal_member_info`
+    // persists the entry locally BEFORE sending, so an over-limit entry would
+    // leave the CLI holding a member_info the contract refuses. `declared_len()`
+    // is the plaintext byte length for both public and sealed values, so
+    // comparing `nick.len()` here matches the contract check exactly. If even
+    // the "Member" placeholder is over the limit (a room configured with
+    // `max_nickname_size < 6`), DEFER the heal entirely (`None`) rather than
+    // mint an entry the contract rejects (Codex review on PR #358).
     let max_nickname_size = state.configuration.configuration.max_nickname_size;
     let nickname = self_nickname
         .filter(|nick| nick.len() <= max_nickname_size)
-        .unwrap_or("Member")
-        .to_owned();
+        .unwrap_or("Member");
+    if nickname.len() > max_nickname_size {
+        return None; // not even the placeholder fits — defer
+    }
 
     // Seal (public bytes for a public room; AES-256-GCM under the current
     // secret for a private room). `None` for a private room with no secret →
     // defer the heal rather than leak a plaintext nickname.
-    let sealed = seal_invitee_nickname(state, self_sk, invitation_secrets, &nickname)?;
+    let sealed = seal_invitee_nickname(state, self_sk, invitation_secrets, nickname)?;
 
     // version: 0 is safe — the heal only fires when no `member_info` entry
     // exists in `state` (the `has_member_info` check above), so this is never
@@ -971,6 +978,62 @@ mod tests {
             healed.member_info.preferred_nickname.to_string_lossy(),
             "Member",
             "an over-long stored nickname must not block the heal — clamp to placeholder"
+        );
+    }
+
+    /// A room whose `max_nickname_size` is below the 6-byte "Member"
+    /// placeholder length → defer the heal entirely rather than mint a
+    /// member_info the contract's `MemberInfoV1::apply_delta` would reject for
+    /// exceeding the limit (which `heal_member_info` would otherwise persist
+    /// locally before the rejected network UPDATE). Codex review on PR #358.
+    #[test]
+    fn heal_defers_when_placeholder_exceeds_max_nickname_size() {
+        let owner = fresh_signing_key();
+        let member = fresh_signing_key();
+        let mut state = state_with_privacy(&owner, PrivacyMode::Public);
+        // max 5: smaller than "Member" (6 bytes); a valid nonzero limit.
+        let mut config = state.configuration.configuration.clone();
+        config.max_nickname_size = 5;
+        state.configuration =
+            river_core::room_state::configuration::AuthorizedConfigurationV1::new(config, &owner);
+        add_member(&mut state, &owner, &member);
+
+        // No stored nickname → would fall back to "Member" (6 > 5) → defer.
+        assert!(
+            build_member_info_heal(
+                &state,
+                &member,
+                &owner.verifying_key(),
+                &HashMap::new(),
+                None
+            )
+            .is_none(),
+            "must defer when even the \"Member\" placeholder exceeds max_nickname_size"
+        );
+        // An over-long stored nickname → also falls back to "Member" → defer.
+        assert!(
+            build_member_info_heal(
+                &state,
+                &member,
+                &owner.verifying_key(),
+                &HashMap::new(),
+                Some("way too long"),
+            )
+            .is_none(),
+            "an over-long stored nickname with an over-limit placeholder also defers"
+        );
+        // A stored nickname that DOES fit the tiny limit still heals.
+        let healed = build_member_info_heal(
+            &state,
+            &member,
+            &owner.verifying_key(),
+            &HashMap::new(),
+            Some("Ann"),
+        )
+        .expect("a fitting stored nickname heals even under a tiny limit");
+        assert_eq!(
+            healed.member_info.preferred_nickname.to_string_lossy(),
+            "Ann"
         );
     }
 

--- a/cli/src/private_room.rs
+++ b/cli/src/private_room.rs
@@ -7,7 +7,7 @@
 //! byte-identical results so a UI-issued invitation and a CLI-issued
 //! invitation are wire-interchangeable.
 
-use ed25519_dalek::SigningKey;
+use ed25519_dalek::{SigningKey, VerifyingKey};
 use river_core::ecies::{
     decrypt_secret_from_member_blob_raw, encrypt_with_symmetric_key, seal_bytes,
 };
@@ -15,6 +15,7 @@ use river_core::room_state::content::{
     ActionContentV1, ReplyContentV1, TextContentV1, CONTENT_TYPE_REPLY, REPLY_CONTENT_VERSION,
 };
 use river_core::room_state::member::MemberId;
+use river_core::room_state::member_info::{AuthorizedMemberInfo, MemberInfo};
 use river_core::room_state::message::{MessageId, RoomMessageBody};
 use river_core::room_state::privacy::{PrivacyMode, SealedBytes};
 use river_core::room_state::ChatRoomStateV1;
@@ -155,6 +156,112 @@ pub fn seal_invitee_nickname(
             .map(|secret| (*secret, version))
     })?;
     Some(seal_bytes(preferred_nickname.as_bytes(), &secret, version))
+}
+
+/// Self-heal for the "Unknown member" condition (issue freenet/river#304),
+/// the CLI counterpart of the UI's `RoomData::build_member_info_heal` in
+/// `ui/src/room_data.rs`.
+///
+/// When the network's canonical `state` shows this member in `members` but
+/// with no matching `member_info` entry, they render as **"Unknown"** to
+/// every other peer. This builds a self-signed `AuthorizedMemberInfo` to
+/// re-publish so the entry is restored; the caller emits it as a standalone
+/// `member_info`-only UPDATE delta.
+///
+/// Returns `None` when there is nothing to heal:
+/// - the member is the room **owner** (their `member_info` is managed
+///   separately, exactly as the UI skips the owner);
+/// - the member is **not in `state.members`** (not stranded — nothing to
+///   re-publish; `ApiClient::build_rejoin_delta` handles the pruned-member
+///   case where they need re-adding to `members`);
+/// - the member **already has a `member_info` entry** (not stranded).
+///
+/// A non-owner's `member_info` is only valid on the contract when self-signed
+/// by that member's own key, so this heal can ONLY be produced client-side by
+/// the affected member — never owner-side. That is exactly what this returns,
+/// signed with `self_sk`.
+///
+/// The nickname is the persisted `self_nickname` (the handle the member chose
+/// at join time, kept for exactly this case) when present, else the generic
+/// `"Member"` placeholder — the same fallback `ApiClient::build_rejoin_delta`
+/// uses, so the CLI stays self-consistent. (`self_nickname` is `None` only for
+/// a room joined before that field existed, or the room owner, who is skipped
+/// above.) The CLI deliberately does NOT mirror the UI's deterministic
+/// "hacker-handle" default: that 30x30 word table lives in `ui/src/nickname.rs`
+/// and is not shared via `river-core`, and duplicating it here would be a
+/// drift hazard for no functional benefit.
+///
+/// For a **public** room the nickname is published as public bytes. For a
+/// **private** room it must be encrypted: it is sealed under the room's
+/// current-version secret (resolved from the owner-signed contract blob or the
+/// invitation-carried `invitation_secrets`, via [`seal_invitee_nickname`]). If
+/// no secret is available at the current version this returns `None` (deferring
+/// the heal) rather than leak a plaintext nickname — the member stays "Unknown"
+/// until a later GET once the secret has arrived.
+///
+/// Privacy mode and the secret are read entirely from the supplied network
+/// `state` / `invitation_secrets`; the nickname's plaintext is never published
+/// in a private room without a secret to seal it.
+pub fn build_member_info_heal(
+    state: &ChatRoomStateV1,
+    self_sk: &SigningKey,
+    owner_vk: &VerifyingKey,
+    invitation_secrets: &HashMap<u32, [u8; 32]>,
+    self_nickname: Option<&str>,
+) -> Option<AuthorizedMemberInfo> {
+    let self_vk = self_sk.verifying_key();
+    if self_vk == *owner_vk {
+        return None; // the owner's member_info is managed separately
+    }
+    let member_id = MemberId::from(&self_vk);
+
+    let in_members = state
+        .members
+        .members
+        .iter()
+        .any(|m| m.member.member_vk == self_vk);
+    if !in_members {
+        return None; // not a member on the network — nothing to heal here
+    }
+    let has_member_info = state
+        .member_info
+        .member_info
+        .iter()
+        .any(|i| i.member_info.member_id == member_id);
+    if has_member_info {
+        return None; // already present — not stranded
+    }
+
+    // Stranded — re-publish our own member_info. The nickname the member
+    // chose at join time (kept in `self_nickname`) if we still have it, else
+    // the generic "Member" placeholder (the same fallback build_rejoin_delta
+    // uses). A stored nickname longer than the room's current
+    // `max_nickname_size` is dropped to the placeholder: the contract's
+    // `MemberInfoV1::apply_delta` rejects an entry whose `declared_len()`
+    // exceeds the limit, which would make the whole heal UPDATE fail — same
+    // clamp `rejoin_preferred_nickname` applies. `declared_len()` is the
+    // plaintext byte length for both public and sealed values, so comparing
+    // `nick.len()` here matches the contract check exactly.
+    let max_nickname_size = state.configuration.configuration.max_nickname_size;
+    let nickname = self_nickname
+        .filter(|nick| nick.len() <= max_nickname_size)
+        .unwrap_or("Member")
+        .to_owned();
+
+    // Seal (public bytes for a public room; AES-256-GCM under the current
+    // secret for a private room). `None` for a private room with no secret →
+    // defer the heal rather than leak a plaintext nickname.
+    let sealed = seal_invitee_nickname(state, self_sk, invitation_secrets, &nickname)?;
+
+    // version: 0 is safe — the heal only fires when no `member_info` entry
+    // exists in `state` (the `has_member_info` check above), so this is never
+    // version-compared against an existing entry.
+    let info = MemberInfo {
+        member_id,
+        version: 0,
+        preferred_nickname: sealed,
+    };
+    Some(AuthorizedMemberInfo::new_with_member_key(info, self_sk))
 }
 
 /// Decrypt the room's current-version secret out of a raw network
@@ -602,6 +709,317 @@ mod tests {
             sealed.is_none(),
             "must defer when invitation_secrets lacks current_version — \
              sealing under v0 when room is at v1 yields a SealedBytes nobody can unseal"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // build_member_info_heal — issue freenet/river#304
+    // ------------------------------------------------------------------
+
+    use river_core::room_state::member::{AuthorizedMember, Member};
+    use river_core::room_state::member_info::AuthorizedMemberInfo as AuthInfo;
+
+    /// Push `member_sk` into `state.members`, invited directly by the owner
+    /// (so the member is a valid, authorized entry the heal recognises).
+    fn add_member(state: &mut ChatRoomStateV1, owner_sk: &SigningKey, member_sk: &SigningKey) {
+        let member = Member {
+            owner_member_id: owner_sk.verifying_key().into(),
+            invited_by: owner_sk.verifying_key().into(),
+            member_vk: member_sk.verifying_key(),
+        };
+        state
+            .members
+            .members
+            .push(AuthorizedMember::new(member, owner_sk));
+    }
+
+    /// Push a self-signed `member_info` entry for `member_sk`.
+    fn add_member_info(state: &mut ChatRoomStateV1, member_sk: &SigningKey, sealed: SealedBytes) {
+        let info = MemberInfo {
+            member_id: MemberId::from(&member_sk.verifying_key()),
+            version: 0,
+            preferred_nickname: sealed,
+        };
+        state
+            .member_info
+            .member_info
+            .push(AuthInfo::new_with_member_key(info, member_sk));
+    }
+
+    /// Public room, self in `members` but absent from `member_info` → heal
+    /// produces a self-signed public `member_info` carrying the stored
+    /// nickname. (The core "missing → healed" case from the issue.)
+    #[test]
+    fn heal_public_room_missing_member_info_is_healed() {
+        let owner = fresh_signing_key();
+        let member = fresh_signing_key();
+        let mut state = state_with_privacy(&owner, PrivacyMode::Public);
+        add_member(&mut state, &owner, &member);
+
+        let healed = build_member_info_heal(
+            &state,
+            &member,
+            &owner.verifying_key(),
+            &HashMap::new(),
+            Some("Alice"),
+        )
+        .expect("public room with self in members but no member_info must heal");
+
+        assert_eq!(
+            healed.member_info.member_id,
+            MemberId::from(&member.verifying_key())
+        );
+        assert!(
+            healed.member_info.preferred_nickname.is_public(),
+            "public-room heal publishes a public nickname"
+        );
+        assert_eq!(
+            healed.member_info.preferred_nickname.to_string_lossy(),
+            "Alice"
+        );
+        // The entry is self-signed by the member's own key, so the contract
+        // accepts a non-owner member_info — verified end-to-end against the
+        // contract's own `apply_delta` in
+        // `heal_output_is_accepted_by_contract_apply_delta`.
+    }
+
+    /// Private room with a secret available → heal seals the nickname under the
+    /// current version, never leaking plaintext.
+    #[test]
+    fn heal_private_room_with_secret_seals_nickname() {
+        let owner = fresh_signing_key();
+        let member = fresh_signing_key();
+        let mut state = state_with_privacy(&owner, PrivacyMode::Private); // current_version = 0
+        add_member(&mut state, &owner, &member);
+        let mut inv = HashMap::new();
+        inv.insert(0u32, [0x42u8; 32]);
+
+        let healed =
+            build_member_info_heal(&state, &member, &owner.verifying_key(), &inv, Some("Alice"))
+                .expect("private room with a current-version secret must heal");
+        assert!(
+            healed.member_info.preferred_nickname.is_private(),
+            "private-room heal must seal the nickname, never publish plaintext"
+        );
+        assert_eq!(
+            healed.member_info.preferred_nickname.secret_version(),
+            Some(0)
+        );
+        assert_eq!(
+            healed.member_info.preferred_nickname.declared_len(),
+            "Alice".len()
+        );
+    }
+
+    /// Self already has a `member_info` entry → nothing to heal (returns
+    /// `None`, leaving the existing entry untouched). (The "present → unchanged"
+    /// case from the issue.)
+    #[test]
+    fn heal_returns_none_when_member_info_already_present() {
+        let owner = fresh_signing_key();
+        let member = fresh_signing_key();
+        let mut state = state_with_privacy(&owner, PrivacyMode::Public);
+        add_member(&mut state, &owner, &member);
+        add_member_info(&mut state, &member, SealedBytes::public(b"Alice".to_vec()));
+
+        assert!(
+            build_member_info_heal(
+                &state,
+                &member,
+                &owner.verifying_key(),
+                &HashMap::new(),
+                Some("Alice"),
+            )
+            .is_none(),
+            "a member who already has a member_info entry is not stranded — no heal"
+        );
+    }
+
+    /// Self not in `members` → nothing to heal here (the pruned-member case is
+    /// handled by `ApiClient::build_rejoin_delta`, which re-adds to `members`).
+    #[test]
+    fn heal_returns_none_when_self_not_in_members() {
+        let owner = fresh_signing_key();
+        let member = fresh_signing_key();
+        let state = state_with_privacy(&owner, PrivacyMode::Public); // member not added
+
+        assert!(
+            build_member_info_heal(
+                &state,
+                &member,
+                &owner.verifying_key(),
+                &HashMap::new(),
+                Some("Alice"),
+            )
+            .is_none(),
+            "a member not in the network members list has nothing to heal"
+        );
+    }
+
+    /// Owner → never healed (the owner's member_info is managed separately,
+    /// mirroring the UI's owner skip).
+    #[test]
+    fn heal_returns_none_for_owner() {
+        let owner = fresh_signing_key();
+        let mut state = state_with_privacy(&owner, PrivacyMode::Public);
+        // Even if the owner were (oddly) listed in members with no member_info.
+        add_member(&mut state, &owner, &owner);
+
+        assert!(
+            build_member_info_heal(
+                &state,
+                &owner,
+                &owner.verifying_key(),
+                &HashMap::new(),
+                Some("Owner"),
+            )
+            .is_none(),
+            "the owner is skipped — their member_info is managed separately"
+        );
+    }
+
+    /// Private room with NO secret at the current version → defer (return
+    /// `None`) rather than leak a plaintext nickname. The member stays "Unknown"
+    /// until a later GET once the secret arrives.
+    #[test]
+    fn heal_private_room_without_secret_defers() {
+        let owner = fresh_signing_key();
+        let member = fresh_signing_key();
+        let mut state = state_with_privacy(&owner, PrivacyMode::Private);
+        add_member(&mut state, &owner, &member);
+
+        assert!(
+            build_member_info_heal(
+                &state,
+                &member,
+                &owner.verifying_key(),
+                &HashMap::new(), // no invitation secret, no contract blob
+                Some("Alice"),
+            )
+            .is_none(),
+            "private room with no secret must defer the heal, never leak plaintext"
+        );
+    }
+
+    /// Private room rotated past the held version → defer (sealing under a
+    /// stale version would be unreadable to members at the current version).
+    #[test]
+    fn heal_private_room_defers_when_secret_lacks_current_version() {
+        let owner = fresh_signing_key();
+        let member = fresh_signing_key();
+        let mut state = state_with_privacy(&owner, PrivacyMode::Private);
+        state.secrets.current_version = 1; // room rotated to v1
+        add_member(&mut state, &owner, &member);
+        let mut inv = HashMap::new();
+        inv.insert(0u32, [0x42u8; 32]); // member only holds v0
+
+        assert!(
+            build_member_info_heal(&state, &member, &owner.verifying_key(), &inv, Some("Alice"))
+                .is_none(),
+            "must defer when the held secret is not the current version"
+        );
+    }
+
+    /// No persisted nickname → fall back to the generic public "Member"
+    /// placeholder (public room), the same fallback build_rejoin_delta uses.
+    #[test]
+    fn heal_falls_back_to_member_placeholder_when_no_nickname() {
+        let owner = fresh_signing_key();
+        let member = fresh_signing_key();
+        let mut state = state_with_privacy(&owner, PrivacyMode::Public);
+        add_member(&mut state, &owner, &member);
+
+        let healed = build_member_info_heal(
+            &state,
+            &member,
+            &owner.verifying_key(),
+            &HashMap::new(),
+            None,
+        )
+        .expect("public room heals even with no stored nickname");
+        assert_eq!(
+            healed.member_info.preferred_nickname.to_string_lossy(),
+            "Member"
+        );
+    }
+
+    /// A stored nickname longer than the room's current `max_nickname_size`
+    /// must be dropped to "Member" — publishing an over-long entry would make
+    /// the contract reject the whole heal UPDATE (same clamp as
+    /// `rejoin_preferred_nickname`).
+    #[test]
+    fn heal_clamps_over_long_nickname_to_member_placeholder() {
+        let owner = fresh_signing_key();
+        let member = fresh_signing_key();
+        let mut state = state_with_privacy(&owner, PrivacyMode::Public);
+        // max 8: "Member" (6) fits, the stored nickname (20) does not.
+        let mut config = state.configuration.configuration.clone();
+        config.max_nickname_size = 8;
+        state.configuration =
+            river_core::room_state::configuration::AuthorizedConfigurationV1::new(config, &owner);
+        add_member(&mut state, &owner, &member);
+
+        let healed = build_member_info_heal(
+            &state,
+            &member,
+            &owner.verifying_key(),
+            &HashMap::new(),
+            Some("this_is_way_too_long"),
+        )
+        .expect("heals with the placeholder when the stored nickname is over-long");
+        assert_eq!(
+            healed.member_info.preferred_nickname.to_string_lossy(),
+            "Member",
+            "an over-long stored nickname must not block the heal — clamp to placeholder"
+        );
+    }
+
+    /// End-to-end: the healed member_info must be accepted by the room
+    /// contract's own `MemberInfoV1::apply_delta` — the sub-state that
+    /// validates a member_info entry (signature + nickname-length + membership
+    /// retention). A non-owner's member_info is only valid when self-signed by
+    /// that member's own key (the contract calls `verify_signature_with_key`
+    /// against `member.member_vk`), which is exactly what the heal produces.
+    ///
+    /// We exercise `MemberInfoV1::apply_delta` directly rather than the full
+    /// `ChatRoomStateV1::apply_delta` because the latter runs
+    /// `post_apply_cleanup`, which inactivity-prunes a member who has authored
+    /// no message — and the heal deliberately sends ONLY member_info (no
+    /// message). In the real flow the member is kept alive by their join event;
+    /// here we validate the precise contract logic the heal output must
+    /// satisfy. Requires no node.
+    #[test]
+    fn heal_output_is_accepted_by_member_info_apply_delta() {
+        use freenet_scaffold::ComposableState;
+        use river_core::room_state::ChatRoomParametersV1;
+
+        let owner = fresh_signing_key();
+        let owner_vk = owner.verifying_key();
+        let member = fresh_signing_key();
+        let mut state = state_with_privacy(&owner, PrivacyMode::Public);
+        add_member(&mut state, &owner, &member);
+
+        let healed =
+            build_member_info_heal(&state, &member, &owner_vk, &HashMap::new(), Some("Alice"))
+                .expect("self in members, no member_info → heal");
+
+        let params = ChatRoomParametersV1 { owner: owner_vk };
+        // Apply the heal's member_info delta against `state` (the parent that
+        // carries `members` and `configuration`) onto a fresh MemberInfoV1.
+        let mut member_info = state.member_info.clone();
+        member_info
+            .apply_delta(&state, &params, &Some(vec![healed]))
+            .expect("the contract accepts the self-signed member_info heal");
+
+        let member_id = MemberId::from(&member.verifying_key());
+        let entry = member_info
+            .member_info
+            .iter()
+            .find(|i| i.member_info.member_id == member_id)
+            .expect("the healed member_info entry must be retained, not dropped");
+        assert_eq!(
+            entry.member_info.preferred_nickname.to_string_lossy(),
+            "Alice"
         );
     }
 

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -605,6 +605,31 @@ mod tests {
         );
     }
 
+    /// Source-grep pin for the #304 member_info self-heal wiring, in storage.rs
+    /// so the pinned strings are not self-satisfied by the scanned file
+    /// (api.rs). Guards the exact gap #304 fixed: a CLI member stranded in
+    /// `members` but absent from `member_info` (rendering as "Unknown")
+    /// with no remediation path. The heal MUST stay wired into the central
+    /// GET path so every read/send command re-attempts it once a secret
+    /// arrives.
+    #[test]
+    fn member_info_heal_wiring_pinned() {
+        let api_src = include_str!("api.rs");
+        assert!(
+            api_src.contains("self.heal_member_info(room_owner_key, &room_state)"),
+            "get_room must invoke the member_info self-heal (issue #304) so a \
+             member stranded in `members` but absent from `member_info` is \
+             remediated on every GET. Do NOT drop this call."
+        );
+        assert!(
+            api_src.contains("crate::private_room::build_member_info_heal("),
+            "heal_member_info must route the heal decision through the pure \
+             `crate::private_room::build_member_info_heal` (which defers a \
+             private-room heal when no secret is available, never leaking a \
+             plaintext nickname). Do NOT inline an unconditional Some(...)."
+        );
+    }
+
     /// Source-grep pin for the #306 import wiring, in storage.rs so the pinned
     /// strings aren't self-satisfied by the scanned file (commands/identity.rs).
     /// Guards the exact regression #306 fixed: `import_identity` calling the

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -649,6 +649,25 @@ mod tests {
              — otherwise it would republish the stored member's nickname/secrets \
              under the override key. Do NOT drop this guard."
         );
+        // The local heal must fold the member_info in DIRECTLY (push onto
+        // `healed_state.member_info.member_info`), NOT via a full-state
+        // `ChatRoomStateV1::apply_delta` — the latter runs `post_apply_cleanup`,
+        // which would inactivity-prune the very (unanchored) member being healed
+        // and drop the new member_info, since the heal adds no anchoring message
+        // (Codex review round 3 on PR #358). We assert the direct-push exists and
+        // that heal_member_info does not reach for full-state apply_delta.
+        //
+        // Whitespace-insensitive: collapse runs of whitespace before matching so
+        // a future rustfmt line-rewrap can't silently void the pin.
+        let api_collapsed: String = api_src.split_whitespace().collect::<Vec<_>>().join(" ");
+        assert!(
+            api_collapsed
+                .contains("healed_state .member_info .member_info .push(authorized_info.clone());"),
+            "heal_member_info must build the local healed state by directly \
+             pushing the member_info entry, NOT by calling full-state \
+             apply_delta (which runs post_apply_cleanup and would prune the \
+             unanchored member it is trying to heal)."
+        );
     }
 
     /// Source-grep pin for the #306 import wiring, in storage.rs so the pinned

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -616,10 +616,20 @@ mod tests {
     fn member_info_heal_wiring_pinned() {
         let api_src = include_str!("api.rs");
         assert!(
-            api_src.contains("self.heal_member_info(room_owner_key, &room_state)"),
+            api_src.contains("self.heal_member_info(room_owner_key, room_state)"),
             "get_room must invoke the member_info self-heal (issue #304) so a \
              member stranded in `members` but absent from `member_info` is \
              remediated on every GET. Do NOT drop this call."
+        );
+        // get_room must REBIND room_state to the heal's return value, so callers
+        // operate on the repaired state — otherwise a follow-up delta is applied
+        // to the pre-heal state and written back, dropping the healed entry
+        // locally (Codex review on PR #358).
+        assert!(
+            api_src.contains("let room_state = match self.heal_member_info("),
+            "get_room must rebind `room_state` to the healed state returned by \
+             heal_member_info; do NOT discard the heal result and return the \
+             pre-heal state."
         );
         assert!(
             api_src.contains("crate::private_room::build_member_info_heal("),

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -628,6 +628,17 @@ mod tests {
              private-room heal when no secret is available, never leaking a \
              plaintext nickname). Do NOT inline an unconditional Some(...)."
         );
+        // The persisted nickname/secrets belong to the STORED identity; under a
+        // `--signing-key` override selecting a different key they are not this
+        // member's, so heal_member_info must skip rather than republish another
+        // member's nickname under the override key (Codex review on PR #358).
+        assert!(
+            api_src.contains("signing_key.to_bytes() != info.signing_key_bytes"),
+            "heal_member_info must skip the heal when the resolved signing key \
+             differs from the room's stored identity (signing-key override case) \
+             — otherwise it would republish the stored member's nickname/secrets \
+             under the override key. Do NOT drop this guard."
+        );
     }
 
     /// Source-grep pin for the #306 import wiring, in storage.rs so the pinned

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -668,6 +668,20 @@ mod tests {
              apply_delta (which runs post_apply_cleanup and would prune the \
              unanchored member it is trying to heal)."
         );
+
+        // build_member_info_heal must defer for a member who would NOT survive
+        // post_apply_cleanup — otherwise the standalone member_info UPDATE
+        // triggers the contract's cleanup and PRUNES that member from `members`
+        // instead of healing them (Codex review round 5 on PR #358). Pinned from
+        // storage.rs so the asserted string is not self-satisfied by
+        // private_room.rs's own test source.
+        let private_room_src = include_str!("private_room.rs");
+        assert!(
+            private_room_src.contains("post_apply_cleanup(&params)"),
+            "build_member_info_heal must simulate post_apply_cleanup and defer when \
+             the member would be pruned — a heal UPDATE for an unanchored member \
+             removes them instead of repairing. Do NOT drop this anchor guard."
+        );
     }
 
     /// Source-grep pin for the #306 import wiring, in storage.rs so the pinned


### PR DESCRIPTION
## Problem

When `riverctl` accepts a private-room invitation but no secret is available at the room's `current_secret_version` (the room rotated between invitation creation and accept), PR #303 correctly **defers** `member_info` rather than leaking a plaintext nickname. The CLI member then surfaces as **"Unknown"** to every other peer and stays that way indefinitely — there was no remediation path on the CLI side.

The UI fixed the same class of problem in PR #294 via `RoomData::build_member_info_heal`: on every GET of an existing room it detects "self in `members`, absent from `member_info`" and re-publishes a self-signed `member_info`. For a private room the heal defers until the room secret is available, so it never leaks a plaintext nickname.

This ports that heal to riverctl.

Closes #304

## Approach

- **`crate::private_room::build_member_info_heal`** — a pure, node-free function mirroring the UI's `build_member_info_heal`:
  - skips the room **owner** (their `member_info` is managed separately);
  - skips when self is **not in `members`** (the pruned-member case is already handled by `build_rejoin_delta`, which re-adds to `members`);
  - skips when self **already has a `member_info` entry** (not stranded);
  - otherwise builds a self-signed `AuthorizedMemberInfo`. A non-owner's `member_info` is only valid when self-signed by that member's own key, so the heal can only be produced client-side by the affected member — exactly what this returns.
  - Public rooms publish public bytes; private rooms seal under the current-version secret via the existing `seal_invitee_nickname`, **deferring (returning `None`) when no current-version secret is available** so a plaintext nickname is never leaked.
  - An over-long stored nickname is clamped to the `"Member"` placeholder (same guard as `rejoin_preferred_nickname`) so the heal UPDATE can't be rejected for exceeding `max_nickname_size`.

- **`ApiClient::heal_member_info`** — wired into the central GET path (`get_room`), so every read/send command re-attempts the heal once a secret arrives. It's **best-effort**: a heal failure only `warn!`s, never fails the command that fetched the state. It emits a standalone `member_info`-only UPDATE delta and folds the same entry into the locally-stored state.

- **Nickname source** is the existing `StoredRoomInfo.self_nickname` field (added in #321), so this introduces **no new persisted field** and no new `StoredRoomInfo` serde/backward-compat surface.

### Why the GET path (not just accept)

`accept_invitation` already publishes `member_info` when it can, and correctly defers otherwise. The missing piece was *remediation later*, once a secret arrives — which is precisely what the GET-path trigger gives: every subsequent `riverctl` command on the room re-checks and heals. This mirrors the UI, which fires the heal on every GET.

> Note: the triage hypothesis mentioned a hardcoded `"Member"` fallback in `build_rejoin_delta`; that was already fixed in PR #321 via `rejoin_preferred_nickname` (which seals for private rooms and clamps to `max_nickname_size`). No change needed there.

## Testing

`cargo test -p riverctl --lib` — 140 pass. New tests in `cli/src/private_room.rs`:

- `heal_public_room_missing_member_info_is_healed` — missing → healed (public).
- `heal_private_room_with_secret_seals_nickname` — private with secret → sealed, never plaintext.
- `heal_returns_none_when_member_info_already_present` — present → unchanged.
- `heal_returns_none_when_self_not_in_members`, `heal_returns_none_for_owner` — no-op cases.
- `heal_private_room_without_secret_defers`, `heal_private_room_defers_when_secret_lacks_current_version` — private-no-secret / stale-version → defer.
- `heal_falls_back_to_member_placeholder_when_no_nickname`, `heal_clamps_over_long_nickname_to_member_placeholder` — fallback / clamp.
- `heal_output_is_accepted_by_member_info_apply_delta` — end-to-end: the healed entry is accepted and retained by the room contract's own `MemberInfoV1::apply_delta`.

Plus a source-grep pin `storage::tests::member_info_heal_wiring_pinned` guarding the GET-path wiring against silent removal.

`cargo fmt` + `cargo clippy -p riverctl --all-targets` clean. No `common/`/`delegates/`/`contracts/` changes, so no delegate/contract migration needed.

[AI-assisted - Claude]