### PR TITLE
fix(cli): include room description in `debug config` output

### DIFF
--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -58,6 +58,10 @@ struct RoomStateSummary {
 #[derive(Serialize)]
 struct RoomConfig {
     room_name: String,
+    /// Room description. `None` when unset; for a private room this is the
+    /// sealed bytes rendered lossily (riverctl does not unseal here), mirroring
+    /// `riverctl room config`'s no-flags display.
+    description: Option<String>,
     privacy_mode: String,
     configuration_version: u32,
     max_recent_messages: usize,
@@ -67,6 +71,33 @@ struct RoomConfig {
     max_members: usize,
     max_room_name: usize,
     max_room_description: usize,
+}
+
+impl RoomConfig {
+    /// Build the human/JSON view of a room's configuration. Mirrors the fields
+    /// `riverctl room config` prints with no flags — including the description,
+    /// which the dedicated `debug config` command previously omitted. The
+    /// description is rendered lossily and is NOT unsealed for a private room
+    /// (debug-only view), matching the no-flags `room config` path.
+    fn from_configuration(config: &river_core::room_state::configuration::Configuration) -> Self {
+        Self {
+            room_name: config.display.name.to_string_lossy(),
+            description: config
+                .display
+                .description
+                .as_ref()
+                .map(|d| d.to_string_lossy()),
+            privacy_mode: format!("{:?}", config.privacy_mode),
+            configuration_version: config.configuration_version,
+            max_recent_messages: config.max_recent_messages,
+            max_user_bans: config.max_user_bans,
+            max_message_size: config.max_message_size,
+            max_nickname_size: config.max_nickname_size,
+            max_members: config.max_members,
+            max_room_name: config.max_room_name,
+            max_room_description: config.max_room_description,
+        }
+    }
 }
 
 /// Build the JSON summary emitted by `debug contract-get --format json`.
@@ -330,24 +361,17 @@ pub async fn execute(command: DebugCommands, api: ApiClient, format: OutputForma
             let room_state = api.get_room(&owner_vk, false).await?;
 
             let config = &room_state.configuration.configuration;
-            let room_config = RoomConfig {
-                room_name: config.display.name.to_string_lossy(),
-                privacy_mode: format!("{:?}", config.privacy_mode),
-                configuration_version: config.configuration_version,
-                max_recent_messages: config.max_recent_messages,
-                max_user_bans: config.max_user_bans,
-                max_message_size: config.max_message_size,
-                max_nickname_size: config.max_nickname_size,
-                max_members: config.max_members,
-                max_room_name: config.max_room_name,
-                max_room_description: config.max_room_description,
-            };
+            let room_config = RoomConfig::from_configuration(config);
 
             match format {
                 OutputFormat::Human => {
                     println!("Room Configuration");
                     println!("==================");
                     println!("Room name: {}", room_config.room_name);
+                    println!(
+                        "Description: {}",
+                        room_config.description.as_deref().unwrap_or("(none)")
+                    );
                     println!("Privacy mode: {}", room_config.privacy_mode);
                     println!("Config version: {}", room_config.configuration_version);
                     println!();
@@ -407,6 +431,42 @@ mod tests {
         assert_eq!(json["room_name"], "My Room");
         assert_eq!(json["member_count"], 3);
         assert_eq!(json["message_count"], 42);
+    }
+
+    #[test]
+    fn room_config_includes_description() {
+        // Regression guard: `debug config` used to print the room name and
+        // every limit but silently drop the description, even though it is the
+        // command literally named "Show room configuration". Ensure the
+        // description survives both the struct and the JSON projection.
+        use river_core::room_state::configuration::Configuration;
+        use river_core::room_state::privacy::RoomDisplayMetadata;
+
+        let mut config = Configuration::default();
+        config.display =
+            RoomDisplayMetadata::public("My Room".to_string(), Some("Hello **world**".to_string()));
+
+        let rc = RoomConfig::from_configuration(&config);
+        assert_eq!(rc.room_name, "My Room");
+        assert_eq!(rc.description.as_deref(), Some("Hello **world**"));
+
+        let json = serde_json::to_value(&rc).unwrap();
+        assert_eq!(json["description"], "Hello **world**");
+    }
+
+    #[test]
+    fn room_config_description_none_when_unset() {
+        // A room with no description must serialize `description: null` (and
+        // render "(none)" in the human branch via `unwrap_or`), not panic or
+        // omit the field.
+        use river_core::room_state::configuration::Configuration;
+
+        let config = Configuration::default();
+        let rc = RoomConfig::from_configuration(&config);
+        assert_eq!(rc.description, None);
+
+        let json = serde_json::to_value(&rc).unwrap();
+        assert!(json["description"].is_null());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`riverctl debug config <OWNER>` — the command literally named "Show room configuration" — printed the room name and every limit but **silently dropped the description**. The only way to see a room's description from the CLI was `riverctl room config <OWNER>` with no flags, which is non-obvious. Ian hit this gap while fixing the Freenet Official room's description (a broken Dashboard link in the room header).

## Approach

Add `description: Option<String>` to the `RoomConfig` view and print it in both the human and JSON branches of `debug config` ("(none)" / `null` when unset).

The construction is extracted into a small testable `RoomConfig::from_configuration` constructor (previously an inline struct literal in the handler). The description is rendered lossily and **not** unsealed for private rooms — this matches the existing no-flags `room config` display and keeps `debug config` a pure read-only view.

Scope kept deliberately narrow: only `debug config` is touched. `debug room-state` remains a counts summary.

## Testing

- `room_config_includes_description` — pins that a set description survives both the struct and the JSON projection.
- `room_config_description_none_when_unset` — pins that an unset description serializes as `null` (and renders "(none)" via `unwrap_or`).
- `cargo test -p riverctl --lib debug::` green (4 passed).
- `cargo clippy -p riverctl` clean.
- Verified end-to-end against a live node: both `debug config` and `debug config -f json` now show the description.

[AI-assisted - Claude]