### PR TITLE
fix(ui): bound restored-room sync retries and surface a terminal error

### DIFF
--- a/ui/src/components/app/freenet_api/freenet_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/freenet_synchronizer.rs
@@ -486,9 +486,20 @@ impl FreenetSynchronizer {
                                             // promoted to a terminal Error and we stop retrying it.
                                             let mut any_room_still_retrying = false;
                                             for room_key in &matching_rooms {
-                                                let should_retry = SYNC_INFO
-                                                    .write()
-                                                    .record_failed_sync_attempt(room_key);
+                                                // The retry bound only applies to a room still
+                                                // awaiting its initial sync (placeholder state —
+                                                // the #290 case). A room with valid synced state is
+                                                // never given up on, so a transient contract-not-found
+                                                // can't strand it.
+                                                let awaiting_initial_sync =
+                                                    ROOMS.read().map.get(room_key).is_some_and(
+                                                        |rd| rd.is_awaiting_initial_sync(),
+                                                    );
+                                                let should_retry =
+                                                    SYNC_INFO.write().record_failed_sync_attempt(
+                                                        room_key,
+                                                        awaiting_initial_sync,
+                                                    );
                                                 if should_retry {
                                                     any_room_still_retrying = true;
                                                     info!(

--- a/ui/src/components/app/freenet_api/freenet_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/freenet_synchronizer.rs
@@ -5,7 +5,7 @@ use super::error::SynchronizerError;
 use super::response_handler::ResponseHandler;
 use super::room_synchronizer::RoomSynchronizer;
 use crate::components::app::chat_delegate::{mark_legacy_migration_done, set_up_chat_delegate};
-use crate::components::app::sync_info::{RoomSyncStatus, SYNC_INFO};
+use crate::components::app::sync_info::SYNC_INFO;
 use crate::components::app::{ROOMS, SYNC_STATUS, WEB_API};
 use crate::util::{owner_vk_to_contract_key, sleep};
 use dioxus::logger::tracing::{debug, error, info, warn};
@@ -474,36 +474,55 @@ impl FreenetSynchronizer {
                                         }
 
                                         if found {
-                                            // This is likely a race condition where the contract creation
-                                            // hasn't completed before we try to access it
-                                            // see: https://github.com/freenet/freenet-core/issues/1470
-                                            info!("Detected race condition with contract creation. Scheduling retry...");
-
-                                            // Reset the room's sync status to Disconnected so it will be retried
+                                            // A "contract not found" error here is usually the
+                                            // freenet-core#1470 contract-creation race (a freshly-PUT
+                                            // contract briefly not found while creation completes),
+                                            // so we retry. But a restored/imported room whose contract
+                                            // is genuinely absent from the network fails every time —
+                                            // without a bound it re-GETs forever and the
+                                            // "Syncing room state…" spinner spins forever
+                                            // (freenet/river#290). Bound the retries: after
+                                            // MAX_SYNC_ATTEMPTS_BEFORE_ERROR failures the room is
+                                            // promoted to a terminal Error and we stop retrying it.
+                                            let mut any_room_still_retrying = false;
                                             for room_key in &matching_rooms {
-                                                info!("Resetting sync status for room {:?} to Disconnected for retry", 
-                                                      MemberId::from(*room_key));
-                                                SYNC_INFO.write().update_sync_status(
-                                                    room_key,
-                                                    RoomSyncStatus::Disconnected,
-                                                );
+                                                let should_retry = SYNC_INFO
+                                                    .write()
+                                                    .record_failed_sync_attempt(room_key);
+                                                if should_retry {
+                                                    any_room_still_retrying = true;
+                                                    info!(
+                                                        "Contract not found for room {:?} (likely #1470 race) — retrying",
+                                                        MemberId::from(*room_key)
+                                                    );
+                                                } else {
+                                                    warn!(
+                                                        "Contract not found for room {:?} after retry bound — giving up (room absent from network)",
+                                                        MemberId::from(*room_key)
+                                                    );
+                                                }
                                             }
 
-                                            // Schedule a retry after a delay
-                                            let tx = message_tx.clone();
-                                            spawn_local(async move {
-                                                info!("Waiting before retrying room processing...");
-                                                sleep(Duration::from_millis(
-                                                    super::constants::POST_PUT_DELAY_MS,
-                                                ))
-                                                .await;
-                                                info!("Retrying room processing after contract not found error");
-                                                if let Err(e) = tx.unbounded_send(
-                                                    SynchronizerMessage::ProcessRooms,
-                                                ) {
-                                                    error!("Failed to schedule retry: {}", e);
-                                                }
-                                            });
+                                            // Only schedule a retry if at least one matching room is
+                                            // still within its retry budget. Otherwise every matching
+                                            // room is now terminal Error and another ProcessRooms would
+                                            // just no-op for them.
+                                            if any_room_still_retrying {
+                                                let tx = message_tx.clone();
+                                                spawn_local(async move {
+                                                    info!("Waiting before retrying room processing...");
+                                                    sleep(Duration::from_millis(
+                                                        super::constants::POST_PUT_DELAY_MS,
+                                                    ))
+                                                    .await;
+                                                    info!("Retrying room processing after contract not found error");
+                                                    if let Err(e) = tx.unbounded_send(
+                                                        SynchronizerMessage::ProcessRooms,
+                                                    ) {
+                                                        error!("Failed to schedule retry: {}", e);
+                                                    }
+                                                });
+                                            }
                                         } else {
                                             info!(
                                                 "Contract ID {} not found in any of our rooms",

--- a/ui/src/components/app/sync_info.rs
+++ b/ui/src/components/app/sync_info.rs
@@ -28,6 +28,28 @@ pub(crate) fn now_ms() -> f64 {
 
 pub static SYNC_INFO: GlobalSignal<SyncInfo> = Global::new(SyncInfo::new);
 
+/// How many times a room's initial sync may fail before it is promoted to a
+/// terminal [`RoomSyncStatus::Error`] instead of being retried forever
+/// (freenet/river#290).
+///
+/// A restored/imported room whose contract is genuinely absent from the
+/// network never settles: each GET fails, the room is reset to
+/// `Disconnected` (or its `Subscribing` times out), and the next
+/// `ProcessRooms` cycle re-GETs it — spinning the "Syncing room state…"
+/// indicator forever. Bounding the retries lets the UI surface a terminal
+/// error instead.
+///
+/// The bound is deliberately generous so it does NOT regress the
+/// freenet-core#1470 contract-creation race (a freshly-PUT contract that is
+/// briefly "not found" while creation completes), which resolves within a
+/// couple of retries.
+pub const MAX_SYNC_ATTEMPTS_BEFORE_ERROR: u32 = 10;
+
+/// Message shown (and stored in [`RoomSyncStatus::Error`]) when a room's
+/// contract could not be found on the network after the retry bound.
+pub const CONTRACT_NOT_FOUND_ERROR: &str =
+    "This room could not be found on the network — it may have been removed.";
+
 pub struct SyncInfo {
     map: HashMap<VerifyingKey, RoomSyncInfo>,
     instances: HashMap<ContractInstanceId, VerifyingKey>,
@@ -40,6 +62,11 @@ pub struct RoomSyncInfo {
     pub last_synced_state: Option<ChatRoomStateV1>,
     /// Timestamp (in ms) when subscription was initiated, used for timeout detection
     pub subscribing_since: Option<f64>,
+    /// How many initial-sync attempts have failed for this room. Reset to 0
+    /// once the room reaches [`RoomSyncStatus::Subscribed`]. Used to bound the
+    /// otherwise-infinite retry loop for a room whose contract is absent from
+    /// the network (freenet/river#290).
+    pub failed_sync_attempts: u32,
 }
 
 impl SyncInfo {
@@ -65,6 +92,7 @@ impl SyncInfo {
                 sync_status: RoomSyncStatus::Disconnected,
                 last_synced_state: None,
                 subscribing_since: None,
+                failed_sync_attempts: 0,
             });
 
             self.instances.insert(*contract_id, owner_key);
@@ -89,7 +117,46 @@ impl SyncInfo {
             } else {
                 sync_info.subscribing_since = None;
             }
+            // A successful subscription clears the failed-attempt budget so a
+            // later transient outage doesn't inherit a near-exhausted counter
+            // and give up prematurely (freenet/river#290).
+            if status == RoomSyncStatus::Subscribed {
+                sync_info.failed_sync_attempts = 0;
+            }
             sync_info.sync_status = status;
+        }
+    }
+
+    /// Record a failed initial-sync attempt for a room and decide whether to
+    /// keep retrying or give up (freenet/river#290).
+    ///
+    /// Increments the room's `failed_sync_attempts`. If the count has reached
+    /// [`MAX_SYNC_ATTEMPTS_BEFORE_ERROR`], the room is promoted to the terminal
+    /// [`RoomSyncStatus::Error`] and `false` is returned (stop retrying);
+    /// otherwise the room is reset to [`RoomSyncStatus::Disconnected`] so the
+    /// next `ProcessRooms` cycle retries it, and `true` is returned.
+    ///
+    /// Returns `true` if the caller should schedule a retry, `false` if the
+    /// room has been given up on. A room not present in the map (already
+    /// removed) returns `false`.
+    pub fn record_failed_sync_attempt(&mut self, owner_key: &VerifyingKey) -> bool {
+        let Some(sync_info) = self.map.get_mut(owner_key) else {
+            return false;
+        };
+        sync_info.failed_sync_attempts = sync_info.failed_sync_attempts.saturating_add(1);
+        if sync_info.failed_sync_attempts >= MAX_SYNC_ATTEMPTS_BEFORE_ERROR {
+            warn!(
+                "Room {:?} failed initial sync {} times — giving up (contract absent from network)",
+                MemberId::from(*owner_key),
+                sync_info.failed_sync_attempts
+            );
+            sync_info.subscribing_since = None;
+            sync_info.sync_status = RoomSyncStatus::Error(CONTRACT_NOT_FOUND_ERROR.to_string());
+            false
+        } else {
+            sync_info.subscribing_since = None;
+            sync_info.sync_status = RoomSyncStatus::Disconnected;
+            true
         }
     }
 
@@ -152,6 +219,11 @@ impl SyncInfo {
         };
         let current_time = now_ms();
 
+        // Rooms whose `Subscribing` status has timed out. Collected here
+        // because we can't mutate `self.map` while iterating it below; the
+        // timeout counts as a failed sync attempt (freenet/river#290).
+        let mut timed_out: Vec<VerifyingKey> = Vec::new();
+
         for (key, room_data) in rooms.map.iter() {
             // Register new rooms automatically
             if !self.map.contains_key(key) {
@@ -167,7 +239,7 @@ impl SyncInfo {
             }
 
             // Check for subscription timeout - if subscribing for longer than REPUT_DELAY_MS,
-            // reset to Disconnected to trigger a re-PUT
+            // count a failed attempt and (unless the retry bound is reached) re-PUT.
             if sync_info.sync_status == RoomSyncStatus::Subscribing {
                 if let Some(started_at) = sync_info.subscribing_since {
                     let elapsed_ms = current_time - started_at;
@@ -177,20 +249,21 @@ impl SyncInfo {
                             MemberId::from(*key),
                             elapsed_ms / 1000.0
                         );
-                        // Reset to disconnected to trigger re-PUT
-                        // We can't modify the map while iterating, so collect for later
-                        rooms_awaiting_subscription.insert(*key, room_data.room_state.clone());
+                        timed_out.push(*key);
                     }
                 }
             }
         }
 
-        // Now update the status for timed-out rooms
-        for key in rooms_awaiting_subscription.keys() {
-            if let Some(sync_info) = self.map.get_mut(key) {
-                if sync_info.sync_status == RoomSyncStatus::Subscribing {
-                    sync_info.sync_status = RoomSyncStatus::Disconnected;
-                    sync_info.subscribing_since = None;
+        // Now record the failure for timed-out rooms. `record_failed_sync_attempt`
+        // resets the room to `Disconnected` (retry) or, once the bound is hit,
+        // promotes it to terminal `Error` — in which case it must NOT be re-added
+        // to the awaiting set, so the spinner can stop (freenet/river#290).
+        for key in timed_out {
+            let should_retry = self.record_failed_sync_attempt(&key);
+            if should_retry {
+                if let Some(room_data) = rooms.map.get(&key) {
+                    rooms_awaiting_subscription.insert(key, room_data.room_state.clone());
                 }
             }
         }
@@ -366,5 +439,89 @@ mod tests {
             RoomSyncStatus::Subscribed,
             "touch must never change the status"
         );
+    }
+
+    /// freenet/river#290: a room whose contract is absent from the network
+    /// must NOT retry forever. After `MAX_SYNC_ATTEMPTS_BEFORE_ERROR` failed
+    /// attempts it is promoted to a terminal `Error` and `record_failed_sync_attempt`
+    /// returns `false` (stop retrying). Up to that point it stays `Disconnected`
+    /// (retry) so the generous bound preserves the freenet-core#1470 race
+    /// handling.
+    #[test]
+    fn record_failed_sync_attempt_bounds_retries_then_errors() {
+        let mut si = SyncInfo::new();
+        let owner = test_owner(7);
+        si.register_new_room(owner);
+
+        // All but the last attempt: keep retrying, status stays Disconnected.
+        for attempt in 1..MAX_SYNC_ATTEMPTS_BEFORE_ERROR {
+            let should_retry = si.record_failed_sync_attempt(&owner);
+            assert!(should_retry, "attempt {attempt} (< bound) must still retry");
+            assert_eq!(
+                si.map.get(&owner).unwrap().sync_status,
+                RoomSyncStatus::Disconnected,
+                "attempt {attempt} must reset to Disconnected for retry"
+            );
+            assert_eq!(si.map.get(&owner).unwrap().failed_sync_attempts, attempt);
+        }
+
+        // The bound-th attempt gives up: terminal Error, stop retrying.
+        let should_retry = si.record_failed_sync_attempt(&owner);
+        assert!(!should_retry, "reaching the bound must stop retrying");
+        assert!(
+            matches!(si.get_sync_status(&owner), Some(RoomSyncStatus::Error(_))),
+            "reaching the bound must promote the room to terminal Error"
+        );
+        assert!(
+            si.map.get(&owner).unwrap().subscribing_since.is_none(),
+            "giving up must clear the subscribing timestamp"
+        );
+
+        // Further failures keep the room terminal and never re-arm a retry.
+        assert!(!si.record_failed_sync_attempt(&owner));
+        assert!(matches!(
+            si.get_sync_status(&owner),
+            Some(RoomSyncStatus::Error(_))
+        ));
+    }
+
+    /// A successful subscription clears the failed-attempt budget so a later
+    /// transient failure starts counting from zero again rather than tipping a
+    /// long-lived room straight into the terminal Error state.
+    #[test]
+    fn successful_subscription_resets_failure_budget() {
+        let mut si = SyncInfo::new();
+        let owner = test_owner(9);
+        si.register_new_room(owner);
+
+        // Burn most of the budget without reaching the bound.
+        for _ in 1..MAX_SYNC_ATTEMPTS_BEFORE_ERROR {
+            assert!(si.record_failed_sync_attempt(&owner));
+        }
+        assert_eq!(
+            si.map.get(&owner).unwrap().failed_sync_attempts,
+            MAX_SYNC_ATTEMPTS_BEFORE_ERROR - 1
+        );
+
+        // A successful sync resets the counter.
+        si.update_sync_status(&owner, RoomSyncStatus::Subscribed);
+        assert_eq!(si.map.get(&owner).unwrap().failed_sync_attempts, 0);
+
+        // So the next failure starts over and does NOT immediately error.
+        assert!(si.record_failed_sync_attempt(&owner));
+        assert_eq!(
+            si.map.get(&owner).unwrap().sync_status,
+            RoomSyncStatus::Disconnected
+        );
+    }
+
+    /// `record_failed_sync_attempt` on an unknown room is a no-op that reports
+    /// "do not retry" rather than panicking.
+    #[test]
+    fn record_failed_sync_attempt_on_unknown_room_is_noop() {
+        let mut si = SyncInfo::new();
+        let owner = test_owner(11);
+        assert!(!si.record_failed_sync_attempt(&owner));
+        assert!(si.get_sync_status(&owner).is_none());
     }
 }

--- a/ui/src/components/app/sync_info.rs
+++ b/ui/src/components/app/sync_info.rs
@@ -62,10 +62,12 @@ pub struct RoomSyncInfo {
     pub last_synced_state: Option<ChatRoomStateV1>,
     /// Timestamp (in ms) when subscription was initiated, used for timeout detection
     pub subscribing_since: Option<f64>,
-    /// How many initial-sync attempts have failed for this room. Reset to 0
-    /// once the room reaches [`RoomSyncStatus::Subscribed`]. Used to bound the
-    /// otherwise-infinite retry loop for a room whose contract is absent from
-    /// the network (freenet/river#290).
+    /// How many sync attempts have failed for this room. Reset to 0 once the
+    /// room reaches [`RoomSyncStatus::Subscribed`]. Used to bound the
+    /// otherwise-infinite retry loop for a room STILL awaiting its initial sync
+    /// whose contract is absent from the network (freenet/river#290); for a
+    /// room that already holds valid synced state the counter is tracked but
+    /// never trips the bound (see `record_failed_sync_attempt`).
     pub failed_sync_attempts: u32,
 }
 
@@ -127,34 +129,48 @@ impl SyncInfo {
         }
     }
 
-    /// Record a failed initial-sync attempt for a room and decide whether to
-    /// keep retrying or give up (freenet/river#290).
+    /// Record a failed sync attempt for a room and decide whether to keep
+    /// retrying or give up (freenet/river#290).
     ///
-    /// Increments the room's `failed_sync_attempts`. If the count has reached
-    /// [`MAX_SYNC_ATTEMPTS_BEFORE_ERROR`], the room is promoted to the terminal
+    /// Increments the room's `failed_sync_attempts` and always clears
+    /// `subscribing_since`. The retry bound applies **only** to a room that is
+    /// still awaiting its initial sync (`awaiting_initial_sync == true`) — i.e.
+    /// a restored/imported room holding placeholder state whose contract may be
+    /// absent from the network. For such a room, once the count reaches
+    /// [`MAX_SYNC_ATTEMPTS_BEFORE_ERROR`] it is promoted to the terminal
     /// [`RoomSyncStatus::Error`] and `false` is returned (stop retrying);
-    /// otherwise the room is reset to [`RoomSyncStatus::Disconnected`] so the
-    /// next `ProcessRooms` cycle retries it, and `true` is returned.
+    /// before that it is reset to [`RoomSyncStatus::Disconnected`] to retry.
+    ///
+    /// A room that already holds **valid synced state**
+    /// (`awaiting_initial_sync == false`) is NEVER given up on: a transient
+    /// outage must not strand a working room. It is always reset to
+    /// `Disconnected` so the existing self-healing re-PUT behaviour continues
+    /// indefinitely. (The counter is still incremented so logs reflect the
+    /// failure streak, but it never trips the bound for these rooms.)
     ///
     /// Returns `true` if the caller should schedule a retry, `false` if the
     /// room has been given up on. A room not present in the map (already
     /// removed) returns `false`.
-    pub fn record_failed_sync_attempt(&mut self, owner_key: &VerifyingKey) -> bool {
+    pub fn record_failed_sync_attempt(
+        &mut self,
+        owner_key: &VerifyingKey,
+        awaiting_initial_sync: bool,
+    ) -> bool {
         let Some(sync_info) = self.map.get_mut(owner_key) else {
             return false;
         };
         sync_info.failed_sync_attempts = sync_info.failed_sync_attempts.saturating_add(1);
-        if sync_info.failed_sync_attempts >= MAX_SYNC_ATTEMPTS_BEFORE_ERROR {
+        sync_info.subscribing_since = None;
+        if awaiting_initial_sync && sync_info.failed_sync_attempts >= MAX_SYNC_ATTEMPTS_BEFORE_ERROR
+        {
             warn!(
                 "Room {:?} failed initial sync {} times — giving up (contract absent from network)",
                 MemberId::from(*owner_key),
                 sync_info.failed_sync_attempts
             );
-            sync_info.subscribing_since = None;
             sync_info.sync_status = RoomSyncStatus::Error(CONTRACT_NOT_FOUND_ERROR.to_string());
             false
         } else {
-            sync_info.subscribing_since = None;
             sync_info.sync_status = RoomSyncStatus::Disconnected;
             true
         }
@@ -256,11 +272,17 @@ impl SyncInfo {
         }
 
         // Now record the failure for timed-out rooms. `record_failed_sync_attempt`
-        // resets the room to `Disconnected` (retry) or, once the bound is hit,
-        // promotes it to terminal `Error` — in which case it must NOT be re-added
-        // to the awaiting set, so the spinner can stop (freenet/river#290).
+        // resets the room to `Disconnected` (retry) or, once the bound is hit
+        // for a room STILL awaiting its initial sync, promotes it to terminal
+        // `Error` — in which case it must NOT be re-added to the awaiting set,
+        // so the spinner can stop (freenet/river#290). A room that already holds
+        // valid synced state is never given up on; it keeps retrying.
         for key in timed_out {
-            let should_retry = self.record_failed_sync_attempt(&key);
+            let awaiting_initial_sync = rooms
+                .map
+                .get(&key)
+                .is_some_and(|rd| rd.is_awaiting_initial_sync());
+            let should_retry = self.record_failed_sync_attempt(&key, awaiting_initial_sync);
             if should_retry {
                 if let Some(room_data) = rooms.map.get(&key) {
                     rooms_awaiting_subscription.insert(key, room_data.room_state.clone());
@@ -441,21 +463,21 @@ mod tests {
         );
     }
 
-    /// freenet/river#290: a room whose contract is absent from the network
-    /// must NOT retry forever. After `MAX_SYNC_ATTEMPTS_BEFORE_ERROR` failed
-    /// attempts it is promoted to a terminal `Error` and `record_failed_sync_attempt`
-    /// returns `false` (stop retrying). Up to that point it stays `Disconnected`
-    /// (retry) so the generous bound preserves the freenet-core#1470 race
-    /// handling.
+    /// freenet/river#290: a room STILL awaiting its initial sync (placeholder
+    /// state, contract possibly absent from the network) must NOT retry forever.
+    /// After `MAX_SYNC_ATTEMPTS_BEFORE_ERROR` failed attempts it is promoted to a
+    /// terminal `Error` and `record_failed_sync_attempt` returns `false` (stop
+    /// retrying). Up to that point it stays `Disconnected` (retry) so the
+    /// generous bound preserves the freenet-core#1470 race handling.
     #[test]
-    fn record_failed_sync_attempt_bounds_retries_then_errors() {
+    fn record_failed_sync_attempt_bounds_initial_sync_then_errors() {
         let mut si = SyncInfo::new();
         let owner = test_owner(7);
         si.register_new_room(owner);
 
         // All but the last attempt: keep retrying, status stays Disconnected.
         for attempt in 1..MAX_SYNC_ATTEMPTS_BEFORE_ERROR {
-            let should_retry = si.record_failed_sync_attempt(&owner);
+            let should_retry = si.record_failed_sync_attempt(&owner, true);
             assert!(should_retry, "attempt {attempt} (< bound) must still retry");
             assert_eq!(
                 si.map.get(&owner).unwrap().sync_status,
@@ -466,7 +488,7 @@ mod tests {
         }
 
         // The bound-th attempt gives up: terminal Error, stop retrying.
-        let should_retry = si.record_failed_sync_attempt(&owner);
+        let should_retry = si.record_failed_sync_attempt(&owner, true);
         assert!(!should_retry, "reaching the bound must stop retrying");
         assert!(
             matches!(si.get_sync_status(&owner), Some(RoomSyncStatus::Error(_))),
@@ -478,11 +500,40 @@ mod tests {
         );
 
         // Further failures keep the room terminal and never re-arm a retry.
-        assert!(!si.record_failed_sync_attempt(&owner));
+        assert!(!si.record_failed_sync_attempt(&owner, true));
         assert!(matches!(
             si.get_sync_status(&owner),
             Some(RoomSyncStatus::Error(_))
         ));
+    }
+
+    /// A room that already holds valid synced state (`awaiting_initial_sync ==
+    /// false`) must NEVER be given up on — a transient outage must not strand a
+    /// working room (codex review of PR #360). It keeps resetting to
+    /// `Disconnected` so the existing self-healing re-PUT continues, no matter
+    /// how many times it fails.
+    #[test]
+    fn record_failed_sync_attempt_never_errors_a_synced_room() {
+        let mut si = SyncInfo::new();
+        let owner = test_owner(13);
+        si.register_new_room(owner);
+
+        for _ in 0..(MAX_SYNC_ATTEMPTS_BEFORE_ERROR * 3) {
+            let should_retry = si.record_failed_sync_attempt(&owner, false);
+            assert!(
+                should_retry,
+                "a synced room must always keep retrying, never give up"
+            );
+            assert_eq!(
+                si.map.get(&owner).unwrap().sync_status,
+                RoomSyncStatus::Disconnected,
+                "a synced room must stay Disconnected, never reach Error"
+            );
+        }
+        assert!(
+            !matches!(si.get_sync_status(&owner), Some(RoomSyncStatus::Error(_))),
+            "a synced room must never be promoted to terminal Error"
+        );
     }
 
     /// A successful subscription clears the failed-attempt budget so a later
@@ -496,7 +547,7 @@ mod tests {
 
         // Burn most of the budget without reaching the bound.
         for _ in 1..MAX_SYNC_ATTEMPTS_BEFORE_ERROR {
-            assert!(si.record_failed_sync_attempt(&owner));
+            assert!(si.record_failed_sync_attempt(&owner, true));
         }
         assert_eq!(
             si.map.get(&owner).unwrap().failed_sync_attempts,
@@ -508,7 +559,7 @@ mod tests {
         assert_eq!(si.map.get(&owner).unwrap().failed_sync_attempts, 0);
 
         // So the next failure starts over and does NOT immediately error.
-        assert!(si.record_failed_sync_attempt(&owner));
+        assert!(si.record_failed_sync_attempt(&owner, true));
         assert_eq!(
             si.map.get(&owner).unwrap().sync_status,
             RoomSyncStatus::Disconnected
@@ -521,7 +572,7 @@ mod tests {
     fn record_failed_sync_attempt_on_unknown_room_is_noop() {
         let mut si = SyncInfo::new();
         let owner = test_owner(11);
-        assert!(!si.record_failed_sync_attempt(&owner));
+        assert!(!si.record_failed_sync_attempt(&owner, true));
         assert!(si.get_sync_status(&owner).is_none());
     }
 }

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1959,36 +1959,42 @@ pub fn Conversation() -> Element {
                     }
                 };
 
-                // A restored/imported room whose contract is absent from the
-                // network is bounded out to a terminal `RoomSyncStatus::Error`
-                // after a few failed sync attempts (freenet/river#290). The
-                // spinner below is gated on `is_awaiting_initial_sync()`, which
-                // stays true while the room holds placeholder state — so without
-                // this check it would spin forever. Surface the terminal error
-                // instead.
+                // A room still awaiting its initial sync can reach a terminal
+                // `RoomSyncStatus::Error` — most importantly the bounded
+                // contract-absent case (freenet/river#290), but also a failed
+                // GET/PUT send (WebSocket/API error). The spinner below is gated
+                // on `is_awaiting_initial_sync()`, which stays true while the
+                // room holds placeholder state — so without this check it would
+                // spin forever. Surface the STORED error message (not a
+                // hardcoded "not found") so WebSocket/API failures are not
+                // misreported as the room being removed.
                 //
                 // Scoped to rooms that are STILL awaiting initial sync: a room
                 // that already synced real state and later hit some other
                 // `Error` (e.g. a transient PUT failure) is handled by the
-                // normal `Some(room_data)` arm below, not by the "could not be
-                // found on the network" message.
-                let initial_sync_errored = current_room_data.as_ref().is_some_and(|room_data| {
-                    room_data.is_awaiting_initial_sync()
-                        && matches!(
-                            SYNC_INFO
-                                .try_read()
-                                .ok()
-                                .and_then(|si| si.get_sync_status(&room_data.owner_vk).cloned()),
-                            Some(RoomSyncStatus::Error(_))
-                        )
-                });
+                // normal `Some(room_data)` arm below.
+                let initial_sync_error_msg: Option<String> =
+                    current_room_data.as_ref().and_then(|room_data| {
+                        if !room_data.is_awaiting_initial_sync() {
+                            return None;
+                        }
+                        match SYNC_INFO
+                            .try_read()
+                            .ok()
+                            .and_then(|si| si.get_sync_status(&room_data.owner_vk).cloned())
+                        {
+                            Some(RoomSyncStatus::Error(msg)) => Some(msg),
+                            _ => None,
+                        }
+                    });
 
                 match current_room_data.as_ref() {
-                    Some(_) if initial_sync_errored => {
+                    Some(_) if initial_sync_error_msg.is_some() => {
+                        let msg = initial_sync_error_msg.unwrap_or_default();
                         rsx! {
                             div { class: "px-4 py-3 mx-4 mb-4 bg-error-bg rounded-lg text-sm text-red-700 dark:text-red-400 flex items-center gap-3",
                                 Icon { width: 16, height: 16, icon: FaTriangleExclamation }
-                                span { "This room could not be found on the network — it may have been removed." }
+                                span { "{msg}" }
                             }
                         }
                     },

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1,6 +1,7 @@
 #[cfg(target_arch = "wasm32")]
 use crate::components::app::notifications::request_permission_on_first_message;
 use crate::components::app::receive_times::{format_delay, get_delay_secs};
+use crate::components::app::sync_info::{RoomSyncStatus, SYNC_INFO};
 use crate::components::app::{
     MobileView, CURRENT_ROOM, EDIT_ROOM_MODAL, MEMBER_INFO_MODAL, MOBILE_VIEW, ROOMS,
 };
@@ -21,7 +22,9 @@ use crate::components::conversation::message_input::MessageInput;
 use chrono::{DateTime, Utc};
 use dioxus::logger::tracing::*;
 use dioxus::prelude::*;
-use dioxus_free_icons::icons::fa_solid_icons::{FaBars, FaCircleInfo, FaUsers};
+use dioxus_free_icons::icons::fa_solid_icons::{
+    FaBars, FaCircleInfo, FaTriangleExclamation, FaUsers,
+};
 use dioxus_free_icons::Icon;
 use freenet_scaffold::ComposableState;
 use river_core::room_state::member::{MemberId, MembersDelta};
@@ -1956,7 +1959,39 @@ pub fn Conversation() -> Element {
                     }
                 };
 
+                // A restored/imported room whose contract is absent from the
+                // network is bounded out to a terminal `RoomSyncStatus::Error`
+                // after a few failed sync attempts (freenet/river#290). The
+                // spinner below is gated on `is_awaiting_initial_sync()`, which
+                // stays true while the room holds placeholder state — so without
+                // this check it would spin forever. Surface the terminal error
+                // instead.
+                //
+                // Scoped to rooms that are STILL awaiting initial sync: a room
+                // that already synced real state and later hit some other
+                // `Error` (e.g. a transient PUT failure) is handled by the
+                // normal `Some(room_data)` arm below, not by the "could not be
+                // found on the network" message.
+                let initial_sync_errored = current_room_data.as_ref().is_some_and(|room_data| {
+                    room_data.is_awaiting_initial_sync()
+                        && matches!(
+                            SYNC_INFO
+                                .try_read()
+                                .ok()
+                                .and_then(|si| si.get_sync_status(&room_data.owner_vk).cloned()),
+                            Some(RoomSyncStatus::Error(_))
+                        )
+                });
+
                 match current_room_data.as_ref() {
+                    Some(_) if initial_sync_errored => {
+                        rsx! {
+                            div { class: "px-4 py-3 mx-4 mb-4 bg-error-bg rounded-lg text-sm text-red-700 dark:text-red-400 flex items-center gap-3",
+                                Icon { width: 16, height: 16, icon: FaTriangleExclamation }
+                                span { "This room could not be found on the network — it may have been removed." }
+                            }
+                        }
+                    },
                     Some(room_data) if room_data.is_awaiting_initial_sync() => {
                         rsx! {
                             div { class: "px-4 py-3 mx-4 mb-4 bg-surface rounded-lg text-sm text-text-muted flex items-center gap-3",

--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -8,6 +8,7 @@ use crate::components::app::chat_delegate::save_rooms_to_delegate;
 use crate::components::app::document_title::{
     count_unread_in_room_data, mark_current_room_as_read,
 };
+use crate::components::app::sync_info::{RoomSyncStatus, SYNC_INFO};
 use crate::components::app::{MobileView, CREATE_ROOM_MODAL, CURRENT_ROOM, MOBILE_VIEW, ROOMS};
 use crate::components::members::{ConnectionStatusIndicator, ImportIdentityModal};
 use crate::components::room_list::dm_rail_section::DmRailSection;
@@ -16,7 +17,9 @@ use crate::util::ecies::unseal_bytes_with_secrets;
 use dioxus::logger::tracing::error;
 use dioxus::prelude::*;
 use dioxus_free_icons::{
-    icons::fa_solid_icons::{FaArrowLeft, FaComments, FaFileImport, FaLock, FaPlus},
+    icons::fa_solid_icons::{
+        FaArrowLeft, FaComments, FaFileImport, FaLock, FaPlus, FaTriangleExclamation,
+    },
     Icon,
 };
 use ed25519_dalek::VerifyingKey;
@@ -94,7 +97,23 @@ pub fn RoomList() -> Element {
             .into_iter()
             .filter_map(|room_key| {
                 let room_data = rooms.map.get(&room_key)?;
-                let awaiting_sync = room_data.is_awaiting_initial_sync();
+                // A room is "awaiting sync" only while it has placeholder state
+                // AND has not been given up on. Once sync is bounded out to a
+                // terminal Error (freenet/river#290) the spinner must stop, so
+                // we surface an error marker instead of a perpetual spinner.
+                //
+                // Scoped to placeholder-state rooms: a fully-synced room that
+                // later hits some other transient `Error` should not show the
+                // "could not be found on the network" marker.
+                let sync_error = room_data.is_awaiting_initial_sync()
+                    && matches!(
+                        SYNC_INFO
+                            .try_read()
+                            .ok()
+                            .and_then(|si| si.get_sync_status(&room_key).cloned()),
+                        Some(RoomSyncStatus::Error(_))
+                    );
+                let awaiting_sync = room_data.is_awaiting_initial_sync() && !sync_error;
                 // Decrypt room name if room is private and we have the secret
                 let sealed_name = &room_data
                     .room_state
@@ -125,6 +144,7 @@ pub fn RoomList() -> Element {
                     awaiting_sync,
                     is_private,
                     unread,
+                    sync_error,
                 ))
             })
             .collect::<Vec<_>>()
@@ -182,13 +202,14 @@ pub fn RoomList() -> Element {
 
             // Room list
             ul { class: "flex-1 px-2 py-1 space-y-0.5",
-                {room_items.read().iter().map(|(room_key, room_name, is_current, awaiting_sync, is_private, unread)| {
+                {room_items.read().iter().map(|(room_key, room_name, is_current, awaiting_sync, is_private, unread, sync_error)| {
                     let room_key = *room_key;
                     let room_name = room_name.clone();
                     let is_current = *is_current;
                     let awaiting_sync = *awaiting_sync;
                     let is_private = *is_private;
                     let unread = *unread;
+                    let sync_error = *sync_error;
                     // Drag feedback: dim the row being dragged, and draw a top
                     // border on the row the cursor is over (drop lands the
                     // dragged room immediately before it — see `move_room`).
@@ -313,6 +334,16 @@ pub fn RoomList() -> Element {
                                     }
                                     if awaiting_sync {
                                         div { class: "animate-spin w-3 h-3 border-2 border-text-muted border-t-transparent rounded-full flex-shrink-0" }
+                                    } else if sync_error {
+                                        // Terminal sync failure (freenet/river#290): the room's
+                                        // contract could not be found on the network after the
+                                        // retry bound. Show a warning marker instead of a spinner.
+                                        span {
+                                            class: "flex-shrink-0 text-red-600 dark:text-red-400",
+                                            title: "This room could not be found on the network — it may have been removed.",
+                                            "aria-label": "Room sync failed",
+                                            Icon { width: 12, height: 12, icon: FaTriangleExclamation }
+                                        }
                                     }
                                 }
                             }

--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -98,22 +98,29 @@ pub fn RoomList() -> Element {
             .filter_map(|room_key| {
                 let room_data = rooms.map.get(&room_key)?;
                 // A room is "awaiting sync" only while it has placeholder state
-                // AND has not been given up on. Once sync is bounded out to a
-                // terminal Error (freenet/river#290) the spinner must stop, so
-                // we surface an error marker instead of a perpetual spinner.
+                // AND has not been given up on. Once a placeholder room reaches
+                // a terminal Error (the bounded contract-absent case,
+                // freenet/river#290, or a failed GET/PUT send) the spinner must
+                // stop, so we surface an error marker (tooltip = the stored
+                // error message) instead of a perpetual spinner.
                 //
                 // Scoped to placeholder-state rooms: a fully-synced room that
                 // later hits some other transient `Error` should not show the
-                // "could not be found on the network" marker.
-                let sync_error = room_data.is_awaiting_initial_sync()
-                    && matches!(
-                        SYNC_INFO
-                            .try_read()
-                            .ok()
-                            .and_then(|si| si.get_sync_status(&room_key).cloned()),
-                        Some(RoomSyncStatus::Error(_))
-                    );
-                let awaiting_sync = room_data.is_awaiting_initial_sync() && !sync_error;
+                // marker here.
+                let sync_error_msg: Option<String> = if room_data.is_awaiting_initial_sync() {
+                    match SYNC_INFO
+                        .try_read()
+                        .ok()
+                        .and_then(|si| si.get_sync_status(&room_key).cloned())
+                    {
+                        Some(RoomSyncStatus::Error(msg)) => Some(msg),
+                        _ => None,
+                    }
+                } else {
+                    None
+                };
+                let awaiting_sync =
+                    room_data.is_awaiting_initial_sync() && sync_error_msg.is_none();
                 // Decrypt room name if room is private and we have the secret
                 let sealed_name = &room_data
                     .room_state
@@ -144,7 +151,7 @@ pub fn RoomList() -> Element {
                     awaiting_sync,
                     is_private,
                     unread,
-                    sync_error,
+                    sync_error_msg,
                 ))
             })
             .collect::<Vec<_>>()
@@ -202,14 +209,14 @@ pub fn RoomList() -> Element {
 
             // Room list
             ul { class: "flex-1 px-2 py-1 space-y-0.5",
-                {room_items.read().iter().map(|(room_key, room_name, is_current, awaiting_sync, is_private, unread, sync_error)| {
+                {room_items.read().iter().map(|(room_key, room_name, is_current, awaiting_sync, is_private, unread, sync_error_msg)| {
                     let room_key = *room_key;
                     let room_name = room_name.clone();
                     let is_current = *is_current;
                     let awaiting_sync = *awaiting_sync;
                     let is_private = *is_private;
                     let unread = *unread;
-                    let sync_error = *sync_error;
+                    let sync_error_msg = sync_error_msg.clone();
                     // Drag feedback: dim the row being dragged, and draw a top
                     // border on the row the cursor is over (drop lands the
                     // dragged room immediately before it — see `move_room`).
@@ -334,13 +341,14 @@ pub fn RoomList() -> Element {
                                     }
                                     if awaiting_sync {
                                         div { class: "animate-spin w-3 h-3 border-2 border-text-muted border-t-transparent rounded-full flex-shrink-0" }
-                                    } else if sync_error {
-                                        // Terminal sync failure (freenet/river#290): the room's
-                                        // contract could not be found on the network after the
-                                        // retry bound. Show a warning marker instead of a spinner.
+                                    } else if let Some(err_msg) = sync_error_msg {
+                                        // Terminal sync failure for a placeholder room: the
+                                        // bounded contract-absent case (freenet/river#290) or a
+                                        // failed GET/PUT send. Show a warning marker (tooltip = the
+                                        // stored error message) instead of a perpetual spinner.
                                         span {
                                             class: "flex-shrink-0 text-red-600 dark:text-red-400",
-                                            title: "This room could not be found on the network — it may have been removed.",
+                                            title: "{err_msg}",
                                             "aria-label": "Room sync failed",
                                             Icon { width: 12, height: 12, icon: FaTriangleExclamation }
                                         }


### PR DESCRIPTION
## Problem

Follow-up to #287 / PR #289. After #289, a room loaded from delegate storage syncs via `process_rooms()`; an *imported* room (placeholder state, `is_awaiting_initial_sync() == true`) takes the `GET` path with `return_contract_code = true`.

If the room's contract is **genuinely absent from the network** (a long-abandoned room whose contract was dropped, or one never PUT to the current contract key), the sync never settles:

- a **"contract not found"** error resets the room to `Disconnected` and schedules a retry `ProcessRooms` **forever** (the freenet-core#1470 race handler, originally meant for a transient miss), or
- the GET **times out** and the room is reset from `Subscribing` back to `Disconnected` and re-driven on the next `ProcessRooms` cycle, indefinitely.

Either way the room keeps its placeholder state, so `is_awaiting_initial_sync()` stays `true`, and the "Syncing room state from the network…" spinner (`room_list.rs` / `conversation.rs`) **spins forever** (freenet/river#290).

## Approach

Bound the retries and give the loop a terminal state:

- **`RoomSyncInfo` gains a `failed_sync_attempts` counter.** A new `SyncInfo::record_failed_sync_attempt()` increments it and, until the generous bound `MAX_SYNC_ATTEMPTS_BEFORE_ERROR` (10) is reached, resets the room to `Disconnected` (retry); at the bound it promotes the room to terminal `RoomSyncStatus::Error` and returns "stop retrying". The bound is deliberately generous so it does **not** regress the freenet-core#1470 contract-creation race (which resolves within a couple of retries). A successful `Subscribed` clears the counter so a later transient outage starts from zero rather than inheriting a near-exhausted budget.

- **Both failure paths route through the bound:** the contract-not-found error handler in `freenet_synchronizer.rs` (now only schedules a retry while at least one matching room is still within budget), and the `Subscribing`-timeout sweep in `rooms_awaiting_subscription()` (a timed-out room is no longer re-added to the awaiting set once it has been given up on).

- **The spinner sites stop spinning on the terminal state.** `room_list.rs` shows a warning marker instead of the perpetual spinner; `conversation.rs` shows *"This room could not be found on the network — it may have been removed."* Both are scoped to placeholder-state rooms, so a fully-synced room that hits some other transient `Error` (e.g. a PUT failure) is unaffected and keeps its existing rendering.

Why not the owner-reconstruction enhancement from the issue: that's explicitly scoped as a larger, separate enhancement. This PR fixes the never-ending-spinner symptom.

## Testing

New unit tests in `sync_info.rs`:
- `record_failed_sync_attempt_bounds_retries_then_errors` — retries up to the bound (status stays `Disconnected`), then promotes to terminal `Error` and stops. **Verified it FAILS against the pre-fix unbounded behavior** (the room never reaches `Error`, panicking on "reaching the bound must stop retrying") and passes with the fix.
- `successful_subscription_resets_failure_budget` — a `Subscribed` clears the counter so the next failure starts over rather than tipping straight to `Error`.
- `record_failed_sync_attempt_on_unknown_room_is_noop`.

Full `cargo test -p river-ui --bins`: **351 passed, 0 failed.** `cargo fmt` clean; `cargo clippy -p river-ui --bins` introduces no new warnings (the 11 reported are pre-existing and outside the changed regions).

Closes #290

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)