### PR TITLE
fix(ui): recover from peer restart via top-level reload, not iframe self-nav

### DIFF
--- a/ui/src/components/app/freenet_api/connection_manager.rs
+++ b/ui/src/components/app/freenet_api/connection_manager.rs
@@ -140,18 +140,66 @@ mod imp {
                                 // 500ms should be enough for the messages to be queued and
                                 // sent over the WebSocket.
                                 sleep(Duration::from_millis(500)).await;
-                                // Navigate with cache-busting param to ensure the browser
-                                // fetches fresh HTML (with a new auth token) from the
-                                // gateway instead of serving a cached copy.
+                                // Recover the token by reloading the TOP-LEVEL
+                                // document. River runs inside the node shell's
+                                // SANDBOXED child iframe; the shell (top
+                                // document) owns the real WebSocket AND the auth
+                                // token. The node mints that token when it serves
+                                // the shell HTML and holds it only in memory, so a
+                                // node restart invalidates it and ONLY re-fetching
+                                // the shell HTML (a top-level reload) mints a fresh
+                                // one. We can't reload the top from here directly:
+                                // the sandbox has no `allow-top-navigation`, and
+                                // navigating our OWN iframe (the previous behaviour)
+                                // either loops on the same dead token or, during the
+                                // node's ring-rejoin window, gets bounced to the node
+                                // root and X-Frame-blocked -> broken tab. So when
+                                // framed we ask the shell to reload itself via the
+                                // postMessage bridge it already listens on (it
+                                // handles {__freenet_shell__:true, type:"reload"} in
+                                // shell_bridge.js); the shell re-mints the token and
+                                // re-embeds us. When we are NOT framed (local dev /
+                                // dx serve, where we ARE the top document) we reload
+                                // ourselves with a cache-busting param.
                                 if let Some(window) = web_sys::window() {
-                                    let path = window
-                                        .location()
-                                        .pathname()
-                                        .unwrap_or_else(|_| "/".to_string());
-                                    let bust = js_sys::Date::now() as u64;
-                                    let url = format!("{}?_reload={}", path, bust);
-                                    if let Err(e) = window.location().set_href(&url) {
-                                        error!("Failed to navigate for auth reload: {:?}", e);
+                                    let is_top = match window.top() {
+                                        Ok(Some(top)) => {
+                                            js_sys::Object::is(top.as_ref(), window.as_ref())
+                                        }
+                                        // top() blocked/absent: assume we're framed
+                                        // and recover via the shell bridge (the safe
+                                        // path under the sandbox).
+                                        _ => false,
+                                    };
+                                    if is_top {
+                                        let path = window
+                                            .location()
+                                            .pathname()
+                                            .unwrap_or_else(|_| "/".to_string());
+                                        let bust = js_sys::Date::now() as u64;
+                                        let url = format!("{}?_reload={}", path, bust);
+                                        if let Err(e) = window.location().set_href(&url) {
+                                            error!("Failed to navigate for auth reload: {:?}", e);
+                                        }
+                                    } else if let Ok(Some(parent)) = window.parent() {
+                                        let msg = js_sys::Object::new();
+                                        let _ = js_sys::Reflect::set(
+                                            &msg,
+                                            &wasm_bindgen::JsValue::from_str("__freenet_shell__"),
+                                            &wasm_bindgen::JsValue::TRUE,
+                                        );
+                                        let _ = js_sys::Reflect::set(
+                                            &msg,
+                                            &wasm_bindgen::JsValue::from_str("type"),
+                                            &wasm_bindgen::JsValue::from_str("reload"),
+                                        );
+                                        if let Err(e) = parent.post_message(&msg, "*") {
+                                            error!(
+                                                "Failed to ask shell to reload for \
+                                                 auth refresh: {:?}",
+                                                e
+                                            );
+                                        }
                                     }
                                 }
                             });


### PR DESCRIPTION
## Problem
When the local Freenet peer restarts (e.g. auto-update), its in-memory auth-token map is wiped. River's reconnect reopens the WS with the now-stale token, the node replies `AUTH_TOKEN_INVALID` and closes, and River "self-heals" by navigating `window.location`. But River runs in the node shell's **sandboxed child iframe**, so that navigates the *iframe* to its own contract path. During the node's ring-rejoin window that request is served the connecting page, whose meta-refresh yanks the frame to the node root `/`, which denies framing (`X-Frame-Options: deny`) → the tab shows a broken "unhappy" page, and only a manual full-tab refresh fixes it.

Reported symptom (console): repeated `:7509/permission/*` connection-refused during the restart, WS failures, then finally `Refused to display 'http://127.0.0.1:7509/' in a frame because it set 'X-Frame-Options' to 'deny'`.

## Approach
The auth token is owned by the node **shell** (the top-level document that hosts River in the sandboxed iframe) and is only re-minted by re-fetching the shell HTML — i.e. a **top-level** reload. River can't reload the top from inside the sandbox (no `allow-top-navigation`, and we deliberately don't want to widen it — that would let any contract hijack the whole tab). So instead of navigating its own iframe, River asks the shell to reload via the postMessage bridge it already listens on (`{__freenet_shell__: true, type: "reload"}`); the shell re-fetches itself and re-mints the token. When River is **not** framed (local dev / `dx serve`, i.e. it IS the top document) it reloads itself directly with a cache-busting param, as before.

This automates the exact recovery a manual refresh performs today, so a peer restart no longer breaks the UI.

**Coordinated with freenet-core** (the shell change that handles the `reload` message + stops `connecting.html` from framing `/`): freenet/freenet-core PR TBD. This River change degrades gracefully without it — River simply stops navigating the iframe into the X-Frame wall; once nodes ship the shell handler, recovery becomes fully automatic.

## Testing
`cargo check -p river-ui --target wasm32-unknown-unknown` passes. The reconnect/backoff/resync path (`freenet_synchronizer.rs`) is unchanged and already re-subscribes on the fresh connection. The new behaviour is browser-only (sandbox vs top-level detection), so it's covered by manual verification + the freenet-core shell pin test rather than a native unit test.

[AI-assisted - Claude]