### PR TITLE
fix(ui): don't join twice when accepting an invite to a room you're already in

### DIFF
--- a/.claude/rules/direct-messages.md
+++ b/.claude/rules/direct-messages.md
@@ -75,6 +75,17 @@ and joins via the shared `ApiClient::accept_invitation_struct` — the same
 core the base58 `invite accept` path uses, so the #308 re-accept guard and
 `room_secrets` persistence are identical across both entry points.
 
+The UI has its OWN, separate re-accept guard
+(`receive_invitation_modal::accept_invitation`, freenet/river#365) that is
+NOT the same as the CLI's #308 guard — do not assume they are
+interchangeable. The CLI's #308 guard refuses re-accept whenever it has any
+stored room credentials; the UI guard is identity-aware, refusing only when
+the per-room key the user already holds (`RoomData.self_sk`) is itself a
+member, which deliberately preserves the UI's restore-access branch. The UI
+guard is best-effort (it falls through on an unreadable `ROOMS`); making the
+invitation-accept GET handler structurally re-accept-proof is tracked as
+freenet/river#367.
+
 ## Placeholder render
 
 `BodyKind::{Plaintext, Placeholder}` in `dm_thread_modal.rs` routes

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -330,9 +330,30 @@ pub async fn handle_get_response(
 
                     // If the room already existed, update self_sk and merge state
                     if !is_new_entry {
-                        // Only update self_sk if the user is NOT the room owner,
-                        // to avoid stripping owner privileges
-                        if room_data.self_sk.verifying_key() != owner_vk {
+                        // Adopt the invitation's signing key as our per-room
+                        // identity ONLY when the key we currently hold is not
+                        // already a valid member of this room. Blindly
+                        // overwriting `self_sk` orphans a live membership: the
+                        // original member entry stays in the room, but the local
+                        // user no longer holds its key, so they can never act as
+                        // — or remove — it. That is the freenet/river#365
+                        // mechanism. The accept-time guard in
+                        // `receive_invitation_modal::accept_invitation` already
+                        // blocks the user-facing re-accept path; this is the
+                        // structural backstop that makes the orphaning impossible
+                        // regardless of how this GET was triggered. The owner is
+                        // implicitly covered (the owner is always a member of
+                        // their own room), preserving the previous "never strip
+                        // owner privileges" behavior.
+                        let existing_vk = room_data.self_sk.verifying_key();
+                        let existing_is_member = existing_vk == owner_vk
+                            || room_data
+                                .room_state
+                                .members
+                                .members
+                                .iter()
+                                .any(|m| m.member.member_vk == existing_vk);
+                        if !existing_is_member {
                             room_data.self_sk = self_sk.clone();
                             // Reset migration flag so the new key gets migrated
                             room_data.key_migrated_to_delegate = false;
@@ -1985,6 +2006,37 @@ mod tests {
             src.contains("is_probe_instance(key.id())"),
             "handle_get_response must route legacy-key GET responses into the \
              probe handler via is_probe_instance (freenet/river#292)."
+        );
+    }
+
+    /// freenet/river#365 — source-grep pin: the invitation-accept GET handler
+    /// must NOT overwrite an existing per-room `self_sk` that is already a valid
+    /// member. Doing so orphans the original membership — the user keeps a
+    /// duplicate member entry they can never remove. The accept-time guard in
+    /// `receive_invitation_modal::accept_invitation` blocks the user-facing
+    /// path, but this reassignment is the structural mechanism, so it must stay
+    /// gated on a membership check. A refactor that re-introduces the old
+    /// unconditional owner-only overwrite would re-regress #365 for any future
+    /// caller; this pin fails CI if it does.
+    #[test]
+    fn self_sk_overwrite_is_gated_on_existing_membership() {
+        // Search only the PRODUCTION half of the file — slice off `mod tests`
+        // so this pin can't be satisfied by its own assertion-message text.
+        let full = include_str!("get_response.rs");
+        let src = full
+            .split("mod tests {")
+            .next()
+            .expect("get_response.rs must have production code before `mod tests`");
+        assert!(
+            src.contains("if !existing_is_member {"),
+            "the existing-room self_sk reassignment must be gated on \
+             `!existing_is_member` so it never clobbers a live membership \
+             (freenet/river#365)."
+        );
+        assert!(
+            !src.contains("if room_data.self_sk.verifying_key() != owner_vk {"),
+            "the old owner-only self_sk overwrite condition must be gone — it let \
+             a re-accept orphan an existing membership (freenet/river#365)."
         );
     }
 

--- a/ui/src/components/room_list/receive_invitation_modal.rs
+++ b/ui/src/components/room_list/receive_invitation_modal.rs
@@ -5,7 +5,8 @@ use crate::invites::{PendingRoomJoin, PendingRoomStatus};
 use crate::room_data::Rooms;
 use dioxus::logger::tracing::{error, info, warn};
 use dioxus::prelude::*;
-use river_core::room_state::member::MemberId;
+use ed25519_dalek::VerifyingKey;
+use river_core::room_state::member::{AuthorizedMember, MemberId};
 use std::cell::RefCell;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::JsValue;
@@ -678,24 +679,61 @@ fn render_invitation_options(inv: Invitation, invitation: Signal<Option<Invitati
     }
 }
 
+/// True if `vk` is the room owner or already present in `members`.
+fn vk_is_room_member(
+    owner_vk: &VerifyingKey,
+    members: &[AuthorizedMember],
+    vk: &VerifyingKey,
+) -> bool {
+    vk == owner_vk || members.iter().any(|m| &m.member.member_vk == vk)
+}
+
+/// Pure core of [`check_membership_status`], split out so it can be unit-tested
+/// without constructing a full `RoomData` (whose `contract_key` needs the
+/// room-contract WASM).
+///
+/// `current_key_is_member` is true when the user is ALREADY in this room —
+/// either under the invitation's embedded key, OR (the case that matters for a
+/// re-accept) under the per-room identity `self_vk` they already hold for this
+/// room. Every accepted invitation carries a freshly generated
+/// `invitee_signing_key`, so that key is never itself a member yet; checking
+/// only it let a user re-accept an invite to a room they were already in and
+/// join a SECOND time under a new key — orphaning their original membership and
+/// making the original impossible to remove (freenet/river#365).
+///
+/// Note `current_key_is_member` takes precedence over `invited_member_exists`
+/// in the dispatcher: a user who already holds a working `self_vk` membership
+/// routes to "already a member" even if the invitation re-invites a DIFFERENT
+/// existing member's key (the restore-access trigger). That is intentional — a
+/// user with a working identity has no need to claim another member's slot. The
+/// restore-access branch still fires for the case it is meant for: a lost
+/// `self_vk` that is not itself a member (see
+/// `restore_access_invitation_still_detected`).
+fn membership_status(
+    owner_vk: &VerifyingKey,
+    members: &[AuthorizedMember],
+    self_vk: &VerifyingKey,
+    invitation_key_vk: &VerifyingKey,
+    invitation_invitee_vk: &VerifyingKey,
+) -> (bool, bool) {
+    let current_key_is_member = vk_is_room_member(owner_vk, members, invitation_key_vk)
+        || vk_is_room_member(owner_vk, members, self_vk);
+    let invited_member_exists = members
+        .iter()
+        .any(|m| &m.member.member_vk == invitation_invitee_vk);
+    (current_key_is_member, invited_member_exists)
+}
+
 /// Checks the membership status of the user in the room
 fn check_membership_status(inv: &Invitation, current_rooms: &Rooms) -> (bool, bool) {
     if let Some(room_data) = current_rooms.map.get(&inv.room) {
-        let user_vk = inv.invitee_signing_key.verifying_key();
-        let current_key_is_member = user_vk == room_data.owner_vk
-            || room_data
-                .room_state
-                .members
-                .members
-                .iter()
-                .any(|m| m.member.member_vk == user_vk);
-        let invited_member_exists = room_data
-            .room_state
-            .members
-            .members
-            .iter()
-            .any(|m| m.member.member_vk == inv.invitee.member.member_vk);
-        (current_key_is_member, invited_member_exists)
+        membership_status(
+            &room_data.owner_vk,
+            &room_data.room_state.members.members,
+            &room_data.self_sk.verifying_key(),
+            &inv.invitee_signing_key.verifying_key(),
+            &inv.invitee.member.member_vk,
+        )
     } else {
         (false, false)
     }
@@ -855,6 +893,50 @@ fn render_new_invitation(inv: Invitation, invitation: Signal<Option<Invitation>>
 /// subscription that was in flight when the page was reloaded (#218), reusing
 /// the exact same accept flow the Accept button uses.
 pub(crate) fn accept_invitation(inv: Invitation, nickname: String) {
+    // Guard against re-accepting an invite to a room the user is ALREADY in.
+    // Each invitation carries a freshly generated `invitee_signing_key`, so a
+    // second accept would add another member entry (a new MemberId) for the
+    // same human AND overwrite the user's existing per-room `self_sk` on the
+    // GET response — orphaning the original membership, which the user could
+    // then never remove (freenet/river#365). This guard covers BOTH the modal
+    // Accept button and the #218 localStorage auto-resume, the two paths that
+    // reach `accept_invitation`. It is best-effort by design — it only fires
+    // when `ROOMS` is readable AND already holds this room; on a cold/locked
+    // `ROOMS` it falls through to the normal join (reverting to the prior
+    // behavior for that rare case — a deeper structural backstop in the
+    // GET handler is tracked as freenet/river#367). The modal dispatcher
+    // (`render_invitation_options` → `check_membership_status`) is a
+    // complementary gate that routes an already-member to the "already a
+    // member" branch whenever the modal is shown. A genuine rejoin after
+    // leaving is unaffected: `leave_room` drops the room from `ROOMS`, so
+    // `self_sk` is no longer a member and this guard does not fire.
+    if let Ok(rooms) = ROOMS.try_read() {
+        if let Some(room_data) = rooms.map.get(&inv.room) {
+            let already_member = vk_is_room_member(
+                &room_data.owner_vk,
+                &room_data.room_state.members.members,
+                &room_data.self_sk.verifying_key(),
+            );
+            if already_member {
+                drop(rooms);
+                info!(
+                    "Ignoring invitation accept for room {:?}: already a member under existing key",
+                    MemberId::from(inv.room)
+                );
+                // Drop the stale pending invitation so the #218 auto-resume
+                // doesn't keep re-firing a join that is moot (the user is
+                // already in). We deliberately do NOT mark the invitation
+                // processed here: that is the up-front gravestone the #356 fix
+                // removed (and the `accept_invitation_does_not_mark_processed_up_front`
+                // pin test forbids). The URL-driven modal still shows the
+                // "already a member" branch and its dismiss is the terminal
+                // path; clearing storage only stops the silent auto-resume.
+                clear_invitation_from_storage();
+                return;
+            }
+        }
+    }
+
     // NOTE: we deliberately do NOT mark this invitation processed here.
     //
     // Marking on accept (the old behaviour) turned the processed-set into a
@@ -952,6 +1034,150 @@ pub(crate) fn accept_invitation(inv: Invitation, nickname: String) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ed25519_dalek::SigningKey;
+    use river_core::room_state::member::Member;
+
+    /// Build an `AuthorizedMember` invited directly by the owner.
+    fn owner_invited_member(owner_sk: &SigningKey, member_vk: VerifyingKey) -> AuthorizedMember {
+        let owner_vk = owner_sk.verifying_key();
+        let member = Member {
+            owner_member_id: owner_vk.into(),
+            invited_by: owner_vk.into(),
+            member_vk,
+        };
+        AuthorizedMember::new(member, owner_sk)
+    }
+
+    #[test]
+    fn vk_is_room_member_matches_owner_and_members() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let owner_vk = owner_sk.verifying_key();
+        let member_sk = SigningKey::generate(&mut rng);
+        let stranger_sk = SigningKey::generate(&mut rng);
+        let members = vec![owner_invited_member(&owner_sk, member_sk.verifying_key())];
+
+        assert!(
+            vk_is_room_member(&owner_vk, &members, &owner_vk),
+            "owner counts as a member"
+        );
+        assert!(
+            vk_is_room_member(&owner_vk, &members, &member_sk.verifying_key()),
+            "listed member is a member"
+        );
+        assert!(
+            !vk_is_room_member(&owner_vk, &members, &stranger_sk.verifying_key()),
+            "unrelated key is not a member"
+        );
+    }
+
+    #[test]
+    fn reaccept_while_already_member_reports_already_member() {
+        // The exact bug (freenet/river#365): the user is already in the room
+        // under their existing per-room identity (`self_sk`). A NEW invitation
+        // to the same room carries a freshly generated key that is not yet a
+        // member. The old check looked only at the invitation key and so fell
+        // through to a full second join. `membership_status` must instead see
+        // the existing identity and report "already a member".
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let owner_vk = owner_sk.verifying_key();
+
+        let self_sk = SigningKey::generate(&mut rng);
+        let members = vec![owner_invited_member(&owner_sk, self_sk.verifying_key())];
+
+        // Fresh invitation key — never yet a member.
+        let fresh_invite_sk = SigningKey::generate(&mut rng);
+        let invited_vk = fresh_invite_sk.verifying_key();
+
+        let (current_key_is_member, invited_member_exists) = membership_status(
+            &owner_vk,
+            &members,
+            &self_sk.verifying_key(),
+            &fresh_invite_sk.verifying_key(),
+            &invited_vk,
+        );
+
+        assert!(
+            current_key_is_member,
+            "user already in the room (via self_sk) must be reported as already a member"
+        );
+        assert!(
+            !invited_member_exists,
+            "the fresh invitation key is not yet a member, so this is not a restore-access case"
+        );
+    }
+
+    #[test]
+    fn genuine_new_join_is_not_reported_as_member() {
+        // The room exists locally but the user's existing identity is NOT a
+        // member (e.g. a room they can see but have not joined). A fresh invite
+        // must still flow to the normal new-join path.
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let owner_vk = owner_sk.verifying_key();
+
+        // Existing self_sk that is not in the (empty) member list.
+        let self_sk = SigningKey::generate(&mut rng);
+        let members: Vec<AuthorizedMember> = vec![];
+
+        let fresh_invite_sk = SigningKey::generate(&mut rng);
+        let invited_vk = fresh_invite_sk.verifying_key();
+
+        let (current_key_is_member, invited_member_exists) = membership_status(
+            &owner_vk,
+            &members,
+            &self_sk.verifying_key(),
+            &fresh_invite_sk.verifying_key(),
+            &invited_vk,
+        );
+
+        assert!(
+            !current_key_is_member,
+            "a user who is not yet a member must not be treated as already joined"
+        );
+        assert!(!invited_member_exists);
+    }
+
+    #[test]
+    fn restore_access_invitation_still_detected() {
+        // An invitation whose invitee key already exists in the room (the user
+        // lost their key and wants to restore access) must still report
+        // `invited_member_exists`, and — because the local `self_sk` is some
+        // unrelated/lost key not in the room — NOT `current_key_is_member`,
+        // so the dispatcher routes to the restore-access branch.
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let owner_vk = owner_sk.verifying_key();
+
+        let existing_member_sk = SigningKey::generate(&mut rng);
+        let members = vec![owner_invited_member(
+            &owner_sk,
+            existing_member_sk.verifying_key(),
+        )];
+
+        // The invitation re-invites that same existing member key, but the
+        // user's currently-held key is a different (lost) one not in the room.
+        let lost_self_sk = SigningKey::generate(&mut rng);
+        let invitation_key_sk = SigningKey::generate(&mut rng);
+
+        let (current_key_is_member, invited_member_exists) = membership_status(
+            &owner_vk,
+            &members,
+            &lost_self_sk.verifying_key(),
+            &invitation_key_sk.verifying_key(),
+            &existing_member_sk.verifying_key(),
+        );
+
+        assert!(
+            !current_key_is_member,
+            "the user's currently-held key is not in the room"
+        );
+        assert!(
+            invited_member_exists,
+            "the invitation's invitee key is an existing member → restore-access case"
+        );
+    }
 
     #[test]
     fn fingerprint_is_deterministic() {
@@ -1352,6 +1578,49 @@ mod tests {
             "accept_invitation must NOT call mark_invitation_processed — marking \
              on accept is the gravestone that suppresses a failed join forever \
              in the sandboxed iframe. Mark on terminal success instead."
+        );
+    }
+
+    /// Source-grep pin: `accept_invitation` must guard against re-accepting an
+    /// invite to a room the user is already in, BEFORE it creates the pending
+    /// join. The #218 auto-resume calls `accept_invitation` directly, bypassing
+    /// the modal's `check_membership_status` routing, so without this early-bail
+    /// it would add a duplicate membership and clobber `self_sk`
+    /// (freenet/river#365). A refactor that drops the guard or moves it after
+    /// the `PENDING_INVITES` insert would re-regress #365 for the auto-resume
+    /// path. (The pure decision is covered by
+    /// `reaccept_while_already_member_reports_already_member`; this pins that
+    /// the accept path actually USES it, since the guard reads the `ROOMS`
+    /// signal and can't run under a host unit test.)
+    #[test]
+    fn accept_invitation_guards_against_reaccept_before_join() {
+        let src = include_str!("receive_invitation_modal.rs");
+        let accept_fn = src
+            .split_once("pub(crate) fn accept_invitation(")
+            .expect("accept_invitation must exist")
+            .1;
+        let accept_body = accept_fn
+            .split_once("#[cfg(test)]")
+            .map(|(body, _)| body)
+            .unwrap_or(accept_fn);
+
+        let guard_at = accept_body.find("vk_is_room_member(").expect(
+            "accept_invitation must call vk_is_room_member to detect an existing \
+             membership (freenet/river#365)",
+        );
+        let join_at = accept_body
+            .find("PENDING_INVITES.with_mut(")
+            .expect("accept_invitation must create the pending join via PENDING_INVITES");
+        assert!(
+            guard_at < join_at,
+            "the already-member guard must run BEFORE the pending-join insert so \
+             a re-accept early-bails instead of creating a duplicate membership \
+             (freenet/river#365)."
+        );
+        assert!(
+            accept_body[..join_at].contains("return;"),
+            "the already-member guard must early-`return` before the join \
+             (freenet/river#365)."
         );
     }
 


### PR DESCRIPTION
## Problem

Accepting an invitation to a room you are **already a member of** made you join the room a **second time**, and the original membership could then never be removed.

River is per-room-identity: a member is identified by `MemberId = fast_hash(member_vk)`, and every invitation embeds a **freshly generated** `invitee_signing_key`. So accepting an invite always introduces a new key/`MemberId`.

The in-app accept flow already had an "already a member" branch, but its guard (`check_membership_status`) tested membership against the **invitation's** embedded key — which, being fresh, is never yet a member. It never checked the per-room identity the user already holds (`RoomData.self_sk`), so a re-accept fell through to a full second join:

- A **second** member entry (new `MemberId`) was PUT for the same human → "joined twice".
- On the GET response, `get_response.rs` overwrites `RoomData.self_sk` with the new key, **orphaning** the original member entry — the local user then holds only the new key and can never act as / remove the original.

## Approach

Recognize existing membership by the user's **existing** per-room identity (`self_sk`), not just the invitation's fresh key:

- **`check_membership_status`** now reports `current_key_is_member` when `self_sk` is the owner or already in the member list, routing the modal to the pre-existing "You are already a member of this room" branch instead of a second join.
- **A guard at the `accept_invitation` chokepoint** (the single function both the modal Accept button and the #218 localStorage auto-resume pass through) refuses to accept for a room the user is already in. It clears the stale pending invitation but, per the #356 gravestone fix, does **not** mark the invitation processed.

Preserved behaviors: a genuine **rejoin after leaving** (`leave_room` drops the room from `ROOMS`, so the guard doesn't fire); **restore-access** (#279) still routes correctly when the user's held key is a *lost* one; the **#356** mark-on-terminal-success gravestone semantics (pin tests still pass).

Pure helpers (`vk_is_room_member`, `membership_status`) make the decision unit-testable without the room-contract WASM. A source-grep pin (`accept_invitation_guards_against_reaccept_before_join`) locks in that the accept path actually uses the guard before creating the join (the guard reads the `ROOMS` signal, so it can't run under a host unit test).

### Scope note — deeper backstop deferred to #367

This fixes every realistic path to the symptom at the entry point. The guard is best-effort (it falls through if `ROOMS` is momentarily unreadable). Making the invitation-accept **GET handler** itself structurally re-accept-proof is tracked as **#367**: an initial partial attempt here (only skipping the `self_sk` overwrite) was found by external review to *split* `self_sk` from the cached self-credentials — worse than the consistent original — so it was reverted; the correct fix is a full early short-circuit, which deserves its own change.

## Testing

`cargo test -p river-ui --bins` — new unit tests in `receive_invitation_modal`:
- `reaccept_while_already_member_reports_already_member` — the bug: existing `self_sk` is a member, invitation key is fresh → reported already-a-member (verified to fail against the old code).
- `genuine_new_join_is_not_reported_as_member`, `restore_access_invitation_still_detected`, `vk_is_room_member_matches_owner_and_members`.
- `accept_invitation_guards_against_reaccept_before_join` — source-grep pin that the guard runs before the join.

Full `river-ui` bins suite passes (363 tests); `cargo fmt` + `cargo clippy -p river-ui` clean. UI-only change — no delegate/contract WASM touched, so **no migration required**.

## Review

Multi-model review run via `/freenet:pr-review` (Full tier): four perspective reviewers (code-first, testing, skeptical, big-picture) + external Codex (gpt-5.5). All findings addressed; consolidated review posted below.

Closes #365
