### PR TITLE
refactor(ui): drive the backward probe with freenet-migrate's decision driver (#398 phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2296,6 +2296,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "freenet-migrate"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80de2864555343441300c6fa1aced20f989ec16657d651be3bb30bff1d1224c8"
+dependencies = [
+ "blake3",
+ "bs58",
+ "ciborium",
+ "ed25519-dalek",
+ "freenet-scaffold",
+ "freenet-stdlib 0.8.3",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
 name = "freenet-migrate-build"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4683,6 +4699,7 @@ dependencies = [
  "dioxus",
  "dioxus-free-icons",
  "ed25519-dalek",
+ "freenet-migrate",
  "freenet-migrate-build",
  "freenet-scaffold",
  "freenet-stdlib 0.8.3",

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -86,6 +86,10 @@ river-core = { workspace = true, features = ["ecies", "ecies-randomized", "migra
 # Freenet dependencies
 freenet-scaffold.workspace = true
 freenet-stdlib = { workspace = true, features = ["net"] }
+# Sans-IO backward-probe decision driver (freenet/river#398 phase 2). The `ui`
+# default profile exposes the probe/driver surface; its stdlib dep unifies with
+# the workspace's 0.8.x.
+freenet-migrate = "0.3"
 
 futures = "0.3.30"
 futures-timer = "3.0.3"

--- a/ui/src/components/app/freenet_api/backward_probe.rs
+++ b/ui/src/components/app/freenet_api/backward_probe.rs
@@ -18,18 +18,33 @@
 //! * Neither current nor any legacy key has state → only then is the device's
 //!   local snapshot PUT to seed the current key.
 //!
+//! ## The decision driver (freenet/river#398 phase 2)
+//!
+//! The probe *decisions* — candidate order (newest-first), what counts as a
+//! hit, when to advance, when to stop, what to adopt — live in
+//! `freenet_migrate`'s sans-IO [`ProbeDriver`]. This module is the thin I/O
+//! adapter: it pumps GETs and timeouts through the driver and runs the app's
+//! recover-or-seed side effects on the terminal [`Outcome`]. River's
+//! app-specific semantics (CBOR decode, "is this real state", CRDT-merge with
+//! the local snapshot) are supplied by [`RiverProbeOps`].
+//!
+//! The driver's per-candidate correlation is single-shot by construction, so
+//! there is no cross-probe epoch machinery to get wrong (the previous
+//! hand-rolled state machine carried one; it is gone).
+//!
 //! ## Routing & bookkeeping
 //!
 //! A GET response for a *legacy* contract key cannot be resolved back to an
 //! `owner_vk` via `SYNC_INFO` (keyed by the current contract id) or via
-//! `RoomData::contract_key` (also the current id). [`BACKWARD_PROBES`] is the
-//! side-table that maps a probe's legacy `ContractInstanceId` back to the probe
-//! it belongs to.
+//! `RoomData::contract_key` (also the current id). [`PROBE_ROUTES`] is the
+//! side-table that maps the outstanding legacy `ContractInstanceId` back to the
+//! owner whose probe it belongs to; [`PROBE_DRIVERS`] holds one in-flight
+//! [`ProbeDriver`] per owner.
 //!
-//! It is a plain `Mutex`-guarded map, NOT a Dioxus signal: it is internal
-//! bookkeeping with zero UI reactivity (no component or memo ever reads it),
-//! so it must not carry signal semantics. This is the same shape as
-//! `chat_delegate::ENSURE_SUBSCRIPTION_SENT`. Using a plain `Mutex` means
+//! Both are plain `Mutex`-guarded maps, NOT Dioxus signals: internal
+//! bookkeeping with zero UI reactivity (no component or memo ever reads them),
+//! so they must not carry signal semantics. This is the same shape as
+//! `chat_delegate::ENSURE_SUBSCRIPTION_SENT`. Using plain `Mutex`es means
 //! mutations need no `defer()` and cannot cause a re-entrant signal borrow.
 //!
 //! ## Liveness — every probe GET has a watchdog
@@ -37,29 +52,41 @@
 //! A legacy generation whose contract has been garbage-collected from the
 //! network may never produce a `GetResponse`. Every probe GET is therefore
 //! paired with a [`PROBE_GET_TIMEOUT`] watchdog: if the response has not
-//! arrived by then, the watchdog synthesizes an empty response so the probe
+//! arrived by then, the watchdog counts the generation as a miss so the driver
 //! advances to the next generation (and ultimately seeds the current key)
 //! rather than stalling forever. Without this a dormant room — exactly what
-//! this feature targets — could be left permanently stuck.
+//! this feature targets — could be left permanently stuck. Whichever of
+//! {response, watchdog} removes the route first owns the hop; the loser finds
+//! the route gone and no-ops (single-shot).
 
 use crate::components::app::freenet_api::constants::REPUT_DELAY_MS;
+use crate::components::app::freenet_api::response_handler::get_response::{
+    adopt_recovered_probe_state, merge_room_states, seed_current_key_with_local,
+};
 use crate::components::app::sync_info::SYNC_INFO;
-use crate::util::{owner_vk_to_legacy_contract_keys, safe_spawn_local, sleep, to_cbor_vec};
+use crate::util::{owner_vk_to_legacy_contract_keys, safe_spawn_local, sleep, try_from_cbor_slice};
 use dioxus::logger::tracing::{info, warn};
 use ed25519_dalek::VerifyingKey;
+use freenet_migrate::{
+    NewestFirst, Outcome, ProbeDriver, ProbeStateOps, SelectionPolicy, Step, DEFAULT_MAX_PROBE_HOPS,
+};
 use freenet_stdlib::client_api::{ClientRequest, ContractRequest};
-use freenet_stdlib::prelude::{ContractInstanceId, ContractKey};
-use river_core::room_state::ChatRoomStateV1;
+use freenet_stdlib::prelude::ContractInstanceId;
+use river_core::room_state::member::MemberId;
+use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1};
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{LazyLock, Mutex, MutexGuard};
 use std::time::Duration;
 
-/// Hard cap on how many legacy generations a single probe will walk before
-/// giving up. `owner_vk_to_legacy_contract_keys` is already bounded by the
-/// size of the legacy registry; this is defence-in-depth against a runaway
-/// chain if the registry ever grows unexpectedly large.
-const MAX_PROBE_HOPS: usize = 64;
+/// River caps a probe walk at 64 legacy generations (defence-in-depth against a
+/// runaway chain if the legacy registry ever grows unexpectedly large). That
+/// cap is now the driver's default hop count; pin the two together so River's
+/// long-standing bound cannot silently drift if the crate default changes.
+const _: () = assert!(
+    DEFAULT_MAX_PROBE_HOPS == 64,
+    "River relies on the 64-hop backward-probe cap; if freenet_migrate's default \
+     changed, set it explicitly via ProbeDriver::with_max_hops"
+);
 
 /// How long to wait for a probe GET response before treating the legacy
 /// generation as absent and advancing. An existing contract responds well
@@ -75,189 +102,235 @@ const _: () = assert!(
     "PROBE_GET_TIMEOUT must stay below REPUT_DELAY_MS or a probe is reclaimed mid-walk"
 );
 
-/// State of an in-progress backward probe for one room.
-#[derive(Clone)]
-pub struct ProbeState {
-    /// The owner whose stranded room we're recovering.
-    pub owner_vk: VerifyingKey,
-    /// Legacy contract keys not yet tried, ordered newest-first. The key
-    /// currently outstanding (whose GET we're awaiting) is NOT in this list —
-    /// it is the `BACKWARD_PROBES` map key.
-    pub remaining: Vec<ContractKey>,
-    /// Hops taken so far, for the [`MAX_PROBE_HOPS`] cap.
-    pub hops: usize,
-    /// The device's local room snapshot, captured when the probe started.
-    /// Used to (a) CRDT-merge with any recovered state before PUTting it
-    /// forward, so unsynced local edits are not dropped, and (b) seed the
-    /// current key as the genuine last resort if every generation is empty.
-    /// Captured up front so the seed path never depends on a fallible signal
-    /// read at probe-completion time.
-    pub local_snapshot: ChatRoomStateV1,
-    /// Unique token for this outstanding GET. The timeout watchdog captures it
-    /// and only fires if the entry still carries the SAME epoch — so a stale
-    /// watchdog from a completed probe cannot consume a later probe's entry
-    /// that happens to re-use the same legacy contract id.
-    pub epoch: u64,
+/// River's app-supplied state semantics for the sans-IO decision driver: how to
+/// decode a legacy GET response, whether it is *real* state, and how to fold it
+/// with the device's local snapshot. Everything else (candidate order,
+/// single-shot correlation, exhaustion) is owned by the driver.
+struct RiverProbeOps {
+    /// The owner whose stranded room this probe is recovering.
+    owner_vk: VerifyingKey,
 }
 
-/// Monotonic source of [`ProbeState::epoch`] values.
-static PROBE_EPOCH: AtomicU64 = AtomicU64::new(0);
+impl ProbeStateOps for RiverProbeOps {
+    type State = ChatRoomStateV1;
 
-/// Maps the `ContractInstanceId` of the currently-outstanding legacy GET to
-/// the probe it belongs to. Plain `Mutex` map — see the module docs.
-static BACKWARD_PROBES: LazyLock<Mutex<HashMap<ContractInstanceId, ProbeState>>> =
+    fn decode(&self, bytes: &[u8]) -> Option<ChatRoomStateV1> {
+        // Defensive decode: the probe walks many historical generations, and a
+        // very old one may carry a `ChatRoomStateV1` layout the current type
+        // cannot decode. `None` marks the candidate a miss so the driver
+        // advances rather than panicking — matching the CLI's `try_get_state`.
+        try_from_cbor_slice::<ChatRoomStateV1>(bytes)
+    }
+
+    fn is_real(&self, state: &ChatRoomStateV1) -> bool {
+        // "Real" == the configuration signature verifies against the owner (a
+        // default/placeholder state is signed by the all-zero key and fails).
+        // This is the same predicate as `RoomData::is_awaiting_initial_sync`
+        // and the current-key probe-start gate.
+        state.configuration.verify_signature(&self.owner_vk).is_ok()
+    }
+
+    fn merge_with_local(
+        &self,
+        recovered: ChatRoomStateV1,
+        local: &ChatRoomStateV1,
+    ) -> ChatRoomStateV1 {
+        // CRDT-merge the recovered legacy state (primary) with the device's
+        // local snapshot BEFORE it is PUT forward, so unsynced local edits the
+        // device made offline are not dropped. On a genuine merge failure this
+        // keeps the recovered state alone (the shipped keep-primary behavior).
+        let params = ChatRoomParametersV1 {
+            owner: self.owner_vk,
+        };
+        merge_room_states(recovered, local, &params)
+    }
+
+    // `prepare_forward` stays the driver default (identity) on purpose: River
+    // adopts the UNSTRIPPED merged state locally and strips the upgrade pointer
+    // ONLY inside `put_state_to_current_key` (freenet/river#427). Overriding it
+    // here would strip too early and change what is adopted locally — do NOT
+    // add a prepare_forward override; the strip belongs on the forward PUT.
+}
+
+/// Maps the `ContractInstanceId` of the currently-outstanding legacy probe GET
+/// back to the owner whose probe it belongs to. Plain `Mutex` map — see the
+/// module docs. The presence of an entry is what makes a legacy-key GET
+/// response route into the probe handler ([`is_probe_instance`]).
+static PROBE_ROUTES: LazyLock<Mutex<HashMap<ContractInstanceId, VerifyingKey>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-/// Lock the probe table, recovering from a poisoned mutex (a panic while the
+/// One in-flight [`ProbeDriver`] per owner. The driver owns the sans-IO probe
+/// decision state; this module only pumps I/O through it. Deduplicating
+/// concurrent probes for one owner is our job (see [`start_backward_probe`]).
+static PROBE_DRIVERS: LazyLock<Mutex<HashMap<VerifyingKey, ProbeDriver<RiverProbeOps>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Lock the route table, recovering from a poisoned mutex (a panic while the
 /// lock was held must not wedge all future recovery).
-fn probes() -> MutexGuard<'static, HashMap<ContractInstanceId, ProbeState>> {
-    BACKWARD_PROBES.lock().unwrap_or_else(|e| e.into_inner())
+fn routes() -> MutexGuard<'static, HashMap<ContractInstanceId, VerifyingKey>> {
+    PROBE_ROUTES.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Lock the driver table, recovering from a poisoned mutex.
+fn drivers() -> MutexGuard<'static, HashMap<VerifyingKey, ProbeDriver<RiverProbeOps>>> {
+    PROBE_DRIVERS.lock().unwrap_or_else(|e| e.into_inner())
 }
 
 /// Whether `instance_id` is the contract id of an outstanding backward-probe
 /// GET. Used by `handle_get_response` to route legacy-key responses.
 pub fn is_probe_instance(instance_id: &ContractInstanceId) -> bool {
-    probes().contains_key(instance_id)
+    routes().contains_key(instance_id)
 }
 
-/// Whether the outstanding probe for `instance_id` still carries `epoch`. The
-/// timeout watchdog uses this so it acts only on the exact probe GET it was
-/// armed for — never on a later probe that re-used the same contract id.
-fn probe_has_epoch(instance_id: &ContractInstanceId, epoch: u64) -> bool {
-    probes().get(instance_id).map(|p| p.epoch) == Some(epoch)
-}
-
-/// Take (remove) the probe entry for `instance_id`, if any. The caller has
-/// just received (or synthesized, on timeout) the GET response for that
-/// legacy key and is now responsible for either recovering the state or
-/// advancing to the next hop.
-pub fn take_probe(instance_id: &ContractInstanceId) -> Option<ProbeState> {
-    probes().remove(instance_id)
-}
-
-/// Start a backward probe for `owner_vk`'s room: GET the newest legacy
-/// contract key. Called when the current-key GET came back empty.
+/// Start a backward probe for `owner_vk`'s room: build the driver over the
+/// owner's legacy generations (newest-first) and pump the first GET. Called
+/// when the current-key GET came back empty.
 ///
-/// `local_snapshot` is the device's current room state, captured by the
-/// caller; it rides along in [`ProbeState`] for the merge / last-resort seed.
+/// `local_snapshot` is the device's current room state, captured by the caller;
+/// it is moved into the driver for the merge / last-resort seed.
 ///
-/// Returns `true` if a probe is in flight (one was started, or one was
-/// already running for this owner) — the caller must then NOT seed the
-/// current key; the probe owns recovery-or-seed. Returns `false` only when
-/// there are no legacy generations at all, in which case the caller falls
-/// back to seeding the current key itself.
-pub fn start_backward_probe(owner_vk: VerifyingKey, local_snapshot: ChatRoomStateV1) -> bool {
-    let mut legacy_keys = owner_vk_to_legacy_contract_keys(&owner_vk);
+/// Returns `true` if a probe is in flight (one was started, or one was already
+/// running for this owner) — the caller must then NOT seed the current key; the
+/// probe owns recovery-or-seed. Returns `false` only when there are no legacy
+/// generations at all, in which case the caller falls back to seeding the
+/// current key itself.
+pub async fn start_backward_probe(owner_vk: VerifyingKey, local_snapshot: ChatRoomStateV1) -> bool {
+    let legacy_keys = owner_vk_to_legacy_contract_keys(&owner_vk);
     if legacy_keys.is_empty() {
         info!(
             "No legacy room-contract generations — skipping backward probe for {:?}",
-            river_core::room_state::member::MemberId::from(owner_vk)
+            MemberId::from(owner_vk)
         );
         return false;
     }
 
     // Don't start a second probe for an owner that already has one running.
-    // Return `true` so the caller still treats recovery as in-flight.
-    //
-    // There is no gap to race here: a probe always has exactly one
-    // `BACKWARD_PROBES` entry while in flight. `handle_probe_get_response`
-    // runs `take_probe` → `advance_backward_probe` → `fire_probe_get`
-    // (which re-inserts the next hop) with NO `.await` in between, so on
-    // single-threaded WASM no other task — including this guard — can
-    // observe the table mid-advance.
-    if probes().values().any(|p| p.owner_vk == owner_vk) {
+    // Return `true` so the caller still treats recovery as in-flight. A probe's
+    // driver entry lives from here until its terminal Outcome (removed in
+    // `pump_probe`'s Done branch), so a completed probe leaves no entry and a
+    // later probe for the same owner can start fresh.
+    if drivers().contains_key(&owner_vk) {
         info!(
             "Backward probe already in progress for {:?}, not restarting",
-            river_core::room_state::member::MemberId::from(owner_vk)
+            MemberId::from(owner_vk)
         );
         return true;
     }
 
-    // The newest legacy key becomes the outstanding GET; the rest stay in
-    // `remaining` for subsequent hops.
-    let first = legacy_keys.remove(0);
     info!(
         "Starting backward probe for {:?}: {} legacy generation(s) to try",
-        river_core::room_state::member::MemberId::from(owner_vk),
-        legacy_keys.len() + 1
+        MemberId::from(owner_vk),
+        legacy_keys.len()
     );
-    fire_probe_get(owner_vk, first, legacy_keys, 1, local_snapshot);
-    true
-}
 
-/// Advance an in-progress probe to its next legacy key. Called when a legacy
-/// GET came back empty (or its watchdog fired).
-///
-/// Returns `true` if the probe advanced (a GET for the next legacy key was
-/// fired). Returns `false` when the probe is exhausted — every legacy
-/// generation has been tried and none held real state. On `false` the caller
-/// performs the last-resort seed of the current contract key with the
-/// device's local snapshot.
-pub fn advance_backward_probe(state: ProbeState) -> bool {
-    let ProbeState {
-        owner_vk,
-        mut remaining,
-        hops,
+    // `owner_vk_to_legacy_contract_keys` is newest-first BY CONSTRUCTION — it
+    // reverses the oldest-first registry (see `legacy_contract_keys_for_owner`)
+    // — so `assume_ordered` is sound. The whole anti-rollback guarantee rests
+    // on this order: probing newest-first and stopping at the first real state
+    // means an older generation can never shadow a newer one.
+    let candidates = NewestFirst::assume_ordered(legacy_keys.iter().map(|k| *k.id()).collect());
+    let driver = ProbeDriver::new(
+        RiverProbeOps { owner_vk },
         local_snapshot,
-        epoch: _, // each hop's GET gets a fresh epoch from `fire_probe_get`
-    } = state;
-
-    if remaining.is_empty() {
-        info!(
-            "Backward probe for {:?} exhausted all legacy generations — \
-             no stranded state found",
-            river_core::room_state::member::MemberId::from(owner_vk)
-        );
-        return false;
-    }
-    if hops >= MAX_PROBE_HOPS {
-        warn!(
-            "Backward probe for {:?} hit MAX_PROBE_HOPS ({}) — aborting",
-            river_core::room_state::member::MemberId::from(owner_vk),
-            MAX_PROBE_HOPS
-        );
-        return false;
-    }
-
-    let next = remaining.remove(0);
-    fire_probe_get(owner_vk, next, remaining, hops + 1, local_snapshot);
+        candidates,
+        // River adopts exactly one generation (the newest real one) and never
+        // reads older ones — safe for delete-by-absence state (pruned messages
+        // stay pruned). The 64-hop cap is the driver default (asserted above).
+        SelectionPolicy::NewestFirstWins,
+    );
+    drivers().insert(owner_vk, driver);
+    pump_probe(owner_vk).await;
     true
 }
 
-/// Register `key` as the outstanding probe GET for `owner_vk`, send the GET,
-/// and arm a watchdog so an absent legacy generation cannot stall the probe.
-fn fire_probe_get(
-    owner_vk: VerifyingKey,
-    key: ContractKey,
-    remaining: Vec<ContractKey>,
-    hops: usize,
-    local_snapshot: ChatRoomStateV1,
-) {
-    let instance_id = *key.id();
-    let epoch = PROBE_EPOCH.fetch_add(1, Ordering::Relaxed);
+/// Deliver a legacy-key GET response into its owner's probe driver, then pump.
+/// The response's contract id (`id`) was registered by [`fire_probe_get`]; the
+/// FIRST of {this response, the watchdog} to remove the route owns the hop
+/// (single-shot). Unknown ids are the race-loser and no-op.
+pub(crate) async fn deliver_probe_response(id: ContractInstanceId, bytes: Vec<u8>) {
+    let Some(owner_vk) = routes().remove(&id) else {
+        // The route was already consumed — e.g. the timeout watchdog fired
+        // first. Whichever ran first owns the outcome; the loser lands here.
+        warn!("Probe GET response for {id} had no matching probe entry — ignoring");
+        return;
+    };
+    {
+        let mut drivers = drivers();
+        if let Some(driver) = drivers.get_mut(&owner_vk) {
+            driver.on_response(id, &bytes);
+        }
+    }
+    pump_probe(owner_vk).await;
+}
 
-    // Register the probe BEFORE sending the GET so the response handler can
-    // resolve the legacy key when the reply arrives. Plain mutex — synchronous,
-    // no defer, no signal re-entrancy.
-    probes().insert(
-        instance_id,
-        ProbeState {
-            owner_vk,
-            remaining,
-            hops,
-            local_snapshot,
-            epoch,
-        },
-    );
+/// Drive the probe for `owner_vk` one decision forward: ask the driver what to
+/// do next, then either fire a legacy GET (arming a watchdog) or, when the
+/// probe is finished, run the recover-or-seed side effects on its [`Outcome`].
+async fn pump_probe(owner_vk: VerifyingKey) {
+    let step = {
+        let mut drivers = drivers();
+        let Some(driver) = drivers.get_mut(&owner_vk) else {
+            // Driver already finished and was removed — nothing to pump.
+            return;
+        };
+        driver.next_action()
+    };
 
-    // Keep the room out of the subscription-timeout sweep: a probe in flight
-    // IS active subscription progress. Each hop refreshes `subscribing_since`
-    // (hops are <= PROBE_GET_TIMEOUT apart, below REPUT_DELAY_MS — see the
-    // compile-time assert above), so `rooms_awaiting_subscription` does not
-    // reclaim the room mid-probe and re-issue a redundant GET / duplicate
-    // probe. `touch_subscribing_since` only refreshes the timestamp — it does
-    // not force the status — so it no-ops harmlessly if the room is absent
-    // from SYNC_INFO or has genuinely already reached `Subscribed`.
+    match step {
+        Step::Get(id) => fire_probe_get(owner_vk, id),
+        Step::Done => {
+            let outcome = drivers().get_mut(&owner_vk).and_then(|d| d.take_outcome());
+            // Probe finished — drop the driver so a future probe for this owner
+            // can start fresh, and so the dedup guard reads "not in flight".
+            drivers().remove(&owner_vk);
+            match outcome {
+                Some(Outcome::Recovered { merged, source, .. }) => {
+                    info!(
+                        "Backward probe for room {:?} recovered real state from legacy contract \
+                         {} — adopting and PUTting forward onto the current key",
+                        MemberId::from(owner_vk),
+                        source
+                    );
+                    adopt_recovered_probe_state(owner_vk, merged).await;
+                }
+                // Exhaustion (SeedLocal) and the no-legacy edge (NoLegacy, which
+                // `start_backward_probe` guards against but the driver can still
+                // produce) both PUT the device's local snapshot forward as the
+                // genuine last resort — the only path on which local state is
+                // seeded onto the network (the core design principle of #292).
+                Some(Outcome::SeedLocal { local }) | Some(Outcome::NoLegacy { local }) => {
+                    info!(
+                        "Backward probe for room {:?} exhausted — seeding current contract key \
+                         with the local snapshot (last resort)",
+                        MemberId::from(owner_vk)
+                    );
+                    seed_current_key_with_local(owner_vk, local).await;
+                }
+                None => {
+                    // Outcome already taken (a duplicate pump) — nothing to do.
+                }
+            }
+        }
+    }
+}
+
+/// Register `id` as the outstanding probe GET for `owner_vk`, send the GET, and
+/// arm a watchdog so an absent legacy generation cannot stall the probe.
+fn fire_probe_get(owner_vk: VerifyingKey, id: ContractInstanceId) {
+    // Register the route BEFORE sending the GET so the response handler can
+    // resolve the legacy key when the reply arrives (and so `is_probe_instance`
+    // routes it into the probe handler). Plain mutex — synchronous, no defer,
+    // no signal re-entrancy.
+    routes().insert(id, owner_vk);
+
+    // Keep the room out of the subscription-timeout sweep: a probe in flight IS
+    // active subscription progress. Each hop refreshes `subscribing_since` (hops
+    // are <= PROBE_GET_TIMEOUT apart, below REPUT_DELAY_MS — see the compile-time
+    // assert above), so `rooms_awaiting_subscription` does not reclaim the room
+    // mid-probe and re-issue a redundant GET / duplicate probe.
+    // `touch_subscribing_since` only refreshes the timestamp — it does not force
+    // the status — so it no-ops harmlessly if the room is absent from SYNC_INFO
+    // or has genuinely already reached `Subscribed`.
     crate::util::defer(move || {
         SYNC_INFO.with_mut(|sync_info| {
             sync_info.touch_subscribing_since(&owner_vk);
@@ -265,15 +338,14 @@ fn fire_probe_get(
     });
 
     info!(
-        "Backward probe hop {} for {:?}: GET legacy contract {}",
-        hops,
-        river_core::room_state::member::MemberId::from(owner_vk),
-        instance_id
+        "Backward probe for {:?}: GET legacy contract {}",
+        MemberId::from(owner_vk),
+        id
     );
 
     safe_spawn_local(async move {
         let get_request = ContractRequest::Get {
-            key: instance_id,
+            key: id,
             // Legacy generations need their own WASM cached for the GET to
             // resolve on a node that has never seen that contract.
             return_contract_code: true,
@@ -286,33 +358,34 @@ fn fire_probe_get(
             Ok(()) // WebAPI gone — let the watchdog drive the probe forward.
         };
         if let Err(e) = send_result {
-            warn!("Failed to send backward-probe GET for {instance_id}: {e}");
-            // Leave the entry in place: the watchdog below treats the missing
-            // response as empty and advances the probe, so a transient send
+            warn!("Failed to send backward-probe GET for {id}: {e}");
+            // Leave the route in place: the watchdog below treats the missing
+            // response as a miss and advances the probe, so a transient send
             // failure still walks to the next generation rather than silently
             // abandoning recovery.
         }
     });
 
-    // Watchdog: if no real GET response consumes THIS probe entry (matched by
-    // epoch, so a stale watchdog from a finished probe can't fire against a
-    // later probe that re-used the same contract id) within PROBE_GET_TIMEOUT,
-    // synthesize an empty response so the probe advances.
+    // Watchdog: if no GET response consumes THIS route within PROBE_GET_TIMEOUT,
+    // count the legacy generation as a miss and advance. The route-removal race
+    // makes this single-shot — whichever of {response, watchdog} removes the
+    // route first owns the hop; the loser finds it gone and no-ops. This
+    // subsumes the old per-probe epoch machinery.
     safe_spawn_local(async move {
         sleep(PROBE_GET_TIMEOUT).await;
-        if probe_has_epoch(&instance_id, epoch) {
+        if routes().remove(&id) == Some(owner_vk) {
             warn!(
-                "Backward-probe GET for {instance_id} timed out after {}s — \
-                 treating the legacy generation as absent and advancing",
+                "Backward-probe GET for {id} timed out after {}s — treating the legacy \
+                 generation as absent and advancing",
                 PROBE_GET_TIMEOUT.as_secs()
             );
-            // An empty/default state routes through the same handler as a real
-            // empty response: it advances the probe, or seeds on exhaustion.
-            let empty = to_cbor_vec(&ChatRoomStateV1::default());
-            crate::components::app::freenet_api::response_handler::get_response::handle_probe_get_response(
-                key, empty,
-            )
-            .await;
+            if let Some(driver) = drivers().get_mut(&owner_vk) {
+                driver.on_timeout(id);
+            }
+            // Box the recursive pump: `pump_probe` arms this watchdog, so an
+            // un-boxed self-call would make the async fn's future infinitely
+            // sized. The box breaks the type cycle.
+            Box::pin(pump_probe(owner_vk)).await;
         }
     });
 }
@@ -320,85 +393,201 @@ fn fire_probe_get(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ed25519_dalek::SigningKey;
+    use river_core::room_state::configuration::{AuthorizedConfigurationV1, Configuration};
 
-    fn test_owner(seed: u8) -> VerifyingKey {
-        ed25519_dalek::SigningKey::from_bytes(&[seed; 32]).verifying_key()
+    fn owner(seed: u8) -> (SigningKey, VerifyingKey) {
+        let sk = SigningKey::from_bytes(&[seed; 32]);
+        let vk = sk.verifying_key();
+        (sk, vk)
     }
 
-    /// `advance_backward_probe` with an empty `remaining` must report
-    /// exhaustion (`false`) — the probe ends, no panic, no further GET. The
-    /// caller uses the `false` return to seed the current contract key.
+    /// A room state with a genuine owner-signed configuration — what a legacy
+    /// generation holding real state returns.
+    fn signed_state(sk: &SigningKey) -> ChatRoomStateV1 {
+        ChatRoomStateV1 {
+            configuration: AuthorizedConfigurationV1::new(Configuration::default(), sk),
+            ..Default::default()
+        }
+    }
+
+    fn encode(state: &ChatRoomStateV1) -> Vec<u8> {
+        crate::util::to_cbor_vec(state)
+    }
+
+    fn id(n: u8) -> ContractInstanceId {
+        ContractInstanceId::new([n; 32])
+    }
+
+    /// `RiverProbeOps` classification is exactly what the deleted
+    /// `handle_probe_get_response` applied inline: a default/placeholder state
+    /// is NOT real (its signature does not verify → a miss), an owner-signed
+    /// state IS real (a hit), and undecodable bytes decode to `None` (a miss so
+    /// the probe advances rather than panicking).
     #[test]
-    fn advance_with_empty_remaining_reports_exhausted() {
-        let advanced = advance_backward_probe(ProbeState {
-            owner_vk: test_owner(3),
-            remaining: Vec::new(),
-            hops: 1,
-            local_snapshot: ChatRoomStateV1::default(),
-            epoch: 0,
-        });
+    fn river_probe_ops_classifies_real_decodable_and_garbage() {
+        let (sk, vk) = owner(1);
+        let ops = RiverProbeOps { owner_vk: vk };
+
+        let real = signed_state(&sk);
         assert!(
-            !advanced,
-            "an exhausted probe must report false so the caller seeds the current key"
+            ops.is_real(&real),
+            "owner-signed configuration must be real"
+        );
+
+        let empty = ChatRoomStateV1::default();
+        assert!(
+            !ops.is_real(&empty),
+            "default state must NOT be real (a miss)"
+        );
+
+        assert!(
+            ops.decode(&encode(&real)).is_some(),
+            "valid CBOR must decode"
+        );
+        assert!(
+            ops.decode(&[0xffu8; 8]).is_none(),
+            "undecodable bytes must map to None (a miss, never a panic)"
         );
     }
 
-    /// A probe that has hit `MAX_PROBE_HOPS` must also report exhaustion
-    /// (`false`) even when `remaining` is non-empty — the runaway guard must
-    /// not silently swallow the need to seed.
+    /// `prepare_forward` MUST be identity. River strips the upgrade pointer only
+    /// in `put_state_to_current_key` (freenet/river#427) and adopts the
+    /// UNSTRIPPED merged state locally; if `RiverProbeOps` ever stripped in
+    /// `prepare_forward`, the locally-adopted state would silently differ from
+    /// the shipped behavior. This pins that the pointer survives `prepare_forward`.
     #[test]
-    fn advance_at_hop_cap_reports_exhausted() {
-        let dummy_code = freenet_stdlib::prelude::ContractCode::from(b"dummy".to_vec());
-        let dummy_params = freenet_stdlib::prelude::Parameters::from(b"dummy".to_vec());
-        let dummy_key =
-            freenet_stdlib::prelude::ContractKey::from_params_and_code(dummy_params, &dummy_code);
-        let advanced = advance_backward_probe(ProbeState {
-            owner_vk: test_owner(4),
-            remaining: vec![dummy_key],
-            hops: MAX_PROBE_HOPS,
-            local_snapshot: ChatRoomStateV1::default(),
-            epoch: 0,
-        });
-        assert!(
-            !advanced,
-            "a probe at the hop cap must report false so the caller seeds the current key"
+    fn river_probe_ops_prepare_forward_keeps_upgrade_pointer() {
+        use river_core::room_state::upgrade::{AuthorizedUpgradeV1, OptionalUpgradeV1, UpgradeV1};
+
+        let (sk, vk) = owner(2);
+        let ops = RiverProbeOps { owner_vk: vk };
+
+        let upgrade = UpgradeV1 {
+            owner_member_id: MemberId::from(&vk),
+            version: 1,
+            new_chatroom_address: blake3::Hash::from([7u8; 32]),
+        };
+        let authorized = AuthorizedUpgradeV1::new(upgrade, &sk);
+        let mut state = signed_state(&sk);
+        state.upgrade = OptionalUpgradeV1(Some(authorized));
+
+        let forwarded = ops.prepare_forward(state.clone());
+        assert_eq!(
+            forwarded.upgrade, state.upgrade,
+            "prepare_forward must NOT strip the upgrade pointer — stripping happens only in \
+             put_state_to_current_key (freenet/river#427)"
         );
     }
 
-    /// Probe-table semantics: `take_probe` consumes the entry exactly once, so
-    /// a real GET response and the timeout watchdog cannot both advance the
-    /// same hop; and `probe_has_epoch` rejects a stale-epoch watchdog.
+    /// `merge_with_local` (River's `merge_room_states`) preserves the recovered
+    /// state's owner-signed configuration when folding in an empty local
+    /// snapshot (the fresh-import case), so the merged state stays valid.
     #[test]
-    fn take_probe_is_single_shot_and_epoch_guarded() {
-        let id = ContractInstanceId::new([200u8; 32]);
-        probes().insert(
-            id,
-            ProbeState {
-                owner_vk: test_owner(5),
-                remaining: Vec::new(),
-                hops: 1,
-                local_snapshot: ChatRoomStateV1::default(),
-                epoch: 42,
-            },
-        );
-        assert!(is_probe_instance(&id));
-        assert!(probe_has_epoch(&id, 42), "the armed epoch must match");
+    fn river_probe_ops_merge_preserves_recovered_configuration() {
+        let (sk, vk) = owner(3);
+        let ops = RiverProbeOps { owner_vk: vk };
+        let recovered = signed_state(&sk);
+        let merged = ops.merge_with_local(recovered, &ChatRoomStateV1::default());
         assert!(
-            !probe_has_epoch(&id, 99),
-            "a watchdog from a different probe epoch must NOT match"
+            merged.configuration.verify_signature(&vk).is_ok(),
+            "merge must preserve the recovered owner-signed configuration"
         );
+    }
 
-        assert!(
-            take_probe(&id).is_some(),
-            "take_probe returns the entry once"
+    /// End-to-end at the River level: two real generations, the driver adopts
+    /// the NEWEST and never reads the older (anti-rollback). Wiring
+    /// `RiverProbeOps` into a real `ProbeDriver` catches a regression in the
+    /// decode/is_real classification, not just the driver's own generic logic.
+    #[test]
+    fn driver_adopts_newest_real_generation_with_river_ops() {
+        let (sk, vk) = owner(4);
+        let mut driver = ProbeDriver::new(
+            RiverProbeOps { owner_vk: vk },
+            ChatRoomStateV1::default(),
+            NewestFirst::assume_ordered(vec![id(9), id(5)]),
+            SelectionPolicy::NewestFirstWins,
         );
-        assert!(
-            !is_probe_instance(&id),
-            "after take_probe the entry is gone — the watchdog/real-response loser no-ops"
+        let Step::Get(newest) = driver.next_action() else {
+            panic!("expected a GET")
+        };
+        assert_eq!(newest, id(9), "the newest generation must be probed first");
+        driver.on_response(newest, &encode(&signed_state(&sk)));
+        assert_eq!(driver.next_action(), Step::Done);
+        let Some(Outcome::Recovered { source, merged, .. }) = driver.take_outcome() else {
+            panic!("expected recovery from the newest generation");
+        };
+        assert_eq!(
+            source,
+            id(9),
+            "an older generation must not shadow the newer"
         );
+        assert!(merged.configuration.verify_signature(&vk).is_ok());
+    }
+
+    /// End-to-end: every generation misses (a timeout then an empty state), so
+    /// the driver seeds the device's local snapshot forward — the
+    /// no-silent-data-loss guarantee on exhaustion.
+    #[test]
+    fn driver_exhausts_to_seed_local_with_river_ops() {
+        let (sk, vk) = owner(5);
+        let local = signed_state(&sk);
+        let mut driver = ProbeDriver::new(
+            RiverProbeOps { owner_vk: vk },
+            local,
+            NewestFirst::assume_ordered(vec![id(2), id(1)]),
+            SelectionPolicy::NewestFirstWins,
+        );
+        let Step::Get(a) = driver.next_action() else {
+            panic!()
+        };
+        driver.on_timeout(a); // absent generation (watchdog)
+        let Step::Get(b) = driver.next_action() else {
+            panic!()
+        };
+        driver.on_response(b, &encode(&ChatRoomStateV1::default())); // empty → miss
+        assert_eq!(driver.next_action(), Step::Done);
+        let Some(Outcome::SeedLocal { local: seeded }) = driver.take_outcome() else {
+            panic!("exhaustion must seed the local snapshot");
+        };
         assert!(
-            take_probe(&id).is_none(),
-            "a second take_probe returns None"
+            seeded.configuration.verify_signature(&vk).is_ok(),
+            "the seeded local snapshot must survive exhaustion intact"
+        );
+    }
+
+    /// Single-shot correlation at the River level: a candidate times out (the
+    /// probe advances), then its real response arrives late — it must be
+    /// ignored, not adopted. The driver's per-candidate correlation subsumes the
+    /// old epoch machinery this refactor deleted.
+    #[test]
+    fn driver_ignores_late_response_after_timeout_with_river_ops() {
+        let (sk, vk) = owner(6);
+        let mut driver = ProbeDriver::new(
+            RiverProbeOps { owner_vk: vk },
+            ChatRoomStateV1::default(),
+            NewestFirst::assume_ordered(vec![id(2), id(1)]),
+            SelectionPolicy::NewestFirstWins,
+        );
+        let Step::Get(a) = driver.next_action() else {
+            panic!()
+        };
+        driver.on_timeout(a);
+        let Step::Get(b) = driver.next_action() else {
+            panic!()
+        };
+        // Late (stale) hit for the timed-out candidate a — must be dropped.
+        driver.on_response(a, &encode(&signed_state(&sk)));
+        assert_eq!(
+            driver.next_action(),
+            Step::Get(b),
+            "a late response for an advanced-past candidate must not adopt it"
+        );
+        driver.on_response(b, &encode(&ChatRoomStateV1::default()));
+        assert_eq!(driver.next_action(), Step::Done);
+        assert!(
+            matches!(driver.take_outcome(), Some(Outcome::SeedLocal { .. })),
+            "the late hit must not have been adopted"
         );
     }
 }

--- a/ui/src/components/app/freenet_api/backward_probe.rs
+++ b/ui/src/components/app/freenet_api/backward_probe.rs
@@ -39,6 +39,22 @@
 //! hand-rolled per-fire epoch counter; the driver's single-shot correlation
 //! covers everything else.
 //!
+//! Two paths can start a second same-owner probe, with different timing:
+//!
+//! * The **subscription-timeout sweep** (`rooms_awaiting_subscription`) is
+//!   serialized out of the race by construction: a probe re-stamps
+//!   `subscribing_since` every hop and `PROBE_GET_TIMEOUT` (12s) is below
+//!   `REPUT_DELAY_MS` (20s, the sweep threshold), so the sweep never reclaims a
+//!   room and re-GETs it mid-probe. That ordering is what the compile-time
+//!   assert below pins.
+//! * The **reconnect path** is NOT serialized: on a WebSocket reconnect
+//!   `room_synchronizer` sets the room `Disconnected` and clears
+//!   `subscribing_since`, and `rooms_awaiting_subscription` then re-GETs with no
+//!   throttle — so a fresh current-key GET (and a second probe) can start well
+//!   inside the first probe's 12s window. This is the path the per-fire token
+//!   exists to cover; without it the first probe's late watchdog would advance
+//!   the second probe past its newest generation.
+//!
 //! ## Routing & bookkeeping
 //!
 //! A GET response for a *legacy* contract key cannot be resolved back to an
@@ -676,17 +692,30 @@ mod tests {
     fn stale_watchdog_does_not_advance_a_later_same_owner_probe() {
         let (_sk, vk) = owner(7);
         // Distinct ids so this test can't collide with others sharing the
-        // process-global PROBE_ROUTES map under parallel `cargo test`.
+        // process-global PROBE_ROUTES / PROBE_DRIVERS maps under parallel
+        // `cargo test`.
         let newest = id(70);
         let older = id(71);
 
-        // Probe 1 fired `newest` with token t1 and has since COMPLETED (its
-        // route was removed on completion), but its watchdog W1 is still armed,
-        // holding t1.
-        let t1 = next_fire_token();
+        // This exercises the ROUTE + WATCHDOG-GATE layer where the bug actually
+        // lives — PROBE_ROUTES, the per-fire token, `claim_route_if_current`,
+        // and a REAL driver in PROBE_DRIVERS — not just an in-memory driver. It
+        // models the effects of `fire_probe_get` / `deliver_probe_response` /
+        // the watchdog on the shared maps directly, because those fns are async
+        // and spawn tasks / touch Dioxus signals that cannot run in a host unit
+        // test.
 
-        // Probe 2 then starts for the same owner and re-fires the SAME `newest`
-        // id with a fresh token t2, and is sitting on it as its outstanding GET.
+        // --- Probe 1: fire `newest` (token t1), then complete the hop. ---
+        // `fire_probe_get` inserts (owner, token) and arms a watchdog W1 that
+        // holds t1.
+        let t1 = next_fire_token();
+        routes().insert(newest, (vk, t1));
+        // A real response arrives: `deliver_probe_response` removes the route
+        // and probe 1 completes. W1 stays armed with t1 — nothing cancels it.
+        assert_eq!(routes().remove(&newest), Some((vk, t1)));
+
+        // --- Probe 2: same owner, re-fires the SAME `newest` id (fresh token
+        // t2); its driver is live in PROBE_DRIVERS, sitting on `newest`. ---
         let t2 = next_fire_token();
         routes().insert(newest, (vk, t2));
         let mut probe2 = ProbeDriver::new(
@@ -700,32 +729,40 @@ mod tests {
             Step::Get(newest),
             "probe 2 starts on its newest candidate"
         );
+        drivers().insert(vk, probe2);
 
-        // W1 fires late. Its token (t1) no longer matches `newest`'s route (t2),
-        // so it must NOT claim the route and must NOT call on_timeout on probe 2.
+        // --- W1 fires LATE. Run the watchdog's EXACT gate: it advances
+        // (on_timeout + pump) ONLY if `claim_route_if_current` returns true. ---
+        let w1_claimed = claim_route_if_current(newest, vk, t1);
+        if w1_claimed {
+            // The buggy path this guards: this would advance probe 2 past its
+            // newest candidate onto `older` — a silent rollback.
+            drivers().get_mut(&vk).unwrap().on_timeout(newest);
+        }
+
         assert!(
-            !claim_route_if_current(newest, vk, t1),
-            "a stale watchdog (old token) must not claim a later probe's reused route"
+            !w1_claimed,
+            "a stale watchdog (old token t1) must not claim probe 2's reused route"
         );
         assert_eq!(
             routes().get(&newest),
             Some(&(vk, t2)),
-            "probe 2's route must survive the stale watchdog"
+            "probe 2's route must survive the stale watchdog untouched"
         );
         assert_eq!(
-            probe2.next_action(),
+            drivers().get_mut(&vk).unwrap().next_action(),
             Step::Get(newest),
-            "probe 2 must still probe its newest candidate — no rollback"
+            "probe 2's driver must be untouched — still on its newest candidate, no rollback"
         );
 
-        // Sanity: probe 2's OWN watchdog (token t2) DOES claim the route.
+        // --- Contrast: probe 2's OWN watchdog (token t2) DOES claim its route. ---
         assert!(
             claim_route_if_current(newest, vk, t2),
             "the current fire's watchdog claims its own route"
         );
-        assert!(
-            routes().remove(&newest).is_none(),
-            "the matching claim already removed the route"
-        );
+
+        // Cleanup the process-global maps this test populated.
+        drivers().remove(&vk);
+        routes().remove(&newest);
     }
 }

--- a/ui/src/components/app/freenet_api/backward_probe.rs
+++ b/ui/src/components/app/freenet_api/backward_probe.rs
@@ -28,9 +28,16 @@
 //! app-specific semantics (CBOR decode, "is this real state", CRDT-merge with
 //! the local snapshot) are supplied by [`RiverProbeOps`].
 //!
-//! The driver's per-candidate correlation is single-shot by construction, so
-//! there is no cross-probe epoch machinery to get wrong (the previous
-//! hand-rolled state machine carried one; it is gone).
+//! The driver's per-candidate correlation is single-shot WITHIN a single
+//! probe. It does NOT cover cross-probe reuse: sequential probes for the SAME
+//! owner walk the SAME deterministic legacy ids, so a later probe re-registers
+//! an id an earlier probe's watchdog is still armed against. Each probe GET
+//! therefore carries a monotonic **per-fire token** ([`PROBE_ROUTES`] value):
+//! a watchdog advances its probe only if the route it armed against still
+//! carries its own token, so a stale watchdog from a completed probe can never
+//! advance a LATER probe that reused the same id. The token replaces the old
+//! hand-rolled per-fire epoch counter; the driver's single-shot correlation
+//! covers everything else.
 //!
 //! ## Routing & bookkeeping
 //!
@@ -38,8 +45,8 @@
 //! `owner_vk` via `SYNC_INFO` (keyed by the current contract id) or via
 //! `RoomData::contract_key` (also the current id). [`PROBE_ROUTES`] is the
 //! side-table that maps the outstanding legacy `ContractInstanceId` back to the
-//! owner whose probe it belongs to; [`PROBE_DRIVERS`] holds one in-flight
-//! [`ProbeDriver`] per owner.
+//! `(owner_vk, per-fire token)` of the probe GET it belongs to; [`PROBE_DRIVERS`]
+//! holds one in-flight [`ProbeDriver`] per owner.
 //!
 //! Both are plain `Mutex`-guarded maps, NOT Dioxus signals: internal
 //! bookkeeping with zero UI reactivity (no component or memo ever reads them),
@@ -55,9 +62,11 @@
 //! arrived by then, the watchdog counts the generation as a miss so the driver
 //! advances to the next generation (and ultimately seeds the current key)
 //! rather than stalling forever. Without this a dormant room — exactly what
-//! this feature targets — could be left permanently stuck. Whichever of
-//! {response, watchdog} removes the route first owns the hop; the loser finds
-//! the route gone and no-ops (single-shot).
+//! this feature targets — could be left permanently stuck. Within one probe,
+//! whichever of {response, watchdog} removes the route first owns the hop; the
+//! loser finds the route gone and no-ops. Across probes, the per-fire token
+//! (above) stops a stale watchdog from claiming a later probe's re-registered
+//! route.
 
 use crate::components::app::freenet_api::constants::REPUT_DELAY_MS;
 use crate::components::app::freenet_api::response_handler::get_response::{
@@ -75,6 +84,7 @@ use freenet_stdlib::prelude::ContractInstanceId;
 use river_core::room_state::member::MemberId;
 use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1};
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{LazyLock, Mutex, MutexGuard};
 use std::time::Duration;
 
@@ -153,11 +163,23 @@ impl ProbeStateOps for RiverProbeOps {
 }
 
 /// Maps the `ContractInstanceId` of the currently-outstanding legacy probe GET
-/// back to the owner whose probe it belongs to. Plain `Mutex` map — see the
-/// module docs. The presence of an entry is what makes a legacy-key GET
-/// response route into the probe handler ([`is_probe_instance`]).
-static PROBE_ROUTES: LazyLock<Mutex<HashMap<ContractInstanceId, VerifyingKey>>> =
+/// back to the `(owner_vk, per-fire token)` of the probe GET it belongs to.
+/// Plain `Mutex` map — see the module docs. The presence of an entry is what
+/// makes a legacy-key GET response route into the probe handler
+/// ([`is_probe_instance`]); the token lets a watchdog tell its own outstanding
+/// fire apart from a later probe that reused the same deterministic id.
+static PROBE_ROUTES: LazyLock<Mutex<HashMap<ContractInstanceId, (VerifyingKey, u64)>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Monotonic source of the per-fire route token. Bumped once per
+/// [`fire_probe_get`]; the value stored in [`PROBE_ROUTES`] and captured by that
+/// fire's watchdog. Globally unique, so a token match implies the SAME fire.
+static PROBE_FIRE_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// A fresh, globally-unique per-fire token for one probe GET.
+fn next_fire_token() -> u64 {
+    PROBE_FIRE_SEQ.fetch_add(1, Ordering::Relaxed)
+}
 
 /// One in-flight [`ProbeDriver`] per owner. The driver owns the sans-IO probe
 /// decision state; this module only pumps I/O through it. Deduplicating
@@ -167,8 +189,27 @@ static PROBE_DRIVERS: LazyLock<Mutex<HashMap<VerifyingKey, ProbeDriver<RiverProb
 
 /// Lock the route table, recovering from a poisoned mutex (a panic while the
 /// lock was held must not wedge all future recovery).
-fn routes() -> MutexGuard<'static, HashMap<ContractInstanceId, VerifyingKey>> {
+fn routes() -> MutexGuard<'static, HashMap<ContractInstanceId, (VerifyingKey, u64)>> {
     PROBE_ROUTES.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Remove `id`'s route ONLY if it still carries `(owner_vk, token)` — the
+/// per-fire guard a watchdog uses to advance its probe. Returns `true` (route
+/// removed) only when this watchdog owns the CURRENT outstanding fire for `id`.
+///
+/// The check-and-remove is one locked step: a stale watchdog whose token no
+/// longer matches (a later same-owner probe re-fired the same deterministic id
+/// with a fresh token) leaves the route untouched and does not advance the
+/// later probe. This is what the deleted per-fire epoch counter guarded.
+fn claim_route_if_current(id: ContractInstanceId, owner_vk: VerifyingKey, token: u64) -> bool {
+    let mut routes = routes();
+    match routes.get(&id) {
+        Some(&(o, t)) if o == owner_vk && t == token => {
+            routes.remove(&id);
+            true
+        }
+        _ => false,
+    }
 }
 
 /// Lock the driver table, recovering from a poisoned mutex.
@@ -248,7 +289,13 @@ pub async fn start_backward_probe(owner_vk: VerifyingKey, local_snapshot: ChatRo
 /// FIRST of {this response, the watchdog} to remove the route owns the hop
 /// (single-shot). Unknown ids are the race-loser and no-op.
 pub(crate) async fn deliver_probe_response(id: ContractInstanceId, bytes: Vec<u8>) {
-    let Some(owner_vk) = routes().remove(&id) else {
+    // The per-fire token is deliberately IGNORED here (unlike the watchdog): a
+    // GET response for `id` is a valid response for whatever fire currently owns
+    // `id`'s route, and the driver is single-shot on its own outstanding
+    // candidate — if the owning driver has already advanced past `id`, its
+    // `on_response(id, ..)` is a no-op. So routing by the current owner is
+    // always correct; only the stale-timeout case needs the token.
+    let Some((owner_vk, _token)) = routes().remove(&id) else {
         // The route was already consumed — e.g. the timeout watchdog fired
         // first. Whichever ran first owns the outcome; the loser lands here.
         warn!("Probe GET response for {id} had no matching probe entry — ignoring");
@@ -317,11 +364,16 @@ async fn pump_probe(owner_vk: VerifyingKey) {
 /// Register `id` as the outstanding probe GET for `owner_vk`, send the GET, and
 /// arm a watchdog so an absent legacy generation cannot stall the probe.
 fn fire_probe_get(owner_vk: VerifyingKey, id: ContractInstanceId) {
+    // A fresh per-fire token: it stamps this route and is captured by the
+    // watchdog below, so a stale watchdog from a completed probe cannot advance
+    // a LATER probe that reused the same deterministic legacy id.
+    let token = next_fire_token();
+
     // Register the route BEFORE sending the GET so the response handler can
     // resolve the legacy key when the reply arrives (and so `is_probe_instance`
     // routes it into the probe handler). Plain mutex — synchronous, no defer,
     // no signal re-entrancy.
-    routes().insert(id, owner_vk);
+    routes().insert(id, (owner_vk, token));
 
     // Keep the room out of the subscription-timeout sweep: a probe in flight IS
     // active subscription progress. Each hop refreshes `subscribing_since` (hops
@@ -367,13 +419,16 @@ fn fire_probe_get(owner_vk: VerifyingKey, id: ContractInstanceId) {
     });
 
     // Watchdog: if no GET response consumes THIS route within PROBE_GET_TIMEOUT,
-    // count the legacy generation as a miss and advance. The route-removal race
-    // makes this single-shot — whichever of {response, watchdog} removes the
-    // route first owns the hop; the loser finds it gone and no-ops. This
-    // subsumes the old per-probe epoch machinery.
+    // count the legacy generation as a miss and advance. `claim_route_if_current`
+    // makes this single-shot AND cross-probe-safe: it advances only if `id`'s
+    // route still carries THIS fire's `token`. Within one probe, whichever of
+    // {response, watchdog} removes the route first owns the hop (the loser
+    // finds it gone). Across probes, a completed probe's late watchdog finds a
+    // later probe's fresh token on the reused id and no-ops — the guard the old
+    // per-fire epoch counter used to provide.
     safe_spawn_local(async move {
         sleep(PROBE_GET_TIMEOUT).await;
-        if routes().remove(&id) == Some(owner_vk) {
+        if claim_route_if_current(id, owner_vk, token) {
             warn!(
                 "Backward-probe GET for {id} timed out after {}s — treating the legacy \
                  generation as absent and advancing",
@@ -556,10 +611,11 @@ mod tests {
         );
     }
 
-    /// Single-shot correlation at the River level: a candidate times out (the
+    /// Single-shot correlation WITHIN one probe: a candidate times out (the
     /// probe advances), then its real response arrives late — it must be
-    /// ignored, not adopted. The driver's per-candidate correlation subsumes the
-    /// old epoch machinery this refactor deleted.
+    /// ignored, not adopted. This is the driver's per-candidate correlation;
+    /// the CROSS-probe same-owner case is covered separately by the route
+    /// token (see `stale_watchdog_does_not_advance_a_later_same_owner_probe`).
     #[test]
     fn driver_ignores_late_response_after_timeout_with_river_ops() {
         let (sk, vk) = owner(6);
@@ -588,6 +644,75 @@ mod tests {
         assert!(
             matches!(driver.take_outcome(), Some(Outcome::SeedLocal { .. })),
             "the late hit must not have been adopted"
+        );
+    }
+
+    /// Regression (Codex review of #398 phase 2): a stale watchdog from a
+    /// COMPLETED probe must not advance a LATER probe for the same owner that
+    /// re-registered the same deterministic legacy id.
+    ///
+    /// Sequential same-owner probes walk the SAME legacy ids (they are derived
+    /// from the owner + a fixed legacy-WASM registry), so probe 1's still-armed
+    /// watchdog and probe 2's fresh route collide on one id. The per-fire route
+    /// token is what tells them apart: the stale watchdog's token no longer
+    /// matches, so `claim_route_if_current` refuses to claim probe 2's route,
+    /// and probe 2 stays on its NEWEST candidate. Without the token (the bug the
+    /// deleted epoch counter guarded), the stale watchdog would skip probe 2's
+    /// newest generation and roll it back to an older one.
+    #[test]
+    fn stale_watchdog_does_not_advance_a_later_same_owner_probe() {
+        let (_sk, vk) = owner(7);
+        // Distinct ids so this test can't collide with others sharing the
+        // process-global PROBE_ROUTES map under parallel `cargo test`.
+        let newest = id(70);
+        let older = id(71);
+
+        // Probe 1 fired `newest` with token t1 and has since COMPLETED (its
+        // route was removed on completion), but its watchdog W1 is still armed,
+        // holding t1.
+        let t1 = next_fire_token();
+
+        // Probe 2 then starts for the same owner and re-fires the SAME `newest`
+        // id with a fresh token t2, and is sitting on it as its outstanding GET.
+        let t2 = next_fire_token();
+        routes().insert(newest, (vk, t2));
+        let mut probe2 = ProbeDriver::new(
+            RiverProbeOps { owner_vk: vk },
+            ChatRoomStateV1::default(),
+            NewestFirst::assume_ordered(vec![newest, older]),
+            SelectionPolicy::NewestFirstWins,
+        );
+        assert_eq!(
+            probe2.next_action(),
+            Step::Get(newest),
+            "probe 2 starts on its newest candidate"
+        );
+
+        // W1 fires late. Its token (t1) no longer matches `newest`'s route (t2),
+        // so it must NOT claim the route and must NOT call on_timeout on probe 2.
+        assert!(
+            !claim_route_if_current(newest, vk, t1),
+            "a stale watchdog (old token) must not claim a later probe's reused route"
+        );
+        assert_eq!(
+            routes().get(&newest),
+            Some(&(vk, t2)),
+            "probe 2's route must survive the stale watchdog"
+        );
+        assert_eq!(
+            probe2.next_action(),
+            Step::Get(newest),
+            "probe 2 must still probe its newest candidate — no rollback"
+        );
+
+        // Sanity: probe 2's OWN watchdog (token t2) DOES claim the route.
+        assert!(
+            claim_route_if_current(newest, vk, t2),
+            "the current fire's watchdog claims its own route"
+        );
+        assert!(
+            routes().remove(&newest).is_none(),
+            "the matching claim already removed the route"
         );
     }
 }

--- a/ui/src/components/app/freenet_api/backward_probe.rs
+++ b/ui/src/components/app/freenet_api/backward_probe.rs
@@ -304,6 +304,19 @@ pub(crate) async fn deliver_probe_response(id: ContractInstanceId, bytes: Vec<u8
     {
         let mut drivers = drivers();
         if let Some(driver) = drivers.get_mut(&owner_vk) {
+            // Observability only — the driver makes the actual decision. This
+            // re-classifies the bytes purely to keep the pre-driver era's
+            // per-candidate logs (once per probe hop, cost negligible).
+            let ops = RiverProbeOps { owner_vk };
+            match ops.decode(&bytes) {
+                None => warn!(
+                    "Legacy contract {id} returned undeserializable state — skipping generation"
+                ),
+                Some(state) if !ops.is_real(&state) => {
+                    info!("Legacy contract {id} is empty — advancing to older generation")
+                }
+                Some(_) => {}
+            }
             driver.on_response(id, &bytes);
         }
     }

--- a/ui/src/components/app/freenet_api/connection_watchdog.rs
+++ b/ui/src/components/app/freenet_api/connection_watchdog.rs
@@ -107,7 +107,7 @@ static WS_ACTIVITY_SEQ: AtomicU64 = AtomicU64::new(0);
 static WS_CONNECT_SEQ: AtomicU64 = AtomicU64::new(0);
 
 // All three are plain atomics, NOT Dioxus signals — internal bookkeeping with
-// zero UI reactivity, like `backward_probe::BACKWARD_PROBES`.
+// zero UI reactivity, like `backward_probe::PROBE_ROUTES`.
 
 /// Record that an inbound WebSocket message just arrived — proof the socket is
 /// alive. Called from the `WebApi` result callback for every inbound

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -1,5 +1,7 @@
-// `pub(crate)` so the backward-probe watchdog (freenet_api::backward_probe)
-// can call `get_response::handle_probe_get_response` on timeout (#292).
+// `pub(crate)` so the backward-probe adapter (freenet_api::backward_probe) can
+// call `get_response::{adopt_recovered_probe_state, seed_current_key_with_local,
+// merge_room_states}` when its decision driver reaches a terminal outcome (#292,
+// #398 phase 2).
 pub(crate) mod get_response;
 mod put_response;
 mod subscribe_response;

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -1,5 +1,5 @@
 use crate::components::app::freenet_api::backward_probe::{
-    advance_backward_probe, start_backward_probe, take_probe,
+    deliver_probe_response, start_backward_probe,
 };
 use crate::components::app::freenet_api::error::SynchronizerError;
 use crate::components::app::freenet_api::response_handler::update_notification::{
@@ -44,7 +44,7 @@ pub async fn handle_get_response(
     // owner via SYNC_INFO / ROOMS (both keyed by the CURRENT contract
     // id), so route it into the probe handler before any other lookup.
     if crate::components::app::freenet_api::backward_probe::is_probe_instance(key.id()) {
-        handle_probe_get_response(key, state).await;
+        deliver_probe_response(*key.id(), state).await;
         return Ok(());
     }
 
@@ -832,7 +832,7 @@ pub async fn handle_get_response(
                     MemberId::from(owner_vk)
                 );
                 // Capture the device's local snapshot now and hand it to the
-                // probe. It rides along in `ProbeState` so the probe can both
+                // probe. It is moved into the probe driver so the probe can both
                 // CRDT-merge it with any recovered state and use it for the
                 // last-resort seed — without a fallible signal read at
                 // probe-completion time.
@@ -842,7 +842,7 @@ pub async fn handle_get_response(
                     .get(&owner_vk)
                     .map(|rd| rd.room_state.clone())
                     .unwrap_or_default();
-                if start_backward_probe(owner_vk, local_snapshot) {
+                if start_backward_probe(owner_vk, local_snapshot).await {
                     // A probe is in flight. It is responsible for either
                     // recovering stranded state (CRDT-merge + PUT-forward)
                     // or, on full exhaustion, seeding the current key with
@@ -1174,159 +1174,92 @@ pub async fn handle_get_response(
     Ok(())
 }
 
-/// Handle a GET response whose contract id matches an outstanding
-/// backward probe (freenet/river#292, Task 3).
+/// Adopt a backward-probe-recovered state (freenet/river#292, Task 3): the
+/// probe driver found real state in a legacy generation and already
+/// CRDT-merged it with the device's local snapshot. Adopt the merged state
+/// into the room's `RoomData` in `ROOMS` and PUT it forward onto the CURRENT
+/// contract key so the room is no longer stranded.
 ///
-/// The GET was for a *legacy* room-contract generation. Two outcomes:
-///
-/// * **The legacy key holds real state** (its `configuration` signature
-///   verifies against the owner): this is the room's last-active
-///   stranded state. CRDT-merge it into the room's `RoomData` in `ROOMS`
-///   and PUT it forward onto the CURRENT contract key so the room is no
-///   longer stranded. The probe ends here.
-/// * **The legacy key is empty/default**: advance the probe to the next
-///   (older) legacy key. If the probe is now exhausted — every
-///   generation tried, nothing found — seed the CURRENT contract key
-///   with the device's local snapshot as the genuine last resort.
-pub(crate) async fn handle_probe_get_response(key: ContractKey, state: Vec<u8>) {
-    let Some(probe) = take_probe(key.id()) else {
-        // Race: the probe entry was already consumed — e.g. the real GET
-        // response and the timeout watchdog both fired. Whichever ran first
-        // owns the outcome; the loser lands here. Nothing to do.
-        warn!(
-            "Probe GET response for {} had no matching probe entry — ignoring",
-            key.id()
-        );
-        return;
-    };
-    let owner_vk = probe.owner_vk;
-
-    // Deserialize defensively: the probe walks many historical generations,
-    // and a very old one may carry a `ChatRoomStateV1` whose layout the
-    // current type cannot decode. Treat an undeserializable legacy state as
-    // empty (default) so the probe advances to the next generation rather
-    // than panicking — matching the CLI's `try_get_state` (freenet/river#292).
-    let recovered_state: ChatRoomStateV1 = match try_from_cbor_slice::<ChatRoomStateV1>(&state) {
-        Some(s) => s,
-        None => {
-            warn!(
-                "Backward probe: legacy contract {} returned undeserializable state \
-                 (incompatible older generation) — treating as empty",
-                key.id()
-            );
-            ChatRoomStateV1::default()
-        }
-    };
-    let recovered_has_real_state = recovered_state
-        .configuration
-        .verify_signature(&owner_vk)
-        .is_ok();
-
-    if recovered_has_real_state {
-        info!(
-            "Backward probe for room {:?} recovered real state from legacy contract {} \
-             — adopting and PUTting forward onto the current key",
-            MemberId::from(owner_vk),
-            key.id()
-        );
-
-        // No need to follow this recovered state's own upgrade pointer: the
-        // probe walks generations newest-first, so every generation newer than
-        // this one was already probed and found empty. The newest-first probe
-        // order subsumes forward upgrade-pointer following.
-        //
-        // CRDT-merge the recovered state with the device's local snapshot
-        // BEFORE PUTting it forward, so unsynced local edits the device made
-        // offline are not dropped from the migrating PUT. This matches the
-        // CLI's `get_migration_state`, which merges network + local.
-        let params = ChatRoomParametersV1 { owner: owner_vk };
-        let merged_state = merge_room_states(recovered_state, &probe.local_snapshot, &params);
-
-        // Adopt the merged state into the room's RoomData. If the room is
-        // still a placeholder (a fresh import), replace wholesale — exactly
-        // as the normal imported-room GET path does, because the placeholder's
-        // `owner_member_id` differs and `merge` would reject it.
-        let rooms_state = merged_state.clone();
-        crate::util::defer(move || {
-            ROOMS.with_mut(|rooms| {
-                if let Some(room_data) = rooms.map.get_mut(&owner_vk) {
-                    let params = ChatRoomParametersV1 { owner: owner_vk };
-                    if room_data.is_awaiting_initial_sync() {
-                        room_data.room_state = rooms_state;
-                        room_data.capture_self_membership_data(&params);
-                        let _ = room_data.repopulate_secrets_from_state();
-                    } else {
-                        let current_state = room_data.room_state.clone();
-                        match room_data
-                            .room_state
-                            .merge(&current_state, &params, &rooms_state)
-                        {
-                            Ok(_) => {
-                                room_data.capture_self_membership_data(&params);
-                                let _ = room_data.repopulate_secrets_from_state();
-                            }
-                            Err(e) => {
-                                error!(
-                                    "Backward probe: failed to merge recovered state \
-                                     for room {:?}: {}",
-                                    MemberId::from(owner_vk),
-                                    e
-                                );
-                            }
+/// `merged` is the driver's `Outcome::Recovered` payload: `merge_with_local`
+/// applied, `prepare_forward` (identity for River) applied. It is UNSTRIPPED —
+/// the upgrade pointer is stripped only inside `put_state_to_current_key`
+/// (freenet/river#427), and the UNSTRIPPED value is what is adopted locally.
+pub(crate) async fn adopt_recovered_probe_state(
+    owner_vk: ed25519_dalek::VerifyingKey,
+    merged: ChatRoomStateV1,
+) {
+    // Adopt the merged state into the room's RoomData. If the room is still a
+    // placeholder (a fresh import), replace wholesale — exactly as the normal
+    // imported-room GET path does, because the placeholder's `owner_member_id`
+    // differs and `merge` would reject it.
+    let rooms_state = merged.clone();
+    crate::util::defer(move || {
+        ROOMS.with_mut(|rooms| {
+            if let Some(room_data) = rooms.map.get_mut(&owner_vk) {
+                let params = ChatRoomParametersV1 { owner: owner_vk };
+                if room_data.is_awaiting_initial_sync() {
+                    room_data.room_state = rooms_state;
+                    room_data.capture_self_membership_data(&params);
+                    let _ = room_data.repopulate_secrets_from_state();
+                } else {
+                    let current_state = room_data.room_state.clone();
+                    match room_data
+                        .room_state
+                        .merge(&current_state, &params, &rooms_state)
+                    {
+                        Ok(_) => {
+                            room_data.capture_self_membership_data(&params);
+                            let _ = room_data.repopulate_secrets_from_state();
+                        }
+                        Err(e) => {
+                            error!(
+                                "Backward probe: failed to merge recovered state \
+                                 for room {:?}: {}",
+                                MemberId::from(owner_vk),
+                                e
+                            );
                         }
                     }
-                } else {
-                    warn!(
-                        "Backward probe recovered state for room {:?} but it is no \
-                         longer in ROOMS — discarding",
-                        MemberId::from(owner_vk)
-                    );
                 }
-            });
+            } else {
+                warn!(
+                    "Backward probe recovered state for room {:?} but it is no \
+                     longer in ROOMS — discarding",
+                    MemberId::from(owner_vk)
+                );
+            }
         });
+    });
 
-        // PUT the merged state forward onto the current contract key so the
-        // room is no longer stranded, and subscribe to it.
-        put_state_to_current_key(owner_vk, merged_state, "recovered (backward probe)").await;
+    // PUT the merged state forward onto the current contract key so the room
+    // is no longer stranded, and subscribe to it. `put_state_to_current_key`
+    // strips the upgrade pointer on the way out (freenet/river#427).
+    put_state_to_current_key(owner_vk, merged, "recovered (backward probe)").await;
 
-        crate::util::defer(move || {
-            SYNC_INFO.with_mut(|sync_info| {
-                sync_info.register_new_room(owner_vk);
-                sync_info.update_sync_status(&owner_vk, RoomSyncStatus::Subscribing);
-            });
-            // Enable notifications — the room now has real state, exactly
-            // as the normal imported-room GET path does once it has
-            // adopted network state.
-            mark_initial_sync_complete(&owner_vk);
+    crate::util::defer(move || {
+        SYNC_INFO.with_mut(|sync_info| {
+            sync_info.register_new_room(owner_vk);
+            sync_info.update_sync_status(&owner_vk, RoomSyncStatus::Subscribing);
         });
-        crate::components::app::mark_needs_sync(owner_vk);
-        return;
-    }
+        // Enable notifications — the room now has real state, exactly as the
+        // normal imported-room GET path does once it has adopted network state.
+        mark_initial_sync_complete(&owner_vk);
+    });
+    crate::components::app::mark_needs_sync(owner_vk);
+}
 
-    // Legacy key empty — advance to the next older generation. Capture the
-    // local snapshot first so the exhaustion seed below has it without a
-    // fallible signal read (the probe is consumed by `advance_backward_probe`).
-    let local_snapshot = probe.local_snapshot.clone();
-    if advance_backward_probe(probe) {
-        info!(
-            "Backward probe for room {:?}: legacy contract {} empty, advancing",
-            MemberId::from(owner_vk),
-            key.id()
-        );
-        return;
-    }
-
-    // Probe exhausted — no legacy generation held real state. Last resort:
-    // seed the current contract key with the device's local snapshot. This is
-    // the ONLY path on which the local snapshot is PUT onto the network (the
-    // core design principle of #292). The snapshot was captured up front, so
-    // this seed always runs — it never depends on a signal read here.
-    info!(
-        "Backward probe for room {:?} exhausted — seeding current contract key \
-         with the local snapshot (last resort)",
-        MemberId::from(owner_vk)
-    );
-    put_state_to_current_key(owner_vk, local_snapshot, "local snapshot (last resort)").await;
+/// Seed the CURRENT contract key with the device's local snapshot as the
+/// genuine last resort (freenet/river#292, Task 3): the probe driver exhausted
+/// every legacy generation (or there were none) without finding real state.
+///
+/// This is the ONLY path on which the local snapshot is PUT onto the network.
+/// `local` is the driver's `Outcome::SeedLocal`/`NoLegacy` payload (the
+/// captured snapshot, `prepare_forward` applied — identity for River).
+pub(crate) async fn seed_current_key_with_local(
+    owner_vk: ed25519_dalek::VerifyingKey,
+    local: ChatRoomStateV1,
+) {
+    put_state_to_current_key(owner_vk, local, "local snapshot (last resort)").await;
     crate::util::defer(move || {
         SYNC_INFO.with_mut(|sync_info| {
             sync_info.register_new_room(owner_vk);
@@ -1337,8 +1270,9 @@ pub(crate) async fn handle_probe_get_response(key: ContractKey, state: Vec<u8>) 
 
 /// CRDT-merge `local` into `primary`, returning the merged state. On a merge
 /// failure (genuinely incompatible states) returns `primary` unchanged rather
-/// than losing it.
-fn merge_room_states(
+/// than losing it. `pub(crate)` so `RiverProbeOps::merge_with_local` (the
+/// backward-probe decision driver's app hook) reuses the exact same merge.
+pub(crate) fn merge_room_states(
     primary: ChatRoomStateV1,
     local: &ChatRoomStateV1,
     params: &ChatRoomParametersV1,

--- a/ui/src/components/app/freenet_api/response_handler/update_notification.rs
+++ b/ui/src/components/app/freenet_api/response_handler/update_notification.rs
@@ -24,7 +24,7 @@ const MAX_UPGRADE_HOPS: usize = 32;
 /// immediately-preceding one — is a cycle) AND the hop cap (`len()`).
 ///
 /// Plain `Mutex` map, NOT a Dioxus signal — internal bookkeeping with zero UI
-/// reactivity, like `backward_probe::BACKWARD_PROBES`.
+/// reactivity, like `backward_probe::PROBE_ROUTES`.
 static UPGRADE_CHAIN_VISITED: LazyLock<Mutex<HashMap<VerifyingKey, HashSet<ContractInstanceId>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 


### PR DESCRIPTION
## Problem

The UI backward-probe recovery (freenet/river#292) is the data-loss-critical
path that recovers a room stranded under an older room-contract generation
(each room-contract WASM upgrade moves the contract key, stranding dormant
rooms under an older key). It carried its own hand-rolled probe state machine:
a `ProbeState` struct, a `BACKWARD_PROBES` side-table, and a `PROBE_EPOCH`
counter whose only job was to make late GET responses / stale watchdogs
single-shot. That is exactly the decision logic freenet-migrate 0.3.0's
sans-IO `ProbeDriver` now owns and tests exhaustively.

## Approach

Phase 2 of #398: swap the probe INTERNALS onto `freenet_migrate::ProbeDriver`,
behavior-preserving. River supplies its app semantics through a `ProbeStateOps`
impl (`RiverProbeOps`):

- `decode` = the existing defensive CBOR decode (`try_from_cbor_slice`, `None`
  on failure → a miss, never a panic).
- `is_real` = `configuration.verify_signature(&owner_vk).is_ok()` (the existing
  predicate; a default/placeholder state is a miss).
- `merge_with_local` = the existing `merge_room_states` CRDT merge (kept
  `pub(crate)` and reused verbatim, including keep-primary-on-merge-failure).
- `prepare_forward` is left as the driver's **identity** default on purpose —
  River adopts the UNSTRIPPED merge locally and strips the upgrade pointer only
  in `put_state_to_current_key` (freenet/river#427). Overriding it would strip
  too early and change what is adopted locally. A unit test pins this.

The hand-rolled machinery becomes two plain-`Mutex` maps (a route table
instance-id → `(owner, per-fire token)`, and one `ProbeDriver` per owner) plus a
`pump_probe` loop over `next_action()`. The terminal `Outcome` runs the same
recover-or-seed side effects, extracted into
`get_response::{adopt_recovered_probe_state, seed_current_key_with_local}` with
the same log strings, ROOMS placeholder-vs-merge adoption, PUT-forward, and
SYNC_INFO / notification updates. The 64-hop cap (now the driver default,
pinned by a compile-time assert) and the 12s watchdog (with its assert vs
`REPUT_DELAY_MS`) are preserved. Per-candidate observability (the pre-driver
"undeserializable" / "empty, advancing" logs) is restored by classifying the
response with the same `RiverProbeOps` predicates for the LOG only — the
decision stays the driver's.

### Correlation: where the driver is enough, and where it is not

`PROBE_EPOCH` is deleted, but its job is split, not simply subsumed:

- **Within a single probe**, the driver's per-candidate single-shot correlation
  (gated by single-shot route removal — first of {response, watchdog} owns the
  hop) covers late responses and stale timeouts.
- **Across sequential probes for the same owner**, the legacy ids are
  deterministic and get reused, so a completed probe's still-armed watchdog can
  fire against a *later* probe that re-registered the same id. The driver cannot
  see that. Each probe GET therefore carries a monotonic **per-fire token** (the
  `PROBE_ROUTES` value); a watchdog advances only if the route still carries its
  own token (`claim_route_if_current`), so a stale watchdog no-ops instead of
  rolling the later probe back to an older generation. This is the guard the old
  per-fire epoch counter provided.

Timing — the two paths that can start a second same-owner probe:

- The **subscription-timeout sweep** is serialized out of the race by
  construction: a probe re-stamps `subscribing_since` every hop and
  `PROBE_GET_TIMEOUT` (12s) is below `REPUT_DELAY_MS` (20s), so the sweep never
  reclaims a room mid-probe (pinned by a compile-time assert).
- The **reconnect path** is NOT serialized: on a WebSocket reconnect
  `room_synchronizer` sets the room `Disconnected` and clears
  `subscribing_since`, and `rooms_awaiting_subscription` re-GETs with no
  throttle — so a second probe can start well inside the first's 12s window.
  This is the unthrottled path the per-fire token exists to cover.

(The cross-probe token is the fix for the Codex/review finding on this PR — see
the `fix(ui): guard the backward probe against a stale cross-probe watchdog` and
`test(ui): exercise the route/watchdog layer …` commits.)

This mapping follows the verified adoptability review in freenet-migrate#5.

## Testing

- `cargo test -p river-ui --bins` — **485 pass**. Driver-integration + route-layer
  tests at the River level: RiverProbeOps classification (real / empty /
  undecodable), `prepare_forward` keeps the upgrade pointer (pins the byte-exact
  #427 behavior), merge preserves the recovered config, newest-generation-wins
  (anti-rollback), exhaustion-seeds-local, single-shot late-response, and the
  cross-probe stale-watchdog regression
  (`stale_watchdog_does_not_advance_a_later_same_owner_probe`) — which drives the
  real PROBE_ROUTES / per-fire token / `claim_route_if_current` gate against a
  live driver in PROBE_DRIVERS, asserting a stale watchdog neither removes the
  later probe's route nor advances its driver. The existing #292 gate +
  import-recovery source-grep pins pass unchanged.
- `cargo test -p river-core` — pass.
- `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync`
  — freenet-migrate 0.3 compiles for wasm32 (its stdlib dep unifies on the
  workspace's 0.8.3, so `ContractInstanceId` types match — no conflict).
- `cargo fmt` clean; clippy clean for the changed files; **no `.wasm` changes**.

Refs #398 (phase 2). Crate review lineage: freenet-migrate#5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wJpXbgCrnkSKgkpmnLGwQ

[AI-assisted - Claude]
