### PR TITLE
fix(ui): gate message send/edit on encoded content size, not raw text bytes

### DIFF
--- a/common/src/room_state/message.rs
+++ b/common/src/room_state/message.rs
@@ -12,6 +12,13 @@ use std::collections::HashMap;
 use std::fmt;
 use std::time::SystemTime;
 
+/// Ciphertext overhead added by AES-256-GCM (`encrypt_with_symmetric_key`):
+/// the 16-byte authentication tag appended to the plaintext. The nonce lives
+/// in a separate field of [`RoomMessageBody::Private`] and does not count
+/// toward [`RoomMessageBody::content_len`]. Pinned against real encryption
+/// by the `measure_*_matches_private_*` tests (feature `ecies-randomized`).
+pub const ENCRYPTION_TAG_OVERHEAD: usize = 16;
+
 /// Computed state for message actions (edits, deletes, reactions)
 /// This is rebuilt from action messages and not serialized
 #[derive(Clone, PartialEq, Debug, Default)]
@@ -706,6 +713,63 @@ impl RoomMessageBody {
         match self {
             Self::Public { data, .. } => data.len(),
             Self::Private { ciphertext, .. } => ciphertext.len(),
+        }
+    }
+
+    /// Exact [`Self::content_len`] of the body [`Self::public`] builds for
+    /// `text` — or, with `encrypted`, of the private body the senders build
+    /// by AES-256-GCM-sealing the encoded `TextContentV1`.
+    ///
+    /// Send gates and byte counters MUST use the `measure_*` functions, not
+    /// `text.len()`: the contract validates encoded content bytes (CBOR
+    /// framing, plus the AEAD tag in private rooms), so a raw-text gate
+    /// passes messages the contract then silently prunes (freenet/river —
+    /// "message was lost" reports).
+    pub fn measure_text(text: &str, encrypted: bool) -> usize {
+        use crate::room_state::content::TextContentV1;
+        let plain = TextContentV1::new(text.to_owned()).encode().len();
+        Self::with_encryption_overhead(plain, encrypted)
+    }
+
+    /// Exact [`Self::content_len`] of the body [`Self::reply`] builds — or,
+    /// with `encrypted`, of the private reply body (encrypted encoded
+    /// `ReplyContentV1`). Reply bodies embed the quoted author name and
+    /// content preview, so their overhead is much larger than plain text.
+    pub fn measure_reply(
+        text: &str,
+        target_message_id: MessageId,
+        target_author_name: &str,
+        target_content_preview: &str,
+        encrypted: bool,
+    ) -> usize {
+        use crate::room_state::content::ReplyContentV1;
+        let plain = ReplyContentV1::new(
+            text.to_owned(),
+            target_message_id,
+            target_author_name.to_owned(),
+            target_content_preview.to_owned(),
+        )
+        .encode()
+        .len();
+        Self::with_encryption_overhead(plain, encrypted)
+    }
+
+    /// Exact [`Self::content_len`] of the body [`Self::edit`] builds — or,
+    /// with `encrypted`, of the private edit body (encrypted encoded
+    /// `ActionContentV1`).
+    pub fn measure_edit(target: MessageId, new_text: &str, encrypted: bool) -> usize {
+        use crate::room_state::content::ActionContentV1;
+        let plain = ActionContentV1::edit(target, new_text.to_owned())
+            .encode()
+            .len();
+        Self::with_encryption_overhead(plain, encrypted)
+    }
+
+    fn with_encryption_overhead(plain_len: usize, encrypted: bool) -> usize {
+        if encrypted {
+            plain_len + ENCRYPTION_TAG_OVERHEAD
+        } else {
+            plain_len
         }
     }
 
@@ -1640,5 +1704,193 @@ mod tests {
             display[1].message.content.as_public_string(),
             Some("World".to_string())
         );
+    }
+}
+
+#[cfg(test)]
+mod measure_tests {
+    use super::*;
+    use crate::room_state::content::{
+        CONTENT_TYPE_REPLY, CONTENT_TYPE_TEXT, REPLY_CONTENT_VERSION, TEXT_CONTENT_VERSION,
+    };
+
+    /// Text samples crossing CBOR length-prefix boundaries (23/24, 255/256
+    /// bytes) and mixing multi-byte UTF-8 (the HostFat report: chars < limit
+    /// but encoded bytes > limit).
+    fn samples() -> Vec<String> {
+        vec![
+            String::new(),
+            "a".repeat(1),
+            "a".repeat(23),
+            "a".repeat(24),
+            "a".repeat(255),
+            "a".repeat(256),
+            "a".repeat(997),
+            "a".repeat(998),
+            "a".repeat(1000),
+            "é".repeat(400),  // 800 bytes, 400 chars
+            "🎉".repeat(200), // 800 bytes, 200 chars
+            format!("{}é🎉", "a".repeat(990)),
+        ]
+    }
+
+    fn target_id() -> MessageId {
+        MessageId(FastHash(0x1234_5678_9abc_def0_u64 as i64))
+    }
+
+    #[test]
+    fn measure_text_matches_public_body() {
+        for text in samples() {
+            let body = RoomMessageBody::public(text.clone());
+            assert_eq!(
+                RoomMessageBody::measure_text(&text, false),
+                body.content_len(),
+                "text bytes={} chars={}",
+                text.len(),
+                text.chars().count()
+            );
+        }
+    }
+
+    #[test]
+    fn measure_reply_matches_reply_body() {
+        let previews = ["", "short", &"préview🎉 ".repeat(10)];
+        let authors = ["", "Alice", "HöstFat"];
+        for text in samples() {
+            for preview in previews {
+                for author in authors {
+                    let body = RoomMessageBody::reply(
+                        text.clone(),
+                        target_id(),
+                        author.to_string(),
+                        preview.to_string(),
+                    );
+                    assert_eq!(
+                        RoomMessageBody::measure_reply(&text, target_id(), author, preview, false),
+                        body.content_len(),
+                        "text bytes={} author={:?} preview bytes={}",
+                        text.len(),
+                        author,
+                        preview.len()
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn measure_edit_matches_edit_body() {
+        for text in samples() {
+            let body = RoomMessageBody::edit(target_id(), text.clone());
+            assert_eq!(
+                RoomMessageBody::measure_edit(target_id(), &text, false),
+                body.content_len(),
+                "text bytes={}",
+                text.len()
+            );
+        }
+    }
+
+    /// Pins the bug class this API exists to prevent: raw text within the
+    /// default 1000-byte limit whose ENCODED content exceeds it. The old UI
+    /// gate compared `text.len()` and let these through; the contract then
+    /// silently pruned them ("a message was lost").
+    #[test]
+    fn raw_text_gate_undercounts_encoded_size() {
+        let max = 1000;
+        let text = "a".repeat(998); // HostFat's case: 998 chars -> 1006 encoded
+        assert!(text.len() <= max);
+        assert!(RoomMessageBody::measure_text(&text, false) > max);
+
+        // A reply blows the budget far earlier because of embedded metadata.
+        let reply_text = "a".repeat(900);
+        assert!(reply_text.len() <= max);
+        assert!(
+            RoomMessageBody::measure_reply(
+                &reply_text,
+                target_id(),
+                "Alice",
+                &"p".repeat(100),
+                false
+            ) > max
+        );
+    }
+
+    #[cfg(feature = "ecies-randomized")]
+    mod private_bodies {
+        use super::*;
+        use crate::ecies::encrypt_with_symmetric_key;
+
+        const SECRET: [u8; 32] = [7u8; 32];
+
+        #[test]
+        fn measure_text_matches_private_body() {
+            for text in samples() {
+                let content_bytes =
+                    crate::room_state::content::TextContentV1::new(text.clone()).encode();
+                let (ciphertext, nonce) = encrypt_with_symmetric_key(&SECRET, &content_bytes);
+                let body = RoomMessageBody::private(
+                    CONTENT_TYPE_TEXT,
+                    TEXT_CONTENT_VERSION,
+                    ciphertext,
+                    nonce,
+                    1,
+                );
+                assert_eq!(
+                    RoomMessageBody::measure_text(&text, true),
+                    body.content_len(),
+                    "text bytes={}",
+                    text.len()
+                );
+            }
+        }
+
+        #[test]
+        fn measure_reply_matches_private_body() {
+            for text in samples() {
+                let reply = crate::room_state::content::ReplyContentV1::new(
+                    text.clone(),
+                    target_id(),
+                    "Alice".to_string(),
+                    "some preview".to_string(),
+                );
+                let (ciphertext, nonce) = encrypt_with_symmetric_key(&SECRET, &reply.encode());
+                let body = RoomMessageBody::private(
+                    CONTENT_TYPE_REPLY,
+                    REPLY_CONTENT_VERSION,
+                    ciphertext,
+                    nonce,
+                    1,
+                );
+                assert_eq!(
+                    RoomMessageBody::measure_reply(
+                        &text,
+                        target_id(),
+                        "Alice",
+                        "some preview",
+                        true
+                    ),
+                    body.content_len(),
+                    "text bytes={}",
+                    text.len()
+                );
+            }
+        }
+
+        #[test]
+        fn measure_edit_matches_private_body() {
+            for text in samples() {
+                let action =
+                    crate::room_state::content::ActionContentV1::edit(target_id(), text.clone());
+                let (ciphertext, nonce) = encrypt_with_symmetric_key(&SECRET, &action.encode());
+                let body = RoomMessageBody::private_action(ciphertext, nonce, 1);
+                assert_eq!(
+                    RoomMessageBody::measure_edit(target_id(), &text, true),
+                    body.content_len(),
+                    "text bytes={}",
+                    text.len()
+                );
+            }
+        }
     }
 }

--- a/common/src/room_state/message.rs
+++ b/common/src/room_state/message.rs
@@ -723,8 +723,8 @@ impl RoomMessageBody {
     /// Send gates and byte counters MUST use the `measure_*` functions, not
     /// `text.len()`: the contract validates encoded content bytes (CBOR
     /// framing, plus the AEAD tag in private rooms), so a raw-text gate
-    /// passes messages the contract then silently prunes (freenet/river —
-    /// "message was lost" reports).
+    /// passes messages the contract then silently prunes (freenet/river#430,
+    /// the "message was lost" reports).
     pub fn measure_text(text: &str, encrypted: bool) -> usize {
         use crate::room_state::content::TextContentV1;
         let plain = TextContentV1::new(text.to_owned()).encode().len();

--- a/common/src/room_state/message.rs
+++ b/common/src/room_state/message.rs
@@ -1798,7 +1798,7 @@ mod measure_tests {
     #[test]
     fn raw_text_gate_undercounts_encoded_size() {
         let max = 1000;
-        let text = "a".repeat(998); // HostFat's case: 998 chars -> 1006 encoded
+        let text = "a".repeat(998); // 998 chars -> 1007 encoded (raw + 9)
         assert!(text.len() <= max);
         assert!(RoomMessageBody::measure_text(&text, false) > max);
 

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -2636,7 +2636,11 @@ fn MessageGroupComponent(
                                                             is_private,
                                                         );
                                                         let over_limit = encoded_bytes > max_message_size;
-                                                        let near_limit = encoded_bytes > max_message_size * 4 / 5;
+                                                        // `/ 5 * 4` (not `* 4 / 5`): max_message_size is
+                                                        // room-config-controlled and falls back to
+                                                        // usize::MAX with no room, so multiply-first
+                                                        // overflows.
+                                                        let near_limit = encoded_bytes > max_message_size / 5 * 4;
                                                         rsx! {
                                                             if near_limit {
                                                                 div {

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -2684,6 +2684,19 @@ fn MessageGroupComponent(
                                                                     },
                                                                     onclick: move |_| {
                                                                         let new_text = edit_text.read().clone();
+                                                                        // Same guard as Enter-save: `disabled` should
+                                                                        // make this unreachable when over, but a
+                                                                        // render-lag click must keep the form open
+                                                                        // rather than fall through to the silent
+                                                                        // safety-net drop.
+                                                                        if RoomMessageBody::measure_edit(
+                                                                            save_msg_id.clone(),
+                                                                            &new_text,
+                                                                            is_private,
+                                                                        ) > max_message_size
+                                                                        {
+                                                                            return;
+                                                                        }
                                                                         if !new_text.is_empty() && new_text != save_original {
                                                                             on_edit.call((save_msg_id.clone(), new_text));
                                                                         }

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1509,6 +1509,25 @@ pub fn Conversation() -> Element {
                     .get_secret()
                     .map(|(secret, version)| (*secret, version));
 
+                // Safety net (see the send-path twin): the edit form disables
+                // Save when the encoded action exceeds max_message_size. If
+                // this fires, the UI gate drifted from the body construction
+                // and the edit is silently dropped — fix the drift.
+                let max_size = current_room_data
+                    .room_state
+                    .configuration
+                    .configuration
+                    .max_message_size;
+                let measured =
+                    RoomMessageBody::measure_edit(target_message_id.clone(), &new_text, is_private);
+                if measured > max_size {
+                    error!(
+                        "BUG: over-size edit passed the UI gate ({} encoded bytes, max {}) — edit dropped",
+                        measured, max_size
+                    );
+                    return;
+                }
+
                 spawn_local(async move {
                     use crate::util::ecies::encrypt_with_symmetric_key;
                     use river_core::room_state::content::ActionContentV1;
@@ -1709,16 +1728,21 @@ pub fn Conversation() -> Element {
                     };
 
                     // Safety net: check encoded content size before signing.
-                    // The input UI blocks sending when text is over limit, but
-                    // encoded size can differ slightly from raw text length.
+                    // Should be unreachable — the input gate measures the same
+                    // encoded size via RoomMessageBody::measure_* (pinned equal
+                    // to content_len() by river-core tests). If this fires, the
+                    // measure helpers have drifted from the body construction
+                    // above and the draft is already cleared: the message is
+                    // LOST, which is the HostFat bug. Fix the drift, don't
+                    // relax this check.
                     let content_size = content.content_len();
                     let max_size = room_state_clone
                         .configuration
                         .configuration
                         .max_message_size;
                     if content_size > max_size {
-                        warn!(
-                            "Message too long: {} encoded bytes, max {} bytes",
+                        error!(
+                            "BUG: over-size message passed the input gate ({} encoded bytes, max {}) — measure_* drifted from body construction; message dropped",
                             content_size, max_size
                         );
                         return;
@@ -1912,6 +1936,21 @@ pub fn Conversation() -> Element {
                                     let groups = groups.clone();
                                     let self_member_id = *self_member_id;
                                     let member_names = member_names.clone();
+                                    // Room limits for the in-place edit form's
+                                    // encoded-size gate (same measure the
+                                    // contract enforces on the edit action).
+                                    let (edit_max_size, edit_is_private) = current_room_data
+                                        .as_ref()
+                                        .map(|rd| {
+                                            (
+                                                rd.room_state
+                                                    .configuration
+                                                    .configuration
+                                                    .max_message_size,
+                                                rd.is_private(),
+                                            )
+                                        })
+                                        .unwrap_or((usize::MAX, false));
                                     // Flatten the message/event groups into render rows,
                                     // inserting a day-change separator row above the first
                                     // item of each local calendar day (a run of messages on
@@ -1993,6 +2032,8 @@ pub fn Conversation() -> Element {
                                                                 group: group,
                                                                 self_member_id: self_member_id,
                                                                 member_names: member_names,
+                                                                max_message_size: edit_max_size,
+                                                                is_private: edit_is_private,
                                                                 last_chat_element: if is_last_group { Some(last_chat_element) } else { None },
                                                                 edit_trigger: edit_trigger,
                                                                 on_react: move |(msg_id, emoji)| {
@@ -2152,6 +2193,7 @@ pub fn Conversation() -> Element {
                         match room_data.can_participate() {
                             Ok(()) => {
                                 let max_msg_size = room_data.room_state.configuration.configuration.max_message_size;
+                                let room_is_private = room_data.is_private();
                                 // Mentionable members for the @ autocomplete: every member
                                 // with a (decrypted) nickname except self, sorted by name.
                                 let self_id = MemberId::from(&room_data.self_sk.verifying_key());
@@ -2184,6 +2226,7 @@ pub fn Conversation() -> Element {
                                         replying_to: replying_to,
                                         on_request_edit_last: request_edit_last,
                                         max_message_size: max_msg_size,
+                                        is_private: room_is_private,
                                         members: mention_members,
                                     }
                                 }
@@ -2295,6 +2338,11 @@ fn MessageGroupComponent(
     group: MessageGroup,
     self_member_id: MemberId,
     member_names: HashMap<MemberId, String>,
+    /// Room max message size in ENCODED content bytes — bounds the edit
+    /// action body (`RoomMessageBody::measure_edit`), not the raw text.
+    max_message_size: usize,
+    /// Whether the room is private (encrypted edits carry the AES-GCM tag).
+    is_private: bool,
     last_chat_element: Option<Signal<Option<Rc<MountedData>>>>,
     edit_trigger: Signal<Option<(String, String)>>,
     on_react: EventHandler<(MessageId, String)>,
@@ -2504,6 +2552,16 @@ fn MessageGroupComponent(
                                                             } else if e.key() == Key::Enter && !e.modifiers().shift() {
                                                                 e.prevent_default();
                                                                 let new_text = edit_text.read().clone();
+                                                                // Encoded-size gate: keep the form open so the
+                                                                // over-limit edit isn't silently discarded.
+                                                                if RoomMessageBody::measure_edit(
+                                                                    msg_id.clone(),
+                                                                    &new_text,
+                                                                    is_private,
+                                                                ) > max_message_size
+                                                                {
+                                                                    return;
+                                                                }
                                                                 if !new_text.is_empty() && new_text != original {
                                                                     on_edit.call((msg_id.clone(), new_text));
                                                                 }
@@ -2567,28 +2625,69 @@ fn MessageGroupComponent(
                                                             },
                                                         }
                                                     }
-                                                    div { class: "flex justify-end gap-3 mt-3",
-                                                        style: "overflow: visible;",
-                                                        button {
-                                                            class: if is_self {
-                                                                "flex-shrink-0 px-3 py-1.5 text-xs rounded-lg bg-white/20 text-white hover:bg-white/30"
-                                                            } else {
-                                                                "flex-shrink-0 px-3 py-1.5 text-xs rounded-lg bg-surface text-text hover:bg-border"
-                                                            },
-                                                            onclick: move |_| editing_message.set(None),
-                                                            "Cancel (Esc)"
-                                                        }
-                                                        button {
-                                                            class: "flex-shrink-0 px-3 py-1.5 text-xs rounded-lg font-medium hover:opacity-90",
-                                                            style: "background-color: #2563eb; color: white;",
-                                                            onclick: move |_| {
-                                                                let new_text = edit_text.read().clone();
-                                                                if !new_text.is_empty() && new_text != save_original {
-                                                                    on_edit.call((save_msg_id.clone(), new_text));
+                                                    // Encoded-size gate for the edit action: same
+                                                    // measure the contract enforces. Without it an
+                                                    // over-limit edit is signed, sent, and silently
+                                                    // pruned by the contract validation.
+                                                    {
+                                                        let encoded_bytes = RoomMessageBody::measure_edit(
+                                                            msg_id_for_save.clone(),
+                                                            &edit_text.read(),
+                                                            is_private,
+                                                        );
+                                                        let over_limit = encoded_bytes > max_message_size;
+                                                        let near_limit = encoded_bytes > max_message_size * 4 / 5;
+                                                        rsx! {
+                                                            if near_limit {
+                                                                div {
+                                                                    class: if over_limit {
+                                                                        "text-xs text-right mt-1 pr-1 text-red-600 dark:text-red-400 font-medium"
+                                                                    } else if is_self {
+                                                                        "text-xs text-right mt-1 pr-1 text-white/70"
+                                                                    } else {
+                                                                        "text-xs text-right mt-1 pr-1 text-text-muted"
+                                                                    },
+                                                                    if over_limit {
+                                                                        "Message too long \u{2014} {encoded_bytes}/{max_message_size} bytes"
+                                                                    } else {
+                                                                        "{encoded_bytes}/{max_message_size}"
+                                                                    }
                                                                 }
-                                                                editing_message.set(None);
-                                                            },
-                                                            "Save (Enter)"
+                                                            }
+                                                            div { class: "flex justify-end gap-3 mt-3",
+                                                                style: "overflow: visible;",
+                                                                button {
+                                                                    class: if is_self {
+                                                                        "flex-shrink-0 px-3 py-1.5 text-xs rounded-lg bg-white/20 text-white hover:bg-white/30"
+                                                                    } else {
+                                                                        "flex-shrink-0 px-3 py-1.5 text-xs rounded-lg bg-surface text-text hover:bg-border"
+                                                                    },
+                                                                    onclick: move |_| editing_message.set(None),
+                                                                    "Cancel (Esc)"
+                                                                }
+                                                                button {
+                                                                    class: "flex-shrink-0 px-3 py-1.5 text-xs rounded-lg font-medium hover:opacity-90",
+                                                                    style: if over_limit {
+                                                                        "background-color: #9ca3af; color: white; cursor: not-allowed; opacity: 0.6;"
+                                                                    } else {
+                                                                        "background-color: #2563eb; color: white;"
+                                                                    },
+                                                                    disabled: over_limit,
+                                                                    title: if over_limit {
+                                                                        format!("Edited message exceeds the {} byte limit", max_message_size)
+                                                                    } else {
+                                                                        String::new()
+                                                                    },
+                                                                    onclick: move |_| {
+                                                                        let new_text = edit_text.read().clone();
+                                                                        if !new_text.is_empty() && new_text != save_original {
+                                                                            on_edit.call((save_msg_id.clone(), new_text));
+                                                                        }
+                                                                        editing_message.set(None);
+                                                                    },
+                                                                    "Save (Enter)"
+                                                                }
+                                                            }
                                                         }
                                                     }
                                                 }

--- a/ui/src/components/conversation/message_input.rs
+++ b/ui/src/components/conversation/message_input.rs
@@ -235,7 +235,10 @@ pub fn MessageInput(
                                 replying_to.read().as_ref(),
                                 is_private,
                             );
-                            let threshold = max_message_size * 4 / 5; // 80%
+                            // `/ 5 * 4` (not `* 4 / 5`): max_message_size is
+                            // room-config-controlled, so multiply-first can
+                            // overflow on a hostile/corrupt config.
+                            let threshold = max_message_size / 5 * 4; // 80%
                             if encoded_bytes > threshold {
                                 let over = encoded_bytes > max_message_size;
                                 if over {

--- a/ui/src/components/conversation/message_input.rs
+++ b/ui/src/components/conversation/message_input.rs
@@ -8,6 +8,26 @@ use super::mention::{
 };
 use super::ReplyContext;
 use river_core::room_state::member::MemberId;
+use river_core::room_state::message::RoomMessageBody;
+
+/// Encoded `content_len()` the draft will have when sent — the measure the
+/// contract enforces (`max_message_size` bounds encoded bytes, not typed
+/// text). Mirrors `handle_send_message`'s body construction: replies embed
+/// the quoted author + preview, private rooms add the AES-GCM tag. Gating on
+/// `text.len()` instead silently lost messages in the encoding-overhead gap
+/// (the contract prunes them after the draft is already cleared).
+fn measure_draft(text: &str, reply: Option<&ReplyContext>, is_private: bool) -> usize {
+    match reply {
+        Some(r) => RoomMessageBody::measure_reply(
+            text,
+            r.message_id.clone(),
+            &r.author_name,
+            &r.content_preview,
+            is_private,
+        ),
+        None => RoomMessageBody::measure_text(text, is_private),
+    }
+}
 
 fn auto_resize_message_input() {
     let Some(el) = get_message_textarea() else {
@@ -38,7 +58,12 @@ pub fn MessageInput(
     replying_to: Signal<Option<ReplyContext>>,
     on_request_edit_last: EventHandler<()>,
     /// Maximum message content size in bytes (from room configuration).
+    /// Bounds the ENCODED content (`RoomMessageBody::content_len`), which is
+    /// what the contract validates — not the raw typed text.
     max_message_size: usize,
+    /// Whether the room is private (encrypted): private bodies carry the
+    /// AES-GCM tag, which counts toward the encoded size.
+    is_private: bool,
     /// Mentionable members (id, current nickname), excluding self, sorted by
     /// name. Drives the `@` autocomplete. Changes only when membership changes,
     /// so it does not affect keystroke-level re-rendering.
@@ -51,7 +76,9 @@ pub fn MessageInput(
 
     let mut send_message = move || {
         let text = message_text.peek().to_string();
-        if !text.is_empty() && text.len() <= max_message_size {
+        let within_limit =
+            measure_draft(&text, replying_to.peek().as_ref(), is_private) <= max_message_size;
+        if !text.is_empty() && within_limit {
             let reply_ctx = replying_to.peek().clone();
             message_text.set(String::new());
             replying_to.set(None);
@@ -198,22 +225,29 @@ pub fn MessageInput(
                                 }
                             }
                         }
-                        // Byte counter — shown when approaching the limit (>80%)
+                        // Byte counter — shown when approaching the limit (>80%).
+                        // Counts ENCODED bytes (what the contract enforces), so
+                        // it stays truthful for replies, private rooms, and
+                        // multi-byte characters.
                         {
-                            let text_bytes = message_text.read().len();
+                            let encoded_bytes = measure_draft(
+                                &message_text.read(),
+                                replying_to.read().as_ref(),
+                                is_private,
+                            );
                             let threshold = max_message_size * 4 / 5; // 80%
-                            if text_bytes > threshold {
-                                let over = text_bytes > max_message_size;
+                            if encoded_bytes > threshold {
+                                let over = encoded_bytes > max_message_size;
                                 if over {
                                     rsx! {
                                         div { class: "text-xs text-right mt-1 pr-1 text-red-600 dark:text-red-400 font-medium",
-                                            "Message too long \u{2014} {text_bytes}/{max_message_size} bytes"
+                                            "Message too long \u{2014} {encoded_bytes}/{max_message_size} bytes"
                                         }
                                     }
                                 } else {
                                     rsx! {
                                         div { class: "text-xs text-right mt-1 pr-1 text-text-muted",
-                                            "{text_bytes}/{max_message_size}"
+                                            "{encoded_bytes}/{max_message_size}"
                                         }
                                     }
                                 }
@@ -223,8 +257,12 @@ pub fn MessageInput(
                         }
                     }
                     {
-                        let text_bytes = message_text.read().len();
-                        let over_limit = text_bytes > max_message_size;
+                        let encoded_bytes = measure_draft(
+                            &message_text.read(),
+                            replying_to.read().as_ref(),
+                            is_private,
+                        );
+                        let over_limit = encoded_bytes > max_message_size;
                         let btn_class = if over_limit {
                             "px-5 py-2.5 bg-gray-400 dark:bg-gray-600 text-white font-medium rounded-xl opacity-50 cursor-not-allowed"
                         } else {

--- a/ui/src/components/conversation/message_input.rs
+++ b/ui/src/components/conversation/message_input.rs
@@ -297,3 +297,57 @@ pub fn MessageInput(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use freenet_scaffold::util::FastHash;
+    use river_core::room_state::message::MessageId;
+
+    fn reply_ctx() -> ReplyContext {
+        ReplyContext {
+            message_id: MessageId(FastHash(42)),
+            author_name: "Alice".to_string(),
+            content_preview: "préview 🎉 of the quoted message".to_string(),
+        }
+    }
+
+    /// Pins the gate's plumbing: `measure_draft` must select the reply
+    /// measurement when a reply is active and thread `is_private` through —
+    /// a revert to `text.len()` (the HostFat message-loss bug) or a dropped
+    /// reply/private branch fails here without needing a browser.
+    #[test]
+    fn measure_draft_matches_room_message_body_measures() {
+        let texts = ["", "short", &"a".repeat(998), &"é".repeat(499)];
+        for text in texts {
+            for is_private in [false, true] {
+                assert_eq!(
+                    measure_draft(text, None, is_private),
+                    RoomMessageBody::measure_text(text, is_private),
+                    "text branch: bytes={} private={}",
+                    text.len(),
+                    is_private
+                );
+                let r = reply_ctx();
+                assert_eq!(
+                    measure_draft(text, Some(&r), is_private),
+                    RoomMessageBody::measure_reply(
+                        text,
+                        r.message_id.clone(),
+                        &r.author_name,
+                        &r.content_preview,
+                        is_private
+                    ),
+                    "reply branch: bytes={} private={}",
+                    text.len(),
+                    is_private
+                );
+            }
+        }
+        // The branches must actually differ (reply embeds metadata) and
+        // private must cost more (AES-GCM tag): guards against collapsing
+        // the match into a single arm.
+        assert!(measure_draft("hi", Some(&reply_ctx()), false) > measure_draft("hi", None, false));
+        assert!(measure_draft("hi", None, true) > measure_draft("hi", None, false));
+    }
+}

--- a/ui/tests/message-size-gate.spec.ts
+++ b/ui/tests/message-size-gate.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect, Page } from "@playwright/test";
+
+// Regression tests for the "message was lost" bug (HostFat, Matrix 2026-07):
+// the input gate compared raw text bytes against max_message_size, but the
+// contract validates the ENCODED content (CBOR framing adds ~9 bytes for
+// plain text). A message in the gap passed the UI gate, had its draft
+// cleared, then was silently dropped by the encoded-size safety net —
+// "WARN Message too long: 1006 encoded bytes, max 1000 bytes" with the
+// counter still under 1000.
+//
+// The example-data rooms use Configuration::default(): max_message_size =
+// 1000 bytes (encoded), public room. Public text encodes as CBOR
+// {text: "..."} = raw bytes + 9 for texts in the 256..65535-byte range.
+
+async function waitForApp(page: Page) {
+  await page.waitForSelector(".app-root", { timeout: 30_000 });
+  await expect(page.locator("aside, .app-root button")).not.toHaveCount(0);
+}
+
+async function selectRoom(page: Page, roomName: string) {
+  const roomBtn = page.getByRole("button", { name: roomName });
+  if (!(await roomBtn.isVisible({ timeout: 500 }).catch(() => false))) {
+    // Narrow-window case: temporarily expand to click the room.
+    const vp = page.viewportSize();
+    if (vp && vp.width < 768) {
+      await page.setViewportSize({ width: 1280, height: vp.height });
+      await expect(roomBtn).toBeVisible({ timeout: 5_000 });
+      await roomBtn.click();
+      await expect(page.getByRole("heading", { name: roomName })).toBeVisible({
+        timeout: 5_000,
+      });
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      return;
+    }
+  }
+  await roomBtn.click();
+  await expect(page.getByRole("heading", { name: roomName })).toBeVisible({
+    timeout: 5_000,
+  });
+}
+
+async function openRoomWithInput(page: Page) {
+  await page.goto("/");
+  await waitForApp(page);
+  // Self is the owner of "Your Private Room" in example data, so the
+  // message input is available there.
+  await selectRoom(page, "Your Private Room");
+  await expect(page.getByTestId("message-input")).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+test.describe("Encoded message size gate", () => {
+  test("998 raw chars (encoded 1007 > 1000) disables Send and keeps the draft on Enter", async ({
+    page,
+  }) => {
+    await openRoomWithInput(page);
+    const input = page.getByTestId("message-input");
+    const text = "a".repeat(998); // raw 998 <= 1000, encoded 1007 > 1000
+    await input.fill(text);
+
+    // The gate must count encoded bytes: Send disabled, counter red.
+    await expect(page.getByTestId("send-message-button")).toBeDisabled();
+    await expect(page.getByText(/Message too long/)).toBeVisible();
+    await expect(page.getByText(/1007\/1000/)).toBeVisible();
+
+    // Enter must NOT clear the draft — before the fix the draft was cleared
+    // and the message silently dropped by the encoded-size safety net.
+    await input.press("Enter");
+    await expect(input).toHaveValue(text);
+  });
+
+  test("990 raw chars (encoded 999 <= 1000) shows the encoded count and keeps Send enabled", async ({
+    page,
+  }) => {
+    await openRoomWithInput(page);
+    const input = page.getByTestId("message-input");
+    await input.fill("a".repeat(990)); // encoded 999
+
+    await expect(page.getByText("999/1000")).toBeVisible();
+    await expect(page.getByTestId("send-message-button")).toBeEnabled();
+  });
+
+  test("multi-byte characters count as encoded bytes, not characters", async ({
+    page,
+  }) => {
+    await openRoomWithInput(page);
+    const input = page.getByTestId("message-input");
+    // 499 chars but 998 UTF-8 bytes -> encoded 1007 > 1000. Users count
+    // characters; the limit is bytes. The gate must block this visibly
+    // instead of losing the message after send.
+    await input.fill("é".repeat(499));
+
+    await expect(page.getByTestId("send-message-button")).toBeDisabled();
+    await expect(page.getByText(/Message too long/)).toBeVisible();
+  });
+});

--- a/ui/tests/message-size-gate.spec.ts
+++ b/ui/tests/message-size-gate.spec.ts
@@ -94,4 +94,80 @@ test.describe("Encoded message size gate", () => {
     await expect(page.getByTestId("send-message-button")).toBeDisabled();
     await expect(page.getByText(/Message too long/)).toBeVisible();
   });
+
+  test("a message at exactly the encoded limit is sendable (no off-by-one)", async ({
+    page,
+  }) => {
+    await openRoomWithInput(page);
+    const input = page.getByTestId("message-input");
+    await input.fill("a".repeat(991)); // encoded exactly 1000
+
+    await expect(page.getByText("1000/1000")).toBeVisible();
+    await expect(page.getByTestId("send-message-button")).toBeEnabled();
+  });
+});
+
+// The in-place edit form previously had NO size gate: an over-limit edit
+// action was signed, sent, and silently pruned by contract validation. The
+// edit action (ActionContentV1: target id + payload) carries more overhead
+// than plain text, so the gate must measure the encoded action.
+test.describe("Encoded size gate on the edit form", () => {
+  test("over-limit edit disables Save, shows the counter, and Enter keeps the form open", async ({
+    page,
+  }) => {
+    await openRoomWithInput(page);
+
+    // Open the edit form on an own message — kebab menu on touch devices,
+    // hover actions on desktop (same affordance split as
+    // message-layout.spec.ts / freenet/river#402).
+    const touch = await page.evaluate(
+      () => window.matchMedia("(hover: none)").matches
+    );
+    let clicked = false;
+    if (touch) {
+      const ownRow = page.locator('[id^="msg-"]:has(.bg-accent)').first();
+      await expect(ownRow).toBeVisible();
+      await ownRow.scrollIntoViewIfNeeded();
+      await ownRow.locator('[data-testid="message-kebab"]').click();
+      await page
+        .locator('[data-testid="message-action-menu"]')
+        .getByRole("button", { name: /edit/i })
+        .click();
+      clicked = true;
+    } else {
+      const bubbles = page.locator(".max-w-prose");
+      const count = await bubbles.count();
+      expect(count).toBeGreaterThan(0);
+      for (let i = 0; i < count; i++) {
+        const bubble = bubbles.nth(i);
+        await bubble.scrollIntoViewIfNeeded();
+        await bubble.hover();
+        const editBtn = bubble
+          .locator("xpath=ancestor::*[starts-with(@id,'msg-')][1]")
+          .getByRole("button", { name: /edit/i });
+        if (await editBtn.isVisible({ timeout: 500 }).catch(() => false)) {
+          await editBtn.click();
+          clicked = true;
+          break;
+        }
+      }
+    }
+    expect(clicked, "found an own-message edit affordance").toBe(true);
+
+    const editArea = page.locator('textarea[id^="edit-msg-"]');
+    await expect(editArea).toBeVisible({ timeout: 5_000 });
+
+    // 998 raw chars: within the limit as raw text, over it as an encoded
+    // edit action (ActionContentV1 overhead > plain-text overhead).
+    await editArea.fill("a".repeat(998));
+
+    const saveBtn = page.getByRole("button", { name: /Save/ });
+    await expect(saveBtn).toBeDisabled();
+    await expect(page.getByText(/Message too long/)).toBeVisible();
+
+    // Enter must not discard the over-limit edit — the form stays open.
+    await editArea.press("Enter");
+    await expect(editArea).toBeVisible();
+    await expect(editArea).toHaveValue("a".repeat(998));
+  });
 });


### PR DESCRIPTION
## Problem

HostFat (Matrix, 2026-07): messages near the 1000-byte limit are **silently lost**. The console shows `Message too long: 1006 encoded bytes, max 1000 bytes` for a message under 1000 characters; the draft is already cleared, so the text is gone with no visible error.

The input gate and byte counter compare raw `text.len()` against `max_message_size`, but the contract enforces the **encoded** content size (`RoomMessageBody::content_len`): CBOR framing adds ~9 bytes for plain text, replies embed the quoted author + ~100-char preview (~150 bytes), private rooms add the 16-byte AES-GCM tag. Any message in that gap passes the UI gate, gets its draft cleared, then is dropped by the client safety net (or, failing that, silently pruned by contract validation on every peer). Edits had **no size gate at all** and could be silently pruned the same way.

Closes #430

## Approach

Single source of truth for size: river-core gains `RoomMessageBody::measure_text / measure_reply / measure_edit`, which build the same content the send paths build (identical construction code, so they cannot drift) and add `ENCRYPTION_TAG_OVERHEAD` (16) for private rooms. The UI send gate, byte counter, Send button, and the (new) edit-form gate all use these measures, so the number the user sees is the number the contract enforces. Over-limit drafts stay in the input instead of being lost.

The old silent safety nets remain but now log an error explicitly marked as a measure-drift bug.

riverctl already did this correctly (`guard_message_size` on the built body) and is unchanged.

Alternatives considered: raising `max_message_size` doesn't fix the class (any limit has an encoding gap); subtracting a fixed overhead from the text gate undercounts replies/unicode and drifts.

## Testing

- `measure_tests` in river-core pin `measure_* == content_len()` of actually-built bodies across CBOR length-prefix boundaries, multi-byte UTF-8, reply metadata variants, and — under `ecies-randomized` — real AES-256-GCM private bodies.
- `raw_text_gate_undercounts_encoded_size` pins the bug class itself (998 raw chars → 1007 encoded > 1000; 900-char reply → over).
- New Playwright spec `message-size-gate.spec.ts` pins the user-visible fix: 998 raw chars disables Send, shows `1007/1000`, and **Enter keeps the draft**; 990 chars shows `999/1000` and Send enabled; 499 two-byte chars (998 bytes) disables Send.
- `cargo test -p river-core` (all features): green. `cargo check/clippy -p river-ui` (wasm32): clean.

[AI-assisted - Claude]