### PR TITLE
fix(ui): close public→private TOCTOU window in nickname save (#318)

### DIFF
--- a/common/tests/private_room_test.rs
+++ b/common/tests/private_room_test.rs
@@ -1017,11 +1017,20 @@ fn issue_318_member_info_apply_delta_has_no_contract_privacy_guard() {
     let mut state_for_config = state.clone();
     let old = state_for_config.clone();
     let config_result = state_for_config.apply_delta(&old, &params, &Some(config_delta));
+    // Assert the SPECIFIC rejection reason, not just `is_err()`: the version
+    // bump, signature, and non-zero `max_*` all pass, so the privacy guard at
+    // `configuration.rs` is the only thing that should reject this delta. If
+    // some unrelated future validation starts erroring first, a bare
+    // `is_err()` would keep passing while silently no longer testing the
+    // privacy guard. Pinning the message keeps the test honest.
+    let config_err = config_result.expect_err(
+        "Configuration::apply_delta MUST reject public display metadata in a private room",
+    );
     assert!(
-        config_result.is_err(),
-        "Configuration::apply_delta MUST reject public display metadata in a \
-         private room (the existing contract-level guard #318's UI fix mirrors). \
-         If this no longer errors, the configuration privacy guard regressed.",
+        config_err.contains("encrypted display metadata"),
+        "expected the configuration privacy guard to reject this delta, but got \
+         a different error ({config_err:?}). The existing contract-level guard \
+         (#318's UI fix mirrors it) may have regressed or moved.",
     );
 }
 

--- a/common/tests/private_room_test.rs
+++ b/common/tests/private_room_test.rs
@@ -894,6 +894,137 @@ fn delegate_driven_rotation_round_trip() {
     }
 }
 
+/// freenet/river#318 contract-level invariant pin.
+///
+/// The UI nickname-save flow (`ui/.../nickname_field.rs`) is the privacy gate
+/// that keeps a plaintext `SealedBytes::Public` nickname out of a private
+/// room: it reads `is_private` and seals the nickname atomically with
+/// `apply_delta` so a public→private reconfiguration can't slip a stale
+/// plaintext delta through. That UI guard is load-bearing *because the
+/// contract does NOT enforce the same rule for `member_info`*.
+///
+/// This test pins both halves of that assumption so a future change can't
+/// silently invalidate it:
+///
+/// 1. `MemberInfoV1::apply_delta` ACCEPTS a `SealedBytes::Public`
+///    `preferred_nickname` even when the room is `PrivacyMode::Private`
+///    (there is no contract-level privacy guard for member_info — only
+///    nickname length + signature + membership are checked). If someone
+///    adds such a guard here, this assertion fails first and forces them
+///    to treat it as the coordinated room-contract WASM migration it is
+///    (the guard would move the contract key AND, because composed
+///    `apply_delta` propagates a sub-delta `Err` via `?`, reject the WHOLE
+///    delta from any existing room that already carries a public nickname —
+///    a CRDT-divergence / backwards-compat break per AGENTS.md). The robust
+///    place to enforce this without a migration is the UI, which #318 does.
+///
+/// 2. The analogous `Configuration` write IS rejected at the contract level
+///    (`configuration.rs::apply_delta`), which is why the leak window only
+///    ever affected member_info — room name / description writes fail to
+///    apply locally and never reach `mark_needs_sync`. This is the existing
+///    guard #318's UI fix mirrors in spirit.
+#[test]
+fn issue_318_member_info_apply_delta_has_no_contract_privacy_guard() {
+    use river_core::room_state::member::MembersDelta;
+    use river_core::room_state::member_info::{AuthorizedMemberInfo, MemberInfo, MemberInfoV1};
+    use river_core::room_state::ChatRoomStateV1Delta;
+
+    let owner_sk = SigningKey::generate(&mut OsRng);
+    let owner_vk = owner_sk.verifying_key();
+    let owner_id = MemberId::from(&owner_vk);
+    let params = ChatRoomParametersV1 { owner: owner_vk };
+
+    // A private room with one non-owner member.
+    let member_sk = SigningKey::generate(&mut OsRng);
+    let member_vk = member_sk.verifying_key();
+    let member_id = MemberId::from(&member_vk);
+
+    let mut state = ChatRoomStateV1 {
+        configuration: AuthorizedConfigurationV1::new(
+            Configuration {
+                privacy_mode: PrivacyMode::Private,
+                owner_member_id: owner_id,
+                ..Default::default()
+            },
+            &owner_sk,
+        ),
+        ..Default::default()
+    };
+    state.members.members.push(AuthorizedMember::new(
+        Member {
+            owner_member_id: owner_id,
+            invited_by: owner_id,
+            member_vk,
+        },
+        &owner_sk,
+    ));
+
+    // Part 1: a PUBLIC (plaintext) nickname delta is accepted by the
+    // member_info contract path even though the room is private. This is the
+    // gap #318's UI fix closes; it is NOT closed at the contract level.
+    let public_nickname = MemberInfo {
+        member_id,
+        version: 1,
+        preferred_nickname: SealedBytes::public(b"PlaintextNick".to_vec()),
+    };
+    let authorized = AuthorizedMemberInfo::new_with_member_key(public_nickname, &member_sk);
+
+    let mut member_info_state = MemberInfoV1::default();
+    let apply_result =
+        member_info_state.apply_delta(&state, &params, &Some(vec![authorized.clone()]));
+    assert!(
+        apply_result.is_ok(),
+        "member_info::apply_delta currently accepts a public nickname in a \
+         private room (no contract guard). If this now errors, a contract-level \
+         privacy guard was added — see this test's doc comment: that is a \
+         room-contract WASM migration with CRDT-divergence implications, not a \
+         drop-in fix. Update legacy_room_contracts.toml and reconsider whether \
+         the UI-level guard (#318) is the intended enforcement point.",
+    );
+    assert_eq!(
+        member_info_state.member_info.len(),
+        1,
+        "the public nickname entry should have been stored as-is"
+    );
+    assert!(
+        member_info_state.member_info[0]
+            .member_info
+            .preferred_nickname
+            .is_public(),
+        "stored nickname is the plaintext public variant the UI must prevent reaching here"
+    );
+
+    // Part 2: the analogous Configuration write (public display metadata into
+    // a private room) IS rejected at the contract level. This is why the leak
+    // only ever affected member_info, and is the guard the UI fix mirrors.
+    let bad_config = Configuration {
+        privacy_mode: PrivacyMode::Private,
+        owner_member_id: owner_id,
+        // Public (plaintext) display name in a private room — illegal.
+        display: RoomDisplayMetadata {
+            name: SealedBytes::public(b"Plaintext Room Name".to_vec()),
+            description: None,
+        },
+        configuration_version: state.configuration.configuration.configuration_version + 1,
+        ..Default::default()
+    };
+    let config_delta = ChatRoomStateV1Delta {
+        configuration: Some(AuthorizedConfigurationV1::new(bad_config, &owner_sk)),
+        // include an unrelated member delta to prove it's the config that's rejected
+        members: Some(MembersDelta::new(vec![])),
+        ..Default::default()
+    };
+    let mut state_for_config = state.clone();
+    let old = state_for_config.clone();
+    let config_result = state_for_config.apply_delta(&old, &params, &Some(config_delta));
+    assert!(
+        config_result.is_err(),
+        "Configuration::apply_delta MUST reject public display metadata in a \
+         private room (the existing contract-level guard #318's UI fix mirrors). \
+         If this no longer errors, the configuration privacy guard regressed.",
+    );
+}
+
 // =============================================================================
 // Bug #3 regression tests (Ivvor's 2026-05-17 Matrix report)
 //

--- a/ui/src/components/members/member_info_modal/nickname_field.rs
+++ b/ui/src/components/members/member_info_modal/nickname_field.rs
@@ -70,139 +70,137 @@ pub fn NicknameField(member_info: AuthorizedMemberInfo) -> Element {
                 return;
             }
 
-            // Re-read ROOMS at save time so the privacy guard, the sealing
-            // secret, and the rejoin probe all see the SAME consistent
-            // snapshot. The component captured `self_signing_key` at mount,
-            // but `current_secret_opt` and `members` state can change between
-            // mount and save (the room secret arrives asynchronously after a
-            // private-room join), and using a stale `current_secret_opt =
-            // None` is exactly the freenet/river#299 leak.
-            let (is_private, current_secret_opt, members_delta) = {
-                let Ok(rooms) = ROOMS.try_read() else {
-                    warn!(
-                        "ROOMS.try_read() returned Err during nickname save — \
-                         a concurrent write is in flight; the edit is dropped \
-                         and the user will need to retry"
-                    );
-                    return;
-                };
-                let current_room = CURRENT_ROOM.read();
-                let Some(room_data) = current_room.owner_key.and_then(|k| rooms.map.get(&k)) else {
-                    warn!("No room data available for the current room — nickname edit dropped");
-                    return;
-                };
-                (
-                    room_data.is_private(),
-                    room_data.get_secret().map(|(s, v)| (*s, v)),
-                    room_data.build_rejoin_delta().0,
-                )
+            let Some(signing_key) = self_signing_key.clone() else {
+                warn!("No signing key available");
+                return;
             };
 
-            // Carried into the deferred ROOMS mutation so the cached `self_*`
-            // fields can be kept in step with this edit — `new_value` itself
-            // is moved into the sealed-nickname construction below.
-            let nickname_for_self = new_value.clone();
+            // Resolve the owner key once, synchronously, so the deferred
+            // closure mutates the same room the user is looking at.
+            let Some(owner_key) = CURRENT_ROOM.read().owner_key else {
+                warn!("No room data available for the current room — nickname edit dropped");
+                return;
+            };
 
-            let delta = if let Some(signing_key) = self_signing_key.clone() {
-                // Privacy guard for freenet/river#299: a private room with no
-                // locally-available secret MUST NOT publish a plaintext
-                // nickname into `member_info`. `seal_for_room` returns `None`
-                // in that case so we defer — the user can retry once the
-                // secret has arrived. Revert the input to the on-network
-                // value so the UI doesn't silently lie about what was saved.
-                let current_secret_ref = current_secret_opt.as_ref().map(|(s, v)| (s, *v));
-                let Some(sealed_nickname) =
-                    seal_for_room(is_private, current_secret_ref, new_value.into_bytes())
-                else {
-                    warn!(
-                        "Private room secret not yet available locally — \
-                         nickname edit deferred to avoid leaking a plaintext \
-                         member_info delta (freenet/river#299)."
-                    );
-                    temp_nickname.set(initial_nickname_for_revert.clone());
-                    return;
-                };
-                let new_member_info = MemberInfo {
-                    member_id: member_info.member_info.member_id,
-                    version: member_info.member_info.version + 1,
-                    preferred_nickname: sealed_nickname,
-                };
-                let new_authorized_member_info =
-                    AuthorizedMemberInfo::new_with_member_key(new_member_info, &signing_key);
-                // Re-add ourselves if pruned for inactivity. The member_info
-                // delta is the nickname change itself — no extra entry needed.
-                Some((
-                    ChatRoomStateV1Delta {
+            let member_info = member_info.clone();
+            let initial_nickname_for_revert = initial_nickname_for_revert.clone();
+
+            // freenet/river#318: the privacy read (`is_private` /
+            // `get_secret`), the seal, the delta build, AND `apply_delta`
+            // all happen INSIDE this single deferred `ROOMS.with_mut`
+            // block. Reading privacy state and applying the delta in the
+            // same borrow makes them atomic with respect to the event loop,
+            // so a public→private reconfiguration that lands between the
+            // user's keystroke and this closure firing cannot slip a
+            // plaintext `SealedBytes::public` nickname into a now-private
+            // room. (Previously the seal was built synchronously, before
+            // the `setTimeout(0)`, leaving a one-tick TOCTOU window.)
+            //
+            // Deferring the whole operation also preserves the original
+            // RefCell-reentrancy guard: building and applying off the
+            // current call stack keeps signal borrows from overlapping.
+            crate::util::defer(move || {
+                enum SaveOutcome {
+                    Applied,
+                    /// Private room whose secret hasn't arrived yet: the
+                    /// edit is dropped and the input reverted to the
+                    /// on-network value so the UI doesn't lie about what
+                    /// was saved (freenet/river#299).
+                    DeferredNoSecret,
+                    NotApplied,
+                }
+
+                let outcome = ROOMS.with_mut(|rooms| {
+                    let Some(room_data) = rooms.map.get_mut(&owner_key) else {
+                        warn!("Room state not found for current room");
+                        return SaveOutcome::NotApplied;
+                    };
+
+                    // Read privacy mode + sealing secret from the SAME
+                    // `room_data` we are about to mutate. `get_secret`
+                    // borrows `room_data.secrets`, so copy the secret out
+                    // before we take `&mut` below.
+                    let is_private = room_data.is_private();
+                    let current_secret_opt = room_data.get_secret().map(|(s, v)| (*s, v));
+                    // Re-add ourselves if pruned for inactivity. Only the
+                    // members element (`.0`) is used — the nickname change
+                    // itself is the member_info delta. `.0` carries no
+                    // plaintext nickname, so it is privacy-independent.
+                    let members_delta = room_data.build_rejoin_delta().0;
+
+                    // Privacy guard (freenet/river#299): a private room with
+                    // no locally-available secret MUST NOT publish a
+                    // plaintext nickname into `member_info`. `seal_for_room`
+                    // returns `None` in that case.
+                    let current_secret_ref = current_secret_opt.as_ref().map(|(s, v)| (s, *v));
+                    let Some(sealed_nickname) = seal_for_room(
+                        is_private,
+                        current_secret_ref,
+                        new_value.clone().into_bytes(),
+                    ) else {
+                        warn!(
+                            "Private room secret not yet available locally — \
+                             nickname edit deferred to avoid leaking a plaintext \
+                             member_info delta (freenet/river#299)."
+                        );
+                        return SaveOutcome::DeferredNoSecret;
+                    };
+
+                    let new_member_info = MemberInfo {
+                        member_id: member_info.member_info.member_id,
+                        version: member_info.member_info.version + 1,
+                        preferred_nickname: sealed_nickname,
+                    };
+                    let new_authorized_member_info =
+                        AuthorizedMemberInfo::new_with_member_key(new_member_info, &signing_key);
+                    let delta = ChatRoomStateV1Delta {
                         member_info: Some(vec![new_authorized_member_info.clone()]),
                         members: members_delta,
                         ..Default::default()
-                    },
-                    new_authorized_member_info,
-                ))
-            } else {
-                warn!("No signing key available");
-                None
-            };
+                    };
 
-            if let Some((delta, edited_member_info)) = delta {
-                info!("Saving changes to nickname with delta: {:?}", delta);
+                    info!("Saving changes to nickname with delta: {:?}", delta);
+                    info!(
+                        "State before applying nickname delta: {:?}",
+                        room_data.room_state
+                    );
+                    if let Err(e) = room_data.room_state.apply_delta(
+                        &room_data.room_state.clone(),
+                        &ChatRoomParametersV1 { owner: owner_key },
+                        &Some(delta),
+                    ) {
+                        error!("Failed to apply delta: {:?}", e);
+                        return SaveOutcome::NotApplied;
+                    }
+                    info!(
+                        "State after applying nickname delta: {:?}",
+                        room_data.room_state
+                    );
+                    // Keep the cached self_* fields in step with the edit so
+                    // a self-heal or an inactivity-rejoin before the next
+                    // sync republishes the edited nickname, not the pre-edit
+                    // one. No-op when the edited member is not the local
+                    // user.
+                    room_data.record_self_nickname_edit(
+                        member_id,
+                        new_authorized_member_info,
+                        new_value.clone(),
+                    );
+                    // #310: apply_delta's MessagesV1 step re-runs the
+                    // public-only rebuild_actions_state, which wipes private
+                    // edits/reactions. Re-derive them with decryption so
+                    // changing a nickname doesn't transiently revert an
+                    // edited message. No-op on public rooms.
+                    room_data.rebuild_private_actions_state();
+                    SaveOutcome::Applied
+                });
 
-                // Get the owner key first
-                let owner_key = CURRENT_ROOM.read().owner_key;
-
-                if let Some(owner_key) = owner_key {
-                    // Defer ROOMS mutation to a clean execution context to
-                    // prevent RefCell re-entrant borrow panics.
-                    crate::util::defer(move || {
-                        let applied = ROOMS.with_mut(|rooms| {
-                            if let Some(room_data) = rooms.map.get_mut(&owner_key) {
-                                info!(
-                                    "State before applying nickname delta: {:?}",
-                                    room_data.room_state
-                                );
-                                if let Err(e) = room_data.room_state.apply_delta(
-                                    &room_data.room_state.clone(),
-                                    &ChatRoomParametersV1 { owner: owner_key },
-                                    &Some(delta),
-                                ) {
-                                    error!("Failed to apply delta: {:?}", e);
-                                    false
-                                } else {
-                                    info!(
-                                        "State after applying nickname delta: {:?}",
-                                        room_data.room_state
-                                    );
-                                    // Keep the cached self_* fields in step
-                                    // with the edit so a self-heal or an
-                                    // inactivity-rejoin before the next sync
-                                    // republishes the edited nickname, not
-                                    // the pre-edit one. No-op when the edited
-                                    // member is not the local user.
-                                    room_data.record_self_nickname_edit(
-                                        member_id,
-                                        edited_member_info,
-                                        nickname_for_self,
-                                    );
-                                    // #310: apply_delta's MessagesV1 step re-runs
-                                    // the public-only rebuild_actions_state, which
-                                    // wipes private edits/reactions. Re-derive them
-                                    // with decryption so changing a nickname doesn't
-                                    // transiently revert an edited message. No-op on
-                                    // public rooms.
-                                    room_data.rebuild_private_actions_state();
-                                    true
-                                }
-                            } else {
-                                warn!("Room state not found for current room");
-                                false
-                            }
-                        });
-                        if applied {
-                            crate::components::app::mark_needs_sync(owner_key);
-                        }
-                    });
+                match outcome {
+                    SaveOutcome::Applied => crate::components::app::mark_needs_sync(owner_key),
+                    SaveOutcome::DeferredNoSecret => temp_nickname.set(initial_nickname_for_revert),
+                    SaveOutcome::NotApplied => {}
                 }
-            }
+            });
         }
     };
 
@@ -211,7 +209,7 @@ pub fn NicknameField(member_info: AuthorizedMemberInfo) -> Element {
     };
 
     let on_blur = {
-        let mut save_changes = save_changes.clone();
+        let save_changes = save_changes.clone();
         move |_| {
             let new_value = temp_nickname();
             save_changes(new_value);
@@ -219,7 +217,7 @@ pub fn NicknameField(member_info: AuthorizedMemberInfo) -> Element {
     };
 
     let on_keydown = {
-        let mut save_changes = save_changes.clone();
+        let save_changes = save_changes.clone();
         move |evt: dioxus_core::Event<KeyboardData>| {
             if evt.key() == Key::Enter {
                 let new_value = temp_nickname();


### PR DESCRIPTION
## Problem

PR #317 closed the wide freenet/river#299 leak, but a residual **TOCTOU race** remained in `NicknameField::save_changes` (`ui/src/components/members/member_info_modal/nickname_field.rs`):

1. The privacy read (`is_private` / `get_secret`), the `seal_for_room` call, and the `ChatRoomStateV1Delta` build all ran **synchronously**.
2. `apply_delta` + `mark_needs_sync` ran **later**, inside a `crate::util::defer` (`setTimeout(0)`) closure.
3. If a network message flipped the room **public→private** in that one-tick gap, the pre-built plaintext `SealedBytes::public` nickname was applied to the now-private room and synced out. `MemberInfoV1::apply_delta` has no contract-level privacy guard (it checks only declared length + signature + membership), so it accepted the leak.

The window is tight (~4ms, one event-loop tick) but real, and it leaks a member's plaintext nickname into a nominally-encrypted room.

## Approach

Move the privacy read, the seal, the delta build, **and** `apply_delta` all into the **single deferred `ROOMS.with_mut` block**, reading `is_private` / `get_secret` from the *same* `room_data` borrow the delta is applied to. The read and the apply are now atomic with respect to the event loop, so the race window collapses to zero — a public→private flip either lands fully before the closure (it seals public for a still-public room, correct) or fully after (the room is private and `seal_for_room` encrypts or defers).

The freenet/river#299 no-secret guard is preserved: in a private room with no local secret, `seal_for_room` returns `None`, the edit is dropped, and the input reverts to the on-network value via `temp_nickname.set(...)` — now a deferred signal write, which is a sanctioned pattern (cf. `room_list.rs` drag handlers).

### Why the client, not the contract

The issue notes a "stronger" defense-in-depth option: add a `PrivacyMode` guard to `MemberInfoV1::apply_delta` mirroring `configuration.rs`. **This PR deliberately does NOT take that route**, because it is **not backward-compatible**:

- `member_info.rs::apply_delta` is compiled **into the room-contract WASM**. Changing it moves the contract key (`BLAKE3(wasm, params)`) for every owner → requires a `legacy_room_contracts.toml` migration entry.
- A `return Err` guard would, via the `#[composable]` macro's `?`-propagation, abort the **entire** delta/merge — not just the offending entry. Any existing private room that already carries a public nickname (deployed WASM accepts these today) would have its state **rejected** by new-WASM nodes, diverging from old-WASM nodes. That violates the Backwards Compatibility Rule in `AGENTS.md`.

So the robust *and* backward-compatible enforcement point is the UI, which this PR fixes. The contract-level guard, if ever wanted, belongs in a separate migration-gated change.

## Testing

- New contract-level characterization test `issue_318_member_info_apply_delta_has_no_contract_privacy_guard` in `common/tests/private_room_test.rs` pins both halves of the invariant this fix relies on:
  1. `MemberInfoV1::apply_delta` **accepts** a public nickname in a private room today (no contract guard — the UI must be the gate). If someone adds the guard, this fails first and forces treating it as the coordinated WASM migration it is.
  2. The analogous `Configuration` write **is rejected** at the contract level (the existing guard this fix mirrors in spirit; why the leak only ever affected `member_info`).
- `cargo test -p river-core --test private_room_test` → 12 passed (11 pre-existing + new).
- `cargo test -p river-core --lib` → 181 passed.
- `cargo fmt` clean; `nickname_field.rs` is clippy-clean on the wasm target (zero warnings from the change).
- **No contract WASM change** (`ui/public/contracts/room_contract.wasm` untouched) → `check-room-contract-migration` passes, confirming backward compatibility.

## Compatibility

**Fully backward-compatible.** Client-only change; no contract/delegate WASM modification; no migration entry required.

Closes #318

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)