### PR TITLE
ci: build x86_64-apple-darwin on Apple Silicon (macos-13 retired)

### DIFF
--- a/.github/workflows/release-riverctl.yml
+++ b/.github/workflows/release-riverctl.yml
@@ -79,8 +79,12 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+          # Both macOS targets build on Apple Silicon (macos-latest): the
+          # Intel `macos-13` runner is being retired by GitHub and no longer
+          # gets allocated, so x86_64-apple-darwin is cross-compiled from arm64
+          # (the `rustup target add` + `cargo build --target` step handles it).
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc


### PR DESCRIPTION
## Problem

The first tagged release (`riverctl-v0.1.72`, run [28677460838](https://github.com/freenet/river/actions/runs/28677460838)) got stuck: `verify` + 3 of 4 binary builds (linux, arm64 macOS, windows) succeeded, but **`x86_64-apple-darwin` on `macos-13` sat queued ~11.5h** — GitHub is retiring the Intel `macos-13` runner and no longer allocates it.

**No half-release occurred:** `publish-crates` is gated on `build-binaries`, so the stuck Intel build correctly blocked the crates.io publish. Nothing was published under 0.1.72. (This validated the review's build-before-publish ordering.)

## Fix

Build **both** macOS targets on `macos-latest` (Apple Silicon). `x86_64-apple-darwin` is cross-compiled from arm64 via the existing `rustup target add` + `cargo build --target` step — no native Intel runner needed. Keeps Intel-mac binary coverage.

## Caveat

The release workflow only runs on tags, so PR CI does **not** exercise this cross-compile leg — it's first tested by the re-tagged run. It **fails safe**: if a dependency doesn't cross-compile to x86_64 from arm64, `build-binaries` fails and nothing publishes. Fallback if it fails: drop the `x86_64-apple-darwin` target (ship arm64 macOS + linux + windows) and add it back later.

## To complete the release after merge

Re-point the (unconsumed) tag to the fixed commit:
```bash
git tag -d riverctl-v0.1.72 && git push origin :riverctl-v0.1.72
git tag riverctl-v0.1.72 <new main HEAD> && git push origin riverctl-v0.1.72
```

[AI-assisted - Claude]