### PR TITLE
feat: allow importing an identity over an existing one (warn + confirm)

### DIFF
--- a/cli/src/commands/identity.rs
+++ b/cli/src/commands/identity.rs
@@ -238,7 +238,15 @@ async fn import_identity(
         );
     }
 
-    // Fetch room state from network to populate local storage
+    // Fetch room state from the network. This serves two purposes depending on
+    // which arm `import_room_atomic` takes:
+    //   - NEW room: the fetched state is the initial local copy that gets stored.
+    //   - OVERWRITE (room already exists): the stored state is KEPT untouched
+    //     (room state is identity-independent — see `import_room_atomic`), so
+    //     the fetched state here is DISCARDED. The GET still matters: it
+    //     validates the room is reachable and drives any migration/heal side
+    //     effects (`get_room` re-attempts `member_info` heal, contract-key
+    //     migration, etc.) before we swap in the replacement identity.
     let room_state = api_client
         .get_room(&export.room_owner, false)
         .await
@@ -645,10 +653,15 @@ mod tests {
         );
     }
 
-    /// freenet/river#414: a `--force` import runs the same storage sequence the
-    /// import path uses, but with a new signing key — it must REPLACE the
-    /// stored identity in place (not error, not duplicate). Drives the `Storage`
-    /// calls directly (the async `import_identity` needs a live node).
+    /// freenet/river#414: importing with `--force` and a new signing key must
+    /// REPLACE the stored identity in place (not error, not duplicate). The real
+    /// import path now does this atomically under one lock via
+    /// `Storage::import_room_atomic` (exercised by the `import_room_atomic_*`
+    /// tests, which the async `import_identity` needs a live node to drive
+    /// end-to-end). This test instead drives the underlying `Storage` mutators
+    /// directly to assert the in-place-overwrite CONTRACT they rely on: writing
+    /// the same owner key twice keeps a single room entry and swaps the stored
+    /// signing key.
     #[test]
     fn force_import_overwrites_stored_identity() {
         let owner_sk = signing_key_from_seed(21);
@@ -678,8 +691,11 @@ mod tests {
             "precondition: OLD identity is stored"
         );
 
-        // The `--force` path re-runs the import's storage sequence with the NEW
-        // key: add_room_with_invitation_secrets (overwrites) + store_authorized_member.
+        // Re-write the same owner key with the NEW signing key via the storage
+        // mutators (overwrite + authorized-member store). This is NOT the exact
+        // sequence the import path runs today (that's the single-lock
+        // `import_room_atomic`); it drives the same primitives directly to assert
+        // the overwrite-in-place contract those upper layers depend on.
         storage
             .add_room_with_invitation_secrets(
                 &owner_vk,

--- a/cli/src/commands/identity.rs
+++ b/cli/src/commands/identity.rs
@@ -214,30 +214,22 @@ async fn import_identity(
 
     let room_key_str = bs58::encode(export.room_owner.as_bytes()).into_string();
 
-    // If we already have an identity for this room, refuse UNLESS the user
-    // opted in to replacing it with --force/--overwrite (freenet/river#414).
-    // Replacing rewrites the stored signing key, so the previous identity is
-    // lost locally unless it was exported first.
-    // Compare against the RAW persisted key on disk, NOT `get_room`'s
-    // override-resolved key: with `--signing-key-file` / `RIVER_SIGNING_KEY_FILE`
-    // active, the resolved key is the override, so a real identity change could
-    // look unchanged (skipping the DM prune) or an unchanged identity could look
-    // changed (pruning wrongly). The persisted `signing_key_bytes` is the actual
-    // stored identity being replaced (freenet/river#414).
+    // Fast-path pre-check (freenet/river#414): compare against the RAW persisted
+    // key (NOT `get_room`'s `--signing-key-file` override-resolved key) so we can
+    // skip a pointless network GET when we'd only refuse, and emit the replace
+    // warning. This is ADVISORY — the authoritative new-vs-overwrite + key-changed
+    // decision is re-made atomically INSIDE `import_room_atomic`'s lock AFTER the
+    // GET, so a concurrent `riverctl` import during the await cannot make us
+    // overwrite (or skip the DM prune) on a stale view (Codex round-6 P1-5).
     let persisted_old_key = api_client
         .storage()
         .persisted_signing_key_bytes(&export.room_owner)?;
-    let room_exists = persisted_old_key.is_some();
-    // Whether --force is actually swapping to a DIFFERENT identity. Used below
-    // to prune the old identity's per-room DM cache: if they differ, the
-    // outbound-DM plaintext / archived threads belong to the old identity and
-    // must not leak into the new one.
-    let identity_changed =
-        persisted_old_key.is_some_and(|old| old != export.signing_key.to_bytes());
-    if let Some(refusal) = import_overwrite_refusal(room_exists, force, &room_key_str) {
+    if let Some(refusal) =
+        import_overwrite_refusal(persisted_old_key.is_some(), force, &room_key_str)
+    {
         return Err(anyhow!(refusal));
     }
-    if room_exists {
+    if persisted_old_key.is_some() {
         // force && exists: proceeding to replace — warn about the lost key.
         eprintln!(
             "WARNING: replacing the existing identity for room {}. The previous \
@@ -257,58 +249,12 @@ async fn import_identity(
             )
         })?;
 
-    // Store the room with the imported identity, seeding the persisted
-    // `invitation_secrets` from the export so a non-owner of a private room
-    // keeps the secret across a device migration (freenet/river#306). For a
-    // public room or an export taken before this field existed, the map is
-    // empty and this behaves exactly like the previous `add_room` call.
-    let contract_key = api_client.owner_vk_to_contract_key(&export.room_owner);
-    api_client.storage().add_room_with_invitation_secrets(
-        &export.room_owner,
-        &export.signing_key,
-        room_state,
-        &contract_key,
-        export.invitation_secrets.clone(),
-    )?;
-
-    // Store the authorized member and invite chain for rejoin support
-    api_client.storage().store_authorized_member(
-        &export.room_owner,
-        &export.authorized_member,
-        &export.invite_chain,
-    )?;
-
-    // A --force replace with a DIFFERENT signing key just swapped the room's
-    // identity. Prune the OLD identity's per-room outbound-DM plaintext and
-    // archived-thread records so they don't leak into (or wrongly hide threads
-    // for) the new identity, exactly as `room leave` does (freenet/river#414).
-    // Best-effort: the identity is already committed, so a prune hiccup warns
-    // rather than failing the import (mirrors `Storage::remove_room`).
-    if force && identity_changed {
-        if let Err(e) = api_client
-            .storage()
-            .prune_outbound_dms_for_room(&export.room_owner)
-        {
-            eprintln!(
-                "WARNING: failed to prune the previous identity's DM cache for room {}: {}",
-                room_key_str, e
-            );
-        }
-    }
-
-    // Persist the imported nickname so a later rejoin (after an inactivity
-    // prune) restores it instead of "Member".
-    //
-    // Prefer the public-plaintext nickname carried in `member_info`. A
-    // private room's exported `member_info` nickname is sealed, so
-    // `to_string_lossy` yields an "[Encrypted: …]" placeholder, not the real
-    // name; persisting that would be worse than the generic fallback.
-    //
-    // When `member_info` carries no usable public nickname (it is absent —
-    // e.g. an export taken before the private-room join-heal sealed it,
-    // freenet/river#298 — or sealed), fall back to the plaintext
-    // `self_nickname` the export now carries. This is the chosen nickname,
-    // not an "[Encrypted: …]" placeholder, so it is safe to persist.
+    // Compute the nickname to persist BEFORE the atomic write so it goes into the
+    // same `StoredRoomInfo` under one lock (a later rejoin restores it instead of
+    // "Member"). Prefer the public-plaintext `member_info` nickname; else the
+    // plaintext `self_nickname` the export carries. A private room's sealed
+    // `member_info` nickname renders as an "[Encrypted: …]" placeholder via
+    // `to_string_lossy` (worse than the fallback), so it is excluded here.
     let public_member_info_nickname = export.member_info.as_ref().and_then(|info| {
         info.member_info
             .preferred_nickname
@@ -318,10 +264,37 @@ async fn import_identity(
     let nickname_to_persist = public_member_info_nickname
         .clone()
         .or_else(|| export.self_nickname.clone());
-    if let Some(nick) = nickname_to_persist {
-        api_client
-            .storage()
-            .update_self_nickname(&export.room_owner, &nick)?;
+
+    // Atomic import (freenet/river#414 P1-5): re-check existence + key and write
+    // the full record (room + authorized member + invite chain + nickname) under
+    // ONE lock, pruning the old identity's DM cache on a key change — all inside
+    // the lock, so a concurrent import can't interleave. Seeds `invitation_secrets`
+    // from the export so a non-owner of a private room keeps the secret across a
+    // device migration (freenet/river#306).
+    let contract_key = api_client.owner_vk_to_contract_key(&export.room_owner);
+    let outcome = api_client.storage().import_room_atomic(
+        &export.room_owner,
+        &export.signing_key,
+        room_state,
+        &contract_key,
+        export.invitation_secrets.clone(),
+        &export.authorized_member,
+        &export.invite_chain,
+        nickname_to_persist.as_deref(),
+        force,
+    )?;
+
+    if outcome == crate::storage::ImportOutcome::RefusedNeedsForce {
+        // A concurrent import created this room during our network GET — refuse
+        // rather than silently overwrite it (this is the TOCTOU we now catch).
+        return Err(anyhow!(import_overwrite_refusal(
+            true,
+            false,
+            &room_key_str
+        )
+        .expect(
+            "refusal message is Some for an existing room without --force"
+        )));
     }
 
     // For the human/JSON summary, show the real nickname: prefer the

--- a/cli/src/commands/identity.rs
+++ b/cli/src/commands/identity.rs
@@ -22,6 +22,13 @@ pub enum IdentityCommands {
         /// Path to a file containing the armored identity token
         #[arg(long, conflicts_with = "token")]
         file: Option<String>,
+        /// Replace an existing identity for the room instead of refusing.
+        ///
+        /// Overwriting loses the current identity's signing key locally unless
+        /// it was exported first (`riverctl identity export`). The room's
+        /// messages/members live on the network and re-sync (freenet/river#414).
+        #[arg(long, visible_alias = "overwrite")]
+        force: bool,
     },
 }
 
@@ -32,8 +39,8 @@ pub async fn execute(
 ) -> Result<()> {
     match command {
         IdentityCommands::Export { room } => export_identity(&api_client, &room, format).await,
-        IdentityCommands::Import { token, file } => {
-            import_identity(&api_client, token, file, format).await
+        IdentityCommands::Import { token, file, force } => {
+            import_identity(&api_client, token, file, force, format).await
         }
     }
 }
@@ -183,6 +190,7 @@ async fn import_identity(
     api_client: &ApiClient,
     token: Option<String>,
     file: Option<String>,
+    force: bool,
     format: OutputFormat,
 ) -> Result<()> {
     // Read token from argument, file, or stdin
@@ -206,14 +214,21 @@ async fn import_identity(
 
     let room_key_str = bs58::encode(export.room_owner.as_bytes()).into_string();
 
-    // Check if we already have this room
-    if api_client.storage().get_room(&export.room_owner)?.is_some() {
-        return Err(anyhow!(
-            "You already have an identity for room {}. \
-             Remove it first with `riverctl room leave {}` if you want to replace it.",
-            room_key_str,
+    // If we already have an identity for this room, refuse UNLESS the user
+    // opted in to replacing it with --force/--overwrite (freenet/river#414).
+    // Replacing rewrites the stored signing key, so the previous identity is
+    // lost locally unless it was exported first.
+    let room_exists = api_client.storage().get_room(&export.room_owner)?.is_some();
+    if let Some(refusal) = import_overwrite_refusal(room_exists, force, &room_key_str) {
+        return Err(anyhow!(refusal));
+    }
+    if room_exists {
+        // force && exists: proceeding to replace — warn about the lost key.
+        eprintln!(
+            "WARNING: replacing the existing identity for room {}. The previous \
+             signing key is lost unless you exported it first.",
             room_key_str
-        ));
+        );
     }
 
     // Fetch room state from network to populate local storage
@@ -307,6 +322,28 @@ async fn import_identity(
     }
 
     Ok(())
+}
+
+/// Decide whether an identity import must be refused because the room already
+/// has a stored identity and the user did not opt into replacing it.
+///
+/// Returns the refusal message when the import should be blocked (an identity
+/// exists and `force` is false), or `None` when the import may proceed —
+/// either the room is new, or `--force`/`--overwrite` authorizes the replace
+/// (freenet/river#414). Pure, so the guard is unit-testable without a node.
+fn import_overwrite_refusal(room_exists: bool, force: bool, room_key_str: &str) -> Option<String> {
+    if room_exists && !force {
+        Some(format!(
+            "You already have an identity for room {room}. \
+             Re-run with `--force` (alias `--overwrite`) to replace it, or \
+             remove it first with `riverctl room leave {room}`. Replacing loses \
+             your current signing key for this room unless you exported it \
+             first with `riverctl identity export {room}`.",
+            room = room_key_str
+        ))
+    } else {
+        None
+    }
 }
 
 fn parse_room_key(s: &str) -> Result<VerifyingKey> {
@@ -566,6 +603,100 @@ mod tests {
         assert!(
             !msg.contains("--signing-key-file") && !msg.contains("RIVER_SIGNING_KEY_FILE"),
             "no-override hint must not reference an override the user never set, got: {msg}"
+        );
+    }
+
+    /// freenet/river#414: without `--force`, importing over an existing room
+    /// refuses — and the refusal must name `--force`, its `--overwrite` alias,
+    /// and the room. With `--force`, or for a brand-new room, it proceeds.
+    #[test]
+    fn import_overwrite_refusal_matrix() {
+        let room = "ExampleRoomKey58";
+
+        // Brand-new room: never refuse, force or not.
+        assert!(import_overwrite_refusal(false, false, room).is_none());
+        assert!(import_overwrite_refusal(false, true, room).is_none());
+
+        // Existing room, no force: refuse with the improved message.
+        let msg = import_overwrite_refusal(true, false, room).expect("must refuse without --force");
+        assert!(
+            msg.contains("--force"),
+            "refusal must point at --force, got: {msg}"
+        );
+        assert!(
+            msg.contains("--overwrite"),
+            "refusal must mention the --overwrite alias, got: {msg}"
+        );
+        assert!(
+            msg.contains(room),
+            "refusal should name the room, got: {msg}"
+        );
+
+        // Existing room, force: proceed (no refusal).
+        assert!(
+            import_overwrite_refusal(true, true, room).is_none(),
+            "--force must authorize replacing an existing identity"
+        );
+    }
+
+    /// freenet/river#414: a `--force` import runs the same storage sequence the
+    /// import path uses, but with a new signing key — it must REPLACE the
+    /// stored identity in place (not error, not duplicate). Drives the `Storage`
+    /// calls directly (the async `import_identity` needs a live node).
+    #[test]
+    fn force_import_overwrites_stored_identity() {
+        let owner_sk = signing_key_from_seed(21);
+        let owner_vk = owner_sk.verifying_key();
+
+        let old_sk = signing_key_from_seed(22);
+        let new_sk = signing_key_from_seed(23);
+        assert_ne!(old_sk.to_bytes(), new_sk.to_bytes());
+
+        let temp_dir = TempDir::new().unwrap();
+        let storage = Storage::new(Some(temp_dir.path().to_str().unwrap())).unwrap();
+        let contract_key = compute_contract_key(&owner_vk);
+
+        // First import establishes the OLD identity.
+        storage
+            .add_room(
+                &owner_vk,
+                &old_sk,
+                create_test_state(&owner_sk),
+                &contract_key,
+            )
+            .unwrap();
+        let (stored, _, _) = storage.get_room(&owner_vk).unwrap().unwrap();
+        assert_eq!(
+            stored.to_bytes(),
+            old_sk.to_bytes(),
+            "precondition: OLD identity is stored"
+        );
+
+        // The `--force` path re-runs the import's storage sequence with the NEW
+        // key: add_room_with_invitation_secrets (overwrites) + store_authorized_member.
+        storage
+            .add_room_with_invitation_secrets(
+                &owner_vk,
+                &new_sk,
+                create_test_state(&owner_sk),
+                &contract_key,
+                HashMap::new(),
+            )
+            .unwrap();
+        storage
+            .store_authorized_member(&owner_vk, &authorized_member_for(&new_sk), &[])
+            .unwrap();
+
+        let (stored, _, _) = storage.get_room(&owner_vk).unwrap().unwrap();
+        assert_eq!(
+            stored.to_bytes(),
+            new_sk.to_bytes(),
+            "force import must overwrite the stored signing key with the imported one"
+        );
+        assert_eq!(
+            storage.load_rooms().unwrap().rooms.len(),
+            1,
+            "overwrite replaces in place — no duplicate room entry"
         );
     }
 }

--- a/cli/src/commands/identity.rs
+++ b/cli/src/commands/identity.rs
@@ -218,7 +218,16 @@ async fn import_identity(
     // opted in to replacing it with --force/--overwrite (freenet/river#414).
     // Replacing rewrites the stored signing key, so the previous identity is
     // lost locally unless it was exported first.
-    let room_exists = api_client.storage().get_room(&export.room_owner)?.is_some();
+    let existing_room = api_client.storage().get_room(&export.room_owner)?;
+    let room_exists = existing_room.is_some();
+    // Whether --force is actually swapping to a DIFFERENT identity. Used below
+    // to prune the old identity's per-room DM cache. (Compares the resolved
+    // stored key; in the normal no-`--signing-key` case this is exactly the
+    // stored identity. If they differ, the outbound-DM plaintext / archived
+    // threads belong to the old identity and must not leak into the new one.)
+    let identity_changed = existing_room
+        .as_ref()
+        .is_some_and(|(old_sk, _, _)| old_sk != &export.signing_key);
     if let Some(refusal) = import_overwrite_refusal(room_exists, force, &room_key_str) {
         return Err(anyhow!(refusal));
     }
@@ -262,6 +271,24 @@ async fn import_identity(
         &export.authorized_member,
         &export.invite_chain,
     )?;
+
+    // A --force replace with a DIFFERENT signing key just swapped the room's
+    // identity. Prune the OLD identity's per-room outbound-DM plaintext and
+    // archived-thread records so they don't leak into (or wrongly hide threads
+    // for) the new identity, exactly as `room leave` does (freenet/river#414).
+    // Best-effort: the identity is already committed, so a prune hiccup warns
+    // rather than failing the import (mirrors `Storage::remove_room`).
+    if force && identity_changed {
+        if let Err(e) = api_client
+            .storage()
+            .prune_outbound_dms_for_room(&export.room_owner)
+        {
+            eprintln!(
+                "WARNING: failed to prune the previous identity's DM cache for room {}: {}",
+                room_key_str, e
+            );
+        }
+    }
 
     // Persist the imported nickname so a later rejoin (after an inactivity
     // prune) restores it instead of "Member".

--- a/cli/src/commands/identity.rs
+++ b/cli/src/commands/identity.rs
@@ -218,16 +218,22 @@ async fn import_identity(
     // opted in to replacing it with --force/--overwrite (freenet/river#414).
     // Replacing rewrites the stored signing key, so the previous identity is
     // lost locally unless it was exported first.
-    let existing_room = api_client.storage().get_room(&export.room_owner)?;
-    let room_exists = existing_room.is_some();
+    // Compare against the RAW persisted key on disk, NOT `get_room`'s
+    // override-resolved key: with `--signing-key-file` / `RIVER_SIGNING_KEY_FILE`
+    // active, the resolved key is the override, so a real identity change could
+    // look unchanged (skipping the DM prune) or an unchanged identity could look
+    // changed (pruning wrongly). The persisted `signing_key_bytes` is the actual
+    // stored identity being replaced (freenet/river#414).
+    let persisted_old_key = api_client
+        .storage()
+        .persisted_signing_key_bytes(&export.room_owner)?;
+    let room_exists = persisted_old_key.is_some();
     // Whether --force is actually swapping to a DIFFERENT identity. Used below
-    // to prune the old identity's per-room DM cache. (Compares the resolved
-    // stored key; in the normal no-`--signing-key` case this is exactly the
-    // stored identity. If they differ, the outbound-DM plaintext / archived
-    // threads belong to the old identity and must not leak into the new one.)
-    let identity_changed = existing_room
-        .as_ref()
-        .is_some_and(|(old_sk, _, _)| old_sk != &export.signing_key);
+    // to prune the old identity's per-room DM cache: if they differ, the
+    // outbound-DM plaintext / archived threads belong to the old identity and
+    // must not leak into the new one.
+    let identity_changed =
+        persisted_old_key.is_some_and(|old| old != export.signing_key.to_bytes());
     if let Some(refusal) = import_overwrite_refusal(room_exists, force, &room_key_str) {
         return Err(anyhow!(refusal));
     }

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -261,6 +261,24 @@ impl Storage {
         self.signing_key_override.is_some()
     }
 
+    /// The RAW persisted `signing_key_bytes` for a room, ignoring any
+    /// `--signing-key-file` / `RIVER_SIGNING_KEY_FILE` override that
+    /// [`Self::get_room`]'s `resolve_signing_key` would apply.
+    ///
+    /// Used by `identity import --force` to decide whether the imported key
+    /// actually changes the stored identity (freenet/river#414): comparing
+    /// against the override-resolved key would misjudge a real change as
+    /// unchanged (skipping the DM prune) or an unchanged identity as changed
+    /// (pruning wrongly). Returns `None` when no room is stored for `owner_vk`.
+    pub fn persisted_signing_key_bytes(&self, owner_vk: &VerifyingKey) -> Result<Option<[u8; 32]>> {
+        let storage = self.load_rooms()?;
+        let owner_key_str = bs58::encode(owner_vk.as_bytes()).into_string();
+        Ok(storage
+            .rooms
+            .get(&owner_key_str)
+            .map(|r| r.signing_key_bytes))
+    }
+
     /// Load all stored rooms, regenerating each room's contract key to match the
     /// currently-bundled WASM (and persisting the regeneration).
     ///
@@ -1723,6 +1741,66 @@ mod tests {
                 .any(|e| e.room_owner_vk == owner_vk.to_bytes()),
             "an unchanged-key re-import must NOT prune the DM cache"
         );
+    }
+
+    /// freenet/river#414 (Codex round 5): `persisted_signing_key_bytes` returns
+    /// the RAW stored key, NOT the `--signing-key` override that `get_room`
+    /// resolves. The `identity import --force` DM-prune decision (`identity_changed`)
+    /// depends on this — comparing against the override would misjudge whether
+    /// the identity actually changed.
+    #[test]
+    fn persisted_signing_key_bytes_ignores_override() {
+        let temp_dir = TempDir::new().unwrap();
+        let dir = temp_dir.path().to_str().unwrap();
+
+        let owner_sk = create_test_signing_key();
+        let owner_vk = owner_sk.verifying_key();
+        let stored_identity = create_test_signing_key();
+        let override_identity = create_test_signing_key();
+        assert_ne!(stored_identity.to_bytes(), override_identity.to_bytes());
+
+        // Persist the room under `stored_identity` (no override active).
+        let storage = Storage::new(Some(dir)).unwrap();
+        let key = expected_contract_key(&owner_vk);
+        storage
+            .add_room(
+                &owner_vk,
+                &stored_identity,
+                create_test_state(&owner_sk),
+                &key,
+            )
+            .unwrap();
+
+        // Re-open the SAME dir with an override selecting a DIFFERENT identity.
+        let overridden =
+            Storage::new_with_override(Some(dir), Some(override_identity.clone())).unwrap();
+
+        // get_room resolves to the override…
+        let (resolved, _, _) = overridden.get_room(&owner_vk).unwrap().unwrap();
+        assert_eq!(
+            resolved.to_bytes(),
+            override_identity.to_bytes(),
+            "get_room applies the --signing-key override"
+        );
+
+        // …but persisted_signing_key_bytes returns the RAW stored key, so the
+        // import DM-prune decision compares against the real stored identity.
+        let persisted = overridden
+            .persisted_signing_key_bytes(&owner_vk)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            persisted,
+            stored_identity.to_bytes(),
+            "persisted key must ignore the override"
+        );
+
+        // Absent room → None.
+        let absent = create_test_signing_key().verifying_key();
+        assert!(overridden
+            .persisted_signing_key_bytes(&absent)
+            .unwrap()
+            .is_none());
     }
 
     /// Regression for issue freenet/river#307 (lost-update race).

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -80,6 +80,23 @@ pub struct RoomStorage {
     pub rooms: HashMap<String, StoredRoomInfo>,
 }
 
+/// Result of [`Storage::import_room_atomic`] (freenet/river#414, Codex round-6
+/// P1-5). Reported back so the caller can print the right message without
+/// re-reading disk (and so the atomic decision — made INSIDE the lock — is the
+/// authoritative one, not the pre-GET snapshot).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportOutcome {
+    /// A room already existed and `force` was false — nothing was written.
+    RefusedNeedsForce,
+    /// The room was inserted/replaced. `was_overwrite` = an entry existed
+    /// before; `identity_changed` = the replaced signing key differed (so the
+    /// old identity's DM cache was pruned in the same lock).
+    Imported {
+        was_overwrite: bool,
+        identity_changed: bool,
+    },
+}
+
 /// Local on-disk persistence for riverctl (`rooms.json` + `outbound_dms.json`).
 ///
 /// **Concurrency model (issue freenet/river#307).** riverctl is a CLI invoked
@@ -491,6 +508,93 @@ impl Storage {
 
             storage.rooms.insert(owner_key_str, room_info);
             self.save_rooms_unlocked(&storage)
+        })
+    }
+
+    /// Atomically import (or `--force`-overwrite) an identity for a room, under a
+    /// SINGLE advisory lock, closing the TOCTOU window (freenet/river#414, Codex
+    /// round-6 P1-5).
+    ///
+    /// The pre-`import` existence/key snapshot in `import_identity` is taken
+    /// BEFORE the network GET, so a concurrent `riverctl` invocation can add an
+    /// identity for this room during the await — after which the un-atomic path
+    /// would still think it's a new room and overwrite it without `--force` (and
+    /// without pruning the old identity's DM cache). This method re-reads the
+    /// persisted key INSIDE the lock, makes the new-vs-overwrite + key-changed
+    /// decision, writes the full `StoredRoomInfo` in one shot (folding in the
+    /// authorized member, invite chain, and nickname — no read-back-and-patch),
+    /// and prunes the old identity's outbound-DM cache when the key changed — all
+    /// before any concurrent writer can interleave. Modeled on `remove_room`,
+    /// the existing one-lock-spanning-both-files method.
+    ///
+    /// Returns `RefusedNeedsForce` (nothing written) when a DIFFERENT-or-same
+    /// identity already exists and `force` is false; otherwise `Imported`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn import_room_atomic(
+        &self,
+        owner_vk: &VerifyingKey,
+        signing_key: &SigningKey,
+        state: ChatRoomStateV1,
+        contract_key: &ContractKey,
+        invitation_secrets: HashMap<u32, [u8; 32]>,
+        authorized_member: &AuthorizedMember,
+        invite_chain: &[AuthorizedMember],
+        self_nickname: Option<&str>,
+        force: bool,
+    ) -> Result<ImportOutcome> {
+        self.with_lock(|| {
+            let mut storage = self.load_rooms_unlocked()?;
+            let owner_key_str = bs58::encode(owner_vk.as_bytes()).into_string();
+
+            // Authoritative re-check INSIDE the lock — this is what closes the
+            // TOCTOU: read the RAW persisted key off the just-loaded snapshot
+            // (never `persisted_signing_key_bytes`, which re-locks and would
+            // self-deadlock per the Storage no-nesting rule).
+            let old_key = storage
+                .rooms
+                .get(&owner_key_str)
+                .map(|r| r.signing_key_bytes);
+            let was_overwrite = old_key.is_some();
+            if was_overwrite && !force {
+                // A concurrent import may have created this room during our GET;
+                // refuse rather than silently overwrite. Nothing written.
+                return Ok(ImportOutcome::RefusedNeedsForce);
+            }
+            let identity_changed = old_key.is_some_and(|k| k != signing_key.to_bytes());
+
+            // Build the FULL record in one shot (matches the fields
+            // `add_room_with_invitation_secrets` + `store_authorized_member` +
+            // `update_self_nickname` would set across three separate locks).
+            storage.rooms.insert(
+                owner_key_str.clone(),
+                StoredRoomInfo {
+                    signing_key_bytes: signing_key.to_bytes(),
+                    state,
+                    contract_key: contract_key.id().to_string(),
+                    self_authorized_member: Some(authorized_member.clone()),
+                    invite_chain: invite_chain.to_vec(),
+                    previous_contract_key: None,
+                    invitation_secrets,
+                    self_nickname: self_nickname.map(str::to_string),
+                },
+            );
+            self.save_rooms_unlocked(&storage)?;
+
+            // Swapping to a DIFFERENT identity: prune the OLD identity's DM cache
+            // in the SAME lock. Best-effort, mirroring `remove_room`: the identity
+            // is already committed, so a prune hiccup warns rather than fails.
+            if identity_changed {
+                if let Err(e) = self.prune_outbound_dms_for_room_unlocked(owner_vk) {
+                    tracing::warn!(
+                        "import: failed to prune the previous identity's DM cache for {owner_key_str}: {e}"
+                    );
+                }
+            }
+
+            Ok(ImportOutcome::Imported {
+                was_overwrite,
+                identity_changed,
+            })
         })
     }
 
@@ -928,9 +1032,11 @@ mod tests {
         );
         let identity_src = include_str!("commands/identity.rs");
         assert!(
-            identity_src.contains("update_self_nickname("),
-            "import_identity must persist the imported (public-room) nickname \
-             via Storage::update_self_nickname."
+            identity_src.contains("nickname_to_persist.as_deref()"),
+            "import_identity must persist the imported nickname — now folded into \
+             the single-lock `Storage::import_room_atomic` write (freenet/river#414 \
+             P1-5) via the `nickname_to_persist` argument, not a separate \
+             `update_self_nickname` call."
         );
     }
 
@@ -1801,6 +1907,173 @@ mod tests {
             .persisted_signing_key_bytes(&absent)
             .unwrap()
             .is_none());
+    }
+
+    /// freenet/river#414 (Codex round-6 P1-5): `import_room_atomic` re-checks
+    /// existence + key INSIDE the lock, closing the TOCTOU where a concurrent
+    /// import created the room during this import's network GET. Simulates the
+    /// interleave by pre-adding the room, then importing over it.
+    #[test]
+    fn import_room_atomic_rechecks_existence_under_lock() {
+        use freenet_scaffold::util::FastHash;
+        use river_core::chat_delegate::{OutboundDmEntry, OutboundDmStore};
+        use river_core::room_state::direct_messages::PurgeToken;
+        use river_core::room_state::member::{Member, MemberId};
+
+        let (storage, _tmp) = create_test_storage();
+        let owner_sk = create_test_signing_key();
+        let owner_vk = owner_sk.verifying_key();
+        let key = expected_contract_key(&owner_vk);
+
+        let old_identity = create_test_signing_key();
+        let new_identity = create_test_signing_key();
+        let member_for = |sk: &SigningKey| {
+            AuthorizedMember::new(
+                Member {
+                    owner_member_id: owner_vk.into(),
+                    invited_by: owner_vk.into(),
+                    member_vk: sk.verifying_key(),
+                },
+                &owner_sk,
+            )
+        };
+
+        // A concurrent `riverctl` created the room under `old_identity` while our
+        // GET was in flight, and cached an outbound DM under it.
+        storage
+            .add_room(&owner_vk, &old_identity, create_test_state(&owner_sk), &key)
+            .unwrap();
+        let peer = MemberId(FastHash(7));
+        storage
+            .save_outbound_dms(&OutboundDmStore {
+                entries: vec![OutboundDmEntry {
+                    room_owner_vk: owner_vk.to_bytes(),
+                    sender: peer,
+                    recipient: peer,
+                    purge_token: PurgeToken([1u8; 16]),
+                    timestamp: 1,
+                    plaintext: "old-identity secret".to_string(),
+                }],
+                hidden_threads: vec![],
+            })
+            .unwrap();
+
+        // WITHOUT --force: the atomic re-check finds the concurrently-added room
+        // and REFUSES — nothing written, the old identity + its DM cache survive.
+        let outcome = storage
+            .import_room_atomic(
+                &owner_vk,
+                &new_identity,
+                create_test_state(&owner_sk),
+                &key,
+                std::collections::HashMap::new(),
+                &member_for(&new_identity),
+                &[],
+                Some("newnick"),
+                false,
+            )
+            .unwrap();
+        assert_eq!(outcome, ImportOutcome::RefusedNeedsForce);
+        assert_eq!(
+            storage
+                .persisted_signing_key_bytes(&owner_vk)
+                .unwrap()
+                .unwrap(),
+            old_identity.to_bytes(),
+            "a refused import must NOT overwrite the concurrently-added identity"
+        );
+        assert!(
+            storage
+                .load_outbound_dms()
+                .unwrap()
+                .entries
+                .iter()
+                .any(|e| e.room_owner_vk == owner_vk.to_bytes()),
+            "a refused import must NOT prune the DM cache"
+        );
+
+        // WITH --force: overwrite in one lock — full record written, key changed,
+        // old identity's DM cache pruned.
+        let outcome = storage
+            .import_room_atomic(
+                &owner_vk,
+                &new_identity,
+                create_test_state(&owner_sk),
+                &key,
+                std::collections::HashMap::new(),
+                &member_for(&new_identity),
+                std::slice::from_ref(&member_for(&new_identity)),
+                Some("newnick"),
+                true,
+            )
+            .unwrap();
+        assert_eq!(
+            outcome,
+            ImportOutcome::Imported {
+                was_overwrite: true,
+                identity_changed: true,
+            }
+        );
+        let rooms = storage.load_rooms().unwrap();
+        let info = rooms
+            .rooms
+            .get(&bs58::encode(owner_vk.as_bytes()).into_string())
+            .unwrap();
+        assert_eq!(info.signing_key_bytes, new_identity.to_bytes());
+        assert!(
+            info.self_authorized_member.is_some(),
+            "the atomic write must fold in the authorized member"
+        );
+        assert_eq!(
+            info.invite_chain.len(),
+            1,
+            "invite chain written in the same lock"
+        );
+        assert_eq!(info.self_nickname.as_deref(), Some("newnick"));
+        assert!(
+            !storage
+                .load_outbound_dms()
+                .unwrap()
+                .entries
+                .iter()
+                .any(|e| e.room_owner_vk == owner_vk.to_bytes()),
+            "a --force key change must prune the old identity's DM cache in the same lock"
+        );
+
+        // A brand-new room (not present) imports without --force and reports no
+        // overwrite / no key change.
+        let fresh_owner_sk = create_test_signing_key();
+        let fresh_owner_vk = fresh_owner_sk.verifying_key();
+        let fresh_key = expected_contract_key(&fresh_owner_vk);
+        let fresh_self = create_test_signing_key();
+        let outcome = storage
+            .import_room_atomic(
+                &fresh_owner_vk,
+                &fresh_self,
+                create_test_state(&fresh_owner_sk),
+                &fresh_key,
+                std::collections::HashMap::new(),
+                &AuthorizedMember::new(
+                    Member {
+                        owner_member_id: fresh_owner_vk.into(),
+                        invited_by: fresh_owner_vk.into(),
+                        member_vk: fresh_self.verifying_key(),
+                    },
+                    &fresh_owner_sk,
+                ),
+                &[],
+                None,
+                false,
+            )
+            .unwrap();
+        assert_eq!(
+            outcome,
+            ImportOutcome::Imported {
+                was_overwrite: false,
+                identity_changed: false,
+            }
+        );
+        assert!(storage.get_room(&fresh_owner_vk).unwrap().is_some());
     }
 
     /// Regression for issue freenet/river#307 (lost-update race).

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -511,31 +511,14 @@ impl Storage {
         })
     }
 
-    /// Atomically import (or `--force`-overwrite) an identity for a room, under a
-    /// SINGLE advisory lock, closing the TOCTOU window (freenet/river#414, Codex
-    /// round-6 P1-5).
+    /// Compile-time exhaustive-destructure classification pin for the
+    /// [`Self::import_room_atomic`] OVERWRITE arm (Fable architectural review).
     ///
-    /// The pre-`import` existence/key snapshot in `import_identity` is taken
-    /// BEFORE the network GET, so a concurrent `riverctl` invocation can add an
-    /// identity for this room during the await — after which the un-atomic path
-    /// would still think it's a new room and overwrite it without `--force` (and
-    /// without pruning the old identity's DM cache). This method re-reads the
-    /// persisted key INSIDE the lock, makes the new-vs-overwrite + key-changed
-    /// decision, writes the full `StoredRoomInfo` in one shot (folding in the
-    /// authorized member, invite chain, and nickname — no read-back-and-patch),
-    /// and prunes the old identity's outbound-DM cache when the key changed — all
-    /// before any concurrent writer can interleave. Modeled on `remove_room`,
-    /// the existing one-lock-spanning-both-files method.
-    ///
-    /// Returns `RefusedNeedsForce` (nothing written) when a DIFFERENT-or-same
-    /// identity already exists and `force` is false; otherwise `Imported`.
-    ///
-    /// COMPILE-TIME CLASSIFICATION PIN (Fable architectural review): the
-    /// exhaustive destructure below has NO `..`, so ADDING A FIELD to
-    /// [`StoredRoomInfo`] FAILS COMPILATION here until a maintainer classifies its
-    /// OVERWRITE verb in the arm above. This is the forcing function that prevents
-    /// the round-11 `previous_contract_key` clobber class (a new field silently
-    /// defaulted in a fresh literal). Verb table:
+    /// The destructure below has NO `..`, so ADDING A FIELD to [`StoredRoomInfo`]
+    /// FAILS COMPILATION here until a maintainer classifies its OVERWRITE verb in
+    /// that arm. This is the forcing function that prevents the round-11
+    /// `previous_contract_key` clobber class (a new field silently defaulted in a
+    /// fresh literal). Verb table:
     ///
     /// ```text
     /// signing_key_bytes      REPLACE (the imported identity)
@@ -564,6 +547,26 @@ impl Storage {
         } = r;
     }
 
+    /// Atomically import (or `--force`-overwrite) an identity for a room, under a
+    /// SINGLE advisory lock, closing the TOCTOU window (freenet/river#414, Codex
+    /// round-6 P1-5).
+    ///
+    /// The pre-`import` existence/key snapshot in `import_identity` is taken
+    /// BEFORE the network GET, so a concurrent `riverctl` invocation can add an
+    /// identity for this room during the await — after which the un-atomic path
+    /// would still think it's a new room and overwrite it without `--force` (and
+    /// without pruning the old identity's DM cache). This method re-reads the
+    /// persisted key INSIDE the lock, makes the new-vs-overwrite + key-changed
+    /// decision, then either MUTATES the stored record in place (OVERWRITE arm —
+    /// keeping the room-scoped `state` / `contract_key` / `previous_contract_key`;
+    /// see the classification pin above) or inserts a fresh record (NEW-room arm),
+    /// folding in the authorized member, invite chain, and nickname, and prunes the
+    /// old identity's outbound-DM cache when the key changed — all before any
+    /// concurrent writer can interleave. Modeled on `remove_room`, the existing
+    /// one-lock-spanning-both-files method.
+    ///
+    /// Returns `RefusedNeedsForce` (nothing written) when a DIFFERENT-or-same
+    /// identity already exists and `force` is false; otherwise `Imported`.
     #[allow(clippy::too_many_arguments)]
     pub fn import_room_atomic(
         &self,
@@ -636,6 +639,13 @@ impl Storage {
                     // coherent UNIT (the chain validates the member): keep the
                     // stored pair when the token carries an empty chain, so we never
                     // pair the token's member with an empty/mismatched chain.
+                    // CROSS-REF: the UI's same-key merge
+                    // (ui/src/components/members.rs `swap_room_identity_in_place`)
+                    // gates the equivalent step on the LOCAL proof being absent
+                    // (`self_authorized_member.is_none()`), whereas this CLI path
+                    // gates on the TOKEN's chain being empty. The conditions differ
+                    // DELIBERATELY (each side's staler-source risk differs); do NOT
+                    // "harmonize" them into one rule.
                     if invite_chain.is_empty() && !old.invite_chain.is_empty() {
                         invite_chain = old.invite_chain.clone();
                         if old.self_authorized_member.is_some() {

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -603,6 +603,21 @@ impl Storage {
         })
     }
 
+    /// Public, self-locking counterpart to
+    /// [`Self::prune_outbound_dms_for_room_unlocked`]: drop every cached
+    /// outbound-DM plaintext entry and archived-thread entry for `owner_vk`'s
+    /// room from `outbound_dms.json`.
+    ///
+    /// Used by `identity import --force` when it REPLACES a room with a
+    /// different signing key (freenet/river#414): the prior identity's plaintext
+    /// outbound DMs and its archived-thread records (keyed by `(room, peer)`)
+    /// must not leak into the new identity's view, so they are pruned exactly as
+    /// [`Self::remove_room`] does on leave. Takes the advisory lock itself; do
+    /// NOT call while already holding it.
+    pub fn prune_outbound_dms_for_room(&self, owner_vk: &VerifyingKey) -> Result<()> {
+        self.with_lock(|| self.prune_outbound_dms_for_room_unlocked(owner_vk))
+    }
+
     /// Drop every cached outbound-DM plaintext entry and archived-thread entry
     /// for `owner_vk`'s room from `outbound_dms.json`. No-op if the cache file
     /// holds nothing for that room. Called by [`Self::remove_room`]; caller MUST
@@ -1580,6 +1595,134 @@ mod tests {
             "the left room's archived-thread entry must be pruned"
         );
         assert_eq!(after.hidden_threads[0].room_owner_vk, kept_vk.to_bytes());
+    }
+
+    /// freenet/river#414 (Codex round 4): `identity import --force` that swaps a
+    /// room to a DIFFERENT signing key must prune the OLD identity's cached
+    /// outbound-DM plaintext + archived threads (they belong to the old
+    /// identity and would otherwise leak into / wrongly hide threads for the new
+    /// one) — but an unchanged-key re-import must NOT prune, and a different
+    /// room's cache always survives. Drives the exact Storage sequence
+    /// `import_identity` runs (decision `old_key != imported_key`, then
+    /// `prune_outbound_dms_for_room`).
+    #[test]
+    fn force_import_prunes_dm_cache_only_on_key_change() {
+        use freenet_scaffold::util::FastHash;
+        use river_core::chat_delegate::{HiddenDmThreadEntry, OutboundDmEntry, OutboundDmStore};
+        use river_core::room_state::direct_messages::PurgeToken;
+        use river_core::room_state::member::MemberId;
+
+        let (storage, _tmp) = create_test_storage();
+        let owner_sk = create_test_signing_key();
+        let owner_vk = owner_sk.verifying_key();
+        let other_vk = create_test_signing_key().verifying_key();
+        let key = expected_contract_key(&owner_vk);
+
+        let old_identity = create_test_signing_key();
+        let new_identity = create_test_signing_key();
+
+        let peer = MemberId(FastHash(7));
+        let seed_dm_cache = || {
+            storage
+                .save_outbound_dms(&OutboundDmStore {
+                    entries: vec![
+                        OutboundDmEntry {
+                            room_owner_vk: owner_vk.to_bytes(),
+                            sender: peer,
+                            recipient: peer,
+                            purge_token: PurgeToken([1u8; 16]),
+                            timestamp: 1,
+                            plaintext: "old-identity secret".to_string(),
+                        },
+                        OutboundDmEntry {
+                            room_owner_vk: other_vk.to_bytes(),
+                            sender: peer,
+                            recipient: peer,
+                            purge_token: PurgeToken([2u8; 16]),
+                            timestamp: 2,
+                            plaintext: "unrelated room".to_string(),
+                        },
+                    ],
+                    hidden_threads: vec![HiddenDmThreadEntry {
+                        room_owner_vk: owner_vk.to_bytes(),
+                        peer,
+                        hidden_at_ts: 1,
+                    }],
+                })
+                .unwrap();
+        };
+
+        // Scenario 1: --force replace with a DIFFERENT key → prune this room's cache.
+        storage
+            .add_room(&owner_vk, &old_identity, create_test_state(&owner_sk), &key)
+            .unwrap();
+        seed_dm_cache();
+        let old_key = storage.get_room(&owner_vk).unwrap().unwrap().0;
+        let identity_changed = old_key.to_bytes() != new_identity.to_bytes();
+        assert!(identity_changed, "precondition: the imported key differs");
+        storage
+            .add_room_with_invitation_secrets(
+                &owner_vk,
+                &new_identity,
+                create_test_state(&owner_sk),
+                &key,
+                std::collections::HashMap::new(),
+            )
+            .unwrap();
+        if identity_changed {
+            storage.prune_outbound_dms_for_room(&owner_vk).unwrap();
+        }
+        let after = storage.load_outbound_dms().unwrap();
+        assert!(
+            !after
+                .entries
+                .iter()
+                .any(|e| e.room_owner_vk == owner_vk.to_bytes()),
+            "the replaced identity's DM plaintext must be pruned"
+        );
+        assert!(
+            after
+                .hidden_threads
+                .iter()
+                .all(|h| h.room_owner_vk != owner_vk.to_bytes()),
+            "the replaced identity's archived threads must be pruned"
+        );
+        assert!(
+            after
+                .entries
+                .iter()
+                .any(|e| e.room_owner_vk == other_vk.to_bytes()),
+            "another room's DM cache must survive"
+        );
+
+        // Scenario 2: re-import the SAME key → no identity change → keep the cache.
+        seed_dm_cache();
+        let old_key2 = storage.get_room(&owner_vk).unwrap().unwrap().0;
+        let identity_changed2 = old_key2.to_bytes() != new_identity.to_bytes();
+        assert!(
+            !identity_changed2,
+            "re-importing the SAME key is not an identity change"
+        );
+        storage
+            .add_room_with_invitation_secrets(
+                &owner_vk,
+                &new_identity,
+                create_test_state(&owner_sk),
+                &key,
+                std::collections::HashMap::new(),
+            )
+            .unwrap();
+        if identity_changed2 {
+            storage.prune_outbound_dms_for_room(&owner_vk).unwrap();
+        }
+        let after2 = storage.load_outbound_dms().unwrap();
+        assert!(
+            after2
+                .entries
+                .iter()
+                .any(|e| e.room_owner_vk == owner_vk.to_bytes()),
+            "an unchanged-key re-import must NOT prune the DM cache"
+        );
     }
 
     /// Regression for issue freenet/river#307 (lost-update race).

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -529,6 +529,41 @@ impl Storage {
     ///
     /// Returns `RefusedNeedsForce` (nothing written) when a DIFFERENT-or-same
     /// identity already exists and `force` is false; otherwise `Imported`.
+    ///
+    /// COMPILE-TIME CLASSIFICATION PIN (Fable architectural review): the
+    /// exhaustive destructure below has NO `..`, so ADDING A FIELD to
+    /// [`StoredRoomInfo`] FAILS COMPILATION here until a maintainer classifies its
+    /// OVERWRITE verb in the arm above. This is the forcing function that prevents
+    /// the round-11 `previous_contract_key` clobber class (a new field silently
+    /// defaulted in a fresh literal). Verb table:
+    ///
+    /// ```text
+    /// signing_key_bytes      REPLACE (the imported identity)
+    /// state                  KEEP    (get_room re-syncs; a concurrent newer stored
+    ///                                 state must not be clobbered by the pre-lock
+    ///                                 GET snapshot)
+    /// contract_key           KEEP    (load_rooms_unlocked regenerates it + keeps
+    ///                                 the previous_contract_key pairing)
+    /// self_authorized_member \ MERGE-same-key / REPLACE-different-key
+    /// invite_chain           / (paired coherent unit)
+    /// previous_contract_key  KEEP    (room-scoped #292 migration pointer)
+    /// invitation_secrets     MERGE-same-key (union, existing wins) / REPLACE-diff
+    /// self_nickname          MERGE-same-key (keep-if-absent) / REPLACE-different
+    /// ```
+    #[allow(dead_code)]
+    fn _stored_room_info_overwrite_classification(r: StoredRoomInfo) {
+        let StoredRoomInfo {
+            signing_key_bytes: _,
+            state: _,
+            contract_key: _,
+            self_authorized_member: _,
+            invite_chain: _,
+            previous_contract_key: _,
+            invitation_secrets: _,
+            self_nickname: _,
+        } = r;
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn import_room_atomic(
         &self,
@@ -562,33 +597,29 @@ impl Storage {
             }
             let identity_changed = old_key.is_some_and(|k| k != signing_key.to_bytes());
 
-            // Assemble the incoming identity metadata.
+            // Assemble the incoming IDENTITY metadata. The four-verb table
+            // (`_stored_room_info_overwrite_classification` pins it at compile time):
+            //   signing_key_bytes     → REPLACE (the imported identity)
+            //   self_authorized_member} → MERGE-same-key / REPLACE-diff (paired unit)
+            //   invite_chain          }
+            //   invitation_secrets    → MERGE-same-key (union, existing wins) / REPLACE
+            //   self_nickname         → MERGE-same-key (keep-if-absent) / REPLACE
+            // ROOM-scoped fields (state, contract_key, previous_contract_key) are
+            // KEPT and are handled by the OVERWRITE arm's in-place mutation below.
             let mut invitation_secrets = invitation_secrets;
             let mut self_nickname = self_nickname.map(str::to_string);
             let mut invite_chain = invite_chain.to_vec();
             let mut self_authorized_member = Some(authorized_member.clone());
-            // `previous_contract_key` is ROOM-scoped, NOT identity-scoped: it is the
-            // freenet/river#292 room-contract migration pointer (`ensure_room_migrated`
-            // can leave it set after a failed old-state merge while still returning
-            // the current key, so a later command retries the merge). The import
-            // never carries a new one, so preserve the stored value on ANY overwrite
-            // (same-key OR different-key) — clearing it would prevent the retry and
-            // can strand state that exists only under the previous contract
-            // generation (Codex round-11 P1).
-            let mut previous_contract_key = None;
 
             // Same-key re-import over an existing room (`was_overwrite &&
             // !identity_changed`): the incoming token may be a legacy/stale export
-            // that decodes optional fields as ABSENT/EMPTY. GENERAL RULE (Codex
-            // round-7/8): for EVERY field the token may carry absent/stale, RETAIN
-            // the stored value rather than overwrite it with an empty one — a
-            // genuine identity change instead REPLACES (old identity's metadata
-            // must not carry forward).
-            if let Some(old) = storage.rooms.get(&owner_key_str) {
-                // Room-scoped, so preserved regardless of identity change.
-                previous_contract_key = old.previous_contract_key.clone();
-
-                if !identity_changed {
+            // that decodes optional fields as ABSENT/EMPTY. RETAIN the stored value
+            // rather than overwrite it with an empty one (round-7/8). A genuine
+            // identity change instead REPLACES (old identity's metadata must not
+            // carry forward). Computed against an IMMUTABLE borrow of the stored
+            // record so the OVERWRITE mutation below can take a fresh `get_mut`.
+            if was_overwrite && !identity_changed {
+                if let Some(old) = storage.rooms.get(&owner_key_str) {
                     // invitation_secrets: merge, existing wins — the stored map may
                     // be the ONLY copy of a private room's key, so an empty token
                     // must not wipe it (history would become unreadable, round-7).
@@ -614,22 +645,44 @@ impl Storage {
                 }
             }
 
-            // Build the FULL record in one shot (matches the fields
-            // `add_room_with_invitation_secrets` + `store_authorized_member` +
-            // `update_self_nickname` would set across three separate locks).
-            storage.rooms.insert(
-                owner_key_str.clone(),
-                StoredRoomInfo {
-                    signing_key_bytes: signing_key.to_bytes(),
-                    state,
-                    contract_key: contract_key.id().to_string(),
-                    self_authorized_member,
-                    invite_chain,
-                    previous_contract_key,
-                    invitation_secrets,
-                    self_nickname,
-                },
-            );
+            if let Some(existing) = storage.rooms.get_mut(&owner_key_str) {
+                // OVERWRITE arm — MUTATE IN PLACE. Only the identity fields are
+                // re-assigned; the ROOM-scoped fields are KEPT by never touching
+                // them (this is what makes the field classification robust — a new
+                // field isn't silently defaulted to a fresh literal):
+                //   - `state` KEEP — the `state` param is the PRE-LOCK network-GET
+                //     snapshot (identity.rs); a concurrent riverctl that persisted
+                //     newer state between that GET and this lock must NOT be
+                //     clobbered by the stale snapshot. `get_room` re-syncs from the
+                //     network anyway, so KEEP is safe (round-12 live-bug fix).
+                //   - `contract_key` KEEP — `load_rooms_unlocked` regenerates it
+                //     under the lock and maintains the `previous_contract_key`
+                //     pairing; the import site doesn't.
+                //   - `previous_contract_key` KEEP — room-scoped #292 migration
+                //     pointer (round-11).
+                existing.signing_key_bytes = signing_key.to_bytes();
+                existing.self_authorized_member = self_authorized_member;
+                existing.invite_chain = invite_chain;
+                existing.invitation_secrets = invitation_secrets;
+                existing.self_nickname = self_nickname;
+            } else {
+                // NEW-room arm — a brand-new room writes the fetched `state`,
+                // regenerated `contract_key`, and no migration pointer. Correct for
+                // a room this client has never seen.
+                storage.rooms.insert(
+                    owner_key_str.clone(),
+                    StoredRoomInfo {
+                        signing_key_bytes: signing_key.to_bytes(),
+                        state,
+                        contract_key: contract_key.id().to_string(),
+                        self_authorized_member,
+                        invite_chain,
+                        previous_contract_key: None,
+                        invitation_secrets,
+                        self_nickname,
+                    },
+                );
+            }
             self.save_rooms_unlocked(&storage)?;
 
             // Swapping to a DIFFERENT identity: prune the OLD identity's DM cache
@@ -2404,6 +2457,95 @@ mod tests {
             previous_of(&storage).as_deref(),
             Some("prev-migration-key"),
             "different-key --force must ALSO preserve previous_contract_key (room-scoped)"
+        );
+    }
+
+    /// freenet/river#414 (Fable review, round-12 live bug): the OVERWRITE arm
+    /// mutates in place and KEEPS the stored `state`. It must NOT write the
+    /// pre-lock network-GET snapshot passed by `import_identity`, or a concurrent
+    /// riverctl that persisted NEWER state between that GET and this lock would be
+    /// clobbered by the stale snapshot.
+    #[test]
+    fn import_room_atomic_overwrite_keeps_stored_state() {
+        use river_core::room_state::member::Member;
+
+        let (storage, _tmp) = create_test_storage();
+        let owner_sk = create_test_signing_key();
+        let owner_vk = owner_sk.verifying_key();
+        let key = expected_contract_key(&owner_vk);
+        let owner_key_str = bs58::encode(owner_vk.as_bytes()).into_string();
+        let member_for = |sk: &SigningKey| {
+            AuthorizedMember::new(
+                Member {
+                    owner_member_id: owner_vk.into(),
+                    invited_by: owner_vk.into(),
+                    member_vk: sk.verifying_key(),
+                },
+                &owner_sk,
+            )
+        };
+
+        // Store the room (initial state has no members).
+        let identity = create_test_signing_key();
+        storage
+            .import_room_atomic(
+                &owner_vk,
+                &identity,
+                create_test_state(&owner_sk),
+                &key,
+                std::collections::HashMap::new(),
+                &member_for(&identity),
+                &[],
+                None,
+                false,
+            )
+            .unwrap();
+
+        // Simulate a concurrent riverctl persisting NEWER state (a member added)
+        // between the pre-lock GET snapshot and our --force lock.
+        let newer_member = member_for(&create_test_signing_key());
+        {
+            let mut rs = storage.load_rooms().unwrap();
+            rs.rooms
+                .get_mut(&owner_key_str)
+                .unwrap()
+                .state
+                .members
+                .members
+                .push(newer_member.clone());
+            storage.save_rooms(&rs).unwrap();
+        }
+
+        // A --force overwrite whose `state` arg is a STALE snapshot (the plain
+        // create_test_state, WITHOUT the newer member).
+        storage
+            .import_room_atomic(
+                &owner_vk,
+                &identity,
+                create_test_state(&owner_sk),
+                &key,
+                std::collections::HashMap::new(),
+                &member_for(&identity),
+                &[],
+                None,
+                true,
+            )
+            .unwrap();
+
+        // The newer stored state must SURVIVE (KEEP), not be clobbered by the
+        // stale pre-lock snapshot.
+        let after = storage.load_rooms().unwrap();
+        let members = &after.rooms[&owner_key_str].state.members.members;
+        assert_eq!(
+            members.len(),
+            1,
+            "overwrite must KEEP the stored state, not clobber it with the pre-lock snapshot"
+        );
+        assert!(
+            members
+                .iter()
+                .any(|m| m.member.member_vk == newer_member.member.member_vk),
+            "the concurrently-persisted newer member must survive the --force overwrite"
         );
     }
 

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -562,6 +562,25 @@ impl Storage {
             }
             let identity_changed = old_key.is_some_and(|k| k != signing_key.to_bytes());
 
+            // Same-key re-import over an existing room (`was_overwrite &&
+            // !identity_changed`): PRESERVE the stored invitation secrets by
+            // merging them into the incoming map, existing wins on collision. The
+            // incoming token's map may be empty/incomplete (a legacy/stale export
+            // taken before the owner's `encrypted_secrets` backfill arrived), and
+            // for a private room still awaiting that backfill the stored map can be
+            // the ONLY copy of the room key — overwriting it with the token's empty
+            // map would make history permanently unreadable (Codex round-7). A
+            // genuine identity change instead REPLACES: the old identity's secrets
+            // must not carry forward to the new one.
+            let mut invitation_secrets = invitation_secrets;
+            if was_overwrite && !identity_changed {
+                if let Some(old) = storage.rooms.get(&owner_key_str) {
+                    for (version, secret) in &old.invitation_secrets {
+                        invitation_secrets.entry(*version).or_insert(*secret);
+                    }
+                }
+            }
+
             // Build the FULL record in one shot (matches the fields
             // `add_room_with_invitation_secrets` + `store_authorized_member` +
             // `update_self_nickname` would set across three separate locks).
@@ -2074,6 +2093,110 @@ mod tests {
             }
         );
         assert!(storage.get_room(&fresh_owner_vk).unwrap().is_some());
+    }
+
+    /// freenet/river#414 (Codex round 7): a SAME-key `--force` re-import must
+    /// RETAIN the stored `invitation_secrets` (merging the token's map in,
+    /// existing wins) — the token may be a legacy/stale export with an empty map,
+    /// and for a private room awaiting the owner backfill the stored map can be
+    /// the only copy of the room key. A DIFFERENT-key `--force` still REPLACES.
+    #[test]
+    fn import_room_atomic_same_key_preserves_invitation_secrets() {
+        use river_core::room_state::member::Member;
+
+        let (storage, _tmp) = create_test_storage();
+        let owner_sk = create_test_signing_key();
+        let owner_vk = owner_sk.verifying_key();
+        let key = expected_contract_key(&owner_vk);
+        let member_for = |sk: &SigningKey| {
+            AuthorizedMember::new(
+                Member {
+                    owner_member_id: owner_vk.into(),
+                    invited_by: owner_vk.into(),
+                    member_vk: sk.verifying_key(),
+                },
+                &owner_sk,
+            )
+        };
+
+        // Store the room under `identity` with the ONLY copy of the room key at v3.
+        let identity = create_test_signing_key();
+        let mut secrets = std::collections::HashMap::new();
+        secrets.insert(3u32, [0x55u8; 32]);
+        storage
+            .import_room_atomic(
+                &owner_vk,
+                &identity,
+                create_test_state(&owner_sk),
+                &key,
+                secrets,
+                &member_for(&identity),
+                &[],
+                None,
+                false,
+            )
+            .unwrap();
+
+        // --force re-import of the SAME identity from a token with EMPTY secrets.
+        let outcome = storage
+            .import_room_atomic(
+                &owner_vk,
+                &identity,
+                create_test_state(&owner_sk),
+                &key,
+                std::collections::HashMap::new(),
+                &member_for(&identity),
+                &[],
+                None,
+                true,
+            )
+            .unwrap();
+        assert_eq!(
+            outcome,
+            ImportOutcome::Imported {
+                was_overwrite: true,
+                identity_changed: false,
+            }
+        );
+        assert_eq!(
+            storage
+                .get_invitation_secrets(&owner_vk)
+                .unwrap()
+                .get(&3u32),
+            Some(&[0x55u8; 32]),
+            "same-key --force re-import must RETAIN the stored invitation secret \
+             (only copy of the room key)"
+        );
+
+        // A DIFFERENT-key --force re-import REPLACES (drops the old secret).
+        let new_identity = create_test_signing_key();
+        let outcome = storage
+            .import_room_atomic(
+                &owner_vk,
+                &new_identity,
+                create_test_state(&owner_sk),
+                &key,
+                std::collections::HashMap::new(),
+                &member_for(&new_identity),
+                &[],
+                None,
+                true,
+            )
+            .unwrap();
+        assert_eq!(
+            outcome,
+            ImportOutcome::Imported {
+                was_overwrite: true,
+                identity_changed: true,
+            }
+        );
+        assert!(
+            storage
+                .get_invitation_secrets(&owner_vk)
+                .unwrap()
+                .is_empty(),
+            "different-key --force re-import must REPLACE (drop the old identity's secrets)"
+        );
     }
 
     /// Regression for issue freenet/river#307 (lost-update race).

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -562,21 +562,42 @@ impl Storage {
             }
             let identity_changed = old_key.is_some_and(|k| k != signing_key.to_bytes());
 
-            // Same-key re-import over an existing room (`was_overwrite &&
-            // !identity_changed`): PRESERVE the stored invitation secrets by
-            // merging them into the incoming map, existing wins on collision. The
-            // incoming token's map may be empty/incomplete (a legacy/stale export
-            // taken before the owner's `encrypted_secrets` backfill arrived), and
-            // for a private room still awaiting that backfill the stored map can be
-            // the ONLY copy of the room key — overwriting it with the token's empty
-            // map would make history permanently unreadable (Codex round-7). A
-            // genuine identity change instead REPLACES: the old identity's secrets
-            // must not carry forward to the new one.
+            // Assemble the incoming identity metadata.
             let mut invitation_secrets = invitation_secrets;
+            let mut self_nickname = self_nickname.map(str::to_string);
+            let mut invite_chain = invite_chain.to_vec();
+            let mut self_authorized_member = Some(authorized_member.clone());
+
+            // Same-key re-import over an existing room (`was_overwrite &&
+            // !identity_changed`): the incoming token may be a legacy/stale export
+            // that decodes optional fields as ABSENT/EMPTY. GENERAL RULE (Codex
+            // round-7/8): for EVERY field the token may carry absent/stale, RETAIN
+            // the stored value rather than overwrite it with an empty one — a
+            // genuine identity change instead REPLACES (old identity's metadata
+            // must not carry forward).
             if was_overwrite && !identity_changed {
                 if let Some(old) = storage.rooms.get(&owner_key_str) {
+                    // invitation_secrets: merge, existing wins — the stored map may
+                    // be the ONLY copy of a private room's key, so an empty token
+                    // must not wipe it (history would become unreadable, round-7).
                     for (version, secret) in &old.invitation_secrets {
                         invitation_secrets.entry(*version).or_insert(*secret);
+                    }
+                    // self_nickname: an absent token nickname must NOT erase the
+                    // stored chosen nickname (else `build_rejoin_delta` falls back
+                    // to "Member" after an inactivity prune).
+                    if self_nickname.is_none() {
+                        self_nickname = old.self_nickname.clone();
+                    }
+                    // membership proof (self_authorized_member + invite_chain) is a
+                    // coherent UNIT (the chain validates the member): keep the
+                    // stored pair when the token carries an empty chain, so we never
+                    // pair the token's member with an empty/mismatched chain.
+                    if invite_chain.is_empty() && !old.invite_chain.is_empty() {
+                        invite_chain = old.invite_chain.clone();
+                        if old.self_authorized_member.is_some() {
+                            self_authorized_member = old.self_authorized_member.clone();
+                        }
                     }
                 }
             }
@@ -590,11 +611,11 @@ impl Storage {
                     signing_key_bytes: signing_key.to_bytes(),
                     state,
                     contract_key: contract_key.id().to_string(),
-                    self_authorized_member: Some(authorized_member.clone()),
-                    invite_chain: invite_chain.to_vec(),
+                    self_authorized_member,
+                    invite_chain,
                     previous_contract_key: None,
                     invitation_secrets,
-                    self_nickname: self_nickname.map(str::to_string),
+                    self_nickname,
                 },
             );
             self.save_rooms_unlocked(&storage)?;
@@ -2196,6 +2217,79 @@ mod tests {
                 .unwrap()
                 .is_empty(),
             "different-key --force re-import must REPLACE (drop the old identity's secrets)"
+        );
+    }
+
+    /// freenet/river#414 (Codex round-8, systematic same-key audit): a same-key
+    /// `--force` re-import from a stale token (absent nickname, empty invite
+    /// chain) must RETAIN the stored nickname + membership proof, not erase them
+    /// (else `build_rejoin_delta` falls back to "Member").
+    #[test]
+    fn import_room_atomic_same_key_preserves_nickname_and_chain() {
+        use river_core::room_state::member::Member;
+
+        let (storage, _tmp) = create_test_storage();
+        let owner_sk = create_test_signing_key();
+        let owner_vk = owner_sk.verifying_key();
+        let key = expected_contract_key(&owner_vk);
+        let identity = create_test_signing_key();
+        let member = AuthorizedMember::new(
+            Member {
+                owner_member_id: owner_vk.into(),
+                invited_by: owner_vk.into(),
+                member_vk: identity.verifying_key(),
+            },
+            &owner_sk,
+        );
+
+        // Store the room WITH a chosen nickname and a non-empty invite chain.
+        storage
+            .import_room_atomic(
+                &owner_vk,
+                &identity,
+                create_test_state(&owner_sk),
+                &key,
+                std::collections::HashMap::new(),
+                &member,
+                std::slice::from_ref(&member),
+                Some("Chosen Name"),
+                false,
+            )
+            .unwrap();
+
+        // --force re-import of the SAME key from a stale token: no nickname, empty chain.
+        storage
+            .import_room_atomic(
+                &owner_vk,
+                &identity,
+                create_test_state(&owner_sk),
+                &key,
+                std::collections::HashMap::new(),
+                &member,
+                &[],
+                None,
+                true,
+            )
+            .unwrap();
+
+        let rooms = storage.load_rooms().unwrap();
+        let info = rooms
+            .rooms
+            .get(&bs58::encode(owner_vk.as_bytes()).into_string())
+            .unwrap();
+        assert_eq!(
+            info.self_nickname.as_deref(),
+            Some("Chosen Name"),
+            "an absent token nickname must NOT erase the stored chosen nickname"
+        );
+        assert_eq!(
+            info.invite_chain.len(),
+            1,
+            "an empty token invite_chain must NOT erase the stored chain"
+        );
+        assert!(
+            info.self_authorized_member.is_some(),
+            "the stored membership proof must survive a stale same-key re-import"
         );
     }
 

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -567,6 +567,15 @@ impl Storage {
             let mut self_nickname = self_nickname.map(str::to_string);
             let mut invite_chain = invite_chain.to_vec();
             let mut self_authorized_member = Some(authorized_member.clone());
+            // `previous_contract_key` is ROOM-scoped, NOT identity-scoped: it is the
+            // freenet/river#292 room-contract migration pointer (`ensure_room_migrated`
+            // can leave it set after a failed old-state merge while still returning
+            // the current key, so a later command retries the merge). The import
+            // never carries a new one, so preserve the stored value on ANY overwrite
+            // (same-key OR different-key) — clearing it would prevent the retry and
+            // can strand state that exists only under the previous contract
+            // generation (Codex round-11 P1).
+            let mut previous_contract_key = None;
 
             // Same-key re-import over an existing room (`was_overwrite &&
             // !identity_changed`): the incoming token may be a legacy/stale export
@@ -575,8 +584,11 @@ impl Storage {
             // the stored value rather than overwrite it with an empty one — a
             // genuine identity change instead REPLACES (old identity's metadata
             // must not carry forward).
-            if was_overwrite && !identity_changed {
-                if let Some(old) = storage.rooms.get(&owner_key_str) {
+            if let Some(old) = storage.rooms.get(&owner_key_str) {
+                // Room-scoped, so preserved regardless of identity change.
+                previous_contract_key = old.previous_contract_key.clone();
+
+                if !identity_changed {
                     // invitation_secrets: merge, existing wins — the stored map may
                     // be the ONLY copy of a private room's key, so an empty token
                     // must not wipe it (history would become unreadable, round-7).
@@ -613,7 +625,7 @@ impl Storage {
                     contract_key: contract_key.id().to_string(),
                     self_authorized_member,
                     invite_chain,
-                    previous_contract_key: None,
+                    previous_contract_key,
                     invitation_secrets,
                     self_nickname,
                 },
@@ -2290,6 +2302,108 @@ mod tests {
         assert!(
             info.self_authorized_member.is_some(),
             "the stored membership proof must survive a stale same-key re-import"
+        );
+    }
+
+    /// freenet/river#414 (Codex round-11 P1): `previous_contract_key` is
+    /// ROOM-scoped (the #292 room-contract migration pointer), not
+    /// identity-scoped. An overwrite import must carry the STORED value forward —
+    /// on BOTH same-key AND different-key overwrites — instead of clearing it,
+    /// else a pending contract-migration retry is lost and state under the
+    /// previous generation can be stranded.
+    #[test]
+    fn import_room_atomic_preserves_previous_contract_key() {
+        use river_core::room_state::member::Member;
+
+        let (storage, _tmp) = create_test_storage();
+        let owner_sk = create_test_signing_key();
+        let owner_vk = owner_sk.verifying_key();
+        let key = expected_contract_key(&owner_vk);
+        let owner_key_str = bs58::encode(owner_vk.as_bytes()).into_string();
+        let member_for = |sk: &SigningKey| {
+            AuthorizedMember::new(
+                Member {
+                    owner_member_id: owner_vk.into(),
+                    invited_by: owner_vk.into(),
+                    member_vk: sk.verifying_key(),
+                },
+                &owner_sk,
+            )
+        };
+        let previous_of = |s: &Storage| {
+            s.load_rooms()
+                .unwrap()
+                .rooms
+                .get(&owner_key_str)
+                .unwrap()
+                .previous_contract_key
+                .clone()
+        };
+
+        let identity = create_test_signing_key();
+        storage
+            .import_room_atomic(
+                &owner_vk,
+                &identity,
+                create_test_state(&owner_sk),
+                &key,
+                std::collections::HashMap::new(),
+                &member_for(&identity),
+                &[],
+                None,
+                false,
+            )
+            .unwrap();
+
+        // Simulate a pending #292 room-contract migration pointer on the record.
+        {
+            let mut rs = storage.load_rooms().unwrap();
+            rs.rooms
+                .get_mut(&owner_key_str)
+                .unwrap()
+                .previous_contract_key = Some("prev-migration-key".to_string());
+            storage.save_rooms(&rs).unwrap();
+        }
+
+        // SAME-key --force overwrite: the pointer must survive.
+        storage
+            .import_room_atomic(
+                &owner_vk,
+                &identity,
+                create_test_state(&owner_sk),
+                &key,
+                std::collections::HashMap::new(),
+                &member_for(&identity),
+                &[],
+                None,
+                true,
+            )
+            .unwrap();
+        assert_eq!(
+            previous_of(&storage).as_deref(),
+            Some("prev-migration-key"),
+            "same-key --force must preserve previous_contract_key (room-scoped)"
+        );
+
+        // DIFFERENT-key --force overwrite: room-scoped, so it must ALSO survive.
+        let new_identity = create_test_signing_key();
+        storage
+            .import_room_atomic(
+                &owner_vk,
+                &new_identity,
+                create_test_state(&owner_sk),
+                &key,
+                std::collections::HashMap::new(),
+                &member_for(&new_identity),
+                &[],
+                None,
+                true,
+            )
+            .unwrap();
+        assert_eq!(
+            previous_of(&storage).as_deref(),
+            Some("prev-migration-key"),
+            "different-key --force must ALSO preserve previous_contract_key (room-scoped)"
         );
     }
 

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -2207,42 +2207,92 @@ mod tests {
         );
     }
 
-    /// freenet/river#414 (Codex round-6 P2-3): an identity overwrite records a
-    /// per-room DM-prune tombstone so a late-arriving DM-load response can't
-    /// resurrect the OLD identity's entries. Pin the tombstone bookkeeping and
-    /// the suppression decision: entries at/older than the cutoff are dropped,
-    /// the NEW identity's strictly-newer entries survive, and repeat prunes keep
-    /// the latest cutoff.
+    /// freenet/river#414 (Codex round-6 P2-3; IDENTITY-based since round-9 P2):
+    /// an identity overwrite records a per-room DM-prune tombstone keyed to the
+    /// NEW identity's `MemberId`. A late DM-load response drops any entry whose
+    /// `sender` is NOT the new identity — independent of the entry's timestamp, so
+    /// a device clock skew / FUTURE-DATED old-identity entry can no longer slip
+    /// through (the round-8 wall-clock cutoff bug). Hidden (archive) entries carry
+    /// no identity, so they are dropped at the room level.
     #[test]
-    fn dm_prune_tombstone_suppresses_stale_entries_only() {
+    fn dm_prune_tombstone_suppresses_replaced_identity_regardless_of_timestamp() {
         reset_dm_prune_tombstones();
         let room = sk(41).verifying_key();
-        let other = sk(42).verifying_key();
+        let other_room = sk(42).verifying_key();
+        let new_id = MemberId(FastHash(1));
+        let old_id = MemberId(FastHash(2));
 
-        // No tombstone → nothing suppressed.
+        // No tombstone → nothing suppressed (outbound or hidden).
         assert!(dm_prune_tombstone_for(&room).is_none());
-        assert!(!dm_prune_suppresses(dm_prune_tombstone_for(&room), 100));
+        assert!(!dm_prune_suppresses_outbound(
+            dm_prune_tombstone_for(&room),
+            old_id
+        ));
+        assert!(!dm_prune_suppresses_hidden(dm_prune_tombstone_for(&room)));
 
-        // Prune at t=100.
-        record_dm_prune_tombstone(room, 100);
-        assert_eq!(dm_prune_tombstone_for(&room), Some(100));
+        // Overwrite to `new_id`.
+        record_dm_prune_tombstone(room, new_id);
+        assert_eq!(dm_prune_tombstone_for(&room), Some(new_id));
 
-        // The OLD identity's entries (ts <= 100, incl. same-second) are dropped;
-        // the NEW identity's later entries (ts > 100) survive.
-        assert!(dm_prune_suppresses(dm_prune_tombstone_for(&room), 50));
-        assert!(dm_prune_suppresses(dm_prune_tombstone_for(&room), 100));
-        assert!(!dm_prune_suppresses(dm_prune_tombstone_for(&room), 101));
+        // An OLD-identity outbound entry is dropped; the NEW identity's is kept —
+        // regardless of timestamp (the future-dated old-identity case the
+        // wall-clock cutoff missed).
+        assert!(dm_prune_suppresses_outbound(
+            dm_prune_tombstone_for(&room),
+            old_id
+        ));
+        assert!(!dm_prune_suppresses_outbound(
+            dm_prune_tombstone_for(&room),
+            new_id
+        ));
 
-        // A different room is unaffected.
-        assert!(!dm_prune_suppresses(dm_prune_tombstone_for(&other), 50));
+        // Hidden entries (no identity) are dropped at the room level for a pruned
+        // room, and kept for an un-pruned one.
+        assert!(dm_prune_suppresses_hidden(dm_prune_tombstone_for(&room)));
+        assert!(!dm_prune_suppresses_hidden(dm_prune_tombstone_for(
+            &other_room
+        )));
+        assert!(!dm_prune_suppresses_outbound(
+            dm_prune_tombstone_for(&other_room),
+            old_id
+        ));
 
-        // A repeat prune keeps the LATEST cutoff (a later prune never lowers it).
-        record_dm_prune_tombstone(room, 40);
-        assert_eq!(dm_prune_tombstone_for(&room), Some(100));
-        record_dm_prune_tombstone(room, 200);
-        assert_eq!(dm_prune_tombstone_for(&room), Some(200));
+        // A second overwrite updates the tombstone to the newest identity.
+        let newest_id = MemberId(FastHash(3));
+        record_dm_prune_tombstone(room, newest_id);
+        assert_eq!(dm_prune_tombstone_for(&room), Some(newest_id));
+        assert!(dm_prune_suppresses_outbound(
+            dm_prune_tombstone_for(&room),
+            new_id
+        ));
+        assert!(!dm_prune_suppresses_outbound(
+            dm_prune_tombstone_for(&room),
+            newest_id
+        ));
 
         reset_dm_prune_tombstones();
+    }
+
+    /// freenet/river#414 (Codex round-9 P1): the identity-import gate must ALSO
+    /// treat an in-flight load worker (`PENDING_LOADS != 0`) as "recovery in
+    /// progress" so an import can't be decided while the #345 recovery is still
+    /// restoring rooms. (`is_legacy_migration_in_progress()` is a localStorage read
+    /// that is always false off-WASM, so this pins the `PENDING_LOADS` branch.)
+    #[test]
+    fn rooms_recovery_in_progress_tracks_pending_loads() {
+        use std::sync::atomic::Ordering;
+        PENDING_LOADS.store(0, Ordering::Relaxed);
+        assert!(
+            !rooms_recovery_in_progress(),
+            "no legacy migration + no pending loads → not in recovery"
+        );
+        PENDING_LOADS.store(1, Ordering::Relaxed);
+        assert!(
+            rooms_recovery_in_progress(),
+            "an in-flight load worker must gate imports (recovery/load pending)"
+        );
+        PENDING_LOADS.store(0, Ordering::Relaxed);
+        assert!(!rooms_recovery_in_progress());
     }
 
     /// freenet/river#414 (Codex round-8 P1): when a late DM-load response is
@@ -3641,48 +3691,64 @@ async fn fire_load_outbound_dms_request() {
 /// would otherwise overwrite the fresher current entries). Both
 /// senders signed equivalently-derived tokens, so the timestamp is the
 /// only authoritative recency signal.
-/// Per-room DM-prune tombstones (freenet/river#414, Codex round-6 P2-3).
+/// Per-room DM-prune tombstones (freenet/river#414, Codex round-6 P2-3;
+/// identity-based since round-9 P2).
 ///
-/// Maps a room `owner_vk` → the unix-second at which its DM state was pruned by
-/// an identity overwrite. The outbound-DM store loads via a SEPARATE
-/// fire-and-forget request, so hydration can finish (and permit the overwrite)
-/// before the DM response arrives; the prune then finds empty signals and
-/// records nothing, and the late DM response re-hydrates the OLD identity's
-/// plaintext + hidden-thread entries. This tombstone is consulted by
-/// [`hydrate_outbound_dms_cache`] / [`hydrate_hidden_dm_threads`] to DROP any
-/// arriving entry for that room whose own timestamp is at/older than the prune.
+/// Maps a room `owner_vk` → the CURRENT (post-overwrite) local identity's
+/// `MemberId`. The outbound-DM store loads via a SEPARATE fire-and-forget
+/// request, so hydration can finish (and permit the overwrite) before the DM
+/// response arrives; the prune then finds empty signals and records nothing, and
+/// the late DM response would re-hydrate the OLD identity's plaintext +
+/// hidden-thread entries. This tombstone is consulted by
+/// [`hydrate_outbound_dms_cache`] / [`hydrate_hidden_dm_threads`] to DROP those
+/// late entries.
 ///
-/// Time-bounded on purpose: the NEW identity's future DMs / archives (timestamp
-/// STRICTLY newer than the prune) are never suppressed, so a later save that
-/// re-persists the store and a subsequent re-hydration keep working.
-static DM_PRUNE_TOMBSTONES: std::sync::LazyLock<Mutex<HashMap<VerifyingKey, u64>>> =
+/// IDENTITY-based, NOT wall-clock (Codex round-9 P2): the earlier design dropped
+/// entries whose `timestamp <= prune_cutoff`, but a device clock correction — or
+/// an already-future-dated cached entry — let an OLD-identity entry (timestamp >
+/// cutoff) slip through and leak the replaced identity's DM data. An outbound
+/// entry carries its `sender` `MemberId`, so we drop any whose sender is NOT the
+/// current identity, independent of timestamp. The store is session-scoped and
+/// the NEW identity's own sends go through `save_outbound_dm` (not hydration), so
+/// within a session a hydration response only ever replays pre-overwrite / legacy
+/// data — never the new identity's freshly-saved entries.
+static DM_PRUNE_TOMBSTONES: std::sync::LazyLock<Mutex<HashMap<VerifyingKey, MemberId>>> =
     std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
 
-/// Record that room `owner_vk`'s DM state was pruned at `pruned_at_secs`. Keeps
-/// the LATEST prune time on repeat (a second overwrite pushes the cutoff up).
-pub(crate) fn record_dm_prune_tombstone(owner_vk: VerifyingKey, pruned_at_secs: u64) {
+/// Record that room `owner_vk`'s DM state was pruned by an overwrite to
+/// `current_member_id` (the NEW identity). Any hydrated entry for this room NOT
+/// authored by `current_member_id` belongs to a replaced identity and is dropped.
+pub(crate) fn record_dm_prune_tombstone(owner_vk: VerifyingKey, current_member_id: MemberId) {
     if let Ok(mut m) = DM_PRUNE_TOMBSTONES.lock() {
-        let slot = m.entry(owner_vk).or_insert(0);
-        *slot = (*slot).max(pruned_at_secs);
+        m.insert(owner_vk, current_member_id);
     }
 }
 
-/// The prune cutoff for a room, if any. An arriving DM/hidden entry for this
-/// room whose timestamp is `<=` this value belongs to the pruned identity and
-/// must be dropped.
-fn dm_prune_tombstone_for(owner_vk: &VerifyingKey) -> Option<u64> {
+/// The room's current identity `MemberId` if it was pruned by an overwrite.
+fn dm_prune_tombstone_for(owner_vk: &VerifyingKey) -> Option<MemberId> {
     DM_PRUNE_TOMBSTONES
         .lock()
         .ok()
         .and_then(|m| m.get(owner_vk).copied())
 }
 
-/// Whether an arriving DM / hidden-thread entry with timestamp `entry_ts` is
-/// suppressed by a prune `cutoff` (the room's tombstone). `<=` because the
-/// prune and the entry can land in the same second; the NEW identity's entries
-/// are timestamped strictly after the prune. Pure so it is unit-testable.
-fn dm_prune_suppresses(cutoff: Option<u64>, entry_ts: u64) -> bool {
-    cutoff.is_some_and(|c| entry_ts <= c)
+/// Whether an arriving OUTBOUND-DM entry from `entry_sender` is suppressed by the
+/// room's prune tombstone: dropped iff the room was pruned AND the sender is NOT
+/// the current identity (i.e. it belongs to a replaced identity). Independent of
+/// the entry's timestamp (Codex round-9 P2). Pure so it is unit-testable.
+fn dm_prune_suppresses_outbound(current: Option<MemberId>, entry_sender: MemberId) -> bool {
+    matches!(current, Some(c) if entry_sender != c)
+}
+
+/// Whether an arriving HIDDEN-thread (archive) entry is suppressed: dropped iff
+/// the room was pruned. Hidden entries carry no local-identity field, so they are
+/// dropped at the room level. Safe because the tombstone is session-scoped and
+/// the NEW identity's archives go through the save path (not hydration), so a
+/// same-session hydration only replays the replaced identity's pre-overwrite
+/// entries; a reload starts with an empty tombstone and the already-sanitized
+/// persisted store.
+fn dm_prune_suppresses_hidden(current: Option<MemberId>) -> bool {
+    current.is_some()
 }
 
 /// Reset the DM-prune tombstones. For tests only; production never calls this.
@@ -3691,15 +3757,6 @@ pub(crate) fn reset_dm_prune_tombstones() {
     if let Ok(mut m) = DM_PRUNE_TOMBSTONES.lock() {
         m.clear();
     }
-}
-
-/// Current unix time in whole seconds (matches the DM entry `timestamp` clock).
-pub(crate) fn unix_now_secs() -> u64 {
-    use std::time::UNIX_EPOCH;
-    crate::util::get_current_system_time()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
 }
 
 pub fn hydrate_outbound_dms_cache(entries: Vec<OutboundDmEntry>) -> usize {
@@ -3716,11 +3773,12 @@ pub fn hydrate_outbound_dms_cache(entries: Vec<OutboundDmEntry>) -> usize {
                         continue;
                     }
                 };
-                // Drop an entry that predates an identity-overwrite prune for this
-                // room (freenet/river#414 P2-3): it belongs to the replaced
-                // identity. The NEW identity's later DMs have a strictly-newer
-                // timestamp and are kept.
-                if dm_prune_suppresses(dm_prune_tombstone_for(&room_vk), entry.timestamp) {
+                // Drop an entry authored by a REPLACED identity for a room that
+                // was overwritten (freenet/river#414 P2-3, identity-based since
+                // round-9): the entry's `sender` is the old identity, not the
+                // current one. Independent of the entry's timestamp — a device
+                // clock skew / future-dated entry can no longer slip through.
+                if dm_prune_suppresses_outbound(dm_prune_tombstone_for(&room_vk), entry.sender) {
                     suppressed_any = true;
                     continue;
                 }
@@ -3903,18 +3961,19 @@ pub fn hydrate_hidden_dm_threads(entries: Vec<HiddenDmThreadEntry>) -> usize {
         return 0;
     }
     crate::util::defer(move || {
-        // Drop hidden-thread entries that predate an identity-overwrite prune for
-        // their room (freenet/river#414 P2-3): they belong to the replaced
-        // identity. The NEW identity's later archives have a strictly-newer
-        // `hidden_at_ts` and are kept.
+        // Drop hidden-thread (archive) entries for a room that was overwritten
+        // (freenet/river#414 P2-3, identity-based since round-9): they belong to
+        // the replaced identity. Hidden entries carry no local-identity field, so
+        // they are dropped at the ROOM level, independent of timestamp (a clock
+        // skew can no longer let a future-dated archive slip through). Safe: the
+        // tombstone is session-scoped and the NEW identity's archives arrive via
+        // the save path, not hydration (see `dm_prune_suppresses_hidden`).
         let before_filter = entries.len();
         let entries: Vec<HiddenDmThreadEntry> = entries
             .into_iter()
             .filter(|entry| {
                 match ed25519_dalek::VerifyingKey::from_bytes(&entry.room_owner_vk) {
-                    Ok(room_vk) => {
-                        !dm_prune_suppresses(dm_prune_tombstone_for(&room_vk), entry.hidden_at_ts)
-                    }
+                    Ok(room_vk) => !dm_prune_suppresses_hidden(dm_prune_tombstone_for(&room_vk)),
                     Err(_) => true, // invalid VK is handled downstream
                 }
             })
@@ -4327,20 +4386,23 @@ pub fn prune_outbound_dms_for_purges() {
 /// (or wrongly hide threads for) the NEW identity. Call ONLY when the key
 /// actually changed.
 ///
+/// `new_member_id` is the CURRENT (post-overwrite) identity's `MemberId`; the
+/// tombstone drops any hydrated entry NOT authored by it.
+///
 /// Signal-safe: all mutation runs inside `crate::util::defer()`; the delegate
 /// persist is a coalesced `safe_spawn_local`. No-op (skips the whole
 /// defer/with_mut) when nothing is cached for the room.
-pub fn prune_dm_state_for_room(owner_vk: ed25519_dalek::VerifyingKey) {
+pub fn prune_dm_state_for_room(owner_vk: ed25519_dalek::VerifyingKey, new_member_id: MemberId) {
     use crate::components::direct_messages::{HIDDEN_DM_THREADS, OUTBOUND_DMS};
 
     // Record the prune tombstone UNCONDITIONALLY and FIRST (freenet/river#414
     // P2-3): the outbound-DM store loads via a separate fire-and-forget request,
     // so the signals may still be empty here while the OLD identity's entries are
-    // in flight. The tombstone makes `hydrate_outbound_dms_cache` /
-    // `hydrate_hidden_dm_threads` drop those entries when they arrive, instead of
-    // resurrecting the replaced identity's DM state. Must run before the
-    // has-nothing-cached early return below.
-    record_dm_prune_tombstone(owner_vk, unix_now_secs());
+    // in flight. The tombstone (keyed to the NEW identity) makes
+    // `hydrate_outbound_dms_cache` / `hydrate_hidden_dm_threads` drop those
+    // entries when they arrive, instead of resurrecting the replaced identity's
+    // DM state. Must run before the has-nothing-cached early return below.
+    record_dm_prune_tombstone(owner_vk, new_member_id);
 
     // `try_read` so we cooperate with any in-flight write; skip the whole
     // defer path when there is nothing cached for this room.
@@ -4794,6 +4856,27 @@ fn legacy_migration_in_progress_key() -> String {
         LEGACY_MIGRATION_IN_PROGRESS_PREFIX,
         legacy_set_fingerprint()
     )
+}
+
+/// Whether the room set is still being RECOVERED and is therefore NOT yet
+/// fully authoritative (freenet/river#414, Codex round-9 P1).
+///
+/// Distinct from `ROOMS_LOAD_STATE == Loaded`: during the freenet/river#345
+/// interrupted-legacy-migration RECOVERY, the per-room loader intentionally sets
+/// `Loaded` (so the partial room list renders instead of a spinner) BEFORE the
+/// background recovery workers restore rooms missing from the partial per-room
+/// index — and `SAW_FETCH_FAILURE` stays false. Importing an identity for one of
+/// those still-missing rooms in that window would misclassify it as new and
+/// overwrite its recovered persisted slot with empty state (DATA LOSS). The
+/// identity-import gate ANDs `!rooms_recovery_in_progress()` on top of
+/// `Loaded && !saw_fetch_failure`, so imports wait for recovery to finish.
+///
+/// True while EITHER the interrupted-migration flag is set (recovery pending /
+/// running — cleared only on a full successful re-save) OR any awaited load
+/// worker is still in flight (`PENDING_LOADS != 0`). This does NOT weaken the
+/// recovery; it only makes imports wait for it.
+pub(crate) fn rooms_recovery_in_progress() -> bool {
+    is_legacy_migration_in_progress() || PENDING_LOADS.load(Ordering::Relaxed) != 0
 }
 
 /// True if a legacy migration was started but not confirmed complete (see

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -2245,6 +2245,32 @@ mod tests {
         reset_dm_prune_tombstones();
     }
 
+    /// freenet/river#414 (Codex round-8 P1): when a late DM-load response is
+    /// filtered by the prune tombstone, the sanitized store must be PERSISTED
+    /// back to the delegate — otherwise the in-memory filter is undone on the
+    /// next reload (the tombstone is session-only). Source-grep pin that both
+    /// hydration paths persist on suppression (the delegate save needs a runtime,
+    /// so the behaviour itself isn't unit-testable here).
+    #[test]
+    fn late_dm_hydration_persists_sanitized_store() {
+        // The needle is assembled at runtime so this test's own source does NOT
+        // contain the contiguous call string (else it would self-match). Count
+        // the CALL form (name + `();`); the fn def uses `() {`, so it isn't
+        // counted. Two calls = one in hydrate_outbound_dms_cache, one in
+        // hydrate_hidden_dm_threads.
+        let src = include_str!("chat_delegate.rs");
+        let needle = format!(
+            "{}{}",
+            "persist_sanitized_dm_store_after_tombstone_filter", "();"
+        );
+        assert_eq!(
+            src.matches(&needle).count(),
+            2,
+            "both hydrate_outbound_dms_cache and hydrate_hidden_dm_threads must \
+             persist the sanitized store when a tombstone filters a late entry"
+        );
+    }
+
     // ===== Outbound DM revives hidden thread (Codex P1 fix) =====
     // The testing-reviewer's BLOCKING #3 on PR #265. The "explicit
     // unhide on outbound" path lives in `dm_thread_modal::do_send` /
@@ -3680,6 +3706,7 @@ pub fn hydrate_outbound_dms_cache(entries: Vec<OutboundDmEntry>) -> usize {
     use crate::components::direct_messages::OUTBOUND_DMS;
     let count = entries.len();
     crate::util::defer(move || {
+        let mut suppressed_any = false;
         OUTBOUND_DMS.with_mut(|cache| {
             for entry in entries {
                 let room_vk = match ed25519_dalek::VerifyingKey::from_bytes(&entry.room_owner_vk) {
@@ -3694,6 +3721,7 @@ pub fn hydrate_outbound_dms_cache(entries: Vec<OutboundDmEntry>) -> usize {
                 // identity. The NEW identity's later DMs have a strictly-newer
                 // timestamp and are kept.
                 if dm_prune_suppresses(dm_prune_tombstone_for(&room_vk), entry.timestamp) {
+                    suppressed_any = true;
                     continue;
                 }
                 let key = (room_vk, entry.recipient, entry.purge_token);
@@ -3707,8 +3735,33 @@ pub fn hydrate_outbound_dms_cache(entries: Vec<OutboundDmEntry>) -> usize {
                 }
             }
         });
+        // The delegate's persisted store still contains the entries we just
+        // dropped in memory (the response came FROM it). Persist the sanitized
+        // snapshot so the replaced identity's plaintext is actually removed from
+        // storage, not just this session's memory — otherwise the next reload
+        // re-hydrates it (the tombstone is session-only). freenet/river#414 P1
+        // (Codex round-8). Reuses the coalesced save path.
+        if suppressed_any {
+            persist_sanitized_dm_store_after_tombstone_filter();
+        }
     });
     count
+}
+
+/// Persist the sanitized outbound-DM store after a tombstone filter dropped a
+/// late-hydration entry, so the replaced identity's plaintext / archive state is
+/// removed from the delegate store (not just in-memory). Reuses the coalesced
+/// `save_outbound_dms_to_delegate` path; failures warn (best-effort, the
+/// in-memory state is already sanitized). freenet/river#414 P1 (Codex round-8).
+fn persist_sanitized_dm_store_after_tombstone_filter() {
+    crate::util::safe_spawn_local(async {
+        if let Err(e) = save_outbound_dms_to_delegate().await {
+            warn!(
+                "Failed to persist sanitized DM store after tombstone filter: {}",
+                e
+            );
+        }
+    });
 }
 
 /// Session-scoped tombstone set for `(room, peer)` pairs the local
@@ -3854,6 +3907,7 @@ pub fn hydrate_hidden_dm_threads(entries: Vec<HiddenDmThreadEntry>) -> usize {
         // their room (freenet/river#414 P2-3): they belong to the replaced
         // identity. The NEW identity's later archives have a strictly-newer
         // `hidden_at_ts` and are kept.
+        let before_filter = entries.len();
         let entries: Vec<HiddenDmThreadEntry> = entries
             .into_iter()
             .filter(|entry| {
@@ -3865,6 +3919,7 @@ pub fn hydrate_hidden_dm_threads(entries: Vec<HiddenDmThreadEntry>) -> usize {
                 }
             })
             .collect();
+        let suppressed_any = entries.len() < before_filter;
         // Snapshot the tombstone set under its own lock so we don't
         // hold it across the signal write (the with_mut closure may
         // run subscriber notifications synchronously on Drop).
@@ -3886,6 +3941,12 @@ pub fn hydrate_hidden_dm_threads(entries: Vec<HiddenDmThreadEntry>) -> usize {
                 hidden.insert(key, entry);
             }
         });
+        // Persist the sanitized store when a tombstone dropped a late archive
+        // entry, so the replaced identity's archive state is removed from the
+        // delegate (not just memory). freenet/river#414 P1 (Codex round-8).
+        if suppressed_any {
+            persist_sanitized_dm_store_after_tombstone_filter();
+        }
     });
     count
 }

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -2207,6 +2207,44 @@ mod tests {
         );
     }
 
+    /// freenet/river#414 (Codex round-6 P2-3): an identity overwrite records a
+    /// per-room DM-prune tombstone so a late-arriving DM-load response can't
+    /// resurrect the OLD identity's entries. Pin the tombstone bookkeeping and
+    /// the suppression decision: entries at/older than the cutoff are dropped,
+    /// the NEW identity's strictly-newer entries survive, and repeat prunes keep
+    /// the latest cutoff.
+    #[test]
+    fn dm_prune_tombstone_suppresses_stale_entries_only() {
+        reset_dm_prune_tombstones();
+        let room = sk(41).verifying_key();
+        let other = sk(42).verifying_key();
+
+        // No tombstone → nothing suppressed.
+        assert!(dm_prune_tombstone_for(&room).is_none());
+        assert!(!dm_prune_suppresses(dm_prune_tombstone_for(&room), 100));
+
+        // Prune at t=100.
+        record_dm_prune_tombstone(room, 100);
+        assert_eq!(dm_prune_tombstone_for(&room), Some(100));
+
+        // The OLD identity's entries (ts <= 100, incl. same-second) are dropped;
+        // the NEW identity's later entries (ts > 100) survive.
+        assert!(dm_prune_suppresses(dm_prune_tombstone_for(&room), 50));
+        assert!(dm_prune_suppresses(dm_prune_tombstone_for(&room), 100));
+        assert!(!dm_prune_suppresses(dm_prune_tombstone_for(&room), 101));
+
+        // A different room is unaffected.
+        assert!(!dm_prune_suppresses(dm_prune_tombstone_for(&other), 50));
+
+        // A repeat prune keeps the LATEST cutoff (a later prune never lowers it).
+        record_dm_prune_tombstone(room, 40);
+        assert_eq!(dm_prune_tombstone_for(&room), Some(100));
+        record_dm_prune_tombstone(room, 200);
+        assert_eq!(dm_prune_tombstone_for(&room), Some(200));
+
+        reset_dm_prune_tombstones();
+    }
+
     // ===== Outbound DM revives hidden thread (Codex P1 fix) =====
     // The testing-reviewer's BLOCKING #3 on PR #265. The "explicit
     // unhide on outbound" path lives in `dm_thread_modal::do_send` /
@@ -3577,6 +3615,67 @@ async fn fire_load_outbound_dms_request() {
 /// would otherwise overwrite the fresher current entries). Both
 /// senders signed equivalently-derived tokens, so the timestamp is the
 /// only authoritative recency signal.
+/// Per-room DM-prune tombstones (freenet/river#414, Codex round-6 P2-3).
+///
+/// Maps a room `owner_vk` → the unix-second at which its DM state was pruned by
+/// an identity overwrite. The outbound-DM store loads via a SEPARATE
+/// fire-and-forget request, so hydration can finish (and permit the overwrite)
+/// before the DM response arrives; the prune then finds empty signals and
+/// records nothing, and the late DM response re-hydrates the OLD identity's
+/// plaintext + hidden-thread entries. This tombstone is consulted by
+/// [`hydrate_outbound_dms_cache`] / [`hydrate_hidden_dm_threads`] to DROP any
+/// arriving entry for that room whose own timestamp is at/older than the prune.
+///
+/// Time-bounded on purpose: the NEW identity's future DMs / archives (timestamp
+/// STRICTLY newer than the prune) are never suppressed, so a later save that
+/// re-persists the store and a subsequent re-hydration keep working.
+static DM_PRUNE_TOMBSTONES: std::sync::LazyLock<Mutex<HashMap<VerifyingKey, u64>>> =
+    std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Record that room `owner_vk`'s DM state was pruned at `pruned_at_secs`. Keeps
+/// the LATEST prune time on repeat (a second overwrite pushes the cutoff up).
+pub(crate) fn record_dm_prune_tombstone(owner_vk: VerifyingKey, pruned_at_secs: u64) {
+    if let Ok(mut m) = DM_PRUNE_TOMBSTONES.lock() {
+        let slot = m.entry(owner_vk).or_insert(0);
+        *slot = (*slot).max(pruned_at_secs);
+    }
+}
+
+/// The prune cutoff for a room, if any. An arriving DM/hidden entry for this
+/// room whose timestamp is `<=` this value belongs to the pruned identity and
+/// must be dropped.
+fn dm_prune_tombstone_for(owner_vk: &VerifyingKey) -> Option<u64> {
+    DM_PRUNE_TOMBSTONES
+        .lock()
+        .ok()
+        .and_then(|m| m.get(owner_vk).copied())
+}
+
+/// Whether an arriving DM / hidden-thread entry with timestamp `entry_ts` is
+/// suppressed by a prune `cutoff` (the room's tombstone). `<=` because the
+/// prune and the entry can land in the same second; the NEW identity's entries
+/// are timestamped strictly after the prune. Pure so it is unit-testable.
+fn dm_prune_suppresses(cutoff: Option<u64>, entry_ts: u64) -> bool {
+    cutoff.is_some_and(|c| entry_ts <= c)
+}
+
+/// Reset the DM-prune tombstones. For tests only; production never calls this.
+#[cfg(test)]
+pub(crate) fn reset_dm_prune_tombstones() {
+    if let Ok(mut m) = DM_PRUNE_TOMBSTONES.lock() {
+        m.clear();
+    }
+}
+
+/// Current unix time in whole seconds (matches the DM entry `timestamp` clock).
+pub(crate) fn unix_now_secs() -> u64 {
+    use std::time::UNIX_EPOCH;
+    crate::util::get_current_system_time()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
 pub fn hydrate_outbound_dms_cache(entries: Vec<OutboundDmEntry>) -> usize {
     use crate::components::direct_messages::OUTBOUND_DMS;
     let count = entries.len();
@@ -3590,6 +3689,13 @@ pub fn hydrate_outbound_dms_cache(entries: Vec<OutboundDmEntry>) -> usize {
                         continue;
                     }
                 };
+                // Drop an entry that predates an identity-overwrite prune for this
+                // room (freenet/river#414 P2-3): it belongs to the replaced
+                // identity. The NEW identity's later DMs have a strictly-newer
+                // timestamp and are kept.
+                if dm_prune_suppresses(dm_prune_tombstone_for(&room_vk), entry.timestamp) {
+                    continue;
+                }
                 let key = (room_vk, entry.recipient, entry.purge_token);
                 match cache.by_token.get(&key) {
                     Some(existing) if existing.timestamp >= entry.timestamp => {
@@ -3744,6 +3850,21 @@ pub fn hydrate_hidden_dm_threads(entries: Vec<HiddenDmThreadEntry>) -> usize {
         return 0;
     }
     crate::util::defer(move || {
+        // Drop hidden-thread entries that predate an identity-overwrite prune for
+        // their room (freenet/river#414 P2-3): they belong to the replaced
+        // identity. The NEW identity's later archives have a strictly-newer
+        // `hidden_at_ts` and are kept.
+        let entries: Vec<HiddenDmThreadEntry> = entries
+            .into_iter()
+            .filter(|entry| {
+                match ed25519_dalek::VerifyingKey::from_bytes(&entry.room_owner_vk) {
+                    Ok(room_vk) => {
+                        !dm_prune_suppresses(dm_prune_tombstone_for(&room_vk), entry.hidden_at_ts)
+                    }
+                    Err(_) => true, // invalid VK is handled downstream
+                }
+            })
+            .collect();
         // Snapshot the tombstone set under its own lock so we don't
         // hold it across the signal write (the with_mut closure may
         // run subscriber notifications synchronously on Drop).
@@ -4150,6 +4271,15 @@ pub fn prune_outbound_dms_for_purges() {
 /// defer/with_mut) when nothing is cached for the room.
 pub fn prune_dm_state_for_room(owner_vk: ed25519_dalek::VerifyingKey) {
     use crate::components::direct_messages::{HIDDEN_DM_THREADS, OUTBOUND_DMS};
+
+    // Record the prune tombstone UNCONDITIONALLY and FIRST (freenet/river#414
+    // P2-3): the outbound-DM store loads via a separate fire-and-forget request,
+    // so the signals may still be empty here while the OLD identity's entries are
+    // in flight. The tombstone makes `hydrate_outbound_dms_cache` /
+    // `hydrate_hidden_dm_threads` drop those entries when they arrive, instead of
+    // resurrecting the replaced identity's DM state. Must run before the
+    // has-nothing-cached early return below.
+    record_dm_prune_tombstone(owner_vk, unix_now_secs());
 
     // `try_read` so we cooperate with any in-flight write; skip the whole
     // defer path when there is nothing cached for this room.
@@ -4743,6 +4873,22 @@ pub(crate) static SAW_FETCH_FAILURE: AtomicBool = AtomicBool::new(false);
 /// Record that a listed room's fetch failed to materialize.
 pub(crate) fn mark_fetch_failure() {
     SAW_FETCH_FAILURE.store(true, Ordering::Relaxed);
+}
+
+/// Whether any LISTED room's fetch failed to materialize during the current
+/// load attempt (`SAW_FETCH_FAILURE`).
+///
+/// This is the COMPLETENESS signal the identity-import gate needs
+/// (freenet/river#414, Codex round-6 P1-1): `per_room_terminal` resolves the
+/// rail to `Loaded` as soon as ≥1 room materialized, IGNORING whether other
+/// listed rooms failed — so `Loaded` alone does NOT mean "every room loaded".
+/// A room that failed to hydrate is absent from `ROOMS`, so importing its token
+/// would misclassify it as a brand-new room and build-empty over its populated
+/// persisted slot (DATA LOSS). The import decision therefore requires
+/// `Loaded` AND `!saw_fetch_failure` (a COMPLETE load). Reset at load start and
+/// on Retry, so a successful retry clears it.
+pub(crate) fn saw_fetch_failure() -> bool {
+    SAW_FETCH_FAILURE.load(Ordering::Relaxed)
 }
 
 /// The terminal state the backstop resolves a still-non-terminal load to,

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -4404,6 +4404,13 @@ pub fn prune_dm_state_for_room(owner_vk: ed25519_dalek::VerifyingKey, new_member
     // DM state. Must run before the has-nothing-cached early return below.
     record_dm_prune_tombstone(owner_vk, new_member_id);
 
+    // Re-seed `DM_LAST_SEEN` for the NEW identity (freenet/river#414 round-10 P2):
+    // that map is keyed only by `(room, peer)`, so the OLD identity's last-seen
+    // cutoffs would otherwise carry over and wrongly suppress unread badges for
+    // messages the new identity has never seen. Runs before the early return —
+    // it does not depend on the outbound-DM cache being populated.
+    crate::components::direct_messages::reseed_dm_last_seen_for_room(owner_vk);
+
     // `try_read` so we cooperate with any in-flight write; skip the whole
     // defer path when there is nothing cached for this room.
     let has_entries = {

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -3305,6 +3305,23 @@ fn reconcile_room_present(
                 // (local-authoritative), don't merge the other identity's
                 // state, and don't fail the whole save (M1 fix: scoped to this
                 // one room rather than wedging all persistence).
+                //
+                // KNOWN LIMITATION — multi-tab identity-overwrite reversal
+                // (freenet/river#420). This branch is last-writer-wins: it keeps
+                // whichever identity the SAVING session holds, with no way to
+                // tell which of the two identities is NEWER. So after a user
+                // replaces a room identity (freenet/river#414,
+                // `members.rs::complete_identity_import`), a second tab/device
+                // still holding the OLD identity will write it back here as its
+                // local copy on its next save, and on the next cold load the
+                // stale identity can win — silently undoing the replacement. The
+                // proper fix is a persisted, monotonically-increasing
+                // identity-generation counter on the per-room slot so this
+                // branch can adopt the higher generation instead of the last
+                // writer; that is a delegate/persisted-state change tracked in
+                // #420 and out of scope for the #414 escape hatch. Until then the
+                // overwrite-confirm dialog tells the user to close other sessions
+                // for the room first.
                 local.clone()
             } else {
                 let mut m = local.clone();
@@ -4113,6 +4130,59 @@ pub fn prune_outbound_dms_for_purges() {
         crate::util::safe_spawn_local(async {
             if let Err(e) = save_outbound_dms_to_delegate().await {
                 warn!("Failed to persist pruned outbound DM cache: {}", e);
+            }
+        });
+    });
+}
+
+/// Drop every cached outbound-DM plaintext entry and archived-thread entry for
+/// `owner_vk`'s room from the in-memory `OUTBOUND_DMS` / `HIDDEN_DM_THREADS`
+/// signals and persist the trimmed store.
+///
+/// The UI counterpart of the CLI `identity import --force` prune
+/// (freenet/river#414): when an identity overwrite swaps `self_sk` for a room,
+/// the OLD identity's outbound-DM plaintext and archive state must not leak into
+/// (or wrongly hide threads for) the NEW identity. Call ONLY when the key
+/// actually changed.
+///
+/// Signal-safe: all mutation runs inside `crate::util::defer()`; the delegate
+/// persist is a coalesced `safe_spawn_local`. No-op (skips the whole
+/// defer/with_mut) when nothing is cached for the room.
+pub fn prune_dm_state_for_room(owner_vk: ed25519_dalek::VerifyingKey) {
+    use crate::components::direct_messages::{HIDDEN_DM_THREADS, OUTBOUND_DMS};
+
+    // `try_read` so we cooperate with any in-flight write; skip the whole
+    // defer path when there is nothing cached for this room.
+    let has_entries = {
+        let Ok(cache) = OUTBOUND_DMS.try_read() else {
+            return;
+        };
+        cache.by_token.keys().any(|(room, _, _)| *room == owner_vk)
+    };
+    let has_hidden = {
+        let Ok(hidden) = HIDDEN_DM_THREADS.try_read() else {
+            return;
+        };
+        hidden.keys().any(|(room, _)| *room == owner_vk)
+    };
+    if !has_entries && !has_hidden {
+        return;
+    }
+
+    crate::util::defer(move || {
+        OUTBOUND_DMS.with_mut(|cache| {
+            cache.by_token.retain(|(room, _, _), _| *room != owner_vk);
+        });
+        HIDDEN_DM_THREADS.with_mut(|hidden| {
+            hidden.retain(|(room, _), _| *room != owner_vk);
+        });
+        info!("Pruned outbound-DM cache + archive state for a replaced room identity");
+        crate::util::safe_spawn_local(async {
+            if let Err(e) = save_outbound_dms_to_delegate().await {
+                warn!(
+                    "Failed to persist pruned DM state after identity replace: {}",
+                    e
+                );
             }
         });
     });

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -2273,6 +2273,46 @@ mod tests {
         reset_dm_prune_tombstones();
     }
 
+    /// freenet/river#414 (Codex round-11 P2): the OUTBOUND prune is DURABLE across
+    /// reload. Simulates a reload: the in-memory tombstone is EMPTY, but the room's
+    /// persisted current identity (from `ROOMS`, modelled here as the resolver's
+    /// second argument) still drives suppression. `resolve_dm_keep_identity`
+    /// prefers the in-session tombstone, else falls back to the durable identity —
+    /// so the replaced identity's cached plaintext is dropped next session even
+    /// though nothing sanitized the store in the overwrite session.
+    #[test]
+    fn outbound_prune_is_durable_via_room_identity() {
+        let new_id = MemberId(FastHash(10));
+        let old_id = MemberId(FastHash(11));
+        assert_ne!(new_id, old_id);
+
+        // Fresh session after overwrite+reload: no in-memory tombstone, but ROOMS
+        // holds the NEW identity as the room's current `self_sk`.
+        let keep = resolve_dm_keep_identity(None, Some(new_id));
+        assert_eq!(
+            keep,
+            Some(new_id),
+            "durable identity is used when no tombstone"
+        );
+        // The replaced identity's cached entry is STILL dropped after reload…
+        assert!(dm_prune_suppresses_outbound(keep, old_id));
+        // …and the new identity's entries survive.
+        assert!(!dm_prune_suppresses_outbound(keep, new_id));
+
+        // The in-session tombstone takes precedence over the durable identity.
+        let session_id = MemberId(FastHash(12));
+        assert_eq!(
+            resolve_dm_keep_identity(Some(session_id), Some(new_id)),
+            Some(session_id)
+        );
+
+        // A normal (never-loaded, no-identity) room suppresses nothing.
+        assert!(!dm_prune_suppresses_outbound(
+            resolve_dm_keep_identity(None, None),
+            old_id
+        ));
+    }
+
     /// freenet/river#414 (Codex round-9 P1): the identity-import gate must ALSO
     /// treat an in-flight load worker (`PENDING_LOADS != 0`) as "recovery in
     /// progress" so an import can't be decided while the #345 recovery is still
@@ -3708,10 +3748,17 @@ async fn fire_load_outbound_dms_request() {
 /// an already-future-dated cached entry — let an OLD-identity entry (timestamp >
 /// cutoff) slip through and leak the replaced identity's DM data. An outbound
 /// entry carries its `sender` `MemberId`, so we drop any whose sender is NOT the
-/// current identity, independent of timestamp. The store is session-scoped and
-/// the NEW identity's own sends go through `save_outbound_dm` (not hydration), so
-/// within a session a hydration response only ever replays pre-overwrite / legacy
-/// data — never the new identity's freshly-saved entries.
+/// current identity, independent of timestamp.
+///
+/// This in-memory map is SESSION-scoped, but the OUTBOUND filter is DURABLE across
+/// reload (Codex round-11 P2): when the tombstone is absent (a fresh session after
+/// an overwrite-then-reload), [`hydrate_outbound_dms_cache`] falls back to the
+/// room's persisted current identity in `ROOMS` (`current_room_identity_member_id`).
+/// So even if the DM store was never sanitized in the overwrite session (the prune
+/// ran with empty signals) the replaced identity's plaintext is still dropped next
+/// session. Hidden (archive) entries have no identity field, so they remain
+/// session-scoped (the reload case is self-healing — the new identity's later
+/// messages un-hide the thread, and no plaintext is involved).
 static DM_PRUNE_TOMBSTONES: std::sync::LazyLock<Mutex<HashMap<VerifyingKey, MemberId>>> =
     std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
 
@@ -3738,6 +3785,39 @@ fn dm_prune_tombstone_for(owner_vk: &VerifyingKey) -> Option<MemberId> {
 /// the entry's timestamp (Codex round-9 P2). Pure so it is unit-testable.
 fn dm_prune_suppresses_outbound(current: Option<MemberId>, entry_sender: MemberId) -> bool {
     matches!(current, Some(c) if entry_sender != c)
+}
+
+/// The room's CURRENT local identity `MemberId` from `ROOMS` (the DURABLE source
+/// of truth — the per-room slot persists the current `self_sk`), or `None` if the
+/// room isn't loaded / `ROOMS` is mid-write.
+///
+/// This is what makes the outbound-DM prune DURABLE across reload (Codex round-11
+/// P2): the in-memory `DM_PRUNE_TOMBSTONES` is session-scoped, so after an
+/// overwrite-then-reload the tombstone is gone — but `ROOMS[room].self_sk` still
+/// reflects the NEW identity (persisted at overwrite via the per-room save). An
+/// outbound entry whose `sender` is not the room's current identity belongs to a
+/// replaced identity and is dropped, timestamp-independent. Safe universally: the
+/// outbound cache is per-node (single identity per room), so a normal room's
+/// cached entries all carry the current identity and are never dropped. Startup
+/// fires the room-list request BEFORE the DM load, so on the common reload path
+/// `ROOMS` is populated by the time the DM response hydrates.
+fn current_room_identity_member_id(owner_vk: &VerifyingKey) -> Option<MemberId> {
+    use dioxus::prelude::ReadableExt;
+    let rooms = ROOMS.try_read().ok()?;
+    rooms
+        .map
+        .get(owner_vk)
+        .map(|rd| MemberId::from(&rd.self_sk.verifying_key()))
+}
+
+/// The identity a room's cached outbound DMs must match: the in-memory prune
+/// tombstone (in-session fast path) if present, else the durable current identity
+/// from `ROOMS`. Pure so the tombstone-vs-durable precedence is unit-testable.
+fn resolve_dm_keep_identity(
+    tombstone: Option<MemberId>,
+    room_identity: Option<MemberId>,
+) -> Option<MemberId> {
+    tombstone.or(room_identity)
 }
 
 /// Whether an arriving HIDDEN-thread (archive) entry is suppressed: dropped iff
@@ -3773,12 +3853,19 @@ pub fn hydrate_outbound_dms_cache(entries: Vec<OutboundDmEntry>) -> usize {
                         continue;
                     }
                 };
-                // Drop an entry authored by a REPLACED identity for a room that
-                // was overwritten (freenet/river#414 P2-3, identity-based since
-                // round-9): the entry's `sender` is the old identity, not the
-                // current one. Independent of the entry's timestamp — a device
-                // clock skew / future-dated entry can no longer slip through.
-                if dm_prune_suppresses_outbound(dm_prune_tombstone_for(&room_vk), entry.sender) {
+                // Drop an entry authored by a REPLACED identity for a room whose
+                // identity was overwritten (freenet/river#414 P2-3, identity-based
+                // since round-9): the entry's `sender` is not the room's current
+                // identity. Independent of timestamp — a device clock skew /
+                // future-dated entry can no longer slip through. The "keep"
+                // identity comes from the in-memory tombstone (in-session) OR,
+                // DURABLY across reload (round-11 P2), the room's persisted
+                // `self_sk` in `ROOMS`.
+                let keep_identity = resolve_dm_keep_identity(
+                    dm_prune_tombstone_for(&room_vk),
+                    current_room_identity_member_id(&room_vk),
+                );
+                if dm_prune_suppresses_outbound(keep_identity, entry.sender) {
                     suppressed_any = true;
                     continue;
                 }

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -1455,7 +1455,11 @@ fn hydrate_loaded_rooms(loaded_rooms: Rooms, is_legacy_delegate: bool, attempt: 
             let owner_contract_id = *owner_contract_id;
             crate::util::safe_spawn_local(async move {
                 let result =
-                    crate::signing::migrate_signing_key(delegate_room_key, &signing_key).await;
+                    // HYDRATION: startup LoadRooms re-migrating an already-stored
+                    // key — NOT a new identity choice, so it must not override the
+                    // registry and is discarded if superseded (freenet/river#414 P1).
+                    crate::signing::migrate_signing_key(delegate_room_key, &signing_key, false)
+                        .await;
 
                 if result != crate::signing::MigrationResult::Failed {
                     // Must defer signal mutations from spawn_local to

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -1460,10 +1460,19 @@ fn hydrate_loaded_rooms(loaded_rooms: Rooms, is_legacy_delegate: bool, attempt: 
                 if result != crate::signing::MigrationResult::Failed {
                     // Must defer signal mutations from spawn_local to
                     // avoid RefCell already borrowed panics in Dioxus runtime
+                    let migrated_key = signing_key.clone();
                     crate::util::defer(move || {
                         let mut sanitized = false;
                         ROOMS.with_mut(|rooms| {
                             if let Some(room_data) = rooms.map.get_mut(&room_key_copy) {
+                                // Only mark migrated for the identity that actually
+                                // completed: an overwrite may have replaced `self_sk`
+                                // while this migration ran, and marking the room
+                                // migrated for a superseded key would strand the new
+                                // identity (freenet/river#414).
+                                if room_data.self_sk != migrated_key {
+                                    return;
+                                }
                                 room_data.key_migrated_to_delegate = true;
                                 let params = river_core::room_state::ChatRoomParametersV1 {
                                     owner: room_key_copy,

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -1123,9 +1123,20 @@ pub async fn handle_get_response(
                                 crate::signing::migrate_signing_key(room_key, &self_sk, false)
                                     .await;
                             if result != crate::signing::MigrationResult::Failed {
+                                let migrated_key = self_sk.clone();
                                 crate::util::defer(move || {
                                     ROOMS.with_mut(|rooms| {
                                         if let Some(room_data) = rooms.map.get_mut(&owner_vk) {
+                                            // Only mark migrated for the identity that
+                                            // actually completed: an overwrite may have
+                                            // replaced `self_sk` while this migration ran,
+                                            // and marking the room migrated + sanitizing
+                                            // for a superseded key would strand the new
+                                            // identity (freenet/river#414, round-10 P2 —
+                                            // the guard the other 3 callbacks already have).
+                                            if room_data.self_sk != migrated_key {
+                                                return;
+                                            }
                                             room_data.key_migrated_to_delegate = true;
                                             let params = ChatRoomParametersV1 { owner: owner_vk };
                                             let removed =
@@ -2205,6 +2216,27 @@ mod tests {
             src.contains("is_probe_instance(key.id())"),
             "handle_get_response must route legacy-key GET responses into the \
              probe handler via is_probe_instance (freenet/river#292)."
+        );
+    }
+
+    /// freenet/river#414 round-10 P2 — source-grep pin: the post-GET migration
+    /// completion callback must guard `key_migrated_to_delegate = true` +
+    /// `remove_unverifiable_messages` on the captured key still matching the
+    /// room's CURRENT `self_sk`, exactly like the other three migration
+    /// callbacks. Without it, an identity overwrite mid-migration marks the NEW
+    /// RoomData migrated (and sanitizes it) for a superseded key.
+    #[test]
+    fn post_get_migration_callback_guards_on_current_self_sk() {
+        let full = include_str!("get_response.rs");
+        let src = full
+            .split("mod tests {")
+            .next()
+            .expect("get_response.rs must have production code before `mod tests`");
+        assert!(
+            src.contains("if room_data.self_sk != migrated_key {"),
+            "the post-GET migration completion callback must discard a stale-key \
+             result (room_data.self_sk != migrated_key) before marking migrated \
+             (freenet/river#414 round-10 P2)."
         );
     }
 

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -765,6 +765,15 @@ pub async fn handle_get_response(
                                 let mut sanitized = false;
                                 ROOMS.with_mut(|rooms| {
                                     if let Some(room_data) = rooms.map.get_mut(&owner_vk) {
+                                        // Only mark migrated for the identity that
+                                        // actually completed: an overwrite may have
+                                        // replaced `self_sk` while this migration ran,
+                                        // and marking the room migrated for a
+                                        // superseded key would strand the new identity
+                                        // (freenet/river#414).
+                                        if room_data.self_sk != signing_key_clone {
+                                            return;
+                                        }
                                         room_data.key_migrated_to_delegate = true;
                                         let params = river_core::room_state::ChatRoomParametersV1 {
                                             owner: owner_vk,

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -757,7 +757,10 @@ pub async fn handle_get_response(
                     wasm_bindgen_futures::spawn_local(async move {
                         let room_key = owner_vk.to_bytes();
                         let result =
-                            crate::signing::migrate_signing_key(room_key, &signing_key_clone).await;
+                            // AUTHORITATIVE: accepting an invitation chooses this
+                            // room's identity now (freenet/river#414 P1).
+                            crate::signing::migrate_signing_key(room_key, &signing_key_clone, true)
+                                .await;
                         if result != crate::signing::MigrationResult::Failed {
                             // Must defer signal mutations from spawn_local to
                             // avoid RefCell already borrowed panics in Dioxus runtime
@@ -1112,7 +1115,13 @@ pub async fn handle_get_response(
                         wasm_bindgen_futures::spawn_local(async move {
                             let room_key = owner_vk.to_bytes();
                             let result =
-                                crate::signing::migrate_signing_key(room_key, &self_sk).await;
+                                // HYDRATION: re-migrating the already-stored
+                                // `self_sk` read from ROOMS after the imported
+                                // room's GET-first sync — NOT a new identity
+                                // choice, so it must not override the registry and
+                                // is discarded if superseded (freenet/river#414 P1).
+                                crate::signing::migrate_signing_key(room_key, &self_sk, false)
+                                    .await;
                             if result != crate::signing::MigrationResult::Failed {
                                 crate::util::defer(move || {
                                     ROOMS.with_mut(|rooms| {

--- a/ui/src/components/app/freenet_api/room_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/room_synchronizer.rs
@@ -66,7 +66,15 @@ fn compute_update_data(
 /// idempotent: re-sending it is harmless if it raced another heal, and once
 /// the entry lands the next `build_member_info_heal` returns `None`, so the
 /// UPDATE stops firing.
-fn send_member_info_heal_update(owner_vk: VerifyingKey, heal_info: AuthorizedMemberInfo) {
+///
+/// `pub(crate)` so the identity-overwrite path (`members.rs::complete_identity_import`)
+/// can trigger the heal too: an in-place identity swap does NO GET, so without
+/// this the new identity would render "Unknown" until an unrelated future heal
+/// (freenet/river#414, Codex round-6 P2-4).
+pub(crate) fn send_member_info_heal_update(
+    owner_vk: VerifyingKey,
+    heal_info: AuthorizedMemberInfo,
+) {
     let key = owner_vk_to_contract_key(&owner_vk);
     let heal_delta = ChatRoomStateV1Delta {
         member_info: Some(vec![heal_info]),

--- a/ui/src/components/app/sync_info.rs
+++ b/ui/src/components/app/sync_info.rs
@@ -129,6 +129,35 @@ impl SyncInfo {
         }
     }
 
+    /// Reset an already-tracked room to the fresh-import (GET-first) sync path.
+    ///
+    /// Used when an imported identity OVERWRITES a room that is already tracked
+    /// (freenet/river#414). The previous identity may have driven the room to
+    /// [`RoomSyncStatus::Subscribed`] with a populated `last_synced_state`. If
+    /// it stays that way, the overwrite's empty placeholder `RoomData` looks
+    /// like a LOCAL EDIT to [`Self::needs_to_send_update`], which would ship a
+    /// bogus delta computed off the OLD state and never re-GET the room for the
+    /// new identity (the GET-first branch in `room_synchronizer` only runs for
+    /// `Disconnected` rooms). Resetting to `Disconnected` with no
+    /// `last_synced_state` makes [`Self::rooms_awaiting_subscription`] pick the
+    /// room up and — because the imported `RoomData` is
+    /// `is_awaiting_initial_sync()` — take the GET-first branch, exactly like a
+    /// brand-new import.
+    ///
+    /// Returns `true` if a tracked room was reset, `false` if the room was not
+    /// registered — a brand-new import is already on the GET-first path, so the
+    /// caller may invoke this unconditionally.
+    pub fn reset_room_for_resync(&mut self, owner_key: &VerifyingKey) -> bool {
+        let Some(sync_info) = self.map.get_mut(owner_key) else {
+            return false;
+        };
+        sync_info.sync_status = RoomSyncStatus::Disconnected;
+        sync_info.last_synced_state = None;
+        sync_info.subscribing_since = None;
+        sync_info.failed_sync_attempts = 0;
+        true
+    }
+
     /// Record a failed sync attempt for a room and decide whether to keep
     /// retrying or give up (freenet/river#290).
     ///
@@ -460,6 +489,54 @@ mod tests {
             si.map.get(&owner).unwrap().sync_status,
             RoomSyncStatus::Subscribed,
             "touch must never change the status"
+        );
+    }
+
+    /// freenet/river#414: overwriting an identity for an ALREADY-`Subscribed`
+    /// room must reset that room to the GET-first path (`Disconnected`, no
+    /// `last_synced_state`) so the imported identity re-fetches full state,
+    /// rather than leaving it `Subscribed` where `needs_to_send_update` would
+    /// ship a bogus delta off the overwrite's empty placeholder state.
+    #[test]
+    fn reset_room_for_resync_restores_get_first_path() {
+        let mut si = SyncInfo::new();
+        let owner = test_owner(21);
+
+        // A room the previous identity already drove to Subscribed, with a
+        // populated last-synced baseline and a failure streak.
+        si.register_new_room(owner);
+        si.update_sync_status(&owner, RoomSyncStatus::Subscribed);
+        si.update_last_synced_state(&owner, &ChatRoomStateV1::default());
+        si.map.get_mut(&owner).unwrap().failed_sync_attempts = 3;
+        assert_eq!(
+            si.map.get(&owner).unwrap().sync_status,
+            RoomSyncStatus::Subscribed
+        );
+        assert!(si.map.get(&owner).unwrap().last_synced_state.is_some());
+
+        // Overwrite import resets it to the fresh-import GET-first state.
+        assert!(
+            si.reset_room_for_resync(&owner),
+            "a tracked room must report it was reset"
+        );
+        let info = si.map.get(&owner).unwrap();
+        assert_eq!(
+            info.sync_status,
+            RoomSyncStatus::Disconnected,
+            "reset must return the room to Disconnected so rooms_awaiting_subscription re-GETs it"
+        );
+        assert!(
+            info.last_synced_state.is_none(),
+            "reset must clear the stale baseline so no delta is computed off empty state"
+        );
+        assert!(info.subscribing_since.is_none());
+        assert_eq!(info.failed_sync_attempts, 0);
+
+        // A brand-new import (room not tracked) is already GET-first: no-op.
+        let fresh = test_owner(22);
+        assert!(
+            !si.reset_room_for_resync(&fresh),
+            "an untracked room needs no reset (already on the GET-first path)"
         );
     }
 

--- a/ui/src/components/app/sync_info.rs
+++ b/ui/src/components/app/sync_info.rs
@@ -129,35 +129,6 @@ impl SyncInfo {
         }
     }
 
-    /// Reset an already-tracked room to the fresh-import (GET-first) sync path.
-    ///
-    /// Used when an imported identity OVERWRITES a room that is already tracked
-    /// (freenet/river#414). The previous identity may have driven the room to
-    /// [`RoomSyncStatus::Subscribed`] with a populated `last_synced_state`. If
-    /// it stays that way, the overwrite's empty placeholder `RoomData` looks
-    /// like a LOCAL EDIT to [`Self::needs_to_send_update`], which would ship a
-    /// bogus delta computed off the OLD state and never re-GET the room for the
-    /// new identity (the GET-first branch in `room_synchronizer` only runs for
-    /// `Disconnected` rooms). Resetting to `Disconnected` with no
-    /// `last_synced_state` makes [`Self::rooms_awaiting_subscription`] pick the
-    /// room up and — because the imported `RoomData` is
-    /// `is_awaiting_initial_sync()` — take the GET-first branch, exactly like a
-    /// brand-new import.
-    ///
-    /// Returns `true` if a tracked room was reset, `false` if the room was not
-    /// registered — a brand-new import is already on the GET-first path, so the
-    /// caller may invoke this unconditionally.
-    pub fn reset_room_for_resync(&mut self, owner_key: &VerifyingKey) -> bool {
-        let Some(sync_info) = self.map.get_mut(owner_key) else {
-            return false;
-        };
-        sync_info.sync_status = RoomSyncStatus::Disconnected;
-        sync_info.last_synced_state = None;
-        sync_info.subscribing_since = None;
-        sync_info.failed_sync_attempts = 0;
-        true
-    }
-
     /// Record a failed sync attempt for a room and decide whether to keep
     /// retrying or give up (freenet/river#290).
     ///
@@ -489,54 +460,6 @@ mod tests {
             si.map.get(&owner).unwrap().sync_status,
             RoomSyncStatus::Subscribed,
             "touch must never change the status"
-        );
-    }
-
-    /// freenet/river#414: overwriting an identity for an ALREADY-`Subscribed`
-    /// room must reset that room to the GET-first path (`Disconnected`, no
-    /// `last_synced_state`) so the imported identity re-fetches full state,
-    /// rather than leaving it `Subscribed` where `needs_to_send_update` would
-    /// ship a bogus delta off the overwrite's empty placeholder state.
-    #[test]
-    fn reset_room_for_resync_restores_get_first_path() {
-        let mut si = SyncInfo::new();
-        let owner = test_owner(21);
-
-        // A room the previous identity already drove to Subscribed, with a
-        // populated last-synced baseline and a failure streak.
-        si.register_new_room(owner);
-        si.update_sync_status(&owner, RoomSyncStatus::Subscribed);
-        si.update_last_synced_state(&owner, &ChatRoomStateV1::default());
-        si.map.get_mut(&owner).unwrap().failed_sync_attempts = 3;
-        assert_eq!(
-            si.map.get(&owner).unwrap().sync_status,
-            RoomSyncStatus::Subscribed
-        );
-        assert!(si.map.get(&owner).unwrap().last_synced_state.is_some());
-
-        // Overwrite import resets it to the fresh-import GET-first state.
-        assert!(
-            si.reset_room_for_resync(&owner),
-            "a tracked room must report it was reset"
-        );
-        let info = si.map.get(&owner).unwrap();
-        assert_eq!(
-            info.sync_status,
-            RoomSyncStatus::Disconnected,
-            "reset must return the room to Disconnected so rooms_awaiting_subscription re-GETs it"
-        );
-        assert!(
-            info.last_synced_state.is_none(),
-            "reset must clear the stale baseline so no delta is computed off empty state"
-        );
-        assert!(info.subscribing_since.is_none());
-        assert_eq!(info.failed_sync_attempts, 0);
-
-        // A brand-new import (room not tracked) is already GET-first: no-op.
-        let fresh = test_owner(22);
-        assert!(
-            !si.reset_room_for_resync(&fresh),
-            "an untracked room needs no reset (already on the GET-first path)"
         );
     }
 

--- a/ui/src/components/direct_messages.rs
+++ b/ui/src/components/direct_messages.rs
@@ -555,6 +555,50 @@ pub(crate) fn compute_dm_last_seen(
     updates
 }
 
+/// Re-seed [`DM_LAST_SEEN`] for a single room after an identity swap
+/// (freenet/river#414 round-10 P2).
+///
+/// `DM_LAST_SEEN` is keyed only by `(room, peer)`, so the OLD identity's
+/// last-seen cutoffs would carry over to the NEW identity's threads and wrongly
+/// suppress unread badges for messages the new identity has never seen. This
+/// drops the room's stale cutoffs and re-seeds them from the NEW identity's
+/// inbound DMs (`compute_dm_last_seen` keys on `room_data.self_sk`, which is now
+/// the swapped-in identity) — the same "don't flood history as unread" seed
+/// logic `seed_dm_last_seen_if_needed` uses, scoped to one room. Reads the
+/// CURRENT (post-swap) rooms snapshot, so the caller must run it AFTER the swap
+/// has updated `self_sk`. Signal-safe: the `DM_LAST_SEEN` mutation is deferred.
+pub fn reseed_dm_last_seen_for_room(owner_vk: VerifyingKey) {
+    let updates = {
+        let Ok(rooms) = crate::components::app::ROOMS.try_read() else {
+            return;
+        };
+        compute_dm_last_seen(&rooms)
+    };
+    crate::util::defer(move || {
+        DM_LAST_SEEN.with_mut(|seen| {
+            apply_dm_last_seen_reseed(seen, owner_vk, &updates);
+        });
+    });
+}
+
+/// Pure re-seed step for [`reseed_dm_last_seen_for_room`]: drop every existing
+/// last-seen cutoff for `owner_vk` (the replaced identity's) and set the new
+/// identity's from `updates` (already computed by `compute_dm_last_seen`, so
+/// keyed on the swapped-in `self_sk`), leaving other rooms untouched. Pure so
+/// the re-seed is unit-testable without the `ROOMS`/`DM_LAST_SEEN` signals.
+pub(crate) fn apply_dm_last_seen_reseed(
+    seen: &mut HashMap<(VerifyingKey, MemberId), u64>,
+    owner_vk: VerifyingKey,
+    updates: &HashMap<(VerifyingKey, MemberId), u64>,
+) {
+    seen.retain(|(room, _), _| *room != owner_vk);
+    for ((room, peer), ts) in updates {
+        if *room == owner_vk {
+            seen.insert((*room, *peer), *ts);
+        }
+    }
+}
+
 /// Initialise [`DM_LAST_SEEN`] from current room state so previously-existing
 /// inbound DMs don't show up as "unread" every time the page reloads.
 ///
@@ -737,6 +781,42 @@ mod tests {
     fn compute_dm_last_seen_returns_empty_for_empty_rooms() {
         let updates = compute_dm_last_seen(&empty_rooms());
         assert!(updates.is_empty());
+    }
+
+    /// freenet/river#414 (Codex round-10 P2): on an identity swap, the room's
+    /// stale last-seen cutoffs (the OLD identity's) must be dropped and replaced
+    /// by the NEW identity's, so unread badges reflect the new identity's actual
+    /// seen-state — while OTHER rooms are untouched.
+    #[test]
+    fn apply_dm_last_seen_reseed_replaces_room_only() {
+        let room_a = fixed_sk(1).verifying_key();
+        let room_b = fixed_sk(2).verifying_key();
+        let old_peer: MemberId = (&fixed_sk(3).verifying_key()).into();
+        let new_peer: MemberId = (&fixed_sk(4).verifying_key()).into();
+        let other_peer: MemberId = (&fixed_sk(5).verifying_key()).into();
+
+        let mut seen: HashMap<(VerifyingKey, MemberId), u64> = HashMap::new();
+        // Room A: the OLD identity's cutoffs.
+        seen.insert((room_a, old_peer), 100);
+        // Room B: an unrelated room's cutoff (must survive).
+        seen.insert((room_b, other_peer), 50);
+
+        // The NEW identity's computed last-seen for room A only.
+        let mut updates: HashMap<(VerifyingKey, MemberId), u64> = HashMap::new();
+        updates.insert((room_a, new_peer), 200);
+        // (compute_dm_last_seen also returns other rooms; the helper must ignore them.)
+        updates.insert((room_b, other_peer), 999);
+
+        apply_dm_last_seen_reseed(&mut seen, room_a, &updates);
+
+        // Room A's OLD-identity cutoff is gone; the NEW identity's is seeded.
+        assert!(
+            !seen.contains_key(&(room_a, old_peer)),
+            "the replaced identity's last-seen must be dropped"
+        );
+        assert_eq!(seen.get(&(room_a, new_peer)), Some(&200));
+        // Room B is untouched (NOT overwritten by the ignored update).
+        assert_eq!(seen.get(&(room_b, other_peer)), Some(&50));
     }
 
     #[test]

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -956,11 +956,175 @@ fn ExportIdentityModal(is_active: Signal<bool>) -> Element {
     }
 }
 
+/// Whether a room identity is already stored for `owner_key`.
+///
+/// When true, importing a fresh identity for that room would REPLACE the
+/// stored one, losing access to the current signing key unless it was
+/// exported first. The import flow therefore prompts for confirmation
+/// rather than refusing outright (freenet/river#414). Pure — no signal
+/// access — so the decision is unit-testable.
+fn import_room_identity_exists(rooms: &crate::room_data::Rooms, owner_key: &VerifyingKey) -> bool {
+    rooms.map.contains_key(owner_key)
+}
+
+/// Build the [`RoomData`](crate::room_data::RoomData) for an imported
+/// identity from its export.
+///
+/// Pure (no signal access) so the import/overwrite behaviour is
+/// unit-testable. The returned `RoomData` carries the imported `self_sk`,
+/// so inserting it into `Rooms::map` under `owner_vk` **replaces** any
+/// existing identity for that room — this is what makes overwrite-on-import
+/// work (freenet/river#414). The room state starts empty and is fully
+/// populated on the next network sync.
+fn build_imported_room_data(export: IdentityExport) -> crate::room_data::RoomData {
+    let owner_key = export.room_owner;
+
+    // Compute contract key from owner key + current WASM
+    let params = ChatRoomParametersV1 { owner: owner_key };
+    let params_bytes = to_cbor_vec(&params);
+    let contract_code = ContractCode::from(ROOM_CONTRACT_WASM);
+    let contract_key =
+        ContractKey::from_params_and_code(Parameters::from(params_bytes), &contract_code);
+
+    // Create RoomData from the import, using room name from export if available
+    let mut initial_state = river_core::room_state::ChatRoomStateV1::default();
+    if let Some(ref name) = export.room_name {
+        initial_state.configuration.configuration.display =
+            river_core::room_state::privacy::RoomDisplayMetadata::public(name.clone(), None);
+    }
+    crate::room_data::RoomData {
+        owner_vk: owner_key,
+        room_state: initial_state, // Will be fully populated on sync
+        self_sk: export.signing_key,
+        contract_key,
+        last_read_message_id: None,
+        secrets: HashMap::new(),
+        current_secret_version: None,
+        last_secret_rotation: None,
+        key_migrated_to_delegate: false,
+        self_authorized_member: Some(export.authorized_member),
+        invite_chain: export.invite_chain,
+        self_member_info: export.member_info,
+        // Imported room: the heal prefers `self_member_info` from the export
+        // when present. If the export pre-dates the member_info seal (a
+        // private-room identity exported before the join's self-heal ran)
+        // `export.member_info` is `None`, but the export still carries the
+        // chosen nickname in `self_nickname`, so the heal restores it instead
+        // of minting a generated default (freenet/river#298).
+        self_nickname: export.self_nickname,
+        previous_contract_key: None,
+        // Restore the invitation-carried room secrets so a non-owner of a
+        // private room keeps the secret across a device migration
+        // (freenet/river#306). Folded into the `#[serde(skip)]` `secrets` map
+        // by `repopulate_secrets_from_state` on the next sync. Empty for
+        // public rooms, owners, and pre-#306 exports.
+        invitation_secrets: export.invitation_secrets,
+    }
+}
+
+/// Insert an imported room into the map, **replacing** any existing identity
+/// for `owner_vk` and clearing a prior leave tombstone.
+///
+/// Importing is an explicit rejoin: clear any prior leave tombstone for this
+/// owner_key so the merge path doesn't silently filter the room out on next
+/// reload (freenet/river#247). Separated from the signal/delegate plumbing so
+/// the overwrite semantics are unit-testable (freenet/river#414).
+fn apply_imported_room(rooms: &mut crate::room_data::Rooms, room_data: crate::room_data::RoomData) {
+    let owner_key = room_data.owner_vk;
+    rooms.removed_rooms.remove(&owner_key);
+    rooms.map.insert(owner_key, room_data);
+}
+
+/// Complete an identity import: insert (overwriting any existing identity),
+/// select the room, mark it needing sync, and migrate the imported signing
+/// key to the delegate. Shared by the first-time import path and the
+/// overwrite-confirm path (freenet/river#414).
+fn complete_identity_import(
+    export: IdentityExport,
+    mut success_msg: Signal<Option<String>>,
+    mut error_msg: Signal<Option<String>>,
+) {
+    let room_data = build_imported_room_data(export);
+    let owner_key = room_data.owner_vk;
+
+    // Migrate the imported signing key to the delegate immediately. Without
+    // this, the delegate may have a stale key from a prior session, causing
+    // all message signatures to be rejected by the contract ("State
+    // verification failed: Invalid signature").
+    let signing_key_for_migration = room_data.self_sk.clone();
+    let room_key_bytes = owner_key.to_bytes();
+
+    // Defer signal mutations to a clean execution context to prevent RefCell
+    // re-entrant borrow panics.
+    crate::util::defer(move || {
+        ROOMS.with_mut(|rooms| {
+            // Record the explicit rejoin so the per-room save overwrites a
+            // remote `Tombstone` slot with `Present` rather than adopting the
+            // leave (freenet/river#345 round-9), then insert (replacing any
+            // existing identity for this room — freenet/river#414).
+            crate::components::app::chat_delegate::mark_room_rejoined(owner_key);
+            apply_imported_room(rooms, room_data);
+        });
+
+        CURRENT_ROOM.with_mut(|current| {
+            current.owner_key = Some(owner_key);
+        });
+
+        crate::components::app::mark_needs_sync(owner_key);
+
+        // Migrate signing key to delegate in background
+        crate::util::safe_spawn_local(async move {
+            let result =
+                crate::signing::migrate_signing_key(room_key_bytes, &signing_key_for_migration)
+                    .await;
+            match result {
+                crate::signing::MigrationResult::Stored
+                | crate::signing::MigrationResult::StaleKeyOverwritten
+                | crate::signing::MigrationResult::AlreadyCurrent => {
+                    dioxus::logger::tracing::info!("Import: signing key migrated to delegate");
+                    crate::util::defer(move || {
+                        let mut sanitized = false;
+                        ROOMS.with_mut(|rooms| {
+                            if let Some(rd) = rooms.map.get_mut(&owner_key) {
+                                rd.key_migrated_to_delegate = true;
+                                // Remove any messages with invalid signatures
+                                // left by a stale delegate key
+                                let params = ChatRoomParametersV1 { owner: owner_key };
+                                let removed = crate::signing::remove_unverifiable_messages(
+                                    &mut rd.room_state,
+                                    &params,
+                                );
+                                sanitized = removed > 0;
+                            }
+                        });
+                        if sanitized {
+                            crate::components::app::mark_needs_sync(owner_key);
+                        }
+                    });
+                }
+                crate::signing::MigrationResult::Failed => {
+                    dioxus::logger::tracing::warn!(
+                        "Import: delegate key migration failed, will use fallback signing"
+                    );
+                }
+            }
+        });
+
+        success_msg.set(Some("Identity imported! Syncing room state...".to_string()));
+        error_msg.set(None);
+    });
+}
+
 #[component]
 pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
     let mut token_input = use_signal(String::new);
     let mut error_msg = use_signal(|| None::<String>);
     let mut success_msg = use_signal(|| None::<String>);
+    // When true, a room identity already exists for the pasted token's owner,
+    // so we prompt to confirm replacing it rather than importing silently
+    // (freenet/river#414). The token stays in `token_input` and is re-parsed
+    // on confirm.
+    let mut overwrite_confirm = use_signal(|| false);
 
     if !*is_active.read() {
         return rsx! {};
@@ -972,149 +1136,50 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
             Ok(export) => {
                 let owner_key = export.room_owner;
 
-                // Check if we already have this room
-                {
+                // If we already have an identity for this room, importing would
+                // replace it (and lose the current signing key unless it was
+                // exported). Prompt for confirmation instead of refusing
+                // (freenet/river#414).
+                let already_exists = {
                     let Ok(rooms) = ROOMS.try_read() else {
                         return;
                     };
-                    if rooms.map.contains_key(&owner_key) {
-                        error_msg.set(Some(
-                            "You already have an identity for this room.".to_string(),
-                        ));
-                        return;
-                    }
-                }
-
-                // Compute contract key from owner key + current WASM
-                let params = ChatRoomParametersV1 { owner: owner_key };
-                let params_bytes = to_cbor_vec(&params);
-                let contract_code = ContractCode::from(ROOM_CONTRACT_WASM);
-                let contract_key = ContractKey::from_params_and_code(
-                    Parameters::from(params_bytes),
-                    &contract_code,
-                );
-
-                // Create RoomData from the import, using room name from export if available
-                let mut initial_state = river_core::room_state::ChatRoomStateV1::default();
-                if let Some(ref name) = export.room_name {
-                    initial_state.configuration.configuration.display =
-                        river_core::room_state::privacy::RoomDisplayMetadata::public(
-                            name.clone(),
-                            None,
-                        );
-                }
-                let room_data = crate::room_data::RoomData {
-                    owner_vk: owner_key,
-                    room_state: initial_state, // Will be fully populated on sync
-                    self_sk: export.signing_key,
-                    contract_key,
-                    last_read_message_id: None,
-                    secrets: HashMap::new(),
-                    current_secret_version: None,
-                    last_secret_rotation: None,
-                    key_migrated_to_delegate: false,
-                    self_authorized_member: Some(export.authorized_member),
-                    invite_chain: export.invite_chain,
-                    self_member_info: export.member_info,
-                    // Imported room: the heal prefers `self_member_info` from
-                    // the export when present. If the export pre-dates the
-                    // member_info seal (a private-room identity exported
-                    // before the join's self-heal ran) `export.member_info`
-                    // is `None`, but the export still carries the chosen
-                    // nickname in `self_nickname`, so the heal restores it
-                    // instead of minting a generated default (freenet/river#298).
-                    self_nickname: export.self_nickname,
-                    previous_contract_key: None,
-                    // Restore the invitation-carried room secrets so a
-                    // non-owner of a private room keeps the secret across a
-                    // device migration (freenet/river#306). Folded into the
-                    // `#[serde(skip)]` `secrets` map by
-                    // `repopulate_secrets_from_state` on the next sync. Empty
-                    // for public rooms, owners, and pre-#306 exports.
-                    invitation_secrets: export.invitation_secrets,
+                    import_room_identity_exists(&rooms, &owner_key)
                 };
-
-                // Migrate the imported signing key to the delegate immediately.
-                // Without this, the delegate may have a stale key from a prior
-                // session, causing all message signatures to be rejected by the
-                // contract ("State verification failed: Invalid signature").
-                let signing_key_for_migration = room_data.self_sk.clone();
-                let room_key_bytes = owner_key.to_bytes();
-
-                // Defer signal mutations to a clean execution context to
-                // prevent RefCell re-entrant borrow panics.
-                crate::util::defer(move || {
-                    ROOMS.with_mut(|rooms| {
-                        // Importing a room is an explicit rejoin — clear any
-                        // prior leave tombstone for this owner_key so the
-                        // merge path doesn't silently filter the room out
-                        // on next reload (freenet/river#247). Also record the
-                        // explicit rejoin so the per-room save overwrites a
-                        // remote `Tombstone` slot with `Present` rather than
-                        // adopting the leave (freenet/river#345 round-9).
-                        rooms.removed_rooms.remove(&owner_key);
-                        crate::components::app::chat_delegate::mark_room_rejoined(owner_key);
-                        rooms.map.insert(owner_key, room_data);
-                    });
-
-                    CURRENT_ROOM.with_mut(|current| {
-                        current.owner_key = Some(owner_key);
-                    });
-
-                    crate::components::app::mark_needs_sync(owner_key);
-
-                    // Migrate signing key to delegate in background
-                    crate::util::safe_spawn_local(async move {
-                        let result = crate::signing::migrate_signing_key(
-                            room_key_bytes,
-                            &signing_key_for_migration,
-                        )
-                        .await;
-                        match result {
-                            crate::signing::MigrationResult::Stored
-                            | crate::signing::MigrationResult::StaleKeyOverwritten
-                            | crate::signing::MigrationResult::AlreadyCurrent => {
-                                dioxus::logger::tracing::info!(
-                                    "Import: signing key migrated to delegate"
-                                );
-                                crate::util::defer(move || {
-                                    let mut sanitized = false;
-                                    ROOMS.with_mut(|rooms| {
-                                        if let Some(rd) = rooms.map.get_mut(&owner_key) {
-                                            rd.key_migrated_to_delegate = true;
-                                            // Remove any messages with invalid signatures
-                                            // left by a stale delegate key
-                                            let params = ChatRoomParametersV1 { owner: owner_key };
-                                            let removed =
-                                                crate::signing::remove_unverifiable_messages(
-                                                    &mut rd.room_state,
-                                                    &params,
-                                                );
-                                            sanitized = removed > 0;
-                                        }
-                                    });
-                                    if sanitized {
-                                        crate::components::app::mark_needs_sync(owner_key);
-                                    }
-                                });
-                            }
-                            crate::signing::MigrationResult::Failed => {
-                                dioxus::logger::tracing::warn!(
-                                    "Import: delegate key migration failed, will use fallback signing"
-                                );
-                            }
-                        }
-                    });
-
-                    success_msg.set(Some("Identity imported! Syncing room state...".to_string()));
+                if already_exists {
+                    overwrite_confirm.set(true);
                     error_msg.set(None);
-                });
+                    success_msg.set(None);
+                    return;
+                }
+
+                complete_identity_import(export, success_msg, error_msg);
             }
             Err(e) => {
                 error_msg.set(Some(format!("Invalid token: {}", e)));
                 success_msg.set(None);
             }
         }
+    };
+
+    // User confirmed replacing the existing identity: re-parse the token
+    // (still in `token_input`) and complete the overwrite.
+    let handle_replace_confirm = move |_| {
+        let input = token_input.read().clone();
+        overwrite_confirm.set(false);
+        match IdentityExport::from_armored_string(&input) {
+            Ok(export) => complete_identity_import(export, success_msg, error_msg),
+            Err(e) => {
+                error_msg.set(Some(format!("Invalid token: {}", e)));
+                success_msg.set(None);
+            }
+        }
+    };
+
+    // User backed out of the overwrite: return to the input state, keeping the
+    // pasted token so they can reconsider.
+    let handle_replace_cancel = move |_| {
+        overwrite_confirm.set(false);
     };
 
     rsx! {
@@ -1124,6 +1189,7 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
                 is_active.set(false);
                 error_msg.set(None);
                 success_msg.set(None);
+                overwrite_confirm.set(false);
                 token_input.set(String::new());
             },
             div {
@@ -1151,21 +1217,46 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
                         "{msg}"
                     }
                 }
-                div { class: "flex justify-end gap-3 mt-4",
-                    button {
-                        class: "px-4 py-2 bg-surface hover:bg-surface-hover text-text text-sm rounded-lg transition-colors border border-border",
-                        onclick: move |_| {
-                            is_active.set(false);
-                            error_msg.set(None);
-                            success_msg.set(None);
-                            token_input.set(String::new());
-                        },
-                        "Cancel"
+                if *overwrite_confirm.read() {
+                    // A room identity already exists — warn before replacing it.
+                    div {
+                        "data-testid": "import-identity-replace-warning",
+                        class: "mt-3 text-sm text-amber-400 bg-amber-500/10 border border-amber-500/30 rounded-lg p-3",
+                        "This room already has an identity. Importing will REPLACE it \u{2014} you'll lose access to your current identity for this room unless you've exported it first."
                     }
-                    button {
-                        class: "px-4 py-2 bg-accent hover:bg-accent-hover text-white text-sm font-medium rounded-lg transition-colors",
-                        onclick: handle_import,
-                        "Import"
+                    div { class: "flex justify-end gap-3 mt-4",
+                        button {
+                            "data-testid": "import-identity-replace-cancel",
+                            class: "px-4 py-2 bg-surface hover:bg-surface-hover text-text text-sm rounded-lg transition-colors border border-border",
+                            onclick: handle_replace_cancel,
+                            "Cancel"
+                        }
+                        button {
+                            "data-testid": "import-identity-replace-confirm",
+                            class: "px-4 py-2 bg-red-600 hover:bg-red-700 text-white text-sm font-medium rounded-lg transition-colors",
+                            onclick: handle_replace_confirm,
+                            "Replace identity"
+                        }
+                    }
+                } else {
+                    div { class: "flex justify-end gap-3 mt-4",
+                        button {
+                            class: "px-4 py-2 bg-surface hover:bg-surface-hover text-text text-sm rounded-lg transition-colors border border-border",
+                            onclick: move |_| {
+                                is_active.set(false);
+                                error_msg.set(None);
+                                success_msg.set(None);
+                                overwrite_confirm.set(false);
+                                token_input.set(String::new());
+                            },
+                            "Cancel"
+                        }
+                        button {
+                            "data-testid": "import-identity-submit",
+                            class: "px-4 py-2 bg-accent hover:bg-accent-hover text-white text-sm font-medium rounded-lg transition-colors",
+                            onclick: handle_import,
+                            "Import"
+                        }
                     }
                 }
             }
@@ -1186,6 +1277,112 @@ mod tests {
             member_vk: *invitee_vk,
         };
         AuthorizedMember::new(member, owner_sk)
+    }
+
+    /// An empty [`Rooms`](crate::room_data::Rooms) for the overwrite-import
+    /// tests (`Rooms` derives no `Default`, so build it field-by-field —
+    /// mirrors the `empty_rooms` helper in `chat_delegate.rs`).
+    fn empty_rooms() -> crate::room_data::Rooms {
+        crate::room_data::Rooms {
+            map: HashMap::new(),
+            current_room_key: None,
+            removed_rooms: HashSet::new(),
+            notification_modes: HashMap::new(),
+            room_order: Vec::new(),
+            migrated_rooms: Vec::new(),
+        }
+    }
+
+    /// A minimal owner export whose `signing_key` is `self_sk` for the room
+    /// owned by `owner_sk`. Enough to drive `build_imported_room_data` /
+    /// `apply_imported_room` in the overwrite tests.
+    fn export_for(owner_sk: &SigningKey, self_sk: &SigningKey) -> IdentityExport {
+        let owner_vk = owner_sk.verifying_key();
+        let self_vk = self_sk.verifying_key();
+        IdentityExport {
+            room_owner: owner_vk,
+            signing_key: self_sk.clone(),
+            authorized_member: authorized_member(owner_sk, &self_vk),
+            invite_chain: vec![],
+            member_info: None,
+            room_name: None,
+            self_nickname: None,
+            invitation_secrets: HashMap::new(),
+        }
+    }
+
+    /// freenet/river#414: importing into a room that already has an identity
+    /// routes to the overwrite-confirm path, NOT a hard error. The component
+    /// branches on `import_room_identity_exists`, so pin that decision: true
+    /// when the room is present, false when absent.
+    #[test]
+    fn existing_room_import_routes_to_confirm() {
+        let owner_sk = SigningKey::from_bytes(&[41u8; 32]);
+        let owner_vk = owner_sk.verifying_key();
+
+        let mut rooms = empty_rooms();
+        assert!(
+            !import_room_identity_exists(&rooms, &owner_vk),
+            "no stored identity yet: first-time import path (no confirm)"
+        );
+
+        // Seed an existing identity for the room.
+        let existing_sk = SigningKey::from_bytes(&[42u8; 32]);
+        let existing = build_imported_room_data(export_for(&owner_sk, &existing_sk));
+        rooms.map.insert(owner_vk, existing);
+
+        assert!(
+            import_room_identity_exists(&rooms, &owner_vk),
+            "an identity now exists: import must prompt for overwrite confirmation, not refuse"
+        );
+    }
+
+    /// freenet/river#414: confirming an overwrite replaces the stored signing
+    /// key with the imported one and clears any leave tombstone.
+    #[test]
+    fn confirming_overwrite_replaces_stored_identity() {
+        let owner_sk = SigningKey::from_bytes(&[43u8; 32]);
+        let owner_vk = owner_sk.verifying_key();
+
+        let old_sk = SigningKey::from_bytes(&[44u8; 32]);
+        let new_sk = SigningKey::from_bytes(&[45u8; 32]);
+        assert_ne!(old_sk.to_bytes(), new_sk.to_bytes());
+
+        // Start with the OLD identity stored, and a stale leave tombstone.
+        let mut rooms = empty_rooms();
+        rooms.map.insert(
+            owner_vk,
+            build_imported_room_data(export_for(&owner_sk, &old_sk)),
+        );
+        rooms.removed_rooms.insert(owner_vk);
+
+        // The confirm path re-parses the token and rebuilds RoomData: it must
+        // carry the NEW signing key for the SAME room.
+        let room_data = build_imported_room_data(export_for(&owner_sk, &new_sk));
+        assert_eq!(room_data.owner_vk, owner_vk);
+        assert_eq!(
+            room_data.self_sk.to_bytes(),
+            new_sk.to_bytes(),
+            "rebuilt RoomData must carry the imported signing key"
+        );
+
+        // Applying it overwrites the stored identity and clears the tombstone.
+        apply_imported_room(&mut rooms, room_data);
+
+        assert_eq!(
+            rooms.map.len(),
+            1,
+            "overwrite replaces in place, not appends a second entry"
+        );
+        assert_eq!(
+            rooms.map.get(&owner_vk).unwrap().self_sk.to_bytes(),
+            new_sk.to_bytes(),
+            "stored identity must now be the imported one"
+        );
+        assert!(
+            !rooms.removed_rooms.contains(&owner_vk),
+            "import is an explicit rejoin: the leave tombstone must be cleared"
+        );
     }
 
     /// Frozen cross-side wire-format fixture (issue freenet/river#302/#305).

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -983,15 +983,15 @@ fn resolve_confirmed_import(
     snapshot
 }
 
-/// Build the [`RoomData`](crate::room_data::RoomData) for an imported
-/// identity from its export.
+/// Build the [`RoomData`](crate::room_data::RoomData) for a **brand-new**
+/// imported room (one this client has never seen).
 ///
-/// Pure (no signal access) so the import/overwrite behaviour is
-/// unit-testable. The returned `RoomData` carries the imported `self_sk`,
-/// so inserting it into `Rooms::map` under `owner_vk` **replaces** any
-/// existing identity for that room — this is what makes overwrite-on-import
-/// work (freenet/river#414). The room state starts empty and is fully
-/// populated on the next network sync.
+/// Pure (no signal access) so it is unit-testable. The room state starts
+/// empty (`is_awaiting_initial_sync()`), so the synchronizer takes the
+/// GET-first path and fills it from the network. This is used ONLY for the
+/// new-room path; an OVERWRITE of an existing room instead swaps the identity
+/// in place via [`swap_room_identity_in_place`] and KEEPS the room's state
+/// (room state is identity-independent — freenet/river#414 redesign).
 fn build_imported_room_data(export: IdentityExport) -> crate::room_data::RoomData {
     let owner_key = export.room_owner;
 
@@ -1038,36 +1038,94 @@ fn build_imported_room_data(export: IdentityExport) -> crate::room_data::RoomDat
     }
 }
 
-/// Insert an imported room into the map, **replacing** any existing identity
-/// for `owner_vk` and clearing a prior leave tombstone.
+/// Swap a room's identity IN PLACE for an imported one, **keeping the existing
+/// `room_state`** (freenet/river#414 redesign).
 ///
-/// Importing is an explicit rejoin: clear any prior leave tombstone for this
-/// owner_key so the merge path doesn't silently filter the room out on next
-/// reload (freenet/river#247). Separated from the signal/delegate plumbing so
-/// the overwrite semantics are unit-testable (freenet/river#414).
-fn apply_imported_room(rooms: &mut crate::room_data::Rooms, room_data: crate::room_data::RoomData) {
-    let owner_key = room_data.owner_vk;
-    rooms.removed_rooms.remove(&owner_key);
-    rooms.map.insert(owner_key, room_data);
+/// Room state is identity-independent: it is shared contract state fetched by
+/// the room's contract key, the same for every member. Only `self_sk` (and the
+/// membership proof it signs) is identity-specific. So an overwrite must NOT
+/// rebuild the room from an empty `ChatRoomStateV1::default()` and re-fetch —
+/// that empty-rebuild was the root of the sync-reset / stale-load / bogus-delta
+/// cluster. Instead we replace the identity-specific fields from the export and
+/// keep `room_state`, `contract_key`, `previous_contract_key`, and the local
+/// `last_read_message_id`.
+///
+/// Ordering matters: `self_sk` is set BEFORE `repopulate_secrets_from_state`,
+/// which decrypts the owner-signed `encrypted_secrets` blobs addressed to *this
+/// member* — a local recompute against the kept state, no network fetch. Folds
+/// in the invitation-carried room secrets (identity-independent, symmetric per
+/// version) and marks the delegate key un-migrated so the new key is (re)stored.
+///
+/// Returns whether the signing key actually changed (drives the DM-cache
+/// prune). Pure (no signals) so the overwrite is unit-testable.
+fn swap_room_identity_in_place(
+    existing: &mut crate::room_data::RoomData,
+    export: IdentityExport,
+) -> bool {
+    let key_changed = existing.self_sk != export.signing_key;
+    existing.self_sk = export.signing_key;
+    existing.self_authorized_member = Some(export.authorized_member);
+    existing.invite_chain = export.invite_chain;
+    existing.self_member_info = export.member_info;
+    existing.self_nickname = export.self_nickname;
+    // Room secrets are per-room (symmetric per version), not per-identity, so a
+    // union is safe; keep any version already present (the owner-signed contract
+    // blob is authoritative and supersedes on the next repopulate).
+    for (version, secret) in export.invitation_secrets {
+        existing.invitation_secrets.entry(version).or_insert(secret);
+    }
+    // The new key has not been stored in the delegate yet.
+    existing.key_migrated_to_delegate = false;
+    // Recompute in-memory decrypted secrets for the NEW identity's access
+    // (private rooms) from the KEPT room_state — local, no network fetch.
+    existing.repopulate_secrets_from_state();
+    key_changed
 }
 
-/// Complete an identity import: insert (overwriting any existing identity),
-/// select the room, mark it needing sync, and migrate the imported signing
-/// key to the delegate. Shared by the first-time import path and the
-/// overwrite-confirm path (freenet/river#414).
+/// Whether the room set is HYDRATED enough to reliably decide new-vs-overwrite.
+///
+/// Under the in-place redesign this decision is safety-critical: deciding
+/// "no room" on an unhydrated view would route a real, populated room to the
+/// build-empty NEW path and overwrite it with empty state (data loss). The
+/// room set is authoritative only once the startup delegate load has RESOLVED
+/// (`Loaded`). `Loading`/`Migrating` mean "we don't know the set yet", and
+/// `LoadFailed` means a known room failed to load (so a room could be missing
+/// from the in-memory map) — none of these are safe to decide on
+/// (freenet/river#414 redesign).
+fn rooms_load_is_authoritative(
+    state: crate::components::app::chat_delegate::RoomsLoadState,
+) -> bool {
+    matches!(
+        state,
+        crate::components::app::chat_delegate::RoomsLoadState::Loaded
+    )
+}
+
+/// Complete an identity import (freenet/river#414 redesign).
+///
+/// Splits the two genuinely-different cases:
+/// - **New room** (not in `ROOMS`): build an empty placeholder + let the
+///   GET-first sync fill it — the correct path for a room this client has
+///   never seen.
+/// - **Overwrite** (already in `ROOMS`): swap the identity IN PLACE and KEEP
+///   the existing `room_state`. Room state is identity-independent, so an
+///   overwrite must not throw it away and re-fetch (the old empty-rebuild was
+///   the root of the sync-reset / stale-load / bogus-delta cluster).
+///
+/// Precondition: the caller has confirmed the room set is authoritative
+/// (`rooms_load_is_authoritative`), so the new-vs-overwrite decision below is
+/// reliable and can't misclassify a real room as new during startup.
 fn complete_identity_import(
     export: IdentityExport,
     mut success_msg: Signal<Option<String>>,
     mut error_msg: Signal<Option<String>>,
 ) {
-    let room_data = build_imported_room_data(export);
-    let owner_key = room_data.owner_vk;
-
+    let owner_key = export.room_owner;
     // Migrate the imported signing key to the delegate immediately. Without
     // this, the delegate may have a stale key from a prior session, causing
     // all message signatures to be rejected by the contract ("State
     // verification failed: Invalid signature").
-    let signing_key_for_migration = room_data.self_sk.clone();
+    let new_sk = export.signing_key.clone();
     let room_key_bytes = owner_key.to_bytes();
 
     // Defer signal mutations to a clean execution context to prevent RefCell
@@ -1085,20 +1143,29 @@ fn complete_identity_import(
     // identity-generation counter (see #420). The confirm dialog tells the user
     // to close other tabs/devices first, which avoids the reversal in practice.
     crate::util::defer(move || {
-        // Whether this import REPLACES a DIFFERENT identity already stored for
-        // the room (computed inside the same borrow that inserts, so a transient
-        // read failure can't abort the import). Drives the DM-state prune below.
+        // Drives the DM-state prune below: true only when an overwrite actually
+        // swaps to a different signing key.
         let mut identity_changed = false;
         ROOMS.with_mut(|rooms| {
-            if let Some(existing) = rooms.map.get(&owner_key) {
-                identity_changed = existing.self_sk != signing_key_for_migration;
-            }
-            // Record the explicit rejoin so the per-room save overwrites a
-            // remote `Tombstone` slot with `Present` rather than adopting the
-            // leave (freenet/river#345 round-9), then insert (replacing any
-            // existing identity for this room — freenet/river#414).
+            // Importing is an explicit rejoin: clear any leave tombstone and
+            // record the rejoin so a remote `Tombstone` slot is overwritten with
+            // `Present` rather than adopting the leave (freenet/river#247/#345).
+            // Applies to both the new-room and overwrite paths.
+            rooms.removed_rooms.remove(&owner_key);
             crate::components::app::chat_delegate::mark_room_rejoined(owner_key);
-            apply_imported_room(rooms, room_data);
+
+            match rooms.map.get_mut(&owner_key) {
+                // OVERWRITE: swap the identity in place, KEEP room_state.
+                Some(existing) => {
+                    identity_changed = swap_room_identity_in_place(existing, export);
+                }
+                // NEW room: empty placeholder; the GET-first sync fills it.
+                None => {
+                    rooms
+                        .map
+                        .insert(owner_key, build_imported_room_data(export));
+                }
+            }
         });
 
         // Overwriting a DIFFERENT identity: prune the OLD identity's cached
@@ -1114,22 +1181,19 @@ fn complete_identity_import(
             current.owner_key = Some(owner_key);
         });
 
-        // If this import REPLACED an already-tracked room (an overwrite of a
-        // Subscribed room), reset its sync entry so it takes the same GET-first
-        // fetch a brand-new import gets, instead of `needs_to_send_update`
-        // shipping a bogus delta off the now-empty placeholder state
-        // (freenet/river#414). No-op for a brand-new import (not yet tracked),
-        // which is already on the GET-first path.
-        crate::components::app::sync_info::SYNC_INFO
-            .with_mut(|sync_info| sync_info.reset_room_for_resync(&owner_key));
-
+        // Persist the room (the overwrite's new `self_sk` rides in the per-room
+        // delegate slot via `save_rooms_to_delegate`, which the NEEDS_SYNC effect
+        // fires) and drive a normal sync. For a NEW room the placeholder is
+        // `is_awaiting_initial_sync()`, so the synchronizer takes the GET-first
+        // path; for an OVERWRITE the kept `room_state` matches `last_synced_state`,
+        // so no bogus delta is sent and no re-fetch is forced. The redesign keeps
+        // state, so there is NO forced sync-entry reset here (the old empty-rebuild
+        // scaffolding is gone — freenet/river#414).
         crate::components::app::mark_needs_sync(owner_key);
 
         // Migrate signing key to delegate in background
         crate::util::safe_spawn_local(async move {
-            let result =
-                crate::signing::migrate_signing_key(room_key_bytes, &signing_key_for_migration)
-                    .await;
+            let result = crate::signing::migrate_signing_key(room_key_bytes, &new_sk).await;
             match result {
                 crate::signing::MigrationResult::Stored
                 | crate::signing::MigrationResult::StaleKeyOverwritten
@@ -1146,7 +1210,7 @@ fn complete_identity_import(
                                 // its own migration owns `key_migrated_to_delegate`
                                 // — don't mark it for a superseded key
                                 // (freenet/river#414).
-                                if rd.self_sk != signing_key_for_migration {
+                                if rd.self_sk != new_sk {
                                     return;
                                 }
                                 rd.key_migrated_to_delegate = true;
@@ -1195,6 +1259,16 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
         return rsx! {};
     }
 
+    // Reactive hydration gate (freenet/river#414 redesign): the room set must be
+    // authoritative before the Import button is enabled, so the new-vs-overwrite
+    // decision is never made on an unhydrated view (which would build-empty over
+    // a real room). Reading `ROOMS_LOAD_STATE` here subscribes the modal, so it
+    // re-renders — and the button enables — the moment the load resolves.
+    let rooms_hydrated = crate::components::app::chat_delegate::ROOMS_LOAD_STATE
+        .try_read()
+        .map(|g| rooms_load_is_authoritative(*g))
+        .unwrap_or(false);
+
     // Reset-and-close, matching the deferred pattern in `join_with_code_modal`
     // and `.claude/rules/dioxus-signal-safety.md`: signal mutations from event
     // handlers run inside `crate::util::defer()` so they execute in a clean
@@ -1214,6 +1288,28 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
         match IdentityExport::from_armored_string(&input) {
             Ok(export) => {
                 let owner_key = export.room_owner;
+
+                // Safety-critical (freenet/river#414 redesign): NEVER decide
+                // new-vs-overwrite on an unhydrated room set — a false "no room"
+                // would route a real, populated room to the build-empty NEW path
+                // and overwrite it with empty state. The Import button is disabled
+                // until hydrated (see `rooms_hydrated` in the render); this is the
+                // defense-in-depth net against a click landing before the render
+                // has re-disabled the button.
+                let load_state = crate::components::app::chat_delegate::ROOMS_LOAD_STATE
+                    .try_read()
+                    .map(|g| *g)
+                    .unwrap_or(crate::components::app::chat_delegate::RoomsLoadState::Loading);
+                if !rooms_load_is_authoritative(load_state) {
+                    crate::util::defer(move || {
+                        error_msg.set(Some(
+                            "Still loading your rooms — please wait a moment and try again."
+                                .to_string(),
+                        ));
+                        success_msg.set(None);
+                    });
+                    return;
+                }
 
                 // If we already have an identity for this room, importing would
                 // replace it (and lose the current signing key unless it was
@@ -1353,6 +1449,17 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
                         }
                     }
                 } else {
+                    // Until the room set is authoritative, importing could
+                    // misclassify a real room as new and overwrite it with empty
+                    // state — so the Import button waits for hydration
+                    // (freenet/river#414 redesign).
+                    if !rooms_hydrated {
+                        div {
+                            "data-testid": "import-identity-loading-rooms",
+                            class: "mt-3 text-sm text-text-muted",
+                            "Loading your rooms\u{2026} the import will be available in a moment."
+                        }
+                    }
                     div { class: "flex justify-end gap-3 mt-4",
                         button {
                             class: "px-4 py-2 bg-surface hover:bg-surface-hover text-text text-sm rounded-lg transition-colors border border-border",
@@ -1361,7 +1468,8 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
                         }
                         button {
                             "data-testid": "import-identity-submit",
-                            class: "px-4 py-2 bg-accent hover:bg-accent-hover text-white text-sm font-medium rounded-lg transition-colors",
+                            class: "px-4 py-2 bg-accent hover:bg-accent-hover text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed",
+                            disabled: !rooms_hydrated,
                             onclick: handle_import,
                             "Import"
                         }
@@ -1403,7 +1511,7 @@ mod tests {
 
     /// A minimal owner export whose `signing_key` is `self_sk` for the room
     /// owned by `owner_sk`. Enough to drive `build_imported_room_data` /
-    /// `apply_imported_room` in the overwrite tests.
+    /// `swap_room_identity_in_place` in the overwrite tests.
     fn export_for(owner_sk: &SigningKey, self_sk: &SigningKey) -> IdentityExport {
         let owner_vk = owner_sk.verifying_key();
         let self_vk = self_sk.verifying_key();
@@ -1445,52 +1553,96 @@ mod tests {
         );
     }
 
-    /// freenet/river#414: confirming an overwrite replaces the stored signing
-    /// key with the imported one and clears any leave tombstone.
+    /// freenet/river#414 REDESIGN: overwriting an existing room's identity swaps
+    /// `self_sk` (and the membership proof) IN PLACE while KEEPING the existing
+    /// `room_state`. Room state is identity-independent shared contract state, so
+    /// an overwrite must never throw it away and rebuild empty (the old bug that
+    /// caused the sync-reset / bogus-delta cluster).
     #[test]
-    fn confirming_overwrite_replaces_stored_identity() {
+    fn overwrite_swaps_identity_in_place_keeping_room_state() {
         let owner_sk = SigningKey::from_bytes(&[43u8; 32]);
-        let owner_vk = owner_sk.verifying_key();
-
         let old_sk = SigningKey::from_bytes(&[44u8; 32]);
         let new_sk = SigningKey::from_bytes(&[45u8; 32]);
         assert_ne!(old_sk.to_bytes(), new_sk.to_bytes());
 
-        // Start with the OLD identity stored, and a stale leave tombstone.
-        let mut rooms = empty_rooms();
-        rooms.map.insert(
-            owner_vk,
-            build_imported_room_data(export_for(&owner_sk, &old_sk)),
+        // Existing room under the OLD identity with a POPULATED, distinguishable
+        // state (a member added) so we can assert the state is KEPT.
+        let mut existing = build_imported_room_data(export_for(&owner_sk, &old_sk));
+        let member_vk = SigningKey::from_bytes(&[77u8; 32]).verifying_key();
+        existing
+            .room_state
+            .members
+            .members
+            .push(authorized_member(&owner_sk, &member_vk));
+        existing.key_migrated_to_delegate = true; // pretend the old key was migrated
+        let kept_state = existing.room_state.clone();
+        assert_ne!(
+            kept_state,
+            river_core::room_state::ChatRoomStateV1::default(),
+            "precondition: the existing room has non-empty state"
         );
-        rooms.removed_rooms.insert(owner_vk);
 
-        // The confirm path re-parses the token and rebuilds RoomData: it must
-        // carry the NEW signing key for the SAME room.
-        let room_data = build_imported_room_data(export_for(&owner_sk, &new_sk));
-        assert_eq!(room_data.owner_vk, owner_vk);
+        // Overwrite with the NEW identity.
+        let key_changed =
+            swap_room_identity_in_place(&mut existing, export_for(&owner_sk, &new_sk));
+
+        assert!(key_changed, "swapping to a different key reports a change");
         assert_eq!(
-            room_data.self_sk.to_bytes(),
+            existing.self_sk.to_bytes(),
             new_sk.to_bytes(),
-            "rebuilt RoomData must carry the imported signing key"
-        );
-
-        // Applying it overwrites the stored identity and clears the tombstone.
-        apply_imported_room(&mut rooms, room_data);
-
-        assert_eq!(
-            rooms.map.len(),
-            1,
-            "overwrite replaces in place, not appends a second entry"
+            "self_sk must become the imported identity"
         );
         assert_eq!(
-            rooms.map.get(&owner_vk).unwrap().self_sk.to_bytes(),
-            new_sk.to_bytes(),
-            "stored identity must now be the imported one"
+            existing.room_state, kept_state,
+            "room_state must be KEPT untouched (identity-independent) — NOT rebuilt empty"
         );
         assert!(
-            !rooms.removed_rooms.contains(&owner_vk),
-            "import is an explicit rejoin: the leave tombstone must be cleared"
+            !existing.key_migrated_to_delegate,
+            "the new key hasn't been migrated to the delegate yet"
         );
+    }
+
+    /// freenet/river#414 REDESIGN: an overwrite of a PRIVATE room repopulates the
+    /// new identity's in-memory decrypted secrets from the KEPT state — a local
+    /// recompute (here via the invitation-carried secret fold), never a network
+    /// fetch.
+    #[test]
+    fn overwrite_repopulates_private_room_secrets_for_new_identity() {
+        let owner_sk = SigningKey::from_bytes(&[61u8; 32]);
+        let old_sk = SigningKey::from_bytes(&[62u8; 32]);
+        let new_sk = SigningKey::from_bytes(&[63u8; 32]);
+
+        // Existing PRIVATE room under the old identity (no secrets loaded yet).
+        let mut existing = build_imported_room_data(export_for(&owner_sk, &old_sk));
+        existing.room_state.configuration.configuration.privacy_mode =
+            river_core::room_state::privacy::PrivacyMode::Private;
+        assert!(existing.is_private());
+        assert!(existing.secrets.is_empty());
+
+        // The imported (new) identity carries an invitation secret at v0.
+        let mut export = export_for(&owner_sk, &new_sk);
+        export.invitation_secrets.insert(0u32, [0xABu8; 32]);
+
+        swap_room_identity_in_place(&mut existing, export);
+
+        assert_eq!(existing.self_sk.to_bytes(), new_sk.to_bytes());
+        assert_eq!(
+            existing.secrets.get(&0u32),
+            Some(&[0xABu8; 32]),
+            "overwrite must repopulate the new identity's in-memory secrets from kept state"
+        );
+    }
+
+    /// freenet/river#414 REDESIGN (safety-critical): the new-vs-overwrite
+    /// decision is authoritative ONLY once the room set has resolved (`Loaded`).
+    /// Deciding on an unhydrated view could build-empty over a real room.
+    #[test]
+    fn rooms_load_authoritative_only_when_loaded() {
+        use crate::components::app::chat_delegate::RoomsLoadState;
+        assert!(rooms_load_is_authoritative(RoomsLoadState::Loaded));
+        assert!(!rooms_load_is_authoritative(RoomsLoadState::Loading));
+        assert!(!rooms_load_is_authoritative(RoomsLoadState::Migrating));
+        assert!(!rooms_load_is_authoritative(RoomsLoadState::LoadFailed));
     }
 
     /// freenet/river#414 (Codex round 2): confirming an overwrite imports the
@@ -2089,20 +2241,43 @@ mod tests {
         );
     }
 
-    /// Source-grep pin (freenet/river#414): `complete_identity_import` MUST
-    /// reset the room's sync entry via `reset_room_for_resync` so an overwrite
-    /// of an already-`Subscribed` room re-GETs full state instead of shipping a
-    /// bogus delta off the empty placeholder. Catches a refactor that drops the
-    /// reset (which unit tests on the pure helpers alone would not notice, since
-    /// the wiring lives in the deferred signal block).
+    /// Source-grep pin (freenet/river#414 REDESIGN): the overwrite path must
+    /// swap the identity IN PLACE (keeping room_state) and must NOT resurrect the
+    /// deleted empty-rebuild scaffolding. The behavioural swap logic is
+    /// unit-tested on the pure helper; this pins that the deferred signal block
+    /// actually routes overwrite → `swap_room_identity_in_place` and does not
+    /// re-add `reset_room_for_resync` (which only existed to nurse the rebuilt
+    /// empty room).
     #[test]
-    fn complete_identity_import_resets_sync_for_overwrite() {
+    fn complete_identity_import_overwrites_in_place_without_resync_reset() {
         let prod = production_source();
         assert!(
-            prod.contains("reset_room_for_resync"),
-            "complete_identity_import must call SYNC_INFO.reset_room_for_resync \
-             so an overwrite import re-GETs full state (freenet/river#414); \
-             without it a Subscribed room ships a delta off empty state."
+            prod.contains("swap_room_identity_in_place(existing, export)"),
+            "complete_identity_import must swap the identity in place on overwrite \
+             (keeping room_state), not rebuild empty (freenet/river#414 redesign)"
+        );
+        assert!(
+            !prod.contains("reset_room_for_resync"),
+            "the empty-rebuild scaffolding (reset_room_for_resync) must stay \
+             deleted — the redesign keeps room_state, so there is nothing to nurse"
+        );
+    }
+
+    /// Source-grep pin (freenet/river#414 REDESIGN, safety-critical): the import
+    /// handler must gate the new-vs-overwrite decision on `rooms_load_is_authoritative`
+    /// so it never decides on an unhydrated room set (which would build-empty over
+    /// a real room). Both the render-time button gate and the handler safety-net
+    /// must be present.
+    #[test]
+    fn handle_import_gates_on_hydration() {
+        let prod = production_source();
+        assert!(
+            prod.contains("if !rooms_load_is_authoritative(load_state)"),
+            "handle_import must refuse to decide on an unhydrated room set (#414 redesign)"
+        );
+        assert!(
+            prod.contains("disabled: !rooms_hydrated"),
+            "the Import button must be disabled until the room set is hydrated (#414 redesign)"
         );
     }
 

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1165,6 +1165,10 @@ fn swap_room_identity_in_place(
         // - membership proof (`self_authorized_member` + `invite_chain`) is a
         //   coherent UNIT (the chain validates the member), so keep them TOGETHER:
         //   adopt the token's pair only when the local membership proof is absent;
+        //   CROSS-REF: the CLI counterpart
+        //   (cli/src/storage.rs `import_room_atomic`) gates the equivalent step on
+        //   the TOKEN's chain being empty, not the LOCAL proof being absent — the
+        //   two conditions differ DELIBERATELY; do NOT harmonize them into one rule.
         if existing.self_authorized_member.is_none() {
             existing.self_authorized_member = Some(export.authorized_member);
             existing.invite_chain = export.invite_chain;

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1072,8 +1072,27 @@ fn complete_identity_import(
 
     // Defer signal mutations to a clean execution context to prevent RefCell
     // re-entrant borrow panics.
+    //
+    // KNOWN LIMITATION — multi-tab reversal (freenet/river#420). This overwrite
+    // updates THIS session's identity and re-saves the per-room delegate slot,
+    // but a SECOND tab/device for the same room still holding the OLD identity
+    // will write it back as `RoomSlot::Present` on its next save.
+    // `chat_delegate::reconcile_room_present` is local-authoritative on a
+    // self_sk conflict (last-writer-wins; there is no identity generation to
+    // decide which is newer), so on the next cold load a stale tab can silently
+    // undo the replacement. Full multi-tab identity coordination is out of scope
+    // for this get-unstuck escape hatch; the proper fix is a persisted
+    // identity-generation counter (see #420). The confirm dialog tells the user
+    // to close other tabs/devices first, which avoids the reversal in practice.
     crate::util::defer(move || {
+        // Whether this import REPLACES a DIFFERENT identity already stored for
+        // the room (computed inside the same borrow that inserts, so a transient
+        // read failure can't abort the import). Drives the DM-state prune below.
+        let mut identity_changed = false;
         ROOMS.with_mut(|rooms| {
+            if let Some(existing) = rooms.map.get(&owner_key) {
+                identity_changed = existing.self_sk != signing_key_for_migration;
+            }
             // Record the explicit rejoin so the per-room save overwrites a
             // remote `Tombstone` slot with `Present` rather than adopting the
             // leave (freenet/river#345 round-9), then insert (replacing any
@@ -1081,6 +1100,15 @@ fn complete_identity_import(
             crate::components::app::chat_delegate::mark_room_rejoined(owner_key);
             apply_imported_room(rooms, room_data);
         });
+
+        // Overwriting a DIFFERENT identity: prune the OLD identity's cached
+        // outbound-DM plaintext + archive state so it doesn't leak into (or
+        // wrongly hide threads for) the new identity — symmetric to the CLI
+        // `identity import --force` prune (freenet/river#414). Only on a real
+        // key change; a brand-new import or a same-key re-import prunes nothing.
+        if identity_changed {
+            crate::components::app::chat_delegate::prune_dm_state_for_room(owner_key);
+        }
 
         CURRENT_ROOM.with_mut(|current| {
             current.owner_key = Some(owner_key);
@@ -1301,6 +1329,14 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
                         "data-testid": "import-identity-replace-warning",
                         class: "mt-3 text-sm text-amber-400 bg-amber-500/10 border border-amber-500/30 rounded-lg p-3",
                         "This room already has an identity. Importing will REPLACE it \u{2014} you'll lose access to your current identity for this room unless you've exported it first."
+                    }
+                    // Multi-tab reversal caveat (freenet/river#420): another
+                    // session still on the old identity can write it back and undo
+                    // the switch on next load, so tell the user to close them first.
+                    div {
+                        "data-testid": "import-identity-replace-multitab-warning",
+                        class: "mt-2 text-sm text-amber-400 bg-amber-500/10 border border-amber-500/30 rounded-lg p-3",
+                        "Close any other tabs or devices open to this room first. A session still using the old identity can write it back and undo the switch."
                     }
                     div { class: "flex justify-end gap-3 mt-4",
                         button {
@@ -2090,6 +2126,42 @@ mod tests {
             !normalized.contains("token_input.set(e.value()); pending_import.set(None);"),
             "the token oninput must not clear pending_import synchronously right \
              after setting the value (freenet/river#414) — defer the clear"
+        );
+    }
+
+    /// Source-grep pin (freenet/river#414, Codex round 5): the UI overwrite path
+    /// must prune the OLD identity's DM state when the imported key changes,
+    /// symmetric to the CLI `--force` prune. Catches a refactor that drops the
+    /// `prune_dm_state_for_room` wiring from the deferred signal block.
+    #[test]
+    fn complete_identity_import_prunes_dm_state_on_key_change() {
+        let prod = production_source();
+        assert!(
+            prod.contains("prune_dm_state_for_room(owner_key)"),
+            "complete_identity_import must prune the old identity's DM state on an \
+             overwrite that changes self_sk (freenet/river#414)"
+        );
+        // Gated on the key actually changing.
+        assert!(
+            prod.contains("if identity_changed {"),
+            "the DM-state prune must be gated on the identity actually changing"
+        );
+    }
+
+    /// Source-grep pin (freenet/river#420): the overwrite-confirm dialog must
+    /// carry the multi-tab reversal warning telling the user to close other
+    /// sessions for the room first (the documented limitation of the #414
+    /// escape hatch).
+    #[test]
+    fn overwrite_confirm_dialog_warns_about_multitab_reversal() {
+        let prod = production_source();
+        assert!(
+            prod.contains("import-identity-replace-multitab-warning"),
+            "the confirm dialog must show the multi-tab reversal warning (#420)"
+        );
+        assert!(
+            prod.contains("Close any other tabs or devices open to this room first"),
+            "the multi-tab warning must tell the user to close other sessions first"
         );
     }
 

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1163,24 +1163,31 @@ fn swap_room_identity_in_place(
 /// "no room" on an incomplete view would route a real, populated room to the
 /// build-empty NEW path and overwrite its populated persisted slot (data loss).
 ///
-/// Requires BOTH (Codex round-6 P1-1):
+/// Requires ALL of (Codex round-6 P1-1, round-9 P1):
 /// - the startup delegate load RESOLVED (`Loaded`) — `Loading`/`Migrating` mean
-///   "we don't know the set yet"; `LoadFailed` means a known room failed; and
+///   "we don't know the set yet"; `LoadFailed` means a known room failed;
 /// - NO listed room's fetch failed (`!saw_fetch_failure`). `per_room_terminal`
 ///   resolves to `Loaded` the instant ≥1 room materialized even if OTHER listed
 ///   rooms failed to hydrate, so `Loaded` alone is not "complete". A room absent
-///   from `ROOMS` because its fetch failed would be misclassified as new.
+///   from `ROOMS` because its fetch failed would be misclassified as new; and
+/// - the freenet/river#345 RECOVERY is not in progress (`!recovery_in_progress`).
+///   The interrupted-legacy-migration recovery sets `Loaded` (to render the
+///   partial list) BEFORE background workers restore rooms still missing from the
+///   partial per-room index. Importing for one of those in that window would
+///   overwrite its recovered slot with empty state. So we wait for recovery too.
 ///
-/// If a fetch failed, the caller refuses the import ("some rooms didn't finish
-/// loading — retry") rather than risk classifying a real room as new.
+/// If any condition fails the caller refuses the import ("some rooms didn't
+/// finish loading — retry") rather than risk classifying a real room as new.
 fn rooms_load_is_authoritative(
     state: crate::components::app::chat_delegate::RoomsLoadState,
     saw_fetch_failure: bool,
+    recovery_in_progress: bool,
 ) -> bool {
     matches!(
         state,
         crate::components::app::chat_delegate::RoomsLoadState::Loaded
     ) && !saw_fetch_failure
+        && !recovery_in_progress
 }
 
 /// Complete an identity import (freenet/river#414 redesign).
@@ -1278,8 +1285,15 @@ fn complete_identity_import(
         // wrongly hide threads for) the new identity — symmetric to the CLI
         // `identity import --force` prune (freenet/river#414). Only on a real
         // key change; a brand-new import or a same-key re-import prunes nothing.
+        // The tombstone is keyed to the NEW identity's MemberId so a late DM
+        // response drops entries authored by any replaced identity, regardless of
+        // their timestamp (freenet/river#414 round-9 P2).
         if identity_changed {
-            crate::components::app::chat_delegate::prune_dm_state_for_room(owner_key);
+            let new_member_id = MemberId::from(&new_sk.verifying_key());
+            crate::components::app::chat_delegate::prune_dm_state_for_room(
+                owner_key,
+                new_member_id,
+            );
         }
 
         CURRENT_ROOM.with_mut(|current| {
@@ -1367,19 +1381,23 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
         return rsx! {};
     }
 
-    // Reactive hydration gate (freenet/river#414 redesign, Codex round-6 P1-1):
-    // the room set must be COMPLETELY loaded before the Import button is enabled,
-    // so the new-vs-overwrite decision is never made on an incomplete view (which
-    // would build-empty over a real room). Reading `ROOMS_LOAD_STATE` here
-    // subscribes the modal, so it re-renders — and the button enables — the
-    // moment the load resolves; `saw_fetch_failure()` is read alongside so a
-    // partial load (some listed rooms failed) keeps the button disabled.
+    // Reactive hydration gate (freenet/river#414 redesign, Codex round-6 P1-1 +
+    // round-9 P1): the room set must be COMPLETELY loaded AND not mid-recovery
+    // before the Import button is enabled, so the new-vs-overwrite decision is
+    // never made on an incomplete view (which would build-empty over a real
+    // room). Reading `ROOMS_LOAD_STATE` here subscribes the modal so it re-renders
+    // when the load resolves; a `ROOMS.try_read()` touch adds a subscription so it
+    // ALSO re-renders when #345 recovery hydrates a room (recovery leaves
+    // `ROOMS_LOAD_STATE == Loaded` throughout). `saw_fetch_failure()` and
+    // `rooms_recovery_in_progress()` are read alongside (non-signal sources).
+    let _ = ROOMS.try_read(); // subscribe: re-render when recovery hydrates rooms
     let rooms_hydrated = crate::components::app::chat_delegate::ROOMS_LOAD_STATE
         .try_read()
         .map(|g| {
             rooms_load_is_authoritative(
                 *g,
                 crate::components::app::chat_delegate::saw_fetch_failure(),
+                crate::components::app::chat_delegate::rooms_recovery_in_progress(),
             )
         })
         .unwrap_or(false);
@@ -1405,25 +1423,27 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
                 let owner_key = export.room_owner;
 
                 // Safety-critical (freenet/river#414 redesign, Codex round-6
-                // P1-1): NEVER decide new-vs-overwrite on an incompletely-loaded
-                // room set — a false "no room" would route a real, populated room
-                // to the build-empty NEW path and overwrite its populated
-                // persisted slot. This requires a COMPLETE load (resolved AND no
-                // listed room's fetch failed); a partial load could be missing the
-                // very room being imported. The Import button is disabled until
-                // then (see `rooms_hydrated` in the render); this is the
-                // defense-in-depth net against a click landing before the render
-                // has re-disabled the button.
+                // P1-1 + round-9 P1): NEVER decide new-vs-overwrite on an
+                // incompletely-loaded OR mid-recovery room set — a false "no room"
+                // would route a real, populated room to the build-empty NEW path
+                // and overwrite its populated persisted slot. This requires a
+                // COMPLETE load (resolved AND no listed room's fetch failed) AND
+                // that the #345 recovery has finished; a partial load / pending
+                // recovery could be missing the very room being imported. The
+                // Import button is disabled until then (see `rooms_hydrated`); this
+                // is the defense-in-depth net against a click landing before the
+                // render has re-disabled the button.
                 let load_state = crate::components::app::chat_delegate::ROOMS_LOAD_STATE
                     .try_read()
                     .map(|g| *g)
                     .unwrap_or(crate::components::app::chat_delegate::RoomsLoadState::Loading);
                 let saw_failure = crate::components::app::chat_delegate::saw_fetch_failure();
-                if !rooms_load_is_authoritative(load_state, saw_failure) {
+                let recovery = crate::components::app::chat_delegate::rooms_recovery_in_progress();
+                if !rooms_load_is_authoritative(load_state, saw_failure, recovery) {
                     crate::util::defer(move || {
                         error_msg.set(Some(
-                            "Some rooms didn't finish loading — retry loading your rooms \
-                             before importing an identity."
+                            "Still finishing loading your rooms — please wait a moment and \
+                             try again."
                                 .to_string(),
                         ));
                         success_msg.set(None);
@@ -1950,33 +1970,54 @@ mod tests {
         );
     }
 
-    /// freenet/river#414 REDESIGN (safety-critical, Codex round-6 P1-1): the
-    /// new-vs-overwrite decision is authoritative ONLY on a COMPLETE load —
-    /// `Loaded` AND no listed room's fetch failed. `Loaded` alone is
-    /// insufficient because `per_room_terminal` resolves to `Loaded` the instant
-    /// ≥1 room materialized, even if other listed rooms failed to hydrate (so a
-    /// room could be missing from the map and get misclassified as new).
+    /// freenet/river#414 REDESIGN (safety-critical, Codex round-6 P1-1 + round-9
+    /// P1): the new-vs-overwrite decision is authoritative ONLY on a COMPLETE load
+    /// — `Loaded` AND no listed room's fetch failed AND the #345 recovery is not
+    /// in progress. `Loaded` alone is insufficient (`per_room_terminal` resolves
+    /// to `Loaded` the instant ≥1 room materialized, and recovery sets `Loaded`
+    /// before restoring still-missing rooms), so a room could be missing from the
+    /// map and get misclassified as new.
     #[test]
     fn rooms_load_authoritative_requires_complete_load() {
         use crate::components::app::chat_delegate::RoomsLoadState;
-        // Complete load: Loaded AND no fetch failure → authoritative.
-        assert!(rooms_load_is_authoritative(RoomsLoadState::Loaded, false));
-        // Loaded but a listed room's fetch failed → NOT authoritative (data-loss
-        // guard: the missing room could be the one being imported).
-        assert!(!rooms_load_is_authoritative(RoomsLoadState::Loaded, true));
-        // Unresolved / failed / migrating are never authoritative, fetch flag
-        // notwithstanding.
-        assert!(!rooms_load_is_authoritative(RoomsLoadState::Loading, false));
+        // Complete load: Loaded, no fetch failure, no recovery → authoritative.
+        assert!(rooms_load_is_authoritative(
+            RoomsLoadState::Loaded,
+            false,
+            false
+        ));
+        // Loaded but a listed room's fetch failed → NOT authoritative.
+        assert!(!rooms_load_is_authoritative(
+            RoomsLoadState::Loaded,
+            true,
+            false
+        ));
+        // Loaded but the #345 recovery is still in progress → NOT authoritative
+        // (a still-missing room could be the one being imported = data loss).
+        assert!(!rooms_load_is_authoritative(
+            RoomsLoadState::Loaded,
+            false,
+            true
+        ));
+        // Unresolved / failed / migrating are never authoritative.
+        assert!(!rooms_load_is_authoritative(
+            RoomsLoadState::Loading,
+            false,
+            false
+        ));
         assert!(!rooms_load_is_authoritative(
             RoomsLoadState::Migrating,
+            false,
             false
         ));
         assert!(!rooms_load_is_authoritative(
             RoomsLoadState::LoadFailed,
+            false,
             false
         ));
         assert!(!rooms_load_is_authoritative(
             RoomsLoadState::LoadFailed,
+            true,
             true
         ));
     }
@@ -2608,9 +2649,9 @@ mod tests {
     fn handle_import_gates_on_hydration() {
         let prod = production_source();
         assert!(
-            prod.contains("if !rooms_load_is_authoritative(load_state, saw_failure)"),
-            "handle_import must refuse to decide on an incompletely-loaded room set \
-             (#414 redesign, Codex round-6 P1-1)"
+            prod.contains("if !rooms_load_is_authoritative(load_state, saw_failure, recovery)"),
+            "handle_import must refuse to decide on an incompletely-loaded or \
+             mid-recovery room set (#414 redesign, Codex round-6 P1-1 + round-9 P1)"
         );
         assert!(
             prod.contains("disabled: !rooms_hydrated"),
@@ -2668,11 +2709,17 @@ mod tests {
     /// `prune_dm_state_for_room` wiring from the deferred signal block.
     #[test]
     fn complete_identity_import_prunes_dm_state_on_key_change() {
-        let prod = production_source();
+        // Whitespace-normalized so the multi-line call (owner_key + new_member_id)
+        // is matched regardless of rustfmt wrapping.
+        let prod = production_source()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
         assert!(
-            prod.contains("prune_dm_state_for_room(owner_key)"),
-            "complete_identity_import must prune the old identity's DM state on an \
-             overwrite that changes self_sk (freenet/river#414)"
+            prod.contains("prune_dm_state_for_room( owner_key, new_member_id, )")
+                || prod.contains("prune_dm_state_for_room(owner_key, new_member_id)"),
+            "complete_identity_import must prune the old identity's DM state (keyed to \
+             the NEW MemberId) on an overwrite that changes self_sk (freenet/river#414)"
         );
         // Gated on the key actually changing.
         assert!(

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1052,9 +1052,17 @@ fn build_imported_room_data(export: IdentityExport) -> crate::room_data::RoomDat
 ///
 /// Ordering matters: `self_sk` is set BEFORE `repopulate_secrets_from_state`,
 /// which decrypts the owner-signed `encrypted_secrets` blobs addressed to *this
-/// member* — a local recompute against the kept state, no network fetch. Folds
-/// in the invitation-carried room secrets (identity-independent, symmetric per
-/// version) and marks the delegate key un-migrated so the new key is (re)stored.
+/// member* — a local recompute against the kept state, no network fetch.
+///
+/// An overwrite may hand the room to a DIFFERENT identity, so we must NOT carry
+/// the OLD identity's decrypt access forward (Codex round-6 P1-2): the old
+/// identity's in-memory decrypted `secrets` (plus `current_secret_version` /
+/// `last_secret_rotation`) are cleared, and the invitation-carried secrets are
+/// REPLACED with the new identity's (not unioned — an A-only version B has no
+/// contract blob for must not remain readable). `repopulate_secrets_from_state`
+/// then rebuilds only what the NEW identity can actually decrypt from the kept
+/// state, and `rebuild_private_actions_state` re-derives the edit/reaction
+/// action cache under the new identity's (possibly narrower) secret access.
 ///
 /// Returns whether the signing key actually changed (drives the DM-cache
 /// prune). Pure (no signals) so the overwrite is unit-testable.
@@ -1068,37 +1076,50 @@ fn swap_room_identity_in_place(
     existing.invite_chain = export.invite_chain;
     existing.self_member_info = export.member_info;
     existing.self_nickname = export.self_nickname;
-    // Room secrets are per-room (symmetric per version), not per-identity, so a
-    // union is safe; keep any version already present (the owner-signed contract
-    // blob is authoritative and supersedes on the next repopulate).
-    for (version, secret) in export.invitation_secrets {
-        existing.invitation_secrets.entry(version).or_insert(secret);
-    }
+    // Drop the OLD identity's decrypt access: its in-memory decrypted secrets
+    // and the derived version pointers. These are `#[serde(skip)]` runtime
+    // caches; the new identity's are rebuilt from the kept state below.
+    existing.secrets.clear();
+    existing.current_secret_version = None;
+    existing.last_secret_rotation = None;
+    // REPLACE (do not union) the invitation-carried room secrets with the new
+    // identity's, so the old identity's invitation secrets can't grant the new
+    // identity read access to a version it holds no contract blob for.
+    existing.invitation_secrets = export.invitation_secrets;
     // The new key has not been stored in the delegate yet.
     existing.key_migrated_to_delegate = false;
     // Recompute in-memory decrypted secrets for the NEW identity's access
-    // (private rooms) from the KEPT room_state — local, no network fetch.
+    // (private rooms) from the KEPT room_state — local, no network fetch — then
+    // re-derive the action cache (edits/deletes/reactions) under those secrets.
     existing.repopulate_secrets_from_state();
+    existing.rebuild_private_actions_state();
     key_changed
 }
 
-/// Whether the room set is HYDRATED enough to reliably decide new-vs-overwrite.
+/// Whether the room set is COMPLETELY loaded — safe to decide new-vs-overwrite.
 ///
 /// Under the in-place redesign this decision is safety-critical: deciding
-/// "no room" on an unhydrated view would route a real, populated room to the
-/// build-empty NEW path and overwrite it with empty state (data loss). The
-/// room set is authoritative only once the startup delegate load has RESOLVED
-/// (`Loaded`). `Loading`/`Migrating` mean "we don't know the set yet", and
-/// `LoadFailed` means a known room failed to load (so a room could be missing
-/// from the in-memory map) — none of these are safe to decide on
-/// (freenet/river#414 redesign).
+/// "no room" on an incomplete view would route a real, populated room to the
+/// build-empty NEW path and overwrite its populated persisted slot (data loss).
+///
+/// Requires BOTH (Codex round-6 P1-1):
+/// - the startup delegate load RESOLVED (`Loaded`) — `Loading`/`Migrating` mean
+///   "we don't know the set yet"; `LoadFailed` means a known room failed; and
+/// - NO listed room's fetch failed (`!saw_fetch_failure`). `per_room_terminal`
+///   resolves to `Loaded` the instant ≥1 room materialized even if OTHER listed
+///   rooms failed to hydrate, so `Loaded` alone is not "complete". A room absent
+///   from `ROOMS` because its fetch failed would be misclassified as new.
+///
+/// If a fetch failed, the caller refuses the import ("some rooms didn't finish
+/// loading — retry") rather than risk classifying a real room as new.
 fn rooms_load_is_authoritative(
     state: crate::components::app::chat_delegate::RoomsLoadState,
+    saw_fetch_failure: bool,
 ) -> bool {
     matches!(
         state,
         crate::components::app::chat_delegate::RoomsLoadState::Loaded
-    )
+    ) && !saw_fetch_failure
 }
 
 /// Complete an identity import (freenet/river#414 redesign).
@@ -1146,6 +1167,13 @@ fn complete_identity_import(
         // Drives the DM-state prune below: true only when an overwrite actually
         // swaps to a different signing key.
         let mut identity_changed = false;
+        // For an OVERWRITE only: the new identity's member_info heal, built inside
+        // the borrow and sent AFTER it releases (the same ordering the UPDATE-path
+        // heal uses). An in-place overwrite does NO GET, so without this the new
+        // identity would render "Unknown" to peers until an unrelated future heal
+        // (freenet/river#414, Codex round-6 P2-4). A NEW room GET-first-syncs, so
+        // its GET-path heal covers it.
+        let mut pending_member_info_heal = None;
         ROOMS.with_mut(|rooms| {
             // Importing is an explicit rejoin: clear any leave tombstone and
             // record the rejoin so a remote `Tombstone` slot is overwritten with
@@ -1158,6 +1186,12 @@ fn complete_identity_import(
                 // OVERWRITE: swap the identity in place, KEEP room_state.
                 Some(existing) => {
                     identity_changed = swap_room_identity_in_place(existing, export);
+                    // Build the heal against the KEPT state (secrets were just
+                    // repopulated for the new identity by the swap). Returns None
+                    // when self isn't stranded, isn't a member, or — for a private
+                    // room — the secret isn't available yet (deferred, no leak).
+                    pending_member_info_heal =
+                        existing.build_member_info_heal(&existing.room_state);
                 }
                 // NEW room: empty placeholder; the GET-first sync fills it.
                 None => {
@@ -1167,6 +1201,16 @@ fn complete_identity_import(
                 }
             }
         });
+
+        // Send the new identity's member_info heal AFTER the ROOMS borrow is
+        // released (freenet/river#414 P2-4). `send_member_info_heal_update`
+        // builds the member_info-only UPDATE delta and spawns the send itself; it
+        // is self-signed and idempotent, so a race with any other heal is safe.
+        if let Some(heal_info) = pending_member_info_heal {
+            crate::components::app::freenet_api::room_synchronizer::send_member_info_heal_update(
+                owner_key, heal_info,
+            );
+        }
 
         // Overwriting a DIFFERENT identity: prune the OLD identity's cached
         // outbound-DM plaintext + archive state so it doesn't leak into (or
@@ -1259,14 +1303,21 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
         return rsx! {};
     }
 
-    // Reactive hydration gate (freenet/river#414 redesign): the room set must be
-    // authoritative before the Import button is enabled, so the new-vs-overwrite
-    // decision is never made on an unhydrated view (which would build-empty over
-    // a real room). Reading `ROOMS_LOAD_STATE` here subscribes the modal, so it
-    // re-renders — and the button enables — the moment the load resolves.
+    // Reactive hydration gate (freenet/river#414 redesign, Codex round-6 P1-1):
+    // the room set must be COMPLETELY loaded before the Import button is enabled,
+    // so the new-vs-overwrite decision is never made on an incomplete view (which
+    // would build-empty over a real room). Reading `ROOMS_LOAD_STATE` here
+    // subscribes the modal, so it re-renders — and the button enables — the
+    // moment the load resolves; `saw_fetch_failure()` is read alongside so a
+    // partial load (some listed rooms failed) keeps the button disabled.
     let rooms_hydrated = crate::components::app::chat_delegate::ROOMS_LOAD_STATE
         .try_read()
-        .map(|g| rooms_load_is_authoritative(*g))
+        .map(|g| {
+            rooms_load_is_authoritative(
+                *g,
+                crate::components::app::chat_delegate::saw_fetch_failure(),
+            )
+        })
         .unwrap_or(false);
 
     // Reset-and-close, matching the deferred pattern in `join_with_code_modal`
@@ -1289,21 +1340,26 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
             Ok(export) => {
                 let owner_key = export.room_owner;
 
-                // Safety-critical (freenet/river#414 redesign): NEVER decide
-                // new-vs-overwrite on an unhydrated room set — a false "no room"
-                // would route a real, populated room to the build-empty NEW path
-                // and overwrite it with empty state. The Import button is disabled
-                // until hydrated (see `rooms_hydrated` in the render); this is the
+                // Safety-critical (freenet/river#414 redesign, Codex round-6
+                // P1-1): NEVER decide new-vs-overwrite on an incompletely-loaded
+                // room set — a false "no room" would route a real, populated room
+                // to the build-empty NEW path and overwrite its populated
+                // persisted slot. This requires a COMPLETE load (resolved AND no
+                // listed room's fetch failed); a partial load could be missing the
+                // very room being imported. The Import button is disabled until
+                // then (see `rooms_hydrated` in the render); this is the
                 // defense-in-depth net against a click landing before the render
                 // has re-disabled the button.
                 let load_state = crate::components::app::chat_delegate::ROOMS_LOAD_STATE
                     .try_read()
                     .map(|g| *g)
                     .unwrap_or(crate::components::app::chat_delegate::RoomsLoadState::Loading);
-                if !rooms_load_is_authoritative(load_state) {
+                let saw_failure = crate::components::app::chat_delegate::saw_fetch_failure();
+                if !rooms_load_is_authoritative(load_state, saw_failure) {
                     crate::util::defer(move || {
                         error_msg.set(Some(
-                            "Still loading your rooms — please wait a moment and try again."
+                            "Some rooms didn't finish loading — retry loading your rooms \
+                             before importing an identity."
                                 .to_string(),
                         ));
                         success_msg.set(None);
@@ -1633,16 +1689,76 @@ mod tests {
         );
     }
 
-    /// freenet/river#414 REDESIGN (safety-critical): the new-vs-overwrite
-    /// decision is authoritative ONLY once the room set has resolved (`Loaded`).
-    /// Deciding on an unhydrated view could build-empty over a real room.
+    /// freenet/river#414 REDESIGN (Codex round-6 P1-2): an overwrite must NOT
+    /// carry the OLD identity's decrypt access forward. The old identity's
+    /// in-memory decrypted `secrets` are cleared, and invitation-carried secrets
+    /// are REPLACED (not unioned) with the new identity's — so a version only the
+    /// old identity could read does not remain readable by the new one.
     #[test]
-    fn rooms_load_authoritative_only_when_loaded() {
+    fn overwrite_drops_old_identity_decrypt_access() {
+        let owner_sk = SigningKey::from_bytes(&[71u8; 32]);
+        let old_sk = SigningKey::from_bytes(&[72u8; 32]);
+        let new_sk = SigningKey::from_bytes(&[73u8; 32]);
+
+        // Existing PRIVATE room where the OLD identity had decrypted secret v9
+        // and an invitation secret v5 the NEW identity has no blob for.
+        let mut existing = build_imported_room_data(export_for(&owner_sk, &old_sk));
+        existing.room_state.configuration.configuration.privacy_mode =
+            river_core::room_state::privacy::PrivacyMode::Private;
+        existing.secrets.insert(9u32, [0x11u8; 32]);
+        existing.current_secret_version = Some(9);
+        existing.last_secret_rotation = Some(std::time::SystemTime::now());
+        existing.invitation_secrets.insert(5u32, [0x22u8; 32]);
+
+        // The imported (new) identity carries only invitation secret v0.
+        let mut export = export_for(&owner_sk, &new_sk);
+        export.invitation_secrets.insert(0u32, [0x33u8; 32]);
+
+        swap_room_identity_in_place(&mut existing, export);
+
+        // The old identity's decrypted secret v9 is gone (cleared before repopulate).
+        assert!(
+            !existing.secrets.contains_key(&9u32),
+            "old identity's decrypted secret must be cleared, not carried forward"
+        );
+        // invitation_secrets REPLACED: the old identity's v5 must be gone…
+        assert!(
+            !existing.invitation_secrets.contains_key(&5u32),
+            "old identity's invitation secret must NOT be unioned into the new identity"
+        );
+        // …and only the NEW identity's v0 remains (folded into secrets by repopulate).
+        assert_eq!(existing.secrets.get(&0u32), Some(&[0x33u8; 32]));
+    }
+
+    /// freenet/river#414 REDESIGN (safety-critical, Codex round-6 P1-1): the
+    /// new-vs-overwrite decision is authoritative ONLY on a COMPLETE load —
+    /// `Loaded` AND no listed room's fetch failed. `Loaded` alone is
+    /// insufficient because `per_room_terminal` resolves to `Loaded` the instant
+    /// ≥1 room materialized, even if other listed rooms failed to hydrate (so a
+    /// room could be missing from the map and get misclassified as new).
+    #[test]
+    fn rooms_load_authoritative_requires_complete_load() {
         use crate::components::app::chat_delegate::RoomsLoadState;
-        assert!(rooms_load_is_authoritative(RoomsLoadState::Loaded));
-        assert!(!rooms_load_is_authoritative(RoomsLoadState::Loading));
-        assert!(!rooms_load_is_authoritative(RoomsLoadState::Migrating));
-        assert!(!rooms_load_is_authoritative(RoomsLoadState::LoadFailed));
+        // Complete load: Loaded AND no fetch failure → authoritative.
+        assert!(rooms_load_is_authoritative(RoomsLoadState::Loaded, false));
+        // Loaded but a listed room's fetch failed → NOT authoritative (data-loss
+        // guard: the missing room could be the one being imported).
+        assert!(!rooms_load_is_authoritative(RoomsLoadState::Loaded, true));
+        // Unresolved / failed / migrating are never authoritative, fetch flag
+        // notwithstanding.
+        assert!(!rooms_load_is_authoritative(RoomsLoadState::Loading, false));
+        assert!(!rooms_load_is_authoritative(
+            RoomsLoadState::Migrating,
+            false
+        ));
+        assert!(!rooms_load_is_authoritative(
+            RoomsLoadState::LoadFailed,
+            false
+        ));
+        assert!(!rooms_load_is_authoritative(
+            RoomsLoadState::LoadFailed,
+            true
+        ));
     }
 
     /// freenet/river#414 (Codex round 2): confirming an overwrite imports the
@@ -2272,12 +2388,34 @@ mod tests {
     fn handle_import_gates_on_hydration() {
         let prod = production_source();
         assert!(
-            prod.contains("if !rooms_load_is_authoritative(load_state)"),
-            "handle_import must refuse to decide on an unhydrated room set (#414 redesign)"
+            prod.contains("if !rooms_load_is_authoritative(load_state, saw_failure)"),
+            "handle_import must refuse to decide on an incompletely-loaded room set \
+             (#414 redesign, Codex round-6 P1-1)"
         );
         assert!(
             prod.contains("disabled: !rooms_hydrated"),
-            "the Import button must be disabled until the room set is hydrated (#414 redesign)"
+            "the Import button must be disabled until the room set is fully loaded (#414 redesign)"
+        );
+    }
+
+    /// Source-grep pin (freenet/river#414, Codex round-6 P2-4): an in-place
+    /// overwrite does NO GET, so `complete_identity_import` must itself trigger
+    /// the new identity's member_info heal (via the shared
+    /// `send_member_info_heal_update`) — otherwise the new identity renders
+    /// "Unknown" to peers until an unrelated future heal. The heal must be built
+    /// inside the ROOMS borrow (against the kept, secret-repopulated state).
+    #[test]
+    fn complete_identity_import_triggers_member_info_heal_on_overwrite() {
+        let prod = production_source();
+        assert!(
+            prod.contains("existing.build_member_info_heal(&existing.room_state)"),
+            "the overwrite must build the new identity's member_info heal against \
+             the kept state (freenet/river#414 P2-4)"
+        );
+        assert!(
+            prod.contains("send_member_info_heal_update("),
+            "complete_identity_import must send the member_info heal UPDATE after an \
+             in-place overwrite, since it does no GET (freenet/river#414 P2-4)"
         );
     }
 

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1076,21 +1076,40 @@ fn swap_room_identity_in_place(
     existing.invite_chain = export.invite_chain;
     existing.self_member_info = export.member_info;
     existing.self_nickname = export.self_nickname;
-    // Drop the OLD identity's decrypt access: its in-memory decrypted secrets
-    // and the derived version pointers. These are `#[serde(skip)]` runtime
-    // caches; the new identity's are rebuilt from the kept state below.
-    existing.secrets.clear();
-    existing.current_secret_version = None;
-    existing.last_secret_rotation = None;
-    // REPLACE (do not union) the invitation-carried room secrets with the new
-    // identity's, so the old identity's invitation secrets can't grant the new
-    // identity read access to a version it holds no contract blob for.
-    existing.invitation_secrets = export.invitation_secrets;
-    // The new key has not been stored in the delegate yet.
+
+    if key_changed {
+        // DIFFERENT identity (a genuine swap): do NOT carry the OLD identity's
+        // decrypt access forward. Clear the in-memory decrypted secrets and the
+        // derived version pointers (`#[serde(skip)]` runtime caches, rebuilt
+        // below), and REPLACE the invitation-carried secrets with the new
+        // identity's — so an A-only version B has no contract blob for cannot
+        // remain readable by B (Codex round-6 P1-2).
+        existing.secrets.clear();
+        existing.current_secret_version = None;
+        existing.last_secret_rotation = None;
+        existing.invitation_secrets = export.invitation_secrets;
+    } else {
+        // SAME identity re-import (the user re-importing their OWN token, e.g. a
+        // legacy/stale one). Clearing/replacing here is DATA LOSS: the token's
+        // `invitation_secrets` may be empty or incomplete (exported before the
+        // owner's `encrypted_secrets` backfill arrived), and for a private room
+        // still awaiting that backfill the existing `invitation_secrets` map can
+        // be the ONLY copy of the room key — wiping it would make history
+        // permanently unreadable. So PRESERVE the existing decrypted caches and
+        // MERGE the token's secrets in, keeping the existing value on collision
+        // (Codex round-7).
+        for (version, secret) in export.invitation_secrets {
+            existing.invitation_secrets.entry(version).or_insert(secret);
+        }
+    }
+
+    // The (re)imported key has not been stored in the delegate yet.
     existing.key_migrated_to_delegate = false;
-    // Recompute in-memory decrypted secrets for the NEW identity's access
-    // (private rooms) from the KEPT room_state — local, no network fetch — then
-    // re-derive the action cache (edits/deletes/reactions) under those secrets.
+    // Recompute the in-memory decrypted secrets from the KEPT room_state — local,
+    // no network fetch — then re-derive the action cache (edits/deletes/reactions)
+    // under those secrets. For a same-key re-import this only tops up (repopulate
+    // never overwrites an existing decrypted version); for a genuine swap it
+    // rebuilds exactly what the new identity can decrypt.
     existing.repopulate_secrets_from_state();
     existing.rebuild_private_actions_state();
     key_changed
@@ -1728,6 +1747,51 @@ mod tests {
         );
         // …and only the NEW identity's v0 remains (folded into secrets by repopulate).
         assert_eq!(existing.secrets.get(&0u32), Some(&[0x33u8; 32]));
+    }
+
+    /// freenet/river#414 (Codex round 7): a SAME-key re-import (the user
+    /// re-importing their OWN identity from a legacy/stale token whose
+    /// `invitation_secrets` may be empty) must PRESERVE the existing secrets, not
+    /// clear+replace them. For a private room still awaiting the owner backfill,
+    /// the existing `invitation_secrets` map can be the ONLY copy of the room key
+    /// — wiping it would make history permanently unreadable.
+    #[test]
+    fn same_key_reimport_preserves_existing_secrets() {
+        let owner_sk = SigningKey::from_bytes(&[81u8; 32]);
+        // The SAME signing key for both the existing room and the re-import.
+        let self_sk = SigningKey::from_bytes(&[82u8; 32]);
+
+        // Existing PRIVATE room where the (same) identity holds the ONLY copy of
+        // the room key at v7, plus its decrypted secret in memory.
+        let mut existing = build_imported_room_data(export_for(&owner_sk, &self_sk));
+        existing.room_state.configuration.configuration.privacy_mode =
+            river_core::room_state::privacy::PrivacyMode::Private;
+        existing.invitation_secrets.insert(7u32, [0x44u8; 32]);
+        existing.secrets.insert(7u32, [0x44u8; 32]);
+        existing.current_secret_version = Some(7);
+
+        // Re-import the SAME identity from a stale token with EMPTY secrets.
+        let export = export_for(&owner_sk, &self_sk);
+        assert!(
+            export.invitation_secrets.is_empty(),
+            "precondition: the stale token carries no invitation secrets"
+        );
+
+        let key_changed = swap_room_identity_in_place(&mut existing, export);
+
+        assert!(!key_changed, "same key must report no change");
+        // The room key (v7) survives — history stays readable.
+        assert_eq!(
+            existing.invitation_secrets.get(&7u32),
+            Some(&[0x44u8; 32]),
+            "same-key re-import must PRESERVE the existing invitation secret \
+             (it can be the only copy of the room key)"
+        );
+        assert_eq!(
+            existing.secrets.get(&7u32),
+            Some(&[0x44u8; 32]),
+            "same-key re-import must NOT clear the decrypted secret cache"
+        );
     }
 
     /// freenet/river#414 REDESIGN (safety-critical, Codex round-6 P1-1): the

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1391,12 +1391,13 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
     // `ROOMS_LOAD_STATE == Loaded` throughout). `saw_fetch_failure()` and
     // `rooms_recovery_in_progress()` are read alongside (non-signal sources).
     let _ = ROOMS.try_read(); // subscribe: re-render when recovery hydrates rooms
+    let saw_fetch_failure = crate::components::app::chat_delegate::saw_fetch_failure();
     let rooms_hydrated = crate::components::app::chat_delegate::ROOMS_LOAD_STATE
         .try_read()
         .map(|g| {
             rooms_load_is_authoritative(
                 *g,
-                crate::components::app::chat_delegate::saw_fetch_failure(),
+                saw_fetch_failure,
                 crate::components::app::chat_delegate::rooms_recovery_in_progress(),
             )
         })
@@ -1594,10 +1595,34 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
                     // state — so the Import button waits for hydration
                     // (freenet/river#414 redesign).
                     if !rooms_hydrated {
-                        div {
-                            "data-testid": "import-identity-loading-rooms",
-                            class: "mt-3 text-sm text-text-muted",
-                            "Loading your rooms\u{2026} the import will be available in a moment."
+                        if saw_fetch_failure {
+                            // A partial load FAILED: the rail shows `List` (some
+                            // room exists) so its own Retry control is hidden, and
+                            // without a way out the import would be blocked
+                            // indefinitely. Give the user a working retry that
+                            // re-fires the load; the gate clears reactively once
+                            // the missing rooms hydrate (freenet/river#414 round-10 P2).
+                            div {
+                                "data-testid": "import-identity-load-failed",
+                                class: "mt-3 text-sm text-amber-400",
+                                "Some rooms didn't finish loading, so importing is paused to avoid overwriting one. Retry loading your rooms to continue."
+                            }
+                            div { class: "flex justify-end mt-2",
+                                button {
+                                    "data-testid": "import-identity-retry-load",
+                                    class: "px-3 py-1.5 bg-surface hover:bg-surface-hover text-text text-xs rounded-lg transition-colors border border-border",
+                                    onclick: move |_| {
+                                        crate::components::app::chat_delegate::retry_rooms_load();
+                                    },
+                                    "Retry loading rooms"
+                                }
+                            }
+                        } else {
+                            div {
+                                "data-testid": "import-identity-loading-rooms",
+                                class: "mt-3 text-sm text-text-muted",
+                                "Loading your rooms\u{2026} the import will be available in a moment."
+                            }
                         }
                     }
                     div { class: "flex justify-end gap-3 mt-4",
@@ -2656,6 +2681,30 @@ mod tests {
         assert!(
             prod.contains("disabled: !rooms_hydrated"),
             "the Import button must be disabled until the room set is fully loaded (#414 redesign)"
+        );
+    }
+
+    /// Source-grep pin (freenet/river#414, Codex round-10 P2): a PARTIAL load
+    /// failure (rail shows `List`, so its own Retry is hidden) must give the
+    /// import modal a working way out — a "Retry loading rooms" control that
+    /// re-fires the load — so imports aren't blocked indefinitely. Guarded on
+    /// `saw_fetch_failure` so it only appears for a real failure.
+    #[test]
+    fn gated_import_offers_retry_on_partial_load_failure() {
+        let prod = production_source();
+        assert!(
+            prod.contains("if saw_fetch_failure {"),
+            "the gated import state must distinguish a partial-load FAILURE from \
+             a still-loading state (freenet/river#414 round-10 P2)"
+        );
+        assert!(
+            prod.contains("chat_delegate::retry_rooms_load();"),
+            "the partial-load-failure state must wire a Retry button to \
+             retry_rooms_load (freenet/river#414 round-10 P2)"
+        );
+        assert!(
+            prod.contains("import-identity-retry-load"),
+            "the Retry control needs a stable data-testid (import-identity-retry-load)"
         );
     }
 

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1038,6 +1038,51 @@ fn build_imported_room_data(export: IdentityExport) -> crate::room_data::RoomDat
     }
 }
 
+/// COMPILE-TIME CLASSIFICATION PIN (Fable architectural review): the exhaustive
+/// destructure below has NO `..`, so ADDING A FIELD to `RoomData` FAILS
+/// COMPILATION here until a maintainer classifies its identity-overwrite verb in
+/// [`swap_room_identity_in_place`]. This is the forcing function that prevents
+/// the field-clobber class of bugs (a new field silently kept/defaulted without a
+/// decision). Verb table — KEEP / REPLACE / MERGE-same-key / CLEAR+RECOMPUTE:
+///
+/// ```text
+/// owner_vk                KEEP (the room owner; identity-independent)
+/// room_state              KEEP (identity-independent shared contract state)
+/// self_sk                 REPLACE (the imported identity)
+/// contract_key            KEEP (owner+WASM derived)
+/// last_read_message_id    KEEP (local read-tracking preference)
+/// secrets                 CLEAR+RECOMPUTE different-key (repopulate_secrets_from_state) / KEEP same-key
+/// current_secret_version  CLEAR+RECOMPUTE different-key / KEEP same-key
+/// last_secret_rotation    CLEAR different-key / KEEP same-key
+/// key_migrated_to_delegate REPLACE (false — the new key isn't migrated yet)
+/// self_authorized_member  \ REPLACE different-key / MERGE-keep-if-absent same-key
+/// invite_chain            / (paired coherent unit)
+/// self_member_info        REPLACE different-key / MERGE-keep-newer same-key
+/// self_nickname           REPLACE different-key / MERGE-keep-if-absent same-key
+/// previous_contract_key   KEEP (room-scoped #292 migration pointer)
+/// invitation_secrets      REPLACE different-key / MERGE-union(existing wins) same-key
+/// ```
+#[allow(dead_code)]
+fn _room_data_swap_classification(rd: crate::room_data::RoomData) {
+    let crate::room_data::RoomData {
+        owner_vk: _,
+        room_state: _,
+        self_sk: _,
+        contract_key: _,
+        last_read_message_id: _,
+        secrets: _,
+        current_secret_version: _,
+        last_secret_rotation: _,
+        key_migrated_to_delegate: _,
+        self_authorized_member: _,
+        invite_chain: _,
+        self_member_info: _,
+        self_nickname: _,
+        previous_contract_key: _,
+        invitation_secrets: _,
+    } = rd;
+}
+
 /// Merge two optional `AuthorizedMemberInfo` records, keeping the HIGHER-version
 /// one (a same-key re-import must not let a stale token clobber a newer local
 /// member_info; an absent incoming keeps local). Ties keep `local`.

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1038,6 +1038,26 @@ fn build_imported_room_data(export: IdentityExport) -> crate::room_data::RoomDat
     }
 }
 
+/// Merge two optional `AuthorizedMemberInfo` records, keeping the HIGHER-version
+/// one (a same-key re-import must not let a stale token clobber a newer local
+/// member_info; an absent incoming keeps local). Ties keep `local`.
+fn merge_keep_newer_member_info(
+    local: Option<river_core::room_state::member_info::AuthorizedMemberInfo>,
+    incoming: Option<river_core::room_state::member_info::AuthorizedMemberInfo>,
+) -> Option<river_core::room_state::member_info::AuthorizedMemberInfo> {
+    match (local, incoming) {
+        (Some(l), Some(i)) => {
+            if i.member_info.version > l.member_info.version {
+                Some(i)
+            } else {
+                Some(l)
+            }
+        }
+        (Some(l), None) => Some(l),
+        (None, i) => i,
+    }
+}
+
 /// Swap a room's identity IN PLACE for an imported one, **keeping the existing
 /// `room_state`** (freenet/river#414 redesign).
 ///
@@ -1072,35 +1092,57 @@ fn swap_room_identity_in_place(
 ) -> bool {
     let key_changed = existing.self_sk != export.signing_key;
     existing.self_sk = export.signing_key;
-    existing.self_authorized_member = Some(export.authorized_member);
-    existing.invite_chain = export.invite_chain;
-    existing.self_member_info = export.member_info;
-    existing.self_nickname = export.self_nickname;
 
     if key_changed {
-        // DIFFERENT identity (a genuine swap): do NOT carry the OLD identity's
-        // decrypt access forward. Clear the in-memory decrypted secrets and the
-        // derived version pointers (`#[serde(skip)]` runtime caches, rebuilt
-        // below), and REPLACE the invitation-carried secrets with the new
-        // identity's — so an A-only version B has no contract blob for cannot
-        // remain readable by B (Codex round-6 P1-2).
+        // DIFFERENT identity (a genuine swap): REPLACE all identity metadata with
+        // the imported one's, and do NOT carry the OLD identity's decrypt access
+        // forward. Clear the in-memory decrypted secrets and the derived version
+        // pointers (`#[serde(skip)]` runtime caches, rebuilt below), and REPLACE
+        // the invitation-carried secrets — so an A-only version B has no contract
+        // blob for cannot remain readable by B (Codex round-6 P1-2).
+        existing.self_authorized_member = Some(export.authorized_member);
+        existing.invite_chain = export.invite_chain;
+        existing.self_member_info = export.member_info;
+        existing.self_nickname = export.self_nickname;
         existing.secrets.clear();
         existing.current_secret_version = None;
         existing.last_secret_rotation = None;
         existing.invitation_secrets = export.invitation_secrets;
     } else {
         // SAME identity re-import (the user re-importing their OWN token, e.g. a
-        // legacy/stale one). Clearing/replacing here is DATA LOSS: the token's
-        // `invitation_secrets` may be empty or incomplete (exported before the
-        // owner's `encrypted_secrets` backfill arrived), and for a private room
-        // still awaiting that backfill the existing `invitation_secrets` map can
-        // be the ONLY copy of the room key — wiping it would make history
-        // permanently unreadable. So PRESERVE the existing decrypted caches and
-        // MERGE the token's secrets in, keeping the existing value on collision
-        // (Codex round-7).
+        // legacy/stale one). A backward-compat decode of an old token yields
+        // ABSENT/EMPTY optional fields; blindly assigning them would ERASE richer
+        // local state. GENERAL RULE (Codex round-7/8): for EVERY field the token
+        // may carry absent/stale, RETAIN the existing local value when the
+        // incoming one is `None`/empty, and never replace a NEWER cached record
+        // with a STALER one. Applied to every identity-metadata field:
+        //
+        // - membership proof (`self_authorized_member` + `invite_chain`) is a
+        //   coherent UNIT (the chain validates the member), so keep them TOGETHER:
+        //   adopt the token's pair only when the local membership proof is absent;
+        if existing.self_authorized_member.is_none() {
+            existing.self_authorized_member = Some(export.authorized_member);
+            existing.invite_chain = export.invite_chain;
+        }
+        // - `self_member_info`: keep the higher-version record (a stale token must
+        //   not clobber a newer local member_info; absent token keeps local);
+        existing.self_member_info =
+            merge_keep_newer_member_info(existing.self_member_info.take(), export.member_info);
+        // - `self_nickname`: a present token value is a deliberate choice; an
+        //   absent one must NOT erase the locally-chosen nickname (else a later
+        //   inactivity prune + rejoin would publish a generated default);
+        if export.self_nickname.is_some() {
+            existing.self_nickname = export.self_nickname;
+        }
+        // - `invitation_secrets`: MERGE (existing wins) — the token may be empty
+        //   and the local map can be the ONLY copy of a private room's key, so
+        //   wiping it would make history permanently unreadable (Codex round-7).
         for (version, secret) in export.invitation_secrets {
             existing.invitation_secrets.entry(version).or_insert(secret);
         }
+        // - decrypted caches (`secrets`/`current_secret_version`/
+        //   `last_secret_rotation`) are PRESERVED (not cleared) — same identity,
+        //   same decrypt access.
     }
 
     // The (re)imported key has not been stored in the delegate yet.
@@ -1256,7 +1298,10 @@ fn complete_identity_import(
 
         // Migrate signing key to delegate in background
         crate::util::safe_spawn_local(async move {
-            let result = crate::signing::migrate_signing_key(room_key_bytes, &new_sk).await;
+            // AUTHORITATIVE: the user just imported/chose this identity, so it
+            // becomes the room's current identity and supersedes any stale
+            // hydration migration for an old key (freenet/river#414 P1).
+            let result = crate::signing::migrate_signing_key(room_key_bytes, &new_sk, true).await;
             match result {
                 crate::signing::MigrationResult::Stored
                 | crate::signing::MigrationResult::StaleKeyOverwritten
@@ -1791,6 +1836,117 @@ mod tests {
             existing.secrets.get(&7u32),
             Some(&[0x44u8; 32]),
             "same-key re-import must NOT clear the decrypted secret cache"
+        );
+    }
+
+    fn member_info_v(
+        sk: &SigningKey,
+        version: u32,
+    ) -> river_core::room_state::member_info::AuthorizedMemberInfo {
+        use river_core::room_state::member_info::{AuthorizedMemberInfo, MemberInfo};
+        let mi = MemberInfo {
+            member_id: MemberId::from(&sk.verifying_key()),
+            version,
+            preferred_nickname: river_core::room_state::privacy::SealedBytes::public(
+                b"nick".to_vec(),
+            ),
+            deputies: vec![],
+        };
+        AuthorizedMemberInfo::new_with_member_key(mi, sk)
+    }
+
+    /// freenet/river#414 (Codex round-8): `merge_keep_newer_member_info` keeps
+    /// the higher-version record and never clobbers a newer local one with a
+    /// staler/absent incoming one.
+    #[test]
+    fn merge_keep_newer_member_info_keeps_higher_version() {
+        let sk = SigningKey::from_bytes(&[91u8; 32]);
+        let v1 = member_info_v(&sk, 1);
+        let v3 = member_info_v(&sk, 3);
+
+        // Newer incoming wins.
+        assert_eq!(
+            merge_keep_newer_member_info(Some(v1.clone()), Some(v3.clone()))
+                .unwrap()
+                .member_info
+                .version,
+            3
+        );
+        // Staler incoming does NOT clobber the newer local.
+        assert_eq!(
+            merge_keep_newer_member_info(Some(v3.clone()), Some(v1.clone()))
+                .unwrap()
+                .member_info
+                .version,
+            3
+        );
+        // Absent incoming keeps local; absent local adopts incoming.
+        assert_eq!(
+            merge_keep_newer_member_info(Some(v3.clone()), None)
+                .unwrap()
+                .member_info
+                .version,
+            3
+        );
+        assert_eq!(
+            merge_keep_newer_member_info(None, Some(v1.clone()))
+                .unwrap()
+                .member_info
+                .version,
+            1
+        );
+        assert!(merge_keep_newer_member_info(None, None).is_none());
+    }
+
+    /// freenet/river#414 (Codex round-8, systematic same-key audit): a same-key
+    /// re-import from a stale token (absent nickname / member_info / invite
+    /// chain) must PRESERVE the locally-cached nickname, member_info, and
+    /// membership proof — not erase them (which would later publish a generated
+    /// default nickname on rejoin, and drop deputy/membership state).
+    #[test]
+    fn same_key_reimport_preserves_nickname_and_membership() {
+        let owner_sk = SigningKey::from_bytes(&[95u8; 32]);
+        let self_sk = SigningKey::from_bytes(&[96u8; 32]);
+
+        let mut existing = build_imported_room_data(export_for(&owner_sk, &self_sk));
+        existing.self_nickname = Some("Chosen Name".to_string());
+        existing.self_member_info = Some(member_info_v(&self_sk, 5));
+        existing.self_authorized_member =
+            Some(authorized_member(&owner_sk, &self_sk.verifying_key()));
+        existing.invite_chain = vec![authorized_member(&owner_sk, &self_sk.verifying_key())];
+
+        // Stale token for the SAME key: absent nickname/member_info, empty chain.
+        let mut export = export_for(&owner_sk, &self_sk);
+        export.self_nickname = None;
+        export.member_info = None;
+        assert!(export.invite_chain.is_empty());
+
+        let key_changed = swap_room_identity_in_place(&mut existing, export);
+
+        assert!(!key_changed);
+        assert_eq!(
+            existing.self_nickname.as_deref(),
+            Some("Chosen Name"),
+            "an absent token nickname must NOT erase the chosen nickname"
+        );
+        assert_eq!(
+            existing
+                .self_member_info
+                .as_ref()
+                .unwrap()
+                .member_info
+                .version,
+            5,
+            "an absent token member_info must NOT erase the local one"
+        );
+        assert!(
+            existing.self_authorized_member.is_some(),
+            "the membership proof must survive a stale re-import"
+        );
+        assert_eq!(
+            existing.invite_chain.len(),
+            1,
+            "an empty token invite_chain must NOT erase the local chain"
         );
     }
 

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -967,6 +967,22 @@ fn import_room_identity_exists(rooms: &crate::room_data::Rooms, owner_key: &Veri
     rooms.map.contains_key(owner_key)
 }
 
+/// Resolve which identity a Replace-confirm imports.
+///
+/// It MUST be the `snapshot` captured when the overwrite warning was shown.
+/// The `_live_token` (the current, still-editable textarea contents) is
+/// deliberately IGNORED so that editing the token after the warning appears
+/// cannot redirect the overwrite to a different room (freenet/river#414):
+/// otherwise a room-A warning followed by pasting room-B's token and clicking
+/// Replace would overwrite room B without ever confirming THAT replacement.
+/// Returns `None` when there is no pending snapshot (nothing to confirm).
+fn resolve_confirmed_import(
+    snapshot: Option<IdentityExport>,
+    _live_token: &str,
+) -> Option<IdentityExport> {
+    snapshot
+}
+
 /// Build the [`RoomData`](crate::room_data::RoomData) for an imported
 /// identity from its export.
 ///
@@ -1120,15 +1136,31 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
     let mut token_input = use_signal(String::new);
     let mut error_msg = use_signal(|| None::<String>);
     let mut success_msg = use_signal(|| None::<String>);
-    // When true, a room identity already exists for the pasted token's owner,
-    // so we prompt to confirm replacing it rather than importing silently
-    // (freenet/river#414). The token stays in `token_input` and is re-parsed
-    // on confirm.
-    let mut overwrite_confirm = use_signal(|| false);
+    // The parsed import awaiting overwrite confirmation. `Some` means a room
+    // identity already exists for this token's owner, so we prompt to confirm
+    // replacing it rather than importing silently (freenet/river#414). This
+    // is a SNAPSHOT of the token that was checked: Replace consumes it, NOT a
+    // fresh read of the (still-editable) textarea, so editing the token after
+    // the warning appears cannot redirect the overwrite to a different room.
+    let mut pending_import = use_signal(|| None::<IdentityExport>);
 
     if !*is_active.read() {
         return rsx! {};
     }
+
+    // Reset-and-close, matching the deferred pattern in `join_with_code_modal`
+    // and `.claude/rules/dioxus-signal-safety.md`: signal mutations from event
+    // handlers run inside `crate::util::defer()` so they execute in a clean
+    // Dioxus context (no re-entrant `RefCell` borrow, root scope present).
+    let reset_and_close = move || {
+        crate::util::defer(move || {
+            is_active.set(false);
+            error_msg.set(None);
+            success_msg.set(None);
+            pending_import.set(None);
+            token_input.set(String::new());
+        });
+    };
 
     let handle_import = move |_| {
         let input = token_input.read().clone();
@@ -1138,8 +1170,8 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
 
                 // If we already have an identity for this room, importing would
                 // replace it (and lose the current signing key unless it was
-                // exported). Prompt for confirmation instead of refusing
-                // (freenet/river#414).
+                // exported). Snapshot the CHECKED token and prompt for
+                // confirmation instead of refusing (freenet/river#414).
                 let already_exists = {
                     let Ok(rooms) = ROOMS.try_read() else {
                         return;
@@ -1147,51 +1179,59 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
                     import_room_identity_exists(&rooms, &owner_key)
                 };
                 if already_exists {
-                    overwrite_confirm.set(true);
-                    error_msg.set(None);
-                    success_msg.set(None);
+                    crate::util::defer(move || {
+                        pending_import.set(Some(export));
+                        error_msg.set(None);
+                        success_msg.set(None);
+                    });
                     return;
                 }
 
                 complete_identity_import(export, success_msg, error_msg);
             }
             Err(e) => {
-                error_msg.set(Some(format!("Invalid token: {}", e)));
-                success_msg.set(None);
+                crate::util::defer(move || {
+                    error_msg.set(Some(format!("Invalid token: {}", e)));
+                    success_msg.set(None);
+                });
             }
         }
     };
 
-    // User confirmed replacing the existing identity: re-parse the token
-    // (still in `token_input`) and complete the overwrite.
+    // User confirmed replacing the existing identity: import the SNAPSHOT
+    // captured when the warning was shown — never a fresh read of the editable
+    // textarea (freenet/river#414).
     let handle_replace_confirm = move |_| {
-        let input = token_input.read().clone();
-        overwrite_confirm.set(false);
-        match IdentityExport::from_armored_string(&input) {
-            Ok(export) => complete_identity_import(export, success_msg, error_msg),
-            Err(e) => {
-                error_msg.set(Some(format!("Invalid token: {}", e)));
-                success_msg.set(None);
-            }
+        let live_token = token_input.read().clone();
+        let snapshot = pending_import.read().clone();
+        let Some(export) = resolve_confirmed_import(snapshot, &live_token) else {
+            return;
+        };
+        // Belt-and-suspenders: bail on a torn ROOMS read rather than acting on
+        // inconsistent state. Existence does not change the action — we import
+        // the SNAPSHOT either way (complete_identity_import inserts whether or
+        // not the room still exists), so the read only guards consistency.
+        if ROOMS.try_read().is_err() {
+            return;
         }
+        crate::util::defer(move || {
+            pending_import.set(None);
+        });
+        complete_identity_import(export, success_msg, error_msg);
     };
 
-    // User backed out of the overwrite: return to the input state, keeping the
-    // pasted token so they can reconsider.
+    // User backed out of the overwrite: drop the snapshot and return to the
+    // input state, keeping the pasted token so they can reconsider.
     let handle_replace_cancel = move |_| {
-        overwrite_confirm.set(false);
+        crate::util::defer(move || {
+            pending_import.set(None);
+        });
     };
 
     rsx! {
         div {
             class: "fixed inset-0 bg-black/50 flex items-center justify-center z-50",
-            onclick: move |_| {
-                is_active.set(false);
-                error_msg.set(None);
-                success_msg.set(None);
-                overwrite_confirm.set(false);
-                token_input.set(String::new());
-            },
+            onclick: move |_| reset_and_close(),
             div {
                 class: "bg-panel border border-border rounded-xl shadow-lg p-6 max-w-lg w-full mx-4",
                 onclick: move |e| e.stop_propagation(),
@@ -1205,7 +1245,16 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
                     class: "w-full h-40 bg-surface border border-border rounded-lg p-3 text-xs font-mono text-text resize-none",
                     placeholder: "-----BEGIN RIVER IDENTITY-----\n...\n-----END RIVER IDENTITY-----",
                     value: "{token_input}",
-                    oninput: move |e| token_input.set(e.value()),
+                    // Controlled input: set the value signal synchronously (the
+                    // documented signal-safety exception — a deferred write to a
+                    // controlled input's bound value lags the DOM and drops
+                    // keystrokes). Editing the token invalidates any pending
+                    // overwrite confirmation so the warning can't outlive the
+                    // token it was raised for (freenet/river#414).
+                    oninput: move |e| {
+                        token_input.set(e.value());
+                        pending_import.set(None);
+                    },
                 }
                 if let Some(err) = &*error_msg.read() {
                     div { class: "mt-2 text-sm text-red-400",
@@ -1217,7 +1266,7 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
                         "{msg}"
                     }
                 }
-                if *overwrite_confirm.read() {
+                if pending_import.read().is_some() {
                     // A room identity already exists — warn before replacing it.
                     div {
                         "data-testid": "import-identity-replace-warning",
@@ -1242,13 +1291,7 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
                     div { class: "flex justify-end gap-3 mt-4",
                         button {
                             class: "px-4 py-2 bg-surface hover:bg-surface-hover text-text text-sm rounded-lg transition-colors border border-border",
-                            onclick: move |_| {
-                                is_active.set(false);
-                                error_msg.set(None);
-                                success_msg.set(None);
-                                overwrite_confirm.set(false);
-                                token_input.set(String::new());
-                            },
+                            onclick: move |_| reset_and_close(),
                             "Cancel"
                         }
                         button {
@@ -1383,6 +1426,51 @@ mod tests {
             !rooms.removed_rooms.contains(&owner_vk),
             "import is an explicit rejoin: the leave tombstone must be cleared"
         );
+    }
+
+    /// freenet/river#414 (Codex round 2): confirming an overwrite imports the
+    /// token SNAPSHOTTED when the warning appeared, NOT a fresh read of the
+    /// (still-editable) textarea. Guards the wrong-room data-loss where a
+    /// room-A warning + textarea swapped to room-B + Replace would overwrite
+    /// room B without ever confirming that replacement.
+    #[test]
+    fn confirm_imports_snapshot_not_edited_textarea() {
+        let owner_a = SigningKey::from_bytes(&[51u8; 32]);
+        let owner_b = SigningKey::from_bytes(&[52u8; 32]);
+        assert_ne!(
+            owner_a.verifying_key(),
+            owner_b.verifying_key(),
+            "rooms A and B must differ for the test to be meaningful"
+        );
+
+        // Snapshot captured when the warning was shown, for room A.
+        let snapshot = export_for(&owner_a, &SigningKey::from_bytes(&[53u8; 32]));
+
+        // The user edits the textarea to room B's token AFTER the warning.
+        let edited_live_token =
+            export_for(&owner_b, &SigningKey::from_bytes(&[54u8; 32])).to_armored_string();
+
+        // The confirm path resolves to the SNAPSHOT (room A), never the edited
+        // live token (room B).
+        let resolved = resolve_confirmed_import(Some(snapshot.clone()), &edited_live_token)
+            .expect("a pending snapshot must resolve to an import");
+        assert_eq!(
+            resolved.room_owner,
+            owner_a.verifying_key(),
+            "must import the snapshot's room (A)"
+        );
+        assert_ne!(
+            resolved.room_owner,
+            owner_b.verifying_key(),
+            "must NOT import the edited textarea's room (B)"
+        );
+
+        // And the RoomData built for the insert targets room A.
+        let room_data = build_imported_room_data(resolved);
+        assert_eq!(room_data.owner_vk, owner_a.verifying_key());
+
+        // No snapshot → nothing to confirm.
+        assert!(resolve_confirmed_import(None, &edited_live_token).is_none());
     }
 
     /// Frozen cross-side wire-format fixture (issue freenet/river#302/#305).

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1111,6 +1111,16 @@ fn complete_identity_import(
                         let mut sanitized = false;
                         ROOMS.with_mut(|rooms| {
                             if let Some(rd) = rooms.map.get_mut(&owner_key) {
+                                // Guard a rapid second replacement: only mark
+                                // migrated if the room's CURRENT identity is
+                                // still the one we just migrated. If a newer
+                                // import replaced it while this migration ran,
+                                // its own migration owns `key_migrated_to_delegate`
+                                // — don't mark it for a superseded key
+                                // (freenet/river#414).
+                                if rd.self_sk != signing_key_for_migration {
+                                    return;
+                                }
                                 rd.key_migrated_to_delegate = true;
                                 // Remove any messages with invalid signatures
                                 // left by a stale delegate key
@@ -1259,10 +1269,20 @@ pub fn ImportIdentityModal(is_active: Signal<bool>) -> Element {
                     // controlled input's bound value lags the DOM and drops
                     // keystrokes). Editing the token invalidates any pending
                     // overwrite confirmation so the warning can't outlive the
-                    // token it was raised for (freenet/river#414).
+                    // token it was raised for (freenet/river#414). The
+                    // `pending_import` clear IS deferred, though: the component
+                    // subscribes to it (the confirm-vs-input branch below), so a
+                    // synchronous clear could re-render mid-write and hit the
+                    // Firefox-mobile `RefCell already borrowed` panic. Only defer
+                    // when something is actually pending, so a normal keystroke
+                    // doesn't schedule a setTimeout.
                     oninput: move |e| {
                         token_input.set(e.value());
-                        pending_import.set(None);
+                        if pending_import.try_read().is_ok_and(|p| p.is_some()) {
+                            crate::util::defer(move || {
+                                pending_import.set(None);
+                            });
+                        }
                     },
                 }
                 if let Some(err) = &*error_msg.read() {
@@ -2047,6 +2067,29 @@ mod tests {
             "complete_identity_import must call SYNC_INFO.reset_room_for_resync \
              so an overwrite import re-GETs full state (freenet/river#414); \
              without it a Subscribed room ships a delta off empty state."
+        );
+    }
+
+    /// Source-grep pin (freenet/river#414, Codex round 4): the token
+    /// `oninput` must NOT clear `pending_import` synchronously — the component
+    /// subscribes to that signal, so a synchronous clear can re-render mid-write
+    /// and hit the Firefox-mobile `RefCell already borrowed` panic. The clear is
+    /// wrapped in `crate::util::defer()`, guarded so a normal keystroke doesn't
+    /// schedule one. Pin both: the guarded/deferred form is present, and the
+    /// bare synchronous pair is gone.
+    #[test]
+    fn oninput_defers_pending_import_clear() {
+        let prod = production_source();
+        assert!(
+            prod.contains("if pending_import.try_read().is_ok_and(|p| p.is_some()) {"),
+            "the token oninput must guard + defer the pending_import clear"
+        );
+        // Whitespace-normalized so indentation/rustfmt changes can't defeat it.
+        let normalized = prod.split_whitespace().collect::<Vec<_>>().join(" ");
+        assert!(
+            !normalized.contains("token_input.set(e.value()); pending_import.set(None);"),
+            "the token oninput must not clear pending_import synchronously right \
+             after setting the value (freenet/river#414) — defer the clear"
         );
     }
 

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1086,6 +1086,15 @@ fn complete_identity_import(
             current.owner_key = Some(owner_key);
         });
 
+        // If this import REPLACED an already-tracked room (an overwrite of a
+        // Subscribed room), reset its sync entry so it takes the same GET-first
+        // fetch a brand-new import gets, instead of `needs_to_send_update`
+        // shipping a bogus delta off the now-empty placeholder state
+        // (freenet/river#414). No-op for a brand-new import (not yet tracked),
+        // which is already on the GET-first path.
+        crate::components::app::sync_info::SYNC_INFO
+            .with_mut(|sync_info| sync_info.reset_room_for_resync(&owner_key));
+
         crate::components::app::mark_needs_sync(owner_key);
 
         // Migrate signing key to delegate in background
@@ -2021,6 +2030,23 @@ mod tests {
             "MemberList must render the nickname as a Dioxus text node \
              (`span {{ \"{{parts.nickname}}\" }}`). Concatenating it into \
              an HTML string reopens freenet/river#227."
+        );
+    }
+
+    /// Source-grep pin (freenet/river#414): `complete_identity_import` MUST
+    /// reset the room's sync entry via `reset_room_for_resync` so an overwrite
+    /// of an already-`Subscribed` room re-GETs full state instead of shipping a
+    /// bogus delta off the empty placeholder. Catches a refactor that drops the
+    /// reset (which unit tests on the pure helpers alone would not notice, since
+    /// the wiring lives in the deferred signal block).
+    #[test]
+    fn complete_identity_import_resets_sync_for_overwrite() {
+        let prod = production_source();
+        assert!(
+            prod.contains("reset_room_for_resync"),
+            "complete_identity_import must call SYNC_INFO.reset_room_for_resync \
+             so an overwrite import re-GETs full state (freenet/river#414); \
+             without it a Subscribed room ships a delta off empty state."
         );
     }
 

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -1779,6 +1779,28 @@ impl Rooms {
                 continue;
             }
 
+            // Identity-conflict guard, BEFORE any contract-key bookkeeping: if
+            // the room is already present with a DIFFERENT `self_sk`, this
+            // incoming copy is a stale/foreign identity for the SAME room. This
+            // happens legitimately during an identity overwrite
+            // (freenet/river#414): a delegate `LoadRooms` response issued before
+            // the replacement can still carry the OLD `self_sk` while `map`
+            // already holds the NEW one. SKIP just this room (keeping the
+            // current local identity) rather than ABORTING the whole merge —
+            // otherwise one stale in-flight copy would drop every other room and
+            // its secret rehydration until reload. The local copy always wins.
+            if let Some(existing) = self.map.get(&vk) {
+                if existing.self_sk != room_data.self_sk {
+                    use dioxus::logger::tracing::warn;
+                    warn!(
+                        "merge: skipping room with conflicting self_sk (kept local \
+                         identity) — likely a stale in-flight load during an \
+                         identity overwrite (freenet/river#414)"
+                    );
+                    continue;
+                }
+            }
+
             // Capture the old contract key before regeneration
             let old_contract_key = room_data.contract_key;
 
@@ -1795,11 +1817,9 @@ impl Rooms {
             if let std::collections::hash_map::Entry::Vacant(e) = self.map.entry(vk) {
                 e.insert(room_data);
             } else {
-                // If the room is already in the map, merge in the new data
+                // Already present with a matching `self_sk` (the conflict case
+                // was skipped above) — merge in the new state.
                 let self_room_data = self.map.get_mut(&vk).unwrap();
-                if self_room_data.self_sk != room_data.self_sk {
-                    return Err("self_sk is different".to_string());
-                }
                 self_room_data.room_state.merge(
                     &self_room_data.room_state.clone(),
                     &ChatRoomParametersV1 { owner: vk },
@@ -2319,6 +2339,73 @@ mod tests {
             "the other tab's room B must be merged in, not clobbered"
         );
         assert_eq!(local.map.len(), 2);
+    }
+
+    /// freenet/river#414 (Codex round 4): a delegate `LoadRooms` response
+    /// issued before an identity overwrite can carry the OLD `self_sk` for a
+    /// room whose `map` copy already holds the NEW one. A `self_sk` conflict on
+    /// ONE room must SKIP only that room (keeping the local identity), NOT abort
+    /// the whole merge and drop every other room + its secret rehydration.
+    #[test]
+    fn merge_skips_conflicting_self_sk_room_but_keeps_the_rest() {
+        let mut rng = rand::thread_rng();
+
+        // Room C (conflict): local holds the NEW identity, incoming a stale OLD one.
+        let owner_c = SigningKey::generate(&mut rng);
+        let new_sk_c = SigningKey::generate(&mut rng);
+        let old_sk_c = SigningKey::generate(&mut rng);
+        let vk_c = owner_c.verifying_key();
+        assert_ne!(new_sk_c.to_bytes(), old_sk_c.to_bytes());
+
+        // Room B: only in the incoming snapshot; must still merge in.
+        let owner_b = SigningKey::generate(&mut rng);
+        let self_b = SigningKey::generate(&mut rng);
+        let vk_b = owner_b.verifying_key();
+
+        let mut local = Rooms {
+            map: HashMap::new(),
+            current_room_key: None,
+            removed_rooms: std::collections::HashSet::new(),
+            notification_modes: Default::default(),
+            room_order: Vec::new(),
+            migrated_rooms: Vec::new(),
+        };
+        local
+            .map
+            .insert(vk_c, make_rejoin_test_room(&owner_c, &new_sk_c, true));
+
+        let mut incoming = Rooms {
+            map: HashMap::new(),
+            current_room_key: None,
+            removed_rooms: std::collections::HashSet::new(),
+            notification_modes: Default::default(),
+            room_order: Vec::new(),
+            migrated_rooms: Vec::new(),
+        };
+        // Stale identity for the SAME room C, plus a brand-new room B.
+        incoming
+            .map
+            .insert(vk_c, make_rejoin_test_room(&owner_c, &old_sk_c, true));
+        incoming
+            .map
+            .insert(vk_b, make_rejoin_test_room(&owner_b, &self_b, true));
+
+        // Must NOT abort despite room C's conflicting self_sk.
+        local
+            .merge(incoming)
+            .expect("a per-room self_sk conflict must not abort the whole merge");
+
+        // The unrelated room B survived instead of being dropped by the conflict.
+        assert!(
+            local.map.contains_key(&vk_b),
+            "the unrelated incoming room must still merge in"
+        );
+        // Room C kept the LOCAL (new) identity; the stale incoming one was skipped.
+        assert_eq!(
+            local.map.get(&vk_c).unwrap().self_sk.to_bytes(),
+            new_sk_c.to_bytes(),
+            "the conflicting room must keep the local (current) identity"
+        );
     }
 
     #[test]

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -1789,6 +1789,15 @@ impl Rooms {
             // current local identity) rather than ABORTING the whole merge —
             // otherwise one stale in-flight copy would drop every other room and
             // its secret rehydration until reload. The local copy always wins.
+            //
+            // STILL NEEDED after the #414 in-place-swap redesign: the redesign
+            // removed the empty-rebuild, but the stale-load race this guards is
+            // independent of it — an overwrite still mutates `map[vk].self_sk`
+            // in place, so a concurrent delegate load carrying the old `self_sk`
+            // still collides here. Without the skip, that one stale room would
+            // still abort the whole merge and drop unrelated rooms. This is a
+            // genuine robustness guard, NOT scaffolding for the deleted empty
+            // room.
             if let Some(existing) = self.map.get(&vk) {
                 if existing.self_sk != room_data.self_sk {
                     use dioxus::logger::tracing::warn;

--- a/ui/src/signing.rs
+++ b/ui/src/signing.rs
@@ -221,14 +221,83 @@ fn migration_lock_for(room_key: &RoomKey) -> std::sync::Arc<futures::lock::Mutex
         .clone()
 }
 
+/// The current AUTHORITATIVE signing identity per room — a RUNTIME-SAFE
+/// (non-signal) mirror of the identity the user last deliberately CHOSE for a
+/// room (imported, or accepted-into). Used by [`migrate_signing_key`] to reject
+/// a SUPERSEDED migration before it stores (freenet/river#414, Codex round-8).
+///
+/// Why this instead of reading `ROOMS`: `migrate_signing_key` runs inside a
+/// spawned task with NO Dioxus runtime, so reading the `ROOMS` GlobalSignal
+/// there panics (the deleted round-5 version's exact bug). A plain `Mutex`
+/// registry is safe to read from any context. Only AUTHORITATIVE call sites
+/// (import / invitation-accept) write it — to their own key — so a stale
+/// HYDRATION migration carrying an OLD key finds a mismatch and is discarded,
+/// while a genuine re-choice (e.g. leave + re-accept a different key) updates
+/// the registry to its own key and so is NOT falsely discarded.
+static CURRENT_ROOM_IDENTITY: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<RoomKey, VerifyingKey>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+fn set_current_room_identity(room_key: RoomKey, vk: VerifyingKey) {
+    if let Ok(mut m) = CURRENT_ROOM_IDENTITY.lock() {
+        m.insert(room_key, vk);
+    }
+}
+
+fn current_room_identity(room_key: &RoomKey) -> Option<VerifyingKey> {
+    CURRENT_ROOM_IDENTITY
+        .lock()
+        .ok()
+        .and_then(|m| m.get(room_key).copied())
+}
+
+/// Whether a migration of `migrating_vk` is SUPERSEDED: the room has a recorded
+/// authoritative identity and it is a DIFFERENT key. Pure, so the discard
+/// decision is unit-testable. `None` (no authoritative identity recorded — a
+/// normal never-imported room) is never superseded.
+fn migration_superseded(
+    current_identity: Option<VerifyingKey>,
+    migrating_vk: VerifyingKey,
+) -> bool {
+    matches!(current_identity, Some(cur) if cur != migrating_vk)
+}
+
+/// Reset the per-room authoritative-identity registry. Tests only.
+#[cfg(test)]
+pub(crate) fn reset_current_room_identity() {
+    if let Ok(mut m) = CURRENT_ROOM_IDENTITY.lock() {
+        m.clear();
+    }
+}
+
 /// Migrate a signing key to the delegate if not already present.
+///
+/// `mark_authoritative` distinguishes an AUTHORITATIVE identity choice (import,
+/// invitation-accept — the user is choosing this identity NOW) from a HYDRATION
+/// re-migration (startup LoadRooms, imported-room GET-first follow-up — merely
+/// re-establishing an already-stored key). An authoritative call records itself
+/// as the room's current identity; every call then checks that registry before
+/// storing and DISCARDS a superseded migration, so a stale hydration task
+/// carrying an OLD key cannot clobber the delegate after an overwrite
+/// (freenet/river#414, Codex round-8).
 ///
 /// Returns a `MigrationResult` indicating what happened:
 /// - `AlreadyCurrent`: key matched, no action needed
 /// - `StaleKeyOverwritten`: old key was replaced (caller should sanitize local messages)
 /// - `Stored`: key was stored for the first time
-/// - `Failed`: migration failed (fallback to local signing should be used)
-pub async fn migrate_signing_key(room_key: RoomKey, signing_key: &SigningKey) -> MigrationResult {
+/// - `Failed`: migration failed OR was discarded as superseded (fallback to local signing)
+pub async fn migrate_signing_key(
+    room_key: RoomKey,
+    signing_key: &SigningKey,
+    mark_authoritative: bool,
+) -> MigrationResult {
+    // An authoritative identity choice (import / accept) records itself as the
+    // room's current identity BEFORE serializing, so its own migration is never
+    // discarded and any later stale hydration for a DIFFERENT key is.
+    if mark_authoritative {
+        set_current_room_identity(room_key, signing_key.verifying_key());
+    }
+
     // Serialize concurrent migrations for THIS room so the non-atomic
     // get/store/get below runs to completion before another migration for the
     // same room can start (freenet/river#414).
@@ -262,6 +331,24 @@ pub async fn migrate_signing_key(room_key: RoomKey, signing_key: &SigningKey) ->
             false
         }
     };
+
+    // Reject a SUPERSEDED migration before storing (freenet/river#414, Codex
+    // round-8): if the room's authoritative identity is now a DIFFERENT key than
+    // the one this task is migrating, a newer identity choice replaced it while
+    // this (stale hydration) migration was queued. Storing the old key would
+    // clobber the delegate — the per-room lock only serializes; it does not stop
+    // a late old-key migration from acquiring the lock second. Runtime-safe (a
+    // plain Mutex, not a signal), so it is valid inside the spawned task.
+    if migration_superseded(
+        current_room_identity(&room_key),
+        signing_key.verifying_key(),
+    ) {
+        warn!(
+            "Discarding superseded signing-key migration — the room's authoritative \
+             identity changed since this migration was queued (freenet/river#414)"
+        );
+        return MigrationResult::Failed;
+    }
 
     // Store the key
     match store_signing_key(room_key, signing_key).await {
@@ -526,6 +613,45 @@ mod tests {
             a2.try_lock().is_some(),
             "releasing the lock must let the next same-room migration proceed"
         );
+    }
+
+    /// freenet/river#414 (Codex round-8): an AUTHORITATIVE identity choice records
+    /// the room's current identity in the runtime-safe registry, and a HYDRATION
+    /// migration carrying a DIFFERENT (superseded) key is discarded; a matching or
+    /// unrecorded key proceeds. Pins the registry bookkeeping + the pure decision.
+    #[test]
+    fn superseded_migration_is_discarded() {
+        reset_current_room_identity();
+        let room: RoomKey = [7u8; 32];
+        let new_key = SigningKey::from_bytes(&[1u8; 32]).verifying_key();
+        let old_key = SigningKey::from_bytes(&[2u8; 32]).verifying_key();
+        assert_ne!(new_key, old_key);
+
+        // No authoritative identity recorded yet → nothing is superseded (a
+        // normal, never-imported room migrates freely).
+        assert!(current_room_identity(&room).is_none());
+        assert!(!migration_superseded(current_room_identity(&room), old_key));
+
+        // An authoritative import/accept records the NEW identity.
+        set_current_room_identity(room, new_key);
+        assert_eq!(current_room_identity(&room), Some(new_key));
+
+        // A stale hydration for the OLD key is now superseded (discarded)…
+        assert!(migration_superseded(current_room_identity(&room), old_key));
+        // …while the authoritative NEW key proceeds.
+        assert!(!migration_superseded(current_room_identity(&room), new_key));
+
+        // A later authoritative RE-choice (e.g. leave + re-accept a third key)
+        // updates the registry to itself, so it is NOT falsely discarded.
+        let third_key = SigningKey::from_bytes(&[3u8; 32]).verifying_key();
+        set_current_room_identity(room, third_key);
+        assert!(!migration_superseded(
+            current_room_identity(&room),
+            third_key
+        ));
+        assert!(migration_superseded(current_room_identity(&room), new_key));
+
+        reset_current_room_identity();
     }
 
     fn make_signed_message(author_sk: &SigningKey, owner_vk: &VerifyingKey) -> AuthorizedMessageV1 {

--- a/ui/src/signing.rs
+++ b/ui/src/signing.rs
@@ -221,6 +221,34 @@ fn migration_lock_for(room_key: &RoomKey) -> std::sync::Arc<futures::lock::Mutex
         .clone()
 }
 
+/// Whether a migration of `migrating_key` is STALE and must be skipped.
+///
+/// A migration is stale when the room is still tracked locally but its CURRENT
+/// identity (`current_self_sk`) is a DIFFERENT key than the one being migrated.
+/// This is the delayed-old-key case (freenet/river#414): a migration queued
+/// from a pre-overwrite `LoadRooms` (whose room `Rooms::merge` then skipped)
+/// can acquire the per-room lock AFTER the new identity's migration and store
+/// the OLD key, clobbering the delegate. The per-room lock only serializes; it
+/// does not stop a late old-key migration from winning, so we reject it here.
+///
+/// `None` (room not tracked) is NOT stale: a brand-new import can legitimately
+/// run its migration before/without a `ROOMS` entry, and there is no newer
+/// identity to conflict with.
+fn migration_is_stale(current_self_sk: Option<&SigningKey>, migrating_key: &SigningKey) -> bool {
+    matches!(current_self_sk, Some(current) if current != migrating_key)
+}
+
+/// The room's CURRENT local signing identity, if the room is tracked in
+/// `ROOMS`. Read via `try_read()` per the signal-safety rules; `None` when the
+/// room isn't tracked, the key bytes are invalid, or `ROOMS` is mid-write.
+/// Used by [`migrate_signing_key`] to reject a stale migration (#414).
+fn current_room_self_sk(room_key: &RoomKey) -> Option<SigningKey> {
+    use dioxus::prelude::ReadableExt;
+    let owner_vk = VerifyingKey::from_bytes(room_key).ok()?;
+    let rooms = crate::components::app::ROOMS.try_read().ok()?;
+    rooms.map.get(&owner_vk).map(|rd| rd.self_sk.clone())
+}
+
 /// Migrate a signing key to the delegate if not already present.
 ///
 /// Returns a `MigrationResult` indicating what happened:
@@ -262,6 +290,20 @@ pub async fn migrate_signing_key(room_key: RoomKey, signing_key: &SigningKey) ->
             false
         }
     };
+
+    // Reject a STALE migration before storing (freenet/river#414): if the
+    // room's current local identity is a DIFFERENT key than the one this call
+    // is migrating, a newer overwrite already replaced it since this migration
+    // was queued. Storing the old key here would clobber the delegate with the
+    // wrong identity — the per-room lock serializes migrations but does not stop
+    // a late old-key migration from winning. Skip it.
+    if migration_is_stale(current_room_self_sk(&room_key).as_ref(), signing_key) {
+        warn!(
+            "Skipping stale signing-key migration — the room's identity changed \
+             since this migration was queued (freenet/river#414)"
+        );
+        return MigrationResult::Failed;
+    }
 
     // Store the key
     match store_signing_key(room_key, signing_key).await {
@@ -525,6 +567,48 @@ mod tests {
         assert!(
             a2.try_lock().is_some(),
             "releasing the lock must let the next same-room migration proceed"
+        );
+    }
+
+    /// freenet/river#414 (Codex round 5): serializing migrations is not enough —
+    /// a delayed OLD-key migration can still acquire the lock after the new one.
+    /// `migrate_signing_key` rejects a migration whose key no longer matches the
+    /// room's CURRENT identity. Pin that decision.
+    #[test]
+    fn migration_is_stale_rejects_superseded_key() {
+        let new_key = SigningKey::from_bytes(&[9u8; 32]);
+        let old_key = SigningKey::from_bytes(&[8u8; 32]);
+        assert_ne!(new_key.to_bytes(), old_key.to_bytes());
+
+        // Room now holds `new_key`: a migration for the OLD key is stale.
+        assert!(
+            migration_is_stale(Some(&new_key), &old_key),
+            "an old key must be rejected once the room's identity has moved on"
+        );
+        // Migrating the CURRENT key is fine.
+        assert!(
+            !migration_is_stale(Some(&new_key), &new_key),
+            "migrating the room's current identity is never stale"
+        );
+        // Untracked room (brand-new import): never stale.
+        assert!(
+            !migration_is_stale(None, &new_key),
+            "a not-yet-tracked room has no newer identity to conflict with"
+        );
+    }
+
+    /// Source-grep pin (freenet/river#414, Codex round 5): `migrate_signing_key`
+    /// must actually consult `migration_is_stale` (against the room's current
+    /// identity) and abort before storing — the pure-helper test above does not
+    /// prove the reject is wired into the store path.
+    #[test]
+    fn migrate_signing_key_wires_staleness_reject() {
+        let src = include_str!("signing.rs");
+        let marker = "#[cfg(test)]";
+        let prod = &src[..src.find(marker).expect("signing.rs has a test module")];
+        assert!(
+            prod.contains("if migration_is_stale(current_room_self_sk(&room_key).as_ref()"),
+            "migrate_signing_key must reject a stale migration before storing (#414)"
         );
     }
 

--- a/ui/src/signing.rs
+++ b/ui/src/signing.rs
@@ -221,34 +221,6 @@ fn migration_lock_for(room_key: &RoomKey) -> std::sync::Arc<futures::lock::Mutex
         .clone()
 }
 
-/// Whether a migration of `migrating_key` is STALE and must be skipped.
-///
-/// A migration is stale when the room is still tracked locally but its CURRENT
-/// identity (`current_self_sk`) is a DIFFERENT key than the one being migrated.
-/// This is the delayed-old-key case (freenet/river#414): a migration queued
-/// from a pre-overwrite `LoadRooms` (whose room `Rooms::merge` then skipped)
-/// can acquire the per-room lock AFTER the new identity's migration and store
-/// the OLD key, clobbering the delegate. The per-room lock only serializes; it
-/// does not stop a late old-key migration from winning, so we reject it here.
-///
-/// `None` (room not tracked) is NOT stale: a brand-new import can legitimately
-/// run its migration before/without a `ROOMS` entry, and there is no newer
-/// identity to conflict with.
-fn migration_is_stale(current_self_sk: Option<&SigningKey>, migrating_key: &SigningKey) -> bool {
-    matches!(current_self_sk, Some(current) if current != migrating_key)
-}
-
-/// The room's CURRENT local signing identity, if the room is tracked in
-/// `ROOMS`. Read via `try_read()` per the signal-safety rules; `None` when the
-/// room isn't tracked, the key bytes are invalid, or `ROOMS` is mid-write.
-/// Used by [`migrate_signing_key`] to reject a stale migration (#414).
-fn current_room_self_sk(room_key: &RoomKey) -> Option<SigningKey> {
-    use dioxus::prelude::ReadableExt;
-    let owner_vk = VerifyingKey::from_bytes(room_key).ok()?;
-    let rooms = crate::components::app::ROOMS.try_read().ok()?;
-    rooms.map.get(&owner_vk).map(|rd| rd.self_sk.clone())
-}
-
 /// Migrate a signing key to the delegate if not already present.
 ///
 /// Returns a `MigrationResult` indicating what happened:
@@ -290,20 +262,6 @@ pub async fn migrate_signing_key(room_key: RoomKey, signing_key: &SigningKey) ->
             false
         }
     };
-
-    // Reject a STALE migration before storing (freenet/river#414): if the
-    // room's current local identity is a DIFFERENT key than the one this call
-    // is migrating, a newer overwrite already replaced it since this migration
-    // was queued. Storing the old key here would clobber the delegate with the
-    // wrong identity — the per-room lock serializes migrations but does not stop
-    // a late old-key migration from winning. Skip it.
-    if migration_is_stale(current_room_self_sk(&room_key).as_ref(), signing_key) {
-        warn!(
-            "Skipping stale signing-key migration — the room's identity changed \
-             since this migration was queued (freenet/river#414)"
-        );
-        return MigrationResult::Failed;
-    }
 
     // Store the key
     match store_signing_key(room_key, signing_key).await {
@@ -567,48 +525,6 @@ mod tests {
         assert!(
             a2.try_lock().is_some(),
             "releasing the lock must let the next same-room migration proceed"
-        );
-    }
-
-    /// freenet/river#414 (Codex round 5): serializing migrations is not enough —
-    /// a delayed OLD-key migration can still acquire the lock after the new one.
-    /// `migrate_signing_key` rejects a migration whose key no longer matches the
-    /// room's CURRENT identity. Pin that decision.
-    #[test]
-    fn migration_is_stale_rejects_superseded_key() {
-        let new_key = SigningKey::from_bytes(&[9u8; 32]);
-        let old_key = SigningKey::from_bytes(&[8u8; 32]);
-        assert_ne!(new_key.to_bytes(), old_key.to_bytes());
-
-        // Room now holds `new_key`: a migration for the OLD key is stale.
-        assert!(
-            migration_is_stale(Some(&new_key), &old_key),
-            "an old key must be rejected once the room's identity has moved on"
-        );
-        // Migrating the CURRENT key is fine.
-        assert!(
-            !migration_is_stale(Some(&new_key), &new_key),
-            "migrating the room's current identity is never stale"
-        );
-        // Untracked room (brand-new import): never stale.
-        assert!(
-            !migration_is_stale(None, &new_key),
-            "a not-yet-tracked room has no newer identity to conflict with"
-        );
-    }
-
-    /// Source-grep pin (freenet/river#414, Codex round 5): `migrate_signing_key`
-    /// must actually consult `migration_is_stale` (against the room's current
-    /// identity) and abort before storing — the pure-helper test above does not
-    /// prove the reject is wired into the store path.
-    #[test]
-    fn migrate_signing_key_wires_staleness_reject() {
-        let src = include_str!("signing.rs");
-        let marker = "#[cfg(test)]";
-        let prod = &src[..src.find(marker).expect("signing.rs has a test module")];
-        assert!(
-            prod.contains("if migration_is_stale(current_room_self_sk(&room_key).as_ref()"),
-            "migrate_signing_key must reject a stale migration before storing (#414)"
         );
     }
 

--- a/ui/src/signing.rs
+++ b/ui/src/signing.rs
@@ -191,6 +191,36 @@ fn extract_signature(
 // Migration and Fallback Functions
 // ============================================================================
 
+/// Per-room async locks serializing [`migrate_signing_key`].
+///
+/// The migration's get/store/get sequence is NOT atomic. Multiple migrations
+/// for the SAME room can run concurrently — startup hydration, the post-GET
+/// migration, and a rapid identity replacement (freenet/river#414) — and
+/// without serialization a second migration could `store` a different key
+/// BETWEEN this task's `store` and its verifying `get`, so the task verifies
+/// the wrong key and a completion callback marks the room migrated against a
+/// delegate that now holds a different identity. Holding a per-room async lock
+/// across the whole sequence makes it atomic w.r.t. other migrations of the
+/// same room. Placed inside `migrate_signing_key` so EVERY call site (import,
+/// hydration, post-GET) is covered, not just the overwrite path.
+///
+/// `std::sync::Mutex` guards only the brief map lookup (never held across an
+/// `.await`); the per-room `futures::lock::Mutex` is the async lock held across
+/// the sequence. Single-threaded WASM, so the std mutex never contends.
+static MIGRATION_LOCKS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<RoomKey, std::sync::Arc<futures::lock::Mutex<()>>>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+fn migration_lock_for(room_key: &RoomKey) -> std::sync::Arc<futures::lock::Mutex<()>> {
+    let mut locks = MIGRATION_LOCKS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    locks
+        .entry(*room_key)
+        .or_insert_with(|| std::sync::Arc::new(futures::lock::Mutex::new(())))
+        .clone()
+}
+
 /// Migrate a signing key to the delegate if not already present.
 ///
 /// Returns a `MigrationResult` indicating what happened:
@@ -199,6 +229,12 @@ fn extract_signature(
 /// - `Stored`: key was stored for the first time
 /// - `Failed`: migration failed (fallback to local signing should be used)
 pub async fn migrate_signing_key(room_key: RoomKey, signing_key: &SigningKey) -> MigrationResult {
+    // Serialize concurrent migrations for THIS room so the non-atomic
+    // get/store/get below runs to completion before another migration for the
+    // same room can start (freenet/river#414).
+    let room_lock = migration_lock_for(&room_key);
+    let _migration_guard = room_lock.lock().await;
+
     // Check if key already exists in delegate
     let was_stale = match get_public_key(room_key).await {
         Ok(Some(existing_vk)) => {
@@ -448,6 +484,49 @@ mod tests {
     use ed25519_dalek::Signer;
     use river_core::room_state::member::{AuthorizedMember, Member, MemberId};
     use river_core::room_state::message::{AuthorizedMessageV1, MessageV1, RoomMessageBody};
+
+    /// freenet/river#414 (Codex round 4): `migrate_signing_key`'s non-atomic
+    /// get/store/get must be serialized PER ROOM so a concurrent migration for
+    /// the same room can't store a different key between this task's store and
+    /// its verify. Pin the lock is (a) per-room and (b) actually mutually
+    /// exclusive for the same room while leaving other rooms free.
+    #[test]
+    fn migration_lock_is_per_room_and_serializes_same_room() {
+        let room_a: RoomKey = [1u8; 32];
+        let room_b: RoomKey = [2u8; 32];
+
+        // Same room → one shared lock; different rooms → distinct locks.
+        let a1 = migration_lock_for(&room_a);
+        let a2 = migration_lock_for(&room_a);
+        let b1 = migration_lock_for(&room_b);
+        assert!(
+            std::sync::Arc::ptr_eq(&a1, &a2),
+            "the same room must share one migration lock"
+        );
+        assert!(
+            !std::sync::Arc::ptr_eq(&a1, &b1),
+            "different rooms must have distinct migration locks"
+        );
+
+        // Holding room A's lock blocks a second acquire for room A (the
+        // get/store/get sequence is serialized) but NOT for room B.
+        let held = a1
+            .try_lock()
+            .expect("first acquire for room A must succeed");
+        assert!(
+            a2.try_lock().is_none(),
+            "a concurrent migration for the SAME room must wait for the lock"
+        );
+        assert!(
+            b1.try_lock().is_some(),
+            "a migration for a DIFFERENT room must not be blocked"
+        );
+        drop(held);
+        assert!(
+            a2.try_lock().is_some(),
+            "releasing the lock must let the next same-room migration proceed"
+        );
+    }
 
     fn make_signed_message(author_sk: &SigningKey, owner_vk: &VerifyingKey) -> AuthorizedMessageV1 {
         let msg = MessageV1 {


### PR DESCRIPTION
## Problem

Importing an identity into a room that already has one was **hard-refused** — UI `ImportIdentityModal` ("You already have an identity for this room.") and CLI `identity import` ("You already have an identity for room …"). This left users **stuck on whichever identity they first used** in a room, with no way to switch to or restore a different signing key.

The overwrite is already mechanically supported: the `rooms.map.insert(owner_key, room_data)` overwrites in place, and the rejoin/tombstone-clear (`removed_rooms.remove`, `mark_room_rejoined`) is already there. Only the guard blocked it.

## Approach

Warn + confirm, never auto-export or force anything (per #414).

**UI (`ui/src/components/members.rs`)** — replace the hard error with a confirmation step. When a room identity already exists, the modal shows an amber warning ("This room already has an identity. Importing will REPLACE it — you'll lose access to your current identity for this room unless you've exported it first.") with **Cancel** / **Replace identity** buttons instead of erroring. On Replace it re-parses the pasted token and runs the existing import flow (the overwriting insert + delegate key migration, unchanged). The build/insert logic is extracted into pure, unit-testable helpers:
- `import_room_identity_exists(&Rooms, &owner_key)` — the "should we prompt?" decision
- `build_imported_room_data(export)` — builds the overwriting `RoomData`
- `apply_imported_room(&mut Rooms, room_data)` — tombstone-clear + insert
- `complete_identity_import(...)` — the shared completion (defer + migration), used by both the first-time and overwrite-confirm paths

Signal mutations stay deferred per `dioxus-signal-safety.md`; reactive reads use `try_read()`. New confirm buttons carry `data-testid`s `import-identity-replace-confirm` / `import-identity-replace-cancel` (plus `import-identity-submit` on the primary button). The non-overwrite (new room) path is unchanged.

The "Export current identity first" affordance was **skipped**: the export modal exports `CURRENT_ROOM`, whereas the import targets whatever room the pasted token identifies (possibly a different room), and the export modal isn't reachable from the import modal without new global wiring — an accurate "export THIS room first" button would be more than the "if it's easy" bar #414 sets. The warning tells the user to export first.

**CLI (`cli/src/commands/identity.rs`)** — add `--force` (visible alias `--overwrite`) to `identity import` that authorizes replacing the stored identity, printing a warning to stderr that the previous signing key is lost unless exported. Without the flag it still refuses, but the message now names `--force`. The refusal decision is a pure helper `import_overwrite_refusal(room_exists, force, key)` for testability. The overwrite itself reuses the existing storage sequence (`add_room_with_invitation_secrets` overwrites in place; `store_authorized_member` / `update_self_nickname` rebuild the rest from the export).

## Testing

New unit tests (all green):
- UI `existing_room_import_routes_to_confirm` — an existing-room import routes to the confirm decision, not a hard error.
- UI `confirming_overwrite_replaces_stored_identity` — confirming rebuilds `RoomData` with the imported signing key, overwrites in place (one entry, new `self_sk`), and clears the leave tombstone.
- CLI `import_overwrite_refusal_matrix` — refuses only when a room exists and `--force` is absent; the refusal names `--force`, `--overwrite`, and the room.
- CLI `force_import_overwrites_stored_identity` — the `--force` storage sequence replaces the stored signing key in place (no duplicate entry).

`cargo test -p river-ui --bins` and `cargo test -p riverctl` green; `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync` compiles; `cargo fmt` clean; my files are clippy-clean (the workspace clippy surfaces only pre-existing findings in untouched crates under a newer local toolchain).

## No migration needed

UI + CLI source only. No `.wasm` / `common/` / `contracts/` / `delegates/` / migration changes — `git status` shows only the two source files.

Closes #414

[AI-assisted - Claude]

## Known limitation: multi-tab reversal (ships documented, tracked in #420)

This ships as a **get-unstuck escape hatch**, not full multi-tab identity coordination (Ian's scope decision). After a user replaces a room identity, a **second tab or device still open on the old identity** can write it back to the per-room delegate slot on its next save; `reconcile_room_present` is last-writer-wins on a `self_sk` conflict (there is no identity-generation counter to decide which is newer), so a stale session can silently undo the switch on the next cold load. Rather than build the fix, this PR:

- **Warns in the overwrite-confirm dialog** to close other tabs/devices for the room first.
- **Documents the limitation** in code at the overwrite site and at `reconcile_room_present`.
- **Files #420** for the proper fix (a persisted, monotonically-increasing identity-generation counter so the reconciler adopts the higher generation instead of the last writer).

The other round-5 findings (stale-migration rejection, UI per-identity DM-state prune, persisted-key comparison for the CLI prune) are fixed, not deferred.


## Scope: field-clobber class closed; async-race class deferred to #420

This PR (Fable-5 architectural pass) restructures the CLI overwrite to an in-place mutation, fixes a live `state`-clobber race, and adds compile-time exhaustive-destructure classification pins to both the CLI (`StoredRoomInfo`) and UI (`RoomData`) so a future field can't be silently defaulted/kept without a KEEP/REPLACE/MERGE/CLEAR decision. That closes the **field-clobber class** of review findings (+ the `state` race).

The remaining **async-race** findings from the review tail — multi-tab reversal, late DM hydration across reload, and the migration/recovery races — are **structurally** addressed by the persisted **identity-generation counter** tracked in **#420**, in a follow-up PR, not here. They are cross-cutting session/multi-tab coordination that a per-field patch can't close, which is why they're consolidated behind #420 rather than patched round-by-round in this PR.
