### PR TITLE
perf: shrink River UI WASM ~15% via size-optimized web profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,22 @@ strip = true        # Strip symbols from binary
 [profile.release.package."*"]
 opt-level = 'z'     # Optimize all dependencies for size as well
 
+# Profile used by `dx build --release` for the web/WASM UI target.
+#
+# The Dioxus CLI (dx) builds the web app under a profile named `wasm-release`.
+# If we do NOT define it here, dx synthesises an ad-hoc one that inherits
+# `release` but overrides `opt-level` to "s". By defining it ourselves, dx
+# uses THIS profile verbatim (it only force-disables `strip`, applying strip
+# later via wasm-opt), so we get `opt-level = "z"` (size) for the UI crate and
+# all its wasm deps instead of dx's "s".
+#
+# This profile is UI-only: the room-contract and chat-delegate WASMs are built
+# with `--profile release` (see Makefile.toml), so their bytes (and therefore
+# the delegate/contract keys) are unaffected by anything here.
+[profile.wasm-release]
+inherits = "release"
+opt-level = 'z'
+
 [profile.wasm-dev]
 inherits = "dev"
 opt-level = 1

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -7,7 +7,9 @@ authors = ["Ian Clarke <ian@freenet.org>"]
 [features]
 default = [] # Add a default feature set if needed, often empty
 delegate = [] # Define the delegate feature
-example-data = []
+# `lipsum` is only used by the (feature-gated) example_data module, so it is an
+# optional dependency pulled in only when example-data is enabled.
+example-data = ["dep:lipsum"]
 no-sync = []
 
 [dependencies]
@@ -27,7 +29,9 @@ getrandom = { version = "0.2.15", features = ["js", "wasm-bindgen", "js-sys"], d
 
 # UI Framework
 dioxus = { version = "0.7.3", features = ["web"] }
-dioxus-free-icons = { version = "0.10.0", features = ["font-awesome-brands", "font-awesome-regular", "font-awesome-solid"] }
+# Only `fa_solid_icons` are referenced in the UI (verified by grep). Dropping
+# the brands/regular feature sets trims their icon modules from the build.
+dioxus-free-icons = { version = "0.10.0", features = ["font-awesome-solid"] }
 
 # Web-related
 web-sys = { workspace = true, features = [
@@ -58,7 +62,7 @@ web-sys = { workspace = true, features = [
 ] }
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true
-lipsum = "0.9.1"
+lipsum = { version = "0.9.1", optional = true }
 
 # Utilities
 blake3.workspace = true


### PR DESCRIPTION
## Problem

`river-ui_bg.wasm` is the dominant load cost for try.freenet.org: ~4.96 MB
uncompressed (~1.1 MB zstd), which is a 3-10s download for real users.

The release profile was already well tuned (`opt-level = 'z'`, `lto`,
`codegen-units = 1`, `panic = 'abort'`, `strip`), **but that profile does not
apply to the web build.** The Dioxus CLI builds the web app under a profile it
names `wasm-release`. When we don't define that profile, dx synthesises an
ad-hoc one that inherits `release` but **overrides `opt-level` to `"s"`**
(`dioxus-cli/src/build/request.rs::profile_args`), so the UI crate was being
compiled for speed-ish size ("s") rather than smallest size ("z").

## Approach

Define `[profile.wasm-release]` ourselves (`inherits = "release"`,
`opt-level = "z"`). dx detects a user-defined profile and uses it verbatim
(it only force-disables `strip`, which it re-applies later via `wasm-opt`), so
the UI crate is now compiled at `opt-level = "z"` like the rest of the release
build.

Measured on a clean `dx build --release` of the UI:

| river-ui_bg.wasm | uncompressed | gzip -9 | zstd-19 |
|---|---|---|---|
| baseline (opt-level s) | 4,964,790 | 1,609,983 | 1,130,678 |
| **opt-level z** | **4,231,712** | **1,422,193** | **1,016,353** |
| reduction | **-733 KB / 14.8%** | **-188 KB / 11.7%** | **-114 KB / 10.1%** |

The entire saving is in the code section. The data section (which contains the
`include_bytes!`-embedded room-contract + chat-delegate WASMs) is unchanged.
Crypto and the other dependencies were **already** `opt-level = "z"` via
`[profile.release.package."*"]`, so this only changes the UI crate's own code
from `s` to `z`; no perf-sensitive dependency is affected, which is why the
runtime impact is negligible for a chat UI.

Also bundled in (both aimed at shrinking the UI build; each is a correctness
cleanup with negligible measured size effect on top of LTO/DCE, ~130 bytes):
- **dioxus-free-icons**: drop the `font-awesome-brands` / `font-awesome-regular`
  feature sets. Only `fa_solid_icons` is referenced anywhere in the UI.
- **lipsum**: mark `optional` and gate behind `example-data`. Its only user is
  the `#[cfg(feature = "example-data")]` `example_data` module.

### UI-build-only — no migration

The room-contract and chat-delegate WASMs are built with `--profile release`
(see `Makefile.toml`), so `[profile.wasm-release]` does not touch them. Verified
byte-identical before/after:

- `ui/public/contracts/room_contract.wasm`: `3425049280a0…` (unchanged)
- `ui/public/contracts/chat_delegate.wasm`: `c42abcdd466d…` (unchanged)

No delegate/contract key change, so no `legacy_delegates.toml` entry is needed.
CI's `check-delegate-migration` / `check-room-contract-migration` /
`check-cli-wasm` should confirm this.

## Testing

- **Full Playwright suite passes** against the optimized build: 282 passed / 3
  skipped (pre-existing) across chromium, firefox, webkit, mobile-chrome, and
  mobile-safari (`cargo make build-ui-example-no-sync` + `npx playwright test`).
- The `example-data` build compiles cleanly with the now-optional `lipsum`
  (feature pulls it in via `dep:lipsum`).
- Contract/delegate WASM hashes confirmed unchanged (see above).

[AI-assisted - Claude]