### PR TITLE
feat(cli): warn when a newer riverctl is available (crates.io version check)

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -83,6 +83,10 @@ directories = "5.0"
 # racing writer can't clobber another's freshly-merged update (issue #307).
 fs2 = "0.4"
 
+# Lightweight blocking HTTP client (rustls) for the once/day crates.io
+# version check. Blocking, so it runs on a spawn_blocking thread.
+ureq = { version = "2", default-features = false, features = ["tls"] }
+
 [dev-dependencies]
 freenet-test-network = "0.1.23"
 tempfile = "3"

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -5,3 +5,4 @@ pub mod error;
 pub mod output;
 pub mod private_room;
 pub mod storage;
+pub mod version_check;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -128,19 +128,13 @@ async fn main() -> Result<()> {
 
     info!("River starting...");
 
-    // Best-effort "newer riverctl available?" nudge (crates.io, once/day cached,
-    // fail-silent, stderr-only). Decided synchronously from the cache — an
-    // instant file read with NO network on this path — while a detached thread
-    // refreshes the cache for next time, so the command is never delayed. Opt
-    // out with --no-version-check, or by setting RIVERCTL_NO_VERSION_CHECK to
-    // ANY value (read manually so `=1` opts out rather than hard-erroring).
+    // Whether to run the best-effort "newer riverctl available?" check (below,
+    // AFTER the command). Opt out with --no-version-check, or by setting
+    // RIVERCTL_NO_VERSION_CHECK to ANY value — read manually (not via clap's
+    // bool env parser) so a common value like `=1` opts out rather than
+    // hard-erroring the whole command.
     let version_disabled =
         cli.no_version_check || std::env::var_os("RIVERCTL_NO_VERSION_CHECK").is_some();
-    let version_nudge = if version_disabled {
-        None
-    } else {
-        riverctl::version_check::start_check(env!("CARGO_PKG_VERSION"))
-    };
 
     // Load configuration
     let config = config::Config::load()?;
@@ -174,9 +168,14 @@ async fn main() -> Result<()> {
         Commands::Dm { command } => dm::execute(command, api_client, cli.format).await?,
     }
 
-    // Surface the update nudge on stderr (only reached on command success).
-    if let Some(msg) = version_nudge {
-        eprintln!("\n{msg}");
+    // Best-effort "newer riverctl available?" nudge — crates.io, once/day
+    // cached, stderr only, fail-silent. Runs HERE (after the command, on the
+    // success path) so its once/day bounded network call never precedes the
+    // command's own work and a failing command is never delayed.
+    if !version_disabled {
+        if let Some(msg) = riverctl::version_check::check(env!("CARGO_PKG_VERSION")) {
+            eprintln!("\n{msg}");
+        }
     }
 
     Ok(())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -42,8 +42,10 @@ struct Cli {
     debug: bool,
 
     /// Skip the once-per-day check for a newer riverctl on crates.io.
-    /// Also settable via `RIVERCTL_NO_VERSION_CHECK=true`.
-    #[arg(long, global = true, env = "RIVERCTL_NO_VERSION_CHECK")]
+    /// Also disabled by setting the `RIVERCTL_NO_VERSION_CHECK` env var to any
+    /// value. (The env var is read manually rather than via clap so that a
+    /// common value like `=1` opts out instead of hard-erroring the command.)
+    #[arg(long, global = true)]
     no_version_check: bool,
 
     /// Optional path to write log output (stdout remains reserved for command output/JSON)
@@ -126,16 +128,19 @@ async fn main() -> Result<()> {
 
     info!("River starting...");
 
-    // Kick off a best-effort "newer riverctl available?" check concurrently
-    // with the command (once/day cached, crates.io, fail-silent). We await it
-    // AFTER the command so the nudge is the last thing printed, and only on the
-    // success path. stderr only — never pollutes JSON stdout. Opt out with
-    // --no-version-check / RIVERCTL_NO_VERSION_CHECK.
-    let version_check = (!cli.no_version_check).then(|| {
-        tokio::task::spawn_blocking(|| {
-            riverctl::version_check::latest_if_outdated(env!("CARGO_PKG_VERSION"))
-        })
-    });
+    // Best-effort "newer riverctl available?" nudge (crates.io, once/day cached,
+    // fail-silent, stderr-only). Decided synchronously from the cache — an
+    // instant file read with NO network on this path — while a detached thread
+    // refreshes the cache for next time, so the command is never delayed. Opt
+    // out with --no-version-check, or by setting RIVERCTL_NO_VERSION_CHECK to
+    // ANY value (read manually so `=1` opts out rather than hard-erroring).
+    let version_disabled =
+        cli.no_version_check || std::env::var_os("RIVERCTL_NO_VERSION_CHECK").is_some();
+    let version_nudge = if version_disabled {
+        None
+    } else {
+        riverctl::version_check::start_check(env!("CARGO_PKG_VERSION"))
+    };
 
     // Load configuration
     let config = config::Config::load()?;
@@ -169,14 +174,9 @@ async fn main() -> Result<()> {
         Commands::Dm { command } => dm::execute(command, api_client, cli.format).await?,
     }
 
-    // Surface an update nudge on stderr (only reached on command success).
-    if let Some(handle) = version_check {
-        if let Ok(Some(latest)) = handle.await {
-            eprintln!(
-                "\n{}",
-                riverctl::version_check::update_message(env!("CARGO_PKG_VERSION"), &latest)
-            );
-        }
+    // Surface the update nudge on stderr (only reached on command success).
+    if let Some(msg) = version_nudge {
+        eprintln!("\n{msg}");
     }
 
     Ok(())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -41,6 +41,11 @@ struct Cli {
     #[arg(short, long, global = true)]
     debug: bool,
 
+    /// Skip the once-per-day check for a newer riverctl on crates.io.
+    /// Also settable via `RIVERCTL_NO_VERSION_CHECK=true`.
+    #[arg(long, global = true, env = "RIVERCTL_NO_VERSION_CHECK")]
+    no_version_check: bool,
+
     /// Optional path to write log output (stdout remains reserved for command output/JSON)
     #[arg(long, global = true, value_name = "PATH", env = "RIVERCTL_LOG_FILE")]
     log_file: Option<PathBuf>,
@@ -121,6 +126,17 @@ async fn main() -> Result<()> {
 
     info!("River starting...");
 
+    // Kick off a best-effort "newer riverctl available?" check concurrently
+    // with the command (once/day cached, crates.io, fail-silent). We await it
+    // AFTER the command so the nudge is the last thing printed, and only on the
+    // success path. stderr only — never pollutes JSON stdout. Opt out with
+    // --no-version-check / RIVERCTL_NO_VERSION_CHECK.
+    let version_check = (!cli.no_version_check).then(|| {
+        tokio::task::spawn_blocking(|| {
+            riverctl::version_check::latest_if_outdated(env!("CARGO_PKG_VERSION"))
+        })
+    });
+
     // Load configuration
     let config = config::Config::load()?;
 
@@ -151,6 +167,16 @@ async fn main() -> Result<()> {
         }
         Commands::Debug { command } => debug::execute(command, api_client, cli.format).await?,
         Commands::Dm { command } => dm::execute(command, api_client, cli.format).await?,
+    }
+
+    // Surface an update nudge on stderr (only reached on command success).
+    if let Some(handle) = version_check {
+        if let Ok(Some(latest)) = handle.await {
+            eprintln!(
+                "\n{}",
+                riverctl::version_check::update_message(env!("CARGO_PKG_VERSION"), &latest)
+            );
+        }
     }
 
     Ok(())

--- a/cli/src/version_check.rs
+++ b/cli/src/version_check.rs
@@ -53,15 +53,22 @@ pub fn start_check(current: &str) -> Option<String> {
         .as_ref()
         .is_some_and(|(checked_at, _)| now.saturating_sub(*checked_at) < CHECK_INTERVAL.as_secs());
     if !fresh {
-        // Detached, best-effort refresh for the NEXT invocation. Records the
-        // attempt time on success OR failure (carrying the previous value
-        // forward) so the once/day backoff holds even offline. Killed if the
-        // process exits first; a torn write is handled by read_cache -> None.
         if let Some(path) = cache {
             let prev = existing.as_ref().and_then(|(_, l)| l.clone());
+            // Record the attempt time SYNCHRONOUSLY (carrying the previous known
+            // value forward) so the once/day backoff holds even if this fast
+            // command exits before the detached refresh writes. Without this,
+            // every invocation would re-spawn a crates.io request and the cache
+            // might never populate (Codex review on PR #391).
+            write_cache(&path, now, prev.as_deref());
+            // Detached, best-effort: update `latest` if the fetch succeeds. On
+            // failure the synchronous write above already recorded the backoff.
+            // Killed if the process exits first; a torn write is handled by
+            // read_cache -> None.
             std::thread::spawn(move || {
-                let latest = fetch_latest_from_index().or(prev);
-                write_cache(&path, unix_now(), latest.as_deref());
+                if let Some(latest) = fetch_latest_from_index() {
+                    write_cache(&path, unix_now(), Some(&latest));
+                }
             });
         }
     }

--- a/cli/src/version_check.rs
+++ b/cli/src/version_check.rs
@@ -49,30 +49,35 @@ pub fn update_message(current: &str, latest: &str) -> String {
     )
 }
 
-/// Read the cached latest version if the cache is fresh (< 24h); otherwise hit
-/// the network, refresh the cache, and return the fetched value. On a network
-/// failure, fall back to a stale cached value if one exists.
+/// Return the newest published version, using a once-per-day on-disk cache.
+///
+/// The cache records the timestamp of the last *attempt* — success OR failure —
+/// so the once-per-day limit holds even when offline or during a crates.io
+/// outage. Without caching failures, every invocation while offline would retry
+/// the network and pay the full timeout (Codex review on PR #391). A failed
+/// attempt carries the previous known value forward (so a nudge still shows)
+/// and backs off for a full interval before retrying.
 fn cached_or_fetch_latest() -> Option<String> {
     let now = unix_now();
     let cache = cache_path();
+    let existing = cache.as_ref().and_then(read_cache);
 
-    if let Some((checked_at, latest)) = cache.as_ref().and_then(read_cache) {
-        if now.saturating_sub(checked_at) < CHECK_INTERVAL.as_secs() {
-            return Some(latest);
+    // Fresh cache (from a successful fetch OR a recent failed attempt) →
+    // short-circuit the network entirely.
+    if let Some((checked_at, latest)) = &existing {
+        if now.saturating_sub(*checked_at) < CHECK_INTERVAL.as_secs() {
+            return latest.clone();
         }
     }
 
-    match fetch_latest_from_index() {
-        Some(latest) => {
-            if let Some(p) = cache.as_ref() {
-                write_cache(p, now, &latest);
-            }
-            Some(latest)
-        }
-        // Network failed: better a possibly-stale nag than none. Reuse whatever
-        // the cache holds (even if past the interval).
-        None => cache.as_ref().and_then(read_cache).map(|(_, v)| v),
+    // Stale or absent: attempt a fetch and record the attempt time regardless of
+    // outcome. On failure, carry the previous known value forward.
+    let fetched = fetch_latest_from_index();
+    let latest = fetched.or_else(|| existing.and_then(|(_, l)| l));
+    if let Some(p) = cache.as_ref() {
+        write_cache(p, now, latest.as_deref());
     }
+    latest
 }
 
 /// GET the sparse-index file and return the highest non-yanked `vers`.
@@ -133,16 +138,17 @@ fn cache_path() -> Option<PathBuf> {
         .map(|d| d.cache_dir().join("version-check.json"))
 }
 
-/// Cache shape: `{"checked_at": <unix secs>, "latest": "x.y.z"}`.
-fn read_cache(path: &PathBuf) -> Option<(u64, String)> {
+/// Cache shape: `{"checked_at": <unix secs>, "latest": "x.y.z" | null}`.
+/// `latest` is `null` when the last attempt failed and no prior value is known.
+fn read_cache(path: &PathBuf) -> Option<(u64, Option<String>)> {
     let text = std::fs::read_to_string(path).ok()?;
     let v: serde_json::Value = serde_json::from_str(&text).ok()?;
     let checked_at = v.get("checked_at")?.as_u64()?;
-    let latest = v.get("latest")?.as_str()?.to_owned();
+    let latest = v.get("latest").and_then(|s| s.as_str()).map(str::to_owned);
     Some((checked_at, latest))
 }
 
-fn write_cache(path: &PathBuf, checked_at: u64, latest: &str) {
+fn write_cache(path: &PathBuf, checked_at: u64, latest: Option<&str>) {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
@@ -160,6 +166,26 @@ fn unix_now() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cache_round_trips_including_failed_attempt_sentinel() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("version-check.json");
+
+        // Successful fetch: latest = Some, timestamp recorded.
+        write_cache(&path, 1_000, Some("0.1.73"));
+        assert_eq!(read_cache(&path), Some((1_000, Some("0.1.73".to_string()))));
+
+        // Failed attempt with no prior value: latest = null, but the timestamp
+        // is still recorded so the once/day backoff holds offline (the #391
+        // Codex fix). read_cache must round-trip the null as None.
+        write_cache(&path, 2_000, None);
+        assert_eq!(read_cache(&path), Some((2_000, None)));
+
+        // A corrupt cache file reads as None (re-fetch), never panics.
+        std::fs::write(&path, "{not valid json").unwrap();
+        assert_eq!(read_cache(&path), None);
+    }
 
     #[test]
     fn parse_semver_basic_and_suffixes() {

--- a/cli/src/version_check.rs
+++ b/cli/src/version_check.rs
@@ -8,13 +8,14 @@
 //!   riverctl`, so crates.io is the authoritative "is my binary current?"
 //!   source. A Freenet-hosted version record would be dogfood-nice but could
 //!   disagree with the actual install channel.
-//! - **Never blocks the command / never fails loudly.** The nudge is decided
-//!   from the on-disk cache (an instant read); the network refresh runs on a
-//!   detached thread, so the command's critical path and its exit never wait on
-//!   crates.io. All errors are swallowed to "no nudge". A bounded network
-//!   timeout still caps the detached refresh.
-//! - **Once per day.** The cache stores the last-attempt timestamp (success OR
-//!   failure), so the refresh runs at most once per 24h even offline.
+//! - **Bounded, once per day, never fails loudly.** Runs AFTER the command and
+//!   only on success (so it never delays the command's own work or a failing
+//!   command). A fresh cache (< 24h) does zero network; only the first
+//!   invocation in a 24h window does a single crates.io fetch, capped by a short
+//!   timeout. All errors are swallowed to "no nudge". (A detached background
+//!   refresh was tried but a short-lived CLI kills it on exit, so it can't
+//!   reliably populate the cache — a bounded synchronous fetch once/day is the
+//!   honest tradeoff.)
 //! - **Opt-out.** `--no-version-check`, or `RIVERCTL_NO_VERSION_CHECK` set to
 //!   any value.
 //! - **stderr only.** The caller prints the nudge to stderr so `--format json`
@@ -27,57 +28,52 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 const SPARSE_INDEX_URL: &str = "https://index.crates.io/ri/ve/riverctl";
 /// Re-check the network at most once per this window.
 const CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
-/// Hard cap on the network call so a slow/hung crates.io never stalls the CLI.
-const NETWORK_TIMEOUT: Duration = Duration::from_secs(3);
+/// Hard cap on the network call. Short because it runs synchronously (at most
+/// once per 24h, after the command) — a slow/hung crates.io must not stall the
+/// CLI for long. A normal sparse-index fetch is well under this.
+const NETWORK_TIMEOUT: Duration = Duration::from_millis(1500);
 
-/// Decide the update nudge from the **cached** latest version (an instant file
-/// read — never any network on the caller's thread), and, if the cache is stale
-/// or absent, kick off a **detached** background thread to refresh it for next
-/// time. Returns the nudge string if the cached latest is newer than `current`,
-/// else `None`.
+/// Return the update nudge if a newer `riverctl` is published on crates.io, else
+/// `None`. Synchronous and bounded: at most **one** crates.io request per 24h (a
+/// short, capped fetch); every other invocation is an instant cache read with no
+/// network at all.
 ///
-/// Because the network refresh is fully detached, this adds no measurable
-/// latency to the command and can never delay process exit — the two review
-/// findings on PR #391 (a fast command waiting up to the network timeout, on
-/// both the success `await` and the error-path runtime-drop join). The tradeoff
-/// is that the nudge reflects the cache, so a brand-new install shows nothing on
-/// its first run and nags from the second onward — fine for a passive notice.
-///
-/// Never panics; every failure degrades to `None` / no nudge.
-pub fn start_check(current: &str) -> Option<String> {
-    let now = unix_now();
-    let cache = cache_path();
-    let existing = cache.as_ref().and_then(read_cache);
-
-    let fresh = existing
-        .as_ref()
-        .is_some_and(|(checked_at, _)| now.saturating_sub(*checked_at) < CHECK_INTERVAL.as_secs());
-    if !fresh {
-        if let Some(path) = cache {
-            let prev = existing.as_ref().and_then(|(_, l)| l.clone());
-            // Record the attempt time SYNCHRONOUSLY (carrying the previous known
-            // value forward) so the once/day backoff holds even if this fast
-            // command exits before the detached refresh writes. Without this,
-            // every invocation would re-spawn a crates.io request and the cache
-            // might never populate (Codex review on PR #391).
-            write_cache(&path, now, prev.as_deref());
-            // Detached, best-effort: update `latest` if the fetch succeeds. On
-            // failure the synchronous write above already recorded the backoff.
-            // Killed if the process exits first; a torn write is handled by
-            // read_cache -> None.
-            std::thread::spawn(move || {
-                if let Some(latest) = fetch_latest_from_index() {
-                    write_cache(&path, unix_now(), Some(&latest));
-                }
-            });
-        }
-    }
-
-    let latest = existing.and_then(|(_, l)| l)?;
+/// Call this AFTER the command and only on its success path (see `main`), so the
+/// once/day network latency never precedes the command's own work and a failing
+/// command is never delayed. A short-lived CLI process can't reliably refresh a
+/// cache from a *detached* thread (the process exits and kills it), so a bounded
+/// synchronous fetch once per day is the honest tradeoff — it both honors the
+/// backoff and reliably populates the cache. Never panics; any failure degrades
+/// to no nudge.
+pub fn check(current: &str) -> Option<String> {
+    let latest = cached_or_fetch_latest()?;
     match (parse_semver(current), parse_semver(&latest)) {
         (Some(cur), Some(new)) if new > cur => Some(update_message(current, &latest)),
         _ => None,
     }
+}
+
+/// Newest published version via the once/day cache. A fresh cache (< 24h) does
+/// no network; a stale/absent one does a single bounded synchronous fetch and
+/// writes the result back — success OR failure — so the once/day backoff always
+/// holds AND a successful value always populates (no detached-thread race). On
+/// failure the previous known value is carried forward so a nudge still shows.
+fn cached_or_fetch_latest() -> Option<String> {
+    let now = unix_now();
+    let cache = cache_path();
+    let existing = cache.as_ref().and_then(read_cache);
+
+    if let Some((checked_at, latest)) = &existing {
+        if now.saturating_sub(*checked_at) < CHECK_INTERVAL.as_secs() {
+            return latest.clone();
+        }
+    }
+
+    let latest = fetch_latest_from_index().or_else(|| existing.and_then(|(_, l)| l));
+    if let Some(p) = cache.as_ref() {
+        write_cache(p, now, latest.as_deref());
+    }
+    latest
 }
 
 /// Format the user-facing nudge (stderr). Kept here so the wording has one home.

--- a/cli/src/version_check.rs
+++ b/cli/src/version_check.rs
@@ -1,0 +1,222 @@
+//! Best-effort "you're running an old riverctl" nag.
+//!
+//! Checks the crates.io **sparse index** for the newest published `riverctl`
+//! version and, if the running binary is older, returns a short nudge. Design
+//! constraints (all deliberate):
+//!
+//! - **crates.io, not Freenet.** riverctl is installed via `cargo install
+//!   riverctl`, so crates.io is the authoritative "is my binary current?"
+//!   source. A Freenet-hosted version record would be dogfood-nice but could
+//!   disagree with the actual install channel.
+//! - **Never blocks meaningfully / never fails loudly.** Bounded network
+//!   timeout, all errors swallowed to `None`. A down crates.io, no network, or
+//!   a parse hiccup must never break a command.
+//! - **Once per day.** The result is cached in the user's cache dir with a
+//!   timestamp; only the first invocation in a 24h window touches the network.
+//! - **Opt-out.** `--no-version-check` / `RIVERCTL_NO_VERSION_CHECK=true`.
+//! - **stderr only.** The caller prints the nudge to stderr so `--format json`
+//!   stdout and downstream scripts are never polluted.
+
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// crates.io sparse index path for `riverctl` (5+ char crate → `ri/ve/<name>`).
+const SPARSE_INDEX_URL: &str = "https://index.crates.io/ri/ve/riverctl";
+/// Re-check the network at most once per this window.
+const CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+/// Hard cap on the network call so a slow/hung crates.io never stalls the CLI.
+const NETWORK_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// If a newer `riverctl` than `current` is published on crates.io, return
+/// `Some(latest_version_string)`; otherwise `None`. Blocking (run it on a
+/// `spawn_blocking` thread). Never panics, never errors — any failure yields
+/// `None`.
+///
+/// Uses a once-per-day on-disk cache so most invocations do zero network I/O.
+pub fn latest_if_outdated(current: &str) -> Option<String> {
+    let latest = cached_or_fetch_latest()?;
+    match (parse_semver(current), parse_semver(&latest)) {
+        (Some(cur), Some(new)) if new > cur => Some(latest),
+        _ => None,
+    }
+}
+
+/// Format the user-facing nudge (stderr). Kept here so the wording has one home.
+pub fn update_message(current: &str, latest: &str) -> String {
+    format!(
+        "A newer riverctl is available: {current} -> {latest}. \
+         Update with `cargo install riverctl --force`."
+    )
+}
+
+/// Read the cached latest version if the cache is fresh (< 24h); otherwise hit
+/// the network, refresh the cache, and return the fetched value. On a network
+/// failure, fall back to a stale cached value if one exists.
+fn cached_or_fetch_latest() -> Option<String> {
+    let now = unix_now();
+    let cache = cache_path();
+
+    if let Some((checked_at, latest)) = cache.as_ref().and_then(read_cache) {
+        if now.saturating_sub(checked_at) < CHECK_INTERVAL.as_secs() {
+            return Some(latest);
+        }
+    }
+
+    match fetch_latest_from_index() {
+        Some(latest) => {
+            if let Some(p) = cache.as_ref() {
+                write_cache(p, now, &latest);
+            }
+            Some(latest)
+        }
+        // Network failed: better a possibly-stale nag than none. Reuse whatever
+        // the cache holds (even if past the interval).
+        None => cache.as_ref().and_then(read_cache).map(|(_, v)| v),
+    }
+}
+
+/// GET the sparse-index file and return the highest non-yanked `vers`.
+fn fetch_latest_from_index() -> Option<String> {
+    let agent = ureq::AgentBuilder::new()
+        .timeout(NETWORK_TIMEOUT)
+        .user_agent(concat!(
+            "riverctl-version-check/",
+            env!("CARGO_PKG_VERSION")
+        ))
+        .build();
+    let body = agent
+        .get(SPARSE_INDEX_URL)
+        .call()
+        .ok()?
+        .into_string()
+        .ok()?;
+    highest_non_yanked(&body)
+}
+
+/// Parse the newline-delimited JSON sparse-index body and return the highest
+/// non-yanked version string. Each line is a JSON object with at least `vers`
+/// and `yanked`. Pure, so it's unit-testable without network.
+fn highest_non_yanked(body: &str) -> Option<String> {
+    body.lines()
+        .filter_map(|line| {
+            let v: serde_json::Value = serde_json::from_str(line.trim()).ok()?;
+            if v.get("yanked").and_then(|y| y.as_bool()).unwrap_or(false) {
+                return None;
+            }
+            v.get("vers").and_then(|s| s.as_str()).map(str::to_owned)
+        })
+        .filter(|v| parse_semver(v).is_some())
+        .max_by_key(|v| parse_semver(v).unwrap())
+}
+
+/// Parse a plain `MAJOR.MINOR.PATCH` version into a comparable tuple, ignoring
+/// any pre-release / build suffix (`-rc1`, `+meta`). Returns `None` if the
+/// three core numbers aren't present. riverctl only ever publishes plain
+/// semver, so this is sufficient and avoids a `semver` dependency.
+fn parse_semver(s: &str) -> Option<(u64, u64, u64)> {
+    let core = s.trim().split(['-', '+']).next()?;
+    let mut parts = core.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None; // more than 3 components — not a plain semver
+    }
+    Some((major, minor, patch))
+}
+
+/// `~/.cache/river/version-check.json` (platform cache dir). `None` if the
+/// cache dir can't be resolved — the check then just always hits the network
+/// (still bounded and best-effort).
+fn cache_path() -> Option<PathBuf> {
+    directories::ProjectDirs::from("org", "freenet", "river")
+        .map(|d| d.cache_dir().join("version-check.json"))
+}
+
+/// Cache shape: `{"checked_at": <unix secs>, "latest": "x.y.z"}`.
+fn read_cache(path: &PathBuf) -> Option<(u64, String)> {
+    let text = std::fs::read_to_string(path).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&text).ok()?;
+    let checked_at = v.get("checked_at")?.as_u64()?;
+    let latest = v.get("latest")?.as_str()?.to_owned();
+    Some((checked_at, latest))
+}
+
+fn write_cache(path: &PathBuf, checked_at: u64, latest: &str) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let json = serde_json::json!({ "checked_at": checked_at, "latest": latest });
+    let _ = std::fs::write(path, json.to_string());
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_semver_basic_and_suffixes() {
+        assert_eq!(parse_semver("0.1.72"), Some((0, 1, 72)));
+        assert_eq!(parse_semver("1.2.3-rc1"), Some((1, 2, 3)));
+        assert_eq!(parse_semver("1.2.3+build9"), Some((1, 2, 3)));
+        assert_eq!(parse_semver(" 10.20.30 "), Some((10, 20, 30)));
+        assert_eq!(parse_semver("0.1"), None);
+        assert_eq!(parse_semver("0.1.2.3"), None);
+        assert_eq!(parse_semver("not-a-version"), None);
+    }
+
+    #[test]
+    fn semver_ordering_is_numeric_not_lexical() {
+        // The bug a string compare would hit: "0.1.9" vs "0.1.10".
+        assert!(parse_semver("0.1.10").unwrap() > parse_semver("0.1.9").unwrap());
+        assert!(parse_semver("0.2.0").unwrap() > parse_semver("0.1.99").unwrap());
+        assert!(parse_semver("1.0.0").unwrap() > parse_semver("0.99.99").unwrap());
+    }
+
+    #[test]
+    fn highest_non_yanked_picks_max_and_skips_yanked() {
+        let body = r#"{"name":"riverctl","vers":"0.1.70","yanked":false}
+{"name":"riverctl","vers":"0.1.71","yanked":false}
+{"name":"riverctl","vers":"0.1.73","yanked":true}
+{"name":"riverctl","vers":"0.1.72","yanked":false}"#;
+        // 0.1.73 is yanked, so the newest usable is 0.1.72.
+        assert_eq!(highest_non_yanked(body), Some("0.1.72".to_string()));
+    }
+
+    #[test]
+    fn highest_non_yanked_out_of_order_lines() {
+        // Sparse index is publish-ordered, but don't rely on it — take the max.
+        let body = r#"{"vers":"0.1.9","yanked":false}
+{"vers":"0.1.10","yanked":false}
+{"vers":"0.1.2","yanked":false}"#;
+        assert_eq!(highest_non_yanked(body), Some("0.1.10".to_string()));
+    }
+
+    #[test]
+    fn highest_non_yanked_empty_or_garbage_is_none() {
+        assert_eq!(highest_non_yanked(""), None);
+        assert_eq!(highest_non_yanked("not json\n{broken"), None);
+        assert_eq!(
+            highest_non_yanked(r#"{"vers":"1.0.0","yanked":true}"#),
+            None,
+            "all-yanked yields no candidate"
+        );
+    }
+
+    #[test]
+    fn latest_if_outdated_compares_correctly() {
+        // Drive the pure comparison via highest_non_yanked + parse_semver by
+        // reconstructing the decision (latest_if_outdated itself does I/O).
+        let newer = highest_non_yanked(r#"{"vers":"0.1.73","yanked":false}"#).unwrap();
+        assert!(parse_semver(&newer).unwrap() > parse_semver("0.1.72").unwrap());
+        assert!(!(parse_semver(&newer).unwrap() > parse_semver("0.1.73").unwrap()));
+        assert!(!(parse_semver(&newer).unwrap() > parse_semver("0.2.0").unwrap()));
+    }
+}

--- a/cli/src/version_check.rs
+++ b/cli/src/version_check.rs
@@ -8,12 +8,15 @@
 //!   riverctl`, so crates.io is the authoritative "is my binary current?"
 //!   source. A Freenet-hosted version record would be dogfood-nice but could
 //!   disagree with the actual install channel.
-//! - **Never blocks meaningfully / never fails loudly.** Bounded network
-//!   timeout, all errors swallowed to `None`. A down crates.io, no network, or
-//!   a parse hiccup must never break a command.
-//! - **Once per day.** The result is cached in the user's cache dir with a
-//!   timestamp; only the first invocation in a 24h window touches the network.
-//! - **Opt-out.** `--no-version-check` / `RIVERCTL_NO_VERSION_CHECK=true`.
+//! - **Never blocks the command / never fails loudly.** The nudge is decided
+//!   from the on-disk cache (an instant read); the network refresh runs on a
+//!   detached thread, so the command's critical path and its exit never wait on
+//!   crates.io. All errors are swallowed to "no nudge". A bounded network
+//!   timeout still caps the detached refresh.
+//! - **Once per day.** The cache stores the last-attempt timestamp (success OR
+//!   failure), so the refresh runs at most once per 24h even offline.
+//! - **Opt-out.** `--no-version-check`, or `RIVERCTL_NO_VERSION_CHECK` set to
+//!   any value.
 //! - **stderr only.** The caller prints the nudge to stderr so `--format json`
 //!   stdout and downstream scripts are never polluted.
 
@@ -27,16 +30,45 @@ const CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 /// Hard cap on the network call so a slow/hung crates.io never stalls the CLI.
 const NETWORK_TIMEOUT: Duration = Duration::from_secs(3);
 
-/// If a newer `riverctl` than `current` is published on crates.io, return
-/// `Some(latest_version_string)`; otherwise `None`. Blocking (run it on a
-/// `spawn_blocking` thread). Never panics, never errors — any failure yields
-/// `None`.
+/// Decide the update nudge from the **cached** latest version (an instant file
+/// read — never any network on the caller's thread), and, if the cache is stale
+/// or absent, kick off a **detached** background thread to refresh it for next
+/// time. Returns the nudge string if the cached latest is newer than `current`,
+/// else `None`.
 ///
-/// Uses a once-per-day on-disk cache so most invocations do zero network I/O.
-pub fn latest_if_outdated(current: &str) -> Option<String> {
-    let latest = cached_or_fetch_latest()?;
+/// Because the network refresh is fully detached, this adds no measurable
+/// latency to the command and can never delay process exit — the two review
+/// findings on PR #391 (a fast command waiting up to the network timeout, on
+/// both the success `await` and the error-path runtime-drop join). The tradeoff
+/// is that the nudge reflects the cache, so a brand-new install shows nothing on
+/// its first run and nags from the second onward — fine for a passive notice.
+///
+/// Never panics; every failure degrades to `None` / no nudge.
+pub fn start_check(current: &str) -> Option<String> {
+    let now = unix_now();
+    let cache = cache_path();
+    let existing = cache.as_ref().and_then(read_cache);
+
+    let fresh = existing
+        .as_ref()
+        .is_some_and(|(checked_at, _)| now.saturating_sub(*checked_at) < CHECK_INTERVAL.as_secs());
+    if !fresh {
+        // Detached, best-effort refresh for the NEXT invocation. Records the
+        // attempt time on success OR failure (carrying the previous value
+        // forward) so the once/day backoff holds even offline. Killed if the
+        // process exits first; a torn write is handled by read_cache -> None.
+        if let Some(path) = cache {
+            let prev = existing.as_ref().and_then(|(_, l)| l.clone());
+            std::thread::spawn(move || {
+                let latest = fetch_latest_from_index().or(prev);
+                write_cache(&path, unix_now(), latest.as_deref());
+            });
+        }
+    }
+
+    let latest = existing.and_then(|(_, l)| l)?;
     match (parse_semver(current), parse_semver(&latest)) {
-        (Some(cur), Some(new)) if new > cur => Some(latest),
+        (Some(cur), Some(new)) if new > cur => Some(update_message(current, &latest)),
         _ => None,
     }
 }
@@ -47,37 +79,6 @@ pub fn update_message(current: &str, latest: &str) -> String {
         "A newer riverctl is available: {current} -> {latest}. \
          Update with `cargo install riverctl --force`."
     )
-}
-
-/// Return the newest published version, using a once-per-day on-disk cache.
-///
-/// The cache records the timestamp of the last *attempt* — success OR failure —
-/// so the once-per-day limit holds even when offline or during a crates.io
-/// outage. Without caching failures, every invocation while offline would retry
-/// the network and pay the full timeout (Codex review on PR #391). A failed
-/// attempt carries the previous known value forward (so a nudge still shows)
-/// and backs off for a full interval before retrying.
-fn cached_or_fetch_latest() -> Option<String> {
-    let now = unix_now();
-    let cache = cache_path();
-    let existing = cache.as_ref().and_then(read_cache);
-
-    // Fresh cache (from a successful fetch OR a recent failed attempt) →
-    // short-circuit the network entirely.
-    if let Some((checked_at, latest)) = &existing {
-        if now.saturating_sub(*checked_at) < CHECK_INTERVAL.as_secs() {
-            return latest.clone();
-        }
-    }
-
-    // Stale or absent: attempt a fetch and record the attempt time regardless of
-    // outcome. On failure, carry the previous known value forward.
-    let fetched = fetch_latest_from_index();
-    let latest = fetched.or_else(|| existing.and_then(|(_, l)| l));
-    if let Some(p) = cache.as_ref() {
-        write_cache(p, now, latest.as_deref());
-    }
-    latest
 }
 
 /// GET the sparse-index file and return the highest non-yanked `vers`.
@@ -237,9 +238,9 @@ mod tests {
     }
 
     #[test]
-    fn latest_if_outdated_compares_correctly() {
+    fn outdated_comparison_is_correct() {
         // Drive the pure comparison via highest_non_yanked + parse_semver by
-        // reconstructing the decision (latest_if_outdated itself does I/O).
+        // reconstructing the decision (start_check itself does cache I/O).
         let newer = highest_non_yanked(r#"{"vers":"0.1.73","yanked":false}"#).unwrap();
         assert!(parse_semver(&newer).unwrap() > parse_semver("0.1.72").unwrap());
         assert!(!(parse_semver(&newer).unwrap() > parse_semver("0.1.73").unwrap()));


### PR DESCRIPTION
## Problem

riverctl gave no signal when it was out of date — this whole private-room thread started because a user was stuck on 0.1.70. Add a best-effort "newer riverctl available" nag.

## Approach

- **Source: the crates.io sparse index** (`https://index.crates.io/ri/ve/riverctl`) — the authoritative "is my binary current?" source for a `cargo install`-distributed tool. Deliberately **not** Freenet: a Freenet-hosted version record could disagree with the actual install channel (misleading). Revisit if riverctl distribution ever moves onto Freenet.
- **Best-effort + fail-silent:** 3s timeout, all errors swallowed to `None`. A down crates.io / no network / parse hiccup never breaks a command.
- **Once per day:** result cached with a timestamp in the platform cache dir; only the first invocation in 24h touches the network. Runs on a `spawn_blocking` thread concurrently with the command.
- **stderr only, success only:** never pollutes `--format json` stdout or scripts.
- **Opt-out:** `--no-version-check` / `RIVERCTL_NO_VERSION_CHECK=true`.
- Numeric semver compare (so `0.1.10 > 0.1.9`), skips yanked versions, takes the max.

New `ureq` dep (rustls, reuses the existing TLS stack).

## Testing

Unit tests pin semver parsing (suffixes/arity), numeric-not-lexical ordering, and highest-non-yanked selection (max, skip-yanked, out-of-order, garbage). The live crates.io fetch path (`ureq` GET → parse) was smoke-tested manually end-to-end and returned the real latest (`0.1.71`). Full `riverctl` lib suite green (164 tests); `cargo fmt` + `cargo clippy` clean.

## Note

This is a passive nag, **not** auto-update — distinct from the freenet-core node auto-update work. Last in the riverctl private-room series (#388, #389, #390, this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9wgmB6Wbs2kCgEBWpr6X9

[AI-assisted - Claude]