### PR TITLE
fix(ci): pin time to 0.3.51 to unbreak cookie 0.18.1 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,8 +92,18 @@ jobs:
     # Pin constant_time_eq to a version compatible with the pinned rustc
     # in rust-toolchain.toml. Newer versions require rustc ≥ 1.95 but we
     # pin rustc to keep WASM hashes deterministic; see rust-toolchain.toml.
+    #
+    # Pin `time` to 0.3.51: this repo has no committed Cargo.lock, so CI
+    # re-resolves dependencies on every run. time 0.3.52 changed the
+    # `Parsable::parse` signature, which cookie 0.18.1 (pulled in as a
+    # dev-dependency of room-contract via the `freenet` crate, exercised by
+    # `cargo test --package room-contract --features net`) cannot compile
+    # against. 0.3.51 still satisfies serde_with 3.x's `~0.3.47` floor.
+    # Remove once cookie ships a time-0.3.52-compatible release.
     - name: Pin dependencies compatible with pinned rustc
-      run: cargo update -p constant_time_eq --precise 0.4.2
+      run: |
+        cargo update -p constant_time_eq --precise 0.4.2
+        cargo update -p time --precise 0.3.51
 
     - name: Build Project
       run: cargo make build
@@ -254,11 +264,12 @@ jobs:
       run: npx playwright install --with-deps chromium firefox webkit
       working-directory: ./ui/tests
 
-    # Pin constant_time_eq — see comment in the build job.
+    # Pin constant_time_eq and time — see comment in the build job.
     - name: Pin dependencies compatible with pinned rustc
       run: |
         cargo generate-lockfile
         cargo update -p constant_time_eq --precise 0.4.2
+        cargo update -p time --precise 0.3.51
 
     - name: Build UI with example data
       run: cargo make build-ui-example-no-sync


### PR DESCRIPTION
## Problem

CI's `build` job is **red for every PR and push as of 2026-06-30**:

```
error[E0061]: this method takes 2 arguments but 1 argument was supplied
   --> cookie-0.18.1/src/parse.rs:226:27
   --> time-0.3.52/src/parsing/parsable.rs:62:12
error: could not compile `cookie` (lib) due to 1 previous error
```

This repo commits **no `Cargo.lock`** and CI does not pass `--locked`, so every run re-resolves dependencies from crates.io. `time 0.3.52` (published today) changed the `Parsable::parse` signature; `cookie 0.18.1` — a dev-dependency of `room-contract` via the `freenet` crate, compiled by `cargo test --package room-contract --features net` — still calls it with the old arity. Nothing in the source changed; the dependency graph drifted.

## Approach

`time` can't just be held below the break — `serde_with 3.21.0` (via `freenet-stdlib 0.6.1`) requires `time = "~0.3.47"`. The compatible window is `0.3.47`–`0.3.51`. Pin to **0.3.51** (newest that satisfies the floor and stays below the break) using the same `cargo update --precise` mechanism already used for `constant_time_eq`, in both the `build` and `ui-playwright-tests` jobs.

## Testing

Reproduced and verified locally:
- `cargo test --package room-contract --features net --no-run` with `time 0.3.52` → fails on `cookie` (E0061).
- After `cargo update -p time --precise 0.3.51` → `cookie` and the room-contract test build compile cleanly.

CI on this PR is the end-to-end confirmation.

## Follow-up

This class of break recurs because CI re-resolves on every run. The durable fix is to **commit a `Cargo.lock`** (or build with `--locked`) so CI stops drifting with each upstream publish. Pinning here is the minimal unblock; the lockfile question is worth a separate discussion. The `time` pin should be dropped once `cookie` ships a `time 0.3.52`-compatible release.

[AI-assisted - Claude]