### PR TITLE
feat(ui): add touch-friendly room reorder controls (#348)

### DIFF
--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -18,7 +18,8 @@ use dioxus::logger::tracing::error;
 use dioxus::prelude::*;
 use dioxus_free_icons::{
     icons::fa_solid_icons::{
-        FaArrowLeft, FaComments, FaFileImport, FaLock, FaPlus, FaTriangleExclamation,
+        FaArrowLeft, FaArrowsUpDown, FaChevronDown, FaChevronUp, FaComments, FaFileImport, FaLock,
+        FaPlus, FaTriangleExclamation,
     },
     Icon,
 };
@@ -81,6 +82,13 @@ pub fn RoomList() -> Element {
     let mut dragged_room = use_signal(|| None::<VerifyingKey>);
     let mut drag_over_room = use_signal(|| None::<VerifyingKey>);
     let mut drag_over_end = use_signal(|| false);
+
+    // Touch-friendly reorder mode (freenet/river#348). HTML5 drag-and-drop is
+    // pointer-only — browsers don't emit drag events for touch gestures — so a
+    // toggle reveals per-row up/down controls that call the same input-agnostic
+    // `move_room_up`/`move_room_down` persistence helpers. Read via `try_read`
+    // and mutated through `crate::util::defer()` like the drag signals above.
+    let mut reorder_mode = use_signal(|| false);
 
     // Memoize the room list to avoid reading signals during render.
     // Rooms render in the user's drag-chosen order first, then any
@@ -164,6 +172,11 @@ pub fn RoomList() -> Element {
     let dragged_now: Option<VerifyingKey> = dragged_room.try_read().ok().and_then(|g| *g);
     let drag_over_now: Option<VerifyingKey> = drag_over_room.try_read().ok().and_then(|g| *g);
     let drag_over_end_now: bool = drag_over_end.try_read().map(|g| *g).unwrap_or(false);
+    let reorder_now: bool = reorder_mode.try_read().map(|g| *g).unwrap_or(false);
+    // Total rooms, used to disable the up control on the first row and the down
+    // control on the last. Also gates the reorder toggle's visibility: with one
+    // room there is nothing to reorder.
+    let room_count: usize = room_items.read().len();
 
     rsx! {
         aside {
@@ -197,14 +210,48 @@ pub fn RoomList() -> Element {
                     Icon { width: 16, height: 16, icon: FaComments }
                     span { "Rooms" }
                 }
-                button {
-                    "data-testid": "create-room-button",
-                    class: "p-1.5 rounded-md text-text-muted hover:text-accent hover:bg-surface transition-colors",
-                    title: "Create Room",
-                    onclick: move |_| {
-                        CREATE_ROOM_MODAL.write().show = true;
-                    },
-                    Icon { width: 14, height: 14, icon: FaPlus }
+                div { class: "flex items-center gap-1",
+                    // Reorder-mode toggle — the touch-friendly path to room
+                    // reordering (freenet/river#348). Only meaningful with at
+                    // least two rooms, so it's hidden below that to keep the
+                    // header uncluttered on first load — but stays visible while
+                    // reorder mode is on (even if rooms drop to one) so the user
+                    // can always toggle back out rather than getting stuck.
+                    if room_count > 1 || reorder_now {
+                        button {
+                            class: format!(
+                                "p-1.5 rounded-md transition-colors {}",
+                                if reorder_now {
+                                    "text-accent bg-accent/10"
+                                } else {
+                                    "text-text-muted hover:text-accent hover:bg-surface"
+                                },
+                            ),
+                            title: if reorder_now { "Done reordering" } else { "Reorder rooms" },
+                            "aria-label": "Reorder rooms",
+                            "aria-pressed": "{reorder_now}",
+                            "data-testid": "reorder-rooms-toggle",
+                            onclick: move |_| {
+                                // Defer the toggle per the Dioxus signal-safety
+                                // rules — this component reads `reorder_mode`
+                                // during render.
+                                crate::util::defer(move || {
+                                    let next = !*reorder_mode.peek();
+                                    reorder_mode.set(next);
+                                });
+                            },
+                            Icon { width: 14, height: 14, icon: FaArrowsUpDown }
+                        }
+                    }
+                    button {
+                        "data-testid": "create-room-button",
+                        class: "p-1.5 rounded-md text-text-muted hover:text-accent hover:bg-surface transition-colors",
+                        title: "Create Room",
+                        onclick: move |_| {
+                            CREATE_ROOM_MODAL.write().show = true;
+                        },
+                        Icon { width: 14, height: 14, icon: FaPlus }
+                    }
                 }
             }
 
@@ -212,7 +259,7 @@ pub fn RoomList() -> Element {
             ul {
                 "data-testid": "room-list",
                 class: "flex-1 px-2 py-1 space-y-0.5",
-                {room_items.read().iter().map(|(room_key, room_name, is_current, awaiting_sync, is_private, unread, sync_error_msg)| {
+                {room_items.read().iter().enumerate().map(|(idx, (room_key, room_name, is_current, awaiting_sync, is_private, unread, sync_error_msg))| {
                     let room_key = *room_key;
                     let room_name = room_name.clone();
                     let is_current = *is_current;
@@ -220,6 +267,10 @@ pub fn RoomList() -> Element {
                     let is_private = *is_private;
                     let unread = *unread;
                     let sync_error_msg = sync_error_msg.clone();
+                    // Row position, for disabling the up control on the first
+                    // row and the down control on the last (reorder mode).
+                    let is_first = idx == 0;
+                    let is_last = idx + 1 == room_count;
                     // Drag feedback: dim the row being dragged, and draw a top
                     // border on the row the cursor is over (drop lands the
                     // dragged room immediately before it — see `move_room`).
@@ -296,9 +347,10 @@ pub fn RoomList() -> Element {
                                     drag_over_end.set(false);
                                 });
                             },
+                            div { class: "flex items-center",
                             button {
                                 class: format!(
-                                    "w-full text-left px-3 py-2 rounded-lg text-sm transition-colors {}",
+                                    "flex-1 min-w-0 text-left px-3 py-2 rounded-lg text-sm transition-colors {}",
                                     if is_current {
                                         "bg-accent/10 text-accent font-medium"
                                     } else {
@@ -362,6 +414,75 @@ pub fn RoomList() -> Element {
                                         }
                                     }
                                 }
+                            }
+                            // Touch-friendly reorder controls (freenet/river#348):
+                            // up/down move the room one slot, calling the same
+                            // input-agnostic persistence helpers the drag path
+                            // uses. Disabled at the list boundaries (first row
+                            // can't go up; last can't go down). Only rendered in
+                            // reorder mode so the rail stays clean by default.
+                            if reorder_now {
+                                div { class: "flex items-center flex-shrink-0 pr-1 gap-0.5",
+                                    button {
+                                        r#type: "button",
+                                        class: format!(
+                                            "p-2 rounded-md transition-colors {}",
+                                            if is_first {
+                                                "text-text-muted/30 cursor-not-allowed"
+                                            } else {
+                                                "text-text-muted hover:text-accent hover:bg-surface"
+                                            },
+                                        ),
+                                        disabled: is_first,
+                                        title: "Move up",
+                                        "aria-label": "Move room up",
+                                        "data-testid": "reorder-room-up",
+                                        onclick: move |evt| {
+                                            // Sibling of the room-open button, so a tap
+                                            // here must not bubble into row selection.
+                                            evt.stop_propagation();
+                                            // `move_room_up` is a no-op at the top, but
+                                            // the button is also `disabled` there.
+                                            crate::util::defer(move || {
+                                                ROOMS.with_mut(|rooms| rooms.move_room_up(room_key));
+                                                spawn(async move {
+                                                    if let Err(e) = save_rooms_to_delegate().await {
+                                                        error!("Failed to save room order: {}", e);
+                                                    }
+                                                });
+                                            });
+                                        },
+                                        Icon { width: 14, height: 14, icon: FaChevronUp }
+                                    }
+                                    button {
+                                        r#type: "button",
+                                        class: format!(
+                                            "p-2 rounded-md transition-colors {}",
+                                            if is_last {
+                                                "text-text-muted/30 cursor-not-allowed"
+                                            } else {
+                                                "text-text-muted hover:text-accent hover:bg-surface"
+                                            },
+                                        ),
+                                        disabled: is_last,
+                                        title: "Move down",
+                                        "aria-label": "Move room down",
+                                        "data-testid": "reorder-room-down",
+                                        onclick: move |evt| {
+                                            evt.stop_propagation();
+                                            crate::util::defer(move || {
+                                                ROOMS.with_mut(|rooms| rooms.move_room_down(room_key));
+                                                spawn(async move {
+                                                    if let Err(e) = save_rooms_to_delegate().await {
+                                                        error!("Failed to save room order: {}", e);
+                                                    }
+                                                });
+                                            });
+                                        },
+                                        Icon { width: 14, height: 14, icon: FaChevronDown }
+                                    }
+                                }
+                            }
                             }
                         }
                     }

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -1734,6 +1734,41 @@ impl Rooms {
         order.push(item);
         self.room_order = order;
     }
+
+    /// Move `room` one position earlier in the display order, persisting the
+    /// resulting full order. Backs the touch-friendly "move up" control in the
+    /// rail's reorder mode (drag-and-drop is pointer-only — see
+    /// freenet/river#348). Like [`Rooms::move_room`], it operates on the
+    /// current effective order so the first reorder of an as-yet-unordered list
+    /// materialises the full order. No-ops if `room` is not a current room or
+    /// is already first.
+    pub fn move_room_up(&mut self, room: VerifyingKey) {
+        let mut order = self.ordered_room_keys();
+        let Some(pos) = order.iter().position(|k| k == &room) else {
+            return;
+        };
+        if pos == 0 {
+            return;
+        }
+        order.swap(pos, pos - 1);
+        self.room_order = order;
+    }
+
+    /// Move `room` one position later in the display order, persisting the
+    /// resulting full order. Backs the touch-friendly "move down" control in
+    /// the rail's reorder mode (see freenet/river#348). No-ops if `room` is not
+    /// a current room or is already last.
+    pub fn move_room_down(&mut self, room: VerifyingKey) {
+        let mut order = self.ordered_room_keys();
+        let Some(pos) = order.iter().position(|k| k == &room) else {
+            return;
+        };
+        if pos + 1 >= order.len() {
+            return;
+        }
+        order.swap(pos, pos + 1);
+        self.room_order = order;
+    }
 }
 
 #[cfg(test)]
@@ -3521,6 +3556,76 @@ mod tests {
         for k in &keys {
             assert!(rooms.room_order.contains(k));
         }
+    }
+
+    /// `move_room_up` swaps a room with the one above it, materialising the
+    /// full order from the deterministic baseline (the touch-friendly analog of
+    /// dragging a row up one slot — freenet/river#348).
+    #[test]
+    fn move_room_up_swaps_with_previous() {
+        let keys: Vec<VerifyingKey> = (1..=4).map(vk_from_seed).collect();
+        let mut rooms = rooms_with_keys(&keys);
+        let base = rooms.ordered_room_keys();
+
+        rooms.move_room_up(base[2]);
+        let after = rooms.ordered_room_keys();
+        assert_eq!(after, vec![base[0], base[2], base[1], base[3]]);
+        // The full order is now persisted (every current room, no stale keys).
+        assert_eq!(rooms.room_order, after);
+    }
+
+    /// `move_room_down` swaps a room with the one below it.
+    #[test]
+    fn move_room_down_swaps_with_next() {
+        let keys: Vec<VerifyingKey> = (1..=4).map(vk_from_seed).collect();
+        let mut rooms = rooms_with_keys(&keys);
+        let base = rooms.ordered_room_keys();
+
+        rooms.move_room_down(base[1]);
+        let after = rooms.ordered_room_keys();
+        assert_eq!(after, vec![base[0], base[2], base[1], base[3]]);
+        assert_eq!(rooms.room_order, after);
+    }
+
+    /// Moving up the first room (or down the last room) is a no-op — the
+    /// boundary controls are disabled in the UI, but the helper must not
+    /// corrupt the order even if called.
+    #[test]
+    fn move_room_up_down_noop_at_boundaries() {
+        let keys: Vec<VerifyingKey> = (1..=3).map(vk_from_seed).collect();
+        let mut rooms = rooms_with_keys(&keys);
+        let base = rooms.ordered_room_keys();
+
+        rooms.move_room_up(base[0]);
+        assert!(
+            rooms.room_order.is_empty(),
+            "moving the first room up must not reorder or materialise"
+        );
+
+        rooms.move_room_down(base[2]);
+        assert!(
+            rooms.room_order.is_empty(),
+            "moving the last room down must not reorder or materialise"
+        );
+
+        // Unknown key is also a no-op.
+        let ghost = vk_from_seed(99);
+        rooms.move_room_up(ghost);
+        rooms.move_room_down(ghost);
+        assert!(rooms.room_order.is_empty(), "unknown key is a no-op");
+    }
+
+    /// Repeated up/down moves round-trip back to the starting order — the
+    /// swap-adjacent helpers are exact inverses of each other.
+    #[test]
+    fn move_room_up_then_down_round_trips() {
+        let keys: Vec<VerifyingKey> = (1..=4).map(vk_from_seed).collect();
+        let mut rooms = rooms_with_keys(&keys);
+        let base = rooms.ordered_room_keys();
+
+        rooms.move_room_down(base[1]);
+        rooms.move_room_up(base[1]);
+        assert_eq!(rooms.ordered_room_keys(), base);
     }
 
     /// Leaving a room drops it from the manual order.

--- a/ui/tests/room-reorder-touch.spec.ts
+++ b/ui/tests/room-reorder-touch.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect, Page } from "@playwright/test";
+
+// Regression test for freenet/river#348.
+//
+// PR #346 added drag-and-drop room reordering using HTML5 `draggable` + drag
+// events, which browsers do NOT emit for touch gestures (iOS Safari / Android
+// Chrome). Touch users could therefore never reorder rooms. The fix adds a
+// "reorder mode" toggle in the Rooms header that reveals per-row up/down
+// controls. Those controls reorder via a plain `onclick`, which fires for both
+// pointer AND touch input, so reordering now works regardless of input type.
+//
+// The controls call the same input-agnostic persistence helpers
+// (`move_room_up` / `move_room_down` in ui/src/room_data.rs) that the drag path
+// uses, so this test exercises the full gesture → reorder wiring.
+
+async function waitForApp(page: Page) {
+  await page.waitForSelector(".app-root", { timeout: 30_000 });
+  await expect(page.locator("aside, .app-root button")).not.toHaveCount(0);
+}
+
+// Stable per-room testids (`room-item-{base58(owner_vk)}`, added in #363) in
+// rail (DOM) order. Identity-based, so it's robust to duplicate display names.
+async function railOrder(page: Page): Promise<string[]> {
+  return await page
+    .locator('[data-testid^="room-item-"]')
+    .evaluateAll((els) =>
+      els.map((e) => e.getAttribute("data-testid") || "").filter(Boolean)
+    );
+}
+
+test.describe("Touch-friendly room reorder (#348)", () => {
+  // Force a desktop width so the rail is visible on the mobile Playwright
+  // projects too. The up/down controls use a plain onclick (fires for touch and
+  // pointer alike), so the reorder behaviour is identical across input types —
+  // the bug was specifically that drag EVENTS never fire for touch.
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("reorder toggle reveals per-row up/down controls", async ({ page }) => {
+    await page.goto("/");
+    await waitForApp(page);
+
+    // Example data ships three rooms, so reordering is meaningful.
+    const names = await railOrder(page);
+    expect(names.length).toBeGreaterThanOrEqual(2);
+
+    // Controls are hidden until reorder mode is on.
+    await expect(page.getByTestId("reorder-room-up")).toHaveCount(0);
+    await expect(page.getByTestId("reorder-room-down")).toHaveCount(0);
+
+    await page.getByTestId("reorder-rooms-toggle").click();
+
+    // One up + one down control per row now.
+    await expect(page.getByTestId("reorder-room-up")).toHaveCount(names.length);
+    await expect(page.getByTestId("reorder-room-down")).toHaveCount(
+      names.length
+    );
+
+    // Boundary controls are disabled: the first row can't move up, the last
+    // row can't move down.
+    await expect(page.getByTestId("reorder-room-up").first()).toBeDisabled();
+    await expect(page.getByTestId("reorder-room-down").last()).toBeDisabled();
+
+    // Toggling off hides the controls again.
+    await page.getByTestId("reorder-rooms-toggle").click();
+    await expect(page.getByTestId("reorder-room-up")).toHaveCount(0);
+  });
+
+  test("move-down swaps a room with the one below it", async ({ page }) => {
+    await page.goto("/");
+    await waitForApp(page);
+
+    const before = await railOrder(page);
+    expect(before.length).toBeGreaterThanOrEqual(2);
+
+    await page.getByTestId("reorder-rooms-toggle").click();
+    await expect(page.getByTestId("reorder-room-down").first()).toBeEnabled();
+
+    // Move the first room down one slot.
+    await page.getByTestId("reorder-room-down").first().click();
+
+    await expect(async () => {
+      const after = await railOrder(page);
+      expect(after[0]).toBe(before[1]);
+      expect(after[1]).toBe(before[0]);
+      // Every other row keeps its position.
+      expect(after.slice(2)).toEqual(before.slice(2));
+    }).toPass({ timeout: 5_000 });
+  });
+
+  test("move-up swaps a room with the one above it", async ({ page }) => {
+    await page.goto("/");
+    await waitForApp(page);
+
+    const before = await railOrder(page);
+    expect(before.length).toBeGreaterThanOrEqual(2);
+
+    await page.getByTestId("reorder-rooms-toggle").click();
+
+    // Move the second room up one slot (its up control is the 2nd up button).
+    await page.getByTestId("reorder-room-up").nth(1).click();
+
+    await expect(async () => {
+      const after = await railOrder(page);
+      expect(after[0]).toBe(before[1]);
+      expect(after[1]).toBe(before[0]);
+      expect(after.slice(2)).toEqual(before.slice(2));
+    }).toPass({ timeout: 5_000 });
+  });
+});


### PR DESCRIPTION
## Problem

PR #346 added drag-and-drop room reordering in the Rooms rail using HTML5 `draggable` plus drag events. Browsers do not emit those events for touch gestures (iOS Safari, Android Chrome), so touch users could not reorder rooms at all. Issue #348 tracked adding a touch-friendly path.

## Approach

Add a "reorder mode" toggle to the Rooms header. When active, each room row shows up/down controls that move the room one slot, disabled at the list boundaries (the first row cannot move up, the last cannot move down). They reorder via a plain `onclick`, which fires for both touch and pointer input, so the touch gap closes without changing the existing drag-and-drop path (which stays for desktop pointer users).

The toggle is hidden until there are at least two rooms (nothing to reorder), but stays visible while reorder mode is on even if rooms drop to one, so the user can always toggle back out rather than getting stuck.

The controls call two new input-agnostic persistence helpers, `Rooms::move_room_up` / `move_room_down`, which swap adjacent entries in the effective order and persist the full order. They mirror the existing `move_room` / `move_room_to_end` drag helpers in `ui/src/room_data.rs`. All signal reads use `try_read()` and all mutations route through `crate::util::defer()`, per the Dioxus WASM signal-safety rules.

Scope: this is a UI-only change. Nothing under `common/`, `delegates/`, or `contracts/` is touched, so no delegate/contract migration is required.

## Testing

- Unit tests (`ui/src/room_data.rs`): swap-with-previous, swap-with-next, no-op at boundaries / unknown key, and an up-then-down round-trip. Run via `cargo test -p river-ui --bins`.
- Playwright (`ui/tests/room-reorder-touch.spec.ts`): the toggle reveals and hides per-row controls with correct boundary-disabling, and move-up / move-down swap the expected rows (asserted by the stable `room-item-{id}` testids from #363). Passes across all five browser projects including mobile-chrome and mobile-safari, the touch targets.
- Full local Playwright suite green (282 passed, 3 skipped) and the river-ui native unit tests green on the rebased branch.

Closes #348

[AI-assisted - Claude]
