### PR TITLE
chore: bump riverctl to 0.1.73 for release

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riverctl"
-version = "0.1.72"
+version = "0.1.73"
 edition = "2021"
 authors = ["Freenet Project"]
 description = "Command-line interface for River decentralized chat on Freenet"


### PR DESCRIPTION
Version bump to release the riverctl private-room series to crates.io + GitHub:

- #388 — read encrypted rooms (message bodies, room names, nicknames)
- #389 — seal private-room writes (set-nickname / room config plaintext-leak fix)
- #390 — `room create --private`
- #391 — crates.io version-check nag

**0.1.72 is skipped**: the `riverctl-v0.1.72` tag already exists (pointing at an old commit `9b45c2fd`) and 0.1.72 was never published to crates.io (its max is 0.1.71) — a half-broken prior release. Releasing as 0.1.73 avoids the tag collision.

After merge, tagging `riverctl-v0.1.73` from main triggers `release-riverctl.yml` (crates.io publish + GitHub release with prebuilt binaries).

Mechanical version bump — no code change.

[AI-assisted - Claude]