### PR TITLE
fix(cli): riverctl can't read encrypted rooms — decrypt message bodies, room names, and nicknames

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -2969,6 +2969,15 @@ impl ApiClient {
         // Fetch fresh state from network so build_rejoin_delta can detect pruning
         let mut room_state = self.get_room(room_owner_key, false).await?;
 
+        // Decrypt the room's private content BEFORE selecting the reply target:
+        // this rebuilds `actions_state` from the decrypted private edit/delete
+        // actions, so a target the user already deleted is correctly excluded
+        // (`display_messages()` hides it) and an edited target's quoted preview
+        // reflects the edit rather than the stale original. Returns the secrets
+        // used to decrypt the preview body below (empty map / no-op for a public
+        // room, so behaviour there is unchanged).
+        let secrets = self.room_display_secrets(room_owner_key, &mut room_state);
+
         // Find the target message to extract author name and content preview
         let target_msg = room_state
             .recent_messages
@@ -2986,19 +2995,10 @@ impl ApiClient {
             .map(|info| info.member_info.preferred_nickname.to_string_lossy())
             .unwrap_or_else(|| target_msg.message.author.to_string());
 
-        // Collect the room's decryption secrets so the quoted preview of a
-        // PRIVATE target message is its plaintext, not "<encrypted>". Without
-        // this, the CLI sealed "<encrypted>" into the reply's `ReplyContentV1`,
-        // so the quoted context showed "<encrypted>" to every reader forever.
-        // (Reused below to seal the reply body itself — a public room yields an
-        // empty map and unchanged behaviour.)
-        let invitation_secrets = self.storage.get_invitation_secrets(room_owner_key)?;
-        let secrets = crate::private_room::collect_secrets_for_room(
-            &room_state,
-            &signing_key,
-            &invitation_secrets,
-        );
-
+        // Quote the target's plaintext. A PRIVATE target body is decrypted via
+        // `secrets`; without this the CLI sealed "<encrypted>" into the reply's
+        // `ReplyContentV1`, so the quoted context read "<encrypted>" to every
+        // reader forever.
         let target_content_preview: String =
             message_display_text_with_secrets(&room_state, target_msg, &secrets)
                 .chars()
@@ -3013,6 +3013,7 @@ impl ApiClient {
         // target author name and content preview are sealed alongside the reply
         // text in a private room (they are part of `ReplyContentV1`), so the
         // reply context is not leaked in the clear.
+        let invitation_secrets = self.storage.get_invitation_secrets(room_owner_key)?;
         let content = crate::private_room::build_reply_body(
             &room_state,
             &signing_key,

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -194,6 +194,30 @@ pub(crate) fn render_mentions_for_terminal(room_state: &ChatRoomStateV1, text: &
     })
 }
 
+/// Resolve a member's `preferred_nickname` [`SealedBytes`] to its display
+/// string, decrypting a **private**-room sealed nickname with `secrets`.
+///
+/// Mirrors the UI (`unseal_bytes_with_secrets` at
+/// `ui/src/components/members.rs`): a public nickname yields its plaintext; a
+/// private one is decrypted with the version-matched room secret; when the
+/// secret is unavailable it falls back to the sealed placeholder
+/// (`[Encrypted: N bytes, vN]`) rather than showing raw ciphertext. `secrets`
+/// is empty for a public room / a room not in local storage, so public
+/// nicknames are unaffected.
+///
+/// Without this, riverctl rendered every private-room member as
+/// `[Encrypted: N bytes, vN]` — and, worse, `send_reply` sealed that
+/// placeholder into `ReplyContentV1.target_author_name`, persisting it to
+/// contract state for every reader (including the UI).
+pub(crate) fn unseal_nickname_display(
+    nickname: &river_core::room_state::privacy::SealedBytes,
+    secrets: &HashMap<u32, [u8; 32]>,
+) -> String {
+    river_core::ecies::unseal_bytes_with_secrets(nickname, secrets)
+        .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
+        .unwrap_or_else(|_| nickname.to_string_lossy())
+}
+
 /// Convert bare `@nickname` mentions in an outgoing message into full mention
 /// tokens, resolving each against the room's current members. Only **public**
 /// nicknames are matched (riverctl does not decrypt private-room nicknames) and
@@ -2987,12 +3011,17 @@ impl ApiClient {
                 anyhow!("Target message not found in recent messages. Cannot reply to expired messages via CLI.")
             })?;
 
+        // Decrypt the target author's nickname with the room secrets — in a
+        // private room this is sealed, and `build_reply_body` seals it into
+        // `ReplyContentV1.target_author_name` and PERSISTS it to contract state.
+        // Without decrypting here, the reply's quoted author would read
+        // "[Encrypted: N bytes, vN]" to every reader (including the UI) forever.
         let target_author_name = room_state
             .member_info
             .member_info
             .iter()
             .find(|info| info.member_info.member_id == target_msg.message.author)
-            .map(|info| info.member_info.preferred_nickname.to_string_lossy())
+            .map(|info| unseal_nickname_display(&info.member_info.preferred_nickname, &secrets))
             .unwrap_or_else(|| target_msg.message.author.to_string());
 
         // Quote the target's plaintext. A PRIVATE target body is decrypted via
@@ -3246,6 +3275,7 @@ impl ApiClient {
                         &mut deleted_emitted,
                         room_owner_key,
                         &format,
+                        &secrets,
                     )?;
                     // Surface reactions added/removed since a message was already
                     // streamed. Runs AFTER emit_new_and_edited so a brand-new
@@ -3255,6 +3285,7 @@ impl ApiClient {
                         &mut seen_reactions,
                         room_owner_key,
                         &format,
+                        &secrets,
                     )?;
                     if max_messages > 0 && new_message_count >= max_messages {
                         return Ok(());
@@ -3351,6 +3382,7 @@ impl ApiClient {
         deleted_emitted: &mut HashSet<String>,
         room_owner_key: &VerifyingKey,
         format: &OutputFormat,
+        secrets: &HashMap<u32, [u8; 32]>,
     ) -> Result<()> {
         // We can only report a deletion while the original message is still in
         // the recent-messages window. If a message is pruned out of the window
@@ -3362,7 +3394,7 @@ impl ApiClient {
             }
             let key = monitor_seen_key(msg);
             if should_emit_deletion(seen, deleted_emitted, &key) {
-                Self::output_deletion(room_state, msg, room_owner_key, format)?;
+                Self::output_deletion(room_state, msg, room_owner_key, format, secrets)?;
                 deleted_emitted.insert(key);
             }
         }
@@ -3389,6 +3421,7 @@ impl ApiClient {
         seen_reactions: &mut HashMap<String, String>,
         room_owner_key: &VerifyingKey,
         format: &OutputFormat,
+        secrets: &HashMap<u32, [u8; 32]>,
     ) -> Result<()> {
         for msg in room_state.recent_messages.display_messages() {
             let key = monitor_seen_key(msg);
@@ -3399,7 +3432,7 @@ impl ApiClient {
                 ReactionEmit::NotSurfaced => continue,
                 ReactionEmit::Unchanged => continue,
                 ReactionEmit::Changed => {
-                    Self::output_reaction_change(room_state, msg, room_owner_key, format)?;
+                    Self::output_reaction_change(room_state, msg, room_owner_key, format, secrets)?;
                 }
             }
             seen_reactions.insert(key, fingerprint);
@@ -3417,6 +3450,7 @@ impl ApiClient {
         msg: &river_core::room_state::message::AuthorizedMessageV1,
         room_owner_key: &VerifyingKey,
         format: &OutputFormat,
+        secrets: &HashMap<u32, [u8; 32]>,
     ) -> Result<()> {
         let msg_id = msg.id();
         let reactions = room_state.recent_messages.reactions(&msg_id);
@@ -3426,7 +3460,7 @@ impl ApiClient {
             .member_info
             .iter()
             .find(|info| info.member_info.member_id == msg.message.author)
-            .map(|info| info.member_info.preferred_nickname.to_string_lossy());
+            .map(|info| unseal_nickname_display(&info.member_info.preferred_nickname, secrets));
         let datetime: DateTime<Utc> = msg.message.time.into();
 
         match format {
@@ -3483,6 +3517,7 @@ impl ApiClient {
         msg: &river_core::room_state::message::AuthorizedMessageV1,
         room_owner_key: &VerifyingKey,
         format: &OutputFormat,
+        secrets: &HashMap<u32, [u8; 32]>,
     ) -> Result<()> {
         let msg_id = msg.id();
         let author_str = msg.message.author.to_string();
@@ -3491,7 +3526,7 @@ impl ApiClient {
             .member_info
             .iter()
             .find(|info| info.member_info.member_id == msg.message.author)
-            .map(|info| info.member_info.preferred_nickname.to_string_lossy());
+            .map(|info| unseal_nickname_display(&info.member_info.preferred_nickname, secrets));
         let datetime: DateTime<Utc> = msg.message.time.into();
 
         match format {
@@ -3558,13 +3593,15 @@ impl ApiClient {
                 let author_str = msg.message.author.to_string();
                 let author_short = author_str.chars().take(8).collect::<String>();
 
-                // Get nickname if available
+                // Get nickname if available (decrypted for a private room)
                 let nickname = room_state
                     .member_info
                     .member_info
                     .iter()
                     .find(|info| info.member_info.member_id == msg.message.author)
-                    .map(|info| info.member_info.preferred_nickname.to_string_lossy())
+                    .map(|info| {
+                        unseal_nickname_display(&info.member_info.preferred_nickname, secrets)
+                    })
                     .unwrap_or(author_short);
 
                 let datetime: DateTime<Utc> = msg.message.time.into();
@@ -3611,7 +3648,9 @@ impl ApiClient {
                     .member_info
                     .iter()
                     .find(|info| info.member_info.member_id == msg.message.author)
-                    .map(|info| info.member_info.preferred_nickname.to_string_lossy());
+                    .map(|info| {
+                        unseal_nickname_display(&info.member_info.preferred_nickname, secrets)
+                    });
 
                 let datetime: DateTime<Utc> = msg.message.time.into();
 
@@ -4247,6 +4286,7 @@ impl ApiClient {
                                 &mut deleted_emitted,
                                 room_owner_key,
                                 &format,
+                                &secrets,
                             )?;
                             // Surface reactions added/removed since a message was
                             // already streamed. Runs AFTER emit_new_and_edited so a
@@ -4256,6 +4296,7 @@ impl ApiClient {
                                 &mut seen_reactions,
                                 room_owner_key,
                                 &format,
+                                &secrets,
                             )?;
                         }
                         Err(e) => {
@@ -4759,6 +4800,43 @@ mod display_text_tests {
             message_display_text_with_secrets(&state, &msg, &secrets),
             "my reply"
         );
+    }
+
+    /// A member nickname is `SealedBytes`: public in a public room, AES-256-GCM
+    /// sealed in a private room. `unseal_nickname_display` must decrypt the
+    /// private case with the room secret and fall back to the placeholder (never
+    /// raw ciphertext) when the secret is unavailable — this is what stops
+    /// `message list` / `member list` / `send_reply` from showing (and, for
+    /// replies, persisting) "[Encrypted: N bytes, vN]" as the author.
+    #[test]
+    fn unseal_nickname_display_decrypts_private_and_falls_back() {
+        use river_core::ecies::seal_bytes;
+        use river_core::room_state::privacy::SealedBytes;
+
+        let secret = [4u8; 32];
+        let sealed = seal_bytes(b"Alice", &secret, 0);
+
+        // With the matching secret → plaintext nickname.
+        let secrets = HashMap::from([(0u32, secret)]);
+        assert_eq!(unseal_nickname_display(&sealed, &secrets), "Alice");
+
+        // Without the secret → the "[Encrypted: …]" placeholder, never raw
+        // ciphertext.
+        assert_eq!(
+            unseal_nickname_display(&sealed, &HashMap::new()),
+            "[Encrypted: 5 bytes, v0]"
+        );
+
+        // Wrong key at the right version → placeholder (decrypt fails cleanly).
+        let wrong = HashMap::from([(0u32, [9u8; 32])]);
+        assert_eq!(
+            unseal_nickname_display(&sealed, &wrong),
+            "[Encrypted: 5 bytes, v0]"
+        );
+
+        // A public nickname is unaffected (public room / empty secrets).
+        let public = SealedBytes::public(b"Bob".to_vec());
+        assert_eq!(unseal_nickname_display(&public, &HashMap::new()), "Bob");
     }
 
     /// A private-room EDIT is an encrypted action message. The public-only
@@ -5408,6 +5486,7 @@ mod monitor_tests {
             &mut seen_reactions,
             &owner_vk,
             &OutputFormat::Json,
+            &HashMap::new(),
         )
         .unwrap();
         let after = seen_reactions.get(&key).cloned();
@@ -5443,8 +5522,14 @@ mod monitor_tests {
 
         // emit_reaction_changes must NOT seed it (which would let a *later*
         // reaction flip-flop to Changed and emit — the codex-found bug).
-        ApiClient::emit_reaction_changes(&state, &mut seen, &owner_vk, &OutputFormat::Json)
-            .unwrap();
+        ApiClient::emit_reaction_changes(
+            &state,
+            &mut seen,
+            &owner_vk,
+            &OutputFormat::Json,
+            &HashMap::new(),
+        )
+        .unwrap();
         assert!(
             !seen.contains_key(&key),
             "an unsurfaced message must not be seeded by emit_reaction_changes; \
@@ -5478,8 +5563,14 @@ mod monitor_tests {
             ReactionEmit::Unchanged,
             "an unchanged reaction set must not re-emit on every poll"
         );
-        ApiClient::emit_reaction_changes(&state, &mut seen, &owner_vk, &OutputFormat::Json)
-            .unwrap();
+        ApiClient::emit_reaction_changes(
+            &state,
+            &mut seen,
+            &owner_vk,
+            &OutputFormat::Json,
+            &HashMap::new(),
+        )
+        .unwrap();
         assert_eq!(
             seen.get(&key).cloned(),
             Some(fp),

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -88,13 +88,43 @@ pub fn compute_contract_key(owner_vk: &VerifyingKey) -> ContractKey {
 /// Before this helper, riverctl rendered join events as
 /// `[nickname]: <encrypted>` because the display path conflated "no text
 /// content" with "encrypted".
+/// Public-only convenience wrapper (no decryption). Production display paths
+/// always thread the room `secrets` via [`message_display_text_with_secrets`];
+/// this 2-arg form is retained for the tests that exercise public content and
+/// the genuine `<encrypted>` fallback (empty secrets).
+#[cfg(test)]
 pub(crate) fn message_display_text(
     room_state: &ChatRoomStateV1,
     msg: &river_core::room_state::message::AuthorizedMessageV1,
 ) -> String {
+    message_display_text_with_secrets(room_state, msg, &HashMap::new())
+}
+
+/// Like [`message_display_text`], but able to decrypt a **private** (encrypted)
+/// message body when the caller supplies the room's `secrets` map
+/// (version → 32-byte AES-256-GCM key), as collected by
+/// [`crate::private_room::collect_secrets_for_room`].
+///
+/// riverctl previously rendered every private-room message body as
+/// `<encrypted>` because the display path only decoded *public* content — the
+/// CLI could send into a private room but not read it back (a river↔XMPP bridge
+/// saw `"content":"<encrypted>"` for every message). This mirrors the UI's
+/// `decrypt_message_content`: public bodies decode directly; a private
+/// Text/Reply body is decrypted with the secret matching its `secret_version`
+/// and its plaintext returned. A body whose secret is unavailable (not a
+/// member, or an older rotated-past version) still falls back to `<encrypted>`.
+///
+/// `secrets` is empty for a public room or a room not in local storage, in
+/// which case behaviour is identical to the public-only path.
+pub(crate) fn message_display_text_with_secrets(
+    room_state: &ChatRoomStateV1,
+    msg: &river_core::room_state::message::AuthorizedMessageV1,
+    secrets: &HashMap<u32, [u8; 32]>,
+) -> String {
     let raw = room_state
         .recent_messages
         .effective_text(msg)
+        .or_else(|| decrypt_private_body_text(&msg.message.content, secrets))
         .unwrap_or_else(|| {
             msg.message
                 .content
@@ -103,6 +133,48 @@ pub(crate) fn message_display_text(
                 .unwrap_or_else(|| "<encrypted>".to_string())
         });
     render_mentions_for_terminal(room_state, &raw)
+}
+
+/// Decrypt a **private** message body to its display text, mirroring the UI's
+/// `decrypt_message_content` private branch. Returns `None` for a public body
+/// (the caller decodes those directly), for a body whose `secret_version` has
+/// no key in `secrets`, or on any decrypt/decode failure — so the caller falls
+/// back to the public decode path / `<encrypted>`.
+fn decrypt_private_body_text(
+    content: &river_core::room_state::message::RoomMessageBody,
+    secrets: &HashMap<u32, [u8; 32]>,
+) -> Option<String> {
+    use river_core::room_state::content::{
+        ReplyContentV1, TextContentV1, CONTENT_TYPE_REPLY, CONTENT_TYPE_TEXT,
+    };
+    use river_core::room_state::message::RoomMessageBody;
+
+    let RoomMessageBody::Private {
+        content_type,
+        ciphertext,
+        nonce,
+        secret_version,
+        ..
+    } = content
+    else {
+        return None;
+    };
+    let secret = secrets.get(secret_version)?;
+    let plaintext =
+        river_core::ecies::decrypt_with_symmetric_key(secret, ciphertext, nonce).ok()?;
+    if *content_type == CONTENT_TYPE_TEXT {
+        if let Ok(text) = TextContentV1::decode(&plaintext) {
+            return Some(text.text);
+        }
+    }
+    if *content_type == CONTENT_TYPE_REPLY {
+        if let Ok(reply) = ReplyContentV1::decode(&plaintext) {
+            return Some(reply.text);
+        }
+    }
+    // Decrypted but not a known text-bearing content type: show the raw
+    // plaintext rather than falling back to "<encrypted>" (matches the UI).
+    Some(String::from_utf8_lossy(&plaintext).to_string())
 }
 
 /// Replace `@[name](rv:id)` mention tokens with `@<name>` for terminal display.
@@ -209,22 +281,104 @@ fn reply_context(
 /// Mentions are resolved on the FULL stored preview *before* the display-length
 /// truncation, so a mention token sitting near the cutoff isn't sliced into
 /// raw `@[name](rv:..` syntax.
+/// Public-only convenience wrapper (no decryption); test counterpart of
+/// [`reply_context_display_with_secrets`]. Production paths thread the room
+/// `secrets` so a private reply's sealed context decrypts.
+#[cfg(test)]
 pub(crate) fn reply_context_display(
     room_state: &ChatRoomStateV1,
     msg: &river_core::room_state::message::AuthorizedMessageV1,
 ) -> Option<(String, String)> {
-    use river_core::room_state::content::{DecodedContent, CONTENT_TYPE_REPLY};
+    reply_context_display_with_secrets(room_state, msg, &HashMap::new())
+}
+
+/// Like [`reply_context_display`], but able to decrypt the reply context of a
+/// **private** reply when the caller supplies the room's `secrets` map. A
+/// private reply seals its `ReplyContentV1` (target author name + quoted
+/// preview) alongside the reply text, so without the secret the whole reply
+/// context is opaque and no `[reply to …]` prefix could be shown. Public
+/// replies decode directly, exactly as before. Returns `None` for a non-reply,
+/// or when a private reply's secret is unavailable / undecodable.
+pub(crate) fn reply_context_display_with_secrets(
+    room_state: &ChatRoomStateV1,
+    msg: &river_core::room_state::message::AuthorizedMessageV1,
+    secrets: &HashMap<u32, [u8; 32]>,
+) -> Option<(String, String)> {
+    use river_core::room_state::content::{DecodedContent, ReplyContentV1, CONTENT_TYPE_REPLY};
+    use river_core::room_state::message::RoomMessageBody;
     if msg.message.content.content_type() != CONTENT_TYPE_REPLY {
         return None;
     }
-    match msg.message.content.decode_content() {
-        Some(DecodedContent::Reply(reply)) => {
-            let rendered = render_mentions_for_terminal(room_state, &reply.target_content_preview);
-            let preview = truncate_reply_preview(&rendered);
-            Some((reply.target_author_name, preview))
+    let reply = match msg.message.content.decode_content() {
+        // Public reply — decoded directly.
+        Some(DecodedContent::Reply(reply)) => reply,
+        // Private reply — decrypt then decode the sealed ReplyContentV1.
+        _ => {
+            let RoomMessageBody::Private {
+                ciphertext,
+                nonce,
+                secret_version,
+                ..
+            } = &msg.message.content
+            else {
+                return None;
+            };
+            let secret = secrets.get(secret_version)?;
+            let plaintext =
+                river_core::ecies::decrypt_with_symmetric_key(secret, ciphertext, nonce).ok()?;
+            ReplyContentV1::decode(&plaintext).ok()?
         }
-        _ => None,
+    };
+    let rendered = render_mentions_for_terminal(room_state, &reply.target_content_preview);
+    let preview = truncate_reply_preview(&rendered);
+    Some((reply.target_author_name, preview))
+}
+
+/// Rebuild a room's message `actions_state` (edits / deletes / reactions) using
+/// decrypted content for **private** action messages.
+///
+/// `ChatRoomStateV1`'s `apply_delta`/`merge` end with the *non-decrypting*
+/// `rebuild_actions_state()`, which can only decode PUBLIC action messages —
+/// every edit / delete / reaction carried by a PRIVATE action message is
+/// dropped. So without this, a private-room edit shows the message's ORIGINAL
+/// text and a private-room deletion never hides the message. This is the CLI
+/// counterpart of the UI's `RoomData::rebuild_private_actions_state`
+/// (`ui/src/room_data.rs`): it decrypts each private action body with the
+/// version-matched room secret and re-derives `actions_state` from the
+/// decrypted actions. No-op for a public room (its public rebuild is already
+/// correct) or when `secrets` is empty.
+fn rebuild_private_actions_state(
+    room_state: &mut ChatRoomStateV1,
+    secrets: &HashMap<u32, [u8; 32]>,
+) {
+    use river_core::room_state::message::{MessageId, RoomMessageBody};
+
+    if secrets.is_empty() {
+        return;
     }
+    let decrypted: HashMap<MessageId, Vec<u8>> = room_state
+        .recent_messages
+        .messages
+        .iter()
+        .filter(|m| m.message.content.is_action())
+        .filter_map(|m| match &m.message.content {
+            RoomMessageBody::Private {
+                ciphertext,
+                nonce,
+                secret_version,
+                ..
+            } => secrets
+                .get(secret_version)
+                .and_then(|s| {
+                    river_core::ecies::decrypt_with_symmetric_key(s, ciphertext, nonce).ok()
+                })
+                .map(|plaintext| (m.id(), plaintext)),
+            _ => None,
+        })
+        .collect();
+    room_state
+        .recent_messages
+        .rebuild_actions_state_with_decrypted(&decrypted);
 }
 
 /// Whether a message seen by a monitor stream is brand new, an edit of one
@@ -812,6 +966,46 @@ impl ApiClient {
             }
             _ => Err(anyhow!("Unexpected response type: {:?}", response)),
         }
+    }
+
+    /// Prepare a freshly-fetched `room_state` for **display** in a private
+    /// room: collect the local member's decryption secrets and, in place,
+    /// rebuild the message `actions_state` (edits/deletes/reactions) from the
+    /// decrypted private action messages. Returns the secrets map so the caller
+    /// can decrypt message *bodies* at render time via
+    /// [`message_display_text_with_secrets`] / [`reply_context_display_with_secrets`].
+    ///
+    /// Returns an empty map (and leaves `room_state` untouched) for a public
+    /// room or a room not in local storage — a non-member cannot decrypt, and
+    /// the display path then behaves exactly as the pre-existing public-only
+    /// path. Secret collection needs the fetched `room_state` (it decrypts the
+    /// owner-signed `encrypted_secrets` blobs), so this is called per fetch.
+    pub(crate) fn room_display_secrets(
+        &self,
+        room_owner_key: &VerifyingKey,
+        room_state: &mut ChatRoomStateV1,
+    ) -> HashMap<u32, [u8; 32]> {
+        use river_core::room_state::privacy::PrivacyMode;
+
+        if room_state.configuration.configuration.privacy_mode != PrivacyMode::Private {
+            return HashMap::new();
+        }
+        // The signing key of the identity we joined this room as, from local
+        // storage. Absent → we are not a stored member → we cannot decrypt.
+        let Some((self_sk, _, _)) = self.storage.get_room(room_owner_key).ok().flatten() else {
+            return HashMap::new();
+        };
+        let invitation_secrets = self
+            .storage
+            .get_invitation_secrets(room_owner_key)
+            .unwrap_or_default();
+        let secrets = crate::private_room::collect_secrets_for_room(
+            room_state,
+            &self_sk,
+            &invitation_secrets,
+        );
+        rebuild_private_actions_state(room_state, &secrets);
+        secrets
     }
 
     pub async fn get_room(
@@ -2792,10 +2986,24 @@ impl ApiClient {
             .map(|info| info.member_info.preferred_nickname.to_string_lossy())
             .unwrap_or_else(|| target_msg.message.author.to_string());
 
-        let target_content_preview: String = message_display_text(&room_state, target_msg)
-            .chars()
-            .take(100)
-            .collect();
+        // Collect the room's decryption secrets so the quoted preview of a
+        // PRIVATE target message is its plaintext, not "<encrypted>". Without
+        // this, the CLI sealed "<encrypted>" into the reply's `ReplyContentV1`,
+        // so the quoted context showed "<encrypted>" to every reader forever.
+        // (Reused below to seal the reply body itself — a public room yields an
+        // empty map and unchanged behaviour.)
+        let invitation_secrets = self.storage.get_invitation_secrets(room_owner_key)?;
+        let secrets = crate::private_room::collect_secrets_for_room(
+            &room_state,
+            &signing_key,
+            &invitation_secrets,
+        );
+
+        let target_content_preview: String =
+            message_display_text_with_secrets(&room_state, target_msg, &secrets)
+                .chars()
+                .take(100)
+                .collect();
 
         // Resolve any bare @nickname mentions in the reply body.
         let reply_text = resolve_outgoing_mentions(&room_state, &reply_text);
@@ -2805,7 +3013,6 @@ impl ApiClient {
         // target author name and content preview are sealed alongside the reply
         // text in a private room (they are part of `ReplyContentV1`), so the
         // reply context is not leaked in the clear.
-        let invitation_secrets = self.storage.get_invitation_secrets(room_owner_key)?;
         let content = crate::private_room::build_reply_body(
             &room_state,
             &signing_key,
@@ -2957,7 +3164,9 @@ impl ApiClient {
 
         // Show initial messages if requested
         if initial_messages > 0 {
-            let room_state = self.get_room(room_owner_key, false).await?;
+            let mut room_state = self.get_room(room_owner_key, false).await?;
+            // Decrypt private-room content for display (no-op for public rooms).
+            let secrets = self.room_display_secrets(room_owner_key, &mut room_state);
 
             // Use display_messages() to filter out action/deleted messages (matches `message list`)
             let all_msgs: Vec<_> = room_state.recent_messages.display_messages().collect();
@@ -2965,7 +3174,10 @@ impl ApiClient {
 
             for msg in &all_msgs[start..] {
                 let key = monitor_seen_key(msg);
-                seen_messages.insert(key.clone(), message_display_text(&room_state, msg));
+                seen_messages.insert(
+                    key.clone(),
+                    message_display_text_with_secrets(&room_state, msg, &secrets),
+                );
                 // Seed the reactions fingerprint for shown messages so reactions
                 // already present at startup aren't re-emitted as a live change;
                 // only later changes to them surface.
@@ -2974,7 +3186,7 @@ impl ApiClient {
                     reactions_fingerprint(room_state.recent_messages.reactions(&msg.id())),
                 );
 
-                Self::output_message(&room_state, msg, room_owner_key, &format, false)?;
+                Self::output_message(&room_state, msg, room_owner_key, &format, false, &secrets)?;
             }
         }
 
@@ -3013,7 +3225,9 @@ impl ApiClient {
             // message whose effective content changed (an edit) and emits ones
             // not seen before; it respects max_messages for NEW messages.
             match self.get_room(room_owner_key, false).await {
-                Ok(room_state) => {
+                Ok(mut room_state) => {
+                    // Decrypt private-room content for display (no-op for public rooms).
+                    let secrets = self.room_display_secrets(room_owner_key, &mut room_state);
                     Self::emit_new_and_edited(
                         &room_state,
                         &mut seen_messages,
@@ -3023,6 +3237,7 @@ impl ApiClient {
                         &format,
                         max_messages,
                         &mut new_message_count,
+                        &secrets,
                     )?;
                     Self::emit_deletions(
                         &room_state,
@@ -3080,16 +3295,17 @@ impl ApiClient {
         format: &OutputFormat,
         max_new: usize,
         new_count: &mut usize,
+        secrets: &HashMap<u32, [u8; 32]>,
     ) -> Result<()> {
         for msg in room_state.recent_messages.display_messages() {
             let key = monitor_seen_key(msg);
-            let content = message_display_text(room_state, msg);
+            let content = message_display_text_with_secrets(room_state, msg, secrets);
             let is_edit = match classify_seen(seen, &key, &content) {
                 EmitKind::Unchanged => continue,
                 EmitKind::Edited => true,
                 EmitKind::New => false,
             };
-            Self::output_message(room_state, msg, room_owner_key, format, is_edit)?;
+            Self::output_message(room_state, msg, room_owner_key, format, is_edit, secrets)?;
             // Surfacing a message (showing it new OR as an edit) lifts any
             // start-time delete-suppression: a now-surfaced message's later
             // deletion MUST be reportable. Without this, an unshown pre-existing
@@ -3323,16 +3539,18 @@ impl ApiClient {
         room_owner_key: &VerifyingKey,
         format: &OutputFormat,
         is_edit: bool,
+        secrets: &HashMap<u32, [u8; 32]>,
     ) -> Result<()> {
         // Get display content (handles edits and non-text public content like
-        // join events; only genuinely encrypted bodies render as "<encrypted>")
-        let content = message_display_text(room_state, msg);
+        // join events; `secrets` decrypts private-room bodies — only a body
+        // whose secret is unavailable renders as "<encrypted>")
+        let content = message_display_text_with_secrets(room_state, msg, secrets);
 
         // Get message ID for checking edited status and reactions
         let msg_id = msg.id();
         let edited = room_state.recent_messages.is_edited(&msg_id);
         let reactions = room_state.recent_messages.reactions(&msg_id);
-        let reply = reply_context_display(room_state, msg);
+        let reply = reply_context_display_with_secrets(room_state, msg, secrets);
 
         match format {
             OutputFormat::Human => {
@@ -3847,7 +4065,10 @@ impl ApiClient {
         let contract_key = self.owner_vk_to_contract_key(room_owner_key);
         let contract_instance_id = *contract_key.id();
         {
-            let room_state = self.get_room(room_owner_key, false).await?;
+            let mut room_state = self.get_room(room_owner_key, false).await?;
+            // Decrypt private-room content for display (no-op for public rooms).
+            // Must run before the immutable `display_msgs` borrow below.
+            let secrets = self.room_display_secrets(room_owner_key, &mut room_state);
 
             // Determine which messages will be displayed initially (the last N
             // non-deleted). Only these count as "shown" for deletion purposes.
@@ -3870,7 +4091,7 @@ impl ApiClient {
                 if !msg.message.content.is_action() {
                     seen_messages.insert(
                         monitor_seen_key(msg),
-                        message_display_text(&room_state, msg),
+                        message_display_text_with_secrets(&room_state, msg, &secrets),
                     );
                 }
             }
@@ -3895,7 +4116,14 @@ impl ApiClient {
                         monitor_seen_key(msg),
                         reactions_fingerprint(room_state.recent_messages.reactions(&msg.id())),
                     );
-                    Self::output_message(&room_state, msg, room_owner_key, &format, false)?;
+                    Self::output_message(
+                        &room_state,
+                        msg,
+                        room_owner_key,
+                        &format,
+                        false,
+                        &secrets,
+                    )?;
                 }
             }
         }
@@ -3997,7 +4225,10 @@ impl ApiClient {
                     let _ = update;
                     drop(web_api); // get_room needs the web_api lock
                     match self.get_room(room_owner_key, false).await {
-                        Ok(room_state) => {
+                        Ok(mut room_state) => {
+                            // Decrypt private-room content for display (no-op for public rooms).
+                            let secrets =
+                                self.room_display_secrets(room_owner_key, &mut room_state);
                             Self::emit_new_and_edited(
                                 &room_state,
                                 &mut seen_messages,
@@ -4007,6 +4238,7 @@ impl ApiClient {
                                 &format,
                                 max_messages,
                                 &mut new_message_count,
+                                &secrets,
                             )?;
                             Self::emit_deletions(
                                 &room_state,
@@ -4377,7 +4609,9 @@ mod migration_recovery_tests {
 #[cfg(test)]
 mod display_text_tests {
     use super::*;
-    use river_core::room_state::message::{AuthorizedMessageV1, MessageV1, RoomMessageBody};
+    use river_core::room_state::message::{
+        AuthorizedMessageV1, MessageId, MessageV1, RoomMessageBody,
+    };
     use std::time::SystemTime;
 
     /// Build a `ChatRoomStateV1` whose `recent_messages` holds a single
@@ -4434,6 +4668,148 @@ mod display_text_tests {
         assert_eq!(
             message_display_text(&state, &msg),
             "[Unsupported message type 99.1 - please upgrade]"
+        );
+    }
+
+    /// Seal `text` as a private (AES-256-GCM) `TextContentV1` body under
+    /// `secret`/`version`, mirroring the wire bytes the UI and
+    /// `private_room::build_message_body` produce.
+    fn private_text_body(secret: &[u8; 32], version: u32, text: &str) -> RoomMessageBody {
+        use river_core::room_state::content::TextContentV1;
+        let bytes = TextContentV1::new(text.to_string()).encode();
+        let (ciphertext, nonce) = river_core::ecies::encrypt_with_symmetric_key(secret, &bytes);
+        RoomMessageBody::private_text(ciphertext, nonce, version)
+    }
+
+    /// Core regression for the reported bug (riverctl `message list` on an
+    /// encrypted room showed `"content":"<encrypted>"`): a private text body
+    /// must decrypt to its plaintext when the room secret is supplied, while
+    /// still falling back to "<encrypted>" when it is not.
+    #[test]
+    fn private_text_decrypts_with_secret() {
+        let secret = [7u8; 32];
+        let (state, msg) = state_with_message(private_text_body(&secret, 0, "secret hello"));
+
+        // No secrets (non-member / pre-fix behaviour) → still "<encrypted>".
+        assert_eq!(message_display_text(&state, &msg), "<encrypted>");
+
+        // Correct secret for the body's version → plaintext.
+        let secrets = HashMap::from([(0u32, secret)]);
+        assert_eq!(
+            message_display_text_with_secrets(&state, &msg, &secrets),
+            "secret hello"
+        );
+
+        // A secrets map lacking this body's version (e.g. rotated past) →
+        // "<encrypted>", never a panic or a wrong-key garble.
+        let other_version = HashMap::from([(1u32, secret)]);
+        assert_eq!(
+            message_display_text_with_secrets(&state, &msg, &other_version),
+            "<encrypted>"
+        );
+
+        // Wrong key at the right version → decrypt fails → "<encrypted>".
+        let wrong_key = HashMap::from([(0u32, [8u8; 32])]);
+        assert_eq!(
+            message_display_text_with_secrets(&state, &msg, &wrong_key),
+            "<encrypted>"
+        );
+    }
+
+    /// A private reply seals its whole `ReplyContentV1` (target author + quoted
+    /// preview + reply text). Without the secret the reply context is opaque
+    /// (no `[reply to …]` prefix); with it, both the context and the body
+    /// decrypt.
+    #[test]
+    fn private_reply_context_decrypts_with_secret() {
+        use river_core::room_state::content::{
+            ReplyContentV1, CONTENT_TYPE_REPLY, REPLY_CONTENT_VERSION,
+        };
+        let secret = [9u8; 32];
+        let reply = ReplyContentV1::new(
+            "my reply".to_string(),
+            MessageId(freenet_scaffold::util::FastHash(0)),
+            "Alice".to_string(),
+            "quoted original".to_string(),
+        );
+        let (ciphertext, nonce) =
+            river_core::ecies::encrypt_with_symmetric_key(&secret, &reply.encode());
+        let body = RoomMessageBody::private(
+            CONTENT_TYPE_REPLY,
+            REPLY_CONTENT_VERSION,
+            ciphertext,
+            nonce,
+            0,
+        );
+        let (state, msg) = state_with_message(body);
+
+        // Opaque without the secret.
+        assert_eq!(reply_context_display(&state, &msg), None);
+
+        // Author + quoted preview decrypt with the secret.
+        let secrets = HashMap::from([(0u32, secret)]);
+        let (author, preview) = reply_context_display_with_secrets(&state, &msg, &secrets)
+            .expect("private reply context decrypts");
+        assert_eq!(author, "Alice");
+        assert_eq!(preview, "quoted original");
+
+        // And the reply body itself decrypts to the reply text.
+        assert_eq!(
+            message_display_text_with_secrets(&state, &msg, &secrets),
+            "my reply"
+        );
+    }
+
+    /// A private-room EDIT is an encrypted action message. The public-only
+    /// `rebuild_actions_state` that `apply_delta` runs drops it, so the body
+    /// decrypts to its ORIGINAL text; only after
+    /// [`rebuild_private_actions_state`] (which the display paths now run) does
+    /// the edited text surface.
+    #[test]
+    fn private_edit_shows_edited_text_after_rebuild() {
+        use river_core::room_state::content::ActionContentV1;
+        let author_sk = SigningKey::from_bytes(&[11u8; 32]);
+        let owner_vk = SigningKey::from_bytes(&[12u8; 32]).verifying_key();
+        let secret = [5u8; 32];
+
+        let author = |content: RoomMessageBody, secs: u64| {
+            AuthorizedMessageV1::new(
+                MessageV1 {
+                    room_owner: MemberId::from(owner_vk),
+                    author: MemberId::from(&author_sk.verifying_key()),
+                    content,
+                    time: SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(secs),
+                },
+                &author_sk,
+            )
+        };
+
+        let orig = author(private_text_body(&secret, 0, "before edit"), 0);
+        let action = ActionContentV1::edit(orig.id(), "after edit".to_string());
+        let (ciphertext, nonce) =
+            river_core::ecies::encrypt_with_symmetric_key(&secret, &action.encode());
+        let edit = author(RoomMessageBody::private_action(ciphertext, nonce, 0), 1);
+
+        let mut state = ChatRoomStateV1::default();
+        state.recent_messages.messages.push(orig.clone());
+        state.recent_messages.messages.push(edit);
+
+        let secrets = HashMap::from([(0u32, secret)]);
+
+        // Before the decrypt-aware rebuild: original text (the private edit
+        // action was dropped by the public-only rebuild).
+        assert!(!state.recent_messages.is_edited(&orig.id()));
+        assert_eq!(
+            message_display_text_with_secrets(&state, &orig, &secrets),
+            "before edit"
+        );
+
+        // After it: the edit applies.
+        rebuild_private_actions_state(&mut state, &secrets);
+        assert!(state.recent_messages.is_edited(&orig.id()));
+        assert_eq!(
+            message_display_text_with_secrets(&state, &orig, &secrets),
+            "after edit"
         );
     }
 }
@@ -5171,6 +5547,7 @@ mod monitor_tests {
             &OutputFormat::Json,
             0,
             &mut new_count,
+            &HashMap::new(),
         )
         .unwrap();
 

--- a/cli/src/commands/dm.rs
+++ b/cli/src/commands/dm.rs
@@ -351,7 +351,13 @@ async fn execute_list(
     let self_vk = signing_key.verifying_key();
     let self_id = MemberId::from(&self_vk);
 
-    let room_state = api.get_room(&room_owner_key, false).await?;
+    let mut room_state = api.get_room(&room_owner_key, false).await?;
+
+    // For a private room, collect the local member's secrets so DM
+    // counterparty nicknames (AES-256-GCM sealed) decrypt instead of showing
+    // "[Encrypted: N bytes, vN]". Empty / no-op for a public room. Must run
+    // before the immutable borrows below.
+    let secrets = api.room_display_secrets(&room_owner_key, &mut room_state);
 
     let with_filter = with
         .map(|s| resolve_recipient_id(&room_state, &room_owner_key, s))
@@ -363,7 +369,8 @@ async fn execute_list(
             .unwrap_or(0)
     });
 
-    // Build a nickname lookup so output is human-readable.
+    // Build a nickname lookup so output is human-readable (decrypted for a
+    // private room).
     let nicknames: HashMap<MemberId, String> = room_state
         .member_info
         .member_info
@@ -371,7 +378,7 @@ async fn execute_list(
         .map(|info| {
             (
                 info.member_info.member_id,
-                info.member_info.preferred_nickname.to_string_lossy(),
+                crate::api::unseal_nickname_display(&info.member_info.preferred_nickname, &secrets),
             )
         })
         .collect();

--- a/cli/src/commands/member.rs
+++ b/cli/src/commands/member.rs
@@ -47,7 +47,13 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
                 .map_err(|e| anyhow!("Invalid room ID: {}", e))?;
 
             // Get the room state
-            let room_state = api.get_room(&owner_vk, false).await?;
+            let mut room_state = api.get_room(&owner_vk, false).await?;
+
+            // For a private room, collect the local member's secrets so member
+            // nicknames (which are AES-256-GCM sealed) decrypt instead of
+            // rendering as "[Encrypted: N bytes, vN]". Empty / no-op for a
+            // public room or a room not in local storage.
+            let secrets = api.room_display_secrets(&owner_vk, &mut room_state);
 
             // Collect member info
             let members: Vec<_> = room_state
@@ -55,7 +61,10 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
                 .member_info
                 .iter()
                 .map(|info| {
-                    let nickname = info.member_info.preferred_nickname.to_string_lossy();
+                    let nickname = crate::api::unseal_nickname_display(
+                        &info.member_info.preferred_nickname,
+                        &secrets,
+                    );
                     let member_id = info.member_info.member_id.to_string();
                     (member_id, nickname)
                 })

--- a/cli/src/commands/message.rs
+++ b/cli/src/commands/message.rs
@@ -225,13 +225,18 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
                             let author_str = msg.message.author.to_string();
                             let author_short = author_str.chars().take(8).collect::<String>();
 
-                            // Get nickname if available
+                            // Get nickname if available (decrypted for a private room)
                             let nickname = room_state
                                 .member_info
                                 .member_info
                                 .iter()
                                 .find(|info| info.member_info.member_id == msg.message.author)
-                                .map(|info| info.member_info.preferred_nickname.to_string_lossy())
+                                .map(|info| {
+                                    crate::api::unseal_nickname_display(
+                                        &info.member_info.preferred_nickname,
+                                        &secrets,
+                                    )
+                                })
                                 .unwrap_or(author_short);
 
                             let datetime: DateTime<Utc> = msg.message.time.into();
@@ -308,7 +313,12 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
                                 .member_info
                                 .iter()
                                 .find(|info| info.member_info.member_id == msg.message.author)
-                                .map(|info| info.member_info.preferred_nickname.to_string_lossy());
+                                .map(|info| {
+                                    crate::api::unseal_nickname_display(
+                                        &info.member_info.preferred_nickname,
+                                        &secrets,
+                                    )
+                                });
 
                             let datetime: DateTime<Utc> = msg.message.time.into();
 

--- a/cli/src/commands/message.rs
+++ b/cli/src/commands/message.rs
@@ -188,7 +188,16 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
                     .map_err(|e| anyhow::anyhow!("Invalid room ID: {}", e))?;
 
             // Get room state
-            let room_state = api.get_room(&room_owner_key, false).await?;
+            let mut room_state = api.get_room(&room_owner_key, false).await?;
+
+            // For a private room, collect the local member's decryption secrets
+            // and rebuild the message actions_state (edits/deletes/reactions)
+            // from the decrypted private actions. Empty map / no-op for a public
+            // room or a room not in local storage — private bodies then still
+            // render as "<encrypted>", exactly as before. Must run before
+            // display_messages() so a decrypted private *deletion* hides its
+            // message.
+            let secrets = api.room_display_secrets(&room_owner_key, &mut room_state);
 
             // Get only display messages (non-deleted, non-action)
             let mut messages: Vec<_> = room_state.recent_messages.display_messages().collect();
@@ -228,10 +237,16 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
                             let datetime: DateTime<Utc> = msg.message.time.into();
                             let local_time: DateTime<Local> = datetime.into();
 
-                            // Get display content (handles edits and non-text
-                            // public content like join events; only genuinely
-                            // encrypted bodies render as "<encrypted>")
-                            let content = crate::api::message_display_text(&room_state, msg);
+                            // Get display content (handles edits, non-text
+                            // public content like join events, and — via
+                            // `secrets` — decrypted private-room bodies; only a
+                            // body whose secret is unavailable renders as
+                            // "<encrypted>")
+                            let content = crate::api::message_display_text_with_secrets(
+                                &room_state,
+                                msg,
+                                &secrets,
+                            );
 
                             // Check if message is edited
                             let msg_id = msg.id();
@@ -242,11 +257,13 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
                             // stream via crate::api::reply_context_display so the
                             // two renderings can't drift, including the truncation
                             // marker appended by truncate_reply_preview).
-                            let reply_prefix = crate::api::reply_context_display(&room_state, msg)
-                                .map(|(author, preview)| {
-                                    format!("[reply to {}: {}] ", author, preview)
-                                })
-                                .unwrap_or_default();
+                            let reply_prefix = crate::api::reply_context_display_with_secrets(
+                                &room_state,
+                                msg,
+                                &secrets,
+                            )
+                            .map(|(author, preview)| format!("[reply to {}: {}] ", author, preview))
+                            .unwrap_or_default();
 
                             // Get reactions
                             let reactions_str = room_state
@@ -295,10 +312,16 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
 
                             let datetime: DateTime<Utc> = msg.message.time.into();
 
-                            // Get display content (handles edits and non-text
-                            // public content like join events; only genuinely
-                            // encrypted bodies render as "<encrypted>")
-                            let content = crate::api::message_display_text(&room_state, msg);
+                            // Get display content (handles edits, non-text
+                            // public content like join events, and — via
+                            // `secrets` — decrypted private-room bodies; only a
+                            // body whose secret is unavailable renders as
+                            // "<encrypted>")
+                            let content = crate::api::message_display_text_with_secrets(
+                                &room_state,
+                                msg,
+                                &secrets,
+                            );
 
                             // Check edited status
                             let edited = room_state.recent_messages.is_edited(&msg_id);
@@ -316,7 +339,12 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
                             // Reply context (null for non-replies) — same shape
                             // as the monitor stream's JSON, so a bridge sees
                             // reply_to on both the backfill and the live feed.
-                            let reply_to = crate::api::reply_context_display(&room_state, msg).map(
+                            let reply_to = crate::api::reply_context_display_with_secrets(
+                                &room_state,
+                                msg,
+                                &secrets,
+                            )
+                            .map(
                                 |(author, preview)| json!({ "author": author, "preview": preview }),
                             );
 

--- a/cli/src/commands/room.rs
+++ b/cli/src/commands/room.rs
@@ -294,14 +294,24 @@ pub async fn execute(command: RoomCommands, api: ApiClient, format: OutputFormat
 
             if !has_changes {
                 // No changes requested, show current config
-                let room_state = api.get_room(&owner_key, false).await?;
+                let mut room_state = api.get_room(&owner_key, false).await?;
+                // For a private room the name/description are AES-256-GCM sealed;
+                // decrypt them with the local member's secrets so this shows the
+                // real values instead of "[Encrypted: N bytes, vN]". Falls back
+                // to that placeholder when the secret is unavailable.
+                let secrets = api.room_display_secrets(&owner_key, &mut room_state);
+                let unseal = |sealed: &river_core::room_state::privacy::SealedBytes| {
+                    river_core::ecies::unseal_bytes_with_secrets(sealed, &secrets)
+                        .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
+                        .unwrap_or_else(|_| sealed.to_string_lossy())
+                };
                 let cfg = &room_state.configuration.configuration;
-                let room_name = cfg.display.name.to_string_lossy();
+                let room_name = unseal(&cfg.display.name);
                 let room_desc = cfg
                     .display
                     .description
                     .as_ref()
-                    .map(|d| d.to_string_lossy())
+                    .map(unseal)
                     .unwrap_or_else(|| "(none)".to_string());
                 println!("Current configuration:");
                 println!("  name: {}", room_name);

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -649,13 +649,27 @@ impl Storage {
                 let mut key_array = [0u8; 32];
                 key_array.copy_from_slice(&owner_key_bytes);
                 if let Ok(owner_vk) = VerifyingKey::from_bytes(&key_array) {
-                    let room_name = room_info
-                        .state
-                        .configuration
-                        .configuration
-                        .display
-                        .name
-                        .to_string_lossy();
+                    let sealed_name = &room_info.state.configuration.configuration.display.name;
+                    // A private room's name is AES-256-GCM sealed under the room
+                    // secret. Decrypt it with the local member's secrets so
+                    // `room list` shows the real name instead of the
+                    // "[Encrypted: N bytes, vN]" placeholder that `to_string_lossy`
+                    // yields for a sealed value. Falls back to that placeholder
+                    // when the secret is unavailable (not yet synced / rotated
+                    // past); a public name decrypts trivially to its bytes.
+                    let room_name = if sealed_name.is_private() {
+                        let self_sk = self.resolve_signing_key(&room_info.signing_key_bytes);
+                        let secrets = crate::private_room::collect_secrets_for_room(
+                            &room_info.state,
+                            &self_sk,
+                            &room_info.invitation_secrets,
+                        );
+                        river_core::ecies::unseal_bytes_with_secrets(sealed_name, &secrets)
+                            .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
+                            .unwrap_or_else(|_| sealed_name.to_string_lossy())
+                    } else {
+                        sealed_name.to_string_lossy()
+                    };
                     rooms.push((owner_vk, room_name, room_info.contract_key.clone()));
                 }
             }
@@ -697,6 +711,85 @@ mod tests {
         };
         state.configuration = AuthorizedConfigurationV1::new(config, owner_sk);
         state
+    }
+
+    /// A `room list` on a **private** room must show the decrypted name, not
+    /// the "[Encrypted: N bytes, vN]" placeholder (reported on Matrix
+    /// 2026-07-08: riverctl "cant see ... the real room name"). Here the room
+    /// secret is supplied via `invitation_secrets`, mirroring a just-joined
+    /// invitee before the owner's delegate has back-filled the contract blob.
+    #[test]
+    fn list_rooms_decrypts_private_room_name() {
+        use river_core::ecies::seal_bytes;
+        use river_core::room_state::privacy::PrivacyMode;
+
+        let (storage, _temp_dir) = create_test_storage();
+        let owner_sk = create_test_signing_key();
+        let owner_vk = owner_sk.verifying_key();
+        let secret = [3u8; 32];
+        let version = 0u32;
+
+        // Build a PRIVATE room whose display name is sealed under `secret`.
+        let mut state = create_test_state(&owner_sk);
+        state.configuration.configuration.privacy_mode = PrivacyMode::Private;
+        state.configuration.configuration.display.name =
+            seal_bytes(b"Secret Room", &secret, version);
+        // Re-sign so the (mutated) configuration stays owner-authorized.
+        state.configuration =
+            AuthorizedConfigurationV1::new(state.configuration.configuration.clone(), &owner_sk);
+        let contract_key = expected_contract_key(&owner_vk);
+
+        // Store with the secret carried as an invitation secret.
+        let mut invitation_secrets = HashMap::new();
+        invitation_secrets.insert(version, secret);
+        storage
+            .add_room_with_invitation_secrets(
+                &owner_vk,
+                &owner_sk,
+                state,
+                &contract_key,
+                invitation_secrets,
+            )
+            .unwrap();
+
+        let rooms = storage.list_rooms().unwrap();
+        let (_, name, _) = rooms
+            .iter()
+            .find(|(vk, _, _)| *vk == owner_vk)
+            .expect("room present");
+        assert_eq!(name, "Secret Room");
+    }
+
+    /// Without the secret, the private name gracefully falls back to the
+    /// placeholder rather than erroring or panicking.
+    #[test]
+    fn list_rooms_private_name_falls_back_without_secret() {
+        use river_core::ecies::seal_bytes;
+        use river_core::room_state::privacy::PrivacyMode;
+
+        let (storage, _temp_dir) = create_test_storage();
+        let owner_sk = create_test_signing_key();
+        let owner_vk = owner_sk.verifying_key();
+
+        let mut state = create_test_state(&owner_sk);
+        state.configuration.configuration.privacy_mode = PrivacyMode::Private;
+        state.configuration.configuration.display.name = seal_bytes(b"Secret Room", &[3u8; 32], 0);
+        state.configuration =
+            AuthorizedConfigurationV1::new(state.configuration.configuration.clone(), &owner_sk);
+        let contract_key = expected_contract_key(&owner_vk);
+
+        // No invitation secrets, and the state carries no owner-signed blob for
+        // this member → the secret is unavailable.
+        storage
+            .add_room(&owner_vk, &owner_sk, state, &contract_key)
+            .unwrap();
+
+        let rooms = storage.list_rooms().unwrap();
+        let (_, name, _) = rooms
+            .iter()
+            .find(|(vk, _, _)| *vk == owner_vk)
+            .expect("room present");
+        assert_eq!(name, "[Encrypted: 11 bytes, v0]");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

riverctl could **send** into an encrypted (private) room but couldn't **read** it back. Reported on Matrix (2026-07-08) by users building a river↔XMPP bridge. One root cause — the CLI's symmetric-decryption code lived only in `#[cfg(test)]` modules and was never wired into any display path. Three visible surfaces:

1. **Message bodies** — `message list` / `stream` / `--subscribe` rendered every body as `<encrypted>`.
2. **Room name** — `room list` / `room config` showed `[Encrypted: N bytes, vN]` instead of the real name.
3. **Member/author nicknames** — every participant rendered as `[Encrypted: N bytes, vN]` in `message list`, `member list`, `dm list`, and the stream. Worse: `send_reply` sealed that placeholder into `ReplyContentV1.target_author_name` and **persisted it to contract state**, so a riverctl reply quoted `[Encrypted…]` as the author to every reader (including the desktop UI) forever.

The desktop UI decrypts all of this; the CLI had the pieces (`collect_secrets_for_room`) but never used them for display.

## Approach

Mirror the UI, entirely within the `riverctl` crate. No `common/` / contract / delegate WASM change → **no delegate migration**.

- **Bodies:** `message_display_text_with_secrets` / `reply_context_display_with_secrets` decrypt private Text/Reply bodies (+ a private reply's sealed context) with the version-matched secret; unavailable/wrong secret → `<encrypted>`, never a panic or garble.
- **Actions:** `ApiClient::room_display_secrets` collects the local member's secrets and rebuilds `actions_state` from decrypted private edit/delete/reaction actions (the public-only rebuild `apply_delta` runs drops them). Recomputed per fetch so rotation is picked up. Empty / no-op for a public room or a room not in local storage.
- **Room name:** `room list` (storage) and `room config` unseal the private name (+ description) via `unseal_bytes_with_secrets`.
- **Nicknames:** shared `unseal_nickname_display` wired into `message list`, `member list`, `dm list`, stream message/deletion/reaction events, and `send_reply`'s quoted author (stops persisting the sealed placeholder).
- `send_reply` also rebuilds private actions before selecting the target, so a deleted target is excluded and an edited target's preview reflects the edit.

All secret collection + extra reads are error-swallowing (best-effort) — worst case degrades to `<encrypted>`/placeholder, never breaks a command or a stream. Public-room behaviour is byte-identical to before (empty secrets map).

## Scope note

This PR is the **read/display** side ("riverctl can now read private rooms"). An audit turned up separate **write-side** gaps that are NOT in this PR and warrant their own follow-ups: `member set-nickname` sends a *plaintext* nickname into a private room (privacy leak), `room config --name/--description` don't seal, and `room create` can't make a private room. Tracking those separately.

## Testing

Unit tests pin: private text decrypt / missing-version / wrong-key / public; private reply context; private edit surfaces after rebuild; `room list` decrypts the private name and falls back without the secret; `unseal_nickname_display` decrypt / missing / wrong-key / public. Full `riverctl` lib suite green (155 tests); `cargo fmt` + `cargo clippy` clean.

Not yet exercised end-to-end against a live private room — unit tests cover the exact decode/decrypt transforms that were broken; wiring is a straight `get_room → room_display_secrets → display` thread-through.

## Review

External Codex review clean (its one P2 — rebuild private actions before selecting the reply target — is addressed). Two Claude adversarial passes confirmed no P1s and surfaced the nickname gap + the `send_reply` persistence bug, both now fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9wgmB6Wbs2kCgEBWpr6X9

[AI-assisted - Claude]