### PR TITLE
refactor: adopt freenet-migrate-build codegen for both legacy registries (#398 phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2293,6 +2293,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "freenet-migrate-build"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1f8c31bbf8b6902fa6b1afb866cdba9234578ac8923d6a75f3e6043551db39f"
+dependencies = [
+ "blake3",
+ "bs58",
+ "serde",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -4645,6 +4657,7 @@ dependencies = [
  "curve25519-dalek",
  "data-encoding",
  "ed25519-dalek",
+ "freenet-migrate-build",
  "freenet-scaffold",
  "freenet-scaffold-macro",
  "freenet-stdlib 0.8.3",
@@ -4670,6 +4683,7 @@ dependencies = [
  "dioxus",
  "dioxus-free-icons",
  "ed25519-dalek",
+ "freenet-migrate-build",
  "freenet-scaffold",
  "freenet-stdlib 0.8.3",
  "futures",
@@ -4684,7 +4698,6 @@ dependencies = [
  "serde",
  "sha2",
  "thiserror 2.0.18",
- "toml 0.8.23",
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -6773,7 +6786,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -72,10 +72,9 @@ migration = []
 mentions = []
 
 [build-dependencies]
-# Used by build.rs to parse legacy_room_contracts.toml and generate the
-# LEGACY_ROOM_CONTRACT_CODE_HASHES registry (freenet/river#292).
-serde = { version = "1", features = ["derive"] }
-toml = "0.8"
+# Parses legacy_room_contracts.toml, validates every hash, and generates the
+# LEGACY_ROOM_CONTRACT_CODE_HASHES registry (freenet/river#292, #398).
+freenet-migrate-build = "0.2"
 
 [dev-dependencies]
 rand.workspace = true

--- a/common/build.rs
+++ b/common/build.rs
@@ -6,111 +6,25 @@
 //! `src/migration.rs` to re-derive older-generation contract keys so a
 //! long-dormant room can be recovered. See freenet/river#292.
 //!
-//! This mirrors `ui/build.rs::generate_legacy_delegates()` for the chat
-//! delegate. The TOML lives inside this crate (not at the repo root) so it is
-//! published with `river-core` and riverctl built from crates.io keeps the
-//! full registry.
+//! Codegen is delegated to `freenet-migrate-build` (freenet/river#398): it
+//! parses the existing `[[entry]]` registry, validates every hash at build
+//! time, and emits the same `&[[u8; 32]]` const this script used to hand-roll.
+//! The TOML lives inside this crate (not at the repo root) so it is published
+//! with `river-core` and riverctl built from crates.io keeps the full
+//! registry; `allow_missing_registry` preserves the empty-list fallback for
+//! docs.rs and other non-workspace builds.
 
-use serde::Deserialize;
-use std::env;
-use std::fs;
-use std::path::Path;
-
-#[derive(Deserialize)]
-struct LegacyRoomContracts {
-    entry: Vec<LegacyEntry>,
-}
-
-#[derive(Deserialize)]
-struct LegacyEntry {
-    version: String,
-    description: String,
-    date: String,
-    code_hash: String,
-}
+use freenet_migrate_build::Component;
 
 fn main() {
-    let toml_path = Path::new("legacy_room_contracts.toml");
-    println!("cargo:rerun-if-changed=legacy_room_contracts.toml");
     println!("cargo:rerun-if-changed=build.rs");
-
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let dest = Path::new(&out_dir).join("legacy_room_contracts.rs");
-
-    let toml_content = match fs::read_to_string(toml_path) {
-        Ok(c) => c,
-        Err(e) => {
-            // During docs.rs or other non-workspace builds the file may be
-            // absent; fall back to an empty registry rather than failing.
-            eprintln!("cargo:warning=legacy_room_contracts.toml not found ({e}), using empty list");
-            fs::write(
-                &dest,
-                "pub const LEGACY_ROOM_CONTRACT_CODE_HASHES: &[[u8; 32]] = &[];\n",
-            )
-            .unwrap();
-            return;
-        }
-    };
-
-    let parsed: LegacyRoomContracts =
-        toml::from_str(&toml_content).expect("Failed to parse legacy_room_contracts.toml");
-
-    let mut code = String::new();
-    code.push_str(
-        "// AUTO-GENERATED from legacy_room_contracts.toml — do not edit.\n\
-         // Regenerate by editing legacy_room_contracts.toml and rebuilding.\n\n\
-         pub const LEGACY_ROOM_CONTRACT_CODE_HASHES: &[[u8; 32]] = &[\n",
-    );
-
-    for entry in &parsed.entry {
-        let ch_bytes = hex_to_byte_array(&entry.code_hash, &entry.version);
-        code.push_str(&format!(
-            "    // {}: {} ({})\n",
-            entry.version, entry.description, entry.date
-        ));
-        code.push_str(&format_byte_array(&ch_bytes, "    "));
-    }
-
-    code.push_str("];\n");
-
-    // Only write if the content changed, to avoid spurious recompilation.
-    let existing = fs::read_to_string(&dest).unwrap_or_default();
-    if existing != code {
-        fs::write(&dest, &code).unwrap();
-    }
-}
-
-fn hex_to_byte_array(hex: &str, version: &str) -> [u8; 32] {
-    if hex.len() != 64 {
-        panic!(
-            "{version} code_hash hex string has {} chars, expected 64",
-            hex.len()
-        );
-    }
-    let bytes: Vec<u8> = (0..hex.len())
-        .step_by(2)
-        .map(|i| {
-            u8::from_str_radix(&hex[i..i + 2], 16)
-                .unwrap_or_else(|_| panic!("{version} code_hash has invalid hex"))
-        })
-        .collect();
-    let mut arr = [0u8; 32];
-    arr.copy_from_slice(&bytes);
-    arr
-}
-
-fn format_byte_array(arr: &[u8; 32], indent: &str) -> String {
-    let mut s = format!("{indent}[\n");
-    for chunk in arr.chunks(10) {
-        s.push_str(&format!("{indent}    "));
-        for (i, b) in chunk.iter().enumerate() {
-            if i > 0 {
-                s.push_str(", ");
-            }
-            s.push_str(&format!("{b}"));
-        }
-        s.push_str(",\n");
-    }
-    s.push_str(&format!("{indent}],\n"));
-    s
+    // The crate emits cargo:rerun-if-changed for the TOML itself.
+    freenet_migrate_build::codegen()
+        .entry_registry("legacy_room_contracts.toml", Component::Contract)
+        .canonical_consts(false)
+        .contract_hash_view("LEGACY_ROOM_CONTRACT_CODE_HASHES")
+        .out_file("legacy_room_contracts.rs")
+        .allow_missing_registry(true)
+        .emit()
+        .expect("freenet-migrate-build: generate legacy room-contract hashes");
 }

--- a/common/src/migration.rs
+++ b/common/src/migration.rs
@@ -92,6 +92,24 @@ mod tests {
     use ed25519_dalek::SigningKey;
     use rand::rngs::OsRng;
 
+    /// Value-pin for the generated registry (the room-contract analogue of
+    /// river-ui's `legacy_set_fingerprint_is_stable_across_codegen_changes`):
+    /// blake3 over the code hashes in registry order. Codegen/tooling changes
+    /// (freenet/river#398 moved generation to `freenet-migrate-build`) must
+    /// reproduce the const's exact values AND order — a drift would misdirect
+    /// the dormant-room backward probe. This SHOULD change when a genuinely
+    /// new generation is registered — update the constant then — but must
+    /// NEVER change from a codegen swap.
+    #[test]
+    fn registry_values_and_order_are_stable_across_codegen_changes() {
+        let mut hasher = blake3::Hasher::new();
+        for hash in LEGACY_ROOM_CONTRACT_CODE_HASHES {
+            hasher.update(hash);
+        }
+        assert_eq!(LEGACY_ROOM_CONTRACT_CODE_HASHES.len(), 27);
+        assert_eq!(&hasher.finalize().to_hex()[..16], "d931340e569e9c74");
+    }
+
     #[test]
     fn registry_is_non_empty_and_hashes_are_distinct() {
         // The registry must carry every historical generation; a regression

--- a/common/tests/migration_test.rs
+++ b/common/tests/migration_test.rs
@@ -1,7 +1,11 @@
 //! Validates that legacy_delegates.toml entries are well-formed.
 //!
 //! For entries V3+, verifies that delegate_key = BLAKE3(code_hash_bytes).
-//! V1 and V2 predate the BLAKE3 fix and may use a different derivation.
+//! V1 predates the BLAKE3 fix and uses a different (unreconstructible)
+//! derivation; it is marked `irregular_key = true` in the TOML. V2+ all
+//! derive correctly. (V2 was historically exempted here too, but its key in
+//! fact derives correctly — found when freenet-migrate-build's per-row
+//! cross-check ran against the full registry, freenet/river#398.)
 
 use serde::Deserialize;
 use std::fs;
@@ -98,10 +102,11 @@ fn all_entries_have_valid_hex() {
 fn delegate_key_is_blake3_of_code_hash() {
     let entries = load_entries();
 
-    // V1 and V2 predate the BLAKE3 derivation fix; skip them
+    // V1 predates the BLAKE3 derivation fix; skip it (it carries
+    // `irregular_key = true` in the TOML). V2+ must all derive.
     let verifiable: Vec<&Entry> = entries
         .iter()
-        .filter(|e| !matches!(e.version.as_str(), "V1" | "V2"))
+        .filter(|e| e.version.as_str() != "V1")
         .collect();
 
     assert!(!verifiable.is_empty(), "No verifiable entries (V3+) found");

--- a/legacy_delegates.toml
+++ b/legacy_delegates.toml
@@ -18,6 +18,11 @@ description = "Before signing API was added"
 date = "2026-01-15"
 delegate_key = "1a9330820e806cda54eca7dab22b84f20cfa793ebe61a2615312cc6e6ebcfff6"
 code_hash = "783996bde3bc2235affec9deb8a0f7e9d21fa131dcf003000bb03f467db0f831"
+# V1's recorded delegate_key predates the standard BLAKE3(code_hash) derivation
+# (it derives from nothing reconstructible); the recorded key is what the old
+# delegate actually had on the network, so it is trusted as-is. V2+ all derive
+# correctly and get full validation. See freenet-migrate-build's registry docs.
+irregular_key = true
 
 [[entry]]
 version = "V2"

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -93,5 +93,6 @@ futures-timer = "3.0.3"
 # Add this section for the build script
 [build-dependencies]
 chrono = "0.4"
-toml = "0.8"
-serde = { version = "1", features = ["derive"] }
+# Parses ../legacy_delegates.toml, validates every hash + key derivation, and
+# generates the LEGACY_DELEGATES registry (freenet/river#398).
+freenet-migrate-build = "0.2"

--- a/ui/build.rs
+++ b/ui/build.rs
@@ -1,23 +1,6 @@
 use chrono::Utc;
-use serde::Deserialize;
-use std::env;
-use std::fs;
-use std::path::Path;
+use freenet_migrate_build::Component;
 use std::process::Command;
-
-#[derive(Deserialize)]
-struct LegacyDelegates {
-    entry: Vec<LegacyEntry>,
-}
-
-#[derive(Deserialize)]
-struct LegacyEntry {
-    version: String,
-    description: String,
-    date: String,
-    delegate_key: String,
-    code_hash: String,
-}
 
 fn main() {
     generate_build_info();
@@ -49,105 +32,27 @@ fn generate_build_info() {
     println!("cargo:rustc-env=GIT_COMMIT_HASH={}", git_hash);
 }
 
+/// Generate the `LEGACY_DELEGATES` const from `../legacy_delegates.toml` via
+/// `freenet-migrate-build` (freenet/river#398): same `&[([u8; 32], [u8; 32])]`
+/// shape and (delegate_key, code_hash) order this script used to hand-roll,
+/// with every hash — and each row's `delegate_key` derivation — validated at
+/// build time.
+///
+/// * `.rerun_if_changed(false)`: we intentionally emit NO `cargo:rerun-if-changed`
+///   anywhere in this script — Cargo's default re-run heuristic is what keeps
+///   `BUILD_TIMESTAMP_ISO` fresh, and printing ANY such directive would disable
+///   it. We always regenerate; the crate only rewrites the file when content
+///   changed, so no spurious recompilation.
+/// * `.allow_missing_registry(true)`: the TOML lives at the repo root (outside
+///   this crate), so docs.rs / non-workspace builds fall back to an empty list.
 fn generate_legacy_delegates() {
-    // NOTE: We intentionally do NOT emit cargo:rerun-if-changed here.
-    // The original build.rs relies on always re-running to keep BUILD_TIMESTAMP_ISO
-    // fresh. Adding rerun-if-changed would make Cargo skip re-runs, breaking that.
-    // Instead we always regenerate and only write if content changed.
-    let toml_path = Path::new("..").join("legacy_delegates.toml");
-
-    let toml_content = match fs::read_to_string(&toml_path) {
-        Ok(c) => c,
-        Err(e) => {
-            // During docs.rs or non-workspace builds, the file may not exist
-            eprintln!(
-                "cargo:warning=legacy_delegates.toml not found ({}), using empty list",
-                e
-            );
-            let out_dir = env::var("OUT_DIR").unwrap();
-            let dest = Path::new(&out_dir).join("legacy_delegates.rs");
-            fs::write(
-                dest,
-                "pub const LEGACY_DELEGATES: &[([u8; 32], [u8; 32])] = &[];\n",
-            )
-            .unwrap();
-            return;
-        }
-    };
-
-    let parsed: LegacyDelegates =
-        toml::from_str(&toml_content).expect("Failed to parse legacy_delegates.toml");
-
-    let mut code = String::new();
-    code.push_str(
-        "// AUTO-GENERATED from legacy_delegates.toml — do not edit.\n\
-         // Regenerate by touching legacy_delegates.toml and rebuilding.\n\n\
-         pub const LEGACY_DELEGATES: &[([u8; 32], [u8; 32])] = &[\n",
-    );
-
-    for entry in &parsed.entry {
-        let dk_bytes = hex_to_byte_array(&entry.delegate_key, &entry.version, "delegate_key");
-        let ch_bytes = hex_to_byte_array(&entry.code_hash, &entry.version, "code_hash");
-
-        code.push_str(&format!(
-            "    // {}: {} ({})\n",
-            entry.version, entry.description, entry.date
-        ));
-        code.push_str("    (\n");
-        code.push_str(&format_byte_array(&dk_bytes, "        "));
-        code.push_str(&format_byte_array(&ch_bytes, "        "));
-        code.push_str("    ),\n");
-    }
-
-    code.push_str("];\n");
-
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let dest = Path::new(&out_dir).join("legacy_delegates.rs");
-    // Only write if content changed, to avoid triggering unnecessary recompilation
-    let existing = fs::read_to_string(&dest).unwrap_or_default();
-    if existing != code {
-        fs::write(&dest, &code).unwrap();
-    }
-}
-
-fn hex_to_byte_array(hex: &str, version: &str, field: &str) -> [u8; 32] {
-    if hex.len() != 64 {
-        panic!(
-            "{} {} hex string has {} chars, expected 64",
-            version,
-            field,
-            hex.len()
-        );
-    }
-    let bytes: Vec<u8> = (0..hex.len())
-        .step_by(2)
-        .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).unwrap())
-        .collect();
-    if bytes.len() != 32 {
-        panic!(
-            "{} {} has {} bytes, expected 32",
-            version,
-            field,
-            bytes.len()
-        );
-    }
-    let mut arr = [0u8; 32];
-    arr.copy_from_slice(&bytes);
-    arr
-}
-
-fn format_byte_array(arr: &[u8; 32], indent: &str) -> String {
-    let mut s = format!("{indent}[\n");
-    for chunk in arr.chunks(10) {
-        s.push_str(&format!("{indent}    "));
-        for (i, b) in chunk.iter().enumerate() {
-            if i > 0 {
-                s.push_str(", ");
-            }
-            s.push_str(&format!("{b}"));
-        }
-        s.push_str(",\n");
-    }
-    s.push_str(&format!("{indent}],\n"));
-    s
+    freenet_migrate_build::codegen()
+        .entry_registry("../legacy_delegates.toml", Component::Delegate)
+        .canonical_consts(false)
+        .delegate_pair_view("LEGACY_DELEGATES")
+        .out_file("legacy_delegates.rs")
+        .rerun_if_changed(false)
+        .allow_missing_registry(true)
+        .emit()
+        .expect("freenet-migrate-build: generate legacy delegates");
 }

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -1898,6 +1898,20 @@ mod tests {
         assert!(key.ends_with(&fp));
     }
 
+    /// The legacy-set fingerprint is derived from `LEGACY_DELEGATES`'s exact
+    /// contents AND order, and it keys the per-user "migration done"
+    /// localStorage flag — so any change to how the const is GENERATED
+    /// (freenet/river#398 moved codegen to `freenet-migrate-build`) must
+    /// reproduce it byte-identically, or every user silently re-runs legacy
+    /// migration once. Pinned to the value computed from the current
+    /// `legacy_delegates.toml` (24 entries, V1..V24 file order). This value
+    /// SHOULD change when a genuinely new legacy entry is added — update the
+    /// constant then — but must NEVER change from a codegen/tooling swap.
+    #[test]
+    fn legacy_set_fingerprint_is_stable_across_codegen_changes() {
+        assert_eq!(legacy_set_fingerprint(), "741360a5d34a3a8c");
+    }
+
     /// The "migration in progress" and "migration done" localStorage keys MUST
     /// be distinct — they're set/cleared independently, and a shared key would
     /// make clearing one corrupt the other (freenet/river#345 follow-up: the

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -1904,7 +1904,8 @@ mod tests {
     /// (freenet/river#398 moved codegen to `freenet-migrate-build`) must
     /// reproduce it byte-identically, or every user silently re-runs legacy
     /// migration once. Pinned to the value computed from the current
-    /// `legacy_delegates.toml` (24 entries, V1..V24 file order). This value
+    /// `legacy_delegates.toml` (24 entries spanning V1..V27 — V4–V6 removed —
+    /// in file order). This value
     /// SHOULD change when a genuinely new legacy entry is added — update the
     /// constant then — but must NEVER change from a codegen/tooling swap.
     #[test]


### PR DESCRIPTION
## Problem

River's two legacy registries (`legacy_delegates.toml`, `common/legacy_room_contracts.toml`) are turned into Rust consts by two hand-rolled build scripts — a duplicated copy of the exact pattern the `freenet-migrate` crate generalizes, with no validation beyond hex-length panics. The crate's own origin app doesn't dogfood it (#398).

## Approach

Phase 1 of #398 (deliberately minimal + behavior-preserving): swap only **who generates the consts**. River keeps running its own migration machinery unchanged.

- `common/build.rs` + `ui/build.rs` now call `freenet_migrate_build::codegen()` (0.2.0, freenet/freenet-migrate#4) reading the **existing** `[[entry]]` TOMLs — same const names, types, `(delegate_key, code_hash)` tuple order, and byte values. −233/+89 lines.
- Every build now **validates** the registries: hash decode errors are build failures, and every delegate row's key is cross-checked against `BLAKE3(code_hash ‖ params)` — restoring at build time the compile check the ecosystem lost (the Feb 2026 wrong-derivation incident class).
- `ui/build.rs` behaviors preserved: `.rerun_if_changed(false)` keeps the `BUILD_TIMESTAMP_ISO` re-run heuristic alive; `.allow_missing_registry(true)` keeps the docs.rs missing-TOML fallback. `common/build.rs` keeps its rerun directives + fallback.

**Registry data finding** (from running the crate's validation over the full 24-row registry): **V1** is the only row whose recorded delegate key predates the standard derivation — it now carries `irregular_key = true` (recorded key trusted as-is; it's the key the old delegate actually had on the network). **V2's key derives correctly**, so `migration_test.rs`'s historical "V1 | V2" exemption was over-broad and is tightened to V1 only — V2 now gets full validation it never had.

## Testing

- **New pin:** `legacy_set_fingerprint_is_stable_across_codegen_changes` locks the legacy-set fingerprint (`741360a5d34a3a8c`) that keys the per-user migration-done localStorage flag. If a codegen change altered `LEGACY_DELEGATES` bytes **or order**, every user would silently re-run legacy migration — this test makes that loud. It passing on this PR is the proof the swap is byte-identical.
- 480 river-ui native tests pass; `migration_test` + `room_contract_migration_test` pass; `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync` clean.
- No WASM files touched; `check-delegate-migration` / `check-room-contract-migration` / `check-cli-wasm` CI confirm byte-identical WASMs.

The crate side merged as freenet/freenet-migrate#4 (Full-tier multi-perspective review; its fixtures include River's complete registries verbatim, so the exact data this PR feeds it is pinned upstream too).

Next phases of #398 (separate PRs, after this): contract-probe internals on the crate's decision driver, then the delegate path in shadow mode.

Part of #398 / freenet-core#2776.

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wJpXbgCrnkSKgkpmnLGwQ