### PR TITLE
ci: tag-triggered riverctl release (crates.io + GitHub release)

### DIFF
--- a/.claude/rules/river-publish.md
+++ b/.claude/rules/river-publish.md
@@ -80,13 +80,68 @@ git push origin main
 
 **Version policy:** the canonical source is `published-contract/contract-version.txt`, which `cargo make sign-webapp` increments and writes back each publish. NEVER base the version on wall-clock time (`date +%s / 60`) — the previous scheme bit us 2026-05-16 when the on-network version had drifted ahead of the timestamp-derived value. The counter file makes the version a strict monotonic local invariant; gaps are fine (the contract enforces monotonicity, not contiguity).
 
-## Publishing River UI + riverctl Together
+## Two independent release surfaces
 
-**CRITICAL:** When room contract WASM changes, both UI and riverctl must be republished — they embed the WASM and derive the contract key from it.
+The river repo publishes **two things on independent cadences** — do not conflate them:
+
+| Artifact | Where it goes | How it's released |
+|----------|---------------|-------------------|
+| **riverctl** (the CLI) | crates.io (`river-core` + `riverctl`) + GitHub release with prebuilt binaries | **tag-triggered CI** — see below |
+| **River UI** (Dioxus webapp) | Freenet (contract key `raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv`) | `cargo make publish-river` (the checklist above) |
+
+They are NOT 1:1 — a CLI-only fix ships riverctl without touching the UI, and a UI-only change publishes to Freenet without a new riverctl. The one coupling is room-contract WASM: when it changes, BOTH must be republished (they embed the WASM and derive the contract key from it).
+
+## Releasing riverctl (crates.io + GitHub release) — tag-triggered
+
+**Canonical path since 2026-07.** riverctl is released by pushing a git tag; the
+`.github/workflows/release-riverctl.yml` workflow then publishes to crates.io
+AND cuts the GitHub release (with prebuilt Linux/macOS/Windows binaries and
+auto-generated notes). This is why the GitHub releases page previously rotted at
+v0.1.22 while crates.io marched on — publishing used to be a laptop-only
+`cargo publish` that never touched GitHub.
 
 ```bash
-cargo make publish-all
+# 1. Bump the version in cli/Cargo.toml (via a normal PR), and — if the
+#    common/ crate (river-core) also changed — bump [workspace.package] version
+#    and riverctl's `river-core = { version = "..." }` requirement to match.
+#    Merge to main. (CI's check-cli-wasm guards the embedded room_contract.wasm.)
+
+# 2. From main, tag with the riverctl version and push the tag:
+git checkout main && git pull
+git tag riverctl-v$(grep -m1 '^version' cli/Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+git push origin riverctl-v<version>
 ```
+
+The workflow then:
+1. **verify** — refuses to run unless the tag version == `cli/Cargo.toml` version
+   AND the tagged commit is on `origin/main` (publish-from-main gate).
+2. **publish-crates** — publishes `river-core` (only if that version isn't already
+   on crates.io, waiting for index propagation) then `riverctl`. Idempotent, so a
+   CLI-only release skips the unchanged river-core.
+3. **build-binaries** — cross-builds `riverctl` for x86_64 Linux, x86_64 + aarch64
+   macOS, and x86_64 Windows.
+4. **github-release** — creates the GitHub release with those binaries + notes.
+
+**Requires repo secret `CARGO_REGISTRY_TOKEN`** (a crates.io publish-update token
+scoped to `river-core` + `riverctl`):
+```bash
+gh secret set CARGO_REGISTRY_TOKEN --repo freenet/river
+```
+
+**Tag scheme:** `riverctl-v<version>` (the `riverctl-` prefix disambiguates from
+the historical bare `v*` tags and leaves room for a future `ui-v*` scheme). The
+version is riverctl's own (`cli/Cargo.toml`), independent of `river-core`'s
+workspace version.
+
+### Local `cargo make publish-all` (legacy / fallback)
+
+`cargo make publish-all` still exists and publishes UI + bumps + `cargo publish`
+riverctl from your laptop. Prefer the tag-triggered CI path above for riverctl —
+it publishes from main under review and keeps crates.io and GitHub in sync. Use
+`publish-all` only for the coupled UI+riverctl WASM-change case when you
+specifically need to drive the Freenet publish and the CLI publish together
+locally; even then, consider publishing the UI locally and releasing riverctl via
+the tag.
 
 ## How Delegate Migration Works
 

--- a/.github/workflows/release-riverctl.yml
+++ b/.github/workflows/release-riverctl.yml
@@ -17,13 +17,20 @@ name: Release riverctl
 # `verify` job refuses to run if the tag version != cli/Cargo.toml version, or
 # if the tagged commit is not on origin/main (publish-from-main gate).
 #
-# Requires repo secret CARGO_REGISTRY_TOKEN (crates.io publish-update token
-# scoped to river-core + riverctl).
+# Requires repo secret CARGO_REGISTRY_TOKEN — a crates.io token that can publish
+# river-core + riverctl. Least-privilege: prefer a token SCOPED to just those
+# two crates with the publish-update scope; a broader (all-crates) token widens
+# the blast radius if the secret ever leaks.
 
 on:
   push:
     tags:
       - 'riverctl-v*'
+
+# Least-privilege default: jobs get read-only GITHUB_TOKEN. github-release
+# elevates to `contents: write` for itself only (see that job).
+permissions:
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -34,7 +41,7 @@ jobs:
     outputs:
       version: ${{ steps.check.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: Verify tag matches cli/Cargo.toml and commit is on main
@@ -50,20 +57,72 @@ jobs:
             echo "::error::Tag ($tag_version) does not match cli/Cargo.toml ($cargo_version). Bump the manifest, merge, then re-tag."
             exit 1
           fi
-          git fetch origin main --quiet
+          # actions/checkout with fetch-depth:0 already populates
+          # refs/remotes/origin/*; refresh origin/main explicitly to the latest
+          # so the ancestry check runs against current main.
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
             echo "::error::Tagged commit $GITHUB_SHA is not on origin/main. riverctl is published only from main."
             exit 1
           fi
           echo "version=$tag_version" >> "$GITHUB_OUTPUT"
 
-  publish-crates:
+  # Build the (recoverable) binaries BEFORE the irreversible crates.io publish,
+  # so an un-buildable target never leaves crates.io published-but-releaseless.
+  build-binaries:
     needs: verify
+    env:
+      VERSION: ${{ needs.verify.outputs.version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-13
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Install pinned Rust toolchain + target
+        shell: bash
+        run: |
+          rustup toolchain install       # installs the channel from rust-toolchain.toml
+          rustup target add "${{ matrix.target }}"
+      - name: Build riverctl
+        run: cargo build --release -p riverctl --target ${{ matrix.target }}
+      - name: Package (unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          name="riverctl-${VERSION}-${{ matrix.target }}"
+          tar -czf "$name.tar.gz" -C "target/${{ matrix.target }}/release" riverctl
+          echo "ASSET=$name.tar.gz" >> "$GITHUB_ENV"
+      - name: Package (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $name = "riverctl-$env:VERSION-${{ matrix.target }}"
+          Compress-Archive -Path "target/${{ matrix.target }}/release/riverctl.exe" -DestinationPath "$name.zip"
+          "ASSET=$name.zip" | Out-File -FilePath $env:GITHUB_ENV -Append
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: riverctl-${{ matrix.target }}
+          path: ${{ env.ASSET }}
+
+  publish-crates:
+    # Gate on the binary builds: don't run the irreversible crates.io publish
+    # unless every target compiled.
+    needs: [verify, build-binaries]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install pinned Rust toolchain
-        run: rustup show   # installs the channel pinned in rust-toolchain.toml
+        run: rustup toolchain install   # installs the channel from rust-toolchain.toml
       - name: Publish river-core then riverctl (skip if already on crates.io)
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -84,12 +143,23 @@ jobs:
               | python3 -c "import sys,json; d=json.load(sys.stdin); print(next(p['version'] for p in d['packages'] if p['name']=='$1'))"
           }
 
-          # crates.io reports a specific version as present when the versions
-          # array contains "num":"<ver>". Uses the exact-match crate endpoint.
+          # Is <pkg> <ver> already published? Read the SPARSE INDEX
+          # (index.crates.io) — the same source `cargo publish` resolves
+          # dependencies against, and one not subject to the crates.io JSON
+          # API's crawler/rate-limit blocking. Fetch into a variable first so a
+          # `curl | grep` SIGPIPE under `pipefail` can't misreport the result.
+          # A crate/version that doesn't exist yet 404s -> treated as absent.
           version_on_crates_io() {
-            local pkg="$1" ver="$2"
-            curl -fsSL -H "User-Agent: $ua" "https://crates.io/api/v1/crates/$pkg" \
-              | grep -q "\"num\":\"$ver\""
+            local pkg="$1" ver="$2" path body
+            case ${#pkg} in
+              1) path="1/$pkg" ;;
+              2) path="2/$pkg" ;;
+              3) path="3/${pkg:0:1}/$pkg" ;;
+              *) path="${pkg:0:2}/${pkg:2:2}/$pkg" ;;
+            esac
+            body="$(curl -fsSL --retry 3 --retry-delay 2 -H "User-Agent: $ua" \
+              "https://index.crates.io/$path" 2>/dev/null)" || return 1
+            grep -qF "\"vers\":\"$ver\"" <<<"$body"
           }
 
           publish_if_needed() {
@@ -106,13 +176,13 @@ jobs:
             # verification build can resolve the just-published version.
             for i in $(seq 1 30); do
               if version_on_crates_io "$pkg" "$ver"; then
-                echo "==> $pkg $ver visible on crates.io"
+                echo "==> $pkg $ver visible on the sparse index"
                 return 0
               fi
-              echo "    waiting for $pkg $ver to appear on crates.io ($i/30)..."
+              echo "    waiting for $pkg $ver to appear on the sparse index ($i/30)..."
               sleep 10
             done
-            echo "::error::$pkg $ver did not appear on crates.io within timeout"
+            echo "::error::$pkg $ver did not appear on the sparse index within timeout"
             exit 1
           }
 
@@ -121,69 +191,31 @@ jobs:
           publish_if_needed river-core
           publish_if_needed riverctl
 
-  build-binaries:
-    needs: verify
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-          - target: x86_64-apple-darwin
-            os: macos-13
-          - target: aarch64-apple-darwin
-            os: macos-latest
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install pinned Rust toolchain + target
-        shell: bash
-        run: |
-          rustup show                      # installs channel from rust-toolchain.toml
-          rustup target add ${{ matrix.target }}
-      - name: Build riverctl
-        run: cargo build --release -p riverctl --target ${{ matrix.target }}
-      - name: Package (unix)
-        if: runner.os != 'Windows'
-        shell: bash
-        run: |
-          name="riverctl-${{ needs.verify.outputs.version }}-${{ matrix.target }}"
-          tar -czf "$name.tar.gz" -C "target/${{ matrix.target }}/release" riverctl
-          echo "ASSET=$name.tar.gz" >> "$GITHUB_ENV"
-      - name: Package (windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $name = "riverctl-${{ needs.verify.outputs.version }}-${{ matrix.target }}"
-          Compress-Archive -Path "target/${{ matrix.target }}/release/riverctl.exe" -DestinationPath "$name.zip"
-          "ASSET=$name.zip" | Out-File -FilePath $env:GITHUB_ENV -Append
-      - uses: actions/upload-artifact@v4
-        with:
-          name: riverctl-${{ matrix.target }}
-          path: ${{ env.ASSET }}
-
   github-release:
     needs: [verify, publish-crates, build-binaries]
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # required to create the GitHub release
+      contents: write   # elevate above the top-level read-only floor to create the release
+    env:
+      VERSION: ${{ needs.verify.outputs.version }}
+      TAG: ${{ github.ref_name }}
+      GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Download binary artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: dist
           merge-multiple: true
-      - name: Create GitHub release
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Create or update GitHub release
         run: |
           set -euo pipefail
-          gh release create "${GITHUB_REF_NAME}" \
-            --title "riverctl v${{ needs.verify.outputs.version }}" \
-            --generate-notes \
-            dist/*
+          # Idempotent: if the release already exists (e.g. a re-run after a
+          # transient failure), upload/replace the assets instead of aborting.
+          if ! gh release create "$TAG" \
+                --title "riverctl v${VERSION}" \
+                --generate-notes \
+                dist/*; then
+            echo "Release $TAG already exists — uploading assets with --clobber"
+            gh release upload "$TAG" dist/* --clobber
+          fi

--- a/.github/workflows/release-riverctl.yml
+++ b/.github/workflows/release-riverctl.yml
@@ -1,0 +1,189 @@
+name: Release riverctl
+
+# Tag-triggered release for the `riverctl` CLI.
+#
+# This is riverctl ONLY. The River UI (Dioxus webapp) is published to Freenet
+# via `cargo make publish-river` and releases on its own cadence — do NOT wire
+# UI publishing into this workflow (see .claude/rules/river-publish.md).
+#
+# Release flow:
+#   1. Bump `version` in cli/Cargo.toml via a normal PR, merge to main.
+#      (CI's check-cli-wasm already guards the embedded room_contract.wasm.)
+#   2. git tag riverctl-v<version> && git push origin riverctl-v<version>
+#   3. This workflow publishes to crates.io AND cuts the GitHub release
+#      (with prebuilt binaries + auto-generated notes).
+#
+# The tag is both the trigger and the source of truth for the version: the
+# `verify` job refuses to run if the tag version != cli/Cargo.toml version, or
+# if the tagged commit is not on origin/main (publish-from-main gate).
+#
+# Requires repo secret CARGO_REGISTRY_TOKEN (crates.io publish-update token
+# scoped to river-core + riverctl).
+
+on:
+  push:
+    tags:
+      - 'riverctl-v*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Verify tag matches cli/Cargo.toml and commit is on main
+        id: check
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          tag_version="${tag#riverctl-v}"
+          cargo_version="$(grep -m1 '^version' cli/Cargo.toml | sed 's/.*"\(.*\)".*/\1/')"
+          echo "tag version:   $tag_version"
+          echo "Cargo version: $cargo_version"
+          if [ "$tag_version" != "$cargo_version" ]; then
+            echo "::error::Tag ($tag_version) does not match cli/Cargo.toml ($cargo_version). Bump the manifest, merge, then re-tag."
+            exit 1
+          fi
+          git fetch origin main --quiet
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tagged commit $GITHUB_SHA is not on origin/main. riverctl is published only from main."
+            exit 1
+          fi
+          echo "version=$tag_version" >> "$GITHUB_OUTPUT"
+
+  publish-crates:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pinned Rust toolchain
+        run: rustup show   # installs the channel pinned in rust-toolchain.toml
+      - name: Publish river-core then riverctl (skip if already on crates.io)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
+            echo "::error::CARGO_REGISTRY_TOKEN secret is not set. Add it with: gh secret set CARGO_REGISTRY_TOKEN --repo freenet/river"
+            exit 1
+          fi
+          ua="river-release-ci (https://github.com/freenet/river)"
+
+          # Resolve a package's version via cargo metadata — robust to
+          # workspace inheritance (common/ uses `version.workspace = true`,
+          # so grepping its Cargo.toml would yield the literal string, not
+          # the resolved version).
+          pkg_version() {
+            cargo metadata --no-deps --format-version 1 \
+              | python3 -c "import sys,json; d=json.load(sys.stdin); print(next(p['version'] for p in d['packages'] if p['name']=='$1'))"
+          }
+
+          # crates.io reports a specific version as present when the versions
+          # array contains "num":"<ver>". Uses the exact-match crate endpoint.
+          version_on_crates_io() {
+            local pkg="$1" ver="$2"
+            curl -fsSL -H "User-Agent: $ua" "https://crates.io/api/v1/crates/$pkg" \
+              | grep -q "\"num\":\"$ver\""
+          }
+
+          publish_if_needed() {
+            local pkg="$1"
+            local ver
+            ver="$(pkg_version "$pkg")"
+            if version_on_crates_io "$pkg" "$ver"; then
+              echo "==> $pkg $ver already on crates.io — skipping"
+              return 0
+            fi
+            echo "==> Publishing $pkg $ver"
+            cargo publish -p "$pkg"
+            # Wait for the sparse index to catch up so a dependent crate's
+            # verification build can resolve the just-published version.
+            for i in $(seq 1 30); do
+              if version_on_crates_io "$pkg" "$ver"; then
+                echo "==> $pkg $ver visible on crates.io"
+                return 0
+              fi
+              echo "    waiting for $pkg $ver to appear on crates.io ($i/30)..."
+              sleep 10
+            done
+            echo "::error::$pkg $ver did not appear on crates.io within timeout"
+            exit 1
+          }
+
+          # river-core (the common/ crate) is riverctl's only workspace
+          # dependency that must exist on crates.io before riverctl publishes.
+          publish_if_needed river-core
+          publish_if_needed riverctl
+
+  build-binaries:
+    needs: verify
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-13
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pinned Rust toolchain + target
+        shell: bash
+        run: |
+          rustup show                      # installs channel from rust-toolchain.toml
+          rustup target add ${{ matrix.target }}
+      - name: Build riverctl
+        run: cargo build --release -p riverctl --target ${{ matrix.target }}
+      - name: Package (unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          name="riverctl-${{ needs.verify.outputs.version }}-${{ matrix.target }}"
+          tar -czf "$name.tar.gz" -C "target/${{ matrix.target }}/release" riverctl
+          echo "ASSET=$name.tar.gz" >> "$GITHUB_ENV"
+      - name: Package (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $name = "riverctl-${{ needs.verify.outputs.version }}-${{ matrix.target }}"
+          Compress-Archive -Path "target/${{ matrix.target }}/release/riverctl.exe" -DestinationPath "$name.zip"
+          "ASSET=$name.zip" | Out-File -FilePath $env:GITHUB_ENV -Append
+      - uses: actions/upload-artifact@v4
+        with:
+          name: riverctl-${{ matrix.target }}
+          path: ${{ env.ASSET }}
+
+  github-release:
+    needs: [verify, publish-crates, build-binaries]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # required to create the GitHub release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Download binary artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "riverctl v${{ needs.verify.outputs.version }}" \
+            --generate-notes \
+            dist/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,8 +143,17 @@ cargo fmt
 
 ### Publishing & Verification
 
+There are **two independent release surfaces** (see `.claude/rules/river-publish.md`):
+- **River UI** (Dioxus webapp → Freenet): `cargo make publish-river`.
+- **riverctl** (CLI → crates.io + GitHub release): **tag-triggered CI**. Bump
+  `cli/Cargo.toml`, merge, then `git tag riverctl-v<version> && git push origin
+  riverctl-v<version>`. The `release-riverctl.yml` workflow publishes to crates.io
+  and cuts the GitHub release with prebuilt binaries. (Requires the
+  `CARGO_REGISTRY_TOKEN` repo secret.) Do NOT wire UI publishing into that
+  workflow — they release on independent cadences.
+
 ```bash
-cargo make publish-river                    # Publish release build to Freenet
+cargo make publish-river                    # Publish UI release build to Freenet
 ```
 
 The web container contract requires signed metadata with a version

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -592,7 +592,13 @@ echo "Bumped riverctl: $CURRENT → $NEW_VERSION"
 '''
 
 [tasks.publish-all]
-description = "Publish both River UI and riverctl together (keeps WASM in sync)"
+# NOTE: the canonical way to release riverctl is now the tag-triggered CI
+# workflow (.github/workflows/release-riverctl.yml) — push a `riverctl-v<ver>`
+# tag and CI publishes to crates.io AND cuts the GitHub release with binaries.
+# See .claude/rules/river-publish.md "Releasing riverctl". This local task
+# remains for the coupled UI+riverctl WASM-change case / as a fallback; it
+# publishes from your laptop and does NOT create a GitHub release.
+description = "Publish River UI + riverctl locally (legacy; prefer tag-triggered CI for riverctl)"
 dependencies = ["sync-cli-wasm"]
 script = '''
 #!/bin/bash

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riverctl"
-version = "0.1.71"
+version = "0.1.72"
 edition = "2021"
 authors = ["Freenet Project"]
 description = "Command-line interface for River decentralized chat on Freenet"


### PR DESCRIPTION
## Problem

The GitHub releases page on this repo is stale at **v0.1.22 (Dec 25, 2025)** while `riverctl` has kept shipping to crates.io (**0.1.71**, Jun 2026). The cause: publishing is a laptop-only `cargo make publish-all` that runs `cargo publish` but never creates a git tag or a GitHub release. So the releases page shows a misleading "Latest", offers no prebuilt binaries, and the crates.io publish happens from an unreviewed local checkout.

## Approach

Add `.github/workflows/release-riverctl.yml`, triggered by pushing a `riverctl-v<version>` tag. The tag is both the trigger and the version source of truth.

Jobs:
1. **verify** — refuses to run unless the tag version == `cli/Cargo.toml` version **and** the tagged commit is on `origin/main` (publish-from-main gate).
2. **publish-crates** — publishes `river-core` (only if that version isn't already on crates.io, waiting for sparse-index propagation) then `riverctl`. Idempotent/skip-if-exists, so a CLI-only release skips the unchanged `river-core`. Versions resolved via `cargo metadata` because `common/` (river-core) inherits `[workspace.package]` version.
3. **build-binaries** — cross-builds `riverctl` for x86_64 Linux, x86_64 + aarch64 macOS, x86_64 Windows (GitHub-hosted runners; repo is public so these are free).
4. **github-release** — creates the GitHub release with those binaries + `--generate-notes`.

**Scoped to riverctl only.** The River UI (Dioxus → Freenet, contract key `raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv`) keeps releasing independently via `cargo make publish-river` — they are not 1:1 and must stay decoupled.

Docs updated so future work uses the tag flow: a "Releasing riverctl" section + a "two independent release surfaces" table in `.claude/rules/river-publish.md`, a pointer in `AGENTS.md`, and a deprecation note on the local `publish-all` task.

## Required before this can publish

Add the crates.io token as a repo secret (not currently present in repo or org secrets):
```bash
gh secret set CARGO_REGISTRY_TOKEN --repo freenet/river
```
A crates.io **publish-update** token scoped to `river-core` + `riverctl`.

## Testing

- YAML validated; version extraction and `cargo metadata` resolution checked locally (river-core 0.1.12, riverctl 0.1.71).
- The full publish path is only exercised on a real tag push (needs the secret). First real release will supersede v0.1.22 as "Latest".
- No WASM files touched (verified per the repo's wasm-safety rule).

## Notes / open questions

- Existing stale releases (v0.1.22 etc.) are left as history; the first tagged release becomes "Latest". Say if you'd rather I delete the old ones.
- Binary target set is the standard four — easy to trim/extend (e.g. add linux musl static).
- I left `cargo make publish-all` functional but documented it as legacy/fallback rather than ripping `cargo publish` out of it, to avoid surprising anything that depends on it. Happy to remove the crates publish from it in a follow-up so there's a single publish path.

[AI-assisted - Claude]