### PR TITLE
feat(ui): add stable data-testid hooks for automation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,26 @@ counterpart is **`.claude/rules/river-publish.md`**.
 - Run `cd common && cargo test private_room` when modifying encryption or secret distribution.
 - Use `cargo make test` before every PR to ensure all components still build and pass tests.
 
+## UI Test IDs (`data-testid`)
+
+Stable hooks for automation (Playwright, debugging, external tools). Dioxus'
+`data-dioxus-id` attributes are render-order indices that change between
+renders, so automation MUST target `data-testid` instead (freenet/river#25).
+
+Naming convention:
+- **kebab-case**, scoped by surface: `<surface>-<role>` (e.g.
+  `create-room-name-input`, `send-message-button`, `member-info-modal`).
+- **List containers** get a plain id: `room-list`, `member-list`.
+- **List items** use the entity-ID pattern `<entity>-item-{id}` so a specific
+  row is addressable: `room-item-{base58(owner_vk)}`,
+  `member-item-{member_id}`. Selecting any item: `[data-testid^="room-item-"]`.
+
+Test IDs are additive markup only — never change rendering or logic. When
+adding a new interactive surface, give it a `data-testid` following the above.
+Existing coverage spans the room list + items, member list + items, the
+create-room / edit-room / invite-member / member-info / receive-invitation
+modals and their primary inputs/buttons, and the message input + send button.
+
 ## State Authorization Rule
 
 **Every piece of data in contract state must be cryptographically authorized. Never accept

--- a/ui/src/components/conversation/message_input.rs
+++ b/ui/src/components/conversation/message_input.rs
@@ -160,6 +160,7 @@ pub fn MessageInput(
                         }
                         textarea {
                             id: "message-input",
+                            "data-testid": "message-input",
                             class: "w-full px-4 py-2.5 bg-surface border border-border rounded-xl text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors resize-none min-h-[44px] overflow-y-auto",
                             style: "max-height: 168px;",
                             placeholder: "Type your message...",
@@ -237,6 +238,7 @@ pub fn MessageInput(
                         rsx! {
                             button {
                                 r#type: "button",
+                                "data-testid": "send-message-button",
                                 class: "{btn_class}",
                                 disabled: over_limit,
                                 title: "{tooltip}",

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -399,9 +399,15 @@ pub fn MemberList() -> Element {
             }
 
             // Member list - scrollable independently
-            ul { class: "flex-1 px-2 py-2 space-y-0.5 overflow-y-auto min-h-0",
+            ul {
+                "data-testid": "member-list",
+                class: "flex-1 px-2 py-2 space-y-0.5 overflow-y-auto min-h-0",
                 for (parts, member_id) in members {
-                    li { key: "{member_id}",
+                    li {
+                        key: "{member_id}",
+                        // Stable per-member hook for automation (freenet/river#25).
+                        // Entity-ID pattern: `member-item-{member_id}`.
+                        "data-testid": "member-item-{member_id}",
                         button {
                             class: "w-full text-left px-3 py-1.5 rounded-lg text-sm text-text hover:bg-surface transition-colors truncate",
                             title: "Member ID: {member_id}",
@@ -425,6 +431,7 @@ pub fn MemberList() -> Element {
             // Action buttons - fixed at bottom
             div { class: "p-3 border-t border-border flex-shrink-0 space-y-2",
                 button {
+                    "data-testid": "invite-member-button",
                     class: "w-full flex items-center justify-center gap-2 px-3 py-2 bg-accent hover:bg-accent-hover text-white text-sm font-medium rounded-lg transition-colors",
                     onclick: move |_| invite_modal_active.set(true),
                     Icon { icon: FaUserPlus, width: 14, height: 14 }
@@ -436,6 +443,7 @@ pub fn MemberList() -> Element {
                 // it now lives via `DmRailSection`. Per-room and
                 // cross-room DM discovery are both surfaced there.
                 button {
+                    "data-testid": "export-id-button",
                     class: "w-full flex items-center justify-center gap-1.5 px-2 py-1.5 bg-surface hover:bg-surface-hover text-text-muted text-xs font-medium rounded-lg transition-colors border border-border",
                     onclick: move |_| export_modal_active.set(true),
                     Icon { icon: FaFileExport, width: 12, height: 12 }

--- a/ui/src/components/members/invite_member_modal.rs
+++ b/ui/src/components/members/invite_member_modal.rs
@@ -140,6 +140,7 @@ pub fn InviteMemberModal(is_active: Signal<bool>) -> Element {
         // Modal
         div { class: "fixed inset-0 z-50 flex items-center justify-center p-4",
             div {
+                "data-testid": "invite-member-modal",
                 class: "bg-panel rounded-xl shadow-xl max-w-lg w-full max-h-[90vh] overflow-y-auto",
                 onclick: move |e| e.stop_propagation(),
 
@@ -147,6 +148,7 @@ pub fn InviteMemberModal(is_active: Signal<bool>) -> Element {
                 div { class: "px-6 py-4 border-b border-border flex items-center justify-between",
                     h2 { class: "text-lg font-semibold text-text", "Invite Member" }
                     button {
+                        "data-testid": "invite-member-close-button",
                         class: "p-1 text-text-muted hover:text-text transition-colors",
                         onclick: move |_| is_active.set(false),
                         Icon { icon: FaXmark, width: 14, height: 14 }
@@ -265,12 +267,14 @@ fn InvitationContent(
             label { class: "block text-sm font-medium text-text mb-1", "Invitation link:" }
             div { class: "flex gap-2",
                 input {
+                    "data-testid": "invite-link-input",
                     class: "flex-1 px-3 py-2 bg-surface border border-border rounded-lg text-sm text-text font-mono truncate",
                     r#type: "text",
                     value: invitation_url,
                     readonly: true
                 }
                 button {
+                    "data-testid": "invite-copy-link-button",
                     class: "px-3 py-2 bg-accent hover:bg-accent-hover text-white text-sm rounded-lg transition-colors flex items-center gap-2",
                     onclick: copy_link_to_clipboard,
                     Icon { icon: FaCopy, width: 14, height: 14 }
@@ -291,12 +295,14 @@ fn InvitationContent(
         // Action buttons
         div { class: "flex flex-wrap gap-2",
             button {
+                "data-testid": "invite-copy-message-button",
                 class: "px-4 py-2 bg-accent hover:bg-accent-hover text-white text-sm font-medium rounded-lg transition-colors flex items-center gap-2",
                 onclick: copy_message_to_clipboard,
                 Icon { icon: FaCopy, width: 14, height: 14 }
                 span { "{copy_msg_text}" }
             }
             button {
+                "data-testid": "invite-new-invitation-button",
                 class: "px-4 py-2 bg-surface hover:bg-surface-hover text-text text-sm rounded-lg transition-colors flex items-center gap-2",
                 onclick: move |_| {
                     copy_msg_text.set("Copy Message".to_string());
@@ -308,6 +314,7 @@ fn InvitationContent(
                 span { "New Invitation" }
             }
             button {
+                "data-testid": "invite-member-close-footer-button",
                 class: "px-4 py-2 text-text-muted hover:text-text text-sm rounded-lg transition-colors",
                 onclick: move |_| is_active.set(false),
                 "Close"

--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -199,6 +199,7 @@ pub fn MemberInfoModal() -> Element {
                 }
                 // Modal content
                 div {
+                    "data-testid": "member-info-modal",
                     class: "relative z-10 w-full max-w-md mx-4 bg-panel rounded-xl shadow-xl border border-border",
                     div {
                         class: "p-6",
@@ -243,6 +244,7 @@ pub fn MemberInfoModal() -> Element {
                             class: "mb-4",
                             label { class: "block text-sm font-medium text-text-muted mb-2", "Member ID" }
                             input {
+                                "data-testid": "member-info-id-input",
                                 class: "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text font-mono text-sm",
                                 value: "{member_id_str}",
                                 readonly: true
@@ -265,6 +267,7 @@ pub fn MemberInfoModal() -> Element {
                                 rsx! {
                                     div { class: "mb-4 flex gap-2",
                                         button {
+                                            "data-testid": "member-info-dm-button",
                                             class: "flex-1 px-3 py-1.5 bg-surface hover:bg-surface-hover text-text text-sm font-medium rounded-lg transition-colors border border-border",
                                             "aria-label": "Send direct message",
                                             onclick: move |_| {
@@ -278,6 +281,7 @@ pub fn MemberInfoModal() -> Element {
                                             "DM"
                                         }
                                         button {
+                                            "data-testid": "member-info-share-invite-button",
                                             class: format!(
                                                 "flex-1 px-3 py-1.5 text-sm font-medium rounded-lg transition-colors border border-border {}",
                                                 if share_button_enabled {
@@ -337,6 +341,7 @@ pub fn MemberInfoModal() -> Element {
                     }
                     // Close button
                     button {
+                        "data-testid": "member-info-close-button",
                         class: "absolute top-3 right-3 p-1 text-text-muted hover:text-text transition-colors",
                         onclick: handle_close_modal,
                         "✕"

--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -198,6 +198,7 @@ pub fn RoomList() -> Element {
                     span { "Rooms" }
                 }
                 button {
+                    "data-testid": "create-room-button",
                     class: "p-1.5 rounded-md text-text-muted hover:text-accent hover:bg-surface transition-colors",
                     title: "Create Room",
                     onclick: move |_| {
@@ -208,7 +209,9 @@ pub fn RoomList() -> Element {
             }
 
             // Room list
-            ul { class: "flex-1 px-2 py-1 space-y-0.5",
+            ul {
+                "data-testid": "room-list",
+                class: "flex-1 px-2 py-1 space-y-0.5",
                 {room_items.read().iter().map(|(room_key, room_name, is_current, awaiting_sync, is_private, unread, sync_error_msg)| {
                     let room_key = *room_key;
                     let room_name = room_name.clone();
@@ -225,9 +228,14 @@ pub fn RoomList() -> Element {
                     // shift.
                     let is_dragged = dragged_now == Some(room_key);
                     let is_drag_over = drag_over_now == Some(room_key);
+                    let room_testid =
+                        format!("room-item-{}", bs58::encode(room_key.to_bytes()).into_string());
                     rsx! {
                         li {
                             key: "{room_key:?}",
+                            // Stable per-room hook for automation (freenet/river#25).
+                            // Entity-ID pattern: `room-item-{base58(owner_vk)}`.
+                            "data-testid": "{room_testid}",
                             // Rooms are reorderable by drag-and-drop. The whole
                             // row is the drag handle; the inner button still
                             // handles click-to-open (a click is distinct from a

--- a/ui/src/components/room_list/create_room_modal.rs
+++ b/ui/src/components/room_list/create_room_modal.rs
@@ -136,6 +136,7 @@ pub fn CreateRoomModal() -> Element {
         // Modal
         div { class: "fixed inset-0 z-50 flex items-center justify-center p-4",
             div {
+                "data-testid": "create-room-modal",
                 class: "bg-panel rounded-xl shadow-xl max-w-md w-full",
                 onclick: move |e| e.stop_propagation(),
 
@@ -149,6 +150,7 @@ pub fn CreateRoomModal() -> Element {
                     div {
                         label { class: "block text-sm font-medium text-text mb-1", "Room Name" }
                         input {
+                            "data-testid": "create-room-name-input",
                             class: "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent",
                             value: "{room_name}",
                             placeholder: "Enter room name",
@@ -159,6 +161,7 @@ pub fn CreateRoomModal() -> Element {
                     div {
                         label { class: "block text-sm font-medium text-text mb-1", "Your Nickname" }
                         input {
+                            "data-testid": "create-room-nickname-input",
                             class: "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent",
                             value: "{nickname}",
                             placeholder: "Enter your nickname",
@@ -168,6 +171,7 @@ pub fn CreateRoomModal() -> Element {
 
                     label { class: "flex items-center gap-3 cursor-pointer",
                         input {
+                            "data-testid": "create-room-private-checkbox",
                             r#type: "checkbox",
                             class: "w-4 h-4 rounded border-border text-accent focus:ring-accent/50",
                             checked: "{is_private}",
@@ -182,6 +186,7 @@ pub fn CreateRoomModal() -> Element {
                 // Footer
                 div { class: "px-6 py-4 border-t border-border flex justify-end gap-3",
                     button {
+                        "data-testid": "create-room-cancel-button",
                         class: "px-4 py-2 text-sm text-text-muted hover:text-text hover:bg-surface rounded-lg transition-colors",
                         onclick: move |_| {
                             CREATE_ROOM_MODAL.with_mut(|modal| {
@@ -191,6 +196,7 @@ pub fn CreateRoomModal() -> Element {
                         "Cancel"
                     }
                     button {
+                        "data-testid": "create-room-submit-button",
                         class: "px-4 py-2 bg-accent hover:bg-accent-hover text-white text-sm font-medium rounded-lg transition-colors",
                         onclick: create_room,
                         "Create Room"

--- a/ui/src/components/room_list/edit_room_modal.rs
+++ b/ui/src/components/room_list/edit_room_modal.rs
@@ -68,6 +68,7 @@ pub fn EditRoomModal() -> Element {
                 }
                 // Modal content
                 div {
+                    "data-testid": "edit-room-modal",
                     class: "relative z-10 w-full max-w-md mx-4 bg-panel rounded-xl shadow-xl border border-border max-h-[90vh] overflow-y-auto",
                     div {
                         class: "p-6",
@@ -340,6 +341,7 @@ pub fn EditRoomModal() -> Element {
                             div {
                                 class: "mt-4",
                                 button {
+                                    "data-testid": "edit-room-leave-button",
                                     class: "px-4 py-2 border border-red-500 text-red-500 hover:bg-red-500/10 rounded-lg transition-colors",
                                     onclick: move |_| show_leave_confirmation.set(true),
                                     "Leave Room"
@@ -349,6 +351,7 @@ pub fn EditRoomModal() -> Element {
                     }
                     // Close button
                     button {
+                        "data-testid": "edit-room-close-button",
                         class: "absolute top-3 right-3 p-1 text-text-muted hover:text-text transition-colors",
                         onclick: move |_| {
                             EDIT_ROOM_MODAL.write().room = None;

--- a/ui/src/components/room_list/receive_invitation_modal.rs
+++ b/ui/src/components/room_list/receive_invitation_modal.rs
@@ -506,6 +506,7 @@ pub fn ReceiveInvitationModal(invitation: Signal<Option<Invitation>>) -> Element
             }
             // Modal content
             div {
+                "data-testid": "receive-invitation-modal",
                 class: "relative z-10 w-full max-w-md mx-4 bg-panel rounded-xl shadow-xl border border-border",
                 div {
                     class: "p-6",
@@ -800,6 +801,7 @@ fn render_new_invitation(inv: Invitation, invitation: Signal<Option<Invitation>>
 
         div { class: "mb-4",
             input {
+                "data-testid": "receive-invitation-nickname-input",
                 class: "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent",
                 r#type: "text",
                 value: "{nickname}",
@@ -824,6 +826,7 @@ fn render_new_invitation(inv: Invitation, invitation: Signal<Option<Invitation>>
         div {
             class: "flex gap-3",
             button {
+                "data-testid": "receive-invitation-accept-button",
                 class: "px-4 py-2 bg-accent hover:bg-accent-hover text-white font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed",
                 disabled: nickname.read().trim().is_empty(),
                 onclick: move |_| {
@@ -832,6 +835,7 @@ fn render_new_invitation(inv: Invitation, invitation: Signal<Option<Invitation>>
                 "Accept"
             }
             button {
+                "data-testid": "receive-invitation-decline-button",
                 class: "px-4 py-2 bg-surface hover:bg-surface-hover text-text rounded-lg transition-colors",
                 onclick: {
                     let inv_for_decline = inv.clone();


### PR DESCRIPTION
## Problem

River's UI elements only carry Dioxus' `data-dioxus-id` attributes, which are render-order indices that change between renders. Automation (Playwright, debugging, external tools) had no reliable way to target elements — it required brittle DOM traversal. (freenet/river#25)

## Approach

Add stable `data-testid` attributes to the key interactive surfaces. **Purely additive markup** — no rendering or logic changes, so no delegate/contract/common WASM is affected and no migration is needed (only `ui/src/` + `AGENTS.md` changed).

**Naming convention** (documented in `AGENTS.md`):
- kebab-case, scoped by surface: `<surface>-<role>` (e.g. `create-room-name-input`, `send-message-button`).
- list containers get a plain id: `room-list`, `member-list`.
- list items use the entity-ID pattern `<entity>-item-{id}` so a specific row is addressable: `room-item-{base58(owner_vk)}`, `member-item-{member_id}`. Select any item with `[data-testid^="room-item-"]`.

This builds on the `data-testid` hooks the Playwright suite already relies on (`rooms-rail`, `members-rail`, `connection-status-indicator`, `room-unread-badge`).

### Surfaces tagged
- **Room list**: `room-list`, `room-item-{base58(owner_vk)}`, `create-room-button`
- **Member list**: `member-list`, `member-item-{member_id}`, `invite-member-button`, `export-id-button`
- **Create-room modal**: `create-room-modal`, `create-room-name-input`, `create-room-nickname-input`, `create-room-private-checkbox`, `create-room-submit-button`, `create-room-cancel-button`
- **Edit-room modal**: `edit-room-modal`, `edit-room-leave-button`, `edit-room-close-button`
- **Invite-member modal**: `invite-member-modal`, `invite-link-input`, `invite-copy-link-button`, `invite-copy-message-button`, `invite-new-invitation-button`, `invite-member-close-button`, `invite-member-close-footer-button`
- **Member-info modal**: `member-info-modal`, `member-info-id-input`, `member-info-dm-button`, `member-info-share-invite-button`, `member-info-close-button`
- **Receive-invitation modal**: `receive-invitation-modal`, `receive-invitation-nickname-input`, `receive-invitation-accept-button`, `receive-invitation-decline-button`
- **Message input**: `message-input` (textarea, alongside existing `id`), `send-message-button`

## Testing

`cargo check` / `cargo clippy -p river-ui --target wasm32-unknown-unknown --features no-sync` are clean — no new warnings in any touched file. The attributes are additive and exercised by the existing CI Playwright layout suite. No new test is added because there is no behavioral change to assert; the change is verified by the build plus the existing visual/layout tests continuing to pass.

Closes #25

[AI-assisted - Claude]