### PR TITLE
fix(ui): keep self message bubbles inside the viewport on mobile

### DIFF
--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -2294,10 +2294,20 @@ fn MessageGroupComponent(
                         let reply_target_id_val = msg.reply_to_message_id.clone();
 
                         rsx! {
+                            // `min-w-0 max-w-full` clamps this per-message wrapper to
+                            // its column (`max-w-[75%]`) width. For a SELF message the
+                            // enclosing bubbles wrapper is `flex flex-col items-end`, so
+                            // without this the wrapper is a non-stretched flex item that
+                            // sizes to the bubble's `max-w-prose` (65ch) content width and
+                            // escapes the column. A self reply whose nowrap reply-strip
+                            // preview holds a long URL then overflows both edges of a
+                            // narrow mobile viewport (clipped, text cut off). `min-w-0`
+                            // lets the flex item shrink below its content's min-size so
+                            // `max-w-full` can actually take effect.
                             div {
                                 key: "{msg.id}",
                                 id: "msg-{msg.id}",
-                                class: "flex flex-col group",
+                                class: "flex flex-col group min-w-0 max-w-full",
                                 // Container for message bubble + hover actions
                                 div {
                                     class: "relative",

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -403,6 +403,49 @@ fn add_example_messages(
         messages.messages.push(long_url_msg);
     }
 
+    // A SELF (owner-authored) reply whose quoted preview is the long URL above.
+    // The reply strip renders its preview with `white-space: nowrap`, so an
+    // unbreakable long URL in the preview drives the bubble to its full
+    // `max-w-prose` width. On a self (right-aligned) message that used to
+    // overflow the viewport on narrow mobile screens, clipping the bubble off
+    // both edges. Kept in example data so the mobile-overflow Playwright
+    // regression test has a self bubble that WOULD overflow without the
+    // per-message width clamp.
+    if let Some(long_url_msg) = messages.messages.last().cloned() {
+        let target_id = long_url_msg.id();
+        let target_author_id = long_url_msg.message.author;
+        let target_author_name = room_state
+            .member_info
+            .member_info
+            .iter()
+            .find(|m| m.member_info.member_id == target_author_id)
+            .map(|m| m.member_info.preferred_nickname.to_string_lossy())
+            .unwrap_or_else(|| "someone".to_string());
+        let target_preview = match &long_url_msg.message.content {
+            RoomMessageBody::Public { data, .. } => {
+                let preview_len = data.len().min(120);
+                String::from_utf8_lossy(&data[..preview_len]).to_string()
+            }
+            _ => String::new(),
+        };
+        current_time_ms += 30_000;
+        let self_reply_to_long_url = AuthorizedMessageV1::new(
+            MessageV1 {
+                room_owner: *owner_id,
+                author: *owner_id,
+                time: get_time_from_millis(current_time_ms),
+                content: RoomMessageBody::reply(
+                    "yep, seen that one".to_string(),
+                    target_id,
+                    target_author_name,
+                    target_preview,
+                ),
+            },
+            owner_key,
+        );
+        messages.messages.push(self_reply_to_long_url);
+    }
+
     // Add reactions to messages from OTHER members (not owner)
     // Rule: One reaction per user per message
     // In "Your Private Room" the owner IS self, so this shows self reacting to others

--- a/ui/tests/message-layout.spec.ts
+++ b/ui/tests/message-layout.spec.ts
@@ -481,3 +481,64 @@ test.describe("Auto-scroll to bottom on refresh", () => {
     expect(sentinelInView).toBe(true);
   });
 });
+
+// Mobile self-message overflow: a SELF (right-aligned) bubble must stay fully
+// within a narrow viewport. Regression: a self reply whose reply-strip preview
+// held a long unbreakable URL rendered nowrap, driving the bubble to its full
+// `max-w-prose` (65ch) width. As a non-stretched flex item under the self
+// bubbles wrapper's `items-end`, that wrapper sized to the bubble's content and
+// escaped the `max-w-[75%]` column, so the bubble spilled off BOTH edges of a
+// 375px screen (clipped, message text cut off left and right), exactly the
+// "text going off the edge" report. Received (left-aligned) bubbles were fine
+// because their wrapper is a plain block that already fills the column. Fixed
+// by `min-w-0 max-w-full` on the per-message wrapper (conversation.rs). The
+// example data carries a self reply to the long-URL message so this reproduces.
+test.describe("Self message bubble mobile overflow", () => {
+  test.use({ viewport: { width: 375, height: 667 } });
+
+  test("no message bubble overflows either edge of a 375px viewport", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectRoom(page, "Your Private Room");
+
+    // The specific reproducer must be present: a reply strip quoting the long
+    // URL. (Its textContent keeps the full preview even though CSS ellipsizes
+    // it, so this also proves the strip rendered rather than being absent.)
+    const longReplyStrip = page
+      .locator(".reply-strip")
+      .filter({ hasText: "longlongurl" })
+      .first();
+    await expect(longReplyStrip).toBeVisible({ timeout: 10_000 });
+
+    // Horizontal position is independent of vertical scroll, so every rendered
+    // bubble can be checked at once: each must lie within [0, viewportWidth].
+    // Before the fix the self reply bubble sat at left ≈ -169 / right ≈ 359 in
+    // a 375px viewport (width 528). After the fix it is clamped to the column.
+    const overflow = await page.evaluate(() => {
+      const vw = window.innerWidth;
+      const bad: Array<{ left: number; right: number; width: number; text: string }> = [];
+      for (const b of Array.from(document.querySelectorAll(".max-w-prose"))) {
+        const r = b.getBoundingClientRect();
+        if (r.width === 0) continue;
+        if (r.left < -1 || r.right > vw + 1) {
+          bad.push({
+            left: Math.round(r.left),
+            right: Math.round(r.right),
+            width: Math.round(r.width),
+            text: (b.textContent || "").trim().replace(/\s+/g, " ").slice(0, 40),
+          });
+        }
+      }
+      return { vw, bad };
+    });
+
+    expect(
+      overflow.bad,
+      `message bubbles overflowing the ${overflow.vw}px viewport: ${JSON.stringify(
+        overflow.bad
+      )}`
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

On narrow mobile viewports, **self (right-aligned) message bubbles spill off both edges of the screen**, clipping the message text on the left and right. This is the "text fields going off the edge of the screen" report.

Audited against a real populated peer at iPhone SE (375), iPhone 12/13 (390), small Android (360), and iPhone XR (414), portrait. The self bubbles measured **528px wide inside a 375px viewport** (`left: -169, right: 359`), i.e. right-aligned content clipped off the left edge. Received (gray, left-aligned) bubbles, the room list, the members list, and the create-room / edit-room / invite-member / member-info modals all measured clean at every viewport — the bug is specific to self message bubbles.

Before (real peer): a blue self message reads `org/build/manual/further-reading/…` with the leading `https://freenet.` clipped off the left, and the tail clipped off the right.

## Root cause

The self bubbles wrapper is `flex flex-col items-end`, so each per-message wrapper is a **non-stretched flex item that sizes to its content**. When a self bubble reaches its `max-w-prose` (65ch, ~528px) cap it **escapes the `max-w-[75%]` column**, and because it is right-aligned it overflows off the left edge (clipping on the right). The trigger in the wild is a self **reply** whose reply-strip preview holds a long unbreakable URL: `.reply-strip` renders `white-space: nowrap`, driving the bubble to its full max width. Received (left-aligned) bubbles were unaffected because their wrapper is a plain block that already fills the column.

This does **not** cause document-level horizontal scroll (the bubble is clipped), which is why the existing `#212` doc-overflow assertion never caught it.

## Approach

Add `min-w-0 max-w-full` to the per-message wrapper (`ui/src/components/conversation.rs`) so it can never exceed its column. `min-w-0` lets the flex item shrink below its content's min-size so `max-w-full` (`max-width: 100%`) actually binds. Minimal, no redesign.

Desktop is unchanged: on wide screens the column is wider than `max-w-prose`, so bubbles still cap at the 65ch readable width (verified: widest bubble still 528px at 1280px, no overflow).

## Testing

- **New Playwright regression test** (`ui/tests/message-layout.spec.ts`) at 375px: asserts no `.max-w-prose` bubble overflows either viewport edge. Runs on all 5 CI projects (chromium, firefox, webkit, mobile-chrome, mobile-safari).
- **Reproducing example data**: a self reply to the long-URL message (`ui/src/example_data.rs`). Without the fix that bubble measures `left -169 / right 359 / width 528` at 375px (the test's assertion is non-empty → fails); with the fix it is clamped to the column (`width 257`, no overflow → passes).
- Full existing layout suite green across all 5 projects (**112 passed, 3 skipped**), including `#205/#206/#207/#210/#212/#221` and the responsive-layout suite — no regression.
- After-fix verification across 360 / 375 / 390 / 414 / 768 / 1280: no bubble overflow at any width; desktop unchanged.
- `cargo test -p river-ui --bins`: 374 passed. `cargo fmt` clean.

## Migration

**UI-only change.** Only `ui/src/` and `ui/tests/` are touched — no `common/`, `delegates/`, `contracts/`, or `Cargo.toml`/`Cargo.lock` changes, and no `.wasm` files modified. **No delegate/contract migration required.**

Screenshots (saved locally for review): `before-*` / `repro-nofix-*` show the 528px overflow; `after-fix-*` / `fixed2-*` show it clamped.

[AI-assisted - Claude]