### PR TITLE
fix(ui): show loading/migrating/empty state in room list (#397)

### DIFF
--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -1290,37 +1290,70 @@ mod tests {
     /// combination is a definitive answer and resolves.
     #[test]
     fn per_room_load_stays_loading_only_on_empty_listed_with_fetch_error() {
+        // Signature: should_resolve_per_room_load(map_empty, listed_count,
+        // had_fetch_error, recovering). These cases fix recovering = false; the
+        // recovering = true cases are pinned separately below.
+
         // The one case that must NOT resolve: empty map, index listed rooms, and
         // a fetch error → stay Loading (retry on WS reconnect).
         assert!(
-            !should_resolve_per_room_load(true, 3, true),
+            !should_resolve_per_room_load(true, 3, true, false),
             "empty + listed + fetch error must NOT resolve (stay Loading)"
         );
 
         // Empty but every listed key definitively had no value (no fetch error) →
         // a real, if odd, empty state → resolve.
         assert!(
-            should_resolve_per_room_load(true, 3, false),
+            should_resolve_per_room_load(true, 3, false, false),
             "empty + listed + no fetch error is a definitive empty → resolve"
         );
 
         // Empty and nothing was listed → genuinely empty delegate → resolve.
         assert!(
-            should_resolve_per_room_load(true, 0, false),
+            should_resolve_per_room_load(true, 0, false, false),
             "empty + nothing listed is the new-user empty → resolve"
         );
         // A fetch error is irrelevant when nothing was listed (can't happen, but
         // the decision must still resolve — there's provably nothing to wait for).
         assert!(
-            should_resolve_per_room_load(true, 0, true),
+            should_resolve_per_room_load(true, 0, true, false),
             "empty + nothing listed must resolve regardless of the error flag"
         );
 
         // A non-empty map always resolves (a partial load renders as List; the
         // missing rooms show their own per-room markers), regardless of errors.
-        assert!(should_resolve_per_room_load(false, 3, true));
-        assert!(should_resolve_per_room_load(false, 3, false));
-        assert!(should_resolve_per_room_load(false, 0, false));
+        assert!(should_resolve_per_room_load(false, 3, true, false));
+        assert!(should_resolve_per_room_load(false, 3, false, false));
+        assert!(should_resolve_per_room_load(false, 0, false, false));
+    }
+
+    /// freenet/river#397 Codex review 2 (P2): an interrupted-migration recovery
+    /// on an EMPTY map must stay `Loading` (recovery may still recover stranded
+    /// rooms), even with no fetch error — but recovery is irrelevant once the map
+    /// is non-empty (rooms are already showing).
+    #[test]
+    fn per_room_load_stays_loading_while_recovering_on_empty_map() {
+        // Empty + recovering → stay Loading, regardless of listed/error.
+        assert!(
+            !should_resolve_per_room_load(true, 0, false, true),
+            "empty + recovering must NOT resolve — stranded rooms may still recover"
+        );
+        assert!(
+            !should_resolve_per_room_load(true, 3, false, true),
+            "empty + listed + recovering must NOT resolve"
+        );
+        assert!(
+            !should_resolve_per_room_load(true, 3, true, true),
+            "empty + listed + error + recovering must NOT resolve"
+        );
+
+        // A non-empty map resolves even while recovering (rooms are visible;
+        // recovery continues as a background re-fill).
+        assert!(
+            should_resolve_per_room_load(false, 3, false, true),
+            "non-empty map resolves to List even while recovering"
+        );
+        assert!(should_resolve_per_room_load(false, 0, true, true));
     }
 
     /// freenet/river#397 Codex review (P2-1): the load backstop must be armed
@@ -4192,18 +4225,26 @@ pub(crate) fn backstop_resolve(current: RoomsLoadState) -> RoomsLoadState {
 ///   (some rooms loaded, some errored) has a non-empty map and resolves to
 ///   `List`; the missing rooms surface their own per-room `awaiting_sync`/error
 ///   markers.
-/// - empty + nothing listed (`listed_count == 0`) → resolve (`true`): a
-///   genuinely empty delegate (the new-user / no-rooms case).
-/// - empty + listed + NO fetch error → resolve (`true`): every listed key
-///   definitively returned `value: None` — a real (if odd) empty state, not a
-///   failure to fetch.
+/// - empty + nothing listed (`listed_count == 0`) + not recovering → resolve
+///   (`true`): a genuinely empty delegate (the new-user / no-rooms case).
+/// - empty + listed + NO fetch error + not recovering → resolve (`true`): every
+///   listed key definitively returned `value: None` — a real (if odd) empty
+///   state, not a failure to fetch.
 /// - empty + listed + a fetch error → do NOT resolve (`false`): stay `Loading`.
+/// - empty + `recovering` → do NOT resolve (`false`): an interrupted-migration
+///   recovery is armed/running, and the in-progress flag explicitly says rooms
+///   may be stranded. Even with no fetch error (e.g. the interrupted save wrote
+///   only tombstones while the live-room writes failed), resolving here would
+///   flash "no rooms yet" before the recovery re-run below has a chance to
+///   recover them. Stay `Loading` until recovery concludes (freenet/river#397
+///   Codex review 2, P2).
 pub(crate) fn should_resolve_per_room_load(
     map_empty: bool,
     listed_count: usize,
     had_fetch_error: bool,
+    recovering: bool,
 ) -> bool {
-    !(map_empty && listed_count > 0 && had_fetch_error)
+    !(map_empty && ((listed_count > 0 && had_fetch_error) || recovering))
 }
 
 /// Timeout for the room-list load backstop (see [`backstop_resolve`]). Generous

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -4083,8 +4083,12 @@ pub(crate) fn backstop_resolve(current: RoomsLoadState) -> RoomsLoadState {
 /// on purpose: it must comfortably outlast a real legacy migration's
 /// probe→response→migrate window so it never pre-empts an existing user's
 /// migration, so its only visible effect is resolving the genuinely-empty
-/// new-user case.
-const ROOMS_LOAD_BACKSTOP_MS: u64 = 15_000;
+/// new-user case. Tradeoff (freenet/river#397 review): a longer timeout means a
+/// brand-new user waits fractionally longer for the empty state, but it avoids
+/// flash-emptying an existing user whose legacy `ListResponse` is slow to arrive
+/// on a cold first connect (before the `Migrating` transition fires). 20s is
+/// chosen to sit safely past a realistic slow probe→response→migrate window.
+const ROOMS_LOAD_BACKSTOP_MS: u64 = 20_000;
 
 /// One-shot guard so the backstop is scheduled once per session even though
 /// `set_up_chat_delegate` re-runs on every reconnect.

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -19,7 +19,7 @@ use river_core::chat_delegate::{
 use river_core::room_state::direct_messages::{PurgeToken, MAX_DM_MESSAGES_PER_PAIR};
 use river_core::room_state::member::MemberId;
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{LazyLock, Mutex};
 
 // Legacy single-blob rooms key. Still read for the one-time client-side
@@ -1253,44 +1253,44 @@ mod tests {
         );
     }
 
-    /// freenet/river#397 Codex review 3/4: the UNIVERSAL backstop resolves EVERY
-    /// non-terminal state (`Loading` AND `Migrating`) — to `LoadFailed` if a
-    /// known-rooms fetch failed, else `Loaded` — so the rail can never spin
-    /// forever (a delegate request can time out without the WS disconnecting, so
-    /// "wait for reconnect" cannot guarantee termination). Already-terminal states
-    /// (`Loaded`/`LoadFailed`) pass through unchanged.
+    /// freenet/river#397 Codex review 5: the UNIVERSAL backstop resolves EVERY
+    /// non-terminal state to a terminal, and a stalled `Migrating` (which we set
+    /// ONLY after a non-empty index proved rooms exist) resolves to `LoadFailed`,
+    /// NOT Empty — an honest error+retry for a known-non-empty load that stalled.
+    /// Already-terminal states pass through unchanged.
     #[test]
     fn backstop_resolves_every_non_terminal_state() {
-        // No fetch failure → non-terminal resolves to Loaded (→ Empty when no rooms).
+        // A stalled Migrating → LoadFailed, regardless of the fetch-failure flag
+        // (rooms are KNOWN to exist; showing Empty would be a lie).
         assert_eq!(
-            backstop_resolve(RoomsLoadState::Loading, false),
+            backstop_terminal(RoomsLoadState::Migrating, false),
+            RoomsLoadState::LoadFailed,
+            "a stalled Migrating resolves to LoadFailed, never Empty"
+        );
+        assert_eq!(
+            backstop_terminal(RoomsLoadState::Migrating, true),
+            RoomsLoadState::LoadFailed,
+        );
+        // Loading with no fetch failure → Loaded (genuine empty / new user).
+        assert_eq!(
+            backstop_terminal(RoomsLoadState::Loading, false),
             RoomsLoadState::Loaded,
             "Loading with no fetch failure resolves to Loaded (Empty)"
         );
+        // Loading with a known-rooms fetch failure → LoadFailed.
         assert_eq!(
-            backstop_resolve(RoomsLoadState::Migrating, false),
-            RoomsLoadState::Loaded,
-            "Migrating with no fetch failure resolves to Loaded"
-        );
-        // A known-rooms fetch failure → non-terminal resolves to LoadFailed.
-        assert_eq!(
-            backstop_resolve(RoomsLoadState::Loading, true),
+            backstop_terminal(RoomsLoadState::Loading, true),
             RoomsLoadState::LoadFailed,
             "Loading with a fetch failure resolves to LoadFailed, not a false Empty"
         );
-        assert_eq!(
-            backstop_resolve(RoomsLoadState::Migrating, true),
-            RoomsLoadState::LoadFailed,
-            "Migrating with a fetch failure resolves to LoadFailed"
-        );
         // Already-terminal states pass through, regardless of the flag.
         assert_eq!(
-            backstop_resolve(RoomsLoadState::Loaded, true),
+            backstop_terminal(RoomsLoadState::Loaded, true),
             RoomsLoadState::Loaded,
             "Loaded is terminal and passes through"
         );
         assert_eq!(
-            backstop_resolve(RoomsLoadState::LoadFailed, false),
+            backstop_terminal(RoomsLoadState::LoadFailed, false),
             RoomsLoadState::LoadFailed,
             "LoadFailed is terminal and passes through"
         );
@@ -1308,7 +1308,7 @@ mod tests {
             RoomsLoadState::LoadFailed,
         ] {
             for saw in [false, true] {
-                let out = backstop_resolve(state, saw);
+                let out = backstop_terminal(state, saw);
                 assert!(
                     matches!(out, RoomsLoadState::Loaded | RoomsLoadState::LoadFailed),
                     "{state:?} (saw_fetch_failure={saw}) must terminate at a terminal state, got {out:?}"
@@ -1317,12 +1317,23 @@ mod tests {
         }
     }
 
-    /// freenet/river#397 Codex review 4: the pure `backstop_terminal` picks the
-    /// terminal — `LoadFailed` if a known-rooms fetch failed, else `Loaded`.
+    /// freenet/river#397 Codex review 5 (P2a): a backstop timer armed at
+    /// generation N is a no-op once the generation advances (a Retry bumped it),
+    /// so a stale timer can't resolve the retry's fresh state prematurely.
     #[test]
-    fn backstop_terminal_picks_loadfailed_only_on_fetch_failure() {
-        assert_eq!(backstop_terminal(false), RoomsLoadState::Loaded);
-        assert_eq!(backstop_terminal(true), RoomsLoadState::LoadFailed);
+    fn stale_backstop_timer_is_a_noop() {
+        assert!(
+            backstop_should_apply(3, 3),
+            "same generation → the timer still applies"
+        );
+        assert!(
+            !backstop_should_apply(3, 4),
+            "a newer attempt superseded this timer → no-op"
+        );
+        assert!(
+            !backstop_should_apply(0, 1),
+            "the first retry invalidates the initial-load timer"
+        );
     }
 
     /// freenet/river#397 Codex review 4: the authoritative current-delegate
@@ -1365,7 +1376,7 @@ mod tests {
         let after_probe = load_state_after_probe_legacy(true);
         assert_eq!(after_probe, RoomsLoadState::Loading);
         assert_eq!(
-            backstop_resolve(after_probe, false),
+            backstop_terminal(after_probe, false),
             RoomsLoadState::Loaded,
             "no fetch failure → Empty, not LoadFailed"
         );
@@ -1412,9 +1423,11 @@ mod tests {
         );
     }
 
-    /// freenet/river#397 Codex review 4: the Retry button's `retry_rooms_load`
+    /// freenet/river#397 Codex review 4/5: the Retry button's `retry_rooms_load`
     /// must (a) reset `SAW_FETCH_FAILURE`, (b) return the rail to `Loading`,
-    /// (c) re-arm the once-per-session backstop guard, and (d) re-fire the
+    /// (c) re-enable the legacy probe (`LEGACY_MIGRATION_ATTEMPTED`) so a FAILED
+    /// legacy source is retried, (d) bump `LOAD_ATTEMPT_GEN` (invalidating stale
+    /// backstop timers), (e) re-arm a fresh backstop, and (f) re-fire the
     /// current-delegate list request. Pinned by source-scrape (the fn drives the
     /// Dioxus signal + websocket, so it can't be unit-driven).
     #[test]
@@ -1443,13 +1456,74 @@ mod tests {
             "retry must return the rail to Loading"
         );
         assert!(
+            body.contains("LEGACY_MIGRATION_ATTEMPTED.store(false"),
+            "retry must re-enable the legacy probe so a failed legacy source is retried (P1b)"
+        );
+        assert!(
+            body.contains("LOAD_ATTEMPT_GEN.fetch_add(1"),
+            "retry must bump the attempt generation to invalidate stale backstop timers (P2a)"
+        );
+        assert!(
             body.contains("LOAD_BACKSTOP_SCHEDULED.store(false")
                 && body.contains("schedule_rooms_load_backstop()"),
-            "retry must re-arm the once-per-session backstop"
+            "retry must re-arm the backstop"
         );
         assert!(
             body.contains("fire_list_rooms_request().await"),
             "retry must re-fire the current-delegate load"
+        );
+    }
+
+    /// freenet/river#397 Codex review 5 (P2a): `schedule_rooms_load_backstop`
+    /// captures the attempt generation at arm time and guards its resolution with
+    /// `backstop_should_apply`, so a stale timer is a no-op.
+    #[test]
+    fn backstop_scheduler_is_generation_guarded() {
+        // `schedule_rooms_load_backstop` is defined AFTER this mid-file test
+        // module, so `rfind` (last occurrence) finds the real definition.
+        let src = include_str!("chat_delegate.rs");
+        let fn_start = src
+            .rfind("pub(crate) fn schedule_rooms_load_backstop()")
+            .expect("schedule_rooms_load_backstop must exist");
+        let rest = &src[fn_start + 1..];
+        let fn_end = rest
+            .find("\npub(crate) fn retry_rooms_load()")
+            .map(|i| fn_start + 1 + i)
+            .unwrap_or(src.len());
+        let body = &src[fn_start..fn_end];
+        assert!(
+            body.contains("LOAD_ATTEMPT_GEN.load(Ordering::Relaxed)"),
+            "the scheduler must capture/compare the attempt generation"
+        );
+        assert!(
+            body.contains("backstop_should_apply("),
+            "the scheduler's resolve closure must bail via backstop_should_apply on a stale gen"
+        );
+    }
+
+    /// freenet/river#397 Codex review 5 (P2c): `fire_list_rooms_request` marks the
+    /// attempt failed on a SEND / serialize error, so the backstop resolves to
+    /// LoadFailed (with Retry) rather than a silent Empty.
+    #[test]
+    fn list_request_send_failure_marks_fetch_failure() {
+        // `fire_list_rooms_request` is defined AFTER this mid-file test module;
+        // `rfind` (last occurrence) finds the real definition, not this literal.
+        let src = include_str!("chat_delegate.rs");
+        let fn_start = src
+            .rfind("async fn fire_list_rooms_request()")
+            .expect("fire_list_rooms_request must exist");
+        let rest = &src[fn_start + 1..];
+        let fn_end = rest
+            .find("\n#[allow(dead_code)]")
+            .or_else(|| rest.find("\npub async fn "))
+            .or_else(|| rest.find("\nasync fn "))
+            .map(|i| fn_start + 1 + i)
+            .unwrap_or(src.len());
+        let body = &src[fn_start..fn_end];
+        assert_eq!(
+            body.matches("mark_fetch_failure()").count(),
+            2,
+            "both the serialize-error and send-error arms must mark_fetch_failure"
         );
     }
 
@@ -2580,6 +2654,11 @@ async fn fire_list_rooms_request() {
     let mut payload = Vec::new();
     if let Err(e) = ciborium::ser::into_writer(&request, &mut payload) {
         error!("Failed to serialize list-rooms request: {}", e);
+        // freenet/river#397 Codex review 5 (P2c): the initial list request
+        // definitively failed to send, so the load can never resolve on its own.
+        // Record it as a fetch failure so the backstop resolves to LoadFailed
+        // (with Retry) rather than a silent Empty.
+        mark_fetch_failure();
         return;
     }
 
@@ -2610,6 +2689,10 @@ async fn fire_list_rooms_request() {
 
     if let Err(e) = api_result {
         error!("Failed to send list-rooms request: {}", e);
+        // freenet/river#397 Codex review 5 (P2c): the SEND itself failed (no
+        // response will ever come), so mark the attempt failed — the backstop
+        // then resolves to LoadFailed (with Retry) instead of a silent Empty.
+        mark_fetch_failure();
     } else {
         info!("List-rooms request sent, response will be handled by message loop");
     }
@@ -4256,17 +4339,43 @@ pub(crate) fn mark_fetch_failure() {
     SAW_FETCH_FAILURE.store(true, Ordering::Relaxed);
 }
 
-/// The terminal state a completed-but-empty load / the backstop resolves to,
-/// given whether any known-rooms fetch failed. Pure so both branches are
-/// unit-testable. `saw_fetch_failure` → `LoadFailed` (we KNOW rooms exist but
-/// couldn't load them); otherwise `Loaded` (genuinely empty → the calm "no rooms
-/// yet"). freenet/river#397 Codex review 4.
-pub(crate) fn backstop_terminal(saw_fetch_failure: bool) -> RoomsLoadState {
-    if saw_fetch_failure {
-        RoomsLoadState::LoadFailed
-    } else {
-        RoomsLoadState::Loaded
+/// The terminal state the backstop resolves a still-non-terminal load to,
+/// given the CURRENT state and whether any known-rooms fetch failed. Pure, so
+/// every branch is unit-testable. freenet/river#397 Codex review 4/5:
+/// - `Migrating` → `LoadFailed`. We only ever set `Migrating` after a non-empty
+///   index PROVED rooms exist, so a migration still running at the 30s deadline
+///   is a stall of a known-non-empty load — an honest error+retry, NOT Empty.
+///   It self-corrects to `List` if the migration later completes and hydrates
+///   rooms (a non-empty `ROOMS` outranks the load state).
+/// - `Loading` → `LoadFailed` if a known-rooms fetch failed, else `Loaded`
+///   (a genuine empty / new user with nothing to load).
+/// - `Loaded` / `LoadFailed` are already terminal → returned unchanged.
+pub(crate) fn backstop_terminal(
+    current: RoomsLoadState,
+    saw_fetch_failure: bool,
+) -> RoomsLoadState {
+    match current {
+        RoomsLoadState::Migrating => RoomsLoadState::LoadFailed,
+        RoomsLoadState::Loading => {
+            if saw_fetch_failure {
+                RoomsLoadState::LoadFailed
+            } else {
+                RoomsLoadState::Loaded
+            }
+        }
+        // Already terminal.
+        other => other,
     }
+}
+
+/// Whether a backstop timer armed at generation `armed_gen` should still apply
+/// its resolution, given the current attempt generation. Pure so the stale-timer
+/// invalidation is unit-testable. A retry increments the generation, so a timer
+/// from an earlier attempt (or any other late callback) is a no-op and cannot
+/// resolve the retry's fresh `Loading`/`Migrating` prematurely. freenet/river#397
+/// Codex review 5 (P2a).
+pub(crate) fn backstop_should_apply(armed_gen: u32, current_gen: u32) -> bool {
+    armed_gen == current_gen
 }
 
 /// The current-delegate per-room load terminal (authoritative, awaited — resolves
@@ -4292,51 +4401,47 @@ pub(crate) fn per_room_terminal(
     }
 }
 
-/// The UNIVERSAL backstop transition (freenet/river#397 Codex review 3/4). At the
-/// 30s deadline, ANY non-terminal state (`Loading`/`Migrating`) resolves — to
-/// `LoadFailed` if a known-rooms fetch failed, else `Loaded`. This GUARANTEES
-/// termination: the earlier "stay `Loading`/`Migrating` and rely on a WS
-/// reconnect to retry" could spin forever, because a delegate request can time
-/// out (~10s) WITHOUT disconnecting the WebSocket, so no reconnect ever comes;
-/// and concurrent legacy probes race on this one global signal. Because a genuine
-/// empty resolves FAST to `Loaded` at a definitive completion
-/// (ProbeLegacy-found-nothing / all-tombstone), staying non-terminal until 30s
-/// means a stall/failure — so `SAW_FETCH_FAILURE` decides Empty vs. error. Already
-/// terminal states (`Loaded`/`LoadFailed`) are returned unchanged.
-pub(crate) fn backstop_resolve(current: RoomsLoadState, saw_fetch_failure: bool) -> RoomsLoadState {
-    match current {
-        RoomsLoadState::Loading | RoomsLoadState::Migrating => backstop_terminal(saw_fetch_failure),
-        // Loaded / LoadFailed are already terminal.
-        other => other,
-    }
-}
-
-/// Timeout for the UNIVERSAL room-list load backstop (see [`backstop_resolve`]).
-/// Armed once per session at the START of load (`set_up_chat_delegate`); at the
-/// deadline it resolves any non-terminal state to `Loaded`. Generous (30s) so it
-/// never pre-empts a load or migration that is actually progressing — a slow but
-/// live probe→response→migrate or per-room fetch completes and resolves itself
-/// well before this fires; the backstop only bites on genuine timeout /
-/// all-fetch-fail / concurrency-strand cases, where resolving to Empty is the
-/// accepted residual (freenet/river#397 Codex review 3).
+/// Timeout for the UNIVERSAL room-list load backstop (see [`backstop_terminal`]).
+/// Armed once per session at the START of load (`set_up_chat_delegate`), re-armed
+/// on Retry. At the deadline it resolves any still-non-terminal state to a
+/// terminal (`LoadFailed` if a known-rooms fetch failed or a migration stalled,
+/// else `Loaded`). Generous (30s) so it never pre-empts a load or migration that
+/// is actually progressing — a slow but live probe→response→migrate or per-room
+/// fetch completes and resolves itself well before this fires; the backstop only
+/// bites on genuine timeout / all-fetch-fail / concurrency-strand cases.
 const ROOMS_LOAD_BACKSTOP_MS: u64 = 30_000;
 
 /// One-shot guard so the backstop is scheduled once per session even though
-/// `set_up_chat_delegate` re-runs on every reconnect.
+/// `set_up_chat_delegate` re-runs on every reconnect. Reset by `retry_rooms_load`
+/// so a fresh deadline is armed for the retry.
 static LOAD_BACKSTOP_SCHEDULED: AtomicBool = AtomicBool::new(false);
 
-/// Schedule the room-list load backstop once per session. See
-/// [`backstop_resolve`] for why this is a safety net rather than the primary
-/// signal.
+/// Monotonic load-attempt generation (freenet/river#397 Codex review 5, P2a).
+/// Incremented by every `retry_rooms_load`. A backstop timer captures the
+/// generation at arm time and, at fire time, only applies its resolution if the
+/// generation is unchanged (`backstop_should_apply`), so a stale timer from a
+/// superseded attempt is a no-op and cannot resolve the retry's fresh state.
+static LOAD_ATTEMPT_GEN: AtomicU32 = AtomicU32::new(0);
+
+/// Schedule the room-list load backstop once per session (re-armed by Retry).
+/// See [`backstop_terminal`] for why this is a safety net rather than the primary
+/// signal, and [`backstop_should_apply`] for the stale-timer guard.
 pub(crate) fn schedule_rooms_load_backstop() {
     if LOAD_BACKSTOP_SCHEDULED.swap(true, Ordering::Relaxed) {
         return;
     }
-    crate::util::safe_spawn_local(async {
+    // Capture the attempt generation this timer belongs to.
+    let armed_gen = LOAD_ATTEMPT_GEN.load(Ordering::Relaxed);
+    crate::util::safe_spawn_local(async move {
         crate::util::sleep(std::time::Duration::from_millis(ROOMS_LOAD_BACKSTOP_MS)).await;
-        crate::util::defer(|| {
+        crate::util::defer(move || {
+            // A newer attempt (Retry) superseded this timer → no-op, so a stale
+            // 30s timer can't resolve the retry's fresh Loading/Migrating.
+            if !backstop_should_apply(armed_gen, LOAD_ATTEMPT_GEN.load(Ordering::Relaxed)) {
+                return;
+            }
             let saw_failure = SAW_FETCH_FAILURE.load(Ordering::Relaxed);
-            let resolved = backstop_resolve(*ROOMS_LOAD_STATE.peek(), saw_failure);
+            let resolved = backstop_terminal(*ROOMS_LOAD_STATE.peek(), saw_failure);
             if *ROOMS_LOAD_STATE.peek() != resolved {
                 *ROOMS_LOAD_STATE.write() = resolved;
             }
@@ -4344,20 +4449,29 @@ pub(crate) fn schedule_rooms_load_backstop() {
     });
 }
 
-/// Retry a failed room-list load (freenet/river#397 Codex review 4). Wired to the
-/// `LoadFailed` block's Retry button. Signal-safe: `set_rooms_load_state` and
+/// Retry a failed room-list load (freenet/river#397 Codex review 4/5). Wired to
+/// the `LoadFailed` block's Retry button. Signal-safe: `set_rooms_load_state` and
 /// `safe_spawn_local` both defer, and the atomics are lock-free, so this is safe
 /// to call directly from an `onclick` handler.
 ///
-/// Resets the fetch-failure signal, returns the rail to `Loading`, re-arms the
-/// once-per-session backstop (so a fresh 30s deadline applies), and re-fires the
-/// current-delegate load. If the delegate genuinely has no rooms this time, the
-/// fast ProbeLegacy/PerRoom terminal resolves to `Loaded` (→ Empty); if it
-/// succeeds it renders the list; if it fails again it returns to `LoadFailed`.
+/// Resets the fetch-failure signal, returns the rail to `Loading`, re-enables the
+/// legacy migration probe (so a FAILED legacy source is retried, not skipped),
+/// bumps the attempt generation (invalidating any stale backstop timer), re-arms
+/// a fresh backstop, and re-fires the current-delegate load. If the delegate
+/// genuinely has no rooms this time, the fast ProbeLegacy/PerRoom terminal
+/// resolves to `Loaded` (→ Empty); if it succeeds it renders the list; if it
+/// fails again it returns to `LoadFailed`.
 pub(crate) fn retry_rooms_load() {
     SAW_FETCH_FAILURE.store(false, Ordering::Relaxed);
     set_rooms_load_state(RoomsLoadState::Loading);
-    // Re-arm the once-per-session backstop guard so a fresh deadline is scheduled.
+    // Re-enable the legacy probe so a legacy source that FAILED this session is
+    // retried (freenet/river#397 Codex review 5, P1b). `is_legacy_migration_done`
+    // is deliberately left alone — a genuinely-completed migration shouldn't
+    // re-probe; this only re-arms a probe that failed.
+    LEGACY_MIGRATION_ATTEMPTED.store(false, Ordering::Relaxed);
+    // Bump the attempt generation BEFORE re-arming so the previous timer becomes
+    // a no-op (P2a), then re-arm a fresh 30s deadline.
+    LOAD_ATTEMPT_GEN.fetch_add(1, Ordering::Relaxed);
     LOAD_BACKSTOP_SCHEDULED.store(false, Ordering::Relaxed);
     schedule_rooms_load_backstop();
     crate::util::safe_spawn_local(async {

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -549,12 +549,16 @@ pub async fn set_up_chat_delegate() -> Result<(), String> {
             fire_list_rooms_request().await;
             fire_load_outbound_dms_request().await;
 
-            // Room-list load backstop (freenet/river#397): a pure UI safety net
-            // so a brand-new user whose fire-and-forget legacy probe finds
-            // nothing resolves to the empty state rather than spinning forever.
-            // Once per session; the real completion signals live in the load
-            // path's `set_rooms_load_state` calls.
-            schedule_rooms_load_backstop();
+            // NOTE (freenet/river#397 Codex review, P2-1): the room-list load
+            // backstop is NOT armed here. Arming it unconditionally at startup
+            // would let it flip an in-flight AUTHORITATIVE load (a slow
+            // ListResponse / per-room fetch that takes >20s) to Empty — a false
+            // "no rooms yet". The backstop is only needed for the ONE path with
+            // no synchronous completion signal: a fire-and-forget legacy probe.
+            // It is therefore armed only at the probe-fired sites in
+            // `response_handler.rs`, guarded by `if fired`, by which point the
+            // authoritative current-delegate load has already returned empty, so
+            // the backstop can no longer clobber it.
 
             Ok(())
         }
@@ -1277,6 +1281,102 @@ mod tests {
         let after_probe = load_state_after_probe_legacy(true);
         assert_eq!(after_probe, RoomsLoadState::Loading);
         assert_eq!(backstop_resolve(after_probe), RoomsLoadState::Loaded);
+    }
+
+    /// freenet/river#397 Codex review (P2-2): a per-room load that came back
+    /// EMPTY while the index proved rooms exist AND a listed room failed to fetch
+    /// must NOT resolve — staying `Loading` (the honest spinner) instead of
+    /// flashing "no rooms yet" at a user who provably has rooms. Every other
+    /// combination is a definitive answer and resolves.
+    #[test]
+    fn per_room_load_stays_loading_only_on_empty_listed_with_fetch_error() {
+        // The one case that must NOT resolve: empty map, index listed rooms, and
+        // a fetch error → stay Loading (retry on WS reconnect).
+        assert!(
+            !should_resolve_per_room_load(true, 3, true),
+            "empty + listed + fetch error must NOT resolve (stay Loading)"
+        );
+
+        // Empty but every listed key definitively had no value (no fetch error) →
+        // a real, if odd, empty state → resolve.
+        assert!(
+            should_resolve_per_room_load(true, 3, false),
+            "empty + listed + no fetch error is a definitive empty → resolve"
+        );
+
+        // Empty and nothing was listed → genuinely empty delegate → resolve.
+        assert!(
+            should_resolve_per_room_load(true, 0, false),
+            "empty + nothing listed is the new-user empty → resolve"
+        );
+        // A fetch error is irrelevant when nothing was listed (can't happen, but
+        // the decision must still resolve — there's provably nothing to wait for).
+        assert!(
+            should_resolve_per_room_load(true, 0, true),
+            "empty + nothing listed must resolve regardless of the error flag"
+        );
+
+        // A non-empty map always resolves (a partial load renders as List; the
+        // missing rooms show their own per-room markers), regardless of errors.
+        assert!(should_resolve_per_room_load(false, 3, true));
+        assert!(should_resolve_per_room_load(false, 3, false));
+        assert!(should_resolve_per_room_load(false, 0, false));
+    }
+
+    /// freenet/river#397 Codex review (P2-1): the load backstop must be armed
+    /// ONLY on the fire-and-forget legacy-probe path (guarded by `if fired`),
+    /// never unconditionally at startup — otherwise a slow but authoritative
+    /// current-delegate load (>20s) gets flipped to a false "no rooms yet".
+    #[test]
+    fn backstop_armed_only_on_fire_and_forget_probe() {
+        // (a) `set_up_chat_delegate` must NOT arm the backstop.
+        let self_src = include_str!("chat_delegate.rs");
+        let self_production = self_src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+        let setup_idx = self_production
+            .find("pub async fn set_up_chat_delegate()")
+            .expect("set_up_chat_delegate must exist");
+        // Bound the body at the next top-level item's doc comment.
+        let setup_end = self_production[setup_idx..]
+            .find("Per-session dedup map for")
+            .map(|i| setup_idx + i)
+            .unwrap_or(self_production.len());
+        let setup_body = &self_production[setup_idx..setup_end];
+        assert!(
+            !setup_body.contains("schedule_rooms_load_backstop"),
+            "set_up_chat_delegate must NOT arm the load backstop (P2-1): arming it \
+             unconditionally could flip a slow authoritative load to a false Empty"
+        );
+
+        // (b) In the response handler, the backstop is armed at EXACTLY the two
+        // probe-fired sites (ProbeLegacy + value-gone blob path), each directly
+        // guarded by `if fired`.
+        let rh_src = include_str!("freenet_api/response_handler.rs");
+        let rh_production = rh_src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+        let arm_count = rh_production
+            .matches("schedule_rooms_load_backstop();")
+            .count();
+        assert_eq!(
+            arm_count, 2,
+            "the backstop must be armed at exactly the two probe-fired sites (found {arm_count})"
+        );
+        let mut search_from = 0;
+        while let Some(rel) = rh_production[search_from..].find("schedule_rooms_load_backstop();") {
+            let pos = search_from + rel;
+            let guard = rh_production[..pos]
+                .rfind("if fired {")
+                .expect("each backstop arming must be guarded by `if fired`");
+            assert!(
+                pos - guard < 500,
+                "each schedule_rooms_load_backstop() must be DIRECTLY inside an `if fired` block"
+            );
+            search_from = pos + 1;
+        }
     }
 
     /// Codex P1 finding on PR #259: the legacy-migration-done
@@ -4077,6 +4177,33 @@ pub(crate) fn backstop_resolve(current: RoomsLoadState) -> RoomsLoadState {
         RoomsLoadState::Loading => RoomsLoadState::Loaded,
         other => other,
     }
+}
+
+/// Whether the current-delegate per-room load should RESOLVE the display state
+/// to `Loaded` (freenet/river#397 Codex review, P2-2). Resolve on a DEFINITIVE
+/// answer; stay `Loading` only when the load came back EMPTY but the delegate's
+/// key index PROVED rooms exist AND at least one listed room failed to
+/// materialize (a transport / parse error, NOT a definitive value-absent). In
+/// that failed-load case a WS reconnect re-fires `ListRequest` and retries, so
+/// the honest spinner is correct — we KNOW rooms exist, so flashing "no rooms
+/// yet" would be the feature's own worst failure mode.
+///
+/// - non-empty map → resolve (`true`): we have rooms to show. A PARTIAL load
+///   (some rooms loaded, some errored) has a non-empty map and resolves to
+///   `List`; the missing rooms surface their own per-room `awaiting_sync`/error
+///   markers.
+/// - empty + nothing listed (`listed_count == 0`) → resolve (`true`): a
+///   genuinely empty delegate (the new-user / no-rooms case).
+/// - empty + listed + NO fetch error → resolve (`true`): every listed key
+///   definitively returned `value: None` — a real (if odd) empty state, not a
+///   failure to fetch.
+/// - empty + listed + a fetch error → do NOT resolve (`false`): stay `Loading`.
+pub(crate) fn should_resolve_per_room_load(
+    map_empty: bool,
+    listed_count: usize,
+    had_fetch_error: bool,
+) -> bool {
+    !(map_empty && listed_count > 0 && had_fetch_error)
 }
 
 /// Timeout for the room-list load backstop (see [`backstop_resolve`]). Generous

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -546,18 +546,23 @@ pub async fn set_up_chat_delegate() -> Result<(), String> {
             // skipped (current is authoritative); if it is empty, migration is
             // fired then. This prevents legacy responses from racing with the
             // current delegate and clobbering newer state (freenet/river#253).
+            // Fresh load attempt: clear the fetch-failure signal so a stale
+            // failure from a prior attempt can't mislabel this load as
+            // `LoadFailed` (freenet/river#397 Codex review 4).
+            SAW_FETCH_FAILURE.store(false, Ordering::Relaxed);
+
             fire_list_rooms_request().await;
             fire_load_outbound_dms_request().await;
 
             // Arm the UNIVERSAL room-list load backstop once per session
-            // (freenet/river#397 Codex review 3). This is the single mechanism
+            // (freenet/river#397 Codex review 3/4). This is the single mechanism
             // that GUARANTEES the rail never spins forever: at 30s it resolves ANY
-            // non-terminal state (`Loading` OR `Migrating`) to `Loaded`. It is
-            // generous enough (30s) never to pre-empt a load/migration that is
-            // actually progressing, and because a non-empty `ROOMS` renders `List`
-            // regardless of load state, it only ever shows Empty when genuinely
-            // nothing loaded. Fast definitive completions still resolve earlier;
-            // this is the safety net under all of them.
+            // non-terminal state (`Loading` OR `Migrating`) to a terminal —
+            // `LoadFailed` if a known-rooms fetch failed, else `Loaded`. Generous
+            // enough (30s) never to pre-empt a load/migration that is actually
+            // progressing; a non-empty `ROOMS` renders `List` regardless of load
+            // state. Fast definitive completions still resolve earlier; this is
+            // the safety net under all of them.
             schedule_rooms_load_backstop();
 
             Ok(())
@@ -1248,66 +1253,129 @@ mod tests {
         );
     }
 
-    /// freenet/river#397 Codex review 3: the UNIVERSAL backstop resolves EVERY
-    /// non-terminal state to `Loaded` — both `Loading` AND `Migrating` — so the
-    /// rail can never spin forever (a delegate request can time out without the WS
-    /// disconnecting, so "wait for reconnect" cannot guarantee termination). Only
-    /// `Loaded` stays `Loaded`.
+    /// freenet/river#397 Codex review 3/4: the UNIVERSAL backstop resolves EVERY
+    /// non-terminal state (`Loading` AND `Migrating`) — to `LoadFailed` if a
+    /// known-rooms fetch failed, else `Loaded` — so the rail can never spin
+    /// forever (a delegate request can time out without the WS disconnecting, so
+    /// "wait for reconnect" cannot guarantee termination). Already-terminal states
+    /// (`Loaded`/`LoadFailed`) pass through unchanged.
     #[test]
     fn backstop_resolves_every_non_terminal_state() {
+        // No fetch failure → non-terminal resolves to Loaded (→ Empty when no rooms).
         assert_eq!(
-            backstop_resolve(RoomsLoadState::Loading),
+            backstop_resolve(RoomsLoadState::Loading, false),
             RoomsLoadState::Loaded,
-            "Loading must resolve — a new user with no legacy data never spins forever"
+            "Loading with no fetch failure resolves to Loaded (Empty)"
         );
         assert_eq!(
-            backstop_resolve(RoomsLoadState::Migrating),
+            backstop_resolve(RoomsLoadState::Migrating, false),
             RoomsLoadState::Loaded,
-            "Migrating must ALSO resolve — a stalled migration must not spin forever"
+            "Migrating with no fetch failure resolves to Loaded"
+        );
+        // A known-rooms fetch failure → non-terminal resolves to LoadFailed.
+        assert_eq!(
+            backstop_resolve(RoomsLoadState::Loading, true),
+            RoomsLoadState::LoadFailed,
+            "Loading with a fetch failure resolves to LoadFailed, not a false Empty"
         );
         assert_eq!(
-            backstop_resolve(RoomsLoadState::Loaded),
+            backstop_resolve(RoomsLoadState::Migrating, true),
+            RoomsLoadState::LoadFailed,
+            "Migrating with a fetch failure resolves to LoadFailed"
+        );
+        // Already-terminal states pass through, regardless of the flag.
+        assert_eq!(
+            backstop_resolve(RoomsLoadState::Loaded, true),
             RoomsLoadState::Loaded,
-            "Loaded stays Loaded (idempotent)"
+            "Loaded is terminal and passes through"
+        );
+        assert_eq!(
+            backstop_resolve(RoomsLoadState::LoadFailed, false),
+            RoomsLoadState::LoadFailed,
+            "LoadFailed is terminal and passes through"
         );
     }
 
     /// freenet/river#397: no state strands — every non-terminal input to the
-    /// backstop is a terminal `Loaded` output, so termination is guaranteed for
-    /// ANY load/migration path that fails to resolve itself.
+    /// backstop is a terminal output (`Loaded` or `LoadFailed`), so termination is
+    /// guaranteed for ANY load/migration path that fails to resolve itself.
     #[test]
     fn backstop_guarantees_termination_from_any_state() {
         for state in [
             RoomsLoadState::Loading,
             RoomsLoadState::Migrating,
             RoomsLoadState::Loaded,
+            RoomsLoadState::LoadFailed,
         ] {
-            assert_eq!(
-                backstop_resolve(state),
-                RoomsLoadState::Loaded,
-                "{state:?} must terminate at Loaded"
-            );
+            for saw in [false, true] {
+                let out = backstop_resolve(state, saw);
+                assert!(
+                    matches!(out, RoomsLoadState::Loaded | RoomsLoadState::LoadFailed),
+                    "{state:?} (saw_fetch_failure={saw}) must terminate at a terminal state, got {out:?}"
+                );
+            }
         }
     }
 
-    /// freenet/river#397 end-to-end invariant, composed from the pure pieces: a
-    /// brand-new user fires legacy probes (→ `Loading`), nothing responds, and
-    /// the universal backstop resolves them to `Loaded` (→ the empty state). They
-    /// are NEVER stuck loading forever.
+    /// freenet/river#397 Codex review 4: the pure `backstop_terminal` picks the
+    /// terminal — `LoadFailed` if a known-rooms fetch failed, else `Loaded`.
     #[test]
-    fn new_user_resolves_to_loaded_never_stuck() {
-        let after_probe = load_state_after_probe_legacy(true);
-        assert_eq!(after_probe, RoomsLoadState::Loading);
-        assert_eq!(backstop_resolve(after_probe), RoomsLoadState::Loaded);
+    fn backstop_terminal_picks_loadfailed_only_on_fetch_failure() {
+        assert_eq!(backstop_terminal(false), RoomsLoadState::Loaded);
+        assert_eq!(backstop_terminal(true), RoomsLoadState::LoadFailed);
     }
 
-    /// freenet/river#397 Codex review 3: the universal backstop is armed once per
-    /// session at the START of load, in `set_up_chat_delegate` (reverting the
-    /// round-3 "arm only on probe-fired" design). It must NOT be conditionally
-    /// armed elsewhere — a single unconditional arming is what makes termination
-    /// universal.
+    /// freenet/river#397 Codex review 4: the authoritative current-delegate
+    /// per-room terminal. Rooms present → `Loaded` (List); empty + listed + a
+    /// fetch error → `LoadFailed` (never a false Empty); a genuine empty (nothing
+    /// listed, or every listed slot a clean skip) → `Loaded` (Empty).
     #[test]
-    fn set_up_chat_delegate_arms_backstop() {
+    fn per_room_terminal_distinguishes_failure_from_empty() {
+        // Rooms present → Loaded, regardless of listed/error.
+        assert_eq!(
+            per_room_terminal(false, 3, true),
+            RoomsLoadState::Loaded,
+            "a non-empty map always resolves to Loaded (List)"
+        );
+        assert_eq!(per_room_terminal(false, 0, false), RoomsLoadState::Loaded);
+
+        // Empty + listed + fetch error → LoadFailed.
+        assert_eq!(
+            per_room_terminal(true, 3, true),
+            RoomsLoadState::LoadFailed,
+            "empty with a known-rooms fetch failure must be LoadFailed, not Empty"
+        );
+
+        // Empty + listed + NO fetch error → genuine empty (Loaded → Empty).
+        assert_eq!(
+            per_room_terminal(true, 3, false),
+            RoomsLoadState::Loaded,
+            "empty with all slots cleanly skipped is a genuine empty"
+        );
+        // Empty + nothing listed → genuine empty (new-user).
+        assert_eq!(per_room_terminal(true, 0, false), RoomsLoadState::Loaded);
+        assert_eq!(per_room_terminal(true, 0, true), RoomsLoadState::Loaded);
+    }
+
+    /// freenet/river#397: a brand-new user fires legacy probes (→ `Loading`),
+    /// nothing responds and NO known-rooms fetch failed, so the universal backstop
+    /// resolves them to `Loaded` (→ Empty) — NEVER stuck, and NEVER LoadFailed.
+    #[test]
+    fn new_user_resolves_to_empty_never_stuck_never_failed() {
+        let after_probe = load_state_after_probe_legacy(true);
+        assert_eq!(after_probe, RoomsLoadState::Loading);
+        assert_eq!(
+            backstop_resolve(after_probe, false),
+            RoomsLoadState::Loaded,
+            "no fetch failure → Empty, not LoadFailed"
+        );
+    }
+
+    /// freenet/river#397 Codex review 3/4: the universal backstop is armed once
+    /// per session at the START of load in `set_up_chat_delegate`, which also
+    /// resets `SAW_FETCH_FAILURE`. It must NOT be armed in the response handler.
+    #[test]
+    fn set_up_chat_delegate_arms_backstop_and_resets_fetch_failure() {
         let self_src = include_str!("chat_delegate.rs");
         let self_production = self_src
             .split("mod tests {")
@@ -1326,9 +1394,12 @@ mod tests {
             setup_body.contains("schedule_rooms_load_backstop();"),
             "set_up_chat_delegate must arm the universal load backstop once per session"
         );
+        assert!(
+            setup_body.contains("SAW_FETCH_FAILURE.store(false"),
+            "set_up_chat_delegate must reset SAW_FETCH_FAILURE at the start of a load"
+        );
 
-        // And the response handler must NOT arm it (the round-3 probe-fired arming
-        // is reverted — the universal start-of-load arming replaces it).
+        // And the response handler must NOT arm the backstop.
         let rh_src = include_str!("freenet_api/response_handler.rs");
         let rh_production = rh_src
             .split("mod tests {")
@@ -1337,7 +1408,48 @@ mod tests {
         assert!(
             !rh_production.contains("schedule_rooms_load_backstop"),
             "the response handler must NOT arm the backstop — it is armed once at \
-             start of load in set_up_chat_delegate (Codex review 3)"
+             start of load in set_up_chat_delegate"
+        );
+    }
+
+    /// freenet/river#397 Codex review 4: the Retry button's `retry_rooms_load`
+    /// must (a) reset `SAW_FETCH_FAILURE`, (b) return the rail to `Loading`,
+    /// (c) re-arm the once-per-session backstop guard, and (d) re-fire the
+    /// current-delegate list request. Pinned by source-scrape (the fn drives the
+    /// Dioxus signal + websocket, so it can't be unit-driven).
+    #[test]
+    fn retry_rooms_load_resets_and_refires() {
+        // `retry_rooms_load` is defined AFTER this (mid-file) test module, so
+        // `split("mod tests")` would miss it. `rfind` finds the real definition
+        // (the last occurrence; this test's own literal above is earlier).
+        let src = include_str!("chat_delegate.rs");
+        let fn_start = src
+            .rfind("pub(crate) fn retry_rooms_load()")
+            .expect("retry_rooms_load must exist");
+        let rest = &src[fn_start + 1..];
+        let fn_end = rest
+            .find("\nstatic ")
+            .or_else(|| rest.find("\npub"))
+            .or_else(|| rest.find("\nfn "))
+            .map(|i| fn_start + 1 + i)
+            .unwrap_or(src.len());
+        let body = &src[fn_start..fn_end];
+        assert!(
+            body.contains("SAW_FETCH_FAILURE.store(false"),
+            "retry must reset the fetch-failure signal"
+        );
+        assert!(
+            body.contains("set_rooms_load_state(RoomsLoadState::Loading)"),
+            "retry must return the rail to Loading"
+        );
+        assert!(
+            body.contains("LOAD_BACKSTOP_SCHEDULED.store(false")
+                && body.contains("schedule_rooms_load_backstop()"),
+            "retry must re-arm the once-per-session backstop"
+        );
+        assert!(
+            body.contains("fire_list_rooms_request().await"),
+            "retry must re-fire the current-delegate load"
         );
     }
 
@@ -4078,6 +4190,12 @@ pub enum RoomsLoadState {
     /// completion point or the timeout backstop — never speculatively, so an
     /// existing user mid-migration can't flash "no rooms yet".
     Loaded,
+    /// A load that we know involved rooms FAILED or stalled — a LISTED
+    /// `room:<vk>` key's fetch didn't materialize (transport/parse error), or the
+    /// backstop fired while a known-rooms fetch had failed. Renders a distinct
+    /// error + Retry block rather than a false "no rooms yet" (freenet/river#397
+    /// Codex review 4). Distinguished from a genuine empty by `SAW_FETCH_FAILURE`.
+    LoadFailed,
 }
 
 /// Reactive room-list load state. Starts `Loading`; advanced to `Loaded` at the
@@ -4123,26 +4241,73 @@ pub(crate) fn load_state_after_probe_legacy(fired_legacy_probes: bool) -> RoomsL
     }
 }
 
-/// The UNIVERSAL backstop transition (freenet/river#397 Codex review 3). At the
-/// 30s deadline, ANY non-terminal state resolves to `Loaded` — BOTH `Loading`
-/// AND `Migrating`. This is what GUARANTEES termination: the rounds-3/4 attempt
-/// to "stay `Loading`/`Migrating` and rely on a WS reconnect to retry" could
-/// spin forever, because a delegate request can time out (~10s) WITHOUT
-/// disconnecting the WebSocket, so no reconnect ever comes; and concurrent
-/// legacy probes race on this one global signal. A single backstop that resolves
-/// every non-terminal state removes both failure modes.
+/// Set `true` whenever a LISTED `room:<vk>` key's GET fails to materialize (a
+/// transport `Err`, an unexpected `Ok(other)`, or an unparseable slot) in EITHER
+/// the current-delegate per-room load OR a legacy per-room probe. It is NOT set
+/// for a definitive `value: None` (a legitimate skip) or a `Tombstone` (a genuine
+/// "left room"). This is the signal that distinguishes a genuinely-empty load
+/// (new user → Empty) from a failed load of a user who HAS rooms (→ LoadFailed).
+/// Reset at the start of a load (`set_up_chat_delegate`) and on Retry
+/// (`retry_rooms_load`). freenet/river#397 Codex review 4.
+pub(crate) static SAW_FETCH_FAILURE: AtomicBool = AtomicBool::new(false);
+
+/// Record that a listed room's fetch failed to materialize.
+pub(crate) fn mark_fetch_failure() {
+    SAW_FETCH_FAILURE.store(true, Ordering::Relaxed);
+}
+
+/// The terminal state a completed-but-empty load / the backstop resolves to,
+/// given whether any known-rooms fetch failed. Pure so both branches are
+/// unit-testable. `saw_fetch_failure` → `LoadFailed` (we KNOW rooms exist but
+/// couldn't load them); otherwise `Loaded` (genuinely empty → the calm "no rooms
+/// yet"). freenet/river#397 Codex review 4.
+pub(crate) fn backstop_terminal(saw_fetch_failure: bool) -> RoomsLoadState {
+    if saw_fetch_failure {
+        RoomsLoadState::LoadFailed
+    } else {
+        RoomsLoadState::Loaded
+    }
+}
+
+/// The current-delegate per-room load terminal (authoritative, awaited — resolves
+/// FAST, no waiting on the backstop). Pure decision:
+/// - `map` non-empty → `Loaded` (rooms present → the list renders them);
+/// - `map` empty AND rooms were listed AND a listed fetch failed → `LoadFailed`
+///   (we KNOW rooms exist but couldn't load them — never "no rooms yet");
+/// - `map` empty otherwise (nothing listed, or every listed slot was a clean
+///   `value: None`/`Tombstone`) → `Loaded` (a genuine empty).
 ///
-/// This can only ever *show* Empty when `room_count == 0` at the deadline — a
-/// non-empty `ROOMS` renders `List` regardless of the load state — i.e. only
-/// when genuinely nothing loaded, which is the correct, no-worse-than-baseline
-/// outcome (a proper error/retry state is a separate follow-up). The `Loaded`
-/// arm returns `current` (already `Loaded`) so the two arms differ textually
-/// (avoids `clippy::match_same_arms`) while being behaviourally identical.
-pub(crate) fn backstop_resolve(current: RoomsLoadState) -> RoomsLoadState {
+/// freenet/river#397 Codex review 4.
+pub(crate) fn per_room_terminal(
+    map_empty: bool,
+    listed_count: usize,
+    had_fetch_error: bool,
+) -> RoomsLoadState {
+    if !map_empty {
+        RoomsLoadState::Loaded
+    } else if listed_count > 0 && had_fetch_error {
+        RoomsLoadState::LoadFailed
+    } else {
+        RoomsLoadState::Loaded
+    }
+}
+
+/// The UNIVERSAL backstop transition (freenet/river#397 Codex review 3/4). At the
+/// 30s deadline, ANY non-terminal state (`Loading`/`Migrating`) resolves — to
+/// `LoadFailed` if a known-rooms fetch failed, else `Loaded`. This GUARANTEES
+/// termination: the earlier "stay `Loading`/`Migrating` and rely on a WS
+/// reconnect to retry" could spin forever, because a delegate request can time
+/// out (~10s) WITHOUT disconnecting the WebSocket, so no reconnect ever comes;
+/// and concurrent legacy probes race on this one global signal. Because a genuine
+/// empty resolves FAST to `Loaded` at a definitive completion
+/// (ProbeLegacy-found-nothing / all-tombstone), staying non-terminal until 30s
+/// means a stall/failure — so `SAW_FETCH_FAILURE` decides Empty vs. error. Already
+/// terminal states (`Loaded`/`LoadFailed`) are returned unchanged.
+pub(crate) fn backstop_resolve(current: RoomsLoadState, saw_fetch_failure: bool) -> RoomsLoadState {
     match current {
-        RoomsLoadState::Loaded => current,
-        // Loading AND Migrating are both non-terminal — resolve them.
-        RoomsLoadState::Loading | RoomsLoadState::Migrating => RoomsLoadState::Loaded,
+        RoomsLoadState::Loading | RoomsLoadState::Migrating => backstop_terminal(saw_fetch_failure),
+        // Loaded / LoadFailed are already terminal.
+        other => other,
     }
 }
 
@@ -4170,11 +4335,33 @@ pub(crate) fn schedule_rooms_load_backstop() {
     crate::util::safe_spawn_local(async {
         crate::util::sleep(std::time::Duration::from_millis(ROOMS_LOAD_BACKSTOP_MS)).await;
         crate::util::defer(|| {
-            let resolved = backstop_resolve(*ROOMS_LOAD_STATE.peek());
+            let saw_failure = SAW_FETCH_FAILURE.load(Ordering::Relaxed);
+            let resolved = backstop_resolve(*ROOMS_LOAD_STATE.peek(), saw_failure);
             if *ROOMS_LOAD_STATE.peek() != resolved {
                 *ROOMS_LOAD_STATE.write() = resolved;
             }
         });
+    });
+}
+
+/// Retry a failed room-list load (freenet/river#397 Codex review 4). Wired to the
+/// `LoadFailed` block's Retry button. Signal-safe: `set_rooms_load_state` and
+/// `safe_spawn_local` both defer, and the atomics are lock-free, so this is safe
+/// to call directly from an `onclick` handler.
+///
+/// Resets the fetch-failure signal, returns the rail to `Loading`, re-arms the
+/// once-per-session backstop (so a fresh 30s deadline applies), and re-fires the
+/// current-delegate load. If the delegate genuinely has no rooms this time, the
+/// fast ProbeLegacy/PerRoom terminal resolves to `Loaded` (→ Empty); if it
+/// succeeds it renders the list; if it fails again it returns to `LoadFailed`.
+pub(crate) fn retry_rooms_load() {
+    SAW_FETCH_FAILURE.store(false, Ordering::Relaxed);
+    set_rooms_load_state(RoomsLoadState::Loading);
+    // Re-arm the once-per-session backstop guard so a fresh deadline is scheduled.
+    LOAD_BACKSTOP_SCHEDULED.store(false, Ordering::Relaxed);
+    schedule_rooms_load_backstop();
+    crate::util::safe_spawn_local(async {
+        fire_list_rooms_request().await;
     });
 }
 

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -1336,6 +1336,111 @@ mod tests {
         );
     }
 
+    /// freenet/river#397 Codex review 6: the definitive completion decision once
+    /// every worker has settled. Rooms present → `None` (List renders, leave the
+    /// state); empty + a known-rooms fetch failure → `LoadFailed`; empty + no
+    /// failure → `None` (caller arms the idle timer → Empty after quiescence).
+    #[test]
+    fn settle_terminal_decides_completion() {
+        // Rooms present → None regardless of the failure flag.
+        assert_eq!(settle_terminal(false, false), None);
+        assert_eq!(settle_terminal(false, true), None);
+        // Empty + fetch failure → LoadFailed.
+        assert_eq!(
+            settle_terminal(true, true),
+            Some(RoomsLoadState::LoadFailed),
+            "empty with a known-rooms fetch failure completes to LoadFailed"
+        );
+        // Empty + no failure → None (arm idle → genuine Empty after quiescence),
+        // NOT LoadFailed — this is what makes an all-tombstone/empty legacy
+        // migration resolve to Empty, not error.
+        assert_eq!(
+            settle_terminal(true, false),
+            None,
+            "empty + no failure defers to the idle timer, never LoadFailed"
+        );
+    }
+
+    /// freenet/river#397 Codex review 6: an armed idle resolution applies ONLY
+    /// when nothing superseded it — same activity gen, same attempt gen, and no
+    /// worker active. Any of: a new worker (gen bump), a retry (attempt bump), or
+    /// a pending worker cancels it.
+    #[test]
+    fn idle_resolution_cancelled_by_any_activity() {
+        // All match, no pending → applies.
+        assert!(idle_should_apply(5, 5, 2, 2, 0));
+        // A new worker started (activity gen advanced) → cancelled.
+        assert!(
+            !idle_should_apply(5, 6, 2, 2, 0),
+            "a new worker (activity-gen bump) cancels the idle timer"
+        );
+        // A retry bumped the attempt gen → cancelled.
+        assert!(
+            !idle_should_apply(5, 5, 2, 3, 0),
+            "a retry (attempt-gen bump) cancels the idle timer"
+        );
+        // A worker is active again → cancelled (must not resolve while loading).
+        assert!(
+            !idle_should_apply(5, 5, 2, 2, 1),
+            "a pending worker prevents idle resolution"
+        );
+    }
+
+    /// freenet/river#397 Codex review 6, composed: an all-tombstone / empty
+    /// legacy migration (worker ran, found no LIVE rooms, recorded no fetch
+    /// failure) resolves to Empty, NOT LoadFailed. The worker settles with
+    /// `settle_terminal(empty=true, saw=false) → None` (arm idle), and the idle
+    /// timer's own branch (empty + no failure) resolves to `Loaded` (Empty).
+    #[test]
+    fn all_tombstone_legacy_migration_resolves_to_empty_not_loadfailed() {
+        // Completion decision: empty + no failure defers (arm idle), not LoadFailed.
+        assert_eq!(settle_terminal(true, false), None);
+        // The idle timer applies (nothing superseded it)...
+        assert!(idle_should_apply(9, 9, 1, 1, 0));
+        // ...and its terminal for empty + no failure is Loaded (Empty), not
+        // LoadFailed. (`backstop_terminal(Loading, false)` mirrors that terminal.)
+        assert_eq!(
+            backstop_terminal(RoomsLoadState::Loading, false),
+            RoomsLoadState::Loaded,
+            "empty + no fetch failure resolves to Empty, never LoadFailed"
+        );
+    }
+
+    /// freenet/river#397 Codex review 6: the `LoadWorkerGuard` RAII contract —
+    /// `new` increments the pending counter AND bumps the activity gen; `Drop`
+    /// decrements (saturating) and runs the settled-handler. Source-scrape (it
+    /// drives global signals, so it can't be unit-driven on native).
+    #[test]
+    fn load_worker_guard_counts_and_pulses() {
+        let src = include_str!("chat_delegate.rs");
+        let new_start = src
+            .rfind("impl LoadWorkerGuard {")
+            .expect("LoadWorkerGuard impl must exist");
+        let new_end = src[new_start..]
+            .find("impl Drop for LoadWorkerGuard")
+            .map(|i| new_start + i)
+            .unwrap_or(src.len());
+        let new_body = &src[new_start..new_end];
+        assert!(
+            new_body.contains("PENDING_LOADS.fetch_add(1")
+                && new_body.contains("LOAD_ACTIVITY_GEN.fetch_add(1"),
+            "LoadWorkerGuard::new must inc PENDING_LOADS and bump LOAD_ACTIVITY_GEN"
+        );
+        let drop_start = src
+            .rfind("impl Drop for LoadWorkerGuard")
+            .expect("LoadWorkerGuard Drop must exist");
+        let drop_end = src[drop_start..]
+            .find("\n}\n")
+            .map(|i| drop_start + i)
+            .unwrap_or(src.len());
+        let drop_body = &src[drop_start..drop_end];
+        assert!(
+            drop_body.contains("saturating_sub(1)")
+                && drop_body.contains("on_load_worker_settled()"),
+            "LoadWorkerGuard::drop must saturating-dec PENDING_LOADS and settle"
+        );
+    }
+
     /// freenet/river#397 Codex review 4: the authoritative current-delegate
     /// per-room terminal. Rooms present → `Loaded` (List); empty + listed + a
     /// fetch error → `LoadFailed` (never a false Empty); a genuine empty (nothing
@@ -1462,6 +1567,14 @@ mod tests {
         assert!(
             body.contains("LOAD_ATTEMPT_GEN.fetch_add(1"),
             "retry must bump the attempt generation to invalidate stale backstop timers (P2a)"
+        );
+        assert!(
+            body.contains("PENDING_LOADS.store(0"),
+            "retry must sanity-reset the pending-worker counter (review 6)"
+        );
+        assert!(
+            body.contains("LOAD_ACTIVITY_GEN.fetch_add(1"),
+            "retry must bump the activity generation to cancel any armed idle timer (review 6)"
         );
         assert!(
             body.contains("LOAD_BACKSTOP_SCHEDULED.store(false")
@@ -4401,19 +4514,169 @@ pub(crate) fn per_room_terminal(
     }
 }
 
-/// Timeout for the UNIVERSAL room-list load backstop (see [`backstop_terminal`]).
-/// Armed once per session at the START of load (`set_up_chat_delegate`), re-armed
-/// on Retry. At the deadline it resolves any still-non-terminal state to a
-/// terminal (`LoadFailed` if a known-rooms fetch failed or a migration stalled,
-/// else `Loaded`). Generous (30s) so it never pre-empts a load or migration that
-/// is actually progressing — a slow but live probe→response→migrate or per-room
-/// fetch completes and resolves itself well before this fires; the backstop only
-/// bites on genuine timeout / all-fetch-fail / concurrency-strand cases.
-const ROOMS_LOAD_BACKSTOP_MS: u64 = 30_000;
+// =============================================================================
+// PROGRESS-TRACKED LOAD TERMINATION (freenet/river#397 Codex review 6)
+// Termination is driven by the actual load WORK finishing, not a fixed
+// wall-clock timer: a pending-worker counter + a debounced quiescence idle
+// timer make the primary decision, and a generous hard-max is a last resort.
+// =============================================================================
 
-/// One-shot guard so the backstop is scheduled once per session even though
-/// `set_up_chat_delegate` re-runs on every reconnect. Reset by `retry_rooms_load`
-/// so a fresh deadline is armed for the retry.
+/// Number of ACTIVE awaited load workers (current-delegate load, blob
+/// migration, each legacy per-room probe, each legacy single-blob hydrate).
+/// While this is non-zero the load is still making progress, so nothing resolves
+/// it. Each worker holds a [`LoadWorkerGuard`].
+pub(crate) static PENDING_LOADS: AtomicU32 = AtomicU32::new(0);
+
+/// A "progress pulse" bumped whenever a load worker STARTS. It invalidates any
+/// armed idle-resolution: a new worker beginning means the load is still active,
+/// so a previously-armed quiescence timer must not fire.
+pub(crate) static LOAD_ACTIVITY_GEN: AtomicU32 = AtomicU32::new(0);
+
+/// Quiescence window: once the last worker settles with an empty result and no
+/// fetch failure, wait this long for a late (fire-and-forget legacy) response
+/// before resolving to Empty. A new worker starting (activity-gen bump) cancels
+/// it. Short because delegate ops are node-local (sub-second).
+const LOAD_IDLE_MS: u64 = 4_000;
+
+/// Absolute last-resort safety net (defense-in-depth for invariant 2). The
+/// progress-tracked idle resolution terminates first in practice; this only
+/// fires if the counter logic ever leaks a worker. Generous so it never
+/// pre-empts a genuinely-progressing load.
+const LOAD_HARD_MAX_MS: u64 = 60_000;
+
+/// RAII guard marking an active AWAITED load worker (freenet/river#397 review 6).
+/// `new` increments [`PENDING_LOADS`] and bumps [`LOAD_ACTIVITY_GEN`] (a progress
+/// pulse that cancels any armed idle resolution). `Drop` decrements
+/// `PENDING_LOADS` (saturating, so a stray double-drop / sanity reset can't
+/// underflow) and runs [`on_load_worker_settled`], so completion is detected on
+/// EVERY exit path (success, early return, error). Hold one across each awaited
+/// load worker.
+pub(crate) struct LoadWorkerGuard;
+
+impl LoadWorkerGuard {
+    pub(crate) fn new() -> Self {
+        PENDING_LOADS.fetch_add(1, Ordering::Relaxed);
+        LOAD_ACTIVITY_GEN.fetch_add(1, Ordering::Relaxed);
+        LoadWorkerGuard
+    }
+}
+
+impl Drop for LoadWorkerGuard {
+    fn drop(&mut self) {
+        let _ = PENDING_LOADS.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+            Some(v.saturating_sub(1))
+        });
+        on_load_worker_settled();
+    }
+}
+
+/// The DEFINITIVE completion decision once every load worker has settled. Pure.
+/// - `!room_count_zero` → `None`: rooms are present, the List renders — leave the
+///   load state alone.
+/// - `room_count_zero && saw_fetch_failure` → `Some(LoadFailed)`: empty, and a
+///   known-rooms fetch failed → error+retry, never a false Empty.
+/// - `room_count_zero && !saw_fetch_failure` → `None`: empty with no failure — the
+///   caller arms the debounced idle timer (a late legacy response may still bring
+///   rooms; if none does, quiescence resolves to Empty).
+///
+/// freenet/river#397 Codex review 6.
+pub(crate) fn settle_terminal(
+    room_count_zero: bool,
+    saw_fetch_failure: bool,
+) -> Option<RoomsLoadState> {
+    if !room_count_zero {
+        None
+    } else if saw_fetch_failure {
+        Some(RoomsLoadState::LoadFailed)
+    } else {
+        None
+    }
+}
+
+/// Whether an armed idle-resolution should still apply. Cancelled by any new
+/// worker (activity-gen bump), a retry (attempt-gen bump), or a worker becoming
+/// active again (`pending != 0`). Pure. freenet/river#397 Codex review 6.
+pub(crate) fn idle_should_apply(
+    armed_gen: u32,
+    current_gen: u32,
+    armed_attempt: u32,
+    current_attempt: u32,
+    pending: u32,
+) -> bool {
+    armed_gen == current_gen && armed_attempt == current_attempt && pending == 0
+}
+
+/// Read whether the in-memory rooms map is empty. Only called from within a
+/// `defer` (Dioxus runtime present); `peek` avoids registering a subscription.
+fn rooms_map_is_empty() -> bool {
+    ROOMS.peek().map.is_empty()
+}
+
+/// Write the load state directly. Only called from within a `defer`/runtime
+/// context (the settled + idle handlers run in one); the `peek` guard avoids a
+/// spurious write / re-render when unchanged.
+fn write_load_state_now(state: RoomsLoadState) {
+    if *ROOMS_LOAD_STATE.peek() != state {
+        *ROOMS_LOAD_STATE.write() = state;
+    }
+}
+
+/// Called when a load worker drops (and by the fire-and-forget legacy-probe path
+/// once it's quiescent). If work is still active, no-op. Otherwise makes the
+/// definitive completion decision ([`settle_terminal`]): resolve `LoadFailed` on
+/// a known-rooms failure, leave the state when rooms render (List), or arm the
+/// debounced idle timer for the empty+no-failure case. freenet/river#397 review 6.
+pub(crate) fn on_load_worker_settled() {
+    if PENDING_LOADS.load(Ordering::Relaxed) != 0 {
+        return;
+    }
+    let armed_gen = LOAD_ACTIVITY_GEN.load(Ordering::Relaxed);
+    let armed_attempt = LOAD_ATTEMPT_GEN.load(Ordering::Relaxed);
+    crate::util::defer(move || {
+        // A worker may have STARTED between the drop and this deferred decision.
+        if PENDING_LOADS.load(Ordering::Relaxed) != 0 {
+            return;
+        }
+        let room_count_zero = rooms_map_is_empty();
+        let saw = SAW_FETCH_FAILURE.load(Ordering::Relaxed);
+        match settle_terminal(room_count_zero, saw) {
+            Some(state) => write_load_state_now(state),
+            None if room_count_zero => schedule_idle_resolution(armed_gen, armed_attempt),
+            None => {} // rooms present → List renders, leave the state
+        }
+    });
+}
+
+/// Arm the debounced quiescence timer. After [`LOAD_IDLE_MS`] with no new
+/// activity (same gens, no pending worker), the empty+no-failure load resolves to
+/// `Loaded` (genuine Empty) — or `LoadFailed` if a fetch failure arrived in the
+/// meantime.
+fn schedule_idle_resolution(armed_gen: u32, armed_attempt: u32) {
+    crate::util::safe_spawn_local(async move {
+        crate::util::sleep(std::time::Duration::from_millis(LOAD_IDLE_MS)).await;
+        crate::util::defer(move || {
+            let cur_gen = LOAD_ACTIVITY_GEN.load(Ordering::Relaxed);
+            let cur_attempt = LOAD_ATTEMPT_GEN.load(Ordering::Relaxed);
+            let pending = PENDING_LOADS.load(Ordering::Relaxed);
+            if !idle_should_apply(armed_gen, cur_gen, armed_attempt, cur_attempt, pending) {
+                return; // superseded by new activity / retry / an active worker
+            }
+            if !rooms_map_is_empty() {
+                return; // rooms arrived → List renders
+            }
+            let resolved = if SAW_FETCH_FAILURE.load(Ordering::Relaxed) {
+                RoomsLoadState::LoadFailed
+            } else {
+                RoomsLoadState::Loaded // genuine Empty after quiescence
+            };
+            write_load_state_now(resolved);
+        });
+    });
+}
+
+/// One-shot guard so the hard-max backstop is scheduled once per session even
+/// though `set_up_chat_delegate` re-runs on every reconnect. Reset by
+/// `retry_rooms_load` so a fresh deadline is armed for the retry.
 static LOAD_BACKSTOP_SCHEDULED: AtomicBool = AtomicBool::new(false);
 
 /// Monotonic load-attempt generation (freenet/river#397 Codex review 5, P2a).
@@ -4423,9 +4686,12 @@ static LOAD_BACKSTOP_SCHEDULED: AtomicBool = AtomicBool::new(false);
 /// superseded attempt is a no-op and cannot resolve the retry's fresh state.
 static LOAD_ATTEMPT_GEN: AtomicU32 = AtomicU32::new(0);
 
-/// Schedule the room-list load backstop once per session (re-armed by Retry).
-/// See [`backstop_terminal`] for why this is a safety net rather than the primary
-/// signal, and [`backstop_should_apply`] for the stale-timer guard.
+/// Schedule the HARD-MAX load backstop once per session (re-armed by Retry).
+/// This is the last-resort safety net (freenet/river#397 review 6): the
+/// progress-tracked idle resolution ([`on_load_worker_settled`]) terminates the
+/// load first in practice; this only fires if the worker counter ever leaks.
+/// See [`backstop_terminal`] for the terminal it resolves to and
+/// [`backstop_should_apply`] for the stale-timer (attempt-gen) guard.
 pub(crate) fn schedule_rooms_load_backstop() {
     if LOAD_BACKSTOP_SCHEDULED.swap(true, Ordering::Relaxed) {
         return;
@@ -4433,18 +4699,16 @@ pub(crate) fn schedule_rooms_load_backstop() {
     // Capture the attempt generation this timer belongs to.
     let armed_gen = LOAD_ATTEMPT_GEN.load(Ordering::Relaxed);
     crate::util::safe_spawn_local(async move {
-        crate::util::sleep(std::time::Duration::from_millis(ROOMS_LOAD_BACKSTOP_MS)).await;
+        crate::util::sleep(std::time::Duration::from_millis(LOAD_HARD_MAX_MS)).await;
         crate::util::defer(move || {
             // A newer attempt (Retry) superseded this timer → no-op, so a stale
-            // 30s timer can't resolve the retry's fresh Loading/Migrating.
+            // timer can't resolve the retry's fresh Loading/Migrating.
             if !backstop_should_apply(armed_gen, LOAD_ATTEMPT_GEN.load(Ordering::Relaxed)) {
                 return;
             }
             let saw_failure = SAW_FETCH_FAILURE.load(Ordering::Relaxed);
             let resolved = backstop_terminal(*ROOMS_LOAD_STATE.peek(), saw_failure);
-            if *ROOMS_LOAD_STATE.peek() != resolved {
-                *ROOMS_LOAD_STATE.write() = resolved;
-            }
+            write_load_state_now(resolved);
         });
     });
 }
@@ -4469,8 +4733,14 @@ pub(crate) fn retry_rooms_load() {
     // is deliberately left alone — a genuinely-completed migration shouldn't
     // re-probe; this only re-arms a probe that failed.
     LEGACY_MIGRATION_ATTEMPTED.store(false, Ordering::Relaxed);
-    // Bump the attempt generation BEFORE re-arming so the previous timer becomes
-    // a no-op (P2a), then re-arm a fresh 30s deadline.
+    // Progress-tracking sanity + invalidation (freenet/river#397 review 6): clear
+    // any leaked pending-worker count, and bump BOTH generations so any armed
+    // idle timer AND any stale hard-max timer from the failed attempt become
+    // no-ops. The re-fired list request starts a fresh worker.
+    PENDING_LOADS.store(0, Ordering::Relaxed);
+    LOAD_ACTIVITY_GEN.fetch_add(1, Ordering::Relaxed);
+    // Bump the attempt generation BEFORE re-arming so the previous hard-max timer
+    // becomes a no-op, then re-arm a fresh deadline.
     LOAD_ATTEMPT_GEN.fetch_add(1, Ordering::Relaxed);
     LOAD_BACKSTOP_SCHEDULED.store(false, Ordering::Relaxed);
     schedule_rooms_load_backstop();

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -1616,8 +1616,11 @@ mod tests {
         );
     }
 
-    /// freenet/river#397 Codex review 8: a retry is `begin_load_attempt()` PLUS
-    /// re-enabling the legacy probe (retry-only) PLUS re-firing the list request.
+    /// freenet/river#397 Codex review 9 (P2): a retry re-runs the FULL setup
+    /// (`set_up_chat_delegate` → re-register + load) so a RegisterDelegate failure
+    /// can be repaired, PLUS re-enables the legacy probe (retry-only). It must NOT
+    /// call `begin_load_attempt()` directly (set_up owns it — avoid a double bump)
+    /// nor a bare `fire_list_rooms_request()` (which can't re-register).
     #[test]
     fn retry_rooms_load_resets_and_refires() {
         let src = include_str!("chat_delegate.rs");
@@ -1633,16 +1636,20 @@ mod tests {
             .unwrap_or(src.len());
         let body = &src[fn_start..fn_end];
         assert!(
-            body.contains("begin_load_attempt();"),
-            "retry must begin a fresh load attempt (shared entry point)"
-        );
-        assert!(
             body.contains("LEGACY_MIGRATION_ATTEMPTED.store(false"),
             "retry must re-enable the legacy probe so a failed legacy source is retried (P1b)"
         );
         assert!(
-            body.contains("fire_list_rooms_request().await"),
-            "retry must re-fire the current-delegate load"
+            body.contains("set_up_chat_delegate().await"),
+            "retry must re-run full setup (re-register) via set_up_chat_delegate, not a bare list request"
+        );
+        assert!(
+            !body.contains("begin_load_attempt()"),
+            "retry must NOT call begin_load_attempt directly — set_up_chat_delegate owns the fresh attempt (avoid double bump)"
+        );
+        assert!(
+            !body.contains("fire_list_rooms_request()"),
+            "retry must NOT bypass registration with a bare fire_list_rooms_request"
         );
     }
 
@@ -1707,6 +1714,43 @@ mod tests {
             body.matches("resolve_load_failed_if_empty()").count(),
             2,
             "both error arms must directly resolve LoadFailed (out-of-worker, P2#2)"
+        );
+    }
+
+    /// freenet/river#397 Codex review 9 (P1): a legacy probe SEND that returns Err
+    /// is a transport failure — it marks fetch failure; and if NO probe dispatched
+    /// (all sends failed / connection down) the once-per-session
+    /// `LEGACY_MIGRATION_ATTEMPTED` guard is reset so a reconnect re-probes (the
+    /// probe never left). A send that SUCCEEDS sets `any_dispatched` and does NOT
+    /// mark (the genuine new-user / delegate-not-present case).
+    #[test]
+    fn legacy_probe_transport_failure_marks_and_resets_guard() {
+        // `fire_legacy_migration_request` is the last fn in the file, defined
+        // AFTER this mid-file test module → rfind the real definition.
+        let src = include_str!("chat_delegate.rs");
+        let fn_start = src
+            .rfind("pub(crate) async fn fire_legacy_migration_request()")
+            .expect("fire_legacy_migration_request must exist");
+        let body = &src[fn_start..];
+
+        // Transport-Err arms mark (both the GetRequest and ListRequest sends).
+        assert!(
+            body.matches("mark_fetch_failure();").count() >= 2,
+            "both legacy send-Err arms (GetRequest + ListRequest) must mark_fetch_failure"
+        );
+        // Dispatch is tracked, and a successful send does NOT mark.
+        assert!(
+            body.contains("any_dispatched = true;"),
+            "must track whether any probe actually dispatched (send returned Ok)"
+        );
+        // If nothing dispatched, the guard is reset so a reconnect re-probes.
+        let reset_pos = body
+            .find("if !any_dispatched")
+            .expect("must reset the guard when no probe dispatched");
+        let reset_block = &body[reset_pos..(reset_pos + 200).min(body.len())];
+        assert!(
+            reset_block.contains("LEGACY_MIGRATION_ATTEMPTED.store(false"),
+            "all-sends-failed must reset LEGACY_MIGRATION_ATTEMPTED so a reconnect re-probes"
         );
     }
 
@@ -4857,25 +4901,35 @@ fn schedule_rooms_load_backstop() {
     });
 }
 
-/// Retry a failed room-list load (freenet/river#397 Codex review 4/5/8). Wired to
-/// the `LoadFailed` block's Retry button. Signal-safe: `set_rooms_load_state` and
-/// `safe_spawn_local` both defer, and the atomics are lock-free, so this is safe
-/// to call directly from an `onclick` handler.
+/// Retry a failed room-list load (freenet/river#397 Codex review 4/5/8/9). Wired
+/// to the `LoadFailed` block's Retry button. Signal-safe: `set_rooms_load_state`
+/// and `safe_spawn_local` both defer, and the atomics are lock-free, so this is
+/// safe to call directly from an `onclick` handler.
 ///
-/// A retry is just a fresh load attempt ([`begin_load_attempt`]) PLUS re-enabling
-/// the legacy probe (retry-only, so a legacy source that FAILED this session is
-/// re-probed — `is_legacy_migration_done` is left alone) and re-firing the
-/// current-delegate load. If the delegate genuinely has no rooms this time the
-/// fast ProbeLegacy/PerRoom terminal resolves to `Loaded` (→ Empty); if it
-/// succeeds it renders the list; if it fails again it returns to `LoadFailed`.
+/// Re-runs the FULL setup path — `set_up_chat_delegate()` re-registers the
+/// delegate AND loads — so a `LoadFailed` produced by a `RegisterDelegate`
+/// failure (first use / delegate not installed) can actually be repaired; a bare
+/// `fire_list_rooms_request()` to an unregistered delegate never could (review 9,
+/// P2). `set_up_chat_delegate` calls `begin_load_attempt()` at its top, so we do
+/// NOT call it here (avoid a double attempt bump) — the re-setup owns the fresh
+/// attempt. Retry-only: re-enable the legacy probe so a legacy source that FAILED
+/// this session is re-probed (`is_legacy_migration_done` is left alone). If the
+/// delegate genuinely has no rooms this time the fast ProbeLegacy/PerRoom terminal
+/// resolves to `Loaded` (→ Empty); if it succeeds it renders the list; if setup or
+/// load fails again it returns to `LoadFailed`.
 pub(crate) fn retry_rooms_load() {
-    begin_load_attempt();
     // Retry-only (deliberately NOT in `begin_load_attempt`): re-enable the legacy
     // probe so a legacy source that failed THIS session is retried (P1b). A plain
-    // reconnect must not force this (it would defeat the #253 done-gate).
+    // reconnect must not force this (it would defeat the #253 done-gate). Set
+    // BEFORE the re-setup so `fire_legacy_migration_request` sees it cleared.
     LEGACY_MIGRATION_ATTEMPTED.store(false, Ordering::Relaxed);
     crate::util::safe_spawn_local(async {
-        fire_list_rooms_request().await;
+        // set_up_chat_delegate begins the fresh attempt AND re-registers; its Err
+        // path resolves LoadFailed, so a persistent registration failure re-shows
+        // Retry rather than getting stuck.
+        if let Err(e) = set_up_chat_delegate().await {
+            error!("Retry: chat delegate setup failed: {}", e);
+        }
     });
 }
 
@@ -4946,6 +5000,16 @@ pub(crate) async fn fire_legacy_migration_request() -> bool {
         LEGACY_DELEGATES.len()
     );
 
+    // freenet/river#397 Codex review 9 (P1): distinguish a TRANSPORT failure (a
+    // send that returns Err — connection closed) from the genuine new-user case
+    // (a send that SUCCEEDS but the legacy delegate isn't present, so the node
+    // silently drops the response). A send returning Err → mark_fetch_failure so
+    // the load resolves to LoadFailed (Retry), NOT a false Empty. `any_dispatched`
+    // tracks whether ANY probe actually went out; if none did (connection down),
+    // we reset the once-per-session guard below so a reconnect re-probes — the
+    // probe never left, so don't burn the guard on a transport failure.
+    let mut any_dispatched = false;
+
     for (i, (key_bytes, code_hash_bytes)) in LEGACY_DELEGATES.iter().enumerate() {
         let legacy_code_hash = CodeHash::new(*code_hash_bytes);
         let legacy_delegate_key = DelegateKey::new(*key_bytes, legacy_code_hash);
@@ -4991,19 +5055,25 @@ pub(crate) async fn fire_legacy_migration_request() -> bool {
             };
 
             match api_result {
-                Ok(_) => info!(
-                    "Legacy migration request #{} sent for key {:?}",
-                    i,
-                    String::from_utf8_lossy(storage_key)
-                ),
-                Err(e) => {
+                Ok(_) => {
+                    any_dispatched = true;
                     info!(
-                        "Could not send legacy migration request #{} for key {:?} \
-                         (expected if delegate not present): {}",
+                        "Legacy migration request #{} sent for key {:?}",
+                        i,
+                        String::from_utf8_lossy(storage_key)
+                    );
+                }
+                Err(e) => {
+                    // A send that RETURNS Err is a transport failure (connection
+                    // closed), NOT "delegate not present". Mark it (P1).
+                    info!(
+                        "Legacy migration request #{} for key {:?} failed to send \
+                         (transport): {}",
                         i,
                         String::from_utf8_lossy(storage_key),
                         e
                     );
+                    mark_fetch_failure();
                 }
             }
         }
@@ -5041,11 +5111,25 @@ pub(crate) async fn fire_legacy_migration_request() -> bool {
             }
         };
         match list_result {
-            Ok(_) => info!("Legacy ListRequest #{i} sent for per-room key discovery"),
-            Err(e) => info!(
-                "Could not send legacy ListRequest #{i} (expected if delegate not present): {e}"
-            ),
+            Ok(_) => {
+                any_dispatched = true;
+                info!("Legacy ListRequest #{i} sent for per-room key discovery");
+            }
+            Err(e) => {
+                // Transport failure on the ListRequest send → mark it (P1).
+                info!("Legacy ListRequest #{i} failed to send (transport): {e}");
+                mark_fetch_failure();
+            }
         }
+    }
+
+    // freenet/river#397 Codex review 9 (P1): if NO probe was actually dispatched
+    // (every send failed — connection down), the once-per-session guard was set
+    // for a probe that never left. Reset it so a reconnect re-probes. Keep it set
+    // when at least one probe dispatched (a genuine new user whose node has no
+    // legacy delegate simply gets no response — do NOT re-probe-spam that case).
+    if !any_dispatched {
+        LEGACY_MIGRATION_ATTEMPTED.store(false, Ordering::Relaxed);
     }
     true
 }

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -1717,12 +1717,14 @@ mod tests {
         );
     }
 
-    /// freenet/river#397 Codex review 9 (P1): a legacy probe SEND that returns Err
+    /// freenet/river#397 Codex review 9/10: a legacy probe SEND that returns Err
     /// is a transport failure — it marks fetch failure; and if NO probe dispatched
     /// (all sends failed / connection down) the once-per-session
-    /// `LEGACY_MIGRATION_ATTEMPTED` guard is reset so a reconnect re-probes (the
-    /// probe never left). A send that SUCCEEDS sets `any_dispatched` and does NOT
-    /// mark (the genuine new-user / delegate-not-present case).
+    /// `LEGACY_MIGRATION_ATTEMPTED` guard is reset so a reconnect re-probes. A send
+    /// that SUCCEEDS sets `any_dispatched` and does NOT mark (the genuine new-user
+    /// case). Review 10 (P2#1): the probe captures the attempt and gates BOTH the
+    /// mark and the guard reset on still-current, so a stale probe (superseded by
+    /// a reconnect's begin_load_attempt) can't pollute the new attempt.
     #[test]
     fn legacy_probe_transport_failure_marks_and_resets_guard() {
         // `fire_legacy_migration_request` is the last fn in the file, defined
@@ -1743,14 +1745,26 @@ mod tests {
             body.contains("any_dispatched = true;"),
             "must track whether any probe actually dispatched (send returned Ok)"
         );
-        // If nothing dispatched, the guard is reset so a reconnect re-probes.
+        // Review 10 P2#1: the attempt is captured and the global writes are gated
+        // on still-current so a stale probe can't pollute a reconnect.
+        assert!(
+            body.contains("let attempt = LOAD_ATTEMPT_GEN.load(Ordering::Relaxed);"),
+            "the probe must capture the attempt it belongs to"
+        );
+        assert!(
+            body.matches("load_attempt_is_current(attempt)").count() >= 3,
+            "each mark AND the guard reset must be gated on load_attempt_is_current(attempt)"
+        );
+        // If nothing dispatched, the guard is reset (still-current) so a reconnect
+        // re-probes.
         let reset_pos = body
             .find("if !any_dispatched")
             .expect("must reset the guard when no probe dispatched");
         let reset_block = &body[reset_pos..(reset_pos + 200).min(body.len())];
         assert!(
-            reset_block.contains("LEGACY_MIGRATION_ATTEMPTED.store(false"),
-            "all-sends-failed must reset LEGACY_MIGRATION_ATTEMPTED so a reconnect re-probes"
+            reset_block.contains("load_attempt_is_current(attempt)")
+                && reset_block.contains("LEGACY_MIGRATION_ATTEMPTED.store(false"),
+            "all-sends-failed (still current) must reset LEGACY_MIGRATION_ATTEMPTED so a reconnect re-probes"
         );
     }
 
@@ -4730,6 +4744,15 @@ pub(crate) fn guard_drop_applies(guard_attempt: u32, current_attempt: u32) -> bo
     guard_attempt == current_attempt
 }
 
+/// Whether a captured load-attempt is still the current one. For code that
+/// isn't inside a [`LoadWorkerGuard`] (e.g. `fire_legacy_migration_request`,
+/// which runs across an awaited send sequence) but must still gate its global
+/// writes so a reconnect's `begin_load_attempt` doesn't get polluted by a stale
+/// probe's late failure (review 10 P2#1). Reuses the `guard_drop_applies` rule.
+pub(crate) fn load_attempt_is_current(captured_attempt: u32) -> bool {
+    guard_drop_applies(captured_attempt, LOAD_ATTEMPT_GEN.load(Ordering::Relaxed))
+}
+
 /// The DEFINITIVE completion decision once every load worker has settled. Pure.
 /// - `!room_count_zero` → `None`: rooms are present, the List renders — leave the
 ///   load state alone.
@@ -5008,6 +5031,13 @@ pub(crate) async fn fire_legacy_migration_request() -> bool {
     // tracks whether ANY probe actually went out; if none did (connection down),
     // we reset the once-per-session guard below so a reconnect re-probes — the
     // probe never left, so don't burn the guard on a transport failure.
+    //
+    // Review 10 (P2#1): this probe awaits a whole send sequence, so a reconnect's
+    // `begin_load_attempt` can advance the attempt mid-flight. Capture the attempt
+    // and gate the global writes (`mark_fetch_failure`, the guard reset) on
+    // still-current, so a STALE probe's late send-failure can't pollute the new
+    // attempt's `SAW_FETCH_FAILURE` into a false LoadFailed.
+    let attempt = LOAD_ATTEMPT_GEN.load(Ordering::Relaxed);
     let mut any_dispatched = false;
 
     for (i, (key_bytes, code_hash_bytes)) in LEGACY_DELEGATES.iter().enumerate() {
@@ -5065,7 +5095,9 @@ pub(crate) async fn fire_legacy_migration_request() -> bool {
                 }
                 Err(e) => {
                     // A send that RETURNS Err is a transport failure (connection
-                    // closed), NOT "delegate not present". Mark it (P1).
+                    // closed), NOT "delegate not present". Mark it (P1) — but only
+                    // for the current attempt (P2#1), so a stale probe can't
+                    // pollute a reconnect's fresh load.
                     info!(
                         "Legacy migration request #{} for key {:?} failed to send \
                          (transport): {}",
@@ -5073,7 +5105,9 @@ pub(crate) async fn fire_legacy_migration_request() -> bool {
                         String::from_utf8_lossy(storage_key),
                         e
                     );
-                    mark_fetch_failure();
+                    if load_attempt_is_current(attempt) {
+                        mark_fetch_failure();
+                    }
                 }
             }
         }
@@ -5116,9 +5150,12 @@ pub(crate) async fn fire_legacy_migration_request() -> bool {
                 info!("Legacy ListRequest #{i} sent for per-room key discovery");
             }
             Err(e) => {
-                // Transport failure on the ListRequest send → mark it (P1).
+                // Transport failure on the ListRequest send → mark it (P1),
+                // current-attempt only (P2#1).
                 info!("Legacy ListRequest #{i} failed to send (transport): {e}");
-                mark_fetch_failure();
+                if load_attempt_is_current(attempt) {
+                    mark_fetch_failure();
+                }
             }
         }
     }
@@ -5128,7 +5165,9 @@ pub(crate) async fn fire_legacy_migration_request() -> bool {
     // for a probe that never left. Reset it so a reconnect re-probes. Keep it set
     // when at least one probe dispatched (a genuine new user whose node has no
     // legacy delegate simply gets no response — do NOT re-probe-spam that case).
-    if !any_dispatched {
+    // Gated on still-current (P2#1): a stale probe must not reopen the guard for
+    // the new attempt (whose own probe already ran / set it).
+    if !any_dispatched && load_attempt_is_current(attempt) {
         LEGACY_MIGRATION_ATTEMPTED.store(false, Ordering::Relaxed);
     }
     true

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -549,6 +549,13 @@ pub async fn set_up_chat_delegate() -> Result<(), String> {
             fire_list_rooms_request().await;
             fire_load_outbound_dms_request().await;
 
+            // Room-list load backstop (freenet/river#397): a pure UI safety net
+            // so a brand-new user whose fire-and-forget legacy probe finds
+            // nothing resolves to the empty state rather than spinning forever.
+            // Once per session; the real completion signals live in the load
+            // path's `set_rooms_load_state` calls.
+            schedule_rooms_load_backstop();
+
             Ok(())
         }
         Err(e) => Err(format!("Failed to register chat delegate: {}", e)),
@@ -1208,6 +1215,68 @@ mod tests {
             interrupted.recover,
             "an interrupted migration must re-run to recover stranded rooms"
         );
+    }
+
+    /// freenet/river#397: when the current delegate is empty and we DID dispatch
+    /// legacy probes, we cannot yet tell a new user (nothing coming) from an
+    /// existing user whose legacy data is about to migrate, so we must stay
+    /// `Loading` — never optimistically `Loaded`, which would flash "no rooms
+    /// yet" at the migrating user before their migration starts.
+    #[test]
+    fn probe_legacy_fired_stays_loading() {
+        assert_eq!(
+            load_state_after_probe_legacy(true),
+            RoomsLoadState::Loading,
+            "dispatched probes: a migration might still arrive, so stay Loading"
+        );
+    }
+
+    /// freenet/river#397: when the probe was SKIPPED (already migrated / already
+    /// attempted this session) nothing more is coming, so the load is resolved —
+    /// the fast path that lets a returning empty user reach the calm empty state
+    /// immediately instead of waiting on the backstop.
+    #[test]
+    fn probe_legacy_skipped_resolves_loaded() {
+        assert_eq!(
+            load_state_after_probe_legacy(false),
+            RoomsLoadState::Loaded,
+            "skipped probes: nothing is coming, resolve immediately"
+        );
+    }
+
+    /// freenet/river#397 (#1 safety invariant): the timeout backstop rescues a
+    /// stuck `Loading` (the new-user-with-no-legacy-data case) into `Loaded`, so
+    /// the spinner is never perpetual — but it must NOT override `Migrating` (a
+    /// slow migration keeps its spinner rather than flashing empty) nor re-open
+    /// an already-resolved `Loaded`.
+    #[test]
+    fn backstop_only_rescues_loading() {
+        assert_eq!(
+            backstop_resolve(RoomsLoadState::Loading),
+            RoomsLoadState::Loaded,
+            "a genuinely-new user must resolve to Loaded, never a perpetual spinner"
+        );
+        assert_eq!(
+            backstop_resolve(RoomsLoadState::Migrating),
+            RoomsLoadState::Migrating,
+            "the backstop must not pre-empt an in-progress migration"
+        );
+        assert_eq!(
+            backstop_resolve(RoomsLoadState::Loaded),
+            RoomsLoadState::Loaded,
+            "the backstop must not re-open a resolved load"
+        );
+    }
+
+    /// freenet/river#397 end-to-end invariant, composed from the pure pieces: a
+    /// brand-new user fires legacy probes (→ `Loading`), nothing responds, and
+    /// the backstop resolves them to `Loaded` (→ the empty state). They are NEVER
+    /// stuck loading forever.
+    #[test]
+    fn new_user_resolves_to_loaded_never_stuck() {
+        let after_probe = load_state_after_probe_legacy(true);
+        assert_eq!(after_probe, RoomsLoadState::Loading);
+        assert_eq!(backstop_resolve(after_probe), RoomsLoadState::Loaded);
     }
 
     /// Codex P1 finding on PR #259: the legacy-migration-done
@@ -3922,6 +3991,123 @@ pub fn clear_legacy_migration_in_progress() {
     }
 }
 
+// =============================================================================
+// ROOM-LIST LOAD STATE (freenet/river#397)
+// Drives the rooms rail's non-room display so an empty `ROOMS` map during
+// startup / migration doesn't render a blank list that reads as data loss.
+// =============================================================================
+
+/// Coarse state of the initial room-list load, consumed by `RoomList` to decide
+/// what to show while `ROOMS` is still empty (spinner vs. migrating vs. a calm
+/// "no rooms yet"). Deliberately coarse: the room COUNT (from `ROOMS`) decides
+/// list-vs-none; this only disambiguates the three non-room states.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum RoomsLoadState {
+    /// The initial startup load has not resolved yet — the current delegate's
+    /// `ListResponse` isn't classified, or a fire-and-forget legacy probe is
+    /// outstanding and no migration has started. The honest "we don't know yet".
+    Loading,
+    /// A delegate/room migration is actively recovering rooms (the case Ivvor
+    /// hit after a delegate-WASM upgrade). Shown so a migrating user never reads
+    /// the empty rail as "my rooms are gone".
+    Migrating,
+    /// The load resolved: either rooms are present (the list renders them) or the
+    /// user genuinely has none (the calm empty state). Reached ONLY at a real
+    /// completion point or the timeout backstop — never speculatively, so an
+    /// existing user mid-migration can't flash "no rooms yet".
+    Loaded,
+}
+
+/// Reactive room-list load state. Starts `Loading`; advanced to `Loaded` at the
+/// real completion points (see `set_rooms_load_state` call sites) and to
+/// `Migrating` when a legacy migration re-save starts. A reactive signal (not a
+/// bare localStorage read of `is_legacy_migration_in_progress()`) because the
+/// render must re-run when the state transitions, and a migration's start does
+/// not otherwise touch a signal `RoomList` subscribes to.
+pub static ROOMS_LOAD_STATE: GlobalSignal<RoomsLoadState> = Global::new(|| RoomsLoadState::Loading);
+
+/// Set the room-list load state, deferred per the Dioxus signal-safety rules
+/// (all callers run inside spawned load/migration tasks that may hold a signal
+/// borrow). The `peek` guard avoids spurious writes / re-renders when the state
+/// is unchanged.
+pub(crate) fn set_rooms_load_state(state: RoomsLoadState) {
+    crate::util::defer(move || {
+        if *ROOMS_LOAD_STATE.peek() != state {
+            *ROOMS_LOAD_STATE.write() = state;
+        }
+    });
+}
+
+/// After the current delegate's `ListResponse` is classified as `ProbeLegacy`,
+/// pick the load state. A pure decision so the "new user never gets stuck
+/// loading" invariant is unit-testable.
+///
+/// - `fired_legacy_probes == false` — the probe was skipped (already migrated,
+///   or already attempted this session), so nothing more is coming: the load is
+///   resolved (`Loaded`). This is the fast path for a returning empty user.
+/// - `fired_legacy_probes == true` — probes were dispatched fire-and-forget. A
+///   migration MIGHT still arrive (existing user with legacy-only data) OR
+///   nothing will (brand-new user whose node has no legacy delegates). We cannot
+///   tell synchronously, so we stay `Loading`: the migration path flips us to
+///   `Migrating`/`Loaded` if data arrives, and the timeout backstop
+///   (`backstop_resolve`) flips us to `Loaded` if it doesn't. Staying `Loading`
+///   (never optimistic `Loaded`) is what stops an existing user from flashing
+///   "no rooms yet" before their migration starts.
+pub(crate) fn load_state_after_probe_legacy(fired_legacy_probes: bool) -> RoomsLoadState {
+    if fired_legacy_probes {
+        RoomsLoadState::Loading
+    } else {
+        RoomsLoadState::Loaded
+    }
+}
+
+/// The timeout backstop transition. This is a PURE UI SAFETY NET, not the
+/// primary completion signal (the real signals are the classified-load and
+/// migration-conclusion points that call `set_rooms_load_state`). It exists only
+/// for the one case with no reliable synchronous completion signal — a brand-new
+/// user whose fire-and-forget legacy probe finds nothing, so no response ever
+/// arrives — so that user resolves to the empty state instead of spinning
+/// forever (the #1 safety requirement of freenet/river#397).
+///
+/// It rescues ONLY a still-`Loading` state: it must not override `Migrating` (a
+/// positive signal that rooms are on the way — a slow migration should keep its
+/// spinner, not flash "no rooms yet"), nor re-open `Loaded`.
+pub(crate) fn backstop_resolve(current: RoomsLoadState) -> RoomsLoadState {
+    match current {
+        RoomsLoadState::Loading => RoomsLoadState::Loaded,
+        other => other,
+    }
+}
+
+/// Timeout for the room-list load backstop (see [`backstop_resolve`]). Generous
+/// on purpose: it must comfortably outlast a real legacy migration's
+/// probe→response→migrate window so it never pre-empts an existing user's
+/// migration, so its only visible effect is resolving the genuinely-empty
+/// new-user case.
+const ROOMS_LOAD_BACKSTOP_MS: u64 = 15_000;
+
+/// One-shot guard so the backstop is scheduled once per session even though
+/// `set_up_chat_delegate` re-runs on every reconnect.
+static LOAD_BACKSTOP_SCHEDULED: AtomicBool = AtomicBool::new(false);
+
+/// Schedule the room-list load backstop once per session. See
+/// [`backstop_resolve`] for why this is a safety net rather than the primary
+/// signal.
+pub(crate) fn schedule_rooms_load_backstop() {
+    if LOAD_BACKSTOP_SCHEDULED.swap(true, Ordering::Relaxed) {
+        return;
+    }
+    crate::util::safe_spawn_local(async {
+        crate::util::sleep(std::time::Duration::from_millis(ROOMS_LOAD_BACKSTOP_MS)).await;
+        crate::util::defer(|| {
+            let resolved = backstop_resolve(*ROOMS_LOAD_STATE.peek());
+            if *ROOMS_LOAD_STATE.peek() != resolved {
+                *ROOMS_LOAD_STATE.write() = resolved;
+            }
+        });
+    });
+}
+
 /// Guard to prevent repeated legacy migration attempts within the same session.
 /// The migration is fire-and-forget: if the legacy delegates don't exist on the node,
 /// the node returns "delegate not found" errors that never reach the response handler's
@@ -3964,18 +4150,24 @@ pub(crate) fn arm_legacy_migration_recovery() -> bool {
 /// may have data is unsafe because a legacy response can trigger a save that
 /// overwrites the current delegate's storage before its GET response arrives,
 /// destroying rooms the user created after the last legacy snapshot.
-pub(crate) async fn fire_legacy_migration_request() {
+///
+/// Returns `true` if it actually dispatched legacy probes, `false` if it skipped
+/// (migration already done, or already attempted this session). The room-list
+/// load path (freenet/river#397) uses this to decide whether to stay `Loading`
+/// (probes fired — a migration might still arrive) or resolve to `Loaded`
+/// (nothing more is coming) — see [`load_state_after_probe_legacy`].
+pub(crate) async fn fire_legacy_migration_request() -> bool {
     // Check if migration has already been done (persistent across sessions)
     if is_legacy_migration_done() {
         info!("Legacy migration already done, skipping");
-        return;
+        return false;
     }
 
     // Only attempt migration once per session to avoid error spam on reconnect.
     // If the legacy delegates aren't installed, retrying won't help.
     if LEGACY_MIGRATION_ATTEMPTED.swap(true, Ordering::Relaxed) {
         info!("Legacy migration already attempted this session, skipping");
-        return;
+        return false;
     }
 
     info!(
@@ -4084,4 +4276,5 @@ pub(crate) async fn fire_legacy_migration_request() {
             ),
         }
     }
+    true
 }

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -549,16 +549,16 @@ pub async fn set_up_chat_delegate() -> Result<(), String> {
             fire_list_rooms_request().await;
             fire_load_outbound_dms_request().await;
 
-            // NOTE (freenet/river#397 Codex review, P2-1): the room-list load
-            // backstop is NOT armed here. Arming it unconditionally at startup
-            // would let it flip an in-flight AUTHORITATIVE load (a slow
-            // ListResponse / per-room fetch that takes >20s) to Empty — a false
-            // "no rooms yet". The backstop is only needed for the ONE path with
-            // no synchronous completion signal: a fire-and-forget legacy probe.
-            // It is therefore armed only at the probe-fired sites in
-            // `response_handler.rs`, guarded by `if fired`, by which point the
-            // authoritative current-delegate load has already returned empty, so
-            // the backstop can no longer clobber it.
+            // Arm the UNIVERSAL room-list load backstop once per session
+            // (freenet/river#397 Codex review 3). This is the single mechanism
+            // that GUARANTEES the rail never spins forever: at 30s it resolves ANY
+            // non-terminal state (`Loading` OR `Migrating`) to `Loaded`. It is
+            // generous enough (30s) never to pre-empt a load/migration that is
+            // actually progressing, and because a non-empty `ROOMS` renders `List`
+            // regardless of load state, it only ever shows Empty when genuinely
+            // nothing loaded. Fast definitive completions still resolve earlier;
+            // this is the safety net under all of them.
+            schedule_rooms_load_backstop();
 
             Ok(())
         }
@@ -1248,34 +1248,52 @@ mod tests {
         );
     }
 
-    /// freenet/river#397 (#1 safety invariant): the timeout backstop rescues a
-    /// stuck `Loading` (the new-user-with-no-legacy-data case) into `Loaded`, so
-    /// the spinner is never perpetual — but it must NOT override `Migrating` (a
-    /// slow migration keeps its spinner rather than flashing empty) nor re-open
-    /// an already-resolved `Loaded`.
+    /// freenet/river#397 Codex review 3: the UNIVERSAL backstop resolves EVERY
+    /// non-terminal state to `Loaded` — both `Loading` AND `Migrating` — so the
+    /// rail can never spin forever (a delegate request can time out without the WS
+    /// disconnecting, so "wait for reconnect" cannot guarantee termination). Only
+    /// `Loaded` stays `Loaded`.
     #[test]
-    fn backstop_only_rescues_loading() {
+    fn backstop_resolves_every_non_terminal_state() {
         assert_eq!(
             backstop_resolve(RoomsLoadState::Loading),
             RoomsLoadState::Loaded,
-            "a genuinely-new user must resolve to Loaded, never a perpetual spinner"
+            "Loading must resolve — a new user with no legacy data never spins forever"
         );
         assert_eq!(
             backstop_resolve(RoomsLoadState::Migrating),
-            RoomsLoadState::Migrating,
-            "the backstop must not pre-empt an in-progress migration"
+            RoomsLoadState::Loaded,
+            "Migrating must ALSO resolve — a stalled migration must not spin forever"
         );
         assert_eq!(
             backstop_resolve(RoomsLoadState::Loaded),
             RoomsLoadState::Loaded,
-            "the backstop must not re-open a resolved load"
+            "Loaded stays Loaded (idempotent)"
         );
+    }
+
+    /// freenet/river#397: no state strands — every non-terminal input to the
+    /// backstop is a terminal `Loaded` output, so termination is guaranteed for
+    /// ANY load/migration path that fails to resolve itself.
+    #[test]
+    fn backstop_guarantees_termination_from_any_state() {
+        for state in [
+            RoomsLoadState::Loading,
+            RoomsLoadState::Migrating,
+            RoomsLoadState::Loaded,
+        ] {
+            assert_eq!(
+                backstop_resolve(state),
+                RoomsLoadState::Loaded,
+                "{state:?} must terminate at Loaded"
+            );
+        }
     }
 
     /// freenet/river#397 end-to-end invariant, composed from the pure pieces: a
     /// brand-new user fires legacy probes (→ `Loading`), nothing responds, and
-    /// the backstop resolves them to `Loaded` (→ the empty state). They are NEVER
-    /// stuck loading forever.
+    /// the universal backstop resolves them to `Loaded` (→ the empty state). They
+    /// are NEVER stuck loading forever.
     #[test]
     fn new_user_resolves_to_loaded_never_stuck() {
         let after_probe = load_state_after_probe_legacy(true);
@@ -1283,86 +1301,13 @@ mod tests {
         assert_eq!(backstop_resolve(after_probe), RoomsLoadState::Loaded);
     }
 
-    /// freenet/river#397 Codex review (P2-2): a per-room load that came back
-    /// EMPTY while the index proved rooms exist AND a listed room failed to fetch
-    /// must NOT resolve — staying `Loading` (the honest spinner) instead of
-    /// flashing "no rooms yet" at a user who provably has rooms. Every other
-    /// combination is a definitive answer and resolves.
+    /// freenet/river#397 Codex review 3: the universal backstop is armed once per
+    /// session at the START of load, in `set_up_chat_delegate` (reverting the
+    /// round-3 "arm only on probe-fired" design). It must NOT be conditionally
+    /// armed elsewhere — a single unconditional arming is what makes termination
+    /// universal.
     #[test]
-    fn per_room_load_stays_loading_only_on_empty_listed_with_fetch_error() {
-        // Signature: should_resolve_per_room_load(map_empty, listed_count,
-        // had_fetch_error, recovering). These cases fix recovering = false; the
-        // recovering = true cases are pinned separately below.
-
-        // The one case that must NOT resolve: empty map, index listed rooms, and
-        // a fetch error → stay Loading (retry on WS reconnect).
-        assert!(
-            !should_resolve_per_room_load(true, 3, true, false),
-            "empty + listed + fetch error must NOT resolve (stay Loading)"
-        );
-
-        // Empty but every listed key definitively had no value (no fetch error) →
-        // a real, if odd, empty state → resolve.
-        assert!(
-            should_resolve_per_room_load(true, 3, false, false),
-            "empty + listed + no fetch error is a definitive empty → resolve"
-        );
-
-        // Empty and nothing was listed → genuinely empty delegate → resolve.
-        assert!(
-            should_resolve_per_room_load(true, 0, false, false),
-            "empty + nothing listed is the new-user empty → resolve"
-        );
-        // A fetch error is irrelevant when nothing was listed (can't happen, but
-        // the decision must still resolve — there's provably nothing to wait for).
-        assert!(
-            should_resolve_per_room_load(true, 0, true, false),
-            "empty + nothing listed must resolve regardless of the error flag"
-        );
-
-        // A non-empty map always resolves (a partial load renders as List; the
-        // missing rooms show their own per-room markers), regardless of errors.
-        assert!(should_resolve_per_room_load(false, 3, true, false));
-        assert!(should_resolve_per_room_load(false, 3, false, false));
-        assert!(should_resolve_per_room_load(false, 0, false, false));
-    }
-
-    /// freenet/river#397 Codex review 2 (P2): an interrupted-migration recovery
-    /// on an EMPTY map must stay `Loading` (recovery may still recover stranded
-    /// rooms), even with no fetch error — but recovery is irrelevant once the map
-    /// is non-empty (rooms are already showing).
-    #[test]
-    fn per_room_load_stays_loading_while_recovering_on_empty_map() {
-        // Empty + recovering → stay Loading, regardless of listed/error.
-        assert!(
-            !should_resolve_per_room_load(true, 0, false, true),
-            "empty + recovering must NOT resolve — stranded rooms may still recover"
-        );
-        assert!(
-            !should_resolve_per_room_load(true, 3, false, true),
-            "empty + listed + recovering must NOT resolve"
-        );
-        assert!(
-            !should_resolve_per_room_load(true, 3, true, true),
-            "empty + listed + error + recovering must NOT resolve"
-        );
-
-        // A non-empty map resolves even while recovering (rooms are visible;
-        // recovery continues as a background re-fill).
-        assert!(
-            should_resolve_per_room_load(false, 3, false, true),
-            "non-empty map resolves to List even while recovering"
-        );
-        assert!(should_resolve_per_room_load(false, 0, true, true));
-    }
-
-    /// freenet/river#397 Codex review (P2-1): the load backstop must be armed
-    /// ONLY on the fire-and-forget legacy-probe path (guarded by `if fired`),
-    /// never unconditionally at startup — otherwise a slow but authoritative
-    /// current-delegate load (>20s) gets flipped to a false "no rooms yet".
-    #[test]
-    fn backstop_armed_only_on_fire_and_forget_probe() {
-        // (a) `set_up_chat_delegate` must NOT arm the backstop.
+    fn set_up_chat_delegate_arms_backstop() {
         let self_src = include_str!("chat_delegate.rs");
         let self_production = self_src
             .split("mod tests {")
@@ -1378,38 +1323,22 @@ mod tests {
             .unwrap_or(self_production.len());
         let setup_body = &self_production[setup_idx..setup_end];
         assert!(
-            !setup_body.contains("schedule_rooms_load_backstop"),
-            "set_up_chat_delegate must NOT arm the load backstop (P2-1): arming it \
-             unconditionally could flip a slow authoritative load to a false Empty"
+            setup_body.contains("schedule_rooms_load_backstop();"),
+            "set_up_chat_delegate must arm the universal load backstop once per session"
         );
 
-        // (b) In the response handler, the backstop is armed at EXACTLY the two
-        // probe-fired sites (ProbeLegacy + value-gone blob path), each directly
-        // guarded by `if fired`.
+        // And the response handler must NOT arm it (the round-3 probe-fired arming
+        // is reverted — the universal start-of-load arming replaces it).
         let rh_src = include_str!("freenet_api/response_handler.rs");
         let rh_production = rh_src
             .split("mod tests {")
             .next()
             .expect("production code before `mod tests`");
-        let arm_count = rh_production
-            .matches("schedule_rooms_load_backstop();")
-            .count();
-        assert_eq!(
-            arm_count, 2,
-            "the backstop must be armed at exactly the two probe-fired sites (found {arm_count})"
+        assert!(
+            !rh_production.contains("schedule_rooms_load_backstop"),
+            "the response handler must NOT arm the backstop — it is armed once at \
+             start of load in set_up_chat_delegate (Codex review 3)"
         );
-        let mut search_from = 0;
-        while let Some(rel) = rh_production[search_from..].find("schedule_rooms_load_backstop();") {
-            let pos = search_from + rel;
-            let guard = rh_production[..pos]
-                .rfind("if fired {")
-                .expect("each backstop arming must be guarded by `if fired`");
-            assert!(
-                pos - guard < 500,
-                "each schedule_rooms_load_backstop() must be DIRECTLY inside an `if fired` block"
-            );
-            search_from = pos + 1;
-        }
     }
 
     /// Codex P1 finding on PR #259: the legacy-migration-done
@@ -4194,69 +4123,38 @@ pub(crate) fn load_state_after_probe_legacy(fired_legacy_probes: bool) -> RoomsL
     }
 }
 
-/// The timeout backstop transition. This is a PURE UI SAFETY NET, not the
-/// primary completion signal (the real signals are the classified-load and
-/// migration-conclusion points that call `set_rooms_load_state`). It exists only
-/// for the one case with no reliable synchronous completion signal — a brand-new
-/// user whose fire-and-forget legacy probe finds nothing, so no response ever
-/// arrives — so that user resolves to the empty state instead of spinning
-/// forever (the #1 safety requirement of freenet/river#397).
+/// The UNIVERSAL backstop transition (freenet/river#397 Codex review 3). At the
+/// 30s deadline, ANY non-terminal state resolves to `Loaded` — BOTH `Loading`
+/// AND `Migrating`. This is what GUARANTEES termination: the rounds-3/4 attempt
+/// to "stay `Loading`/`Migrating` and rely on a WS reconnect to retry" could
+/// spin forever, because a delegate request can time out (~10s) WITHOUT
+/// disconnecting the WebSocket, so no reconnect ever comes; and concurrent
+/// legacy probes race on this one global signal. A single backstop that resolves
+/// every non-terminal state removes both failure modes.
 ///
-/// It rescues ONLY a still-`Loading` state: it must not override `Migrating` (a
-/// positive signal that rooms are on the way — a slow migration should keep its
-/// spinner, not flash "no rooms yet"), nor re-open `Loaded`.
+/// This can only ever *show* Empty when `room_count == 0` at the deadline — a
+/// non-empty `ROOMS` renders `List` regardless of the load state — i.e. only
+/// when genuinely nothing loaded, which is the correct, no-worse-than-baseline
+/// outcome (a proper error/retry state is a separate follow-up). The `Loaded`
+/// arm returns `current` (already `Loaded`) so the two arms differ textually
+/// (avoids `clippy::match_same_arms`) while being behaviourally identical.
 pub(crate) fn backstop_resolve(current: RoomsLoadState) -> RoomsLoadState {
     match current {
-        RoomsLoadState::Loading => RoomsLoadState::Loaded,
-        other => other,
+        RoomsLoadState::Loaded => current,
+        // Loading AND Migrating are both non-terminal — resolve them.
+        RoomsLoadState::Loading | RoomsLoadState::Migrating => RoomsLoadState::Loaded,
     }
 }
 
-/// Whether the current-delegate per-room load should RESOLVE the display state
-/// to `Loaded` (freenet/river#397 Codex review, P2-2). Resolve on a DEFINITIVE
-/// answer; stay `Loading` only when the load came back EMPTY but the delegate's
-/// key index PROVED rooms exist AND at least one listed room failed to
-/// materialize (a transport / parse error, NOT a definitive value-absent). In
-/// that failed-load case a WS reconnect re-fires `ListRequest` and retries, so
-/// the honest spinner is correct — we KNOW rooms exist, so flashing "no rooms
-/// yet" would be the feature's own worst failure mode.
-///
-/// - non-empty map → resolve (`true`): we have rooms to show. A PARTIAL load
-///   (some rooms loaded, some errored) has a non-empty map and resolves to
-///   `List`; the missing rooms surface their own per-room `awaiting_sync`/error
-///   markers.
-/// - empty + nothing listed (`listed_count == 0`) + not recovering → resolve
-///   (`true`): a genuinely empty delegate (the new-user / no-rooms case).
-/// - empty + listed + NO fetch error + not recovering → resolve (`true`): every
-///   listed key definitively returned `value: None` — a real (if odd) empty
-///   state, not a failure to fetch.
-/// - empty + listed + a fetch error → do NOT resolve (`false`): stay `Loading`.
-/// - empty + `recovering` → do NOT resolve (`false`): an interrupted-migration
-///   recovery is armed/running, and the in-progress flag explicitly says rooms
-///   may be stranded. Even with no fetch error (e.g. the interrupted save wrote
-///   only tombstones while the live-room writes failed), resolving here would
-///   flash "no rooms yet" before the recovery re-run below has a chance to
-///   recover them. Stay `Loading` until recovery concludes (freenet/river#397
-///   Codex review 2, P2).
-pub(crate) fn should_resolve_per_room_load(
-    map_empty: bool,
-    listed_count: usize,
-    had_fetch_error: bool,
-    recovering: bool,
-) -> bool {
-    !(map_empty && ((listed_count > 0 && had_fetch_error) || recovering))
-}
-
-/// Timeout for the room-list load backstop (see [`backstop_resolve`]). Generous
-/// on purpose: it must comfortably outlast a real legacy migration's
-/// probe→response→migrate window so it never pre-empts an existing user's
-/// migration, so its only visible effect is resolving the genuinely-empty
-/// new-user case. Tradeoff (freenet/river#397 review): a longer timeout means a
-/// brand-new user waits fractionally longer for the empty state, but it avoids
-/// flash-emptying an existing user whose legacy `ListResponse` is slow to arrive
-/// on a cold first connect (before the `Migrating` transition fires). 20s is
-/// chosen to sit safely past a realistic slow probe→response→migrate window.
-const ROOMS_LOAD_BACKSTOP_MS: u64 = 20_000;
+/// Timeout for the UNIVERSAL room-list load backstop (see [`backstop_resolve`]).
+/// Armed once per session at the START of load (`set_up_chat_delegate`); at the
+/// deadline it resolves any non-terminal state to `Loaded`. Generous (30s) so it
+/// never pre-empts a load or migration that is actually progressing — a slow but
+/// live probe→response→migrate or per-room fetch completes and resolves itself
+/// well before this fires; the backstop only bites on genuine timeout /
+/// all-fetch-fail / concurrency-strand cases, where resolving to Empty is the
+/// accepted residual (freenet/river#397 Codex review 3).
+const ROOMS_LOAD_BACKSTOP_MS: u64 = 30_000;
 
 /// One-shot guard so the backstop is scheduled once per session even though
 /// `set_up_chat_delegate` re-runs on every reconnect.

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -511,6 +511,16 @@ fn persist_cipher_material(cipher: &[u8; 32], nonce: &[u8; 24]) {
 }
 
 pub async fn set_up_chat_delegate() -> Result<(), String> {
+    // freenet/river#397 Codex review 8 (P2#2): treat EVERY setup-triggered load
+    // as a fresh attempt — the initial load AND every reconnect/wake, since this
+    // fn re-runs on each. `begin_load_attempt` advances LOAD_ATTEMPT_GEN, so every
+    // worker spawned by the PREVIOUS pass is now stale and its Drop/mark/
+    // set_load_state all no-op (attempt-scoped guard) — overlap is harmless. It
+    // also resets SAW_FETCH_FAILURE, returns the rail to `Loading`, and arms a
+    // fresh gen-guarded hard-max BEFORE RegisterDelegate, so even a registration
+    // failure eventually resolves.
+    begin_load_attempt();
+
     let delegate = create_chat_delegate_container();
 
     // Get a write lock on the API and use it directly
@@ -546,28 +556,21 @@ pub async fn set_up_chat_delegate() -> Result<(), String> {
             // skipped (current is authoritative); if it is empty, migration is
             // fired then. This prevents legacy responses from racing with the
             // current delegate and clobbering newer state (freenet/river#253).
-            // Fresh load attempt: clear the fetch-failure signal so a stale
-            // failure from a prior attempt can't mislabel this load as
-            // `LoadFailed` (freenet/river#397 Codex review 4).
-            SAW_FETCH_FAILURE.store(false, Ordering::Relaxed);
-
+            // The fresh-attempt bookkeeping (SAW_FETCH_FAILURE reset, Loading
+            // state, hard-max arming) already ran in `begin_load_attempt()` above.
             fire_list_rooms_request().await;
             fire_load_outbound_dms_request().await;
 
-            // Arm the UNIVERSAL room-list load backstop once per session
-            // (freenet/river#397 Codex review 3/4). This is the single mechanism
-            // that GUARANTEES the rail never spins forever: at 30s it resolves ANY
-            // non-terminal state (`Loading` OR `Migrating`) to a terminal —
-            // `LoadFailed` if a known-rooms fetch failed, else `Loaded`. Generous
-            // enough (30s) never to pre-empt a load/migration that is actually
-            // progressing; a non-empty `ROOMS` renders `List` regardless of load
-            // state. Fast definitive completions still resolve earlier; this is
-            // the safety net under all of them.
-            schedule_rooms_load_backstop();
-
             Ok(())
         }
-        Err(e) => Err(format!("Failed to register chat delegate: {}", e)),
+        Err(e) => {
+            // freenet/river#397 Codex review 8 (P2#1): RegisterDelegate failed —
+            // a definitive setup failure, and this Err path returns before any
+            // load worker runs. Resolve directly to `LoadFailed` (if empty) so the
+            // user gets Retry immediately rather than waiting for the hard-max.
+            resolve_load_failed_if_empty();
+            Err(format!("Failed to register chat delegate: {}", e))
+        }
     }
 }
 
@@ -1521,11 +1524,13 @@ mod tests {
         );
     }
 
-    /// freenet/river#397 Codex review 3/4: the universal backstop is armed once
-    /// per session at the START of load in `set_up_chat_delegate`, which also
-    /// resets `SAW_FETCH_FAILURE`. It must NOT be armed in the response handler.
+    /// freenet/river#397 Codex review 8: `set_up_chat_delegate` (initial +
+    /// reconnect/wake) begins a fresh load attempt BEFORE `RegisterDelegate`, and
+    /// its `RegisterDelegate` `Err` path resolves the load (LoadFailed if empty)
+    /// so a registration failure doesn't leave the rail stuck `Loading`. The
+    /// response handler must NOT arm the backstop.
     #[test]
-    fn set_up_chat_delegate_arms_backstop_and_resets_fetch_failure() {
+    fn set_up_chat_delegate_begins_load_attempt_before_register() {
         let self_src = include_str!("chat_delegate.rs");
         let self_production = self_src
             .split("mod tests {")
@@ -1534,19 +1539,33 @@ mod tests {
         let setup_idx = self_production
             .find("pub async fn set_up_chat_delegate()")
             .expect("set_up_chat_delegate must exist");
-        // Bound the body at the next top-level item's doc comment.
         let setup_end = self_production[setup_idx..]
             .find("Per-session dedup map for")
             .map(|i| setup_idx + i)
             .unwrap_or(self_production.len());
         let setup_body = &self_production[setup_idx..setup_end];
+
+        let begin = setup_body
+            .find("begin_load_attempt();")
+            .expect("set_up_chat_delegate must begin a fresh load attempt");
+        // Anchor on the actual code token, not the word in the rationale comment.
+        let register = setup_body
+            .find("DelegateRequest::RegisterDelegate")
+            .expect("set_up_chat_delegate must register the delegate");
         assert!(
-            setup_body.contains("schedule_rooms_load_backstop();"),
-            "set_up_chat_delegate must arm the universal load backstop once per session"
+            begin < register,
+            "begin_load_attempt() must run BEFORE RegisterDelegate so even a \
+             registration failure has an armed hard-max"
         );
+
+        // The RegisterDelegate Err path resolves the load (P2#1).
+        let err_arm = setup_body
+            .find("Failed to register chat delegate")
+            .expect("the RegisterDelegate error arm must exist");
+        let err_ctx = &setup_body[err_arm.saturating_sub(200)..err_arm];
         assert!(
-            setup_body.contains("SAW_FETCH_FAILURE.store(false"),
-            "set_up_chat_delegate must reset SAW_FETCH_FAILURE at the start of a load"
+            err_ctx.contains("resolve_load_failed_if_empty()"),
+            "the RegisterDelegate error path must resolve LoadFailed (not stay Loading forever)"
         );
 
         // And the response handler must NOT arm the backstop.
@@ -1557,23 +1576,50 @@ mod tests {
             .expect("production code before `mod tests`");
         assert!(
             !rh_production.contains("schedule_rooms_load_backstop"),
-            "the response handler must NOT arm the backstop — it is armed once at \
-             start of load in set_up_chat_delegate"
+            "the response handler must NOT arm the backstop — it is armed by \
+             begin_load_attempt at every load entry"
         );
     }
 
-    /// freenet/river#397 Codex review 4/5: the Retry button's `retry_rooms_load`
-    /// must (a) reset `SAW_FETCH_FAILURE`, (b) return the rail to `Loading`,
-    /// (c) re-enable the legacy probe (`LEGACY_MIGRATION_ATTEMPTED`) so a FAILED
-    /// legacy source is retried, (d) bump `LOAD_ATTEMPT_GEN` (invalidating stale
-    /// backstop timers), (e) re-arm a fresh backstop, and (f) re-fire the
-    /// current-delegate list request. Pinned by source-scrape (the fn drives the
-    /// Dioxus signal + websocket, so it can't be unit-driven).
+    /// freenet/river#397 Codex review 8: `begin_load_attempt` (the shared load
+    /// entry point) advances the attempt gen, zeroes the pending count, resets
+    /// SAW_FETCH_FAILURE, bumps the activity gen, returns the rail to `Loading`,
+    /// and arms the hard-max. It must NOT touch `LEGACY_MIGRATION_ATTEMPTED` (a
+    /// plain reconnect must not force a legacy re-probe — that's retry-only).
+    #[test]
+    fn begin_load_attempt_resets_and_arms() {
+        // Defined after this mid-file test module → rfind the real definition.
+        let src = include_str!("chat_delegate.rs");
+        let fn_start = src
+            .rfind("pub(crate) fn begin_load_attempt()")
+            .expect("begin_load_attempt must exist");
+        let rest = &src[fn_start + 1..];
+        let fn_end = rest
+            .find("\nfn schedule_rooms_load_backstop()")
+            .or_else(|| rest.find("\n/// "))
+            .map(|i| fn_start + 1 + i)
+            .unwrap_or(src.len());
+        let body = &src[fn_start..fn_end];
+        for needle in [
+            "LOAD_ATTEMPT_GEN.fetch_add(1",
+            "PENDING_LOADS.store(0",
+            "SAW_FETCH_FAILURE.store(false",
+            "LOAD_ACTIVITY_GEN.fetch_add(1",
+            "set_rooms_load_state(RoomsLoadState::Loading)",
+            "schedule_rooms_load_backstop();",
+        ] {
+            assert!(body.contains(needle), "begin_load_attempt must `{needle}`");
+        }
+        assert!(
+            !body.contains("LEGACY_MIGRATION_ATTEMPTED"),
+            "begin_load_attempt must NOT touch LEGACY_MIGRATION_ATTEMPTED (retry-only; #253 gate)"
+        );
+    }
+
+    /// freenet/river#397 Codex review 8: a retry is `begin_load_attempt()` PLUS
+    /// re-enabling the legacy probe (retry-only) PLUS re-firing the list request.
     #[test]
     fn retry_rooms_load_resets_and_refires() {
-        // `retry_rooms_load` is defined AFTER this (mid-file) test module, so
-        // `split("mod tests")` would miss it. `rfind` finds the real definition
-        // (the last occurrence; this test's own literal above is earlier).
         let src = include_str!("chat_delegate.rs");
         let fn_start = src
             .rfind("pub(crate) fn retry_rooms_load()")
@@ -1587,33 +1633,12 @@ mod tests {
             .unwrap_or(src.len());
         let body = &src[fn_start..fn_end];
         assert!(
-            body.contains("SAW_FETCH_FAILURE.store(false"),
-            "retry must reset the fetch-failure signal"
-        );
-        assert!(
-            body.contains("set_rooms_load_state(RoomsLoadState::Loading)"),
-            "retry must return the rail to Loading"
+            body.contains("begin_load_attempt();"),
+            "retry must begin a fresh load attempt (shared entry point)"
         );
         assert!(
             body.contains("LEGACY_MIGRATION_ATTEMPTED.store(false"),
             "retry must re-enable the legacy probe so a failed legacy source is retried (P1b)"
-        );
-        assert!(
-            body.contains("LOAD_ATTEMPT_GEN.fetch_add(1"),
-            "retry must bump the attempt generation to invalidate stale backstop timers (P2a)"
-        );
-        assert!(
-            body.contains("PENDING_LOADS.store(0"),
-            "retry must sanity-reset the pending-worker counter (review 6)"
-        );
-        assert!(
-            body.contains("LOAD_ACTIVITY_GEN.fetch_add(1"),
-            "retry must bump the activity generation to cancel any armed idle timer (review 6)"
-        );
-        assert!(
-            body.contains("LOAD_BACKSTOP_SCHEDULED.store(false")
-                && body.contains("schedule_rooms_load_backstop()"),
-            "retry must re-arm the backstop"
         );
         assert!(
             body.contains("fire_list_rooms_request().await"),
@@ -1621,20 +1646,21 @@ mod tests {
         );
     }
 
-    /// freenet/river#397 Codex review 5 (P2a): `schedule_rooms_load_backstop`
-    /// captures the attempt generation at arm time and guards its resolution with
-    /// `backstop_should_apply`, so a stale timer is a no-op.
+    /// freenet/river#397 Codex review 5/8: `schedule_rooms_load_backstop` captures
+    /// the attempt generation at arm time and guards its resolution with
+    /// `backstop_should_apply`, so a stale timer (from a superseded attempt/
+    /// reconnect) is a no-op. It is now armed PER ATTEMPT (no once-per-session
+    /// guard).
     #[test]
     fn backstop_scheduler_is_generation_guarded() {
-        // `schedule_rooms_load_backstop` is defined AFTER this mid-file test
-        // module, so `rfind` (last occurrence) finds the real definition.
         let src = include_str!("chat_delegate.rs");
         let fn_start = src
-            .rfind("pub(crate) fn schedule_rooms_load_backstop()")
+            .rfind("fn schedule_rooms_load_backstop()")
             .expect("schedule_rooms_load_backstop must exist");
         let rest = &src[fn_start + 1..];
         let fn_end = rest
             .find("\npub(crate) fn retry_rooms_load()")
+            .or_else(|| rest.find("\n/// "))
             .map(|i| fn_start + 1 + i)
             .unwrap_or(src.len());
         let body = &src[fn_start..fn_end];
@@ -1645,6 +1671,10 @@ mod tests {
         assert!(
             body.contains("backstop_should_apply("),
             "the scheduler's resolve closure must bail via backstop_should_apply on a stale gen"
+        );
+        assert!(
+            !body.contains("LOAD_BACKSTOP_SCHEDULED"),
+            "the once-per-session arming guard must be gone (per-attempt arming now)"
         );
     }
 
@@ -4775,35 +4805,48 @@ fn schedule_idle_resolution(armed_gen: u32, armed_attempt: u32) {
     });
 }
 
-/// One-shot guard so the hard-max backstop is scheduled once per session even
-/// though `set_up_chat_delegate` re-runs on every reconnect. Reset by
-/// `retry_rooms_load` so a fresh deadline is armed for the retry.
-static LOAD_BACKSTOP_SCHEDULED: AtomicBool = AtomicBool::new(false);
-
-/// Monotonic load-attempt generation (freenet/river#397 Codex review 5, P2a).
-/// Incremented by every `retry_rooms_load`. A backstop timer captures the
-/// generation at arm time and, at fire time, only applies its resolution if the
-/// generation is unchanged (`backstop_should_apply`), so a stale timer from a
-/// superseded attempt is a no-op and cannot resolve the retry's fresh state.
+/// Monotonic load-attempt generation (freenet/river#397 Codex review 5/8).
+/// Advanced by [`begin_load_attempt`] — i.e. by EVERY load entry point
+/// (`set_up_chat_delegate`'s initial + reconnect/wake passes, and
+/// `retry_rooms_load`). Every attempt-scoped worker and every hard-max timer
+/// captures the generation at start and only acts while it is unchanged
+/// (`guard_drop_applies` / `backstop_should_apply`), so a worker or timer from a
+/// superseded attempt is a complete no-op.
 static LOAD_ATTEMPT_GEN: AtomicU32 = AtomicU32::new(0);
 
-/// Schedule the HARD-MAX load backstop once per session (re-armed by Retry).
-/// This is the last-resort safety net (freenet/river#397 review 6): the
-/// progress-tracked idle resolution ([`on_load_worker_settled`]) terminates the
-/// load first in practice; this only fires if the worker counter ever leaks.
-/// See [`backstop_terminal`] for the terminal it resolves to and
-/// [`backstop_should_apply`] for the stale-timer (attempt-gen) guard.
-pub(crate) fn schedule_rooms_load_backstop() {
-    if LOAD_BACKSTOP_SCHEDULED.swap(true, Ordering::Relaxed) {
-        return;
-    }
+/// Begin a FRESH load attempt (freenet/river#397 Codex review 8). Called at the
+/// TOP of every load entry point — `set_up_chat_delegate` (initial AND every
+/// reconnect/wake) and `retry_rooms_load`. Advancing `LOAD_ATTEMPT_GEN` makes
+/// every worker and timer from the previous pass stale/inert (attempt-scoped
+/// guard), so overlapping passes are harmless. It also zeroes the pending-worker
+/// count, clears `SAW_FETCH_FAILURE`, returns the rail to `Loading`, and arms a
+/// fresh gen-guarded hard-max backstop. Does NOT touch `LEGACY_MIGRATION_ATTEMPTED`
+/// — a plain reconnect must not force a legacy re-probe (preserves the #253 gate);
+/// only `retry_rooms_load` re-enables it.
+pub(crate) fn begin_load_attempt() {
+    LOAD_ATTEMPT_GEN.fetch_add(1, Ordering::Relaxed);
+    PENDING_LOADS.store(0, Ordering::Relaxed);
+    SAW_FETCH_FAILURE.store(false, Ordering::Relaxed);
+    LOAD_ACTIVITY_GEN.fetch_add(1, Ordering::Relaxed);
+    set_rooms_load_state(RoomsLoadState::Loading);
+    schedule_rooms_load_backstop();
+}
+
+/// Arm a fresh gen-guarded HARD-MAX backstop for the current attempt
+/// (freenet/river#397 review 6/8). Armed once per attempt by [`begin_load_attempt`]
+/// (which bumps `LOAD_ATTEMPT_GEN` first), so every prior attempt's timer is a
+/// stale no-op via [`backstop_should_apply`] — correct across reconnects with no
+/// once-per-session guard. Last-resort safety net: the progress-tracked idle
+/// resolution ([`on_load_worker_settled`]) terminates the load first in practice;
+/// this only fires if the worker counter ever leaks. See [`backstop_terminal`].
+fn schedule_rooms_load_backstop() {
     // Capture the attempt generation this timer belongs to.
     let armed_gen = LOAD_ATTEMPT_GEN.load(Ordering::Relaxed);
     crate::util::safe_spawn_local(async move {
         crate::util::sleep(std::time::Duration::from_millis(LOAD_HARD_MAX_MS)).await;
         crate::util::defer(move || {
-            // A newer attempt (Retry) superseded this timer → no-op, so a stale
-            // timer can't resolve the retry's fresh Loading/Migrating.
+            // A newer attempt superseded this timer → no-op, so a stale timer
+            // can't resolve a fresh attempt's Loading/Migrating.
             if !backstop_should_apply(armed_gen, LOAD_ATTEMPT_GEN.load(Ordering::Relaxed)) {
                 return;
             }
@@ -4814,37 +4857,23 @@ pub(crate) fn schedule_rooms_load_backstop() {
     });
 }
 
-/// Retry a failed room-list load (freenet/river#397 Codex review 4/5). Wired to
+/// Retry a failed room-list load (freenet/river#397 Codex review 4/5/8). Wired to
 /// the `LoadFailed` block's Retry button. Signal-safe: `set_rooms_load_state` and
 /// `safe_spawn_local` both defer, and the atomics are lock-free, so this is safe
 /// to call directly from an `onclick` handler.
 ///
-/// Resets the fetch-failure signal, returns the rail to `Loading`, re-enables the
-/// legacy migration probe (so a FAILED legacy source is retried, not skipped),
-/// bumps the attempt generation (invalidating any stale backstop timer), re-arms
-/// a fresh backstop, and re-fires the current-delegate load. If the delegate
-/// genuinely has no rooms this time, the fast ProbeLegacy/PerRoom terminal
-/// resolves to `Loaded` (→ Empty); if it succeeds it renders the list; if it
-/// fails again it returns to `LoadFailed`.
+/// A retry is just a fresh load attempt ([`begin_load_attempt`]) PLUS re-enabling
+/// the legacy probe (retry-only, so a legacy source that FAILED this session is
+/// re-probed — `is_legacy_migration_done` is left alone) and re-firing the
+/// current-delegate load. If the delegate genuinely has no rooms this time the
+/// fast ProbeLegacy/PerRoom terminal resolves to `Loaded` (→ Empty); if it
+/// succeeds it renders the list; if it fails again it returns to `LoadFailed`.
 pub(crate) fn retry_rooms_load() {
-    SAW_FETCH_FAILURE.store(false, Ordering::Relaxed);
-    set_rooms_load_state(RoomsLoadState::Loading);
-    // Re-enable the legacy probe so a legacy source that FAILED this session is
-    // retried (freenet/river#397 Codex review 5, P1b). `is_legacy_migration_done`
-    // is deliberately left alone — a genuinely-completed migration shouldn't
-    // re-probe; this only re-arms a probe that failed.
+    begin_load_attempt();
+    // Retry-only (deliberately NOT in `begin_load_attempt`): re-enable the legacy
+    // probe so a legacy source that failed THIS session is retried (P1b). A plain
+    // reconnect must not force this (it would defeat the #253 done-gate).
     LEGACY_MIGRATION_ATTEMPTED.store(false, Ordering::Relaxed);
-    // Progress-tracking sanity + invalidation (freenet/river#397 review 6): clear
-    // any leaked pending-worker count, and bump BOTH generations so any armed
-    // idle timer AND any stale hard-max timer from the failed attempt become
-    // no-ops. The re-fired list request starts a fresh worker.
-    PENDING_LOADS.store(0, Ordering::Relaxed);
-    LOAD_ACTIVITY_GEN.fetch_add(1, Ordering::Relaxed);
-    // Bump the attempt generation BEFORE re-arming so the previous hard-max timer
-    // becomes a no-op, then re-arm a fresh deadline.
-    LOAD_ATTEMPT_GEN.fetch_add(1, Ordering::Relaxed);
-    LOAD_BACKSTOP_SCHEDULED.store(false, Ordering::Relaxed);
-    schedule_rooms_load_backstop();
     crate::util::safe_spawn_local(async {
         fire_list_rooms_request().await;
     });

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -520,6 +520,11 @@ pub async fn set_up_chat_delegate() -> Result<(), String> {
     // fresh gen-guarded hard-max BEFORE RegisterDelegate, so even a registration
     // failure eventually resolves.
     begin_load_attempt();
+    // Capture the attempt this continuation belongs to (review 11): the
+    // RegisterDelegate + fire_list_rooms_request below run across awaits, so a
+    // reconnect can advance the attempt mid-flight — gate the failure resolve on
+    // still-current.
+    let attempt = LOAD_ATTEMPT_GEN.load(Ordering::Relaxed);
 
     let delegate = create_chat_delegate_container();
 
@@ -564,11 +569,12 @@ pub async fn set_up_chat_delegate() -> Result<(), String> {
             Ok(())
         }
         Err(e) => {
-            // freenet/river#397 Codex review 8 (P2#1): RegisterDelegate failed —
-            // a definitive setup failure, and this Err path returns before any
-            // load worker runs. Resolve directly to `LoadFailed` (if empty) so the
-            // user gets Retry immediately rather than waiting for the hard-max.
-            resolve_load_failed_if_empty();
+            // freenet/river#397 Codex review 8/11: RegisterDelegate failed — a
+            // definitive setup failure, and this Err path returns before any load
+            // worker runs. Resolve directly to `LoadFailed` (if still current +
+            // empty) so the user gets Retry immediately rather than waiting for the
+            // hard-max.
+            resolve_load_failed_if_empty(attempt);
             Err(format!("Failed to register chat delegate: {}", e))
         }
     }
@@ -1431,12 +1437,13 @@ mod tests {
                 && new_body.contains("LOAD_ACTIVITY_GEN.fetch_add(1"),
             "LoadWorkerGuard::new must capture the attempt, inc PENDING_LOADS, bump LOAD_ACTIVITY_GEN"
         );
-        // is_current / the guard's write helpers gate on the current attempt.
+        // The guard exposes attempt() (for spawned/late writes) and attempt-gated
+        // mark/set helpers.
         assert!(
-            new_body.contains("fn is_current(&self)")
+            new_body.contains("fn attempt(&self) -> u32")
                 && new_body.contains("fn mark_fetch_failure(&self)")
                 && new_body.contains("fn set_load_state(&self,"),
-            "LoadWorkerGuard must expose is_current + attempt-gated mark/set helpers"
+            "LoadWorkerGuard must expose attempt() + attempt-gated mark/set helpers"
         );
         let drop_start = src
             .rfind("impl Drop for LoadWorkerGuard")
@@ -1564,8 +1571,8 @@ mod tests {
             .expect("the RegisterDelegate error arm must exist");
         let err_ctx = &setup_body[err_arm.saturating_sub(200)..err_arm];
         assert!(
-            err_ctx.contains("resolve_load_failed_if_empty()"),
-            "the RegisterDelegate error path must resolve LoadFailed (not stay Loading forever)"
+            err_ctx.contains("resolve_load_failed_if_empty(attempt)"),
+            "the RegisterDelegate error path must resolve LoadFailed (attempt-gated, review 11)"
         );
 
         // And the response handler must NOT arm the backstop.
@@ -1685,10 +1692,11 @@ mod tests {
         );
     }
 
-    /// freenet/river#397 review 5/7: `fire_list_rooms_request` runs OUTSIDE any
-    /// load worker, so on a SEND / serialize error it marks the attempt failed AND
-    /// directly resolves `LoadFailed` (if empty) — a definitive stored-data failure
-    /// that would otherwise only be caught by the 60s hard-max (P2#2, case (b)).
+    /// freenet/river#397 review 5/7/11: `fire_list_rooms_request` runs OUTSIDE any
+    /// load worker, ACROSS an awaited send. It captures the attempt and routes its
+    /// serialize/send-error writes through the ATTEMPT-GATED helpers
+    /// (`mark_fetch_failure_if_current` + `resolve_load_failed_if_empty(attempt)`),
+    /// so a reconnect mid-send isn't polluted.
     #[test]
     fn list_request_send_failure_marks_fetch_failure() {
         // `fire_list_rooms_request` is defined AFTER this mid-file test module;
@@ -1705,15 +1713,96 @@ mod tests {
             .map(|i| fn_start + 1 + i)
             .unwrap_or(src.len());
         let body = &src[fn_start..fn_end];
-        assert_eq!(
-            body.matches("mark_fetch_failure()").count(),
-            2,
-            "both the serialize-error and send-error arms must mark_fetch_failure"
+        assert!(
+            body.contains("let attempt = LOAD_ATTEMPT_GEN.load(Ordering::Relaxed);"),
+            "fire_list_rooms_request must capture the attempt it belongs to"
         );
         assert_eq!(
-            body.matches("resolve_load_failed_if_empty()").count(),
+            body.matches("mark_fetch_failure_if_current(attempt)").count(),
             2,
-            "both error arms must directly resolve LoadFailed (out-of-worker, P2#2)"
+            "both the serialize-error and send-error arms must mark_fetch_failure_if_current(attempt)"
+        );
+        assert_eq!(
+            body.matches("resolve_load_failed_if_empty(attempt)").count(),
+            2,
+            "both error arms must resolve LoadFailed via the attempt-gated helper (P2#2 + review 11)"
+        );
+        // No bare (ungated) forms survive.
+        assert!(
+            !body.contains("mark_fetch_failure();")
+                && !body.contains("resolve_load_failed_if_empty();"),
+            "no ungated bare marks/resolves may survive in fire_list_rooms_request"
+        );
+    }
+
+    /// freenet/river#397 Codex review 11 — the class is closed in chat_delegate
+    /// too: the async load entry points capture the attempt and route EVERY
+    /// post-await load-state / failure write through the attempt-gated helpers.
+    /// The ONLY bare `set_rooms_load_state(RoomsLoadState::` in production is
+    /// `begin_load_attempt`'s synchronous, attempt-DEFINING `Loading` (idempotent
+    /// across attempts, no await), and the ONLY bare `mark_fetch_failure()` is the
+    /// internal call inside `mark_fetch_failure_if_current`.
+    #[test]
+    fn async_load_state_writes_gated_on_captured_attempt() {
+        // These helpers/fns are defined AFTER this mid-file test module, so
+        // `rfind` locates the real definitions (not this test's own literals) and
+        // we slice each body forward to check its content robustly.
+        let src = include_str!("chat_delegate.rs");
+
+        // The uniform gated write helpers exist as real fns (the trailing ` {`
+        // ensures we match the definition, not a call or a comment).
+        for def in [
+            "pub(crate) fn set_load_state_if_current(attempt: u32, state: RoomsLoadState) {",
+            "pub(crate) fn mark_fetch_failure_if_current(attempt: u32) {",
+            "pub(crate) fn resolve_load_failed_if_empty(attempt: u32) {",
+        ] {
+            // At least the definition (last occurrence) — and `set_load_state_if_current`
+            // routes through `write_load_state_now` inside the gated closure.
+            let pos = src
+                .rfind(def)
+                .unwrap_or_else(|| panic!("attempt-gated helper `{def}` must be defined"));
+            assert!(
+                pos > src.rfind("mod tests {").unwrap_or(0),
+                "must be a production def"
+            );
+        }
+        // set_load_state_if_current checks the attempt inside the deferred write.
+        let helper = src
+            .rfind("pub(crate) fn set_load_state_if_current(attempt: u32, state: RoomsLoadState) {")
+            .unwrap();
+        let helper_body = &src[helper..(helper + 300).min(src.len())];
+        assert!(
+            helper_body.contains("load_attempt_is_current(attempt)")
+                && helper_body.contains("write_load_state_now(state)"),
+            "set_load_state_if_current must re-check the attempt inside the deferred write"
+        );
+
+        // on_load_worker_settled's DEFERRED decision gates on the armed attempt
+        // (the Drop is gated too, but the defer runs later — review 11).
+        let settled = src
+            .rfind("pub(crate) fn on_load_worker_settled() {")
+            .expect("on_load_worker_settled must exist");
+        let settled_body = &src[settled..(settled + 1200).min(src.len())];
+        assert!(
+            settled_body.contains("load_attempt_is_current(armed_attempt)"),
+            "on_load_worker_settled must gate its deferred settle on the armed attempt"
+        );
+
+        // fire_legacy_migration_request marks via the gated helper.
+        let fire = src
+            .rfind("pub(crate) async fn fire_legacy_migration_request() -> bool {")
+            .expect("fire_legacy_migration_request must exist");
+        let fire_body = &src[fire..];
+        assert!(
+            fire_body.contains("mark_fetch_failure_if_current(attempt)"),
+            "fire_legacy marks must route through mark_fetch_failure_if_current(attempt)"
+        );
+
+        // The LoadWorkerGuard exposes attempt() so spawned closures / hydrate can
+        // gate their late writes on the same attempt.
+        assert!(
+            src.contains("pub(crate) fn attempt(&self) -> u32 {"),
+            "LoadWorkerGuard must expose attempt() for spawned/late writes"
         );
     }
 
@@ -1735,25 +1824,22 @@ mod tests {
             .expect("fire_legacy_migration_request must exist");
         let body = &src[fn_start..];
 
-        // Transport-Err arms mark (both the GetRequest and ListRequest sends).
+        // Transport-Err arms mark via the attempt-gated helper (review 10/11:
+        // both the GetRequest and ListRequest sends).
         assert!(
-            body.matches("mark_fetch_failure();").count() >= 2,
-            "both legacy send-Err arms (GetRequest + ListRequest) must mark_fetch_failure"
+            body.matches("mark_fetch_failure_if_current(attempt)").count() >= 2,
+            "both legacy send-Err arms (GetRequest + ListRequest) must mark_fetch_failure_if_current(attempt)"
         );
         // Dispatch is tracked, and a successful send does NOT mark.
         assert!(
             body.contains("any_dispatched = true;"),
             "must track whether any probe actually dispatched (send returned Ok)"
         );
-        // Review 10 P2#1: the attempt is captured and the global writes are gated
-        // on still-current so a stale probe can't pollute a reconnect.
+        // Review 10 P2#1: the attempt is captured and the guard reset is gated on
+        // still-current so a stale probe can't pollute a reconnect.
         assert!(
             body.contains("let attempt = LOAD_ATTEMPT_GEN.load(Ordering::Relaxed);"),
             "the probe must capture the attempt it belongs to"
-        );
-        assert!(
-            body.matches("load_attempt_is_current(attempt)").count() >= 3,
-            "each mark AND the guard reset must be gated on load_attempt_is_current(attempt)"
         );
         // If nothing dispatched, the guard is reset (still-current) so a reconnect
         // re-probes.
@@ -2889,18 +2975,24 @@ pub(crate) async fn ensure_room_subscription_once(
 async fn fire_list_rooms_request() {
     info!("Firing ListRequest to enumerate delegate keys for room load");
 
+    // freenet/river#397 review 11: this runs in `set_up_chat_delegate`'s
+    // continuation, ACROSS an awaited send. Capture the attempt so its failure
+    // writes (below) gate on still-current — a reconnect that fires
+    // `begin_load_attempt` mid-send must not get a stale LoadFailed.
+    let attempt = LOAD_ATTEMPT_GEN.load(Ordering::Relaxed);
+
     let request = ChatDelegateRequestMsg::ListRequest;
 
     // Serialize and send the request without waiting for response
     let mut payload = Vec::new();
     if let Err(e) = ciborium::ser::into_writer(&request, &mut payload) {
         error!("Failed to serialize list-rooms request: {}", e);
-        // freenet/river#397 Codex review 5/7: the initial list request definitively
-        // failed, so the load can never resolve on its own (no ListResponse → no
-        // worker). Record the failure AND resolve LoadFailed now (if empty) rather
-        // than wait for the 60s hard-max or show a silent Empty.
-        mark_fetch_failure();
-        resolve_load_failed_if_empty();
+        // freenet/river#397 Codex review 5/7/11: the initial list request
+        // definitively failed, so the load can never resolve on its own (no
+        // ListResponse → no worker). Record the failure AND resolve LoadFailed now
+        // (if still current + empty) rather than wait for the hard-max / show Empty.
+        mark_fetch_failure_if_current(attempt);
+        resolve_load_failed_if_empty(attempt);
         return;
     }
 
@@ -2931,11 +3023,12 @@ async fn fire_list_rooms_request() {
 
     if let Err(e) = api_result {
         error!("Failed to send list-rooms request: {}", e);
-        // freenet/river#397 Codex review 5/7: the SEND itself failed (no response
-        // will ever come, no worker), so mark the attempt failed AND resolve
-        // LoadFailed now (if empty) instead of a silent Empty / 60s hard-max wait.
-        mark_fetch_failure();
-        resolve_load_failed_if_empty();
+        // freenet/river#397 Codex review 5/7/11: the SEND itself failed (no
+        // response will ever come, no worker), so mark the attempt failed AND
+        // resolve LoadFailed now (if still current + empty) instead of a silent
+        // Empty / hard-max wait.
+        mark_fetch_failure_if_current(attempt);
+        resolve_load_failed_if_empty(attempt);
     } else {
         info!("List-rooms request sent, response will be handled by message loop");
     }
@@ -4683,9 +4776,11 @@ const LOAD_HARD_MAX_MS: u64 = 60_000;
 /// `PENDING_LOADS`, so a worker still in flight from the OLD attempt must not
 /// touch the new attempt's state. `Drop` therefore no-ops entirely when the
 /// guard's attempt is stale (no decrement, no settle — the count was already
-/// zeroed), and [`Self::is_current`] gates every global write a worker makes
-/// (`mark_fetch_failure`, `set_load_state`) so a stale worker can neither
-/// pollute the retry's `SAW_FETCH_FAILURE` nor write its display state.
+/// zeroed), and its `mark_fetch_failure` / `set_load_state` write helpers (which
+/// route through the attempt-gated `mark_fetch_failure_if_current` /
+/// `set_load_state_if_current`) gate every global write on still-current, so a
+/// stale worker can neither pollute the retry's `SAW_FETCH_FAILURE` nor write its
+/// display state.
 pub(crate) struct LoadWorkerGuard {
     attempt: u32,
 }
@@ -4698,27 +4793,24 @@ impl LoadWorkerGuard {
         LoadWorkerGuard { attempt }
     }
 
-    /// True while this worker still belongs to the current load attempt. A Retry
-    /// advances `LOAD_ATTEMPT_GEN`, so a superseded worker returns `false` and
-    /// must not write any global load state.
-    pub(crate) fn is_current(&self) -> bool {
-        guard_drop_applies(self.attempt, LOAD_ATTEMPT_GEN.load(Ordering::Relaxed))
+    /// The attempt this worker belongs to — threaded into SPAWNED closures /
+    /// helper fns (`hydrate_loaded_rooms`, the blob save closure) that outlive the
+    /// guard's sync body, so their late writes gate on the same attempt (review 11).
+    /// `load_attempt_is_current(worker.attempt())` is the "am I current" query.
+    pub(crate) fn attempt(&self) -> u32 {
+        self.attempt
     }
 
-    /// `mark_fetch_failure`, but ONLY for the current attempt — a stale worker
-    /// must not pollute the retry's `SAW_FETCH_FAILURE` (review 7 P2#1).
+    /// `mark_fetch_failure`, ONLY for the current attempt (review 7/11). Routes
+    /// through the uniform helper.
     pub(crate) fn mark_fetch_failure(&self) {
-        if self.is_current() {
-            mark_fetch_failure();
-        }
+        mark_fetch_failure_if_current(self.attempt);
     }
 
-    /// `set_rooms_load_state`, but ONLY for the current attempt — a stale worker
-    /// must not write the retry's display state (review 7 P2#1).
+    /// `set_rooms_load_state`, ONLY for the current attempt (review 7/11). Routes
+    /// through the uniform helper (checks the attempt at the deferred write).
     pub(crate) fn set_load_state(&self, state: RoomsLoadState) {
-        if self.is_current() {
-            set_rooms_load_state(state);
-        }
+        set_load_state_if_current(self.attempt, state);
     }
 }
 
@@ -4804,16 +4896,43 @@ fn write_load_state_now(state: RoomsLoadState) {
     }
 }
 
-/// Resolve to `LoadFailed` IF the rooms map is currently empty — for a DEFINITIVE
-/// stored-data failure discovered OUTSIDE any live load worker (so no worker
-/// settlement will resolve it) that may run AFTER the state already reached a
-/// terminal `Loaded`(Empty) (freenet/river#397 review 7, P2#2). Deferred so it
-/// reads `ROOMS` and writes the state inside the Dioxus runtime. A non-empty map
-/// is left as `List`. Used by `fire_list_rooms_request`'s send/serialize errors,
-/// which run synchronously for the current attempt.
-pub(crate) fn resolve_load_failed_if_empty() {
-    crate::util::defer(|| {
-        if rooms_map_is_empty() {
+/// UNIFORM attempt-gated load-state write (freenet/river#397 Codex review 11).
+/// EVERY write to `ROOMS_LOAD_STATE` that runs in or after an `.await` MUST route
+/// through this (or the `LoadWorkerGuard` helpers, which delegate to it) with the
+/// attempt captured at its async context's START. Deferred, and the attempt is
+/// re-checked INSIDE the defer (at the write moment), so a superseded attempt's
+/// late write is a no-op — closing the "stale async write lands on the new
+/// attempt" class by construction.
+pub(crate) fn set_load_state_if_current(attempt: u32, state: RoomsLoadState) {
+    crate::util::defer(move || {
+        if load_attempt_is_current(attempt) {
+            write_load_state_now(state);
+        }
+    });
+}
+
+/// UNIFORM attempt-gated `mark_fetch_failure` (review 11). `SAW_FETCH_FAILURE` is
+/// a lock-free atomic, so the check is synchronous at the write point. Route
+/// every post-await mark through this with the captured attempt. `begin_load_attempt`
+/// advances `LOAD_ATTEMPT_GEN` BEFORE it clears `SAW_FETCH_FAILURE`, so a stale
+/// mark that races the reset sees the advanced gen and no-ops.
+pub(crate) fn mark_fetch_failure_if_current(attempt: u32) {
+    if load_attempt_is_current(attempt) {
+        mark_fetch_failure();
+    }
+}
+
+/// Resolve to `LoadFailed` IF the rooms map is currently empty AND `attempt` is
+/// still current — for a DEFINITIVE stored-data failure discovered OUTSIDE any
+/// live load worker (so no worker settlement resolves it) that may run AFTER the
+/// state already reached a terminal `Loaded`(Empty) (freenet/river#397 review
+/// 7/11). Deferred; both the attempt and emptiness are checked inside the defer
+/// (at the write moment). A non-empty map is left as `List`. Used by
+/// `fire_list_rooms_request`'s send/serialize errors and `set_up_chat_delegate`'s
+/// RegisterDelegate failure.
+pub(crate) fn resolve_load_failed_if_empty(attempt: u32) {
+    crate::util::defer(move || {
+        if load_attempt_is_current(attempt) && rooms_map_is_empty() {
             write_load_state_now(RoomsLoadState::LoadFailed);
         }
     });
@@ -4833,6 +4952,14 @@ pub(crate) fn on_load_worker_settled() {
     crate::util::defer(move || {
         // A worker may have STARTED between the drop and this deferred decision.
         if PENDING_LOADS.load(Ordering::Relaxed) != 0 {
+            return;
+        }
+        // A Retry/reconnect may have advanced the attempt between the (current)
+        // worker's Drop and this deferred settle → this settlement belongs to a
+        // superseded attempt, so it must not write the new attempt's state
+        // (review 11). The Drop itself is gated (guard_drop_applies), but the
+        // defer runs later.
+        if !load_attempt_is_current(armed_attempt) {
             return;
         }
         let room_count_zero = rooms_map_is_empty();
@@ -5105,9 +5232,7 @@ pub(crate) async fn fire_legacy_migration_request() -> bool {
                         String::from_utf8_lossy(storage_key),
                         e
                     );
-                    if load_attempt_is_current(attempt) {
-                        mark_fetch_failure();
-                    }
+                    mark_fetch_failure_if_current(attempt);
                 }
             }
         }
@@ -5151,11 +5276,9 @@ pub(crate) async fn fire_legacy_migration_request() -> bool {
             }
             Err(e) => {
                 // Transport failure on the ListRequest send → mark it (P1),
-                // current-attempt only (P2#1).
+                // current-attempt only (P2#1) via the uniform helper (review 11).
                 info!("Legacy ListRequest #{i} failed to send (transport): {e}");
-                if load_attempt_is_current(attempt) {
-                    mark_fetch_failure();
-                }
+                mark_fetch_failure_if_current(attempt);
             }
         }
     }

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -1406,10 +1406,11 @@ mod tests {
         );
     }
 
-    /// freenet/river#397 Codex review 6: the `LoadWorkerGuard` RAII contract —
-    /// `new` increments the pending counter AND bumps the activity gen; `Drop`
-    /// decrements (saturating) and runs the settled-handler. Source-scrape (it
-    /// drives global signals, so it can't be unit-driven on native).
+    /// freenet/river#397 review 6/7: the `LoadWorkerGuard` RAII + attempt-scope
+    /// contract — `new` captures the attempt, increments the pending counter, and
+    /// bumps the activity gen; `Drop` is a complete NO-OP for a superseded attempt
+    /// (guarded by `guard_drop_applies`), else saturating-decs and settles.
+    /// Source-scrape (it drives global signals, so it can't be unit-driven).
     #[test]
     fn load_worker_guard_counts_and_pulses() {
         let src = include_str!("chat_delegate.rs");
@@ -1422,9 +1423,17 @@ mod tests {
             .unwrap_or(src.len());
         let new_body = &src[new_start..new_end];
         assert!(
-            new_body.contains("PENDING_LOADS.fetch_add(1")
+            new_body.contains("let attempt = LOAD_ATTEMPT_GEN.load(Ordering::Relaxed)")
+                && new_body.contains("PENDING_LOADS.fetch_add(1")
                 && new_body.contains("LOAD_ACTIVITY_GEN.fetch_add(1"),
-            "LoadWorkerGuard::new must inc PENDING_LOADS and bump LOAD_ACTIVITY_GEN"
+            "LoadWorkerGuard::new must capture the attempt, inc PENDING_LOADS, bump LOAD_ACTIVITY_GEN"
+        );
+        // is_current / the guard's write helpers gate on the current attempt.
+        assert!(
+            new_body.contains("fn is_current(&self)")
+                && new_body.contains("fn mark_fetch_failure(&self)")
+                && new_body.contains("fn set_load_state(&self,"),
+            "LoadWorkerGuard must expose is_current + attempt-gated mark/set helpers"
         );
         let drop_start = src
             .rfind("impl Drop for LoadWorkerGuard")
@@ -1434,10 +1443,35 @@ mod tests {
             .map(|i| drop_start + i)
             .unwrap_or(src.len());
         let drop_body = &src[drop_start..drop_end];
+        // The stale-attempt no-op MUST precede the decrement (return early).
+        let guard_pos = drop_body
+            .find("guard_drop_applies(")
+            .expect("Drop must check guard_drop_applies");
+        let dec_pos = drop_body
+            .find("saturating_sub(1)")
+            .expect("Drop must saturating-dec PENDING_LOADS");
         assert!(
-            drop_body.contains("saturating_sub(1)")
-                && drop_body.contains("on_load_worker_settled()"),
-            "LoadWorkerGuard::drop must saturating-dec PENDING_LOADS and settle"
+            guard_pos < dec_pos && drop_body[guard_pos..dec_pos].contains("return"),
+            "a superseded worker's Drop must return BEFORE decrementing the new attempt's count"
+        );
+        assert!(
+            drop_body.contains("on_load_worker_settled()"),
+            "a current worker's Drop must settle"
+        );
+    }
+
+    /// freenet/river#397 review 7 (P2#1): `guard_drop_applies` — a worker's Drop
+    /// and writes apply only while its attempt matches the current attempt. A
+    /// Retry advances the attempt, making the old worker's Drop a no-op.
+    #[test]
+    fn stale_worker_guard_is_inert() {
+        assert!(
+            guard_drop_applies(4, 4),
+            "same attempt → the worker still applies"
+        );
+        assert!(
+            !guard_drop_applies(4, 5),
+            "a retry advanced the attempt → the stale worker is a no-op"
         );
     }
 
@@ -1614,9 +1648,10 @@ mod tests {
         );
     }
 
-    /// freenet/river#397 Codex review 5 (P2c): `fire_list_rooms_request` marks the
-    /// attempt failed on a SEND / serialize error, so the backstop resolves to
-    /// LoadFailed (with Retry) rather than a silent Empty.
+    /// freenet/river#397 review 5/7: `fire_list_rooms_request` runs OUTSIDE any
+    /// load worker, so on a SEND / serialize error it marks the attempt failed AND
+    /// directly resolves `LoadFailed` (if empty) — a definitive stored-data failure
+    /// that would otherwise only be caught by the 60s hard-max (P2#2, case (b)).
     #[test]
     fn list_request_send_failure_marks_fetch_failure() {
         // `fire_list_rooms_request` is defined AFTER this mid-file test module;
@@ -1637,6 +1672,11 @@ mod tests {
             body.matches("mark_fetch_failure()").count(),
             2,
             "both the serialize-error and send-error arms must mark_fetch_failure"
+        );
+        assert_eq!(
+            body.matches("resolve_load_failed_if_empty()").count(),
+            2,
+            "both error arms must directly resolve LoadFailed (out-of-worker, P2#2)"
         );
     }
 
@@ -2767,11 +2807,12 @@ async fn fire_list_rooms_request() {
     let mut payload = Vec::new();
     if let Err(e) = ciborium::ser::into_writer(&request, &mut payload) {
         error!("Failed to serialize list-rooms request: {}", e);
-        // freenet/river#397 Codex review 5 (P2c): the initial list request
-        // definitively failed to send, so the load can never resolve on its own.
-        // Record it as a fetch failure so the backstop resolves to LoadFailed
-        // (with Retry) rather than a silent Empty.
+        // freenet/river#397 Codex review 5/7: the initial list request definitively
+        // failed, so the load can never resolve on its own (no ListResponse → no
+        // worker). Record the failure AND resolve LoadFailed now (if empty) rather
+        // than wait for the 60s hard-max or show a silent Empty.
         mark_fetch_failure();
+        resolve_load_failed_if_empty();
         return;
     }
 
@@ -2802,10 +2843,11 @@ async fn fire_list_rooms_request() {
 
     if let Err(e) = api_result {
         error!("Failed to send list-rooms request: {}", e);
-        // freenet/river#397 Codex review 5 (P2c): the SEND itself failed (no
-        // response will ever come), so mark the attempt failed — the backstop
-        // then resolves to LoadFailed (with Retry) instead of a silent Empty.
+        // freenet/river#397 Codex review 5/7: the SEND itself failed (no response
+        // will ever come, no worker), so mark the attempt failed AND resolve
+        // LoadFailed now (if empty) instead of a silent Empty / 60s hard-max wait.
         mark_fetch_failure();
+        resolve_load_failed_if_empty();
     } else {
         info!("List-rooms request sent, response will be handled by message loop");
     }
@@ -4544,30 +4586,74 @@ const LOAD_IDLE_MS: u64 = 4_000;
 /// pre-empts a genuinely-progressing load.
 const LOAD_HARD_MAX_MS: u64 = 60_000;
 
-/// RAII guard marking an active AWAITED load worker (freenet/river#397 review 6).
-/// `new` increments [`PENDING_LOADS`] and bumps [`LOAD_ACTIVITY_GEN`] (a progress
-/// pulse that cancels any armed idle resolution). `Drop` decrements
-/// `PENDING_LOADS` (saturating, so a stray double-drop / sanity reset can't
-/// underflow) and runs [`on_load_worker_settled`], so completion is detected on
-/// EVERY exit path (success, early return, error). Hold one across each awaited
-/// load worker.
-pub(crate) struct LoadWorkerGuard;
+/// RAII guard marking an active AWAITED load worker (freenet/river#397 review
+/// 6/7). `new` captures the current [`LOAD_ATTEMPT_GEN`], increments
+/// [`PENDING_LOADS`], and bumps [`LOAD_ACTIVITY_GEN`] (a progress pulse that
+/// cancels any armed idle resolution).
+///
+/// ATTEMPT-SCOPED (review 7): a Retry bumps `LOAD_ATTEMPT_GEN` and zeroes
+/// `PENDING_LOADS`, so a worker still in flight from the OLD attempt must not
+/// touch the new attempt's state. `Drop` therefore no-ops entirely when the
+/// guard's attempt is stale (no decrement, no settle — the count was already
+/// zeroed), and [`Self::is_current`] gates every global write a worker makes
+/// (`mark_fetch_failure`, `set_load_state`) so a stale worker can neither
+/// pollute the retry's `SAW_FETCH_FAILURE` nor write its display state.
+pub(crate) struct LoadWorkerGuard {
+    attempt: u32,
+}
 
 impl LoadWorkerGuard {
     pub(crate) fn new() -> Self {
+        let attempt = LOAD_ATTEMPT_GEN.load(Ordering::Relaxed);
         PENDING_LOADS.fetch_add(1, Ordering::Relaxed);
         LOAD_ACTIVITY_GEN.fetch_add(1, Ordering::Relaxed);
-        LoadWorkerGuard
+        LoadWorkerGuard { attempt }
+    }
+
+    /// True while this worker still belongs to the current load attempt. A Retry
+    /// advances `LOAD_ATTEMPT_GEN`, so a superseded worker returns `false` and
+    /// must not write any global load state.
+    pub(crate) fn is_current(&self) -> bool {
+        guard_drop_applies(self.attempt, LOAD_ATTEMPT_GEN.load(Ordering::Relaxed))
+    }
+
+    /// `mark_fetch_failure`, but ONLY for the current attempt — a stale worker
+    /// must not pollute the retry's `SAW_FETCH_FAILURE` (review 7 P2#1).
+    pub(crate) fn mark_fetch_failure(&self) {
+        if self.is_current() {
+            mark_fetch_failure();
+        }
+    }
+
+    /// `set_rooms_load_state`, but ONLY for the current attempt — a stale worker
+    /// must not write the retry's display state (review 7 P2#1).
+    pub(crate) fn set_load_state(&self, state: RoomsLoadState) {
+        if self.is_current() {
+            set_rooms_load_state(state);
+        }
     }
 }
 
 impl Drop for LoadWorkerGuard {
     fn drop(&mut self) {
+        // A worker from a SUPERSEDED attempt (a Retry bumped LOAD_ATTEMPT_GEN and
+        // zeroed PENDING_LOADS) must NOT decrement the new attempt's count or
+        // settle it — its Drop is a complete no-op (review 7 P2#1).
+        if !guard_drop_applies(self.attempt, LOAD_ATTEMPT_GEN.load(Ordering::Relaxed)) {
+            return;
+        }
         let _ = PENDING_LOADS.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
             Some(v.saturating_sub(1))
         });
         on_load_worker_settled();
     }
+}
+
+/// Whether a load worker's Drop (or write) still applies, given the attempt it
+/// was created under vs. the current attempt. Pure. A Retry advances the current
+/// attempt, so a superseded worker's Drop and writes are no-ops. review 7 P2#1.
+pub(crate) fn guard_drop_applies(guard_attempt: u32, current_attempt: u32) -> bool {
+    guard_attempt == current_attempt
 }
 
 /// The DEFINITIVE completion decision once every load worker has settled. Pure.
@@ -4619,6 +4705,21 @@ fn write_load_state_now(state: RoomsLoadState) {
     if *ROOMS_LOAD_STATE.peek() != state {
         *ROOMS_LOAD_STATE.write() = state;
     }
+}
+
+/// Resolve to `LoadFailed` IF the rooms map is currently empty — for a DEFINITIVE
+/// stored-data failure discovered OUTSIDE any live load worker (so no worker
+/// settlement will resolve it) that may run AFTER the state already reached a
+/// terminal `Loaded`(Empty) (freenet/river#397 review 7, P2#2). Deferred so it
+/// reads `ROOMS` and writes the state inside the Dioxus runtime. A non-empty map
+/// is left as `List`. Used by `fire_list_rooms_request`'s send/serialize errors,
+/// which run synchronously for the current attempt.
+pub(crate) fn resolve_load_failed_if_empty() {
+    crate::util::defer(|| {
+        if rooms_map_is_empty() {
+            write_load_state_now(RoomsLoadState::LoadFailed);
+        }
+    });
 }
 
 /// Called when a load worker drops (and by the fire-and-forget legacy-probe path

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -357,6 +357,18 @@ impl ResponseHandler {
                                                             "Failed to deserialize rooms data: {}",
                                                             e
                                                         );
+                                                        // freenet/river#397 Codex review 5
+                                                        // (audit): a `rooms_data` blob exists
+                                                        // only because rooms were stored in it.
+                                                        // This arm is reachable only for a LEGACY
+                                                        // delegate (the current-delegate flow is
+                                                        // List-driven), so a parse failure is
+                                                        // known-stored legacy data that failed to
+                                                        // load — mark it so the backstop resolves
+                                                        // to LoadFailed, not a silent Empty. (A
+                                                        // genuine new user has no legacy delegate
+                                                        // responding, so never reaches here.)
+                                                        mark_fetch_failure();
                                                     }
                                                 }
                                             } else {
@@ -938,17 +950,20 @@ async fn migrate_current_blob_to_per_room(recovery: bool) {
                     }
                 });
             }
-            // A corrupt current-delegate blob is unparseable; retrying won't
-            // help. We intentionally do NOT mark migration done (a corrupt blob is
-            // not proof there's nothing to migrate) and do NOT touch the
-            // in-progress flag — if a prior migration left it set, the next session
-            // re-runs recovery, and the already-loaded per-room keys remain intact.
+            // A corrupt current-delegate blob is unparseable. We intentionally do
+            // NOT mark migration done (a corrupt blob is not proof there's nothing
+            // to migrate) and do NOT touch the in-progress flag — if a prior
+            // migration left it set, the next session re-runs recovery, and the
+            // already-loaded per-room keys remain intact.
             Err(e) => {
                 error!("Failed to deserialize current-delegate rooms blob: {}", e);
-                // A definitive terminal (can't parse) is a completion — resolve to
-                // `Loaded` even under recovery so the rail doesn't spin on an
-                // unparseable snapshot.
-                set_rooms_load_state(RoomsLoadState::Loaded);
+                // freenet/river#397 Codex review 5 (P2b): a `rooms_data` blob only
+                // exists because rooms were written to it, so a parse failure is
+                // known-stored-data that failed to load — surface LoadFailed (with
+                // Retry), NOT a false Empty. mark_fetch_failure so the backstop and
+                // any concurrent probe agree this attempt failed.
+                mark_fetch_failure();
+                set_rooms_load_state(RoomsLoadState::LoadFailed);
             }
         },
         Ok(_) => {
@@ -965,7 +980,17 @@ async fn migrate_current_blob_to_per_room(recovery: bool) {
                 set_rooms_load_state(load_state_after_probe_legacy(fired));
             }
         }
-        Err(e) => warn!("Failed to read current-delegate rooms blob: {}", e),
+        Err(e) => {
+            // freenet/river#397 Codex review 5 (audit): we only reach this fn from
+            // `LoadPlan::MigrateCurrentBlob`, i.e. the current delegate's index
+            // LISTED a `rooms_data` key, so the blob exists — a SEND failure
+            // reading it is known-stored-data that failed to load. Mark the
+            // failure so the backstop resolves to LoadFailed (with Retry), not a
+            // silent Empty. (Display is masked by `List` if rooms are concurrently
+            // present.)
+            warn!("Failed to read current-delegate rooms blob: {}", e);
+            mark_fetch_failure();
+        }
     }
 }
 
@@ -1946,6 +1971,54 @@ mod tests {
         assert!(
             legacy_arm.contains("set_rooms_load_state(RoomsLoadState::Loaded)"),
             "the legacy re-save-error arm must resolve the load to Loaded (had_rooms)"
+        );
+    }
+
+    /// freenet/river#397 Codex review 5: every failure to load KNOWN or STORED
+    /// room data routes to `mark_fetch_failure()` + a LoadFailed-capable terminal,
+    /// never a silent Empty. Pins the three stored-data failure sites this pass
+    /// added/changed.
+    #[test]
+    fn stored_room_data_failures_route_to_loadfailed() {
+        let src = include_str!("response_handler.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+
+        // (P2b) corrupt current-delegate `rooms_data` blob → mark_fetch_failure +
+        // LoadFailed (a blob exists only because rooms were written to it).
+        let corrupt = production
+            .find("Failed to deserialize current-delegate rooms blob")
+            .expect("corrupt-current-blob marker must exist");
+        let corrupt_arm = &production[corrupt..(corrupt + 700).min(production.len())];
+        assert!(
+            corrupt_arm.contains("mark_fetch_failure()")
+                && corrupt_arm.contains("set_rooms_load_state(RoomsLoadState::LoadFailed)"),
+            "a corrupt current rooms_data blob must mark_fetch_failure + LoadFailed, not Empty"
+        );
+
+        // (audit) SEND failure reading the current blob (we're here only because
+        // the index listed a rooms_data key) → mark_fetch_failure.
+        let read_err = production
+            .find("Failed to read current-delegate rooms blob")
+            .expect("current-blob read-error marker must exist");
+        let read_arm = &production[read_err..(read_err + 400).min(production.len())];
+        assert!(
+            read_arm.contains("mark_fetch_failure()"),
+            "a failed READ of the current rooms_data blob must mark_fetch_failure"
+        );
+
+        // (audit) parse failure of a legacy `rooms_data` blob → mark_fetch_failure
+        // (a genuine new user never reaches this — no legacy delegate responds).
+        let legacy_parse = production
+            .find("Failed to deserialize rooms data")
+            .expect("legacy rooms_data parse-error marker must exist");
+        let legacy_parse_arm =
+            &production[legacy_parse..(legacy_parse + 1500).min(production.len())];
+        assert!(
+            legacy_parse_arm.contains("mark_fetch_failure()"),
+            "a legacy rooms_data parse failure must mark_fetch_failure"
         );
     }
 

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -629,7 +629,8 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
                 "No per-room keys but a current-delegate rooms_data blob exists — \
                  migrating it to per-room keys"
             );
-            migrate_current_blob_to_per_room().await;
+            // Initial load: owns the display state (recovery = false).
+            migrate_current_blob_to_per_room(false).await;
         }
         LoadPlan::PerRoom { room_vks, has_meta } => {
             // Was a prior legacy migration interrupted before it finished writing
@@ -748,7 +749,10 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
             //   above). No data loss, no spam loop.
             if action.recover && arm_legacy_migration_recovery() {
                 info!("Prior migration was interrupted — re-running to recover any stranded rooms");
-                migrate_current_blob_to_per_room().await;
+                // Background re-fill: the initial per-room load already resolved
+                // the display state to `Loaded` above, so recovery must NOT write
+                // the load state (recovery = true) — see freenet/river#397 review.
+                migrate_current_blob_to_per_room(true).await;
             }
         }
     }
@@ -830,7 +834,17 @@ fn reconstruct_rooms(
 /// `rooms_data`, so nothing else processes or races this read. After hydrating,
 /// a `save_rooms_to_delegate()` writes the per-room keys; the blob is
 /// intentionally left in place as a rollback fallback.
-async fn migrate_current_blob_to_per_room() {
+/// `recovery` distinguishes the two callers (freenet/river#397 review): the
+/// initial `LoadPlan::MigrateCurrentBlob` load (`false`) OWNS the display state,
+/// so it drives `ROOMS_LOAD_STATE`; the interrupted-migration recovery re-run
+/// (`true`) fires AFTER the per-room load already resolved the state to `Loaded`,
+/// so it must be a pure background re-fill that NEVER writes the load state — in
+/// particular it must never push a resolved `Loaded` back to `Loading` (which
+/// its no-current-blob `fire_legacy_migration_request` path would otherwise do,
+/// because `arm_legacy_migration_recovery` reset the attempt guard so the probe
+/// re-fires). Any real migration the recovery triggers still shows `Migrating`
+/// via the legacy `hydrate_loaded_rooms` path, which is not gated here.
+async fn migrate_current_blob_to_per_room(recovery: bool) {
     match send_delegate_request(ChatDelegateRequestMsg::GetVersionedRequest {
         key: ChatDelegateKey::new(ROOMS_STORAGE_KEY.to_vec()),
     })
@@ -848,7 +862,10 @@ async fn migrate_current_blob_to_per_room() {
                 // freenet/river#397: a current-delegate blob explosion is a
                 // migration. Set `Migrating` BEFORE hydrate merges the rooms so a
                 // re-render lands on the "Migrating…" state before the list fills.
-                set_rooms_load_state(RoomsLoadState::Migrating);
+                // Suppressed under `recovery` (the state is already `Loaded`).
+                if !recovery {
+                    set_rooms_load_state(RoomsLoadState::Migrating);
+                }
                 if hydrate_loaded_rooms(loaded, false) {
                     schedule_subscription_timeout_check();
                 }
@@ -859,20 +876,28 @@ async fn migrate_current_blob_to_per_room() {
                 // safe_spawn_local schedules a setTimeout(0) that, being queued
                 // AFTER the merge's defer, runs once the merge has populated
                 // ROOMS (FIFO ordering), mirroring the legacy-delegate re-save.
-                crate::util::safe_spawn_local(async {
+                crate::util::safe_spawn_local(async move {
                     match save_rooms_to_delegate().await {
                         Ok(_) => {
                             clear_legacy_migration_in_progress();
                             mark_legacy_migration_done();
                             // freenet/river#397: the blob explosion completed —
                             // the migration has resolved.
-                            set_rooms_load_state(RoomsLoadState::Loaded);
+                            if !recovery {
+                                set_rooms_load_state(RoomsLoadState::Loaded);
+                            }
                         }
                         Err(e) => {
                             error!("Failed to explode single blob into per-room keys: {}", e);
-                            // Leave the in-progress flag set — next load re-runs.
-                            // The rooms are already hydrated (room_count > 0), so
-                            // the list renders regardless of the load-state value.
+                            // freenet/river#397 (review): a zero-live-room migration
+                            // (e.g. an all-tombstone blob) leaves room_count == 0, so
+                            // a save error must STILL resolve the load — otherwise the
+                            // rail spins on "Migrating…" forever (the backstop only
+                            // rescues `Loading`, not `Migrating`). Leave the
+                            // in-progress flag set so the next load re-runs the fill.
+                            if !recovery {
+                                set_rooms_load_state(RoomsLoadState::Loaded);
+                            }
                         }
                     }
                 });
@@ -887,13 +912,21 @@ async fn migrate_current_blob_to_per_room() {
                 error!("Failed to deserialize current-delegate rooms blob: {}", e);
                 // freenet/river#397: nothing loadable from this blob — resolve so
                 // the rail doesn't spin forever on an unparseable snapshot.
-                set_rooms_load_state(RoomsLoadState::Loaded);
+                if !recovery {
+                    set_rooms_load_state(RoomsLoadState::Loaded);
+                }
             }
         },
         Ok(_) => {
             // Index listed rooms_data but the value is gone — treat as empty.
             let fired = fire_legacy_migration_request().await;
-            set_rooms_load_state(load_state_after_probe_legacy(fired));
+            // freenet/river#397 review: under `recovery` this must NOT run —
+            // `load_state_after_probe_legacy(true)` would downgrade the already
+            // resolved `Loaded` back to `Loading`, flashing a spinner (and, if the
+            // once-per-session backstop already fired, sticking there).
+            if !recovery {
+                set_rooms_load_state(load_state_after_probe_legacy(fired));
+            }
         }
         Err(e) => warn!("Failed to read current-delegate rooms blob: {}", e),
     }
@@ -1453,9 +1486,13 @@ fn hydrate_loaded_rooms(loaded_rooms: Rooms, is_legacy_delegate: bool) -> bool {
                 }
                 Err(e) => {
                     error!("Failed to migrate room data to new delegate: {}", e);
-                    // Leave the in-progress flag set — the next load re-fills.
-                    // The migrated rooms are already hydrated (room_count > 0),
-                    // so the list renders regardless of the load-state value.
+                    // freenet/river#397 (review): a zero-live-room migration (an
+                    // all-tombstone legacy delegate → empty `map`) leaves
+                    // room_count == 0, so a save error must STILL resolve the load
+                    // — otherwise the rail spins on "Migrating…" forever (the
+                    // backstop only rescues `Loading`, not `Migrating`). Leave the
+                    // in-progress flag set so the next load re-fills.
+                    set_rooms_load_state(RoomsLoadState::Loaded);
                 }
             }
         });
@@ -1795,15 +1832,111 @@ mod tests {
         let recover_idx = production
             .find("if action.recover")
             .expect("per-room load must have an `if action.recover` recovery branch");
-        let recover_block = &production[recover_idx..(recover_idx + 300).min(production.len())];
+        let recover_block = &production[recover_idx..(recover_idx + 700).min(production.len())];
         assert!(
-            recover_block.contains("migrate_current_blob_to_per_room().await;"),
-            "the recovery branch must re-run the migration to recover stranded rooms"
+            recover_block.contains("migrate_current_blob_to_per_room(true).await;"),
+            "the recovery branch must re-run the migration (as a background re-fill, \
+             recovery = true) to recover stranded rooms — see freenet/river#397 review"
         );
         assert!(
             recover_block.contains("arm_legacy_migration_recovery()"),
             "recovery must be armed once-per-session (clears the attempt guard so \
              same-session recovery isn't a no-op — codex review of #352)"
+        );
+    }
+
+    /// freenet/river#397 review (MAJOR): both migration re-save `Err` arms MUST
+    /// resolve the load state to `Loaded`. A zero-live-room migration (e.g. an
+    /// all-tombstone legacy delegate — `reconstruct_rooms` routes `Tombstone` to
+    /// `removed_rooms`, leaving `map` empty) sets `Migrating` before the save with
+    /// room_count == 0; if the save then errors and the arm doesn't resolve, the
+    /// rail spins on "Migrating…" forever (the backstop only rescues `Loading`).
+    /// This pins the fix so a future edit that drops either resolve fails CI.
+    #[test]
+    fn migration_save_error_resolves_load_state() {
+        let src = include_str!("response_handler.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+
+        // (a) current-delegate blob explosion save error.
+        let blob_err = production
+            .find("Failed to explode single blob into per-room keys")
+            .expect("blob-explosion save-error marker must exist");
+        let blob_arm = &production[blob_err..(blob_err + 900).min(production.len())];
+        assert!(
+            blob_arm.contains("set_rooms_load_state(RoomsLoadState::Loaded)"),
+            "the blob-explosion save-error arm must resolve the load to Loaded, or a \
+             zero-live-room migration spins on Migrating forever (freenet/river#397 review)"
+        );
+
+        // (b) legacy-delegate re-save error.
+        let legacy_err = production
+            .find("Failed to migrate room data to new delegate")
+            .expect("legacy re-save-error marker must exist");
+        let legacy_arm = &production[legacy_err..(legacy_err + 900).min(production.len())];
+        assert!(
+            legacy_arm.contains("set_rooms_load_state(RoomsLoadState::Loaded)"),
+            "the legacy re-save-error arm must resolve the load to Loaded, or a \
+             zero-live-room migration spins on Migrating forever (freenet/river#397 review)"
+        );
+    }
+
+    /// freenet/river#397 review (MINOR): a background interrupted-migration
+    /// recovery re-run must NEVER downgrade a resolved `Loaded` back to `Loading`.
+    /// `migrate_current_blob_to_per_room` takes a `recovery: bool`, and its
+    /// no-current-blob `fire_legacy_migration_request` path (which returns `true`
+    /// after recovery re-armed the attempt guard, so `load_state_after_probe_legacy`
+    /// would yield `Loading`) MUST guard that write on `!recovery`. Pin both the
+    /// signature and the guard so the suppression can't silently regress.
+    #[test]
+    fn recovery_re_run_never_downgrades_load_state_to_loading() {
+        let src = include_str!("response_handler.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+
+        assert!(
+            production.contains("async fn migrate_current_blob_to_per_room(recovery: bool)"),
+            "migrate_current_blob_to_per_room must thread a `recovery` flag so a \
+             background re-fill can suppress its display-state writes"
+        );
+        // The initial (state-owning) caller passes false; the recovery caller
+        // passes true (the latter is also pinned by
+        // `interrupted_migration_is_recovered_on_next_load`).
+        assert!(
+            production.contains("migrate_current_blob_to_per_room(false).await;"),
+            "the initial LoadPlan::MigrateCurrentBlob caller must own the load state (recovery = false)"
+        );
+        // Slice just the `migrate_current_blob_to_per_room` body (from its
+        // signature to the next top-level `async fn`) so the checks below can't
+        // accidentally match the identically-named write in `load_rooms_per_room`'s
+        // `ProbeLegacy` arm (which is correctly ungated — it OWNS the load).
+        let fn_start = production
+            .find("async fn migrate_current_blob_to_per_room(recovery: bool)")
+            .expect("migrate_current_blob_to_per_room signature must exist");
+        let body_after_sig = &production[fn_start + 1..];
+        let fn_end = body_after_sig
+            .find("\nasync fn ")
+            .map(|i| fn_start + 1 + i)
+            .unwrap_or(production.len());
+        let body = &production[fn_start..fn_end];
+        // The value-gone probe-legacy write — the ONLY one that could yield
+        // `Loading` — must be guarded on `!recovery`.
+        let write_pos = body
+            .find("set_rooms_load_state(load_state_after_probe_legacy(fired))")
+            .expect("the value-gone branch must write via load_state_after_probe_legacy");
+        // The `if !recovery {` guard must DIRECTLY precede the write (same block),
+        // not merely appear somewhere earlier in the function.
+        let guard_pos = body[..write_pos]
+            .rfind("if !recovery {")
+            .expect("migrate_current_blob_to_per_room must guard its writes on !recovery");
+        assert!(
+            write_pos - guard_pos < 80,
+            "the value-gone probe-legacy write must be DIRECTLY inside an `if !recovery` \
+             block so a background recovery never downgrades a resolved Loaded to Loading"
         );
     }
 

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -15,8 +15,8 @@ use crate::components::app::chat_delegate::{
     decide_per_room_load_action, fire_legacy_migration_request, get_versioned_correlation_key,
     hydrate_hidden_dm_threads, hydrate_outbound_dms_cache, is_legacy_delegate_key,
     is_legacy_migration_in_progress, legacy_scoped_correlation, load_state_after_probe_legacy,
-    mark_fetch_failure, mark_legacy_migration_done, mark_legacy_migration_in_progress,
-    parse_room_storage_key, per_room_terminal, prune_outbound_dms_for_purges, room_storage_key,
+    mark_legacy_migration_done, mark_legacy_migration_in_progress, parse_room_storage_key,
+    per_room_terminal, prune_outbound_dms_for_purges, room_storage_key,
     save_outbound_dms_to_delegate, save_rooms_to_delegate, send_delegate_request,
     send_delegate_request_to, set_rooms_load_state, LegacyMigrationAction, LoadWorkerGuard,
     RoomsLoadState, OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY, ROOMS_STORAGE_KEY,
@@ -307,6 +307,16 @@ impl ResponseHandler {
                                         // Check if this is the rooms data
                                         if key.as_bytes() == ROOMS_STORAGE_KEY {
                                             if let Some(rooms_data) = value {
+                                                // Progress-tracked termination
+                                                // (freenet/river#397 review 6/7):
+                                                // the legacy single-blob response
+                                                // is a load worker. The guard wraps
+                                                // BOTH parse arms so the Err arm's
+                                                // failure is attempt-scoped AND its
+                                                // settlement resolves `LoadFailed`
+                                                // even if it arrives AFTER the idle
+                                                // timer already set Empty (P2#2).
+                                                let worker = LoadWorkerGuard::new();
                                                 // Deserialize the rooms data
                                                 match from_reader::<Rooms, _>(&rooms_data[..]) {
                                                     Ok(loaded_rooms) => {
@@ -345,16 +355,6 @@ impl ResponseHandler {
                                                             }
                                                         }
 
-                                                        // Progress-tracked
-                                                        // termination
-                                                        // (freenet/river#397
-                                                        // review 6): the legacy
-                                                        // single-blob hydrate is a
-                                                        // load worker. The guard
-                                                        // bumps activity (cancels a
-                                                        // pending idle resolution)
-                                                        // and, on drop, settles.
-                                                        let _worker = LoadWorkerGuard::new();
                                                         if hydrate_loaded_rooms(
                                                             loaded_rooms,
                                                             is_legacy_delegate,
@@ -367,18 +367,20 @@ impl ResponseHandler {
                                                             "Failed to deserialize rooms data: {}",
                                                             e
                                                         );
-                                                        // freenet/river#397 Codex review 5
-                                                        // (audit): a `rooms_data` blob exists
-                                                        // only because rooms were stored in it.
-                                                        // This arm is reachable only for a LEGACY
-                                                        // delegate (the current-delegate flow is
-                                                        // List-driven), so a parse failure is
-                                                        // known-stored legacy data that failed to
-                                                        // load — mark it so the backstop resolves
-                                                        // to LoadFailed, not a silent Empty. (A
-                                                        // genuine new user has no legacy delegate
-                                                        // responding, so never reaches here.)
-                                                        mark_fetch_failure();
+                                                        // freenet/river#397 review 5/7: a
+                                                        // `rooms_data` blob exists only because
+                                                        // rooms were stored in it. This arm is
+                                                        // reachable only for a LEGACY delegate (the
+                                                        // current-delegate flow is List-driven), so
+                                                        // a parse failure is known-stored legacy
+                                                        // data that failed to load. Attempt-scoped
+                                                        // mark; the guard's settlement (on drop)
+                                                        // resolves `LoadFailed` — correcting a
+                                                        // premature Empty from a late response
+                                                        // (P2#2). (A genuine new user has no legacy
+                                                        // delegate responding, so never reaches
+                                                        // here.)
+                                                        worker.mark_fetch_failure();
                                                     }
                                                 }
                                             } else {
@@ -641,7 +643,12 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
     // settled-handler re-evaluates whether the load is complete. For the
     // ProbeLegacy case the guard drop is exactly the "fired the fire-and-forget
     // probe and became quiescent" point that arms the idle timer.
-    let _worker = LoadWorkerGuard::new();
+    //
+    // Attempt-scoped (review 7): every global write below goes through
+    // `worker.mark_fetch_failure()` / `worker.set_load_state()` so a stale worker
+    // (superseded by a Retry) can neither pollute the new attempt's
+    // `SAW_FETCH_FAILURE` nor write its display state.
+    let worker = LoadWorkerGuard::new();
     match plan_load_from_keys(&keys) {
         LoadPlan::ProbeLegacy => {
             info!("Current delegate has no room data — firing legacy migration probe");
@@ -651,7 +658,7 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
             // empty user). The universal backstop (armed in `set_up_chat_delegate`)
             // guarantees termination if the probe finds nothing.
             let fired = fire_legacy_migration_request().await;
-            set_rooms_load_state(load_state_after_probe_legacy(fired));
+            worker.set_load_state(load_state_after_probe_legacy(fired));
         }
         LoadPlan::MigrateCurrentBlob => {
             info!(
@@ -710,7 +717,7 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
                             // materialize — a fetch failure.
                             error!("Unparseable room slot for {:?}: {}", vk, e);
                             had_fetch_error = true;
-                            mark_fetch_failure();
+                            worker.mark_fetch_failure();
                         }
                     },
                     Ok(ChatDelegateResponseMsg::GetResponse { value: None, .. }) => {
@@ -721,12 +728,12 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
                     Ok(other) => {
                         error!("Unexpected response loading room {:?}: {:?}", vk, other);
                         had_fetch_error = true;
-                        mark_fetch_failure();
+                        worker.mark_fetch_failure();
                     }
                     Err(e) => {
                         error!("Failed to load room {:?}: {}", vk, e);
                         had_fetch_error = true;
-                        mark_fetch_failure();
+                        worker.mark_fetch_failure();
                     }
                 }
             }
@@ -775,7 +782,7 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
             // every slot a clean `value: None`/tombstone) → `Loaded` (Empty). Set
             // BEFORE the recovery re-run below so a recovery that finds stranded
             // rooms and sets `Migrating` wins over this terminal.
-            set_rooms_load_state(per_room_terminal(
+            worker.set_load_state(per_room_terminal(
                 loaded_map_empty,
                 listed_count,
                 had_fetch_error,
@@ -907,8 +914,9 @@ fn reconstruct_rooms(
 /// re-fires). Any real migration the recovery triggers still shows `Migrating`
 /// via the legacy `hydrate_loaded_rooms` path, which is not gated here.
 async fn migrate_current_blob_to_per_room(recovery: bool) {
-    // Progress-tracked termination (freenet/river#397 review 6): awaited worker.
-    let _worker = LoadWorkerGuard::new();
+    // Progress-tracked termination (freenet/river#397 review 6); attempt-scoped
+    // writes (review 7): a stale worker's `worker.*` calls no-op.
+    let worker = LoadWorkerGuard::new();
     match send_delegate_request(ChatDelegateRequestMsg::GetVersionedRequest {
         key: ChatDelegateKey::new(ROOMS_STORAGE_KEY.to_vec()),
     })
@@ -928,7 +936,7 @@ async fn migrate_current_blob_to_per_room(recovery: bool) {
                 // re-render lands on the "Migrating…" state before the list fills.
                 // Suppressed under `recovery` (the state is already `Loaded`).
                 if !recovery {
-                    set_rooms_load_state(RoomsLoadState::Migrating);
+                    worker.set_load_state(RoomsLoadState::Migrating);
                 }
                 // Did the blob carry any LIVE rooms (vs. all tombstones/empty)?
                 // freenet/river#397 Codex review 4: only a completion that merged
@@ -978,10 +986,10 @@ async fn migrate_current_blob_to_per_room(recovery: bool) {
                 // freenet/river#397 Codex review 5 (P2b): a `rooms_data` blob only
                 // exists because rooms were written to it, so a parse failure is
                 // known-stored-data that failed to load — surface LoadFailed (with
-                // Retry), NOT a false Empty. mark_fetch_failure so the backstop and
-                // any concurrent probe agree this attempt failed.
-                mark_fetch_failure();
-                set_rooms_load_state(RoomsLoadState::LoadFailed);
+                // Retry), NOT a false Empty. Attempt-scoped (review 7) so a stale
+                // worker doesn't corrupt the retry.
+                worker.mark_fetch_failure();
+                worker.set_load_state(RoomsLoadState::LoadFailed);
             }
         },
         Ok(_) => {
@@ -995,19 +1003,19 @@ async fn migrate_current_blob_to_per_room(recovery: bool) {
             // skipped, `Loading` when it fired). The universal backstop (armed in
             // `set_up_chat_delegate`) guarantees termination for the fired case.
             if !recovery {
-                set_rooms_load_state(load_state_after_probe_legacy(fired));
+                worker.set_load_state(load_state_after_probe_legacy(fired));
             }
         }
         Err(e) => {
             // freenet/river#397 Codex review 5 (audit): we only reach this fn from
             // `LoadPlan::MigrateCurrentBlob`, i.e. the current delegate's index
             // LISTED a `rooms_data` key, so the blob exists — a SEND failure
-            // reading it is known-stored-data that failed to load. Mark the
-            // failure so the backstop resolves to LoadFailed (with Retry), not a
-            // silent Empty. (Display is masked by `List` if rooms are concurrently
-            // present.)
+            // reading it is known-stored-data that failed to load. Mark the failure
+            // (attempt-scoped, review 7) so the worker's settlement resolves to
+            // LoadFailed rather than a silent Empty. (Display is masked by `List`
+            // if rooms are concurrently present.)
             warn!("Failed to read current-delegate rooms blob: {}", e);
-            mark_fetch_failure();
+            worker.mark_fetch_failure();
         }
     }
 }
@@ -1031,8 +1039,9 @@ async fn migrate_legacy_per_room(legacy_key: DelegateKey, keys: Vec<ChatDelegate
     // function (including the empty-index early return) keeps the load alive
     // while this delegate is being processed, and cancels any pending idle
     // resolution (activity-gen bump) so a concurrent empty completion can't
-    // resolve Empty while this one may still bring rooms.
-    let _worker = LoadWorkerGuard::new();
+    // resolve Empty while this one may still bring rooms. Attempt-scoped writes
+    // (review 7): `worker.*` calls no-op for a stale worker.
+    let worker = LoadWorkerGuard::new();
     let (room_vks, has_meta) = match plan_load_from_keys(&keys) {
         LoadPlan::PerRoom { room_vks, has_meta } => (room_vks, has_meta),
         // No per-room keys on this legacy delegate — its single blob (if any) is
@@ -1052,7 +1061,7 @@ async fn migrate_legacy_per_room(legacy_key: DelegateKey, keys: Vec<ChatDelegate
     // probes may hold rooms); the universal backstop owns that terminal, and any
     // failed legacy fetch below sets `SAW_FETCH_FAILURE` so the backstop resolves
     // to `LoadFailed` rather than a false Empty.
-    set_rooms_load_state(RoomsLoadState::Migrating);
+    worker.set_load_state(RoomsLoadState::Migrating);
 
     info!(
         "Migrating {} per-room slot(s) from legacy delegate",
@@ -1074,13 +1083,13 @@ async fn migrate_legacy_per_room(legacy_key: DelegateKey, keys: Vec<ChatDelegate
                 Ok(slot) => slots.push((vk, slot)),
                 Err(e) => {
                     error!("Unparseable legacy room slot for {:?}: {}", vk, e);
-                    mark_fetch_failure();
+                    worker.mark_fetch_failure();
                 }
             },
             Ok(_) => warn!("Legacy room key {:?} listed but value missing", vk),
             Err(e) => {
                 error!("Failed to load legacy room {:?}: {}", vk, e);
-                mark_fetch_failure();
+                worker.mark_fetch_failure();
             }
         }
     }
@@ -2012,15 +2021,16 @@ mod tests {
             .expect("production code before `mod tests`");
 
         // (P2b) corrupt current-delegate `rooms_data` blob → mark_fetch_failure +
-        // LoadFailed (a blob exists only because rooms were written to it).
+        // LoadFailed (a blob exists only because rooms were written to it), both
+        // attempt-scoped through the worker (review 7).
         let corrupt = production
             .find("Failed to deserialize current-delegate rooms blob")
             .expect("corrupt-current-blob marker must exist");
         let corrupt_arm = &production[corrupt..(corrupt + 700).min(production.len())];
         assert!(
-            corrupt_arm.contains("mark_fetch_failure()")
-                && corrupt_arm.contains("set_rooms_load_state(RoomsLoadState::LoadFailed)"),
-            "a corrupt current rooms_data blob must mark_fetch_failure + LoadFailed, not Empty"
+            corrupt_arm.contains("worker.mark_fetch_failure()")
+                && corrupt_arm.contains("worker.set_load_state(RoomsLoadState::LoadFailed)"),
+            "a corrupt current rooms_data blob must worker.mark_fetch_failure + LoadFailed, not Empty"
         );
 
         // (audit) SEND failure reading the current blob (we're here only because
@@ -2042,9 +2052,47 @@ mod tests {
         let legacy_parse_arm =
             &production[legacy_parse..(legacy_parse + 1500).min(production.len())];
         assert!(
-            legacy_parse_arm.contains("mark_fetch_failure()"),
-            "a legacy rooms_data parse failure must mark_fetch_failure"
+            legacy_parse_arm.contains("worker.mark_fetch_failure()"),
+            "a legacy rooms_data parse failure must worker.mark_fetch_failure (settlement → LoadFailed)"
         );
+    }
+
+    /// freenet/river#397 review 7 (P2#1): every global write a load worker makes
+    /// must be attempt-scoped so a stale worker (superseded by a Retry) can't
+    /// corrupt the new attempt. Pin that NO bare `mark_fetch_failure()` survives
+    /// (all go through `worker.mark_fetch_failure()`) and the worker-body terminal
+    /// writes go through `worker.set_load_state(...)`.
+    #[test]
+    fn worker_global_writes_are_attempt_scoped() {
+        let src = include_str!("response_handler.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+
+        // Every `mark_fetch_failure()` occurrence is part of `worker.mark_fetch_failure()`.
+        assert_eq!(
+            production.matches("mark_fetch_failure()").count(),
+            production.matches("worker.mark_fetch_failure()").count(),
+            "a bare mark_fetch_failure() in a worker body would pollute a stale attempt's SAW_FETCH_FAILURE"
+        );
+        assert!(
+            production.matches("worker.mark_fetch_failure()").count() >= 5,
+            "the current + legacy fetch-failure arms must route through the worker"
+        );
+
+        // The worker-body terminal / probe / migrating writes are attempt-scoped.
+        for terminal in [
+            "worker.set_load_state(per_room_terminal(",
+            "worker.set_load_state(load_state_after_probe_legacy(fired))",
+            "worker.set_load_state(RoomsLoadState::Migrating)",
+            "worker.set_load_state(RoomsLoadState::LoadFailed)",
+        ] {
+            assert!(
+                production.contains(terminal),
+                "worker-body write `{terminal}` must be attempt-scoped via worker.set_load_state"
+            );
+        }
     }
 
     /// freenet/river#397 Codex review 3: in `migrate_current_blob_to_per_room`,
@@ -2090,9 +2138,10 @@ mod tests {
         let body = &production[fn_start..fn_end];
 
         // (b) the value-gone probe-legacy write — the ONLY downgrade — is
-        // `!recovery`-guarded, directly enclosed by the guard (same block).
+        // `!recovery`-guarded, directly enclosed by the guard (same block). It is
+        // attempt-scoped via `worker.set_load_state` (review 7).
         let write_pos = body
-            .find("set_rooms_load_state(load_state_after_probe_legacy(fired))")
+            .find("worker.set_load_state(load_state_after_probe_legacy(fired))")
             .expect("the value-gone branch must write via load_state_after_probe_legacy");
         let guard_pos = body[..write_pos]
             .rfind("if !recovery {")
@@ -2156,9 +2205,9 @@ mod tests {
             .unwrap_or(production.len());
         let body = &production[fn_start..fn_end];
 
-        // `Migrating` is set before the sequential fetch loop.
+        // `Migrating` is set (attempt-scoped, review 7) before the fetch loop.
         let migrating_pos = body
-            .find("set_rooms_load_state(RoomsLoadState::Migrating)")
+            .find("worker.set_load_state(RoomsLoadState::Migrating)")
             .expect("migrate_legacy_per_room must announce Migrating for a non-empty index");
         let loop_pos = body
             .find("for vk in room_vks")
@@ -2173,7 +2222,7 @@ mod tests {
         // write the global load state (concurrent probes may hold rooms). The only
         // load-state write in this function is the `Migrating` above.
         assert_eq!(
-            body.matches("set_rooms_load_state(").count(),
+            body.matches("worker.set_load_state(").count(),
             1,
             "migrate_legacy_per_room must write the load state exactly once (Migrating); \
              the all-empty case must NOT write Loaded (Codex review 3 — not authoritative)"
@@ -2228,28 +2277,30 @@ mod tests {
             let fn_start = production
                 .find(func)
                 .unwrap_or_else(|| panic!("{func} must exist"));
-            // The guard must appear within the first ~700 bytes of the body (before
-            // the first awaited request), not somewhere deep after work started.
-            let head = &production[fn_start..(fn_start + 700).min(production.len())];
+            // The guard must appear near the top of the body (before the first
+            // awaited request), not somewhere deep after work started. Window is
+            // generous to allow for the leading doc/rationale comment.
+            let head = &production[fn_start..(fn_start + 1100).min(production.len())];
             assert!(
                 head.contains("LoadWorkerGuard::new()"),
                 "{func} must hold a LoadWorkerGuard from the top"
             );
         }
 
-        // The legacy single-blob GetResponse hydrate call is preceded by a guard
-        // (the 4th site; the other three are the fn heads checked above). Find the
-        // `flags.subscriptions_initiated` hydrate call and confirm a guard is
-        // constructed just before it.
-        let hydrate_call = production
-            .find("flags.subscriptions_initiated = true;")
-            .expect("legacy GetResponse hydrate call must exist");
-        let guard_before = production[..hydrate_call]
+        // The legacy single-blob GetResponse parse block is the 4th site: the
+        // guard wraps BOTH parse arms (so the Err arm is attempt-scoped and its
+        // settlement resolves LoadFailed — review 7 P2#2). Confirm a guard is
+        // constructed immediately before the `from_reader::<Rooms>(&rooms_data..)`
+        // match that both arms belong to.
+        let parse = production
+            .find("from_reader::<Rooms, _>(&rooms_data[..])")
+            .expect("legacy GetResponse rooms_data parse must exist");
+        let guard_before = production[..parse]
             .rfind("LoadWorkerGuard::new()")
-            .expect("the legacy GetResponse hydrate must be preceded by a guard");
+            .expect("the legacy GetResponse parse must be preceded by a guard");
         assert!(
-            hydrate_call - guard_before < 500,
-            "the legacy single-blob GetResponse hydrate must be wrapped in a LoadWorkerGuard"
+            parse - guard_before < 200,
+            "the legacy single-blob GetResponse parse (both arms) must be wrapped in a LoadWorkerGuard"
         );
     }
 
@@ -2266,13 +2317,14 @@ mod tests {
             .next()
             .expect("production code before `mod tests`");
 
-        // (a) the PerRoom terminal is the pure decision fed all three inputs.
+        // (a) the PerRoom terminal is the pure decision fed all three inputs, and
+        // written through the ATTEMPT-SCOPED `worker.set_load_state` (review 7).
         assert!(
-            production.contains("set_rooms_load_state(per_room_terminal(")
+            production.contains("worker.set_load_state(per_room_terminal(")
                 && production.contains("loaded_map_empty")
                 && production.contains("listed_count")
                 && production.contains("had_fetch_error"),
-            "the PerRoom terminal must be per_room_terminal(loaded_map_empty, listed_count, had_fetch_error)"
+            "the PerRoom terminal must be worker.set_load_state(per_room_terminal(loaded_map_empty, listed_count, had_fetch_error))"
         );
 
         // (b) the per-room fetch loop's three failure arms mark both signals; the

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -15,11 +15,11 @@ use crate::components::app::chat_delegate::{
     decide_per_room_load_action, fire_legacy_migration_request, get_versioned_correlation_key,
     hydrate_hidden_dm_threads, hydrate_outbound_dms_cache, is_legacy_delegate_key,
     is_legacy_migration_in_progress, legacy_scoped_correlation, load_state_after_probe_legacy,
-    mark_legacy_migration_done, mark_legacy_migration_in_progress, parse_room_storage_key,
-    prune_outbound_dms_for_purges, room_storage_key, save_outbound_dms_to_delegate,
-    save_rooms_to_delegate, send_delegate_request, send_delegate_request_to, set_rooms_load_state,
-    LegacyMigrationAction, RoomsLoadState, OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY,
-    ROOMS_STORAGE_KEY,
+    mark_fetch_failure, mark_legacy_migration_done, mark_legacy_migration_in_progress,
+    parse_room_storage_key, per_room_terminal, prune_outbound_dms_for_purges, room_storage_key,
+    save_outbound_dms_to_delegate, save_rooms_to_delegate, send_delegate_request,
+    send_delegate_request_to, set_rooms_load_state, LegacyMigrationAction, RoomsLoadState,
+    OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY, ROOMS_STORAGE_KEY,
 };
 use crate::components::app::document_title::{mark_current_room_as_read, update_document_title};
 use crate::components::app::notifications::mark_initial_sync_complete;
@@ -658,6 +658,14 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
             // passes every room still lands in ROOMS. (Load-vs-SAVE never
             // collides — those use distinct prefixed correlation keys.)
             info!("Loading {} per-room slot(s) from delegate", room_vks.len());
+            // freenet/river#397 Codex review 4: the index PROVED these rooms
+            // exist. Track whether any LISTED room failed to materialize (a
+            // transport / parse error — NOT a definitive `value: None`) so the
+            // authoritative PerRoom terminal can resolve to `LoadFailed` instead
+            // of a false "no rooms yet". Set the global `SAW_FETCH_FAILURE` too so
+            // the backstop (and concurrent legacy probes) see it.
+            let listed_count = room_vks.len();
+            let mut had_fetch_error = false;
             let mut slots: Vec<(ed25519_dalek::VerifyingKey, RoomSlot)> = Vec::new();
             for vk in room_vks {
                 match send_delegate_request(ChatDelegateRequestMsg::GetRequest {
@@ -669,14 +677,29 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
                         value: Some(bytes), ..
                     }) => match from_reader::<RoomSlot, _>(&bytes[..]) {
                         Ok(slot) => slots.push((vk, slot)),
-                        Err(e) => error!("Unparseable room slot for {:?}: {}", vk, e),
+                        Err(e) => {
+                            // A listed room whose slot won't parse failed to
+                            // materialize — a fetch failure.
+                            error!("Unparseable room slot for {:?}: {}", vk, e);
+                            had_fetch_error = true;
+                            mark_fetch_failure();
+                        }
                     },
                     Ok(ChatDelegateResponseMsg::GetResponse { value: None, .. }) => {
-                        // Listed in the index but the value is gone — skip it.
+                        // Listed in the index but the value is gone — a DEFINITIVE
+                        // "no value", a legitimate skip, NOT a fetch failure.
                         warn!("Room key {:?} listed but value missing", vk);
                     }
-                    Ok(other) => error!("Unexpected response loading room {:?}: {:?}", vk, other),
-                    Err(e) => error!("Failed to load room {:?}: {}", vk, e),
+                    Ok(other) => {
+                        error!("Unexpected response loading room {:?}: {:?}", vk, other);
+                        had_fetch_error = true;
+                        mark_fetch_failure();
+                    }
+                    Err(e) => {
+                        error!("Failed to load room {:?}: {}", vk, e);
+                        had_fetch_error = true;
+                        mark_fetch_failure();
+                    }
                 }
             }
 
@@ -709,21 +732,26 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
             };
 
             let loaded = reconstruct_rooms(slots, meta);
+            // Capture emptiness BEFORE `loaded` is moved into hydrate, for the
+            // authoritative terminal decision below.
+            let loaded_map_empty = loaded.map.is_empty();
             if hydrate_loaded_rooms(loaded, false) {
                 schedule_subscription_timeout_check();
             }
 
-            // freenet/river#397 (Codex review 3): the current delegate's per-room
+            // freenet/river#397 (Codex review 4): the current delegate's per-room
             // set is the authoritative initial load — a definitive fast-path
-            // completion, so resolve to `Loaded`. Rooms (if any) render as the
-            // list; a genuinely empty set renders the calm empty state. A rare
-            // all-fetch-fail (the current delegate is the local node's store, so
-            // this is unlikely) shows Empty; the universal 30s backstop is the
-            // termination guarantee for any non-definitive path, so we no longer
-            // hold `Loading` here (that couldn't guarantee termination). Set BEFORE
-            // the recovery re-run below so a recovery that finds stranded rooms and
-            // sets `Migrating` wins over this `Loaded`.
-            set_rooms_load_state(RoomsLoadState::Loaded);
+            // completion. Resolve via the pure `per_room_terminal`: rooms present →
+            // `Loaded` (List); empty with a known-rooms fetch failure → `LoadFailed`
+            // (never a false "no rooms yet"); a genuine empty (nothing listed, or
+            // every slot a clean `value: None`/tombstone) → `Loaded` (Empty). Set
+            // BEFORE the recovery re-run below so a recovery that finds stranded
+            // rooms and sets `Migrating` wins over this terminal.
+            set_rooms_load_state(per_room_terminal(
+                loaded_map_empty,
+                listed_count,
+                had_fetch_error,
+            ));
 
             // Recover from an interrupted migration by re-running it to pick up
             // any room whose per-room key wasn't written before the previous
@@ -872,7 +900,13 @@ async fn migrate_current_blob_to_per_room(recovery: bool) {
                 if !recovery {
                     set_rooms_load_state(RoomsLoadState::Migrating);
                 }
-                if hydrate_loaded_rooms(loaded, false) {
+                // Did the blob carry any LIVE rooms (vs. all tombstones/empty)?
+                // freenet/river#397 Codex review 4: only a completion that merged
+                // live rooms writes `Loaded` — a zero-live-room completion writes
+                // NOTHING so it can't stomp a concurrent legacy probe's `Migrating`
+                // into a false Empty; the universal backstop owns that terminal.
+                let had_rooms = hydrate_loaded_rooms(loaded, false);
+                if had_rooms {
                     schedule_subscription_timeout_check();
                 }
                 // Explode into per-room keys (non-destructive: blob stays).
@@ -887,20 +921,19 @@ async fn migrate_current_blob_to_per_room(recovery: bool) {
                         Ok(_) => {
                             clear_legacy_migration_in_progress();
                             mark_legacy_migration_done();
-                            // freenet/river#397 (Codex review 3): the blob explosion
-                            // COMPLETED — a completion, so resolve to `Loaded` even
-                            // under recovery. Only a DOWNGRADE (the value-gone
-                            // Loading re-fire below) is `!recovery`-suppressed.
-                            set_rooms_load_state(RoomsLoadState::Loaded);
+                            // Resolve to `Loaded` only if we merged live rooms;
+                            // otherwise let the backstop own the terminal.
+                            if had_rooms {
+                                set_rooms_load_state(RoomsLoadState::Loaded);
+                            }
                         }
                         Err(e) => {
                             error!("Failed to explode single blob into per-room keys: {}", e);
-                            // freenet/river#397: a definitive failure is also a
-                            // completion — resolve to `Loaded` (even under recovery)
-                            // so a zero-live-room migration never strands on
-                            // "Migrating…". Leave the in-progress flag set so the
-                            // next load re-runs the fill.
-                            set_rooms_load_state(RoomsLoadState::Loaded);
+                            // Leave the in-progress flag set so the next load
+                            // re-runs the fill. Same had_rooms gate as the Ok arm.
+                            if had_rooms {
+                                set_rooms_load_state(RoomsLoadState::Loaded);
+                            }
                         }
                     }
                 });
@@ -959,15 +992,16 @@ async fn migrate_legacy_per_room(legacy_key: DelegateKey, keys: Vec<ChatDelegate
         LoadPlan::MigrateCurrentBlob | LoadPlan::ProbeLegacy => return,
     };
 
-    // freenet/river#397 Codex review 2 (P1): the legacy index is NON-EMPTY, so
+    // freenet/river#397 Codex review 2/4 (P1): the legacy index is NON-EMPTY, so
     // rooms provably exist under the old delegate key. Announce `Migrating`
     // BEFORE the sequential fetch loop below — otherwise the state stays
-    // `Loading` through the whole fetch window and the 20s backstop (armed by the
-    // ProbeLegacy arm) could flip it to `Loaded`→Empty despite that positive
-    // evidence. `Migrating` is not rescued by the backstop, so this closes the
-    // window. Every return path below concludes to a terminal (invariant 2): the
-    // all-fetches-empty early return resolves to `Loaded`, and the hydrate path's
-    // legacy re-save success/`Err` arms resolve to `Loaded`.
+    // `Loading` through the whole fetch window and the 30s backstop could flip it
+    // to a terminal despite that positive evidence. `Migrating` is not rescued
+    // early by the backstop. On an all-empty/all-failed result this writes NOTHING
+    // to the global state (a single legacy probe is not authoritative — concurrent
+    // probes may hold rooms); the universal backstop owns that terminal, and any
+    // failed legacy fetch below sets `SAW_FETCH_FAILURE` so the backstop resolves
+    // to `LoadFailed` rather than a false Empty.
     set_rooms_load_state(RoomsLoadState::Migrating);
 
     info!(
@@ -988,10 +1022,16 @@ async fn migrate_legacy_per_room(legacy_key: DelegateKey, keys: Vec<ChatDelegate
                 value: Some(bytes), ..
             }) => match from_reader::<RoomSlot, _>(&bytes[..]) {
                 Ok(slot) => slots.push((vk, slot)),
-                Err(e) => error!("Unparseable legacy room slot for {:?}: {}", vk, e),
+                Err(e) => {
+                    error!("Unparseable legacy room slot for {:?}: {}", vk, e);
+                    mark_fetch_failure();
+                }
             },
             Ok(_) => warn!("Legacy room key {:?} listed but value missing", vk),
-            Err(e) => error!("Failed to load legacy room {:?}: {}", vk, e),
+            Err(e) => {
+                error!("Failed to load legacy room {:?}: {}", vk, e);
+                mark_fetch_failure();
+            }
         }
     }
 
@@ -1500,24 +1540,28 @@ fn hydrate_loaded_rooms(loaded_rooms: Rooms, is_legacy_delegate: bool) -> bool {
         // until the user rejoins (freenet/river#345 follow-up). The flag stays
         // set until a FULL re-save succeeds, so the next load knows to re-fill.
         mark_legacy_migration_in_progress();
-        crate::util::safe_spawn_local(async {
+        // freenet/river#397 Codex review 4: only resolve to `Loaded` when this
+        // legacy re-save actually merged live rooms. A zero-live-room / empty
+        // legacy result writes NOTHING to the global state — so a concurrent
+        // legacy probe that DID find rooms (and set `Migrating`) can't be stomped
+        // into a false Empty by this one. The universal backstop owns the
+        // all-nothing terminal (→ `LoadFailed` if a fetch failed, else Empty).
+        crate::util::safe_spawn_local(async move {
             match save_rooms_to_delegate().await {
                 Ok(_) => {
                     info!("Successfully migrated room data to new delegate");
                     clear_legacy_migration_in_progress();
                     mark_legacy_migration_done();
-                    // freenet/river#397: migration concluded — resolve the load.
-                    set_rooms_load_state(RoomsLoadState::Loaded);
+                    if had_loaded_rooms {
+                        set_rooms_load_state(RoomsLoadState::Loaded);
+                    }
                 }
                 Err(e) => {
                     error!("Failed to migrate room data to new delegate: {}", e);
-                    // freenet/river#397 (review): a zero-live-room migration (an
-                    // all-tombstone legacy delegate → empty `map`) leaves
-                    // room_count == 0, so a save error must STILL resolve the load
-                    // — otherwise the rail spins on "Migrating…" forever (the
-                    // backstop only rescues `Loading`, not `Migrating`). Leave the
-                    // in-progress flag set so the next load re-fills.
-                    set_rooms_load_state(RoomsLoadState::Loaded);
+                    // Leave the in-progress flag set so the next load re-fills.
+                    if had_loaded_rooms {
+                        set_rooms_load_state(RoomsLoadState::Loaded);
+                    }
                 }
             }
         });
@@ -1832,7 +1876,7 @@ mod tests {
         let resave_start = production
             .find("Migrating room data from legacy delegate to new delegate")
             .expect("legacy re-save block marker must exist");
-        let resave = &production[resave_start..(resave_start + 1200).min(production.len())];
+        let resave = &production[resave_start..(resave_start + 1800).min(production.len())];
         assert!(
             resave.contains("mark_legacy_migration_in_progress()"),
             "legacy re-save must mark migration in progress BEFORE saving"
@@ -1870,13 +1914,12 @@ mod tests {
         );
     }
 
-    /// freenet/river#397 review (MAJOR): both migration re-save `Err` arms MUST
-    /// resolve the load state to `Loaded`. A zero-live-room migration (e.g. an
-    /// all-tombstone legacy delegate — `reconstruct_rooms` routes `Tombstone` to
-    /// `removed_rooms`, leaving `map` empty) sets `Migrating` before the save with
-    /// room_count == 0; if the save then errors and the arm doesn't resolve, the
-    /// rail spins on "Migrating…" forever (the backstop only rescues `Loading`).
-    /// This pins the fix so a future edit that drops either resolve fails CI.
+    /// freenet/river#397 review: both migration re-save `Err` arms must resolve
+    /// the load to `Loaded` when the migration merged live rooms (`had_rooms`), so
+    /// a save error can't strand the rail on "Migrating…". A zero-live-room result
+    /// intentionally writes NOTHING (the universal backstop owns that terminal —
+    /// Codex review 4 concurrency fix), so the pinned write is `had_rooms`-gated,
+    /// not unconditional. This pins that neither arm silently drops the resolution.
     #[test]
     fn migration_save_error_resolves_load_state() {
         let src = include_str!("response_handler.rs");
@@ -1892,8 +1935,7 @@ mod tests {
         let blob_arm = &production[blob_err..(blob_err + 900).min(production.len())];
         assert!(
             blob_arm.contains("set_rooms_load_state(RoomsLoadState::Loaded)"),
-            "the blob-explosion save-error arm must resolve the load to Loaded, or a \
-             zero-live-room migration spins on Migrating forever (freenet/river#397 review)"
+            "the blob-explosion save-error arm must resolve the load to Loaded (had_rooms)"
         );
 
         // (b) legacy-delegate re-save error.
@@ -1903,8 +1945,7 @@ mod tests {
         let legacy_arm = &production[legacy_err..(legacy_err + 900).min(production.len())];
         assert!(
             legacy_arm.contains("set_rooms_load_state(RoomsLoadState::Loaded)"),
-            "the legacy re-save-error arm must resolve the load to Loaded, or a \
-             zero-live-room migration spins on Migrating forever (freenet/river#397 review)"
+            "the legacy re-save-error arm must resolve the load to Loaded (had_rooms)"
         );
     }
 
@@ -2038,6 +2079,115 @@ mod tests {
             1,
             "migrate_legacy_per_room must write the load state exactly once (Migrating); \
              the all-empty case must NOT write Loaded (Codex review 3 — not authoritative)"
+        );
+
+        // freenet/river#397 Codex review 4: a failed legacy slot fetch records the
+        // global SAW_FETCH_FAILURE (transport Err + unparseable-slot Err) so the
+        // backstop resolves to LoadFailed rather than a false Empty — but NOT a
+        // `value: None` skip.
+        assert_eq!(
+            body.matches("mark_fetch_failure()").count(),
+            2,
+            "the legacy transport-Err and unparseable-slot arms must mark_fetch_failure"
+        );
+        let value_none_pos = body
+            .find("listed but value missing")
+            .expect("legacy value: None arm must exist");
+        let after_none = &body[value_none_pos..(value_none_pos + 120).min(body.len())];
+        assert!(
+            !after_none.contains("mark_fetch_failure()"),
+            "a legacy `value: None` is a legitimate skip, not a fetch failure"
+        );
+    }
+
+    /// freenet/river#397 Codex review 4: the authoritative current-delegate
+    /// PerRoom load must (a) route its terminal through the pure `per_room_terminal`
+    /// fed (map_empty, listed_count, had_fetch_error), and (b) record fetch
+    /// failures both locally (had_fetch_error) and globally (mark_fetch_failure) in
+    /// the three failure arms — but NOT for a definitive `value: None`.
+    #[test]
+    fn per_room_load_uses_terminal_and_marks_fetch_failure() {
+        let src = include_str!("response_handler.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+
+        // (a) the PerRoom terminal is the pure decision fed all three inputs.
+        assert!(
+            production.contains("set_rooms_load_state(per_room_terminal(")
+                && production.contains("loaded_map_empty")
+                && production.contains("listed_count")
+                && production.contains("had_fetch_error"),
+            "the PerRoom terminal must be per_room_terminal(loaded_map_empty, listed_count, had_fetch_error)"
+        );
+
+        // (b) the per-room fetch loop's three failure arms mark both signals; the
+        // value: None arm marks neither. Bound to the loop (marker → `let meta`).
+        let loop_start = production
+            .find("Loading {} per-room slot(s) from delegate")
+            .expect("per-room fetch loop marker must exist");
+        let loop_end = production[loop_start..]
+            .find("let meta = if has_meta")
+            .map(|i| loop_start + i)
+            .expect("the per-room loop must be followed by the meta load");
+        let loop_region = &production[loop_start..loop_end];
+        assert_eq!(
+            loop_region.matches("had_fetch_error = true;").count(),
+            3,
+            "the transport-Err, unexpected-response, and unparseable-slot arms must set had_fetch_error"
+        );
+        assert_eq!(
+            loop_region.matches("mark_fetch_failure()").count(),
+            3,
+            "the same three arms must set the global SAW_FETCH_FAILURE"
+        );
+        let value_none_pos = loop_region
+            .find("listed but value missing")
+            .expect("the value: None arm must exist");
+        let after_none =
+            &loop_region[value_none_pos..(value_none_pos + 140).min(loop_region.len())];
+        assert!(
+            !after_none.contains("had_fetch_error = true;")
+                && !after_none.contains("mark_fetch_failure()"),
+            "a definitive `value: None` is a legitimate skip, not a fetch failure"
+        );
+    }
+
+    /// freenet/river#397 Codex review 4 (concurrency P2): the legacy re-save
+    /// completion (in `hydrate_loaded_rooms`) must resolve `Loaded` only when it
+    /// merged live rooms (`had_loaded_rooms`) — an empty legacy completion writes
+    /// NOTHING so it can't stomp a concurrent probe's `Migrating` into a false
+    /// Empty; the backstop owns the all-nothing terminal.
+    #[test]
+    fn legacy_resave_completion_gated_on_had_rooms() {
+        let src = include_str!("response_handler.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+        // Slice the legacy re-save closure (marker → the `had_loaded_rooms` return
+        // that closes hydrate).
+        let start = production
+            .find("Migrating room data from legacy delegate to new delegate")
+            .expect("legacy re-save marker must exist");
+        let end = production[start..]
+            .find("had_loaded_rooms\n}")
+            .map(|i| start + i)
+            .unwrap_or(production.len());
+        let block = &production[start..end];
+        // Both the Ok and Err arms resolve Loaded, each gated on `if had_loaded_rooms`.
+        assert_eq!(
+            block.matches("if had_loaded_rooms {").count(),
+            2,
+            "both legacy re-save arms must gate the Loaded write on had_loaded_rooms"
+        );
+        assert_eq!(
+            block
+                .matches("set_rooms_load_state(RoomsLoadState::Loaded)")
+                .count(),
+            2,
+            "both legacy re-save arms resolve to Loaded when live rooms merged"
         );
     }
 

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -14,10 +14,11 @@ use crate::components::app::chat_delegate::{
     complete_pending_signing_key_request, decide_legacy_migration_action,
     decide_per_room_load_action, fire_legacy_migration_request, get_versioned_correlation_key,
     hydrate_hidden_dm_threads, hydrate_outbound_dms_cache, is_legacy_delegate_key,
-    is_legacy_migration_in_progress, legacy_scoped_correlation, mark_legacy_migration_done,
-    mark_legacy_migration_in_progress, parse_room_storage_key, prune_outbound_dms_for_purges,
-    room_storage_key, save_outbound_dms_to_delegate, save_rooms_to_delegate, send_delegate_request,
-    send_delegate_request_to, LegacyMigrationAction, OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY,
+    is_legacy_migration_in_progress, legacy_scoped_correlation, load_state_after_probe_legacy,
+    mark_legacy_migration_done, mark_legacy_migration_in_progress, parse_room_storage_key,
+    prune_outbound_dms_for_purges, room_storage_key, save_outbound_dms_to_delegate,
+    save_rooms_to_delegate, send_delegate_request, send_delegate_request_to, set_rooms_load_state,
+    LegacyMigrationAction, RoomsLoadState, OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY,
     ROOMS_STORAGE_KEY,
 };
 use crate::components::app::document_title::{mark_current_room_as_read, update_document_title};
@@ -616,7 +617,12 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
     match plan_load_from_keys(&keys) {
         LoadPlan::ProbeLegacy => {
             info!("Current delegate has no room data — firing legacy migration probe");
-            fire_legacy_migration_request().await;
+            // freenet/river#397: stay `Loading` while a dispatched probe might
+            // still yield a migration; resolve to `Loaded` only if the probe was
+            // skipped (nothing is coming). A brand-new user whose probe finds
+            // nothing is caught by the timeout backstop, never a perpetual spinner.
+            let fired = fire_legacy_migration_request().await;
+            set_rooms_load_state(load_state_after_probe_legacy(fired));
         }
         LoadPlan::MigrateCurrentBlob => {
             info!(
@@ -704,6 +710,13 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
             if hydrate_loaded_rooms(loaded, false) {
                 schedule_subscription_timeout_check();
             }
+
+            // freenet/river#397: the current delegate's per-room set is the
+            // authoritative initial load — it has resolved. Rooms (if any) render
+            // as the list; an empty/all-tombstone set renders the calm empty
+            // state. Set BEFORE the recovery re-run below so an armed recovery's
+            // `Migrating` (set inside `migrate_current_blob_to_per_room`) wins.
+            set_rooms_load_state(RoomsLoadState::Loaded);
 
             // Recover from an interrupted migration by re-running it to pick up
             // any room whose per-room key wasn't written before the previous
@@ -832,6 +845,10 @@ async fn migrate_current_blob_to_per_room() {
                 // rooms on the next per-room load (freenet/river#345 follow-up,
                 // same hazard as the legacy-delegate path).
                 mark_legacy_migration_in_progress();
+                // freenet/river#397: a current-delegate blob explosion is a
+                // migration. Set `Migrating` BEFORE hydrate merges the rooms so a
+                // re-render lands on the "Migrating…" state before the list fills.
+                set_rooms_load_state(RoomsLoadState::Migrating);
                 if hydrate_loaded_rooms(loaded, false) {
                     schedule_subscription_timeout_check();
                 }
@@ -847,10 +864,15 @@ async fn migrate_current_blob_to_per_room() {
                         Ok(_) => {
                             clear_legacy_migration_in_progress();
                             mark_legacy_migration_done();
+                            // freenet/river#397: the blob explosion completed —
+                            // the migration has resolved.
+                            set_rooms_load_state(RoomsLoadState::Loaded);
                         }
                         Err(e) => {
                             error!("Failed to explode single blob into per-room keys: {}", e);
                             // Leave the in-progress flag set — next load re-runs.
+                            // The rooms are already hydrated (room_count > 0), so
+                            // the list renders regardless of the load-state value.
                         }
                     }
                 });
@@ -861,11 +883,17 @@ async fn migrate_current_blob_to_per_room() {
             // do NOT touch the in-progress flag — if a prior migration left it
             // set, the next session re-runs recovery, and the already-loaded
             // per-room keys remain intact regardless.
-            Err(e) => error!("Failed to deserialize current-delegate rooms blob: {}", e),
+            Err(e) => {
+                error!("Failed to deserialize current-delegate rooms blob: {}", e);
+                // freenet/river#397: nothing loadable from this blob — resolve so
+                // the rail doesn't spin forever on an unparseable snapshot.
+                set_rooms_load_state(RoomsLoadState::Loaded);
+            }
         },
         Ok(_) => {
             // Index listed rooms_data but the value is gone — treat as empty.
-            fire_legacy_migration_request().await;
+            let fired = fire_legacy_migration_request().await;
+            set_rooms_load_state(load_state_after_probe_legacy(fired));
         }
         Err(e) => warn!("Failed to read current-delegate rooms blob: {}", e),
     }
@@ -996,6 +1024,16 @@ fn schedule_subscription_timeout_check() {
 /// `flags.subscriptions_initiated`). Holds no `self`/`flags`, so it is callable
 /// from a spawned task as well as the synchronous message-loop arm.
 fn hydrate_loaded_rooms(loaded_rooms: Rooms, is_legacy_delegate: bool) -> bool {
+    // freenet/river#397: a legacy-delegate response means we found the user's
+    // rooms under an OLD delegate key and are about to migrate them (Ivvor's
+    // case). Announce `Migrating` BEFORE the ROOMS merge below (which is
+    // deferred) so a re-render lands on the "Migrating…" state ahead of the list
+    // filling. The current-delegate path (is_legacy_delegate == false) is not a
+    // migration and sets its own resolved state at the call site.
+    if is_legacy_delegate {
+        set_rooms_load_state(RoomsLoadState::Migrating);
+    }
+
     // Tombstone filter for all downstream loops.
     // Includes both: (a) tombstones in the
     // incoming loaded_rooms, and (b) tombstones
@@ -1410,10 +1448,14 @@ fn hydrate_loaded_rooms(loaded_rooms: Rooms, is_legacy_delegate: bool) -> bool {
                     info!("Successfully migrated room data to new delegate");
                     clear_legacy_migration_in_progress();
                     mark_legacy_migration_done();
+                    // freenet/river#397: migration concluded — resolve the load.
+                    set_rooms_load_state(RoomsLoadState::Loaded);
                 }
                 Err(e) => {
                     error!("Failed to migrate room data to new delegate: {}", e);
                     // Leave the in-progress flag set — the next load re-fills.
+                    // The migrated rooms are already hydrated (room_count > 0),
+                    // so the list renders regardless of the load-state value.
                 }
             }
         });

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -758,7 +758,13 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
                         None
                     }
                     Err(e) => {
+                        // freenet/river#397 Codex review 9 (send-side audit): a
+                        // rooms_meta send returning Err is a transport failure
+                        // (connection down — the per-room slot GETs on the same
+                        // connection would fail too). Mark it so the load resolves
+                        // to LoadFailed rather than a silent Empty.
                         error!("Failed to load rooms_meta: {}", e);
+                        worker.mark_fetch_failure();
                         None
                     }
                 }
@@ -1106,7 +1112,15 @@ async fn migrate_legacy_per_room(legacy_key: DelegateKey, keys: Vec<ChatDelegate
             Ok(ChatDelegateResponseMsg::GetResponse {
                 value: Some(bytes), ..
             }) => from_reader::<RoomsMeta, _>(&bytes[..]).ok(),
-            _ => None,
+            // A transport Err on the legacy meta send is a connection failure
+            // (the slot GETs on the same connection fail too) — mark it (review 9
+            // send-side audit); a definitive Ok(None) is a legitimate skip.
+            Err(e) => {
+                error!("Failed to load legacy rooms_meta: {}", e);
+                worker.mark_fetch_failure();
+                None
+            }
+            Ok(_) => None,
         }
     } else {
         None
@@ -2095,6 +2109,39 @@ mod tests {
         }
     }
 
+    /// freenet/river#397 Codex review 9 (send-side audit): a `rooms_meta` GET whose
+    /// SEND returns Err is a transport failure (the same connection the per-room
+    /// slot GETs use), so it routes to `worker.mark_fetch_failure()` — both the
+    /// current-delegate and legacy meta arms — rather than a silent skip.
+    #[test]
+    fn meta_get_transport_failure_marks_fetch_failure() {
+        let src = include_str!("response_handler.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+
+        // Current-delegate meta arm.
+        let cur = production
+            .find("Failed to load rooms_meta")
+            .expect("current rooms_meta error marker must exist");
+        let cur_arm = &production[cur..(cur + 400).min(production.len())];
+        assert!(
+            cur_arm.contains("worker.mark_fetch_failure()"),
+            "a current rooms_meta send-Err must mark_fetch_failure (transport failure)"
+        );
+
+        // Legacy meta arm.
+        let leg = production
+            .find("Failed to load legacy rooms_meta")
+            .expect("legacy rooms_meta error marker must exist");
+        let leg_arm = &production[leg..(leg + 400).min(production.len())];
+        assert!(
+            leg_arm.contains("worker.mark_fetch_failure()"),
+            "a legacy rooms_meta send-Err must mark_fetch_failure (transport failure)"
+        );
+    }
+
     /// freenet/river#397 Codex review 3: in `migrate_current_blob_to_per_room`,
     /// suppress-under-recovery applies ONLY to a DOWNGRADE (the value-gone
     /// `load_state_after_probe_legacy` write, which could push a resolved `Loaded`
@@ -2228,14 +2275,15 @@ mod tests {
              the all-empty case must NOT write Loaded (Codex review 3 — not authoritative)"
         );
 
-        // freenet/river#397 Codex review 4: a failed legacy slot fetch records the
-        // global SAW_FETCH_FAILURE (transport Err + unparseable-slot Err) so the
-        // backstop resolves to LoadFailed rather than a false Empty — but NOT a
+        // freenet/river#397 Codex review 4/9: a failed legacy fetch records the
+        // global SAW_FETCH_FAILURE — the slot transport-Err, the unparseable-slot
+        // Err, AND the meta-GET transport Err (review 9 send-side audit) — so the
+        // backstop resolves to LoadFailed rather than a false Empty; NOT a
         // `value: None` skip.
         assert_eq!(
             body.matches("mark_fetch_failure()").count(),
-            2,
-            "the legacy transport-Err and unparseable-slot arms must mark_fetch_failure"
+            3,
+            "the legacy slot transport-Err, unparseable-slot Err, and meta-GET Err arms must mark_fetch_failure"
         );
         let value_none_pos = body
             .find("listed but value missing")

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -1092,7 +1092,23 @@ async fn migrate_legacy_per_room(legacy_key: DelegateKey, keys: Vec<ChatDelegate
                     worker.mark_fetch_failure();
                 }
             },
-            Ok(_) => warn!("Legacy room key {:?} listed but value missing", vk),
+            Ok(ChatDelegateResponseMsg::GetResponse { value: None, .. }) => {
+                // Definitive "no value for this key" — a legitimate skip, NOT a
+                // fetch failure.
+                warn!("Legacy room key {:?} listed but value missing", vk);
+            }
+            Ok(other) => {
+                // An unexpected response variant (e.g. a delegate protocol
+                // mismatch) is a fetch failure, NOT a definitive missing value —
+                // mirror the current-delegate per-room path (review 10 P2#2), or a
+                // listed room silently fails to materialize and the idle resolver
+                // shows a false Empty.
+                error!(
+                    "Unexpected response loading legacy room {:?}: {:?}",
+                    vk, other
+                );
+                worker.mark_fetch_failure();
+            }
             Err(e) => {
                 error!("Failed to load legacy room {:?}: {}", vk, e);
                 worker.mark_fetch_failure();
@@ -2275,23 +2291,57 @@ mod tests {
              the all-empty case must NOT write Loaded (Codex review 3 — not authoritative)"
         );
 
-        // freenet/river#397 Codex review 4/9: a failed legacy fetch records the
+        // freenet/river#397 Codex review 4/9/10: a failed legacy fetch records the
         // global SAW_FETCH_FAILURE — the slot transport-Err, the unparseable-slot
-        // Err, AND the meta-GET transport Err (review 9 send-side audit) — so the
-        // backstop resolves to LoadFailed rather than a false Empty; NOT a
-        // `value: None` skip.
+        // Err, the unexpected-variant `Ok(other)` arm (review 10 P2#2), AND the
+        // meta-GET transport Err (review 9) — so the backstop resolves to
+        // LoadFailed rather than a false Empty; NOT a `value: None` skip.
         assert_eq!(
             body.matches("mark_fetch_failure()").count(),
-            3,
-            "the legacy slot transport-Err, unparseable-slot Err, and meta-GET Err arms must mark_fetch_failure"
+            4,
+            "legacy slot transport-Err, unparseable-slot Err, Ok(other), and meta-GET Err arms must mark"
         );
+        // The `value: None` arm (definitive missing value) is a legitimate skip,
+        // NOT a fetch failure. Bound the window to that arm alone (the adjacent
+        // `Ok(other)` arm DOES mark).
         let value_none_pos = body
             .find("listed but value missing")
             .expect("legacy value: None arm must exist");
-        let after_none = &body[value_none_pos..(value_none_pos + 120).min(body.len())];
+        let after_none = &body[value_none_pos..(value_none_pos + 55).min(body.len())];
         assert!(
             !after_none.contains("mark_fetch_failure()"),
             "a legacy `value: None` is a legitimate skip, not a fetch failure"
+        );
+    }
+
+    /// freenet/river#397 Codex review 10 (P2#2): the legacy per-slot GET match
+    /// must split the catch-all — an unexpected response variant (`Ok(other)`,
+    /// e.g. a delegate protocol mismatch) is a fetch failure (marks), mirroring
+    /// the current-delegate path; only a definitive `value: None` is a clean skip.
+    #[test]
+    fn legacy_per_slot_unexpected_variant_marks_fetch_failure() {
+        let src = include_str!("response_handler.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+        // Slice the legacy per-slot loop (marker → the `let meta` that follows it).
+        let loop_start = production
+            .find("Migrating {} per-room slot(s) from legacy delegate")
+            .expect("legacy fetch loop marker must exist");
+        let loop_end = production[loop_start..]
+            .find("let meta = if has_meta")
+            .map(|i| loop_start + i)
+            .expect("the legacy loop must be followed by the meta load");
+        let loop_region = &production[loop_start..loop_end];
+        // The unexpected-variant arm exists and marks.
+        let other_pos = loop_region
+            .find("Unexpected response loading legacy room")
+            .expect("legacy per-slot Ok(other) arm must exist");
+        let other_arm = &loop_region[other_pos..(other_pos + 150).min(loop_region.len())];
+        assert!(
+            other_arm.contains("worker.mark_fetch_failure()"),
+            "a legacy per-slot Ok(other) (unexpected variant) must mark_fetch_failure"
         );
     }
 

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -17,8 +17,7 @@ use crate::components::app::chat_delegate::{
     is_legacy_migration_in_progress, legacy_scoped_correlation, load_state_after_probe_legacy,
     mark_legacy_migration_done, mark_legacy_migration_in_progress, parse_room_storage_key,
     prune_outbound_dms_for_purges, room_storage_key, save_outbound_dms_to_delegate,
-    save_rooms_to_delegate, schedule_rooms_load_backstop, send_delegate_request,
-    send_delegate_request_to, set_rooms_load_state, should_resolve_per_room_load,
+    save_rooms_to_delegate, send_delegate_request, send_delegate_request_to, set_rooms_load_state,
     LegacyMigrationAction, RoomsLoadState, OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY,
     ROOMS_STORAGE_KEY,
 };
@@ -618,19 +617,12 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
     match plan_load_from_keys(&keys) {
         LoadPlan::ProbeLegacy => {
             info!("Current delegate has no room data — firing legacy migration probe");
-            // freenet/river#397: stay `Loading` while a dispatched probe might
-            // still yield a migration; resolve to `Loaded` only if the probe was
-            // skipped (nothing is coming). A brand-new user whose probe finds
-            // nothing is caught by the timeout backstop, never a perpetual spinner.
+            // freenet/river#397: stay `Loading` while a dispatched fire-and-forget
+            // probe might still yield a migration; resolve to `Loaded` only if the
+            // probe was skipped (nothing is coming — the fast path for a returning
+            // empty user). The universal backstop (armed in `set_up_chat_delegate`)
+            // guarantees termination if the probe finds nothing.
             let fired = fire_legacy_migration_request().await;
-            if fired {
-                // P2-1 (Codex review): arm the backstop ONLY here — a
-                // fire-and-forget probe has no synchronous completion signal. By
-                // now the authoritative current-delegate load already returned
-                // empty (this is the ProbeLegacy classification), so the backstop
-                // can no longer clobber an in-flight authoritative load.
-                schedule_rooms_load_backstop();
-            }
             set_rooms_load_state(load_state_after_probe_legacy(fired));
         }
         LoadPlan::MigrateCurrentBlob => {
@@ -666,14 +658,6 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
             // passes every room still lands in ROOMS. (Load-vs-SAVE never
             // collides — those use distinct prefixed correlation keys.)
             info!("Loading {} per-room slot(s) from delegate", room_vks.len());
-            // freenet/river#397 Codex review (P2-2): the index PROVED these rooms
-            // exist. If every listed room fails to materialize, the assembled map
-            // is empty — but resolving to Empty would render "no rooms yet" for a
-            // user who provably HAS rooms. Track whether a listed room failed to
-            // fetch (transport / parse error — NOT a definitive `value: None`) so
-            // the resolve decision below can stay `Loading` in that case.
-            let listed_count = room_vks.len();
-            let mut had_fetch_error = false;
             let mut slots: Vec<(ed25519_dalek::VerifyingKey, RoomSlot)> = Vec::new();
             for vk in room_vks {
                 match send_delegate_request(ChatDelegateRequestMsg::GetRequest {
@@ -685,27 +669,14 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
                         value: Some(bytes), ..
                     }) => match from_reader::<RoomSlot, _>(&bytes[..]) {
                         Ok(slot) => slots.push((vk, slot)),
-                        Err(e) => {
-                            // A listed room whose slot won't parse failed to
-                            // materialize — count it as a fetch error.
-                            error!("Unparseable room slot for {:?}: {}", vk, e);
-                            had_fetch_error = true;
-                        }
+                        Err(e) => error!("Unparseable room slot for {:?}: {}", vk, e),
                     },
                     Ok(ChatDelegateResponseMsg::GetResponse { value: None, .. }) => {
-                        // Listed in the index but the value is gone — a DEFINITIVE
-                        // "no value for this key", a legitimate skip, NOT a fetch
-                        // failure (do not set had_fetch_error).
+                        // Listed in the index but the value is gone — skip it.
                         warn!("Room key {:?} listed but value missing", vk);
                     }
-                    Ok(other) => {
-                        error!("Unexpected response loading room {:?}: {:?}", vk, other);
-                        had_fetch_error = true;
-                    }
-                    Err(e) => {
-                        error!("Failed to load room {:?}: {}", vk, e);
-                        had_fetch_error = true;
-                    }
+                    Ok(other) => error!("Unexpected response loading room {:?}: {:?}", vk, other),
+                    Err(e) => error!("Failed to load room {:?}: {}", vk, e),
                 }
             }
 
@@ -738,44 +709,21 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
             };
 
             let loaded = reconstruct_rooms(slots, meta);
-            // Capture emptiness BEFORE `loaded` is moved into hydrate, for the
-            // resolve decision below (freenet/river#397 P2-2).
-            let loaded_map_empty = loaded.map.is_empty();
             if hydrate_loaded_rooms(loaded, false) {
                 schedule_subscription_timeout_check();
             }
 
-            // freenet/river#397: the current delegate's per-room set is the
-            // authoritative initial load. Resolve to `Loaded` on a DEFINITIVE
-            // answer — rooms (if any) render as the list; a genuinely empty /
-            // all-`value: None` set renders the calm empty state. Set BEFORE the
-            // recovery re-run below so an armed recovery's `Migrating` (set inside
-            // `migrate_current_blob_to_per_room`) wins.
-            //
-            // P2-2 (Codex review): but if the load came back EMPTY while the index
-            // listed rooms AND a listed room failed to fetch, DO NOT resolve —
-            // leave the state `Loading` (the honest spinner). We KNOW rooms exist,
-            // so a WS reconnect re-fires `ListRequest` and retries; flashing "no
-            // rooms yet" here would be the feature's own worst failure mode. The
-            // backstop is deliberately NOT armed on this path (arming it would
-            // flip the spinner to Empty and defeat the fix).
-            //
-            // P2 (Codex review 2): likewise do NOT resolve when a migration
-            // recovery is armed (`action.recover`) and the map is empty — the
-            // in-progress flag says rooms may be stranded, and the recovery re-run
-            // below fires the legacy probe / sets `Migrating` if it finds them.
-            // Its terminal: the recovery arms the backstop when it fires the probe
-            // (see `migrate_current_blob_to_per_room`'s value-gone arm), so a
-            // recovery that finds nothing still resolves to `Loaded` rather than
-            // spinning forever.
-            if should_resolve_per_room_load(
-                loaded_map_empty,
-                listed_count,
-                had_fetch_error,
-                action.recover,
-            ) {
-                set_rooms_load_state(RoomsLoadState::Loaded);
-            }
+            // freenet/river#397 (Codex review 3): the current delegate's per-room
+            // set is the authoritative initial load — a definitive fast-path
+            // completion, so resolve to `Loaded`. Rooms (if any) render as the
+            // list; a genuinely empty set renders the calm empty state. A rare
+            // all-fetch-fail (the current delegate is the local node's store, so
+            // this is unlikely) shows Empty; the universal 30s backstop is the
+            // termination guarantee for any non-definitive path, so we no longer
+            // hold `Loading` here (that couldn't guarantee termination). Set BEFORE
+            // the recovery re-run below so a recovery that finds stranded rooms and
+            // sets `Migrating` wins over this `Loaded`.
+            set_rooms_load_state(RoomsLoadState::Loaded);
 
             // Recover from an interrupted migration by re-running it to pick up
             // any room whose per-room key wasn't written before the previous
@@ -939,61 +887,47 @@ async fn migrate_current_blob_to_per_room(recovery: bool) {
                         Ok(_) => {
                             clear_legacy_migration_in_progress();
                             mark_legacy_migration_done();
-                            // freenet/river#397: the blob explosion completed —
-                            // the migration has resolved.
-                            if !recovery {
-                                set_rooms_load_state(RoomsLoadState::Loaded);
-                            }
+                            // freenet/river#397 (Codex review 3): the blob explosion
+                            // COMPLETED — a completion, so resolve to `Loaded` even
+                            // under recovery. Only a DOWNGRADE (the value-gone
+                            // Loading re-fire below) is `!recovery`-suppressed.
+                            set_rooms_load_state(RoomsLoadState::Loaded);
                         }
                         Err(e) => {
                             error!("Failed to explode single blob into per-room keys: {}", e);
-                            // freenet/river#397 (review): a zero-live-room migration
-                            // (e.g. an all-tombstone blob) leaves room_count == 0, so
-                            // a save error must STILL resolve the load — otherwise the
-                            // rail spins on "Migrating…" forever (the backstop only
-                            // rescues `Loading`, not `Migrating`). Leave the
-                            // in-progress flag set so the next load re-runs the fill.
-                            if !recovery {
-                                set_rooms_load_state(RoomsLoadState::Loaded);
-                            }
+                            // freenet/river#397: a definitive failure is also a
+                            // completion — resolve to `Loaded` (even under recovery)
+                            // so a zero-live-room migration never strands on
+                            // "Migrating…". Leave the in-progress flag set so the
+                            // next load re-runs the fill.
+                            set_rooms_load_state(RoomsLoadState::Loaded);
                         }
                     }
                 });
             }
             // A corrupt current-delegate blob is unparseable; retrying won't
-            // help, so do nothing here. We intentionally do NOT mark migration
-            // done (a corrupt blob is not proof there's nothing to migrate) and
-            // do NOT touch the in-progress flag — if a prior migration left it
-            // set, the next session re-runs recovery, and the already-loaded
-            // per-room keys remain intact regardless.
+            // help. We intentionally do NOT mark migration done (a corrupt blob is
+            // not proof there's nothing to migrate) and do NOT touch the
+            // in-progress flag — if a prior migration left it set, the next session
+            // re-runs recovery, and the already-loaded per-room keys remain intact.
             Err(e) => {
                 error!("Failed to deserialize current-delegate rooms blob: {}", e);
-                // freenet/river#397: nothing loadable from this blob — resolve so
-                // the rail doesn't spin forever on an unparseable snapshot.
-                if !recovery {
-                    set_rooms_load_state(RoomsLoadState::Loaded);
-                }
+                // A definitive terminal (can't parse) is a completion — resolve to
+                // `Loaded` even under recovery so the rail doesn't spin on an
+                // unparseable snapshot.
+                set_rooms_load_state(RoomsLoadState::Loaded);
             }
         },
         Ok(_) => {
             // Index listed rooms_data but the value is gone — treat as empty.
             let fired = fire_legacy_migration_request().await;
-            // Arm the backstop whenever a fire-and-forget probe was fired (P2-1) —
-            // NOT gated on `!recovery`. The backstop rescues ONLY `Loading`
-            // (`backstop_resolve`), so on the initial load, when the state already
-            // resolved to `Loaded`/`List`, it is a no-op; but a recovery re-run
-            // that legitimately kept the state `Loading` (an interrupted-migration
-            // empty-map load, freenet/river#397 review 2 P2) needs this as its
-            // terminal — otherwise a recovery that finds no legacy rooms spins on
-            // the honest spinner forever (invariant 2).
-            if fired {
-                schedule_rooms_load_backstop();
-            }
-            // The STATE write stays gated on `!recovery`: under recovery,
-            // `load_state_after_probe_legacy(true)` would downgrade a resolved
-            // `Loaded` (the non-empty-map recovery case) back to `Loading`. The
-            // empty-map recovery case is already `Loading`, so the backstop above
-            // resolves it; the non-empty case must not be touched here.
+            // The STATE write stays gated on `!recovery` — this is the ONE
+            // DOWNGRADE write in this function: under recovery,
+            // `load_state_after_probe_legacy(true)` would push a resolved `Loaded`
+            // (the non-empty-map recovery case) back to `Loading`. On the initial
+            // load it is a legitimate fast-path (`Loaded` when the probe was
+            // skipped, `Loading` when it fired). The universal backstop (armed in
+            // `set_up_chat_delegate`) guarantees termination for the fired case.
             if !recovery {
                 set_rooms_load_state(load_state_after_probe_legacy(fired));
             }
@@ -1080,14 +1014,13 @@ async fn migrate_legacy_per_room(legacy_key: DelegateKey, keys: Vec<ChatDelegate
     };
 
     if slots.is_empty() {
-        // Every listed legacy slot failed to fetch or came back empty — there is
-        // nothing to hydrate, so `Migrating` (set above) has no re-save terminal
-        // to resolve it. Conclude to `Loaded` here so the rail doesn't strand on
-        // "Migrating…" forever (freenet/river#397 Codex review 2, invariant 2). A
-        // fresh session re-probes the legacy delegate (LEGACY_MIGRATION_ATTEMPTED
-        // resets per session, and this path never marked migration done), so this
-        // is a resolved terminal, not permanent data loss.
-        set_rooms_load_state(RoomsLoadState::Loaded);
+        // Every listed legacy slot failed to fetch or came back empty. Do NOT
+        // write the global load state here (freenet/river#397 Codex review 3): a
+        // single legacy delegate finding nothing is NOT authoritative — other
+        // concurrent legacy probes may still have rooms, and writing `Loaded` from
+        // one empty probe could stomp a peer probe that is mid-`Migrating`. The
+        // universal 30s backstop resolves the all-nothing case; a probe that DOES
+        // find rooms sets `Migrating` and hydrates (`room_count > 0` → `List`).
         return;
     }
 
@@ -1975,13 +1908,14 @@ mod tests {
         );
     }
 
-    /// freenet/river#397 review (MINOR): a background interrupted-migration
-    /// recovery re-run must NEVER downgrade a resolved `Loaded` back to `Loading`.
-    /// `migrate_current_blob_to_per_room` takes a `recovery: bool`, and its
-    /// no-current-blob `fire_legacy_migration_request` path (which returns `true`
-    /// after recovery re-armed the attempt guard, so `load_state_after_probe_legacy`
-    /// would yield `Loading`) MUST guard that write on `!recovery`. Pin both the
-    /// signature and the guard so the suppression can't silently regress.
+    /// freenet/river#397 Codex review 3: in `migrate_current_blob_to_per_room`,
+    /// suppress-under-recovery applies ONLY to a DOWNGRADE (the value-gone
+    /// `load_state_after_probe_legacy` write, which could push a resolved `Loaded`
+    /// back to `Loading`). A save COMPLETION (Ok or Err → `Loaded`) must resolve
+    /// EVEN under recovery — otherwise a recovery whose save completes leaves the
+    /// rail stuck. Pin: (a) the signature threads `recovery`; (b) the value-gone
+    /// downgrade write is `!recovery`-guarded; (c) the save-completion closure
+    /// resolves `Loaded` WITHOUT a `!recovery` guard.
     #[test]
     fn recovery_re_run_never_downgrades_load_state_to_loading() {
         let src = include_str!("response_handler.rs");
@@ -1993,7 +1927,7 @@ mod tests {
         assert!(
             production.contains("async fn migrate_current_blob_to_per_room(recovery: bool)"),
             "migrate_current_blob_to_per_room must thread a `recovery` flag so a \
-             background re-fill can suppress its display-state writes"
+             background re-fill can suppress only its DOWNGRADE write"
         );
         // The initial (state-owning) caller passes false; the recovery caller
         // passes true (the latter is also pinned by
@@ -2015,106 +1949,51 @@ mod tests {
             .map(|i| fn_start + 1 + i)
             .unwrap_or(production.len());
         let body = &production[fn_start..fn_end];
-        // The value-gone probe-legacy write — the ONLY one that could yield
-        // `Loading` — must be guarded on `!recovery`.
+
+        // (b) the value-gone probe-legacy write — the ONLY downgrade — is
+        // `!recovery`-guarded, directly enclosed by the guard (same block).
         let write_pos = body
             .find("set_rooms_load_state(load_state_after_probe_legacy(fired))")
             .expect("the value-gone branch must write via load_state_after_probe_legacy");
-        // The `if !recovery {` guard must directly enclose the write (same block).
-        // Its enclosing block also arms the backstop (`if fired { … }`) before the
-        // write, so allow for that intervening block — an UNguarded write would put
-        // the nearest `if !recovery {` far earlier (a different arm), not ~150 back.
         let guard_pos = body[..write_pos]
             .rfind("if !recovery {")
-            .expect("migrate_current_blob_to_per_room must guard its writes on !recovery");
+            .expect("the value-gone downgrade write must be guarded on !recovery");
         assert!(
-            write_pos - guard_pos < 250,
-            "the value-gone probe-legacy write must be inside the `if !recovery` block \
-             so a background recovery never downgrades a resolved Loaded to Loading"
+            write_pos - guard_pos < 120,
+            "the value-gone probe-legacy write must be DIRECTLY inside the `if !recovery` \
+             block so a background recovery never downgrades a resolved Loaded to Loading"
+        );
+
+        // (c) the save-completion closure resolves `Loaded` WITHOUT a `!recovery`
+        // guard — a completion must resolve even under recovery (Codex review 3).
+        let save_pos = body
+            .find("match save_rooms_to_delegate().await {")
+            .expect("the blob-explosion save closure must exist");
+        // Bound to the closure body (up to the corrupt-blob `Err(e) =>` arm that
+        // follows the spawn).
+        let save_end = body[save_pos..]
+            .find("A corrupt current-delegate blob")
+            .map(|i| save_pos + i)
+            .unwrap_or(body.len());
+        let save_closure = &body[save_pos..save_end];
+        assert!(
+            save_closure.contains("set_rooms_load_state(RoomsLoadState::Loaded)"),
+            "the save-completion arms must resolve to Loaded"
+        );
+        assert!(
+            !save_closure.contains("if !recovery"),
+            "a save COMPLETION must resolve Loaded even under recovery — only the \
+             value-gone DOWNGRADE is !recovery-guarded (Codex review 3)"
         );
     }
 
-    /// freenet/river#397 Codex review (P2-2): the PerRoom load must NOT resolve
-    /// to Empty when the index listed rooms but their fetches failed. Pin the
-    /// wiring: (a) the per-room `Loaded` write is guarded by the pure
-    /// `should_resolve_per_room_load(...)` decision (unit-tested in
-    /// chat_delegate.rs), and (b) the fetch-failure arms set `had_fetch_error`.
-    /// The pure helper is the primary coverage; this pin guards against the
-    /// helper being computed-but-ignored or the failure arms silently not
-    /// flagging an error.
-    #[test]
-    fn per_room_load_failure_does_not_resolve_to_empty() {
-        let src = include_str!("response_handler.rs");
-        let production = src
-            .split("mod tests {")
-            .next()
-            .expect("production code before `mod tests`");
-
-        // (a) the PerRoom `Loaded` write is gated on the pure decision.
-        let write_pos = production
-            .find("set_rooms_load_state(RoomsLoadState::Loaded)")
-            .expect("a per-room Loaded write must exist");
-        let guard_pos = production[..write_pos]
-            .rfind("should_resolve_per_room_load(")
-            .expect("the PerRoom Loaded write must be guarded by should_resolve_per_room_load");
-        assert!(
-            write_pos - guard_pos < 300,
-            "the PerRoom Loaded write must be directly gated by should_resolve_per_room_load, \
-             so a failed all-empty load stays Loading instead of flashing Empty"
-        );
-        // The call must be fed all four inputs, including `action.recover` (the
-        // interrupted-migration recovery flag, Codex review 2 P2) — the args live
-        // between the call open-paren and the gated write.
-        let call_args = &production[guard_pos..write_pos];
-        for arg in [
-            "loaded_map_empty",
-            "listed_count",
-            "had_fetch_error",
-            "action.recover",
-        ] {
-            assert!(
-                call_args.contains(arg),
-                "the resolve decision must be fed `{arg}` (map_empty, listed_count, \
-                 had_fetch_error, recovering)"
-            );
-        }
-
-        // (b) the fetch-failure arms flag the error so the decision can see it.
-        // Bound the search to the per-room fetch loop (marker → the `let meta`
-        // that immediately follows it) so we count exactly the per-room arms.
-        let loop_start = production
-            .find("Loading {} per-room slot(s) from delegate")
-            .expect("per-room fetch loop marker must exist");
-        let loop_end = production[loop_start..]
-            .find("let meta = if has_meta")
-            .map(|i| loop_start + i)
-            .expect("the per-room loop must be followed by the meta load");
-        let loop_region = &production[loop_start..loop_end];
-        let error_flags = loop_region.matches("had_fetch_error = true;").count();
-        assert!(
-            error_flags >= 3,
-            "the transport-Err, unexpected-response, and unparseable-slot arms must each \
-             set had_fetch_error (found {error_flags})"
-        );
-        // The definitive value-absent arm must NOT be counted as a fetch error.
-        let value_none_pos = loop_region
-            .find("listed but value missing")
-            .expect("the value: None arm must exist");
-        let after_value_none =
-            &loop_region[value_none_pos..(value_none_pos + 120).min(loop_region.len())];
-        assert!(
-            !after_value_none.contains("had_fetch_error = true;"),
-            "a definitive `value: None` is a legitimate skip, not a fetch error"
-        );
-    }
-
-    /// freenet/river#397 Codex review 2 (P1): `migrate_legacy_per_room` fetches
-    /// each legacy slot sequentially and only sets `Migrating` (via hydrate) at
+    /// freenet/river#397 Codex review 3 (P1): `migrate_legacy_per_room` fetches
+    /// each legacy slot sequentially and hydrates (which sets `Migrating`) only at
     /// the end. Without an early `Migrating`, the whole fetch window sits at
-    /// `Loading`, so the 20s backstop could flip it to Empty despite the legacy
-    /// index proving rooms exist. Pin that it sets `Migrating` BEFORE the fetch
-    /// loop, and that the all-fetches-empty early return has a `Loaded` terminal
-    /// (invariant 2 — no stranded `Migrating`).
+    /// `Loading`, so the backstop could flip it to Empty despite the legacy index
+    /// proving rooms exist. Pin that it sets `Migrating` BEFORE the fetch loop.
+    /// (It must NOT write `Loaded` on the all-empty early return — a single legacy
+    /// probe is not authoritative; the universal backstop resolves that case.)
     #[test]
     fn migrate_legacy_per_room_shows_migrating_before_fetch_loop() {
         let src = include_str!("response_handler.rs");
@@ -2126,9 +2005,14 @@ mod tests {
         let fn_start = production
             .find("async fn migrate_legacy_per_room(")
             .expect("migrate_legacy_per_room must exist");
-        let body_after_sig = &production[fn_start + 1..];
-        let fn_end = body_after_sig
-            .find("\nasync fn ")
+        // Bound at the NEAREST next top-level item — `migrate_legacy_per_room` is
+        // followed by a plain `fn` (`hydrate_loaded_rooms`), so bounding only on
+        // `async fn` would over-run and pick up hydrate's load-state writes.
+        let rest = &production[fn_start + 1..];
+        let fn_end = [rest.find("\nasync fn "), rest.find("\nfn ")]
+            .into_iter()
+            .flatten()
+            .min()
             .map(|i| fn_start + 1 + i)
             .unwrap_or(production.len());
         let body = &production[fn_start..fn_end];
@@ -2146,14 +2030,14 @@ mod tests {
              a known-non-empty legacy load to Empty mid-fetch"
         );
 
-        // The all-fetches-empty early return concludes to `Loaded` (invariant 2).
-        let empty_ret = body
-            .find("if slots.is_empty()")
-            .expect("migrate_legacy_per_room must handle the empty-slots case");
-        let empty_block = &body[empty_ret..(empty_ret + 700).min(body.len())];
-        assert!(
-            empty_block.contains("set_rooms_load_state(RoomsLoadState::Loaded)"),
-            "the all-fetches-empty early return must resolve to Loaded, not strand Migrating"
+        // A single legacy probe finding nothing is NOT authoritative — it must NOT
+        // write the global load state (concurrent probes may hold rooms). The only
+        // load-state write in this function is the `Migrating` above.
+        assert_eq!(
+            body.matches("set_rooms_load_state(").count(),
+            1,
+            "migrate_legacy_per_room must write the load state exactly once (Migrating); \
+             the all-empty case must NOT write Loaded (Codex review 3 — not authoritative)"
         );
     }
 

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -18,8 +18,8 @@ use crate::components::app::chat_delegate::{
     mark_fetch_failure, mark_legacy_migration_done, mark_legacy_migration_in_progress,
     parse_room_storage_key, per_room_terminal, prune_outbound_dms_for_purges, room_storage_key,
     save_outbound_dms_to_delegate, save_rooms_to_delegate, send_delegate_request,
-    send_delegate_request_to, set_rooms_load_state, LegacyMigrationAction, RoomsLoadState,
-    OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY, ROOMS_STORAGE_KEY,
+    send_delegate_request_to, set_rooms_load_state, LegacyMigrationAction, LoadWorkerGuard,
+    RoomsLoadState, OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY, ROOMS_STORAGE_KEY,
 };
 use crate::components::app::document_title::{mark_current_room_as_read, update_document_title};
 use crate::components::app::notifications::mark_initial_sync_complete;
@@ -345,6 +345,16 @@ impl ResponseHandler {
                                                             }
                                                         }
 
+                                                        // Progress-tracked
+                                                        // termination
+                                                        // (freenet/river#397
+                                                        // review 6): the legacy
+                                                        // single-blob hydrate is a
+                                                        // load worker. The guard
+                                                        // bumps activity (cancels a
+                                                        // pending idle resolution)
+                                                        // and, on drop, settles.
+                                                        let _worker = LoadWorkerGuard::new();
                                                         if hydrate_loaded_rooms(
                                                             loaded_rooms,
                                                             is_legacy_delegate,
@@ -626,6 +636,12 @@ impl ResponseHandler {
 ///   WASM-key migration path), exactly as the old empty-`rooms_data` GetResponse
 ///   did.
 async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
+    // Progress-tracked termination (freenet/river#397 review 6): this awaited
+    // worker holds a guard for its whole lifetime, so on EVERY exit path the
+    // settled-handler re-evaluates whether the load is complete. For the
+    // ProbeLegacy case the guard drop is exactly the "fired the fire-and-forget
+    // probe and became quiescent" point that arms the idle timer.
+    let _worker = LoadWorkerGuard::new();
     match plan_load_from_keys(&keys) {
         LoadPlan::ProbeLegacy => {
             info!("Current delegate has no room data — firing legacy migration probe");
@@ -891,6 +907,8 @@ fn reconstruct_rooms(
 /// re-fires). Any real migration the recovery triggers still shows `Migrating`
 /// via the legacy `hydrate_loaded_rooms` path, which is not gated here.
 async fn migrate_current_blob_to_per_room(recovery: bool) {
+    // Progress-tracked termination (freenet/river#397 review 6): awaited worker.
+    let _worker = LoadWorkerGuard::new();
     match send_delegate_request(ChatDelegateRequestMsg::GetVersionedRequest {
         key: ChatDelegateKey::new(ROOMS_STORAGE_KEY.to_vec()),
     })
@@ -1008,6 +1026,13 @@ async fn migrate_current_blob_to_per_room(recovery: bool) {
 /// single-blob legacy format + `outbound_dms` are still handled by the fixed
 /// probes, so this only acts when the legacy delegate actually has per-room keys.
 async fn migrate_legacy_per_room(legacy_key: DelegateKey, keys: Vec<ChatDelegateKey>) {
+    // Progress-tracked termination (freenet/river#397 review 6): a legacy probe
+    // that responded is an active worker. Holding the guard for the whole
+    // function (including the empty-index early return) keeps the load alive
+    // while this delegate is being processed, and cancels any pending idle
+    // resolution (activity-gen bump) so a concurrent empty completion can't
+    // resolve Empty while this one may still bring rooms.
+    let _worker = LoadWorkerGuard::new();
     let (room_vks, has_meta) = match plan_load_from_keys(&keys) {
         LoadPlan::PerRoom { room_vks, has_meta } => (room_vks, has_meta),
         // No per-room keys on this legacy delegate — its single blob (if any) is
@@ -2170,6 +2195,61 @@ mod tests {
         assert!(
             !after_none.contains("mark_fetch_failure()"),
             "a legacy `value: None` is a legitimate skip, not a fetch failure"
+        );
+    }
+
+    /// freenet/river#397 Codex review 6: EVERY awaited load worker must hold a
+    /// `LoadWorkerGuard` so progress-tracked termination sees it start and finish.
+    /// Pin that all four worker sites are wrapped: the current-delegate load, the
+    /// blob migration, each legacy per-room probe, and the legacy single-blob
+    /// hydrate. If a future edit adds a load path without a guard, the counter
+    /// under-counts and the load could resolve prematurely — this fails CI.
+    #[test]
+    fn all_awaited_load_workers_hold_a_guard() {
+        let src = include_str!("response_handler.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+
+        // The four production worker sites each construct a guard.
+        assert_eq!(
+            production.matches("LoadWorkerGuard::new()").count(),
+            4,
+            "exactly four awaited load-worker sites must each hold a LoadWorkerGuard"
+        );
+
+        // Each of the three async worker fns opens with a guard before doing work.
+        for func in [
+            "async fn load_rooms_per_room(",
+            "async fn migrate_current_blob_to_per_room(",
+            "async fn migrate_legacy_per_room(",
+        ] {
+            let fn_start = production
+                .find(func)
+                .unwrap_or_else(|| panic!("{func} must exist"));
+            // The guard must appear within the first ~700 bytes of the body (before
+            // the first awaited request), not somewhere deep after work started.
+            let head = &production[fn_start..(fn_start + 700).min(production.len())];
+            assert!(
+                head.contains("LoadWorkerGuard::new()"),
+                "{func} must hold a LoadWorkerGuard from the top"
+            );
+        }
+
+        // The legacy single-blob GetResponse hydrate call is preceded by a guard
+        // (the 4th site; the other three are the fn heads checked above). Find the
+        // `flags.subscriptions_initiated` hydrate call and confirm a guard is
+        // constructed just before it.
+        let hydrate_call = production
+            .find("flags.subscriptions_initiated = true;")
+            .expect("legacy GetResponse hydrate call must exist");
+        let guard_before = production[..hydrate_call]
+            .rfind("LoadWorkerGuard::new()")
+            .expect("the legacy GetResponse hydrate must be preceded by a guard");
+        assert!(
+            hydrate_call - guard_before < 500,
+            "the legacy single-blob GetResponse hydrate must be wrapped in a LoadWorkerGuard"
         );
     }
 

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -759,7 +759,21 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
             // rooms yet" here would be the feature's own worst failure mode. The
             // backstop is deliberately NOT armed on this path (arming it would
             // flip the spinner to Empty and defeat the fix).
-            if should_resolve_per_room_load(loaded_map_empty, listed_count, had_fetch_error) {
+            //
+            // P2 (Codex review 2): likewise do NOT resolve when a migration
+            // recovery is armed (`action.recover`) and the map is empty — the
+            // in-progress flag says rooms may be stranded, and the recovery re-run
+            // below fires the legacy probe / sets `Migrating` if it finds them.
+            // Its terminal: the recovery arms the backstop when it fires the probe
+            // (see `migrate_current_blob_to_per_room`'s value-gone arm), so a
+            // recovery that finds nothing still resolves to `Loaded` rather than
+            // spinning forever.
+            if should_resolve_per_room_load(
+                loaded_map_empty,
+                listed_count,
+                had_fetch_error,
+                action.recover,
+            ) {
                 set_rooms_load_state(RoomsLoadState::Loaded);
             }
 
@@ -964,16 +978,23 @@ async fn migrate_current_blob_to_per_room(recovery: bool) {
         Ok(_) => {
             // Index listed rooms_data but the value is gone — treat as empty.
             let fired = fire_legacy_migration_request().await;
-            // freenet/river#397 review: under `recovery` this must NOT run —
-            // `load_state_after_probe_legacy(true)` would downgrade the already
-            // resolved `Loaded` back to `Loading`, flashing a spinner (and, if the
-            // once-per-session backstop already fired, sticking there). Outside
-            // recovery, arm the backstop when a fire-and-forget probe was fired
-            // (P2-1) — the same probe-fired condition as the ProbeLegacy arm.
+            // Arm the backstop whenever a fire-and-forget probe was fired (P2-1) —
+            // NOT gated on `!recovery`. The backstop rescues ONLY `Loading`
+            // (`backstop_resolve`), so on the initial load, when the state already
+            // resolved to `Loaded`/`List`, it is a no-op; but a recovery re-run
+            // that legitimately kept the state `Loading` (an interrupted-migration
+            // empty-map load, freenet/river#397 review 2 P2) needs this as its
+            // terminal — otherwise a recovery that finds no legacy rooms spins on
+            // the honest spinner forever (invariant 2).
+            if fired {
+                schedule_rooms_load_backstop();
+            }
+            // The STATE write stays gated on `!recovery`: under recovery,
+            // `load_state_after_probe_legacy(true)` would downgrade a resolved
+            // `Loaded` (the non-empty-map recovery case) back to `Loading`. The
+            // empty-map recovery case is already `Loading`, so the backstop above
+            // resolves it; the non-empty case must not be touched here.
             if !recovery {
-                if fired {
-                    schedule_rooms_load_backstop();
-                }
                 set_rooms_load_state(load_state_after_probe_legacy(fired));
             }
         }
@@ -998,9 +1019,22 @@ async fn migrate_legacy_per_room(legacy_key: DelegateKey, keys: Vec<ChatDelegate
     let (room_vks, has_meta) = match plan_load_from_keys(&keys) {
         LoadPlan::PerRoom { room_vks, has_meta } => (room_vks, has_meta),
         // No per-room keys on this legacy delegate — its single blob (if any) is
-        // handled by the fixed rooms_data probe. Nothing per-room to migrate.
+        // handled by the fixed rooms_data probe. Nothing per-room to migrate, so
+        // do NOT touch the load state here (freenet/river#397 Codex review 2: an
+        // EMPTY legacy index must not show Migrating).
         LoadPlan::MigrateCurrentBlob | LoadPlan::ProbeLegacy => return,
     };
+
+    // freenet/river#397 Codex review 2 (P1): the legacy index is NON-EMPTY, so
+    // rooms provably exist under the old delegate key. Announce `Migrating`
+    // BEFORE the sequential fetch loop below — otherwise the state stays
+    // `Loading` through the whole fetch window and the 20s backstop (armed by the
+    // ProbeLegacy arm) could flip it to `Loaded`→Empty despite that positive
+    // evidence. `Migrating` is not rescued by the backstop, so this closes the
+    // window. Every return path below concludes to a terminal (invariant 2): the
+    // all-fetches-empty early return resolves to `Loaded`, and the hydrate path's
+    // legacy re-save success/`Err` arms resolve to `Loaded`.
+    set_rooms_load_state(RoomsLoadState::Migrating);
 
     info!(
         "Migrating {} per-room slot(s) from legacy delegate",
@@ -1046,11 +1080,20 @@ async fn migrate_legacy_per_room(legacy_key: DelegateKey, keys: Vec<ChatDelegate
     };
 
     if slots.is_empty() {
+        // Every listed legacy slot failed to fetch or came back empty — there is
+        // nothing to hydrate, so `Migrating` (set above) has no re-save terminal
+        // to resolve it. Conclude to `Loaded` here so the rail doesn't strand on
+        // "Migrating…" forever (freenet/river#397 Codex review 2, invariant 2). A
+        // fresh session re-probes the legacy delegate (LEGACY_MIGRATION_ATTEMPTED
+        // resets per session, and this path never marked migration done), so this
+        // is a resolved terminal, not permanent data loss.
+        set_rooms_load_state(RoomsLoadState::Loaded);
         return;
     }
 
     // is_legacy_delegate = true: skip legacy cursor restore, and trigger the
-    // re-save to the CURRENT delegate (which also marks legacy migration done).
+    // re-save to the CURRENT delegate (which also marks legacy migration done and
+    // resolves the load state to `Loaded` on the re-save's success/`Err` arms).
     let loaded = reconstruct_rooms(slots, meta);
     if hydrate_loaded_rooms(loaded, true) {
         schedule_subscription_timeout_check();
@@ -2015,16 +2058,26 @@ mod tests {
             .rfind("should_resolve_per_room_load(")
             .expect("the PerRoom Loaded write must be guarded by should_resolve_per_room_load");
         assert!(
-            write_pos - guard_pos < 220,
+            write_pos - guard_pos < 300,
             "the PerRoom Loaded write must be directly gated by should_resolve_per_room_load, \
              so a failed all-empty load stays Loading instead of flashing Empty"
         );
-        assert!(
-            production.contains(
-                "should_resolve_per_room_load(loaded_map_empty, listed_count, had_fetch_error)"
-            ),
-            "the resolve decision must be fed (map_empty, listed_count, had_fetch_error)"
-        );
+        // The call must be fed all four inputs, including `action.recover` (the
+        // interrupted-migration recovery flag, Codex review 2 P2) — the args live
+        // between the call open-paren and the gated write.
+        let call_args = &production[guard_pos..write_pos];
+        for arg in [
+            "loaded_map_empty",
+            "listed_count",
+            "had_fetch_error",
+            "action.recover",
+        ] {
+            assert!(
+                call_args.contains(arg),
+                "the resolve decision must be fed `{arg}` (map_empty, listed_count, \
+                 had_fetch_error, recovering)"
+            );
+        }
 
         // (b) the fetch-failure arms flag the error so the decision can see it.
         // Bound the search to the per-room fetch loop (marker → the `let meta`
@@ -2052,6 +2105,55 @@ mod tests {
         assert!(
             !after_value_none.contains("had_fetch_error = true;"),
             "a definitive `value: None` is a legitimate skip, not a fetch error"
+        );
+    }
+
+    /// freenet/river#397 Codex review 2 (P1): `migrate_legacy_per_room` fetches
+    /// each legacy slot sequentially and only sets `Migrating` (via hydrate) at
+    /// the end. Without an early `Migrating`, the whole fetch window sits at
+    /// `Loading`, so the 20s backstop could flip it to Empty despite the legacy
+    /// index proving rooms exist. Pin that it sets `Migrating` BEFORE the fetch
+    /// loop, and that the all-fetches-empty early return has a `Loaded` terminal
+    /// (invariant 2 — no stranded `Migrating`).
+    #[test]
+    fn migrate_legacy_per_room_shows_migrating_before_fetch_loop() {
+        let src = include_str!("response_handler.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+
+        let fn_start = production
+            .find("async fn migrate_legacy_per_room(")
+            .expect("migrate_legacy_per_room must exist");
+        let body_after_sig = &production[fn_start + 1..];
+        let fn_end = body_after_sig
+            .find("\nasync fn ")
+            .map(|i| fn_start + 1 + i)
+            .unwrap_or(production.len());
+        let body = &production[fn_start..fn_end];
+
+        // `Migrating` is set before the sequential fetch loop.
+        let migrating_pos = body
+            .find("set_rooms_load_state(RoomsLoadState::Migrating)")
+            .expect("migrate_legacy_per_room must announce Migrating for a non-empty index");
+        let loop_pos = body
+            .find("for vk in room_vks")
+            .expect("migrate_legacy_per_room must have a per-slot fetch loop");
+        assert!(
+            migrating_pos < loop_pos,
+            "Migrating must be set BEFORE the fetch loop so the backstop can't flip \
+             a known-non-empty legacy load to Empty mid-fetch"
+        );
+
+        // The all-fetches-empty early return concludes to `Loaded` (invariant 2).
+        let empty_ret = body
+            .find("if slots.is_empty()")
+            .expect("migrate_legacy_per_room must handle the empty-slots case");
+        let empty_block = &body[empty_ret..(empty_ret + 700).min(body.len())];
+        assert!(
+            empty_block.contains("set_rooms_load_state(RoomsLoadState::Loaded)"),
+            "the all-fetches-empty early return must resolve to Loaded, not strand Migrating"
         );
     }
 

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -17,7 +17,8 @@ use crate::components::app::chat_delegate::{
     is_legacy_migration_in_progress, legacy_scoped_correlation, load_state_after_probe_legacy,
     mark_legacy_migration_done, mark_legacy_migration_in_progress, parse_room_storage_key,
     prune_outbound_dms_for_purges, room_storage_key, save_outbound_dms_to_delegate,
-    save_rooms_to_delegate, send_delegate_request, send_delegate_request_to, set_rooms_load_state,
+    save_rooms_to_delegate, schedule_rooms_load_backstop, send_delegate_request,
+    send_delegate_request_to, set_rooms_load_state, should_resolve_per_room_load,
     LegacyMigrationAction, RoomsLoadState, OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY,
     ROOMS_STORAGE_KEY,
 };
@@ -622,6 +623,14 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
             // skipped (nothing is coming). A brand-new user whose probe finds
             // nothing is caught by the timeout backstop, never a perpetual spinner.
             let fired = fire_legacy_migration_request().await;
+            if fired {
+                // P2-1 (Codex review): arm the backstop ONLY here — a
+                // fire-and-forget probe has no synchronous completion signal. By
+                // now the authoritative current-delegate load already returned
+                // empty (this is the ProbeLegacy classification), so the backstop
+                // can no longer clobber an in-flight authoritative load.
+                schedule_rooms_load_backstop();
+            }
             set_rooms_load_state(load_state_after_probe_legacy(fired));
         }
         LoadPlan::MigrateCurrentBlob => {
@@ -657,6 +666,14 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
             // passes every room still lands in ROOMS. (Load-vs-SAVE never
             // collides — those use distinct prefixed correlation keys.)
             info!("Loading {} per-room slot(s) from delegate", room_vks.len());
+            // freenet/river#397 Codex review (P2-2): the index PROVED these rooms
+            // exist. If every listed room fails to materialize, the assembled map
+            // is empty — but resolving to Empty would render "no rooms yet" for a
+            // user who provably HAS rooms. Track whether a listed room failed to
+            // fetch (transport / parse error — NOT a definitive `value: None`) so
+            // the resolve decision below can stay `Loading` in that case.
+            let listed_count = room_vks.len();
+            let mut had_fetch_error = false;
             let mut slots: Vec<(ed25519_dalek::VerifyingKey, RoomSlot)> = Vec::new();
             for vk in room_vks {
                 match send_delegate_request(ChatDelegateRequestMsg::GetRequest {
@@ -668,14 +685,27 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
                         value: Some(bytes), ..
                     }) => match from_reader::<RoomSlot, _>(&bytes[..]) {
                         Ok(slot) => slots.push((vk, slot)),
-                        Err(e) => error!("Unparseable room slot for {:?}: {}", vk, e),
+                        Err(e) => {
+                            // A listed room whose slot won't parse failed to
+                            // materialize — count it as a fetch error.
+                            error!("Unparseable room slot for {:?}: {}", vk, e);
+                            had_fetch_error = true;
+                        }
                     },
                     Ok(ChatDelegateResponseMsg::GetResponse { value: None, .. }) => {
-                        // Listed in the index but the value is gone — skip it.
+                        // Listed in the index but the value is gone — a DEFINITIVE
+                        // "no value for this key", a legitimate skip, NOT a fetch
+                        // failure (do not set had_fetch_error).
                         warn!("Room key {:?} listed but value missing", vk);
                     }
-                    Ok(other) => error!("Unexpected response loading room {:?}: {:?}", vk, other),
-                    Err(e) => error!("Failed to load room {:?}: {}", vk, e),
+                    Ok(other) => {
+                        error!("Unexpected response loading room {:?}: {:?}", vk, other);
+                        had_fetch_error = true;
+                    }
+                    Err(e) => {
+                        error!("Failed to load room {:?}: {}", vk, e);
+                        had_fetch_error = true;
+                    }
                 }
             }
 
@@ -708,16 +738,30 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
             };
 
             let loaded = reconstruct_rooms(slots, meta);
+            // Capture emptiness BEFORE `loaded` is moved into hydrate, for the
+            // resolve decision below (freenet/river#397 P2-2).
+            let loaded_map_empty = loaded.map.is_empty();
             if hydrate_loaded_rooms(loaded, false) {
                 schedule_subscription_timeout_check();
             }
 
             // freenet/river#397: the current delegate's per-room set is the
-            // authoritative initial load — it has resolved. Rooms (if any) render
-            // as the list; an empty/all-tombstone set renders the calm empty
-            // state. Set BEFORE the recovery re-run below so an armed recovery's
-            // `Migrating` (set inside `migrate_current_blob_to_per_room`) wins.
-            set_rooms_load_state(RoomsLoadState::Loaded);
+            // authoritative initial load. Resolve to `Loaded` on a DEFINITIVE
+            // answer — rooms (if any) render as the list; a genuinely empty /
+            // all-`value: None` set renders the calm empty state. Set BEFORE the
+            // recovery re-run below so an armed recovery's `Migrating` (set inside
+            // `migrate_current_blob_to_per_room`) wins.
+            //
+            // P2-2 (Codex review): but if the load came back EMPTY while the index
+            // listed rooms AND a listed room failed to fetch, DO NOT resolve —
+            // leave the state `Loading` (the honest spinner). We KNOW rooms exist,
+            // so a WS reconnect re-fires `ListRequest` and retries; flashing "no
+            // rooms yet" here would be the feature's own worst failure mode. The
+            // backstop is deliberately NOT armed on this path (arming it would
+            // flip the spinner to Empty and defeat the fix).
+            if should_resolve_per_room_load(loaded_map_empty, listed_count, had_fetch_error) {
+                set_rooms_load_state(RoomsLoadState::Loaded);
+            }
 
             // Recover from an interrupted migration by re-running it to pick up
             // any room whose per-room key wasn't written before the previous
@@ -923,8 +967,13 @@ async fn migrate_current_blob_to_per_room(recovery: bool) {
             // freenet/river#397 review: under `recovery` this must NOT run —
             // `load_state_after_probe_legacy(true)` would downgrade the already
             // resolved `Loaded` back to `Loading`, flashing a spinner (and, if the
-            // once-per-session backstop already fired, sticking there).
+            // once-per-session backstop already fired, sticking there). Outside
+            // recovery, arm the backstop when a fire-and-forget probe was fired
+            // (P2-1) — the same probe-fired condition as the ProbeLegacy arm.
             if !recovery {
+                if fired {
+                    schedule_rooms_load_backstop();
+                }
                 set_rooms_load_state(load_state_after_probe_legacy(fired));
             }
         }
@@ -1928,15 +1977,81 @@ mod tests {
         let write_pos = body
             .find("set_rooms_load_state(load_state_after_probe_legacy(fired))")
             .expect("the value-gone branch must write via load_state_after_probe_legacy");
-        // The `if !recovery {` guard must DIRECTLY precede the write (same block),
-        // not merely appear somewhere earlier in the function.
+        // The `if !recovery {` guard must directly enclose the write (same block).
+        // Its enclosing block also arms the backstop (`if fired { … }`) before the
+        // write, so allow for that intervening block — an UNguarded write would put
+        // the nearest `if !recovery {` far earlier (a different arm), not ~150 back.
         let guard_pos = body[..write_pos]
             .rfind("if !recovery {")
             .expect("migrate_current_blob_to_per_room must guard its writes on !recovery");
         assert!(
-            write_pos - guard_pos < 80,
-            "the value-gone probe-legacy write must be DIRECTLY inside an `if !recovery` \
-             block so a background recovery never downgrades a resolved Loaded to Loading"
+            write_pos - guard_pos < 250,
+            "the value-gone probe-legacy write must be inside the `if !recovery` block \
+             so a background recovery never downgrades a resolved Loaded to Loading"
+        );
+    }
+
+    /// freenet/river#397 Codex review (P2-2): the PerRoom load must NOT resolve
+    /// to Empty when the index listed rooms but their fetches failed. Pin the
+    /// wiring: (a) the per-room `Loaded` write is guarded by the pure
+    /// `should_resolve_per_room_load(...)` decision (unit-tested in
+    /// chat_delegate.rs), and (b) the fetch-failure arms set `had_fetch_error`.
+    /// The pure helper is the primary coverage; this pin guards against the
+    /// helper being computed-but-ignored or the failure arms silently not
+    /// flagging an error.
+    #[test]
+    fn per_room_load_failure_does_not_resolve_to_empty() {
+        let src = include_str!("response_handler.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+
+        // (a) the PerRoom `Loaded` write is gated on the pure decision.
+        let write_pos = production
+            .find("set_rooms_load_state(RoomsLoadState::Loaded)")
+            .expect("a per-room Loaded write must exist");
+        let guard_pos = production[..write_pos]
+            .rfind("should_resolve_per_room_load(")
+            .expect("the PerRoom Loaded write must be guarded by should_resolve_per_room_load");
+        assert!(
+            write_pos - guard_pos < 220,
+            "the PerRoom Loaded write must be directly gated by should_resolve_per_room_load, \
+             so a failed all-empty load stays Loading instead of flashing Empty"
+        );
+        assert!(
+            production.contains(
+                "should_resolve_per_room_load(loaded_map_empty, listed_count, had_fetch_error)"
+            ),
+            "the resolve decision must be fed (map_empty, listed_count, had_fetch_error)"
+        );
+
+        // (b) the fetch-failure arms flag the error so the decision can see it.
+        // Bound the search to the per-room fetch loop (marker → the `let meta`
+        // that immediately follows it) so we count exactly the per-room arms.
+        let loop_start = production
+            .find("Loading {} per-room slot(s) from delegate")
+            .expect("per-room fetch loop marker must exist");
+        let loop_end = production[loop_start..]
+            .find("let meta = if has_meta")
+            .map(|i| loop_start + i)
+            .expect("the per-room loop must be followed by the meta load");
+        let loop_region = &production[loop_start..loop_end];
+        let error_flags = loop_region.matches("had_fetch_error = true;").count();
+        assert!(
+            error_flags >= 3,
+            "the transport-Err, unexpected-response, and unparseable-slot arms must each \
+             set had_fetch_error (found {error_flags})"
+        );
+        // The definitive value-absent arm must NOT be counted as a fetch error.
+        let value_none_pos = loop_region
+            .find("listed but value missing")
+            .expect("the value: None arm must exist");
+        let after_value_none =
+            &loop_region[value_none_pos..(value_none_pos + 120).min(loop_region.len())];
+        assert!(
+            !after_value_none.contains("had_fetch_error = true;"),
+            "a definitive `value: None` is a legitimate skip, not a fetch error"
         );
     }
 

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -18,7 +18,7 @@ use crate::components::app::chat_delegate::{
     mark_legacy_migration_done, mark_legacy_migration_in_progress, parse_room_storage_key,
     per_room_terminal, prune_outbound_dms_for_purges, room_storage_key,
     save_outbound_dms_to_delegate, save_rooms_to_delegate, send_delegate_request,
-    send_delegate_request_to, set_rooms_load_state, LegacyMigrationAction, LoadWorkerGuard,
+    send_delegate_request_to, set_load_state_if_current, LegacyMigrationAction, LoadWorkerGuard,
     RoomsLoadState, OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY, ROOMS_STORAGE_KEY,
 };
 use crate::components::app::document_title::{mark_current_room_as_read, update_document_title};
@@ -358,6 +358,7 @@ impl ResponseHandler {
                                                         if hydrate_loaded_rooms(
                                                             loaded_rooms,
                                                             is_legacy_delegate,
+                                                            worker.attempt(),
                                                         ) {
                                                             flags.subscriptions_initiated = true;
                                                         }
@@ -776,7 +777,7 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
             // Capture emptiness BEFORE `loaded` is moved into hydrate, for the
             // authoritative terminal decision below.
             let loaded_map_empty = loaded.map.is_empty();
-            if hydrate_loaded_rooms(loaded, false) {
+            if hydrate_loaded_rooms(loaded, false, worker.attempt()) {
                 schedule_subscription_timeout_check();
             }
 
@@ -949,7 +950,7 @@ async fn migrate_current_blob_to_per_room(recovery: bool) {
                 // live rooms writes `Loaded` — a zero-live-room completion writes
                 // NOTHING so it can't stomp a concurrent legacy probe's `Migrating`
                 // into a false Empty; the universal backstop owns that terminal.
-                let had_rooms = hydrate_loaded_rooms(loaded, false);
+                let had_rooms = hydrate_loaded_rooms(loaded, false, worker.attempt());
                 if had_rooms {
                     schedule_subscription_timeout_check();
                 }
@@ -960,6 +961,11 @@ async fn migrate_current_blob_to_per_room(recovery: bool) {
                 // safe_spawn_local schedules a setTimeout(0) that, being queued
                 // AFTER the merge's defer, runs once the merge has populated
                 // ROOMS (FIFO ordering), mirroring the legacy-delegate re-save.
+                //
+                // Review 11: this SPAWNED closure runs after the worker's sync body
+                // (its guard may have dropped), so capture the worker's attempt and
+                // gate the Loaded writes on still-current explicitly.
+                let attempt = worker.attempt();
                 crate::util::safe_spawn_local(async move {
                     match save_rooms_to_delegate().await {
                         Ok(_) => {
@@ -968,7 +974,7 @@ async fn migrate_current_blob_to_per_room(recovery: bool) {
                             // Resolve to `Loaded` only if we merged live rooms;
                             // otherwise let the backstop own the terminal.
                             if had_rooms {
-                                set_rooms_load_state(RoomsLoadState::Loaded);
+                                set_load_state_if_current(attempt, RoomsLoadState::Loaded);
                             }
                         }
                         Err(e) => {
@@ -976,7 +982,7 @@ async fn migrate_current_blob_to_per_room(recovery: bool) {
                             // Leave the in-progress flag set so the next load
                             // re-runs the fill. Same had_rooms gate as the Ok arm.
                             if had_rooms {
-                                set_rooms_load_state(RoomsLoadState::Loaded);
+                                set_load_state_if_current(attempt, RoomsLoadState::Loaded);
                             }
                         }
                     }
@@ -1157,7 +1163,7 @@ async fn migrate_legacy_per_room(legacy_key: DelegateKey, keys: Vec<ChatDelegate
     // re-save to the CURRENT delegate (which also marks legacy migration done and
     // resolves the load state to `Loaded` on the re-save's success/`Err` arms).
     let loaded = reconstruct_rooms(slots, meta);
-    if hydrate_loaded_rooms(loaded, true) {
+    if hydrate_loaded_rooms(loaded, true, worker.attempt()) {
         schedule_subscription_timeout_check();
     }
 }
@@ -1210,15 +1216,20 @@ fn schedule_subscription_timeout_check() {
 /// schedule the subscription-timeout backstop (the old
 /// `flags.subscriptions_initiated`). Holds no `self`/`flags`, so it is callable
 /// from a spawned task as well as the synchronous message-loop arm.
-fn hydrate_loaded_rooms(loaded_rooms: Rooms, is_legacy_delegate: bool) -> bool {
+fn hydrate_loaded_rooms(loaded_rooms: Rooms, is_legacy_delegate: bool, attempt: u32) -> bool {
     // freenet/river#397: a legacy-delegate response means we found the user's
     // rooms under an OLD delegate key and are about to migrate them (Ivvor's
     // case). Announce `Migrating` BEFORE the ROOMS merge below (which is
     // deferred) so a re-render lands on the "Migrating…" state ahead of the list
     // filling. The current-delegate path (is_legacy_delegate == false) is not a
     // migration and sets its own resolved state at the call site.
+    //
+    // Review 11: `attempt` is the caller worker's captured attempt. This runs
+    // AFTER awaited fetches (and the re-save below is a SPAWNED closure), so gate
+    // every load-state write on still-current so a reconnect/retry that superseded
+    // the caller isn't polluted.
     if is_legacy_delegate {
-        set_rooms_load_state(RoomsLoadState::Migrating);
+        set_load_state_if_current(attempt, RoomsLoadState::Migrating);
     }
 
     // Tombstone filter for all downstream loops.
@@ -1641,15 +1652,17 @@ fn hydrate_loaded_rooms(loaded_rooms: Rooms, is_legacy_delegate: bool) -> bool {
                     info!("Successfully migrated room data to new delegate");
                     clear_legacy_migration_in_progress();
                     mark_legacy_migration_done();
+                    // Review 11: this runs after the save await, so gate on the
+                    // captured attempt (a reconnect/retry may have superseded us).
                     if had_loaded_rooms {
-                        set_rooms_load_state(RoomsLoadState::Loaded);
+                        set_load_state_if_current(attempt, RoomsLoadState::Loaded);
                     }
                 }
                 Err(e) => {
                     error!("Failed to migrate room data to new delegate: {}", e);
                     // Leave the in-progress flag set so the next load re-fills.
                     if had_loaded_rooms {
-                        set_rooms_load_state(RoomsLoadState::Loaded);
+                        set_load_state_if_current(attempt, RoomsLoadState::Loaded);
                     }
                 }
             }
@@ -2023,8 +2036,8 @@ mod tests {
             .expect("blob-explosion save-error marker must exist");
         let blob_arm = &production[blob_err..(blob_err + 900).min(production.len())];
         assert!(
-            blob_arm.contains("set_rooms_load_state(RoomsLoadState::Loaded)"),
-            "the blob-explosion save-error arm must resolve the load to Loaded (had_rooms)"
+            blob_arm.contains("set_load_state_if_current(attempt, RoomsLoadState::Loaded)"),
+            "the blob-explosion save-error arm must resolve to Loaded (had_rooms), attempt-gated (review 11)"
         );
 
         // (b) legacy-delegate re-save error.
@@ -2033,8 +2046,8 @@ mod tests {
             .expect("legacy re-save-error marker must exist");
         let legacy_arm = &production[legacy_err..(legacy_err + 900).min(production.len())];
         assert!(
-            legacy_arm.contains("set_rooms_load_state(RoomsLoadState::Loaded)"),
-            "the legacy re-save-error arm must resolve the load to Loaded (had_rooms)"
+            legacy_arm.contains("set_load_state_if_current(attempt, RoomsLoadState::Loaded)"),
+            "the legacy re-save-error arm must resolve to Loaded (had_rooms), attempt-gated (review 11)"
         );
     }
 
@@ -2123,6 +2136,48 @@ mod tests {
                 "worker-body write `{terminal}` must be attempt-scoped via worker.set_load_state"
             );
         }
+    }
+
+    /// freenet/river#397 Codex review 11 — the class is closed BY CONSTRUCTION:
+    /// the response handler has ZERO bare `set_rooms_load_state(` and ZERO bare
+    /// `mark_fetch_failure()` — EVERY load-state / failure write (including the
+    /// SPAWNED save closures and `hydrate_loaded_rooms`' legacy writes that outlive
+    /// their worker's sync body) routes through the attempt-gated
+    /// `worker.set_load_state` / `worker.mark_fetch_failure` / `set_load_state_if_current`
+    /// helpers. A future edit that adds an ungated async write fails this pin.
+    #[test]
+    fn no_ungated_async_load_state_writes() {
+        let src = include_str!("response_handler.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+
+        assert!(
+            !production.contains("set_rooms_load_state("),
+            "no bare set_rooms_load_state — use worker.set_load_state / set_load_state_if_current (attempt-gated)"
+        );
+        assert_eq!(
+            production.matches("mark_fetch_failure()").count(),
+            production.matches("worker.mark_fetch_failure()").count(),
+            "no bare mark_fetch_failure — all attempt-scoped via worker.mark_fetch_failure"
+        );
+        // hydrate threads the attempt through, and its legacy writes are gated.
+        assert!(
+            production.contains(
+                "fn hydrate_loaded_rooms(loaded_rooms: Rooms, is_legacy_delegate: bool, attempt: u32)"
+            ),
+            "hydrate_loaded_rooms must take an attempt to gate its legacy load-state writes"
+        );
+        assert!(
+            production.contains("set_load_state_if_current(attempt, RoomsLoadState::Migrating)"),
+            "hydrate's legacy Migrating write must be attempt-gated via set_load_state_if_current"
+        );
+        // The spawned blob-explosion save closure captures the worker's attempt.
+        assert!(
+            production.contains("let attempt = worker.attempt();"),
+            "the spawned save closure must capture worker.attempt() to gate its late Loaded write"
+        );
     }
 
     /// freenet/river#397 Codex review 9 (send-side audit): a `rooms_meta` GET whose
@@ -2228,8 +2283,8 @@ mod tests {
             .unwrap_or(body.len());
         let save_closure = &body[save_pos..save_end];
         assert!(
-            save_closure.contains("set_rooms_load_state(RoomsLoadState::Loaded)"),
-            "the save-completion arms must resolve to Loaded"
+            save_closure.contains("set_load_state_if_current(attempt, RoomsLoadState::Loaded)"),
+            "the save-completion arms must resolve to Loaded (attempt-gated, review 11)"
         );
         assert!(
             !save_closure.contains("if !recovery"),
@@ -2487,10 +2542,10 @@ mod tests {
         );
         assert_eq!(
             block
-                .matches("set_rooms_load_state(RoomsLoadState::Loaded)")
+                .matches("set_load_state_if_current(attempt, RoomsLoadState::Loaded)")
                 .count(),
             2,
-            "both legacy re-save arms resolve to Loaded when live rooms merged"
+            "both legacy re-save arms resolve to Loaded (attempt-gated, review 11) when live rooms merged"
         );
     }
 

--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -5,7 +5,9 @@ pub(crate) mod join_with_code_modal;
 pub(crate) mod receive_invitation_modal;
 pub(crate) mod room_name_field;
 
-use crate::components::app::chat_delegate::save_rooms_to_delegate;
+use crate::components::app::chat_delegate::{
+    save_rooms_to_delegate, RoomsLoadState, ROOMS_LOAD_STATE,
+};
 use crate::components::app::document_title::{
     count_unread_in_room_data, mark_current_room_as_read,
 };
@@ -34,6 +36,52 @@ const BUILD_TIMESTAMP_ISO: &str = env!("BUILD_TIMESTAMP_ISO", "Build timestamp n
 // Stable Dioxus key for the reorder tail drop zone (keys must be unique and
 // distinct from any room's `{room_key:?}`).
 const TAIL_DROP_ZONE_KEY: &str = "room-reorder-tail-drop-zone";
+
+// Stable Dioxus key for the single non-room state row (freenet/river#397). The
+// three states are mutually exclusive, so they share one key and Dioxus reuses
+// the element across transitions.
+const ROOM_LIST_STATE_KEY: &str = "room-list-state";
+
+/// What the rooms rail shows in place of the room list (freenet/river#397).
+/// When the `ROOMS` map is empty during startup / migration, a bare `<ul>`
+/// rendered nothing, so a user with rooms still loading saw a blank list and
+/// assumed data loss. This picks one of three explicit non-room states; a
+/// non-empty list always wins.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum RoomListDisplay {
+    /// Initial load hasn't resolved yet — subtle spinner + "Loading your rooms…".
+    Loading,
+    /// A delegate/room migration is recovering rooms — spinner + "Migrating…".
+    Migrating,
+    /// Load resolved and the user genuinely has no rooms — calm empty state.
+    Empty,
+    /// There is at least one room to render — show the list unchanged.
+    List,
+}
+
+/// Pure decision for the rail's display state, split out so it is unit-testable
+/// without the Dioxus runtime (freenet/river#397).
+///
+/// A non-empty room list ALWAYS renders the list — once there's something to
+/// show, load/migration bookkeeping is irrelevant. Only when `room_count == 0`
+/// do we disambiguate the three non-room states, and `Migrating` outranks
+/// `Loading` (it's the more specific, more reassuring message). `Empty` is
+/// reached ONLY from `Loaded`, so an unresolved or migrating load never shows
+/// "no rooms yet".
+pub(crate) fn room_list_display_state(
+    load_state: RoomsLoadState,
+    room_count: usize,
+) -> RoomListDisplay {
+    if room_count > 0 {
+        RoomListDisplay::List
+    } else {
+        match load_state {
+            RoomsLoadState::Loading => RoomListDisplay::Loading,
+            RoomsLoadState::Migrating => RoomListDisplay::Migrating,
+            RoomsLoadState::Loaded => RoomListDisplay::Empty,
+        }
+    }
+}
 
 /// Convert UTC ISO timestamp to local time string
 fn format_build_time_local() -> String {
@@ -181,6 +229,18 @@ pub fn RoomList() -> Element {
     // room there is nothing to reorder.
     let room_count: usize = room_items.read().len();
 
+    // Rail display state (freenet/river#397). Read the load-state signal
+    // reactively (fallible per the Dioxus signal-safety rules — a concurrent
+    // write returns Err, in which case we treat the load as still `Loading` and
+    // re-render on the next signal settle rather than panicking on Firefox).
+    // Combined with `room_count` this decides whether the rail shows the list,
+    // a loading spinner, a migrating spinner, or the calm empty state.
+    let load_state: RoomsLoadState = ROOMS_LOAD_STATE
+        .try_read()
+        .map(|g| *g)
+        .unwrap_or(RoomsLoadState::Loading);
+    let display = room_list_display_state(load_state, room_count);
+
     rsx! {
         aside {
             // Stable hook for the connection-indicator regression tests
@@ -262,6 +322,44 @@ pub fn RoomList() -> Element {
             ul {
                 "data-testid": "room-list",
                 class: "flex-1 px-2 py-1 space-y-0.5",
+
+                // Non-room states (freenet/river#397). Shown only when there are
+                // no rooms to render — the room-item map and tail drop zone below
+                // produce nothing while empty, so this is purely additive. A
+                // subtle, near-monochrome block: spinner (loading/migrating) or a
+                // calm empty-state hint, vertically centred in the rail.
+                match display {
+                    RoomListDisplay::Loading => rsx! {
+                        li {
+                            key: "{ROOM_LIST_STATE_KEY}",
+                            "data-testid": "room-list-loading",
+                            class: "flex flex-col items-center justify-center gap-2 py-10 px-4 text-center",
+                            div { class: "animate-spin w-4 h-4 border-2 border-text-muted border-t-transparent rounded-full" }
+                            span { class: "text-sm text-text-muted", "Loading your rooms…" }
+                        }
+                    },
+                    RoomListDisplay::Migrating => rsx! {
+                        li {
+                            key: "{ROOM_LIST_STATE_KEY}",
+                            "data-testid": "room-list-migrating",
+                            class: "flex flex-col items-center justify-center gap-2 py-10 px-4 text-center",
+                            div { class: "animate-spin w-4 h-4 border-2 border-text-muted border-t-transparent rounded-full" }
+                            span { class: "text-sm text-text-muted", "Migrating your rooms…" }
+                            span { class: "text-xs text-text-muted opacity-70", "(one-time step after an update)" }
+                        }
+                    },
+                    RoomListDisplay::Empty => rsx! {
+                        li {
+                            key: "{ROOM_LIST_STATE_KEY}",
+                            "data-testid": "room-list-empty",
+                            class: "flex flex-col items-center justify-center gap-1 py-10 px-4 text-center",
+                            span { class: "text-sm text-text-muted", "No rooms yet" }
+                            span { class: "text-xs text-text-muted opacity-70", "Create a room or join one with an invite code." }
+                        }
+                    },
+                    RoomListDisplay::List => rsx! {},
+                }
+
                 {room_items.read().iter().enumerate().map(|(idx, (room_key, room_name, is_current, awaiting_sync, is_private, unread, sync_error_msg))| {
                     let room_key = *room_key;
                     let room_name = room_name.clone();
@@ -583,5 +681,77 @@ pub fn RoomList() -> Element {
         JoinWithCodeModal {
             is_active: join_code_modal_active
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// freenet/river#397: the initial load hasn't resolved and there are no
+    /// rooms yet → show the loading spinner, NOT a blank list or a premature
+    /// "no rooms yet".
+    #[test]
+    fn loading_with_no_rooms_shows_loading() {
+        assert_eq!(
+            room_list_display_state(RoomsLoadState::Loading, 0),
+            RoomListDisplay::Loading
+        );
+    }
+
+    /// freenet/river#397: a migration is in progress with the map still empty
+    /// (Ivvor's case) → show "Migrating…", never "no rooms yet".
+    #[test]
+    fn migrating_with_no_rooms_shows_migrating() {
+        assert_eq!(
+            room_list_display_state(RoomsLoadState::Migrating, 0),
+            RoomListDisplay::Migrating
+        );
+    }
+
+    /// freenet/river#397: the load resolved and the user genuinely has no rooms
+    /// → the calm empty state (only reachable from `Loaded`).
+    #[test]
+    fn loaded_with_no_rooms_shows_empty() {
+        assert_eq!(
+            room_list_display_state(RoomsLoadState::Loaded, 0),
+            RoomListDisplay::Empty
+        );
+    }
+
+    /// freenet/river#397: any rooms present → render the list, regardless of the
+    /// load state (mid-migration, still-loading, or resolved). Once there's
+    /// something to show, load bookkeeping is irrelevant.
+    #[test]
+    fn any_rooms_shows_list_regardless_of_load_state() {
+        for state in [
+            RoomsLoadState::Loading,
+            RoomsLoadState::Migrating,
+            RoomsLoadState::Loaded,
+        ] {
+            assert_eq!(
+                room_list_display_state(state, 1),
+                RoomListDisplay::List,
+                "{state:?} with rooms must render the list"
+            );
+            assert_eq!(
+                room_list_display_state(state, 7),
+                RoomListDisplay::List,
+                "{state:?} with rooms must render the list"
+            );
+        }
+    }
+
+    /// freenet/river#397 (#1 safety invariant): a genuinely-new user, once the
+    /// load resolves (`Loaded`) with zero rooms, lands on the calm empty state —
+    /// never a perpetual spinner. (The resolution itself — Loading→Loaded via the
+    /// completion signal / backstop — is pinned by the chat_delegate tests.)
+    #[test]
+    fn new_user_resolves_to_empty_not_stuck_loading() {
+        assert_eq!(
+            room_list_display_state(RoomsLoadState::Loaded, 0),
+            RoomListDisplay::Empty,
+            "a resolved new user with no rooms must show Empty, never Loading"
+        );
     }
 }

--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -6,7 +6,7 @@ pub(crate) mod receive_invitation_modal;
 pub(crate) mod room_name_field;
 
 use crate::components::app::chat_delegate::{
-    save_rooms_to_delegate, RoomsLoadState, ROOMS_LOAD_STATE,
+    retry_rooms_load, save_rooms_to_delegate, RoomsLoadState, ROOMS_LOAD_STATE,
 };
 use crate::components::app::document_title::{
     count_unread_in_room_data, mark_current_room_as_read,
@@ -55,6 +55,9 @@ pub(crate) enum RoomListDisplay {
     Migrating,
     /// Load resolved and the user genuinely has no rooms — calm empty state.
     Empty,
+    /// A load we KNOW involved rooms failed/stalled — error + Retry block, never
+    /// a false "no rooms yet" (freenet/river#397 Codex review 4).
+    LoadFailed,
     /// There is at least one room to render — show the list unchanged.
     List,
 }
@@ -64,10 +67,10 @@ pub(crate) enum RoomListDisplay {
 ///
 /// A non-empty room list ALWAYS renders the list — once there's something to
 /// show, load/migration bookkeeping is irrelevant. Only when `room_count == 0`
-/// do we disambiguate the three non-room states, and `Migrating` outranks
-/// `Loading` (it's the more specific, more reassuring message). `Empty` is
-/// reached ONLY from `Loaded`, so an unresolved or migrating load never shows
-/// "no rooms yet".
+/// do we disambiguate the non-room states: `Loading`/`Migrating` spinners, the
+/// `LoadFailed` error+retry block, and the calm `Empty`. `Empty` is reached ONLY
+/// from `Loaded`, so an unresolved / migrating / failed load never shows "no
+/// rooms yet".
 pub(crate) fn room_list_display_state(
     load_state: RoomsLoadState,
     room_count: usize,
@@ -79,6 +82,7 @@ pub(crate) fn room_list_display_state(
             RoomsLoadState::Loading => RoomListDisplay::Loading,
             RoomsLoadState::Migrating => RoomListDisplay::Migrating,
             RoomsLoadState::Loaded => RoomListDisplay::Empty,
+            RoomsLoadState::LoadFailed => RoomListDisplay::LoadFailed,
         }
     }
 }
@@ -355,6 +359,25 @@ pub fn RoomList() -> Element {
                             class: "flex flex-col items-center justify-center gap-1 py-10 px-4 text-center",
                             span { class: "text-sm text-text-muted", "No rooms yet" }
                             span { class: "text-xs text-text-muted opacity-70", "Create a room or join one with an invite code." }
+                        }
+                    },
+                    RoomListDisplay::LoadFailed => rsx! {
+                        li {
+                            key: "{ROOM_LIST_STATE_KEY}",
+                            "data-testid": "room-list-error",
+                            class: "flex flex-col items-center justify-center gap-3 py-10 px-4 text-center",
+                            span { class: "text-sm text-text-muted", "Couldn't load your rooms" }
+                            span { class: "text-xs text-text-muted opacity-70", "Check your connection and try again." }
+                            button {
+                                "data-testid": "room-list-retry-button",
+                                class: "flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm text-text-muted bg-surface hover:bg-surface-hover transition-colors",
+                                // Retry re-fires the current-delegate load. Safe to
+                                // call directly — `retry_rooms_load` defers its
+                                // signal write and spawns via setTimeout(0) (Dioxus
+                                // signal-safety rules).
+                                onclick: move |_| retry_rooms_load(),
+                                span { "Retry" }
+                            }
                         }
                     },
                     RoomListDisplay::List => rsx! {},
@@ -719,15 +742,27 @@ mod tests {
         );
     }
 
+    /// freenet/river#397 Codex review 4: a failed load with no rooms → the
+    /// LoadFailed error+retry block, NOT a false "no rooms yet".
+    #[test]
+    fn load_failed_with_no_rooms_shows_error() {
+        assert_eq!(
+            room_list_display_state(RoomsLoadState::LoadFailed, 0),
+            RoomListDisplay::LoadFailed
+        );
+    }
+
     /// freenet/river#397: any rooms present → render the list, regardless of the
-    /// load state (mid-migration, still-loading, or resolved). Once there's
-    /// something to show, load bookkeeping is irrelevant.
+    /// load state (mid-migration, still-loading, resolved, OR failed). Once
+    /// there's something to show, load bookkeeping is irrelevant — a partial load
+    /// that fetched SOME rooms shows them rather than the error block.
     #[test]
     fn any_rooms_shows_list_regardless_of_load_state() {
         for state in [
             RoomsLoadState::Loading,
             RoomsLoadState::Migrating,
             RoomsLoadState::Loaded,
+            RoomsLoadState::LoadFailed,
         ] {
             assert_eq!(
                 room_list_display_state(state, 1),


### PR DESCRIPTION
## Problem

The rooms rail (`ui/src/components/room_list.rs`) rendered its room list straight from the `ROOMS` signal. While `ROOMS` was empty — during startup load, and especially during a delegate/room-contract **migration** — the `<ul>` rendered **nothing**: no loading text, no migrating indicator, no empty state. A user whose rooms were still being loaded or migrated (Ivvor's report on Matrix after the 2026-07-12 stdlib-0.8 republish, which re-keyed the delegate + room contract) saw a blank list and assumed all their rooms were gone. The empty-vs-loading ambiguity hits on every cold start; migration just widens and dramatizes the window.

## Approach

Add an explicit three-state display for the rail when there are no rooms to show:

- **Loading** — initial load hasn't resolved yet → subtle spinner + "Loading your rooms…".
- **Migrating** — a delegate/room migration is recovering rooms → spinner + "Migrating your rooms… (one-time step after an update)".
- **Empty** — load resolved and the user genuinely has no rooms → a calm "No rooms yet" hint.

A non-empty room list **always** renders the list unchanged.

State is a reactive `ROOMS_LOAD_STATE: GlobalSignal<RoomsLoadState>` (Loading → Migrating → Loaded), not a bare read of the non-reactive `is_legacy_migration_in_progress()` localStorage flag, because the migrating→list transition must trigger a re-render and a migration's start doesn't otherwise touch a signal `RoomList` subscribes to. It is set at the **real** load-completion / migration-conclusion points in `response_handler.rs`, and to `Migrating` at the two migration re-save starts.

**Safety (the #1 requirement): a genuinely-new user never spins forever.** The only case with no reliable synchronous completion signal is a brand-new user whose fire-and-forget legacy probe finds nothing; a 15s once-per-session backstop (`ROOMS_LOAD_BACKSTOP_MS`) resolves that `Loading → Loaded → Empty`. The backstop rescues only `Loading` — it never pre-empts an in-progress `Migrating` (a slow migration keeps its spinner rather than flashing "no rooms yet") nor re-opens `Loaded`. The decision to stay `Loading` (never optimistically `Loaded`) when a probe was dispatched is exactly what stops an existing user from flashing "no rooms yet" before their migration starts.

All signal writes are deferred per the Dioxus signal-safety rules; the signal read in `RoomList` is fallible (`try_read`) and defaults to `Loading`.

**No delegate/contract WASM change** — UI-only, so no re-key. Republish is the web-container only.

## Testing

Pure decision helpers, unit-tested (`cargo test -p river-ui --bins`, 9 new, all 398 pass):
- `room_list_display_state(load_state, room_count)`: loading/migrating/empty/list selection; migrating outranks loading; list wins regardless of load state; resolved-new-user → Empty not stuck.
- `load_state_after_probe_legacy(fired)` + `backstop_resolve(current)`: probe-fired stays Loading, probe-skipped resolves Loaded, backstop rescues only Loading (not Migrating/Loaded), new-user end-to-end resolves to Loaded.

Screenshots of all three states (rail-width) attached in review. `cargo fmt`, `cargo make clippy` (wasm), and `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync` clean; no WASM/contract files touched.

Closes #397

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yc3UzF9UUnQQSu8SNCYSLW
