### PR TITLE
fix(ui): stop endless WebSocket reconnect loop after Android resume

### DIFF
--- a/ui/src/components/app/freenet_api/connection_watchdog.rs
+++ b/ui/src/components/app/freenet_api/connection_watchdog.rs
@@ -70,9 +70,9 @@
 //!   *asynchronously* in the synchronizer message loop: if that loop lags
 //!   longer than a probe tick plus [`LIVENESS_PROBE_TIMEOUT_MS`], a naive
 //!   watchdog would re-probe and fire a SECOND `ConnectionLost`, and each one
-//!   independently schedules a reconnect and bumps `consecutive_failures`,
-//!   producing overlapping reconnects and inflated backoff. The latch makes the
-//!   "exactly once" guarantee hold even under message-loop lag.
+//!   independently schedules a reconnect and bumps the reconnect backoff
+//!   counter, producing overlapping reconnects and inflated backoff. The latch
+//!   makes the "exactly once" guarantee hold even under message-loop lag.
 //! * The probe timeout ([`LIVENESS_PROBE_TIMEOUT_MS`]) is far larger than a
 //!   local GET's real latency, so a momentarily slow node does not trigger a
 //!   false reconnect. If no room exists to probe, the watchdog never declares

--- a/ui/src/components/app/freenet_api/constants.rs
+++ b/ui/src/components/app/freenet_api/constants.rs
@@ -41,6 +41,14 @@ pub const RECONNECT_INITIAL_MS: u64 = 3000;
 /// Maximum retry interval for reconnection attempts in milliseconds
 pub const RECONNECT_MAX_MS: u64 = 60_000;
 
+/// How long (ms) a connection must stay up before the reconnect backoff counter
+/// is reset. Resetting merely on socket `onopen` let a socket that opens then
+/// immediately dies reset the counter every cycle, defeating the exponential
+/// backoff and producing an endless ~3s reconnect loop after an Android
+/// background→resume (freenet/river#406). A connection must prove itself stable
+/// for this long before we treat it as a fresh, healthy baseline.
+pub const CONNECTION_STABLE_DWELL_MS: u64 = 15_000;
+
 /// Maximum number of retries for API requests
 pub const MAX_REQUEST_RETRIES: u8 = 3;
 

--- a/ui/src/components/app/freenet_api/constants.rs
+++ b/ui/src/components/app/freenet_api/constants.rs
@@ -47,6 +47,21 @@ pub const RECONNECT_MAX_MS: u64 = 60_000;
 /// backoff and producing an endless ~3s reconnect loop after an Android
 /// background→resume (freenet/river#406). A connection must prove itself stable
 /// for this long before we treat it as a fresh, healthy baseline.
+///
+/// Chosen at 15s deliberately, relative to the neighbouring timers:
+/// - Above connection setup: the dwell starts only *after* `initialize_connection`
+///   returns Ok (i.e. after `onopen`), and setup is bounded by
+///   `CONNECTION_TIMEOUT_MS` (5s), so a slow-but-real connect never eats the dwell.
+/// - Below the watchdog's death window: a half-open socket isn't declared dead
+///   until roughly `LIVENESS_IDLE_PROBE_MS` + `LIVENESS_PROBE_TIMEOUT_MS` (~80s),
+///   so a dwell-reset can't fire on a socket the watchdog is about to kill.
+///
+/// Tradeoff (accepted): a link that repeatedly opens and survives just under 15s
+/// before dying never reaches the dwell, so its backoff climbs toward the 60s cap
+/// even though each attempt partly succeeds. That is the desired behaviour — don't
+/// hammer a genuinely flaky link — and it self-corrects the instant one connection
+/// survives 15s. Ivvor's report is "connects very briefly" (sub-second), which
+/// backs off correctly well before this edge matters.
 pub const CONNECTION_STABLE_DWELL_MS: u64 = 15_000;
 
 /// Maximum number of retries for API requests

--- a/ui/src/components/app/freenet_api/freenet_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/freenet_synchronizer.rs
@@ -49,12 +49,78 @@ fn reconnect_delay_ms(consecutive_failures: u32) -> u64 {
     (capped - jitter_range + jitter).min(RECONNECT_MAX_MS)
 }
 
+/// Reconnect bookkeeping: the exponential-backoff failure counter plus a
+/// single-outstanding-reconnect latch. Extracted from the message loop so the
+/// two behaviours behind the endless Android reconnect loop (freenet/river#406)
+/// are unit-testable: (1) the backoff must GROW across an open-then-die flap
+/// and reset only after a connection proves stable, and (2) a duplicate
+/// ConnectionLost (a dropped socket's orphaned `onclose`, or the watchdog and
+/// transport reporting the same death) must be coalesced, not stack another
+/// reconnect.
+#[derive(Default)]
+struct ReconnectState {
+    consecutive_failures: u32,
+    reconnect_pending: bool,
+}
+
+impl ReconnectState {
+    /// A Connect is now being attempted — clear the single-pending latch.
+    fn note_connect_attempt(&mut self) {
+        self.reconnect_pending = false;
+    }
+
+    /// A ConnectionLost arrived. `Some(delay_ms)` → schedule a reconnect after
+    /// that delay; `None` → a reconnect is already pending, so this is a
+    /// coalesced duplicate loss and must be ignored.
+    fn on_connection_lost(&mut self) -> Option<u64> {
+        if self.reconnect_pending {
+            None
+        } else {
+            Some(self.arm())
+        }
+    }
+
+    /// A Connect attempt failed to open — always schedule a retry.
+    fn on_connect_failed(&mut self) -> u64 {
+        self.arm()
+    }
+
+    /// A connection proved stable for the dwell window. Reset the backoff ONLY
+    /// if it is still the live connection (`still_current`), so an open-then-die
+    /// socket keeps backing off instead of resetting the counter every cycle.
+    fn note_stable(&mut self, still_current: bool) {
+        if still_current {
+            self.consecutive_failures = 0;
+        }
+    }
+
+    /// Current backoff delay, then advance the failure count and arm the latch.
+    fn arm(&mut self) -> u64 {
+        let delay = reconnect_delay_ms(self.consecutive_failures);
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        self.reconnect_pending = true;
+        delay
+    }
+
+    /// Human-facing attempt number for logs (1-based after arming).
+    fn attempt(&self) -> u32 {
+        self.consecutive_failures
+    }
+}
+
 /// Message types for communicating with the synchronizer
 pub enum SynchronizerMessage {
     ProcessRooms,
     Connect,
     /// Sent when WebSocket connection is lost (closed or errored)
     ConnectionLost,
+    /// Sent (delayed) after a Connect succeeds, tagged with the connection
+    /// generation it was scheduled for. Resets the reconnect backoff only if
+    /// that same connection is still up — so backoff is reset by proven
+    /// stability, not merely by a socket opening (freenet/river#406).
+    ConnectionStable {
+        connect_seq: u64,
+    },
     /// Sent when page becomes visible after being hidden (e.g., after sleep/wake)
     PageBecameVisible,
     /// Sent to refresh all room states after reconnection (e.g., after sleep/wake)
@@ -181,25 +247,19 @@ impl FreenetSynchronizer {
                 error!("Failed to send Connect message: {}", e);
             }
 
-            let mut consecutive_failures: u32 = 0;
+            let mut reconnect = ReconnectState::default();
 
-            // Helper: compute delay from current failure count, then increment for next time
-            let schedule_reconnect =
-                |consecutive_failures: &mut u32, tx: &UnboundedSender<SynchronizerMessage>| {
-                    let delay = reconnect_delay_ms(*consecutive_failures);
-                    *consecutive_failures = consecutive_failures.saturating_add(1);
-                    warn!(
-                        "Connection failed (attempt {}), reconnecting in {}ms",
-                        *consecutive_failures, delay
-                    );
-                    let tx = tx.clone();
-                    spawn_local(async move {
-                        sleep(Duration::from_millis(delay)).await;
-                        if let Err(e) = tx.unbounded_send(SynchronizerMessage::Connect) {
-                            error!("Failed to send reconnect message: {}", e);
-                        }
-                    });
-                };
+            // Spawn the delayed reconnect (the async setTimeout part; the backoff
+            // math + pending latch live in `ReconnectState`).
+            let spawn_reconnect = |delay: u64, tx: &UnboundedSender<SynchronizerMessage>| {
+                let tx = tx.clone();
+                spawn_local(async move {
+                    sleep(Duration::from_millis(delay)).await;
+                    if let Err(e) = tx.unbounded_send(SynchronizerMessage::Connect) {
+                        error!("Failed to send reconnect message: {}", e);
+                    }
+                });
+            };
 
             info!("Entering message loop");
             while let Some(msg) = message_rx.next().await {
@@ -237,18 +297,59 @@ impl FreenetSynchronizer {
                         }
                     }
                     SynchronizerMessage::ConnectionLost => {
-                        // Clear the web API so is_connected() returns false
-                        WEB_API.write().take();
-                        *SYNC_STATUS.write() = SynchronizerStatus::Disconnected;
-                        schedule_reconnect(&mut consecutive_failures, &message_tx);
+                        // Coalesce: if a reconnect is already scheduled this is a
+                        // duplicate loss — the socket we're about to drop will
+                        // itself fire `onclose` → another ConnectionLost, and the
+                        // watchdog and transport can both report the same death.
+                        // Acting again would stack extra reconnects and inflate
+                        // the backoff, part of the endless loop (freenet/river#406).
+                        match reconnect.on_connection_lost() {
+                            None => {
+                                info!("ConnectionLost ignored — a reconnect is already pending");
+                            }
+                            Some(delay) => {
+                                // Clear the web API so is_connected() returns false
+                                WEB_API.write().take();
+                                *SYNC_STATUS.write() = SynchronizerStatus::Disconnected;
+                                warn!(
+                                    "Connection lost (attempt {}), reconnecting in {}ms",
+                                    reconnect.attempt(),
+                                    delay
+                                );
+                                spawn_reconnect(delay, &message_tx);
+                            }
+                        }
+                    }
+                    SynchronizerMessage::ConnectionStable { connect_seq } => {
+                        // The connection scheduled at `connect_seq` has now stayed
+                        // up for the dwell window. Reset the backoff ONLY if this
+                        // is still the live connection — a flap that reconnected
+                        // meanwhile bumped `ws_connect_seq`, so its own (later)
+                        // ConnectionStable governs the reset. This is what makes a
+                        // socket that opens-then-dies keep backing off instead of
+                        // resetting the counter every cycle (freenet/river#406).
+                        let still_current = connection_manager.is_connected()
+                            && super::connection_watchdog::ws_connect_seq() == connect_seq;
+                        if still_current {
+                            info!(
+                                "Connection stable for dwell window; resetting reconnect backoff"
+                            );
+                        }
+                        reconnect.note_stable(still_current);
                     }
                     SynchronizerMessage::PageBecameVisible => {
                         // Page became visible after being hidden (e.g., after sleep/wake)
                         // Check if we're still connected, if not trigger reconnection
                         info!("Page visibility changed to visible, checking connection status");
                         if !connection_manager.is_connected() {
-                            // Reset backoff — user is actively looking at the page
-                            consecutive_failures = 0;
+                            // Send Connect for an immediate reconnect attempt (it
+                            // runs now rather than waiting out any pending backoff
+                            // timer). Do NOT reset the backoff here: eagerly zeroing
+                            // it on every resume was part of the never-terminating
+                            // loop. The Connect dedup makes a redundant attempt (if
+                            // a reconnect was already pending) a no-op, and the
+                            // dwell resets the backoff once a connection is stable
+                            // (freenet/river#406).
                             info!("Connection is not active after wake, triggering reconnection");
                             if let Err(e) = message_tx.unbounded_send(SynchronizerMessage::Connect)
                             {
@@ -321,6 +422,21 @@ impl FreenetSynchronizer {
                         }
                     }
                     SynchronizerMessage::Connect => {
+                        // A reconnect (or the first connect) is now being
+                        // attempted; clear the pending latch. A redundant Connect
+                        // — from repeated PageBecameVisible, a frozen background
+                        // timer backlog that all fires at once on resume, or the
+                        // ProcessRooms/RefreshAllRooms no-delay Connect paths —
+                        // must NOT tear down a live connection: initialize_connection
+                        // would overwrite a live WEB_API, dropping its socket, whose
+                        // orphaned `onclose` then injects a spurious ConnectionLost
+                        // and self-sustains the loop (freenet/river#406). Skip when
+                        // already connected.
+                        reconnect.note_connect_attempt();
+                        if connection_manager.is_connected() {
+                            info!("Connect ignored — already connected");
+                            continue;
+                        }
                         info!("Connecting to Freenet");
                         match connection_manager
                             .initialize_connection(message_tx.clone())
@@ -328,7 +444,26 @@ impl FreenetSynchronizer {
                         {
                             Ok(()) => {
                                 info!("Connection established successfully");
-                                consecutive_failures = 0;
+                                // Do NOT reset the backoff on mere socket-open — an
+                                // open-then-die socket would reset it every cycle,
+                                // defeating the exponential backoff. Instead arm a
+                                // dwell check tagged with this connection's
+                                // generation; the backoff resets only if this same
+                                // connection is still up after the dwell window
+                                // (freenet/river#406).
+                                let connect_seq = super::connection_watchdog::ws_connect_seq();
+                                let stable_tx = message_tx.clone();
+                                spawn_local(async move {
+                                    sleep(Duration::from_millis(
+                                        super::constants::CONNECTION_STABLE_DWELL_MS,
+                                    ))
+                                    .await;
+                                    if let Err(e) = stable_tx.unbounded_send(
+                                        SynchronizerMessage::ConnectionStable { connect_seq },
+                                    ) {
+                                        error!("Failed to send ConnectionStable: {}", e);
+                                    }
+                                });
                                 // Check if web API is available without holding the lock
                                 // during process_rooms() call
                                 let api_available = WEB_API.read().is_some();
@@ -380,7 +515,13 @@ impl FreenetSynchronizer {
                             }
                             Err(e) => {
                                 error!("Failed to initialize connection: {}", e);
-                                schedule_reconnect(&mut consecutive_failures, &message_tx);
+                                let delay = reconnect.on_connect_failed();
+                                warn!(
+                                    "Connection failed (attempt {}), reconnecting in {}ms",
+                                    reconnect.attempt(),
+                                    delay
+                                );
+                                spawn_reconnect(delay, &message_tx);
                             }
                         }
                     }
@@ -661,5 +802,61 @@ mod tests {
         }
         // Extreme values must not overflow
         assert_eq!(reconnect_delay_ms(u32::MAX), 60000);
+    }
+
+    // On non-wasm, jitter is deterministic (= jitter_range), so
+    // reconnect_delay_ms(n) == the capped exponential: 3s, 6s, 12s, 24s, 48s, 60s…
+
+    #[test]
+    fn flapping_open_then_die_backs_off() {
+        // The regression: an Android socket that opens then immediately dies
+        // must NOT reset the backoff on mere open. Because the stability dwell is
+        // never reached, `note_stable` is never called, so each loss grows the
+        // delay instead of pinning it at the 3s floor forever (freenet/river#406).
+        let mut r = ReconnectState::default();
+        let mut delays = vec![];
+        for _ in 0..5 {
+            r.note_connect_attempt(); // Connect dequeued
+                                      // socket opens (Ok) — no failure increment, dwell not yet reached
+            let delay = r
+                .on_connection_lost()
+                .expect("first loss of each cycle schedules a reconnect");
+            delays.push(delay);
+        }
+        assert_eq!(delays, vec![3000, 6000, 12000, 24000, 48000]);
+    }
+
+    #[test]
+    fn stable_connection_resets_backoff_but_stale_dwell_does_not() {
+        let mut r = ReconnectState::default();
+        r.note_connect_attempt();
+        r.on_connection_lost(); // failures 0 -> 1
+        r.note_connect_attempt();
+        r.on_connection_lost(); // failures 1 -> 2
+
+        // A dwell for a connection that is no longer the live one must NOT reset.
+        r.note_stable(false);
+        r.note_connect_attempt();
+        assert_eq!(r.on_connection_lost(), Some(12000)); // still failures=2 -> 12s
+
+        // A connection that stayed up for the dwell (still current) resets it.
+        r.note_stable(true);
+        r.note_connect_attempt();
+        assert_eq!(r.on_connection_lost(), Some(3000)); // reset -> 3s
+    }
+
+    #[test]
+    fn duplicate_connection_lost_is_coalesced() {
+        // A dropped socket's orphaned `onclose`, plus the watchdog reporting the
+        // same death, must not each schedule a reconnect (freenet/river#406).
+        let mut r = ReconnectState::default();
+        r.note_connect_attempt();
+        assert_eq!(r.on_connection_lost(), Some(3000)); // schedules; pending latched
+        assert_eq!(r.on_connection_lost(), None); // duplicate ignored
+        assert_eq!(r.on_connection_lost(), None); // and again
+                                                  // The next real attempt clears the latch; a later loss schedules again,
+                                                  // and the duplicates above did NOT inflate the failure count (6s, not 24s).
+        r.note_connect_attempt();
+        assert_eq!(r.on_connection_lost(), Some(6000));
     }
 }

--- a/ui/src/components/app/freenet_api/freenet_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/freenet_synchronizer.rs
@@ -9,7 +9,7 @@ use crate::components::app::chat_delegate::{
 };
 use crate::components::app::sync_info::SYNC_INFO;
 use crate::components::app::{ROOMS, SYNC_STATUS, WEB_API};
-use crate::util::{owner_vk_to_contract_key, sleep};
+use crate::util::{owner_vk_to_contract_key, safe_spawn_local, sleep};
 use dioxus::logger::tracing::{debug, error, info, warn};
 use dioxus::prelude::*;
 use ed25519_dalek::SigningKey;
@@ -49,18 +49,39 @@ fn reconnect_delay_ms(consecutive_failures: u32) -> u64 {
     (capped - jitter_range + jitter).min(RECONNECT_MAX_MS)
 }
 
-/// Reconnect bookkeeping: the exponential-backoff failure counter plus a
-/// single-outstanding-reconnect latch. Extracted from the message loop so the
-/// two behaviours behind the endless Android reconnect loop (freenet/river#406)
-/// are unit-testable: (1) the backoff must GROW across an open-then-die flap
-/// and reset only after a connection proves stable, and (2) a duplicate
-/// ConnectionLost (a dropped socket's orphaned `onclose`, or the watchdog and
-/// transport reporting the same death) must be coalesced, not stack another
-/// reconnect.
+/// A scheduled reconnect: the backoff delay to wait, plus the `generation` that
+/// identifies this specific arming. A delayed reconnect timer captures the
+/// generation and, when it fires, drives a reconnect only if the generation is
+/// still current (`ReconnectState::is_current_reconnect`). This lets an
+/// immediate Connect — from PageBecameVisible/ProcessRooms, or a thawed
+/// background-timer backlog firing all at once on resume — supersede an
+/// already-scheduled backoff timer instead of running in parallel with it, so
+/// reconnect chains can't stack (freenet/river#406).
+#[derive(Clone, Copy)]
+struct ArmedReconnect {
+    delay_ms: u64,
+    generation: u64,
+}
+
+/// Reconnect bookkeeping: the exponential-backoff failure counter, a
+/// single-outstanding-reconnect latch, and a generation counter that lets a
+/// stale reconnect timer detect it has been superseded. Extracted from the
+/// message loop so the behaviours behind the endless Android reconnect loop
+/// (freenet/river#406) are unit-testable: (1) the backoff must GROW across an
+/// open-then-die flap and reset only after a connection proves stable; (2) a
+/// duplicate ConnectionLost (a dropped socket's orphaned `onclose`, or the
+/// watchdog and transport reporting the same death) must be coalesced, not
+/// stack another reconnect; and (3) once a newer reconnect is armed, an older
+/// timer that fires late must drop itself rather than launch a parallel
+/// attempt.
 #[derive(Default)]
 struct ReconnectState {
     consecutive_failures: u32,
     reconnect_pending: bool,
+    /// Bumped on every `arm()`. A delayed reconnect timer is honored only if the
+    /// generation it captured still equals this value (see
+    /// [`is_current_reconnect`](Self::is_current_reconnect)).
+    generation: u64,
 }
 
 impl ReconnectState {
@@ -69,10 +90,10 @@ impl ReconnectState {
         self.reconnect_pending = false;
     }
 
-    /// A ConnectionLost arrived. `Some(delay_ms)` → schedule a reconnect after
-    /// that delay; `None` → a reconnect is already pending, so this is a
+    /// A ConnectionLost arrived. `Some(armed)` → schedule a reconnect with that
+    /// delay/generation; `None` → a reconnect is already pending, so this is a
     /// coalesced duplicate loss and must be ignored.
-    fn on_connection_lost(&mut self) -> Option<u64> {
+    fn on_connection_lost(&mut self) -> Option<ArmedReconnect> {
         if self.reconnect_pending {
             None
         } else {
@@ -81,7 +102,7 @@ impl ReconnectState {
     }
 
     /// A Connect attempt failed to open — always schedule a retry.
-    fn on_connect_failed(&mut self) -> u64 {
+    fn on_connect_failed(&mut self) -> ArmedReconnect {
         self.arm()
     }
 
@@ -94,12 +115,26 @@ impl ReconnectState {
         }
     }
 
-    /// Current backoff delay, then advance the failure count and arm the latch.
-    fn arm(&mut self) -> u64 {
+    /// Whether a delayed reconnect timer tagged with `generation` should still
+    /// drive a reconnect. False once a newer `arm()` has superseded it (a newer
+    /// timer is already scheduled) or the pending reconnect has already been
+    /// consumed — so a late-firing stale timer drops itself instead of stacking
+    /// a parallel attempt (freenet/river#406).
+    fn is_current_reconnect(&self, generation: u64) -> bool {
+        self.reconnect_pending && self.generation == generation
+    }
+
+    /// Current backoff delay, then advance the failure count, arm the latch, and
+    /// bump the generation (invalidating any previously-scheduled timer).
+    fn arm(&mut self) -> ArmedReconnect {
         let delay = reconnect_delay_ms(self.consecutive_failures);
         self.consecutive_failures = self.consecutive_failures.saturating_add(1);
         self.reconnect_pending = true;
-        delay
+        self.generation = self.generation.saturating_add(1);
+        ArmedReconnect {
+            delay_ms: delay,
+            generation: self.generation,
+        }
     }
 
     /// Human-facing attempt number for logs (1-based after arming).
@@ -112,6 +147,14 @@ impl ReconnectState {
 pub enum SynchronizerMessage {
     ProcessRooms,
     Connect,
+    /// Sent (delayed) by a reconnect backoff timer, tagged with the reconnect
+    /// generation it was armed for. Drives a reconnect only if that generation
+    /// is still current — a newer arming (e.g. from an immediate Connect after
+    /// resume) supersedes it, so stale timers drop themselves instead of
+    /// stacking parallel reconnect chains (freenet/river#406).
+    ScheduledReconnect {
+        generation: u64,
+    },
     /// Sent when WebSocket connection is lost (closed or errored)
     ConnectionLost,
     /// Sent (delayed) after a Connect succeeds, tagged with the connection
@@ -250,16 +293,26 @@ impl FreenetSynchronizer {
             let mut reconnect = ReconnectState::default();
 
             // Spawn the delayed reconnect (the async setTimeout part; the backoff
-            // math + pending latch live in `ReconnectState`).
-            let spawn_reconnect = |delay: u64, tx: &UnboundedSender<SynchronizerMessage>| {
-                let tx = tx.clone();
-                spawn_local(async move {
-                    sleep(Duration::from_millis(delay)).await;
-                    if let Err(e) = tx.unbounded_send(SynchronizerMessage::Connect) {
-                        error!("Failed to send reconnect message: {}", e);
-                    }
-                });
-            };
+            // math + pending latch + generation live in `ReconnectState`). The
+            // timer sends `ScheduledReconnect { generation }` rather than a bare
+            // Connect, so a stale timer (superseded by a newer arming) drops
+            // itself in the handler instead of stacking a parallel reconnect
+            // (freenet/river#406). `safe_spawn_local` defers the spawn via
+            // setTimeout(0) so spawning from inside this polled loop future can't
+            // re-enter wasm-bindgen's task scheduler and panic on Firefox mobile
+            // (mirrors the watchdog's own convention).
+            let spawn_reconnect =
+                |armed: ArmedReconnect, tx: &UnboundedSender<SynchronizerMessage>| {
+                    let tx = tx.clone();
+                    safe_spawn_local(async move {
+                        sleep(Duration::from_millis(armed.delay_ms)).await;
+                        if let Err(e) = tx.unbounded_send(SynchronizerMessage::ScheduledReconnect {
+                            generation: armed.generation,
+                        }) {
+                            error!("Failed to send reconnect message: {}", e);
+                        }
+                    });
+                };
 
             info!("Entering message loop");
             while let Some(msg) = message_rx.next().await {
@@ -307,17 +360,38 @@ impl FreenetSynchronizer {
                             None => {
                                 info!("ConnectionLost ignored — a reconnect is already pending");
                             }
-                            Some(delay) => {
+                            Some(armed) => {
                                 // Clear the web API so is_connected() returns false
                                 WEB_API.write().take();
                                 *SYNC_STATUS.write() = SynchronizerStatus::Disconnected;
                                 warn!(
                                     "Connection lost (attempt {}), reconnecting in {}ms",
                                     reconnect.attempt(),
-                                    delay
+                                    armed.delay_ms
                                 );
-                                spawn_reconnect(delay, &message_tx);
+                                spawn_reconnect(armed, &message_tx);
                             }
+                        }
+                    }
+                    SynchronizerMessage::ScheduledReconnect { generation } => {
+                        // A backoff timer fired. Honor it only if it is still the
+                        // current reconnect generation; a newer arming (typically
+                        // an immediate Connect after resume that itself failed, or
+                        // another loss) supersedes it, so an older timer that fires
+                        // late drops itself here instead of launching a second,
+                        // parallel reconnect chain (freenet/river#406). When
+                        // current, funnel through the normal Connect path so the
+                        // connect/dedup logic lives in one place.
+                        if reconnect.is_current_reconnect(generation) {
+                            if let Err(e) = message_tx.unbounded_send(SynchronizerMessage::Connect)
+                            {
+                                error!("Failed to send Connect from ScheduledReconnect: {}", e);
+                            }
+                        } else {
+                            info!(
+                                "Stale reconnect timer (generation {}) dropped — superseded by a newer attempt",
+                                generation
+                            );
                         }
                     }
                     SynchronizerMessage::ConnectionStable { connect_seq } => {
@@ -346,10 +420,12 @@ impl FreenetSynchronizer {
                             // runs now rather than waiting out any pending backoff
                             // timer). Do NOT reset the backoff here: eagerly zeroing
                             // it on every resume was part of the never-terminating
-                            // loop. The Connect dedup makes a redundant attempt (if
-                            // a reconnect was already pending) a no-op, and the
-                            // dwell resets the backoff once a connection is stable
-                            // (freenet/river#406).
+                            // loop. This immediate Connect also bumps the reconnect
+                            // generation if it fails, so any backoff timer already
+                            // scheduled for the old generation drops itself when it
+                            // fires (see `ScheduledReconnect`) rather than adding a
+                            // parallel attempt; the dwell resets the backoff once a
+                            // connection proves stable (freenet/river#406).
                             info!("Connection is not active after wake, triggering reconnection");
                             if let Err(e) = message_tx.unbounded_send(SynchronizerMessage::Connect)
                             {
@@ -423,17 +499,24 @@ impl FreenetSynchronizer {
                     }
                     SynchronizerMessage::Connect => {
                         // A reconnect (or the first connect) is now being
-                        // attempted; clear the pending latch. A redundant Connect
-                        // — from repeated PageBecameVisible, a frozen background
-                        // timer backlog that all fires at once on resume, or the
+                        // attempted; clear the pending latch so the next loss can
+                        // arm a fresh reconnect. A redundant Connect — from
+                        // repeated PageBecameVisible, a frozen background-timer
+                        // backlog that all fires at once on resume, or the
                         // ProcessRooms/RefreshAllRooms no-delay Connect paths —
                         // must NOT tear down a live connection: initialize_connection
                         // would overwrite a live WEB_API, dropping its socket, whose
                         // orphaned `onclose` then injects a spurious ConnectionLost
                         // and self-sustains the loop (freenet/river#406). Skip when
-                        // already connected.
+                        // we already have a live, usable connection. Both conditions
+                        // are required: SYNC_STATUS and WEB_API are written by
+                        // separate deferred tasks, so a late `onopen` can leave
+                        // `is_connected()` true while WEB_API is still None (a
+                        // half-open zombie). Gating on WEB_API too keeps the skip
+                        // self-contained rather than relying on a later onclose to
+                        // re-assert the disconnect.
                         reconnect.note_connect_attempt();
-                        if connection_manager.is_connected() {
+                        if connection_manager.is_connected() && WEB_API.read().is_some() {
                             info!("Connect ignored — already connected");
                             continue;
                         }
@@ -453,7 +536,13 @@ impl FreenetSynchronizer {
                                 // (freenet/river#406).
                                 let connect_seq = super::connection_watchdog::ws_connect_seq();
                                 let stable_tx = message_tx.clone();
-                                spawn_local(async move {
+                                // `safe_spawn_local` (not raw `spawn_local`) defers
+                                // the spawn via setTimeout(0): spawning from inside
+                                // this polled loop future can otherwise re-enter
+                                // wasm-bindgen's task scheduler and panic on Firefox
+                                // mobile — the same convention the liveness watchdog
+                                // uses for exactly this reason.
+                                safe_spawn_local(async move {
                                     sleep(Duration::from_millis(
                                         super::constants::CONNECTION_STABLE_DWELL_MS,
                                     ))
@@ -515,13 +604,13 @@ impl FreenetSynchronizer {
                             }
                             Err(e) => {
                                 error!("Failed to initialize connection: {}", e);
-                                let delay = reconnect.on_connect_failed();
+                                let armed = reconnect.on_connect_failed();
                                 warn!(
                                     "Connection failed (attempt {}), reconnecting in {}ms",
                                     reconnect.attempt(),
-                                    delay
+                                    armed.delay_ms
                                 );
-                                spawn_reconnect(delay, &message_tx);
+                                spawn_reconnect(armed, &message_tx);
                             }
                         }
                     }
@@ -804,9 +893,6 @@ mod tests {
         assert_eq!(reconnect_delay_ms(u32::MAX), 60000);
     }
 
-    // On non-wasm, jitter is deterministic (= jitter_range), so
-    // reconnect_delay_ms(n) == the capped exponential: 3s, 6s, 12s, 24s, 48s, 60s…
-
     #[test]
     fn flapping_open_then_die_backs_off() {
         // The regression: an Android socket that opens then immediately dies
@@ -818,10 +904,10 @@ mod tests {
         for _ in 0..5 {
             r.note_connect_attempt(); // Connect dequeued
                                       // socket opens (Ok) — no failure increment, dwell not yet reached
-            let delay = r
+            let armed = r
                 .on_connection_lost()
                 .expect("first loss of each cycle schedules a reconnect");
-            delays.push(delay);
+            delays.push(armed.delay_ms);
         }
         assert_eq!(delays, vec![3000, 6000, 12000, 24000, 48000]);
     }
@@ -837,12 +923,12 @@ mod tests {
         // A dwell for a connection that is no longer the live one must NOT reset.
         r.note_stable(false);
         r.note_connect_attempt();
-        assert_eq!(r.on_connection_lost(), Some(12000)); // still failures=2 -> 12s
+        assert_eq!(r.on_connection_lost().map(|a| a.delay_ms), Some(12000)); // failures=2 -> 12s
 
         // A connection that stayed up for the dwell (still current) resets it.
         r.note_stable(true);
         r.note_connect_attempt();
-        assert_eq!(r.on_connection_lost(), Some(3000)); // reset -> 3s
+        assert_eq!(r.on_connection_lost().map(|a| a.delay_ms), Some(3000)); // reset -> 3s
     }
 
     #[test]
@@ -851,12 +937,40 @@ mod tests {
         // same death, must not each schedule a reconnect (freenet/river#406).
         let mut r = ReconnectState::default();
         r.note_connect_attempt();
-        assert_eq!(r.on_connection_lost(), Some(3000)); // schedules; pending latched
-        assert_eq!(r.on_connection_lost(), None); // duplicate ignored
-        assert_eq!(r.on_connection_lost(), None); // and again
-                                                  // The next real attempt clears the latch; a later loss schedules again,
-                                                  // and the duplicates above did NOT inflate the failure count (6s, not 24s).
+        assert_eq!(r.on_connection_lost().map(|a| a.delay_ms), Some(3000)); // schedules; pending latched
+        assert!(r.on_connection_lost().is_none()); // duplicate ignored
+        assert!(r.on_connection_lost().is_none()); // and again
+                                                   // The next real attempt clears the latch; a later loss schedules again,
+                                                   // and the duplicates above did NOT inflate the failure count (6s, not 24s).
         r.note_connect_attempt();
-        assert_eq!(r.on_connection_lost(), Some(6000));
+        assert_eq!(r.on_connection_lost().map(|a| a.delay_ms), Some(6000));
+    }
+
+    #[test]
+    fn stale_reconnect_timer_is_dropped_but_current_one_fires() {
+        // A backoff timer must only drive a reconnect if its generation is still
+        // current. When an immediate Connect (e.g. from PageBecameVisible on
+        // resume) supersedes an already-scheduled timer, the old timer that fires
+        // late must drop itself rather than stack a parallel reconnect chain
+        // (freenet/river#406).
+        let mut r = ReconnectState::default();
+
+        // Loss 1 arms a timer at generation g1.
+        r.note_connect_attempt();
+        let g1 = r.on_connection_lost().expect("first loss arms").generation;
+        assert!(r.is_current_reconnect(g1)); // its own timer is current
+
+        // An immediate Connect runs, fails, and arms a NEW timer at g2. That
+        // arming supersedes g1.
+        r.note_connect_attempt(); // clears the pending latch (Connect dequeued)
+        let g2 = r.on_connect_failed().generation;
+        assert_ne!(g1, g2);
+        assert!(!r.is_current_reconnect(g1)); // the g1 timer is now stale -> dropped
+        assert!(r.is_current_reconnect(g2)); // the g2 timer is current -> fires
+
+        // Once the g2 timer's Connect is dequeued (latch cleared), even g2 is no
+        // longer a pending reconnect, so a duplicate firing is a no-op.
+        r.note_connect_attempt();
+        assert!(!r.is_current_reconnect(g2));
     }
 }


### PR DESCRIPTION
## Problem

On Android Chrome with a room open, after the device goes inactive for ~a minute and is reactivated, River's connection indicator cycles **Connected → Disconnected → error** forever. Only a full page refresh stops it. Reported by Ivvor (Matrix):

> Go to River on an Android phone and have a room open. Then let the device go inactive. Leave for a minute or so then reactivate and the mad reconnect cycle begins.

The socket "connects very briefly, then connection closed, then retry very quickly" — a tight loop, not a backing-off retry. (iPad Safari is unaffected because it force-refreshes the page after inactivity.)

## Root cause

Three compounding bugs in the synchronizer reconnect logic (`freenet_synchronizer.rs`):

1. **Backoff reset on mere socket `onopen`.** A socket that opens then immediately dies (the Android resume symptom) reset the failure counter every cycle, so the reconnect delay never grew past the ~3s floor — the "mad cycle."
2. **Redundant `Connect` tore down a live connection.** A repeated `PageBecameVisible`, a frozen background-timer backlog firing all at once on resume, or the `ProcessRooms`/`RefreshAllRooms` no-delay Connect paths could re-enter `initialize_connection`, which overwrote a live `WEB_API` and dropped its socket. That socket's orphaned `onclose` then injected a spurious `ConnectionLost`, self-sustaining the loop.
3. **Duplicate `ConnectionLost` events stacked reconnects.** The dropped socket's own `onclose` plus the liveness watchdog reporting the same death each scheduled a reconnect, inflating backoff and multiplying timers.

## Approach

- **Reset backoff only on proven stability.** After a `Connect` succeeds, arm a dwell check (`CONNECTION_STABLE_DWELL_MS = 15s`) tagged with the connection generation (`ws_connect_seq`). The backoff resets only if *that same* connection is still up after the dwell — so an open-then-die socket keeps backing off (3s→6s→12s→…→60s cap) instead of pinning at 3s.
- **Dedup `Connect`:** skip `initialize_connection` when already connected, so a redundant Connect can't drop a live socket.
- **Coalesce `ConnectionLost`** via a single-pending-reconnect latch, so duplicate losses don't stack.
- **Stop eagerly zeroing backoff on `PageBecameVisible`** (it still sends an immediate Connect; the dedup + dwell handle correctness).

Backoff math + latch extracted into a `ReconnectState` struct so the behaviour is unit-testable off-wasm.

## Testing

- **3 new unit tests** (`ReconnectState`): flap-backs-off (`vec![3000,6000,12000,24000,48000]`), stable-resets-but-stale-dwell-doesn't, duplicate-loss-coalesced. Full suite green (431 tests).
- **Reproduced end-to-end with Playwright** — a mock node socket that opens then dies after 600ms (simulating the Android flapping socket):

  | | Before (main) | After (this PR) |
  |---|---|---|
  | socket opens / 45s | **12** | **4** |
  | reconnect intervals | constant ~3.5s | **4.1s → 5.8s → 12.6s** |
  | backoff grows | ❌ no | ✅ yes |

Closes #406

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)