### PR TITLE
feat(ui): per-room notification bell + dedicated modal

### DIFF
--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -15,6 +15,7 @@ use crate::components::members::member_info_modal::MemberInfoModal;
 use crate::components::members::Invitation;
 use crate::components::room_list::create_room_modal::CreateRoomModal;
 use crate::components::room_list::edit_room_modal::EditRoomModal;
+use crate::components::room_list::notification_modal::NotificationModal;
 use crate::components::room_list::receive_invitation_modal::{
     accept_invitation, clear_invitation_from_storage, decide_recovered_invitation,
     is_invitation_processed, load_invitation_from_storage, load_invitation_nickname_from_storage,
@@ -47,6 +48,8 @@ pub static MEMBER_INFO_MODAL: GlobalSignal<MemberInfoModalSignal> =
     Global::new(|| MemberInfoModalSignal { member: None });
 pub static EDIT_ROOM_MODAL: GlobalSignal<EditRoomModalSignal> =
     Global::new(|| EditRoomModalSignal { room: None });
+pub static NOTIFICATION_MODAL: GlobalSignal<NotificationModalSignal> =
+    Global::new(|| NotificationModalSignal { room: None });
 pub static CREATE_ROOM_MODAL: GlobalSignal<CreateRoomModalSignal> =
     Global::new(|| CreateRoomModalSignal { show: false });
 pub static PENDING_INVITES: GlobalSignal<PendingInvites> = Global::new(PendingInvites::new);
@@ -489,6 +492,7 @@ pub fn App() -> Element {
             }
         }
         EditRoomModal {}
+        NotificationModal {}
         MemberInfoModal {}
         CreateRoomModal {}
         DmThreadModal {}
@@ -518,6 +522,10 @@ fn initial_rooms() -> Rooms {
 }
 
 pub struct EditRoomModalSignal {
+    pub room: Option<VerifyingKey>,
+}
+
+pub struct NotificationModalSignal {
     pub room: Option<VerifyingKey>,
 }
 

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -2034,28 +2034,65 @@ pub fn Conversation() -> Element {
                                 // `<button>` per the HTML spec. Nesting also bubbles link
                                 // clicks to the modal-opening onclick handler.
                                 div { class: "min-w-0 flex-1",
-                                    button {
-                                        // `md:-mx-3` only pulls the hover target outward on
-                                        // desktop, where there is no adjacent hamburger. On
-                                        // mobile the negative margin is dropped so this
-                                        // room-details target stays clear of the hamburger (#402).
-                                        class: "flex items-center gap-2 px-3 py-1.5 md:-mx-3 rounded-lg bg-transparent hover:bg-surface transition-colors cursor-pointer min-w-0 w-full",
-                                        title: "Room details",
-                                        onclick: move |_| {
-                                            crate::util::defer(move || {
-                                                if let Some(current_room) = CURRENT_ROOM.read().owner_key {
-                                                    EDIT_ROOM_MODAL.with_mut(|modal| {
-                                                        modal.room = Some(current_room);
-                                                    });
-                                                }
-                                            });
-                                        },
-                                        h2 { class: "text-lg font-semibold text-text truncate",
-                                            "{current_room_label}"
+                                    // Room title + notification bell on one line, so the bell
+                                    // sits right after the (i) and vertically centred with it —
+                                    // NOT at the header's far edge. The bell is a SIBLING of the
+                                    // room-details button (a <button> can't nest another
+                                    // <button>). The title button is content-sized (no `w-full`)
+                                    // so the bell hugs the (i); a long name still truncates via
+                                    // `min-w-0` + `truncate`.
+                                    div { class: "flex items-center gap-1 min-w-0",
+                                        button {
+                                            // `md:-ml-3` pulls only the LEFT hover edge outward on
+                                            // desktop (no adjacent hamburger there); the right edge
+                                            // stays put so the bell sits close to the (i). On mobile
+                                            // the negative margin is dropped so this room-details
+                                            // target stays clear of the hamburger (#402).
+                                            class: "flex items-center gap-2 px-3 py-1.5 md:-ml-3 rounded-lg bg-transparent hover:bg-surface transition-colors cursor-pointer min-w-0",
+                                            title: "Room details",
+                                            onclick: move |_| {
+                                                crate::util::defer(move || {
+                                                    if let Some(current_room) = CURRENT_ROOM.read().owner_key {
+                                                        EDIT_ROOM_MODAL.with_mut(|modal| {
+                                                            modal.room = Some(current_room);
+                                                        });
+                                                    }
+                                                });
+                                            },
+                                            h2 { class: "text-lg font-semibold text-text truncate",
+                                                "{current_room_label}"
+                                            }
+                                            span {
+                                                class: "text-text-muted flex-shrink-0",
+                                                Icon { icon: FaCircleInfo, width: 16, height: 16 }
+                                            }
                                         }
-                                        span {
-                                            class: "text-text-muted flex-shrink-0",
-                                            Icon { icon: FaCircleInfo, width: 16, height: 16 }
+                                        // Per-room notification preference. Icon reflects state:
+                                        // bell = notifying, bell-slash = muted; the tooltip names
+                                        // the exact mode. Opens the compact NotificationModal.
+                                        // Sized to 16px to pair with the adjacent (i) icon.
+                                        button {
+                                            "data-testid": "notification-bell-button",
+                                            class: "flex-shrink-0 p-1.5 rounded-lg text-text-muted hover:text-accent hover:bg-surface transition-colors",
+                                            title: match *current_notification_mode.read() {
+                                                NotificationMode::All => "Notifications: All messages",
+                                                NotificationMode::MentionsAndReplies => "Notifications: Mentions & replies only",
+                                                NotificationMode::Muted => "Notifications: Muted",
+                                            },
+                                            onclick: move |_| {
+                                                crate::util::defer(move || {
+                                                    if let Some(current_room) = CURRENT_ROOM.read().owner_key {
+                                                        NOTIFICATION_MODAL.with_mut(|modal| {
+                                                            modal.room = Some(current_room);
+                                                        });
+                                                    }
+                                                });
+                                            },
+                                            if *current_notification_mode.read() == NotificationMode::Muted {
+                                                Icon { icon: FaBellSlash, width: 16, height: 16 }
+                                            } else {
+                                                Icon { icon: FaBell, width: 16, height: 16 }
+                                            }
                                         }
                                     }
                                     if let Some(desc_html) = current_room_description_html.read().as_ref() {
@@ -2063,34 +2100,6 @@ pub fn Conversation() -> Element {
                                             class: "prose prose-sm dark:prose-invert max-w-none text-xs text-text-muted truncate [&>p]:m-0 [&>p]:inline",
                                             dangerous_inner_html: "{desc_html}"
                                         }
-                                    }
-                                }
-                                // Per-room notification preference. Sibling of the
-                                // room-name button (not nested — same interactive-content
-                                // rule as the description link). Icon reflects state:
-                                // bell = notifying, bell-slash = muted; the tooltip names
-                                // the exact mode. Opens the compact NotificationModal.
-                                button {
-                                    "data-testid": "notification-bell-button",
-                                    class: "p-2 rounded-lg text-text-muted hover:text-accent hover:bg-surface transition-colors flex-shrink-0",
-                                    title: match *current_notification_mode.read() {
-                                        NotificationMode::All => "Notifications: All messages",
-                                        NotificationMode::MentionsAndReplies => "Notifications: Mentions & replies only",
-                                        NotificationMode::Muted => "Notifications: Muted",
-                                    },
-                                    onclick: move |_| {
-                                        crate::util::defer(move || {
-                                            if let Some(current_room) = CURRENT_ROOM.read().owner_key {
-                                                NOTIFICATION_MODAL.with_mut(|modal| {
-                                                    modal.room = Some(current_room);
-                                                });
-                                            }
-                                        });
-                                    },
-                                    if *current_notification_mode.read() == NotificationMode::Muted {
-                                        Icon { icon: FaBellSlash, width: 18, height: 18 }
-                                    } else {
-                                        Icon { icon: FaBell, width: 18, height: 18 }
                                     }
                                 }
                                 // Mobile: button to open members panel

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -4,9 +4,10 @@ use crate::components::app::notifications::request_permission_on_first_message;
 use crate::components::app::receive_times::{format_delay, get_delay_secs};
 use crate::components::app::sync_info::{RoomSyncStatus, SYNC_INFO};
 use crate::components::app::{
-    MobileView, CURRENT_ROOM, EDIT_ROOM_MODAL, MEMBER_INFO_MODAL, MOBILE_VIEW, ROOMS,
+    MobileView, CURRENT_ROOM, EDIT_ROOM_MODAL, MEMBER_INFO_MODAL, MOBILE_VIEW, NOTIFICATION_MODAL,
+    ROOMS,
 };
-use crate::room_data::SendMessageError;
+use crate::room_data::{NotificationMode, SendMessageError};
 use crate::util::ecies::{encrypt_with_symmetric_key, unseal_bytes_with_secrets};
 use crate::util::{
     date_separator_labels, format_utc_as_full_datetime, format_utc_as_local_time,
@@ -24,8 +25,8 @@ use chrono::{DateTime, Utc};
 use dioxus::logger::tracing::*;
 use dioxus::prelude::*;
 use dioxus_free_icons::icons::fa_solid_icons::{
-    FaBars, FaChevronDown, FaCircleInfo, FaEllipsisVertical, FaFaceSmile, FaPenToSquare, FaReply,
-    FaTrashCan, FaTriangleExclamation, FaUsers,
+    FaBars, FaBell, FaBellSlash, FaChevronDown, FaCircleInfo, FaEllipsisVertical, FaFaceSmile,
+    FaPenToSquare, FaReply, FaTrashCan, FaTriangleExclamation, FaUsers,
 };
 use dioxus_free_icons::Icon;
 use freenet_scaffold::ComposableState;
@@ -1078,6 +1079,20 @@ pub fn Conversation() -> Element {
     // CURRENT_ROOM changes — both read inside the helper.
     let panel_unread = use_memo(count_unread_behind_rooms_panel);
 
+    // The current room's notification mode, for the header bell icon + tooltip.
+    // Absent entry means the default (`All`).
+    let current_notification_mode = use_memo(move || {
+        let current_room = CURRENT_ROOM.read();
+        let Some(key) = current_room.owner_key else {
+            return NotificationMode::All;
+        };
+        ROOMS
+            .try_read()
+            .ok()
+            .and_then(|rooms| rooms.notification_modes.get(&key).copied())
+            .unwrap_or_default()
+    });
+
     // Memoize room description as rendered HTML (markdown)
     let current_room_description_html = use_memo({
         move || {
@@ -2048,6 +2063,34 @@ pub fn Conversation() -> Element {
                                             class: "prose prose-sm dark:prose-invert max-w-none text-xs text-text-muted truncate [&>p]:m-0 [&>p]:inline",
                                             dangerous_inner_html: "{desc_html}"
                                         }
+                                    }
+                                }
+                                // Per-room notification preference. Sibling of the
+                                // room-name button (not nested — same interactive-content
+                                // rule as the description link). Icon reflects state:
+                                // bell = notifying, bell-slash = muted; the tooltip names
+                                // the exact mode. Opens the compact NotificationModal.
+                                button {
+                                    "data-testid": "notification-bell-button",
+                                    class: "p-2 rounded-lg text-text-muted hover:text-accent hover:bg-surface transition-colors flex-shrink-0",
+                                    title: match *current_notification_mode.read() {
+                                        NotificationMode::All => "Notifications: All messages",
+                                        NotificationMode::MentionsAndReplies => "Notifications: Mentions & replies only",
+                                        NotificationMode::Muted => "Notifications: Muted",
+                                    },
+                                    onclick: move |_| {
+                                        crate::util::defer(move || {
+                                            if let Some(current_room) = CURRENT_ROOM.read().owner_key {
+                                                NOTIFICATION_MODAL.with_mut(|modal| {
+                                                    modal.room = Some(current_room);
+                                                });
+                                            }
+                                        });
+                                    },
+                                    if *current_notification_mode.read() == NotificationMode::Muted {
+                                        Icon { icon: FaBellSlash, width: 18, height: 18 }
+                                    } else {
+                                        Icon { icon: FaBell, width: 18, height: 18 }
                                     }
                                 }
                                 // Mobile: button to open members panel

--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -2,6 +2,7 @@ pub(crate) mod create_room_modal;
 pub(crate) mod dm_rail_section;
 pub(crate) mod edit_room_modal;
 pub(crate) mod join_with_code_modal;
+pub(crate) mod notification_modal;
 pub(crate) mod receive_invitation_modal;
 pub(crate) mod room_name_field;
 

--- a/ui/src/components/room_list/edit_room_modal.rs
+++ b/ui/src/components/room_list/edit_room_modal.rs
@@ -1,11 +1,9 @@
 use super::room_name_field::RoomNameField;
 use crate::components::app::chat_delegate::save_rooms_to_delegate;
 use crate::components::app::{CURRENT_ROOM, EDIT_ROOM_MODAL, ROOMS};
-use crate::room_data::NotificationMode;
 use crate::util::ecies::{seal_for_room, unseal_bytes_with_secrets};
 use dioxus::logger::tracing::{error, info, warn};
 use dioxus::prelude::*;
-use ed25519_dalek::VerifyingKey;
 use freenet_scaffold::ComposableState;
 use river_core::room_state::configuration::{AuthorizedConfigurationV1, Configuration};
 use river_core::room_state::privacy::{PrivacyMode, RoomDisplayMetadata};
@@ -100,12 +98,6 @@ pub fn EditRoomModal() -> Element {
                                     }
                                 }
                             }
-                        }
-
-                        // Per-room notification preference (local setting, all
-                        // users — not owner-gated).
-                        if let Some(room_vk) = EDIT_ROOM_MODAL.read().room {
-                            NotificationModeField { room_vk }
                         }
 
                         // Numeric configuration fields (owner-only)
@@ -363,61 +355,6 @@ pub fn EditRoomModal() -> Element {
         }
     } else {
         rsx! {}
-    }
-}
-
-/// Per-room notification preference selector. Local-only setting (persisted in
-/// the `rooms_data` delegate blob, applies on this device), so it is shown to
-/// every member, not just the owner. Reads the current mode from `ROOMS` each
-/// render (no cached hook state) so reopening the modal for a different room
-/// always reflects that room's value.
-#[component]
-fn NotificationModeField(room_vk: VerifyingKey) -> Element {
-    let current = ROOMS
-        .read()
-        .notification_modes
-        .get(&room_vk)
-        .copied()
-        .unwrap_or_default();
-    let current_str = match current {
-        NotificationMode::All => "all",
-        NotificationMode::MentionsAndReplies => "mentions",
-        NotificationMode::Muted => "muted",
-    };
-
-    rsx! {
-        div { class: "mb-4",
-            label { class: "block text-sm font-medium text-text-muted mb-2", "Notifications" }
-            select {
-                class: "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent",
-                value: "{current_str}",
-                onchange: move |evt| {
-                    let mode = match evt.value().as_str() {
-                        "mentions" => NotificationMode::MentionsAndReplies,
-                        "muted" => NotificationMode::Muted,
-                        _ => NotificationMode::All,
-                    };
-                    // Defer the signal mutation (RefCell re-entrancy rule), then
-                    // persist to the delegate so the choice survives reloads.
-                    crate::util::defer(move || {
-                        ROOMS.with_mut(|rooms| {
-                            rooms.notification_modes.insert(room_vk, mode);
-                        });
-                        spawn(async move {
-                            if let Err(e) = save_rooms_to_delegate().await {
-                                error!("Failed to save notification mode: {}", e);
-                            }
-                        });
-                    });
-                },
-                option { value: "all", "All messages" }
-                option { value: "mentions", "Mentions & replies only" }
-                option { value: "muted", "Muted" }
-            }
-            p { class: "text-xs text-text-muted mt-1",
-                "When to notify for this room. Applies on this device only."
-            }
-        }
     }
 }
 

--- a/ui/src/components/room_list/notification_modal.rs
+++ b/ui/src/components/room_list/notification_modal.rs
@@ -1,0 +1,164 @@
+//! Compact per-room notification-preference modal, opened from the bell icon in
+//! the conversation header (`NOTIFICATION_MODAL`). Lets the user pick when a
+//! browser notification fires for a room: every message, mentions & replies
+//! only, or muted.
+//!
+//! This is the canonical entry point for the setting — the room-details
+//! (edit-room) modal deliberately does NOT duplicate it, so there is one home.
+//!
+//! Storage: the choice is a local user setting persisted in the `rooms_meta`
+//! delegate blob (see [`crate::room_data::NotificationMode`] /
+//! [`crate::room_data::RoomsMeta`]), the same model as `room_order`. It
+//! soft-syncs across the user's devices (local-wins merge in `reconcile_meta`),
+//! so the help text says "your devices", not "this device only".
+
+use crate::components::app::chat_delegate::save_rooms_to_delegate;
+use crate::components::app::{NOTIFICATION_MODAL, ROOMS};
+use crate::room_data::NotificationMode;
+use dioxus::logger::tracing::error;
+use dioxus::prelude::*;
+use dioxus_free_icons::icons::fa_solid_icons::{FaAt, FaBell, FaBellSlash, FaCheck, FaXmark};
+use dioxus_free_icons::Icon;
+use ed25519_dalek::VerifyingKey;
+
+/// The three notification modes, with the display strings for the modal rows.
+/// Kept in one place so the row list and the icon/label lookups can't drift.
+const MODES: [(NotificationMode, &str, &str); 3] = [
+    (
+        NotificationMode::All,
+        "All messages",
+        "Notify for every message in this room.",
+    ),
+    (
+        NotificationMode::MentionsAndReplies,
+        "Mentions & replies only",
+        "Notify only when someone @mentions you or replies to your message.",
+    ),
+    (
+        NotificationMode::Muted,
+        "Muted",
+        "Never notify for this room.",
+    ),
+];
+
+/// Read the current notification mode for `room_vk` from `ROOMS`. An absent
+/// entry means [`NotificationMode::All`] (the default).
+fn current_mode(room_vk: &VerifyingKey) -> NotificationMode {
+    ROOMS
+        .try_read()
+        .ok()
+        .and_then(|rooms| rooms.notification_modes.get(room_vk).copied())
+        .unwrap_or_default()
+}
+
+/// Persist a newly-chosen mode: mutate the in-memory map, then write the
+/// `rooms_meta` blob to the delegate. Deferred to satisfy the Dioxus
+/// signal-safety rule (no signal mutation directly inside an event handler).
+fn set_mode(room_vk: VerifyingKey, mode: NotificationMode) {
+    crate::util::defer(move || {
+        ROOMS.with_mut(|rooms| {
+            rooms.notification_modes.insert(room_vk, mode);
+        });
+        spawn(async move {
+            if let Err(e) = save_rooms_to_delegate().await {
+                error!("Failed to save notification mode: {}", e);
+            }
+        });
+        // Close the modal after applying, so a pick is one click.
+        NOTIFICATION_MODAL.write().room = None;
+    });
+}
+
+/// Always-mounted modal; renders nothing unless `NOTIFICATION_MODAL.room` is set.
+#[component]
+pub fn NotificationModal() -> Element {
+    let Some(room_vk) = NOTIFICATION_MODAL.read().room else {
+        return rsx! {};
+    };
+    let selected = current_mode(&room_vk);
+
+    rsx! {
+        // Backdrop (same pattern as EditRoomModal).
+        div {
+            class: "fixed inset-0 z-50 flex items-center justify-center",
+            div {
+                class: "absolute inset-0 bg-black/50",
+                onclick: move |_| {
+                    NOTIFICATION_MODAL.write().room = None;
+                }
+            }
+            // Content — compact (max-w-sm), just the mode picker.
+            div {
+                "data-testid": "notification-modal",
+                class: "relative z-10 w-full max-w-sm mx-4 bg-panel rounded-xl shadow-xl border border-border",
+                div { class: "p-5",
+                    div { class: "flex items-center justify-between mb-4",
+                        h1 { class: "text-lg font-semibold text-text", "Notifications" }
+                        button {
+                            "data-testid": "notification-modal-close",
+                            class: "p-1.5 rounded-lg text-text-muted hover:text-text hover:bg-surface transition-colors",
+                            "aria-label": "Close",
+                            onclick: move |_| {
+                                NOTIFICATION_MODAL.write().room = None;
+                            },
+                            Icon { icon: FaXmark, width: 16, height: 16 }
+                        }
+                    }
+                    div { class: "flex flex-col gap-1",
+                        for (mode , label , description) in MODES {
+                            {
+                                let is_selected = mode == selected;
+                                rsx! {
+                                    button {
+                                        key: "{label}",
+                                        "data-testid": "notification-mode-option",
+                                        class: if is_selected {
+                                            "flex items-start gap-3 w-full text-left px-3 py-2.5 rounded-lg bg-surface border border-accent transition-colors"
+                                        } else {
+                                            "flex items-start gap-3 w-full text-left px-3 py-2.5 rounded-lg border border-transparent hover:bg-surface transition-colors"
+                                        },
+                                        onclick: move |_| {
+                                            // No-op if already selected — just close.
+                                            if is_selected {
+                                                crate::util::defer(move || {
+                                                    NOTIFICATION_MODAL.write().room = None;
+                                                });
+                                            } else {
+                                                set_mode(room_vk, mode);
+                                            }
+                                        },
+                                        span {
+                                            class: if is_selected { "text-accent flex-shrink-0 mt-0.5" } else { "text-text-muted flex-shrink-0 mt-0.5" },
+                                            {mode_icon(mode)}
+                                        }
+                                        div { class: "min-w-0 flex-1",
+                                            div { class: "text-sm font-medium text-text", "{label}" }
+                                            div { class: "text-xs text-text-muted", "{description}" }
+                                        }
+                                        if is_selected {
+                                            span { class: "text-accent flex-shrink-0 mt-0.5",
+                                                Icon { icon: FaCheck, width: 14, height: 14 }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    p { class: "text-xs text-text-muted mt-4",
+                        "Applies to this room and syncs across your devices."
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// The leading icon for a mode row.
+fn mode_icon(mode: NotificationMode) -> Element {
+    match mode {
+        NotificationMode::All => rsx! { Icon { icon: FaBell, width: 16, height: 16 } },
+        NotificationMode::MentionsAndReplies => rsx! { Icon { icon: FaAt, width: 16, height: 16 } },
+        NotificationMode::Muted => rsx! { Icon { icon: FaBellSlash, width: 16, height: 16 } },
+    }
+}

--- a/ui/src/components/room_list/notification_modal.rs
+++ b/ui/src/components/room_list/notification_modal.rs
@@ -83,8 +83,13 @@ pub fn NotificationModal() -> Element {
             class: "fixed inset-0 z-50 flex items-center justify-center",
             div {
                 class: "absolute inset-0 bg-black/50",
+                // Signal mutation from an event handler must be deferred
+                // (dioxus-signal-safety: direct writes here are the Firefox
+                // mobile RefCell re-entrancy crash path).
                 onclick: move |_| {
-                    NOTIFICATION_MODAL.write().room = None;
+                    crate::util::defer(move || {
+                        NOTIFICATION_MODAL.write().room = None;
+                    });
                 }
             }
             // Content — compact (max-w-sm), just the mode picker.
@@ -98,8 +103,12 @@ pub fn NotificationModal() -> Element {
                             "data-testid": "notification-modal-close",
                             class: "p-1.5 rounded-lg text-text-muted hover:text-text hover:bg-surface transition-colors",
                             "aria-label": "Close",
+                            // Deferred close — same signal-safety rule as the
+                            // backdrop handler above.
                             onclick: move |_| {
-                                NOTIFICATION_MODAL.write().room = None;
+                                crate::util::defer(move || {
+                                    NOTIFICATION_MODAL.write().room = None;
+                                });
                             },
                             Icon { icon: FaXmark, width: 16, height: 16 }
                         }

--- a/ui/tests/notification-bell.spec.ts
+++ b/ui/tests/notification-bell.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect, Page } from "@playwright/test";
+
+// The per-room notification preference (All / Mentions & replies / Muted) is
+// reached from a bell icon in the conversation header, which opens a compact
+// dedicated modal. The setting is persisted in the delegate (rooms_meta); these
+// tests exercise the UI surface against example data.
+
+const ROOM = "Public Discussion Room";
+
+async function waitForApp(page: Page) {
+  await page.waitForSelector(".app-root", { timeout: 30_000 });
+  await expect(page.locator("aside, .app-root button")).not.toHaveCount(0);
+}
+
+async function selectRoom(page: Page, roomName: string) {
+  const vp = page.viewportSize();
+  if (vp && vp.width < 1024) {
+    await page.setViewportSize({ width: 1280, height: vp.height });
+  }
+  const roomBtn = page.getByRole("button", { name: roomName });
+  await expect(roomBtn).toBeVisible({ timeout: 5_000 });
+  await roomBtn.click();
+  await expect(
+    page.getByRole("heading", { name: roomName })
+  ).toBeVisible({ timeout: 5_000 });
+}
+
+test.describe("Per-room notification bell", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("bell is in the header and defaults to 'All messages'", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectRoom(page, ROOM);
+
+    const bell = page.getByTestId("notification-bell-button");
+    await expect(bell).toBeVisible();
+    // Example rooms have no stored preference, so the default is All.
+    await expect(bell).toHaveAttribute("title", "Notifications: All messages");
+  });
+
+  test("clicking the bell opens the notification modal with three modes", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectRoom(page, ROOM);
+
+    await page.getByTestId("notification-bell-button").click();
+
+    const modal = page.getByTestId("notification-modal");
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+    await expect(modal.getByTestId("notification-mode-option")).toHaveCount(3);
+    await expect(modal.getByText("All messages")).toBeVisible();
+    await expect(modal.getByText("Mentions & replies only")).toBeVisible();
+    await expect(modal.getByText("Muted")).toBeVisible();
+  });
+
+  test("selecting a mode applies it, closes the modal, and updates the bell", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectRoom(page, ROOM);
+
+    await page.getByTestId("notification-bell-button").click();
+    const modal = page.getByTestId("notification-modal");
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+
+    // Pick "Muted".
+    await modal
+      .getByTestId("notification-mode-option")
+      .filter({ hasText: "Muted" })
+      .click();
+
+    // Modal closes on selection (one-click pick).
+    await expect(modal).toHaveCount(0, { timeout: 5_000 });
+
+    // Bell now reflects the muted state via its tooltip.
+    await expect(
+      page.getByTestId("notification-bell-button")
+    ).toHaveAttribute("title", "Notifications: Muted");
+
+    // Reopening shows the muted row as the selected one (check indicator).
+    await page.getByTestId("notification-bell-button").click();
+    const reopened = page.getByTestId("notification-modal");
+    await expect(reopened).toBeVisible({ timeout: 5_000 });
+    const mutedRow = reopened
+      .getByTestId("notification-mode-option")
+      .filter({ hasText: "Muted" });
+    // Selected row carries the accent border class.
+    await expect(mutedRow).toHaveClass(/border-accent/);
+  });
+
+  test("closing via the ✕ leaves the preference unchanged", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectRoom(page, ROOM);
+
+    await page.getByTestId("notification-bell-button").click();
+    const modal = page.getByTestId("notification-modal");
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+
+    await page.getByTestId("notification-modal-close").click();
+    await expect(modal).toHaveCount(0, { timeout: 5_000 });
+    await expect(
+      page.getByTestId("notification-bell-button")
+    ).toHaveAttribute("title", "Notifications: All messages");
+  });
+
+  test("room-details modal no longer carries the notification setting", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectRoom(page, ROOM);
+
+    // Open room details via the title button.
+    const header = page.locator(".border-b.border-border.bg-panel").first();
+    await header.locator('button[title="Room details"]').click();
+    await expect(
+      page.getByRole("heading", { name: /Room Details/i })
+    ).toBeVisible({ timeout: 5_000 });
+
+    // The notification picker moved to the bell modal; it must not appear here.
+    await expect(
+      page.getByText("Mentions & replies only")
+    ).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Problem

River already has per-room notification preferences (All / Mentions & replies / Muted) — the enum, the notification-filtering logic, and delegate-backed persistence all shipped in #340. But the control was buried in a `<select>` inside the room-details (edit-room) modal, so it was undiscoverable, and its help text said "applies on this device only", which is misleading since the setting is stored in the `rooms_meta` delegate blob and soft-syncs across a user's devices.

## Approach

Surface the setting behind a **bell icon in the conversation header** (right edge, cleanly separated from the room-name/`(i)` "room details" target) that opens a **compact dedicated modal**:

- The bell reflects state — `FaBell` when notifying, `FaBellSlash` when muted — with a `title` tooltip naming the exact mode.
- The modal lists the three modes with icons (bell / @ / bell-slash), the current one highlighted with a check; selecting one applies immediately and closes (one-click pick). Backdrop / ✕ dismiss without change.
- The bell is now the **single home** for the setting, so the dropdown is removed from the room-details modal (one place, no drift).

**Storage is unchanged** — kept in the `rooms_meta` delegate blob (local-wins cross-device merge), same model as `room_order`. This was a deliberate call over localStorage: "mute this room" is the dominant case and users expect mute to follow them across devices, and it keeps notification prefs consistent with the other delegate-backed view preferences. Fixed the misleading copy → "Applies to this room and syncs across your devices."

No delegate/contract/common WASM change (UI-only), so **no migration needed**.

## Testing

- `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync` — clean.
- `cargo test -p river-ui --bins` — 479 passed.
- `cargo clippy` / `cargo fmt` — clean (no new warnings in changed code).
- New `ui/tests/notification-bell.spec.ts` (Playwright): header presence + default, opening the modal (3 modes), select-applies-and-closes + bell/tooltip updates + reopened selection state, close-leaves-unchanged, and that the setting no longer appears in room-details. **25/25 green** across chromium / firefox / webkit / mobile-chrome / mobile-safari.

## Screenshot

Header bell → dedicated modal:

<!-- screenshot attached in PR conversation -->

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
