### PR TITLE
fix(cli): seal nickname/name/description writes in private rooms (stop plaintext leak)

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -3713,6 +3713,27 @@ impl ApiClient {
 
         let my_member_id = signing_key.verifying_key().into();
 
+        // Seal the nickname for the room's privacy mode. In a PRIVATE room the
+        // nickname MUST be AES-256-GCM sealed under the room secret — sending
+        // it as plaintext (the previous unconditional `SealedBytes::public`)
+        // silently deanonymised the member: the contract's `member_info`
+        // validation only checks signature + declared length, so the plaintext
+        // was accepted and published into the private room's state for every
+        // peer to read. Errors (rather than leaks) if the secret isn't available
+        // yet.
+        let invitation_secrets = self.storage.get_invitation_secrets(room_owner_key)?;
+        let secrets = crate::private_room::collect_secrets_for_room(
+            &room_state,
+            &signing_key,
+            &invitation_secrets,
+        );
+        let sealed_nickname = crate::private_room::seal_field_for_room(
+            &room_state,
+            &secrets,
+            new_nickname.as_bytes(),
+        )
+        .map_err(|e| anyhow!(e))?;
+
         // Find our current member info to get the version
         let current_version = room_state
             .member_info
@@ -3726,7 +3747,7 @@ impl ApiClient {
         let new_member_info = MemberInfo {
             member_id: my_member_id,
             version: current_version + 1,
-            preferred_nickname: SealedBytes::public(new_nickname.clone().into_bytes()),
+            preferred_nickname: sealed_nickname,
         };
 
         // Sign with our member key

--- a/cli/src/commands/room.rs
+++ b/cli/src/commands/room.rs
@@ -333,17 +333,49 @@ pub async fn execute(command: RoomCommands, api: ApiClient, format: OutputFormat
             let name_clone = name.clone();
             let description_clone = description.clone();
 
+            // Pre-seal name / description for the room's privacy mode BEFORE the
+            // update. In a PRIVATE room these are AES-256-GCM sealed under the
+            // room secret — the previous unconditional `SealedBytes::public` got
+            // a private-room name REJECTED by the contract's config guard
+            // ("Private room must have encrypted display metadata") and silently
+            // published a private-room description as PLAINTEXT. Only fetch state
+            // when a metadata field is actually changing. `sealed_description`'s
+            // outer Option is "was --description passed", the inner is the value
+            // (None clears it).
+            #[allow(clippy::type_complexity)]
+            let (sealed_name, sealed_description): (
+                Option<SealedBytes>,
+                Option<Option<SealedBytes>>,
+            ) = if name_clone.is_some() || description_clone.is_some() {
+                let mut state = api.get_room(&owner_key, false).await?;
+                let secrets = api.room_display_secrets(&owner_key, &mut state);
+                let sn = match &name_clone {
+                    Some(n) => Some(
+                        crate::private_room::seal_field_for_room(&state, &secrets, n.as_bytes())
+                            .map_err(|e| anyhow::anyhow!(e))?,
+                    ),
+                    None => None,
+                };
+                let sd = match &description_clone {
+                    Some(d) if d.is_empty() => Some(None),
+                    Some(d) => Some(Some(
+                        crate::private_room::seal_field_for_room(&state, &secrets, d.as_bytes())
+                            .map_err(|e| anyhow::anyhow!(e))?,
+                    )),
+                    None => None,
+                };
+                (sn, sd)
+            } else {
+                (None, None)
+            };
+
             match api
                 .update_config(&owner_key, |cfg| {
-                    if let Some(ref n) = name_clone {
-                        cfg.display.name = SealedBytes::public(n.as_bytes().to_vec());
+                    if let Some(ref n) = sealed_name {
+                        cfg.display.name = n.clone();
                     }
-                    if let Some(ref d) = description_clone {
-                        cfg.display.description = if d.is_empty() {
-                            None
-                        } else {
-                            Some(SealedBytes::public(d.as_bytes().to_vec()))
-                        };
+                    if let Some(ref d) = sealed_description {
+                        cfg.display.description = d.clone();
                     }
                     if let Some(v) = max_bans {
                         cfg.max_user_bans = v;

--- a/cli/src/private_room.rs
+++ b/cli/src/private_room.rs
@@ -111,8 +111,9 @@ pub fn collect_secrets_for_room(
 ///   silently leaks plaintext into a private room.
 ///
 /// The write-side counterpart of [`crate::api::unseal_nickname_display`]: the
-/// single sealing decision behind `member set-nickname`, `room config
-/// --name/--description`, and the owner-metadata path of `room create`.
+/// single sealing decision behind `member set-nickname` and `room config
+/// --name/--description`. (`room create` seals its owner metadata inline under a
+/// freshly-generated secret rather than through this state-derived helper.)
 pub fn seal_field_for_room(
     state: &ChatRoomStateV1,
     secrets: &HashMap<u32, [u8; 32]>,

--- a/cli/src/private_room.rs
+++ b/cli/src/private_room.rs
@@ -95,6 +95,43 @@ pub fn collect_secrets_for_room(
     secrets
 }
 
+/// Seal a room display / identity field (room name, description, or member
+/// nickname) according to the room's privacy mode, using a **secrets map**
+/// already collected via [`collect_secrets_for_room`].
+///
+/// - **Public room** → `SealedBytes::public(plaintext)` (unchanged behaviour).
+/// - **Private room** → AES-256-GCM sealed under the room's CURRENT-version
+///   secret, mirroring the UI's `seal_bytes` metadata paths
+///   (`ui/src/room_data.rs`, `ui/src/components/room_list/edit_room_modal.rs`).
+///   **Errors** when that secret is unavailable rather than emitting a public
+///   value: a plaintext name / nickname / description in a private room is both
+///   a privacy leak (it deanonymises the member / room to every peer) AND, for
+///   the name, rejected by the contract's config guard (`configuration.rs`:
+///   "Private room must have encrypted display metadata"). riverctl never
+///   silently leaks plaintext into a private room.
+///
+/// The write-side counterpart of [`crate::api::unseal_nickname_display`]: the
+/// single sealing decision behind `member set-nickname`, `room config
+/// --name/--description`, and the owner-metadata path of `room create`.
+pub fn seal_field_for_room(
+    state: &ChatRoomStateV1,
+    secrets: &HashMap<u32, [u8; 32]>,
+    plaintext: &[u8],
+) -> Result<SealedBytes, String> {
+    if state.configuration.configuration.privacy_mode != PrivacyMode::Private {
+        return Ok(SealedBytes::public(plaintext.to_vec()));
+    }
+    let version = state.secrets.current_version;
+    let secret = secrets.get(&version).ok_or_else(|| {
+        format!(
+            "Private room secret v{version} is not available yet, so this value \
+             cannot be sealed. riverctl will not send plaintext into a private \
+             room. Try again once the room has finished syncing."
+        )
+    })?;
+    Ok(seal_bytes(plaintext, secret, version))
+}
+
 /// Collect a secrets map into the wire-format `Vec<(version, secret)>` carried
 /// by `Invitation::room_secrets`, sorted ascending by version so the encoded
 /// invitation is deterministic — the encoded string is fingerprinted for
@@ -588,6 +625,54 @@ mod tests {
         let state = state_with_privacy(&owner, PrivacyMode::Public);
         let secrets = collect_secrets_for_room(&state, &owner, &HashMap::new());
         assert!(secrets.is_empty(), "public room should yield no secrets");
+    }
+
+    /// A public room seals metadata as-is (plaintext bytes), unchanged from the
+    /// pre-fix behaviour.
+    #[test]
+    fn seal_field_public_room_stays_public() {
+        let owner = fresh_signing_key();
+        let state = state_with_privacy(&owner, PrivacyMode::Public);
+        let sealed = seal_field_for_room(&state, &HashMap::new(), b"Public Room").unwrap();
+        assert!(sealed.is_public());
+        assert_eq!(sealed.as_public_bytes(), Some(b"Public Room".as_ref()));
+    }
+
+    /// A private room seals metadata under the current-version secret, and the
+    /// result round-trips back to the plaintext via `unseal_bytes_with_secrets`.
+    /// This is the fix for the `member set-nickname` / `room config` plaintext
+    /// leak — the sealed value is NOT the plaintext.
+    #[test]
+    fn seal_field_private_room_seals_and_roundtrips() {
+        let owner = fresh_signing_key();
+        let mut state = state_with_privacy(&owner, PrivacyMode::Private);
+        state.secrets.current_version = 0;
+        let secret = generate_room_secret();
+        let secrets = HashMap::from([(0u32, secret)]);
+
+        let sealed = seal_field_for_room(&state, &secrets, b"Alice").expect("seals");
+        assert!(sealed.is_private(), "private-room metadata must be sealed");
+        assert_ne!(
+            sealed.as_public_bytes(),
+            Some(b"Alice".as_ref()),
+            "sealed value must not expose the plaintext"
+        );
+        let plaintext = river_core::ecies::unseal_bytes_with_secrets(&sealed, &secrets).unwrap();
+        assert_eq!(plaintext, b"Alice");
+    }
+
+    /// A private room with NO available secret errors rather than leaking a
+    /// public value into private state — the core of the privacy fix.
+    #[test]
+    fn seal_field_private_room_without_secret_errors() {
+        let owner = fresh_signing_key();
+        let mut state = state_with_privacy(&owner, PrivacyMode::Private);
+        state.secrets.current_version = 3;
+        let err = seal_field_for_room(&state, &HashMap::new(), b"Alice").unwrap_err();
+        assert!(
+            err.contains("v3") && err.contains("not available"),
+            "error should name the missing version, got: {err}"
+        );
     }
 
     /// Owner decrypts the OWNER-ADDRESSED contract blob even though the


### PR DESCRIPTION
## Problem

Audit follow-up to #388 (private-room **read** fix). riverctl's private-room **write** paths sent metadata as **plaintext**, silently deanonymising the member / room:

- **`member set-nickname`** built `preferred_nickname` with an unconditional `SealedBytes::public(...)`. The room contract's `member_info` validation only checks signature + declared length, so the plaintext nickname was **accepted and published** into the private room's state for every peer to read. Changing your nickname via riverctl deanonymised you.
- **`room config --name`** sent a public name into a private room, which the contract's config guard **rejects** ("Private room must have encrypted display metadata") — an opaque failure. **`room config --description`** was accepted as **plaintext** (the guard only inspects the name), leaking it.

## Approach

New shared helper `private_room::seal_field_for_room(state, secrets, plaintext)` — the single write-side sealing decision, the counterpart of the read-side `api::unseal_nickname_display`:

- **Public room** → public bytes (unchanged behaviour).
- **Private room** → AES-256-GCM sealed under the current-version secret (via the existing `collect_secrets_for_room`).
- **No secret available** → **error**, never a public value, so riverctl never leaks plaintext into a private room.

Wired into `set_nickname` and the `room config` name/description path (pre-sealed before `update_config`). Mirrors the UI, which seals these fields.

No `common/` / contract / delegate WASM change → **no migration**.

## Testing

Unit tests pin: public passthrough, private seal + round-trip (sealed value ≠ plaintext, decrypts back), and the no-secret error names the missing version. Full `riverctl` lib suite green (158 tests); `cargo fmt` + `cargo clippy` clean.

Not yet exercised end-to-end against a live private room — the unit tests cover the sealing decision that was wrong; wiring is a direct substitution of the sealing helper for the old `SealedBytes::public`.

## Follow-ups (separate PRs, tracked)

- `room create --private` (riverctl can't create a private room at all yet).
- crates.io version-check nag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9wgmB6Wbs2kCgEBWpr6X9

[AI-assisted - Claude]