### PR TITLE
feat(cli): riverctl identity whoami — report your own MemberId (#438)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4724,7 +4724,7 @@ dependencies = [
 
 [[package]]
 name = "riverctl"
-version = "0.1.80"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Commands include:
 - `riverctl message` - Send and receive messages
 - `riverctl member` - Member management
 - `riverctl invite` - Create and accept invitations
+- `riverctl identity whoami` - Your own member ID in a room (matches the `author` on your messages)
 
 Use `--format json` for machine-readable output. Run `riverctl --help` for full documentation.
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riverctl"
-version = "0.1.80"
+version = "0.2.0"
 edition = "2021"
 authors = ["Freenet Project"]
 description = "Command-line interface for River decentralized chat on Freenet"

--- a/cli/README.md
+++ b/cli/README.md
@@ -58,21 +58,48 @@ riverctl identity whoami <room-owner-vk>         # Your member ID in one room.
 riverctl identity whoami                         # Every room you're in.
 ```
 
-The `member_id` it reports is exactly the `author` value your own messages carry
-in `message list` / `message stream --format json`, which is what a bridge needs
-to filter out its own echo:
+The `member_id` it reports is exactly the top-level `author` value your own
+messages carry in `message list` / `message stream --format json`, which is what
+a bridge needs to filter out its own echo:
 
 ```bash
 me=$(riverctl identity whoami <room-owner-vk> --format json | jq -r .member_id)
-riverctl message stream <room-owner-vk> --format json |
+riverctl message stream <room-owner-vk> --format json --no-version-check |
   jq -c --arg me "$me" 'select(.author != $me)'
 ```
 
-`whoami` reads only local storage — it works with the node stopped, and resolves
-before any message has arrived. Under `--signing-key-file` it reports the
-override identity (the one that will actually sign), and says so via
-`signing_key_source`. `room list --format json` carries the same value as
-`self_member_id`, so one call covers every room.
+(The `author` inside `reply_to` is a display nickname, not a member ID — only
+the top-level `author` is comparable.)
+
+`whoami` needs no node: it resolves from local storage, so it works with the
+peer stopped and before any message has arrived. It does need a *writable*
+config dir, since the shared storage loader may rewrite `rooms.json` when the
+bundled contract WASM has changed. Pass `--no-version-check` (or set
+`RIVERCTL_NO_VERSION_CHECK`) if you poll it, so it never makes the once-a-day
+crates.io version request.
+
+It reports the identity that will actually **sign**, across all three override
+mechanisms, using the same precedence `message send` does — inline
+`--signing-key` / `RIVER_SIGNING_KEY` beats `--signing-key-file` /
+`RIVER_SIGNING_KEY_FILE`, which beats the per-room key in `rooms.json`. The
+winner is reported as `signing_key_source` (`inline` / `override` / `stored`).
+With `--signing-key` the room need not be in local storage at all, matching
+`message send --signing-key`:
+
+```bash
+RIVER_SIGNING_KEY=<base64-key> riverctl identity whoami <room-owner-vk> --format json
+```
+
+`room list --format json` carries the same `self_member_id` (plus
+`signing_key_source`), so one call covers every room. Note that a
+`--signing-key-file` override applies to *every* room, including ones that
+identity is not a member of.
+
+**On comparing IDs.** A `MemberId` renders as 8 base32 characters — a truncated,
+non-cryptographic hash of the verifying key. That is fine for recognising your
+own messages, which is what it is for. Do not treat it as a security boundary:
+it is short enough to collide deliberately, so don't grant trust based on an
+`author` match alone.
 
 Export your identity to move between machines or back it up:
 
@@ -115,8 +142,9 @@ Run `riverctl <group> --help` or `riverctl <group> <cmd> --help` for full flags.
 
 `reply_to` is `null` for non-replies, otherwise `{ "author", "preview" }`. `edit`/`delete` events are emitted only for messages the stream actually surfaced. Bridges should key off `type` and tolerate unknown future types.
 
-`author` is your correspondent's member ID; get your own with `riverctl identity
-whoami <room-owner-vk>` and compare against it to recognise your own messages.
+The top-level `author` is the sending member's ID; get your own with `riverctl
+identity whoami <room-owner-vk>` and compare against it to recognise your own
+messages. (`reply_to.author` is a display nickname, not an ID.)
 
 ## Configuration
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -50,7 +50,31 @@ riverctl invite accept <invite-code>             # On the recipient's machine.
 
 ## Managing your identity
 
-Each room uses a separate signing key. Export it to move between machines or back it up:
+Each room uses a separate signing key, so there is no single global member ID —
+`whoami` is per-room:
+
+```bash
+riverctl identity whoami <room-owner-vk>         # Your member ID in one room.
+riverctl identity whoami                         # Every room you're in.
+```
+
+The `member_id` it reports is exactly the `author` value your own messages carry
+in `message list` / `message stream --format json`, which is what a bridge needs
+to filter out its own echo:
+
+```bash
+me=$(riverctl identity whoami <room-owner-vk> --format json | jq -r .member_id)
+riverctl message stream <room-owner-vk> --format json |
+  jq -c --arg me "$me" 'select(.author != $me)'
+```
+
+`whoami` reads only local storage — it works with the node stopped, and resolves
+before any message has arrived. Under `--signing-key-file` it reports the
+override identity (the one that will actually sign), and says so via
+`signing_key_source`. `room list --format json` carries the same value as
+`self_member_id`, so one call covers every room.
+
+Export your identity to move between machines or back it up:
 
 ```bash
 riverctl identity export <room-owner-vk> > my-identity.token
@@ -74,7 +98,7 @@ riverctl member ban          <room-owner-vk> <member-vk>   # Owner only.
 | `member`   | `list`, `set-nickname`, `ban`                                           |
 | `invite`   | `create`, `accept`                                                      |
 | `dm`       | `send`, `list`, `purge`, `accept`                                       |
-| `identity` | `export`, `import`                                                      |
+| `identity` | `whoami`, `export`, `import`                                            |
 | `debug`    | troubleshooting utilities                                               |
 
 Run `riverctl <group> --help` or `riverctl <group> <cmd> --help` for full flags. All commands accept `--format json` for scripting.
@@ -90,6 +114,9 @@ Run `riverctl <group> --help` or `riverctl <group> <cmd> --help` for full flags.
 | `delete` | A previously-streamed message was deleted | `message_id`, `room`, `author`, `nickname`, `timestamp` (no `content`) |
 
 `reply_to` is `null` for non-replies, otherwise `{ "author", "preview" }`. `edit`/`delete` events are emitted only for messages the stream actually surfaced. Bridges should key off `type` and tolerate unknown future types.
+
+`author` is your correspondent's member ID; get your own with `riverctl identity
+whoami <room-owner-vk>` and compare against it to recognise your own messages.
 
 ## Configuration
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -91,9 +91,10 @@ RIVER_SIGNING_KEY=<base64-key> riverctl identity whoami <room-owner-vk> --format
 ```
 
 `room list --format json` carries the same `self_member_id` (plus
-`signing_key_source`), so one call covers every room. Note that a
-`--signing-key-file` override applies to *every* room, including ones that
-identity is not a member of.
+`signing_key_source`) and honours the same `--signing-key` / `RIVER_SIGNING_KEY`,
+so one call covers every room and always agrees with `whoami`. Note that an
+override applies to *every* room, including ones that identity is not a member
+of — which is what `signing_key_source` is there to tell you.
 
 **On comparing IDs.** A `MemberId` renders as 8 base32 characters — a truncated,
 non-cryptographic hash of the verifying key. That is fine for recognising your

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -445,6 +445,25 @@ pub(crate) fn render_mentions_for_terminal(room_state: &ChatRoomStateV1, text: &
 /// `[Encrypted: N bytes, vN]` — and, worse, `send_reply` sealed that
 /// placeholder into `ReplyContentV1.target_author_name`, persisting it to
 /// contract state for every reader (including the UI).
+/// The `author` an outgoing message from `signing_key` carries.
+///
+/// SINGLE SOURCE OF TRUTH, shared with `riverctl identity whoami`
+/// (freenet/river#438) via `storage::self_identity_from`. whoami's entire
+/// promise is that the ID it reports equals the `author` on this identity's
+/// own messages, so a bridge can filter its own echo. Previously every send
+/// site hand-inlined `MemberId::from(&signing_key.verifying_key())` (in three
+/// different spellings), and whoami inlined a fourth copy — nothing but a
+/// source-scrape kept them in step, and the scrape silently missed the two
+/// paths that send actual chat messages.
+///
+/// Call this from EVERY site that sets `MessageV1::author`. Do not re-inline
+/// the derivation: a new send path that derives `author` its own way breaks
+/// whoami for that path only, which is invisible until a bridge starts
+/// double-posting.
+pub(crate) fn author_member_id(signing_key: &SigningKey) -> MemberId {
+    MemberId::from(&signing_key.verifying_key())
+}
+
 pub(crate) fn unseal_nickname_display(
     nickname: &river_core::room_state::privacy::SealedBytes,
     secrets: &HashMap<u32, [u8; 32]>,
@@ -2145,7 +2164,7 @@ impl ApiClient {
                         // The join event counts as a message, preventing
                         // post_apply_cleanup from pruning the new member.
                         let signing_key = &invitation.invitee_signing_key;
-                        let self_id = MemberId::from(&signing_key.verifying_key());
+                        let self_id = author_member_id(signing_key);
 
                         // Build members delta: invitee + any missing invite chain members
                         let current_member_ids: HashSet<MemberId> = room_state
@@ -2839,7 +2858,7 @@ impl ApiClient {
         let mut room_state = self.get_room(room_owner_key, false).await?;
 
         let sender_vk = signing_key.verifying_key();
-        let sender_member_id: MemberId = (&sender_vk).into();
+        let sender_member_id = author_member_id(signing_key);
 
         // Resolve any bare @nickname mentions to full mention tokens.
         let message_content = resolve_outgoing_mentions(&room_state, &message_content);
@@ -2997,7 +3016,7 @@ impl ApiClient {
         // Create the message
         let message = river_core::room_state::message::MessageV1 {
             room_owner: river_core::room_state::member::MemberId::from(*room_owner_key),
-            author: river_core::room_state::member::MemberId::from(&signing_key.verifying_key()),
+            author: author_member_id(&signing_key),
             content,
             time: std::time::SystemTime::now(),
         };
@@ -3161,7 +3180,7 @@ impl ApiClient {
         // Create the edit action message
         let message = river_core::room_state::message::MessageV1 {
             room_owner: MemberId::from(*room_owner_key),
-            author: MemberId::from(&signing_key.verifying_key()),
+            author: author_member_id(&signing_key),
             content,
             time: std::time::SystemTime::now(),
         };
@@ -3231,7 +3250,7 @@ impl ApiClient {
         // Create the delete action message
         let message = river_core::room_state::message::MessageV1 {
             room_owner: MemberId::from(*room_owner_key),
-            author: MemberId::from(&signing_key.verifying_key()),
+            author: author_member_id(&signing_key),
             content,
             time: std::time::SystemTime::now(),
         };
@@ -3303,7 +3322,7 @@ impl ApiClient {
         // Create the reaction action message
         let message = river_core::room_state::message::MessageV1 {
             room_owner: MemberId::from(*room_owner_key),
-            author: MemberId::from(&signing_key.verifying_key()),
+            author: author_member_id(&signing_key),
             content,
             time: std::time::SystemTime::now(),
         };
@@ -3378,7 +3397,7 @@ impl ApiClient {
         // Create the remove_reaction action message
         let message = river_core::room_state::message::MessageV1 {
             room_owner: MemberId::from(*room_owner_key),
-            author: MemberId::from(&signing_key.verifying_key()),
+            author: author_member_id(&signing_key),
             content,
             time: std::time::SystemTime::now(),
         };
@@ -3497,7 +3516,7 @@ impl ApiClient {
         // Create the reply message
         let message = river_core::room_state::message::MessageV1 {
             room_owner: MemberId::from(*room_owner_key),
-            author: MemberId::from(&signing_key.verifying_key()),
+            author: author_member_id(&signing_key),
             content,
             time: std::time::SystemTime::now(),
         };

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -2730,6 +2730,16 @@ impl ApiClient {
         self.storage.list_rooms()
     }
 
+    /// [`Self::list_rooms`], reporting each room's `self_identity` as
+    /// `signing_key` would sign (the inline `--signing-key` /
+    /// `RIVER_SIGNING_KEY` case). `None` uses each room's effective stored key.
+    pub async fn list_rooms_as(
+        &self,
+        signing_key: Option<&SigningKey>,
+    ) -> Result<Vec<crate::storage::RoomListing>> {
+        self.storage.list_rooms_as(signing_key)
+    }
+
     /// Build a rejoin delta if the user has been pruned from the members list.
     /// Returns (members_delta, member_info_delta) if the user needs to re-add themselves.
     ///

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -2707,19 +2707,8 @@ impl ApiClient {
         }
     }
 
-    pub async fn list_rooms(&self) -> Result<Vec<(String, String, String)>> {
-        self.storage.list_rooms().map(|rooms| {
-            rooms
-                .into_iter()
-                .map(|(owner_vk, name, contract_key)| {
-                    (
-                        bs58::encode(owner_vk.as_bytes()).into_string(),
-                        name,
-                        contract_key,
-                    )
-                })
-                .collect()
-        })
+    pub async fn list_rooms(&self) -> Result<Vec<crate::storage::RoomListing>> {
+        self.storage.list_rooms()
     }
 
     /// Build a rejoin delta if the user has been pruned from the members list.

--- a/cli/src/commands/identity.rs
+++ b/cli/src/commands/identity.rs
@@ -1,5 +1,6 @@
 use crate::api::ApiClient;
 use crate::output::OutputFormat;
+use crate::storage::{SelfIdentity, Storage};
 use anyhow::{anyhow, Result};
 use clap::Subcommand;
 use ed25519_dalek::{SigningKey, VerifyingKey};
@@ -9,6 +10,19 @@ use river_core::room_state::ChatRoomParametersV1;
 
 #[derive(Subcommand)]
 pub enum IdentityCommands {
+    /// Show your own member ID for a room (offline; no node required)
+    ///
+    /// The reported `member_id` is exactly the `author` value that messages
+    /// from this identity carry in `riverctl message list/stream --format
+    /// json`, so a bridge can filter out its own echo without waiting for a
+    /// message to arrive first (freenet/river#438).
+    ///
+    /// With no room, reports every room in local storage — River identities
+    /// are per-room, so there is no single global member ID.
+    Whoami {
+        /// Room owner's verifying key (base58). Omit for all rooms.
+        room: Option<String>,
+    },
     /// Export your identity for a room as a portable token
     Export {
         /// Room owner's verifying key (base58)
@@ -38,11 +52,116 @@ pub async fn execute(
     format: OutputFormat,
 ) -> Result<()> {
     match command {
+        IdentityCommands::Whoami { room } => whoami(api_client.storage(), room.as_deref(), format),
         IdentityCommands::Export { room } => export_identity(&api_client, &room, format).await,
         IdentityCommands::Import { token, file, force } => {
             import_identity(&api_client, token, file, force, format).await
         }
     }
+}
+
+/// `riverctl identity whoami [room]` — report the local user's own member ID
+/// (freenet/river#438).
+///
+/// Deliberately **offline**: everything comes from `rooms.json`, so this works
+/// with the node down and, more importantly, resolves before any message has
+/// been observed. Takes `&Storage` rather than `&ApiClient` precisely so it
+/// cannot acquire a node connection by accident — `main` short-circuits to it
+/// before the client is built, and that short-circuit is only sound while this
+/// signature keeps the node out of reach.
+///
+/// The reported ID reflects the *effective* signing key, so a
+/// `--signing-key-file` override is honoured and disclosed via
+/// `signing_key_source`.
+pub fn whoami(storage: &Storage, room: Option<&str>, format: OutputFormat) -> Result<()> {
+    let source = if storage.has_signing_key_override() {
+        "override"
+    } else {
+        "stored"
+    };
+
+    let entries: Vec<(String, SelfIdentity)> = match room {
+        Some(room_key_str) => {
+            let room_owner_key = parse_room_key(room_key_str)?;
+            let identity = storage.self_identity(&room_owner_key)?.ok_or_else(|| {
+                anyhow!(
+                    "Room {} not found in local storage. Join it first, or run \
+                     `riverctl identity whoami` with no argument to list the \
+                     rooms you do have.",
+                    room_key_str
+                )
+            })?;
+            vec![(
+                bs58::encode(room_owner_key.as_bytes()).into_string(),
+                identity,
+            )]
+        }
+        None => {
+            let mut all: Vec<_> = storage
+                .list_rooms()?
+                .into_iter()
+                .map(|room| {
+                    (
+                        bs58::encode(room.owner_vk.as_bytes()).into_string(),
+                        room.self_identity,
+                    )
+                })
+                .collect();
+            // Stable output: `rooms.json` is a HashMap, so iteration order
+            // varies between runs and would churn any script diffing it.
+            all.sort_by(|(a, _), (b, _)| a.cmp(b));
+            all
+        }
+    };
+
+    match format {
+        OutputFormat::Json => {
+            let json: Vec<_> = entries
+                .iter()
+                .map(|(room_key, identity)| {
+                    serde_json::json!({
+                        "room": room_key,
+                        "member_id": identity.member_id.to_string(),
+                        "verifying_key":
+                            bs58::encode(identity.verifying_key.as_bytes()).into_string(),
+                        "nickname": identity.nickname,
+                        "is_owner": identity.is_owner,
+                        "signing_key_source": source,
+                    })
+                })
+                .collect();
+            // A single named room reports one object, not a one-element array,
+            // so `riverctl identity whoami <room> -f json | jq -r .member_id`
+            // works without an index.
+            if room.is_some() {
+                println!("{}", serde_json::to_string_pretty(&json[0])?);
+            } else {
+                println!("{}", serde_json::to_string_pretty(&json)?);
+            }
+        }
+        OutputFormat::Human => {
+            if entries.is_empty() {
+                println!("No rooms found. Use 'riverctl room create' or accept an invitation.");
+            }
+            for (room_key, identity) in &entries {
+                println!("Room: {}", room_key);
+                println!("  Member ID: {}", identity.member_id);
+                println!(
+                    "  Verifying key: {}",
+                    bs58::encode(identity.verifying_key.as_bytes()).into_string()
+                );
+                println!(
+                    "  Nickname: {}",
+                    identity.nickname.as_deref().unwrap_or("(none)")
+                );
+                println!("  Owner: {}", if identity.is_owner { "yes" } else { "no" });
+                println!("  Signing key: {}", source);
+                println!();
+            }
+        }
+    }
+
+    Ok(())
 }
 
 async fn export_identity(
@@ -412,6 +531,64 @@ fn check_export_coherence(
          authorized member. The signing key's verifying key does not match the \
          cached AuthorizedMember.member_vk for this room. {hint}"
     ))
+}
+
+#[cfg(test)]
+mod whoami_wiring_tests {
+    /// `identity whoami` must be answered from local storage BEFORE the API
+    /// client is constructed (freenet/river#438). `ApiClient::new*` opens a
+    /// WebSocket eagerly, so routing whoami through it makes a pure
+    /// `rooms.json` read fail outright when the node is down — which is
+    /// exactly when a bridge most needs to know its own member ID. This pins
+    /// the short-circuit; a refactor that folds whoami back into the general
+    /// dispatch fails here.
+    #[test]
+    fn whoami_short_circuits_before_client_creation() {
+        let main_src = include_str!("../main.rs");
+        assert!(
+            main_src.contains("identity::whoami(&storage, room.as_deref(), cli.format)"),
+            "main must dispatch `identity whoami` directly against Storage. Do \
+             NOT route it through ApiClient — that opens a WebSocket and makes \
+             an offline, node-free lookup impossible (freenet/river#438)."
+        );
+
+        // The short-circuit must come BEFORE the client is built, or it buys
+        // nothing: the connection would already have been attempted.
+        let whoami_at = main_src
+            .find("identity::whoami(&storage")
+            .expect("whoami dispatch present");
+        let client_at = main_src
+            .find("ApiClient::new_with_signing_key_override(")
+            .expect("client construction present");
+        assert!(
+            whoami_at < client_at,
+            "the whoami short-circuit must precede ApiClient construction in \
+             main; otherwise the WebSocket handshake still runs first."
+        );
+    }
+
+    /// The short-circuit must honour `--signing-key-file`, or whoami would
+    /// report the persisted identity while messages get signed by the
+    /// override — reporting an id that matches none of the bridge's own
+    /// messages, the precise failure this feature exists to prevent.
+    #[test]
+    fn whoami_short_circuit_passes_signing_key_override() {
+        let main_src = include_str!("../main.rs");
+        let start = main_src
+            .find("let whoami_room = match &cli.command")
+            .expect("whoami short-circuit present");
+        let end = main_src[start..]
+            .find("// Create API client")
+            .expect("client construction follows")
+            + start;
+        let block = &main_src[start..end];
+        assert!(
+            block.contains("signing_key_override"),
+            "the whoami short-circuit must pass `signing_key_override` into \
+             Storage, so `--signing-key-file` / RIVER_SIGNING_KEY_FILE selects \
+             the reported identity (freenet/river#438)."
+        );
+    }
 }
 
 #[cfg(test)]

--- a/cli/src/commands/identity.rs
+++ b/cli/src/commands/identity.rs
@@ -577,8 +577,11 @@ mod whoami_wiring_tests {
         let start = main_src
             .find("let whoami_room = match &cli.command")
             .expect("whoami short-circuit present");
+        // Anchor the end on CODE, not on a comment: anchoring on the
+        // "// Create API client" comment made a comment cleanup a false
+        // failure with a misdirecting message (review on PR #439).
         let end = main_src[start..]
-            .find("// Create API client")
+            .find("ApiClient::new_with_signing_key_override(")
             .expect("client construction follows")
             + start;
         let block = &main_src[start..end];

--- a/cli/src/commands/identity.rs
+++ b/cli/src/commands/identity.rs
@@ -217,7 +217,7 @@ fn whoami_json(room_key: &str, identity: &SelfIdentity, source: &str) -> serde_j
 
 /// Parse a base64 32-byte Ed25519 signing key, matching the encoding
 /// `message send --signing-key` / `RIVER_SIGNING_KEY` accepts.
-fn parse_inline_signing_key(encoded: &str) -> Result<SigningKey> {
+pub(crate) fn parse_inline_signing_key(encoded: &str) -> Result<SigningKey> {
     use base64::Engine;
     let bytes = base64::engine::general_purpose::STANDARD
         .decode(encoded.trim())

--- a/cli/src/commands/identity.rs
+++ b/cli/src/commands/identity.rs
@@ -22,6 +22,16 @@ pub enum IdentityCommands {
     Whoami {
         /// Room owner's verifying key (base58). Omit for all rooms.
         room: Option<String>,
+        /// Signing key (base64-encoded 32-byte Ed25519 signing key), matching
+        /// `message send --signing-key` / `RIVER_SIGNING_KEY`.
+        ///
+        /// Report the identity THIS key would send as. Because `message send`
+        /// prefers its inline key over `--signing-key-file` and over
+        /// `rooms.json`, whoami must do the same or it reports an ID that
+        /// matches none of the bridge's own messages. With this set, the room
+        /// need not be in local storage.
+        #[arg(long, env = "RIVER_SIGNING_KEY")]
+        signing_key: Option<String>,
     },
     /// Export your identity for a room as a portable token
     Export {
@@ -52,7 +62,19 @@ pub async fn execute(
     format: OutputFormat,
 ) -> Result<()> {
     match command {
-        IdentityCommands::Whoami { room } => whoami(api_client.storage(), room.as_deref(), format),
+        // Reachable only by library callers: the binary short-circuits Whoami
+        // in `main` BEFORE building the client (so it works offline). Kept so
+        // `execute` stays total rather than growing an `unreachable!()`; a
+        // library caller pays the client's connection for a lookup that does
+        // not need it. Any change to the short-circuit's behaviour (new
+        // options, new precedence) must be mirrored here — both call the same
+        // `whoami`, so only argument plumbing can drift.
+        IdentityCommands::Whoami { room, signing_key } => whoami(
+            api_client.storage(),
+            room.as_deref(),
+            signing_key.as_deref(),
+            format,
+        ),
         IdentityCommands::Export { room } => export_identity(&api_client, &room, format).await,
         IdentityCommands::Import { token, file, force } => {
             import_identity(&api_client, token, file, force, format).await
@@ -63,42 +85,66 @@ pub async fn execute(
 /// `riverctl identity whoami [room]` — report the local user's own member ID
 /// (freenet/river#438).
 ///
-/// Deliberately **offline**: everything comes from `rooms.json`, so this works
-/// with the node down and, more importantly, resolves before any message has
-/// been observed. Takes `&Storage` rather than `&ApiClient` precisely so it
+/// Deliberately **offline**: everything comes from local storage, so this
+/// works with the node down and, more importantly, resolves before any message
+/// has been observed. Takes `&Storage` rather than `&ApiClient` precisely so it
 /// cannot acquire a node connection by accident — `main` short-circuits to it
 /// before the client is built, and that short-circuit is only sound while this
-/// signature keeps the node out of reach.
+/// signature keeps the node out of reach. (It is not strictly read-only: the
+/// shared `Storage` loader takes the advisory lock and may rewrite `rooms.json`
+/// when the bundled WASM's contract key has changed, so the config dir must be
+/// writable.)
 ///
-/// The reported ID reflects the *effective* signing key, so a
-/// `--signing-key-file` override is honoured and disclosed via
-/// `signing_key_source`.
-pub fn whoami(storage: &Storage, room: Option<&str>, format: OutputFormat) -> Result<()> {
-    let source = if storage.has_signing_key_override() {
-        "override"
-    } else {
-        "stored"
+/// The reported ID reflects the identity that would actually SIGN, across all
+/// three override mechanisms, in the same precedence `message send` uses:
+/// an inline `--signing-key` / `RIVER_SIGNING_KEY` beats `--signing-key-file` /
+/// `RIVER_SIGNING_KEY_FILE`, which beats the per-room key in `rooms.json`. The
+/// winner is disclosed as `signing_key_source`.
+pub fn whoami(
+    storage: &Storage,
+    room: Option<&str>,
+    inline_signing_key: Option<&str>,
+    format: OutputFormat,
+) -> Result<()> {
+    let inline_key = inline_signing_key
+        .map(parse_inline_signing_key)
+        .transpose()?;
+
+    let source = match (&inline_key, storage.has_signing_key_override()) {
+        // `message send` takes its inline-key branch before consulting
+        // storage, so an inline key wins even with a file override also set.
+        (Some(_), _) => "inline",
+        (None, true) => "override",
+        (None, false) => "stored",
     };
 
     let entries: Vec<(String, SelfIdentity)> = match room {
         Some(room_key_str) => {
             let room_owner_key = parse_room_key(room_key_str)?;
-            let identity = storage.self_identity(&room_owner_key)?.ok_or_else(|| {
-                anyhow!(
-                    "Room {} not found in local storage. Join it first, or run \
-                     `riverctl identity whoami` with no argument to list the \
-                     rooms you do have.",
-                    room_key_str
-                )
-            })?;
-            vec![(
-                bs58::encode(room_owner_key.as_bytes()).into_string(),
-                identity,
-            )]
+            let room_key = bs58::encode(room_owner_key.as_bytes()).into_string();
+            let stored = storage.self_identity_with(&room_owner_key, inline_key.as_ref())?;
+            let identity = match (stored, &inline_key) {
+                (Some(identity), _) => identity,
+                // An inline key needs no local storage to yield a member ID —
+                // `message send --signing-key` explicitly works without it, so
+                // refusing here would leave that bot workflow unserved.
+                // Nickname is unknowable without the room's state.
+                (None, Some(key)) => crate::storage::self_identity_from_key(&room_owner_key, key),
+                (None, None) => {
+                    return Err(anyhow!(
+                        "Room {} not found in local storage. Join it first, run \
+                         `riverctl identity whoami` with no argument to list the \
+                         rooms you do have, or pass `--signing-key` to report an \
+                         identity without local storage.",
+                        room_key_str
+                    ))
+                }
+            };
+            vec![(room_key, identity)]
         }
         None => {
             let mut all: Vec<_> = storage
-                .list_rooms()?
+                .list_rooms_as(inline_key.as_ref())?
                 .into_iter()
                 .map(|room| {
                     (
@@ -118,25 +164,14 @@ pub fn whoami(storage: &Storage, room: Option<&str>, format: OutputFormat) -> Re
         OutputFormat::Json => {
             let json: Vec<_> = entries
                 .iter()
-                .map(|(room_key, identity)| {
-                    serde_json::json!({
-                        "room": room_key,
-                        "member_id": identity.member_id.to_string(),
-                        "verifying_key":
-                            bs58::encode(identity.verifying_key.as_bytes()).into_string(),
-                        "nickname": identity.nickname,
-                        "is_owner": identity.is_owner,
-                        "signing_key_source": source,
-                    })
-                })
+                .map(|(room_key, identity)| whoami_json(room_key, identity, source))
                 .collect();
             // A single named room reports one object, not a one-element array,
             // so `riverctl identity whoami <room> -f json | jq -r .member_id`
             // works without an index.
-            if room.is_some() {
-                println!("{}", serde_json::to_string_pretty(&json[0])?);
-            } else {
-                println!("{}", serde_json::to_string_pretty(&json)?);
+            match (room.is_some(), json.first()) {
+                (true, Some(one)) => println!("{}", serde_json::to_string_pretty(one)?),
+                _ => println!("{}", serde_json::to_string_pretty(&json)?),
             }
         }
         OutputFormat::Human => {
@@ -155,13 +190,45 @@ pub fn whoami(storage: &Storage, room: Option<&str>, format: OutputFormat) -> Re
                     identity.nickname.as_deref().unwrap_or("(none)")
                 );
                 println!("  Owner: {}", if identity.is_owner { "yes" } else { "no" });
-                println!("  Signing key: {}", source);
+                println!("  Signing key source: {}", source);
                 println!();
             }
         }
     }
 
     Ok(())
+}
+
+/// The `whoami --format json` payload for one room.
+///
+/// Pure, so the field names — the actual contract with a bridge, e.g. the
+/// documented `| jq -r .member_id` — are unit-testable without a node or a
+/// data dir (mirrors `room::join_requires_invitation_json`).
+fn whoami_json(room_key: &str, identity: &SelfIdentity, source: &str) -> serde_json::Value {
+    serde_json::json!({
+        "room": room_key,
+        "member_id": identity.member_id.to_string(),
+        "verifying_key": bs58::encode(identity.verifying_key.as_bytes()).into_string(),
+        "nickname": identity.nickname,
+        "is_owner": identity.is_owner,
+        "signing_key_source": source,
+    })
+}
+
+/// Parse a base64 32-byte Ed25519 signing key, matching the encoding
+/// `message send --signing-key` / `RIVER_SIGNING_KEY` accepts.
+fn parse_inline_signing_key(encoded: &str) -> Result<SigningKey> {
+    use base64::Engine;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(encoded.trim())
+        .map_err(|e| anyhow!("Invalid --signing-key (base64 decode failed): {}", e))?;
+    let bytes: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
+        anyhow!(
+            "Invalid --signing-key: expected 32 bytes, got {}",
+            bytes.len()
+        )
+    })?;
+    Ok(SigningKey::from_bytes(&bytes))
 }
 
 async fn export_identity(
@@ -534,6 +601,71 @@ fn check_export_coherence(
 }
 
 #[cfg(test)]
+mod whoami_payload_tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use river_core::room_state::member::MemberId;
+
+    fn identity(nickname: Option<&str>) -> SelfIdentity {
+        let sk = SigningKey::from_bytes(&[5u8; 32]);
+        let vk = sk.verifying_key();
+        SelfIdentity {
+            member_id: MemberId::from(&vk),
+            verifying_key: vk,
+            nickname: nickname.map(str::to_string),
+            is_owner: false,
+        }
+    }
+
+    /// The JSON field NAMES are the contract with a bridge — `cli/README.md`
+    /// documents `| jq -r .member_id`. Renaming one silently breaks every
+    /// consumer, so pin them.
+    #[test]
+    fn whoami_json_field_names_are_stable() {
+        let id = identity(Some("bridge-bot"));
+        let json = whoami_json("ROOMKEY", &id, "stored");
+
+        assert_eq!(json["room"], "ROOMKEY");
+        assert_eq!(json["member_id"], id.member_id.to_string());
+        assert_eq!(
+            json["verifying_key"],
+            bs58::encode(id.verifying_key.as_bytes()).into_string()
+        );
+        assert_eq!(json["nickname"], "bridge-bot");
+        assert_eq!(json["is_owner"], false);
+        assert_eq!(json["signing_key_source"], "stored");
+
+        let keys: Vec<_> = json.as_object().unwrap().keys().cloned().collect();
+        assert_eq!(
+            keys.len(),
+            6,
+            "unexpected field count — adding a field is fine, but update this \
+             pin and the README so consumers learn about it: {keys:?}"
+        );
+    }
+
+    /// `member_id` must be the `Display` form (what `message list/stream` puts
+    /// in `author`), not a debug or byte rendering.
+    #[test]
+    fn whoami_json_member_id_matches_author_display_form() {
+        let id = identity(None);
+        let json = whoami_json("ROOMKEY", &id, "stored");
+        // `author` in message JSON is `msg.message.author.to_string()`.
+        assert_eq!(json["member_id"], id.member_id.to_string());
+        assert!(!json["member_id"].as_str().unwrap().contains("MemberId"));
+    }
+
+    /// A missing nickname is JSON `null`, not `"None"` or `""` — a bridge
+    /// checking for absence should not have to string-match.
+    #[test]
+    fn whoami_json_absent_nickname_is_null() {
+        let json = whoami_json("ROOMKEY", &identity(None), "override");
+        assert_eq!(json["nickname"], serde_json::Value::Null);
+        assert_eq!(json["signing_key_source"], "override");
+    }
+}
+
+#[cfg(test)]
 mod whoami_wiring_tests {
     /// `identity whoami` must be answered from local storage BEFORE the API
     /// client is constructed (freenet/river#438). `ApiClient::new*` opens a
@@ -542,21 +674,23 @@ mod whoami_wiring_tests {
     /// exactly when a bridge most needs to know its own member ID. This pins
     /// the short-circuit; a refactor that folds whoami back into the general
     /// dispatch fails here.
+    ///
+    /// These scrapes are a backstop with a readable failure message; the
+    /// BEHAVIOURAL proof is `cli/tests/whoami_offline.rs`, which runs the real
+    /// binary against a dead node URL. Anchors here are deliberately short
+    /// (`identity::whoami(`, not a full argument list) — an earlier version
+    /// pinned the whole call and false-failed the moment an argument was
+    /// added, which is noise, not signal.
     #[test]
     fn whoami_short_circuits_before_client_creation() {
         let main_src = include_str!("../main.rs");
-        assert!(
-            main_src.contains("identity::whoami(&storage, room.as_deref(), cli.format)"),
+        let whoami_at = main_src.find("identity::whoami(").expect(
             "main must dispatch `identity whoami` directly against Storage. Do \
              NOT route it through ApiClient — that opens a WebSocket and makes \
-             an offline, node-free lookup impossible (freenet/river#438)."
+             an offline, node-free lookup impossible (freenet/river#438).",
         );
-
         // The short-circuit must come BEFORE the client is built, or it buys
         // nothing: the connection would already have been attempted.
-        let whoami_at = main_src
-            .find("identity::whoami(&storage")
-            .expect("whoami dispatch present");
         let client_at = main_src
             .find("ApiClient::new_with_signing_key_override(")
             .expect("client construction present");
@@ -574,17 +708,20 @@ mod whoami_wiring_tests {
     #[test]
     fn whoami_short_circuit_passes_signing_key_override() {
         let main_src = include_str!("../main.rs");
+        // Anchor BOTH ends on code, never on a comment: an earlier version
+        // anchored the end on a `// Create API client` comment, so deleting
+        // the comment was a false failure with a misdirecting message.
         let start = main_src
-            .find("let whoami_room = match &cli.command")
+            .find("identity::whoami(")
             .expect("whoami short-circuit present");
-        // Anchor the end on CODE, not on a comment: anchoring on the
-        // "// Create API client" comment made a comment cleanup a false
-        // failure with a misdirecting message (review on PR #439).
-        let end = main_src[start..]
+        let end = main_src
             .find("ApiClient::new_with_signing_key_override(")
-            .expect("client construction follows")
-            + start;
-        let block = &main_src[start..end];
+            .expect("client construction follows");
+        // Search back from the dispatch to the Storage the short-circuit built.
+        let block_start = main_src[..start]
+            .rfind("Storage::new_with_override(")
+            .expect("short-circuit builds its own Storage");
+        let block = &main_src[block_start..end];
         assert!(
             block.contains("signing_key_override"),
             "the whoami short-circuit must pass `signing_key_override` into \

--- a/cli/src/commands/room.rs
+++ b/cli/src/commands/room.rs
@@ -165,6 +165,14 @@ pub async fn execute(command: RoomCommands, api: ApiClient, format: OutputFormat
                 eprintln!("Listing rooms...");
             }
 
+            // Disclosed alongside `self_member_id` (freenet/river#438): a
+            // `--signing-key-file` override replaces the reported identity for
+            // every room at once.
+            let signing_key_source = if api.storage().has_signing_key_override() {
+                "override"
+            } else {
+                "stored"
+            };
             match api.list_rooms().await {
                 Ok(rooms) => {
                     if rooms.is_empty() {
@@ -204,6 +212,13 @@ pub async fn execute(command: RoomCommands, api: ApiClient, format: OutputFormat
                                             // message from this identity carries.
                                             "self_member_id":
                                                 room.self_identity.member_id.to_string(),
+                                            // Which identity that is. Under
+                                            // `--signing-key-file` the override
+                                            // applies to EVERY room, including
+                                            // ones it isn't a member of, so say
+                                            // so rather than letting a script
+                                            // read the ids as per-room facts.
+                                            "signing_key_source": signing_key_source,
                                         })
                                     })
                                     .collect();

--- a/cli/src/commands/room.rs
+++ b/cli/src/commands/room.rs
@@ -180,21 +180,30 @@ pub async fn execute(command: RoomCommands, api: ApiClient, format: OutputFormat
                         match format {
                             OutputFormat::Human => {
                                 println!("\n{} room(s) found:\n", rooms.len());
-                                for (owner_key, name, contract_key) in rooms {
-                                    println!("Room: {}", name.green());
-                                    println!("  Owner key: {}", owner_key);
-                                    println!("  Contract key: {}", contract_key);
+                                for room in rooms {
+                                    println!("Room: {}", room.name.green());
+                                    println!(
+                                        "  Owner key: {}",
+                                        bs58::encode(room.owner_vk.as_bytes()).into_string()
+                                    );
+                                    println!("  Contract key: {}", room.contract_key);
+                                    println!("  Your member ID: {}", room.self_identity.member_id);
                                     println!();
                                 }
                             }
                             OutputFormat::Json => {
                                 let json_rooms: Vec<_> = rooms
                                     .into_iter()
-                                    .map(|(owner_key, name, contract_key)| {
+                                    .map(|room| {
                                         serde_json::json!({
-                                            "name": name,
-                                            "owner_key": owner_key,
-                                            "contract_key": contract_key,
+                                            "name": room.name,
+                                            "owner_key": bs58::encode(room.owner_vk.as_bytes())
+                                                .into_string(),
+                                            "contract_key": room.contract_key,
+                                            // freenet/river#438: the `author` a
+                                            // message from this identity carries.
+                                            "self_member_id":
+                                                room.self_identity.member_id.to_string(),
                                         })
                                     })
                                     .collect();

--- a/cli/src/commands/room.rs
+++ b/cli/src/commands/room.rs
@@ -24,7 +24,18 @@ pub enum RoomCommands {
         private: bool,
     },
     /// List all rooms
-    List,
+    List {
+        /// Signing key (base64-encoded 32-byte Ed25519 signing key), matching
+        /// `message send --signing-key` / `RIVER_SIGNING_KEY`.
+        ///
+        /// Only affects `self_member_id` / `signing_key_source`: report the
+        /// identity THIS key would send as, so the value agrees with
+        /// `identity whoami` and with the `author` on messages this key signs.
+        /// Room names still resolve via each room's stored key, since a
+        /// signing identity does not necessarily hold the room secret.
+        #[arg(long, env = "RIVER_SIGNING_KEY")]
+        signing_key: Option<String>,
+    },
     /// Join a room
     Join {
         /// Room ID
@@ -160,20 +171,26 @@ pub async fn execute(command: RoomCommands, api: ApiClient, format: OutputFormat
                 }
             }
         }
-        RoomCommands::List => {
+        RoomCommands::List { signing_key } => {
             if !matches!(format, OutputFormat::Json) {
                 eprintln!("Listing rooms...");
             }
 
-            // Disclosed alongside `self_member_id` (freenet/river#438): a
-            // `--signing-key-file` override replaces the reported identity for
-            // every room at once.
-            let signing_key_source = if api.storage().has_signing_key_override() {
-                "override"
-            } else {
-                "stored"
+            // Same three-way precedence as `identity whoami`, so the two
+            // surfaces never report different ids for the same room
+            // (freenet/river#438). Disclosed alongside `self_member_id`
+            // because an override replaces the identity for EVERY room at
+            // once, including ones it is not a member of.
+            let inline_key = signing_key
+                .as_deref()
+                .map(crate::commands::identity::parse_inline_signing_key)
+                .transpose()?;
+            let signing_key_source = match (&inline_key, api.storage().has_signing_key_override()) {
+                (Some(_), _) => "inline",
+                (None, true) => "override",
+                (None, false) => "stored",
             };
-            match api.list_rooms().await {
+            match api.list_rooms_as(inline_key.as_ref()).await {
                 Ok(rooms) => {
                     if rooms.is_empty() {
                         match format {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -146,26 +146,51 @@ async fn main() -> Result<()> {
         .map(load_signing_key_from_file)
         .transpose()?;
 
-    // Create API client
-    let api_client = api::ApiClient::new_with_signing_key_override(
-        &cli.node_url,
-        config,
-        cli.config_dir.as_deref(),
-        signing_key_override,
-    )
-    .await?;
+    // `identity whoami` (freenet/river#438) is a pure `rooms.json` read, so it
+    // is answered BEFORE the client is built: it must work with the node down,
+    // and a bridge polling for its own member ID should never pay a WebSocket
+    // handshake for it. Every other command needs a connected client.
+    let whoami_room = match &cli.command {
+        Commands::Identity {
+            command: identity::IdentityCommands::Whoami { room },
+        } => Some(room.clone()),
+        _ => None,
+    };
 
-    // Execute command
-    match cli.command {
-        Commands::Room { command } => room::execute(command, api_client, cli.format).await?,
-        Commands::Message { command } => message::execute(command, api_client, cli.format).await?,
-        Commands::Member { command } => member::execute(command, api_client, cli.format).await?,
-        Commands::Invite { command } => invite::execute(command, api_client, cli.format).await?,
-        Commands::Identity { command } => {
-            identity::execute(command, api_client, cli.format).await?
+    if let Some(room) = whoami_room {
+        let storage = riverctl::storage::Storage::new_with_override(
+            cli.config_dir.as_deref(),
+            signing_key_override,
+        )?;
+        identity::whoami(&storage, room.as_deref(), cli.format)?;
+    } else {
+        // Create API client
+        let api_client = api::ApiClient::new_with_signing_key_override(
+            &cli.node_url,
+            config,
+            cli.config_dir.as_deref(),
+            signing_key_override,
+        )
+        .await?;
+
+        // Execute command
+        match cli.command {
+            Commands::Room { command } => room::execute(command, api_client, cli.format).await?,
+            Commands::Message { command } => {
+                message::execute(command, api_client, cli.format).await?
+            }
+            Commands::Member { command } => {
+                member::execute(command, api_client, cli.format).await?
+            }
+            Commands::Invite { command } => {
+                invite::execute(command, api_client, cli.format).await?
+            }
+            Commands::Identity { command } => {
+                identity::execute(command, api_client, cli.format).await?
+            }
+            Commands::Debug { command } => debug::execute(command, api_client, cli.format).await?,
+            Commands::Dm { command } => dm::execute(command, api_client, cli.format).await?,
         }
-        Commands::Debug { command } => debug::execute(command, api_client, cli.format).await?,
-        Commands::Dm { command } => dm::execute(command, api_client, cli.format).await?,
     }
 
     // Best-effort "newer riverctl available?" nudge — crates.io, once/day

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -150,19 +150,24 @@ async fn main() -> Result<()> {
     // is answered BEFORE the client is built: it must work with the node down,
     // and a bridge polling for its own member ID should never pay a WebSocket
     // handshake for it. Every other command needs a connected client.
-    let whoami_room = match &cli.command {
+    let whoami_args = match &cli.command {
         Commands::Identity {
-            command: identity::IdentityCommands::Whoami { room },
-        } => Some(room.clone()),
+            command: identity::IdentityCommands::Whoami { room, signing_key },
+        } => Some((room.clone(), signing_key.clone())),
         _ => None,
     };
 
-    if let Some(room) = whoami_room {
+    if let Some((room, inline_signing_key)) = whoami_args {
         let storage = riverctl::storage::Storage::new_with_override(
             cli.config_dir.as_deref(),
             signing_key_override,
         )?;
-        identity::whoami(&storage, room.as_deref(), cli.format)?;
+        identity::whoami(
+            &storage,
+            room.as_deref(),
+            inline_signing_key.as_deref(),
+            cli.format,
+        )?;
     } else {
         // Create API client
         let api_client = api::ApiClient::new_with_signing_key_override(

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -120,18 +120,45 @@ pub struct RoomListing {
     pub self_identity: SelfIdentity,
 }
 
+/// Shared empty map so the public-nickname path borrows instead of allocating.
+static EMPTY_SECRETS: std::sync::LazyLock<HashMap<u32, [u8; 32]>> =
+    std::sync::LazyLock::new(HashMap::new);
+
+/// A [`SelfIdentity`] derivable from a signing key ALONE, with no stored room.
+///
+/// `member_id` / `verifying_key` / `is_owner` need nothing but the key and the
+/// room's owner key, which is what lets `whoami --signing-key` serve the
+/// stateless bot workflow that `ApiClient::send_message_with_key` supports.
+/// Nickname is unknowable without the room's state, so it is `None`.
+pub(crate) fn self_identity_from_key(
+    room_owner_vk: &VerifyingKey,
+    signing_key: &SigningKey,
+) -> SelfIdentity {
+    let verifying_key = signing_key.verifying_key();
+    SelfIdentity {
+        member_id: crate::api::author_member_id(signing_key),
+        is_owner: verifying_key == *room_owner_vk,
+        verifying_key,
+        nickname: None,
+    }
+}
+
 /// Build a [`SelfIdentity`] from an already-resolved signing key and the
 /// room's stored record.
 ///
 /// Pure (no I/O) so the derivation is unit-testable without a node or a data
-/// dir. Callers must pass the key from [`Storage::resolve_signing_key`] so a
-/// `--signing-key-file` override is reflected — reporting the persisted
-/// identity while the override is the one actually signing messages would be
-/// worse than reporting nothing.
+/// dir. Callers must pass the EFFECTIVE key — [`Storage::resolve_signing_key`]
+/// for the persisted/file-override case, or the inline `--signing-key` — since
+/// reporting the persisted identity while something else actually signs is the
+/// bug this feature exists to prevent.
+///
+/// `secrets`, when `Some`, is a already-collected room secrets map to reuse
+/// for unsealing a private nickname; pass `None` to collect on demand.
 pub(crate) fn self_identity_from(
     room_owner_vk: &VerifyingKey,
     signing_key: &SigningKey,
     room_info: &StoredRoomInfo,
+    secrets: Option<&HashMap<u32, [u8; 32]>>,
 ) -> SelfIdentity {
     let verifying_key = signing_key.verifying_key();
     // The SAME function every send path uses to set `MessageV1::author`, so
@@ -150,21 +177,33 @@ pub(crate) fn self_identity_from(
         .canonical(member_id)
         .and_then(|info| {
             let sealed = &info.member_info.preferred_nickname;
-            let secrets = if sealed.is_private() {
-                crate::private_room::collect_secrets_for_room(
-                    &room_info.state,
-                    signing_key,
-                    &room_info.invitation_secrets,
-                )
-            } else {
-                HashMap::new()
+            // Reuse the caller's secrets when it already collected them (the
+            // `room list` path needs them for the room NAME anyway); only pay
+            // the X25519/AES work here when nobody has. Collecting twice per
+            // private room also double-logged every decrypt failure.
+            let owned;
+            let secrets = match (sealed.is_private(), secrets) {
+                (false, _) => &EMPTY_SECRETS,
+                (true, Some(s)) => s,
+                (true, None) => {
+                    owned = crate::private_room::collect_secrets_for_room(
+                        &room_info.state,
+                        signing_key,
+                        &room_info.invitation_secrets,
+                    );
+                    &owned
+                }
             };
             // `.ok()`, so an undecryptable private nickname falls through to
             // `self_nickname` instead of reporting the sealed placeholder.
-            river_core::ecies::unseal_bytes_with_secrets(sealed, &secrets)
+            river_core::ecies::unseal_bytes_with_secrets(sealed, secrets)
                 .ok()
                 .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
-        });
+        })
+        // An empty nickname is not a nickname: without this, a member_info
+        // record carrying "" wins over the fallback and prints as a blank
+        // name instead of "(none)".
+        .filter(|nickname| !nickname.is_empty());
 
     // `self_nickname` is the PERSISTED identity's nickname, so it is only a
     // valid fallback when the effective key IS the persisted one. Under a
@@ -1001,6 +1040,13 @@ impl Storage {
     }
 
     pub fn list_rooms(&self) -> Result<Vec<RoomListing>> {
+        self.list_rooms_as(None)
+    }
+
+    /// [`Self::list_rooms`], reporting each room's `self_identity` as
+    /// `signing_key` would sign (the inline `--signing-key` /
+    /// `RIVER_SIGNING_KEY` case). `None` uses each room's effective stored key.
+    pub fn list_rooms_as(&self, signing_key: Option<&SigningKey>) -> Result<Vec<RoomListing>> {
         let storage = self.load_rooms()?;
         let mut rooms = Vec::new();
 
@@ -1010,7 +1056,11 @@ impl Storage {
                 let mut key_array = [0u8; 32];
                 key_array.copy_from_slice(&owner_key_bytes);
                 if let Ok(owner_vk) = VerifyingKey::from_bytes(&key_array) {
-                    let self_sk = self.resolve_signing_key(&room_info.signing_key_bytes);
+                    let stored_sk = self.resolve_signing_key(&room_info.signing_key_bytes);
+                    // The room NAME is sealed to the room secret, which the
+                    // room's own stored key unwraps; an inline override key is
+                    // an identity for signing, not necessarily one holding the
+                    // secret, so the name always resolves via the stored key.
                     let sealed_name = &room_info.state.configuration.configuration.display.name;
                     // A private room's name is AES-256-GCM sealed under the room
                     // secret. Decrypt it with the local member's secrets so
@@ -1019,20 +1069,32 @@ impl Storage {
                     // yields for a sealed value. Falls back to that placeholder
                     // when the secret is unavailable (not yet synced / rotated
                     // past); a public name decrypts trivially to its bytes.
+                    let mut secrets = None;
                     let room_name = if sealed_name.is_private() {
-                        let secrets = crate::private_room::collect_secrets_for_room(
+                        let collected = crate::private_room::collect_secrets_for_room(
                             &room_info.state,
-                            &self_sk,
+                            &stored_sk,
                             &room_info.invitation_secrets,
                         );
-                        river_core::ecies::unseal_bytes_with_secrets(sealed_name, &secrets)
-                            .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
-                            .unwrap_or_else(|_| sealed_name.to_string_lossy())
+                        let name =
+                            river_core::ecies::unseal_bytes_with_secrets(sealed_name, &collected)
+                                .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
+                                .unwrap_or_else(|_| sealed_name.to_string_lossy());
+                        // Hand the same map to the nickname unsealing below
+                        // instead of collecting it a second time per room.
+                        secrets = Some(collected);
+                        name
                     } else {
                         sealed_name.to_string_lossy()
                     };
+                    let self_sk = signing_key.unwrap_or(&stored_sk);
                     rooms.push(RoomListing {
-                        self_identity: self_identity_from(&owner_vk, &self_sk, room_info),
+                        self_identity: self_identity_from(
+                            &owner_vk,
+                            self_sk,
+                            room_info,
+                            secrets.as_ref(),
+                        ),
                         owner_vk,
                         name: room_name,
                         contract_key: room_info.contract_key.clone(),
@@ -1051,13 +1113,26 @@ impl Storage {
     /// learn its own `author` value up front, rather than inferring it from
     /// messages it observes.
     pub fn self_identity(&self, room_owner_vk: &VerifyingKey) -> Result<Option<SelfIdentity>> {
+        self.self_identity_with(room_owner_vk, None)
+    }
+
+    /// [`Self::self_identity`], reporting the identity `signing_key` would
+    /// sign as (the inline `--signing-key` / `RIVER_SIGNING_KEY` case) rather
+    /// than the room's effective stored key. `None` uses the stored key.
+    pub fn self_identity_with(
+        &self,
+        room_owner_vk: &VerifyingKey,
+        signing_key: Option<&SigningKey>,
+    ) -> Result<Option<SelfIdentity>> {
         let storage = self.load_rooms()?;
         let key_str = bs58::encode(room_owner_vk.as_bytes()).into_string();
         Ok(storage.rooms.get(&key_str).map(|room_info| {
+            let stored_sk = self.resolve_signing_key(&room_info.signing_key_bytes);
             self_identity_from(
                 room_owner_vk,
-                &self.resolve_signing_key(&room_info.signing_key_bytes),
+                signing_key.unwrap_or(&stored_sk),
                 room_info,
+                None,
             )
         }))
     }
@@ -1144,7 +1219,7 @@ mod tests {
         let member_sk = create_test_signing_key();
         let room_info = stored_room_info(create_test_state(&owner_sk), &member_sk);
 
-        let identity = self_identity_from(&owner_sk.verifying_key(), &member_sk, &room_info);
+        let identity = self_identity_from(&owner_sk.verifying_key(), &member_sk, &room_info, None);
 
         // The exact expression every `author:` field in api.rs is built from.
         let author_on_send = MemberId::from(&member_sk.verifying_key());
@@ -1231,6 +1306,7 @@ mod tests {
             &owner_vk,
             &owner_sk,
             &stored_room_info(create_test_state(&owner_sk), &owner_sk),
+            None,
         );
         assert!(as_owner.is_owner);
         assert_eq!(as_owner.member_id, MemberId::from(&owner_vk));
@@ -1239,6 +1315,7 @@ mod tests {
             &owner_vk,
             &member_sk,
             &stored_room_info(create_test_state(&owner_sk), &member_sk),
+            None,
         );
         assert!(!as_member.is_owner);
         assert_ne!(as_member.member_id, as_owner.member_id);
@@ -1263,7 +1340,7 @@ mod tests {
         let mut room_info = stored_room_info(state, &member_sk);
         room_info.self_nickname = Some("stale-local".to_string());
 
-        let identity = self_identity_from(&owner_sk.verifying_key(), &member_sk, &room_info);
+        let identity = self_identity_from(&owner_sk.verifying_key(), &member_sk, &room_info, None);
         assert_eq!(identity.nickname.as_deref(), Some("from-room"));
     }
 
@@ -1276,13 +1353,13 @@ mod tests {
         let mut room_info = stored_room_info(create_test_state(&owner_sk), &member_sk);
         room_info.self_nickname = Some("only-local".to_string());
 
-        let identity = self_identity_from(&owner_sk.verifying_key(), &member_sk, &room_info);
+        let identity = self_identity_from(&owner_sk.verifying_key(), &member_sk, &room_info, None);
         assert_eq!(identity.nickname.as_deref(), Some("only-local"));
 
         // Neither source available → None, not an empty string.
         let bare = stored_room_info(create_test_state(&owner_sk), &member_sk);
         assert_eq!(
-            self_identity_from(&owner_sk.verifying_key(), &member_sk, &bare).nickname,
+            self_identity_from(&owner_sk.verifying_key(), &member_sk, &bare, None).nickname,
             None
         );
     }
@@ -1307,7 +1384,7 @@ mod tests {
         let mut room_info = stored_room_info(state, &member_sk);
         room_info.self_nickname = Some("local-copy".to_string());
 
-        let identity = self_identity_from(&owner_sk.verifying_key(), &member_sk, &room_info);
+        let identity = self_identity_from(&owner_sk.verifying_key(), &member_sk, &room_info, None);
         assert_eq!(
             identity.nickname.as_deref(),
             Some("local-copy"),
@@ -1340,7 +1417,7 @@ mod tests {
         // The invitation-carried secret, as a just-joined invitee would have.
         room_info.invitation_secrets.insert(0, secret);
 
-        let identity = self_identity_from(&owner_sk.verifying_key(), &member_sk, &room_info);
+        let identity = self_identity_from(&owner_sk.verifying_key(), &member_sk, &room_info, None);
         assert_eq!(identity.nickname.as_deref(), Some("Nacho"));
     }
 
@@ -1358,12 +1435,13 @@ mod tests {
         room_info.self_nickname = Some("persisted-identity".to_string());
 
         // Effective key == persisted key: the fallback is genuinely ours.
-        let same = self_identity_from(&owner_sk.verifying_key(), &persisted_sk, &room_info);
+        let same = self_identity_from(&owner_sk.verifying_key(), &persisted_sk, &room_info, None);
         assert_eq!(same.nickname.as_deref(), Some("persisted-identity"));
 
         // Effective key is an override for a DIFFERENT member: no nickname,
         // rather than the persisted identity's.
-        let overridden = self_identity_from(&owner_sk.verifying_key(), &override_sk, &room_info);
+        let overridden =
+            self_identity_from(&owner_sk.verifying_key(), &override_sk, &room_info, None);
         assert_eq!(
             overridden.nickname, None,
             "an override identity must not inherit the persisted identity's \
@@ -1395,7 +1473,8 @@ mod tests {
         let mut room_info = stored_room_info(state, &persisted_sk);
         room_info.self_nickname = Some("persisted-identity".to_string());
 
-        let identity = self_identity_from(&owner_sk.verifying_key(), &override_sk, &room_info);
+        let identity =
+            self_identity_from(&owner_sk.verifying_key(), &override_sk, &room_info, None);
         assert_eq!(identity.nickname.as_deref(), Some("the-override"));
     }
 
@@ -1439,6 +1518,74 @@ mod tests {
             "whoami must report the OVERRIDE identity, which is the one signing"
         );
         assert_ne!(with.member_id, without.member_id);
+    }
+
+    /// `whoami <room>` and `whoami` (all rooms) run through two independent
+    /// code paths — `self_identity` vs `list_rooms` — so they must be shown to
+    /// agree. A bridge that resolves its ID one way and filters messages the
+    /// other way would otherwise silently mismatch.
+    #[test]
+    fn self_identity_agrees_with_list_rooms() {
+        let (storage, _temp_dir) = create_test_storage();
+        let owner_sk = create_test_signing_key();
+        let owner_vk = owner_sk.verifying_key();
+        let member_sk = create_test_signing_key();
+
+        storage
+            .add_room(
+                &owner_vk,
+                &member_sk,
+                create_test_state(&owner_sk),
+                &expected_contract_key(&owner_vk),
+            )
+            .unwrap();
+
+        let single = storage.self_identity(&owner_vk).unwrap().unwrap();
+        let listed = storage
+            .list_rooms()
+            .unwrap()
+            .into_iter()
+            .find(|r| r.owner_vk == owner_vk)
+            .expect("room present")
+            .self_identity;
+        assert_eq!(single, listed, "the two whoami paths must not diverge");
+
+        // ...including under an inline key, which both paths also accept.
+        let inline = create_test_signing_key();
+        let single_inline = storage
+            .self_identity_with(&owner_vk, Some(&inline))
+            .unwrap()
+            .unwrap();
+        let listed_inline = storage
+            .list_rooms_as(Some(&inline))
+            .unwrap()
+            .into_iter()
+            .find(|r| r.owner_vk == owner_vk)
+            .expect("room present")
+            .self_identity;
+        assert_eq!(single_inline, listed_inline);
+        assert_eq!(
+            single_inline.member_id,
+            MemberId::from(&inline.verifying_key())
+        );
+    }
+
+    /// An empty nickname in the cached state is not a nickname: it must not
+    /// shadow the local fallback and print as a blank name.
+    #[test]
+    fn self_identity_empty_room_nickname_falls_back() {
+        use river_core::room_state::privacy::SealedBytes;
+
+        let owner_sk = create_test_signing_key();
+        let member_sk = create_test_signing_key();
+        let mut state = create_test_state(&owner_sk);
+        push_member_info(&mut state, &member_sk, SealedBytes::public(Vec::new()));
+
+        let mut room_info = stored_room_info(state, &member_sk);
+        room_info.self_nickname = Some("local".to_string());
+
+        let identity = self_identity_from(&owner_sk.verifying_key(), &member_sk, &room_info, None);
+        assert_eq!(identity.nickname.as_deref(), Some("local"));
     }
 
     /// An unknown room reports `None` so the command can print a helpful

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -1081,8 +1081,20 @@ impl Storage {
                                 .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
                                 .unwrap_or_else(|_| sealed_name.to_string_lossy());
                         // Hand the same map to the nickname unsealing below
-                        // instead of collecting it a second time per room.
-                        secrets = Some(collected);
+                        // instead of collecting it a second time per room —
+                        // but ONLY when the identity we are reporting is the
+                        // one that collected it. An inline `--signing-key`
+                        // member may hold its own owner-signed secret blob
+                        // that the stored key cannot open; reusing the stored
+                        // key's map would then report a null nickname here
+                        // while the single-room path (which collects with the
+                        // effective key) resolves it, making the two whoami
+                        // forms disagree (Codex review round 2 on PR #439).
+                        let same_identity = signing_key
+                            .is_none_or(|inline| inline.to_bytes() == stored_sk.to_bytes());
+                        if same_identity {
+                            secrets = Some(collected);
+                        }
                         name
                     } else {
                         sealed_name.to_string_lossy()
@@ -1185,6 +1197,35 @@ mod tests {
             invitation_secrets: HashMap::new(),
             self_nickname: None,
         }
+    }
+
+    /// Add an owner-signed `encrypted_secrets` blob addressing `member_vk`, so
+    /// the room secret is reachable ONLY by that member's key (the real
+    /// distribution path, as opposed to an invitation-carried copy).
+    fn push_owner_secret_for(
+        state: &mut ChatRoomStateV1,
+        owner_sk: &SigningKey,
+        member_vk: &VerifyingKey,
+        secret: &[u8; 32],
+        version: u32,
+    ) {
+        use river_core::ecies::encrypt_secret_for_member;
+        use river_core::room_state::secret::{
+            AuthorizedEncryptedSecretForMember, EncryptedSecretForMemberV1,
+        };
+        let (ciphertext, nonce, ephemeral) = encrypt_secret_for_member(secret, member_vk);
+        let blob = EncryptedSecretForMemberV1 {
+            member_id: MemberId::from(member_vk),
+            secret_version: version,
+            ciphertext,
+            nonce,
+            sender_ephemeral_public_key: ephemeral.to_bytes(),
+            provider: MemberId::from(&owner_sk.verifying_key()),
+        };
+        state
+            .secrets
+            .encrypted_secrets
+            .push(AuthorizedEncryptedSecretForMember::new(blob, owner_sk));
     }
 
     /// Push an `AuthorizedMemberInfo` for `member_sk` carrying `nickname`.
@@ -1568,6 +1609,80 @@ mod tests {
             single_inline.member_id,
             MemberId::from(&inline.verifying_key())
         );
+    }
+
+    /// The two whoami paths must also agree in a PRIVATE room under an inline
+    /// key. `list_rooms_as` collects the room secrets with the room's STORED
+    /// key (it needs them for the room name); reusing that map to unseal an
+    /// INLINE identity's nickname reports null whenever only the inline member
+    /// can open its own owner-signed blob, while the single-room path — which
+    /// collects with the effective key — resolves it (Codex review round 2).
+    #[test]
+    fn inline_identity_nickname_agrees_across_paths_in_private_room() {
+        use river_core::ecies::seal_bytes;
+        use river_core::room_state::privacy::PrivacyMode;
+
+        let (storage, _temp_dir) = create_test_storage();
+        let owner_sk = create_test_signing_key();
+        let owner_vk = owner_sk.verifying_key();
+        let stored_sk = create_test_signing_key();
+        let inline_sk = create_test_signing_key();
+        let secret = [17u8; 32];
+
+        let mut state = create_test_state(&owner_sk);
+        state.configuration.configuration.privacy_mode = PrivacyMode::Private;
+        state.configuration.configuration.display.name = seal_bytes(b"Private", &secret, 0);
+        state.configuration =
+            AuthorizedConfigurationV1::new(state.configuration.configuration.clone(), &owner_sk);
+        // The INLINE identity has a sealed nickname in the room's state.
+        push_member_info(
+            &mut state,
+            &inline_sk,
+            seal_bytes(b"inline-bot", &secret, 0),
+        );
+
+        // The secret is reachable ONLY through an owner-signed blob addressed
+        // to the INLINE member. This is what makes the test bite: the stored
+        // key cannot open it, so a secrets map collected with the stored key
+        // is useless for the inline identity's nickname. Supplying the secret
+        // via `invitation_secrets` instead would let the stored key's map
+        // decrypt it and the test would pass with or without the fix.
+        push_owner_secret_for(
+            &mut state,
+            &owner_sk,
+            &inline_sk.verifying_key(),
+            &secret,
+            0,
+        );
+        state.secrets.current_version = 0;
+
+        storage
+            .add_room(
+                &owner_vk,
+                &stored_sk,
+                state,
+                &expected_contract_key(&owner_vk),
+            )
+            .unwrap();
+
+        let single = storage
+            .self_identity_with(&owner_vk, Some(&inline_sk))
+            .unwrap()
+            .unwrap();
+        let listed = storage
+            .list_rooms_as(Some(&inline_sk))
+            .unwrap()
+            .into_iter()
+            .find(|r| r.owner_vk == owner_vk)
+            .expect("room present")
+            .self_identity;
+
+        assert_eq!(
+            single, listed,
+            "whoami <room> and whoami must agree for an inline identity in a \
+             private room"
+        );
+        assert_eq!(single.nickname.as_deref(), Some("inline-bot"));
     }
 
     /// An empty nickname in the cached state is not a nickname: it must not

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -134,7 +134,10 @@ pub(crate) fn self_identity_from(
     room_info: &StoredRoomInfo,
 ) -> SelfIdentity {
     let verifying_key = signing_key.verifying_key();
-    let member_id = MemberId::from(&verifying_key);
+    // The SAME function every send path uses to set `MessageV1::author`, so
+    // whoami's promise ("this is the author on your own messages") holds by
+    // construction rather than by two copies of a derivation staying in step.
+    let member_id = crate::api::author_member_id(signing_key);
 
     // Prefer the room's own view of the nickname (what other members see),
     // read from the CACHED state so this never needs the node. `canonical`,
@@ -163,11 +166,26 @@ pub(crate) fn self_identity_from(
                 .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
         });
 
+    // `self_nickname` is the PERSISTED identity's nickname, so it is only a
+    // valid fallback when the effective key IS the persisted one. Under a
+    // `--signing-key-file` override selecting a different member, falling back
+    // would label the override's member ID and verifying key with another
+    // account's name (Codex review on PR #439). Reporting no nickname is the
+    // correct answer there — same reasoning as the CLI's member_info heal,
+    // which is likewise skipped under a mismatched override because "the
+    // persisted nickname/secrets are not that identity's"
+    // (`.claude/rules/private-rooms.md`).
+    let local_nickname = if signing_key.to_bytes() == room_info.signing_key_bytes {
+        room_info.self_nickname.clone()
+    } else {
+        None
+    };
+
     SelfIdentity {
         member_id,
         is_owner: verifying_key == *room_owner_vk,
         verifying_key,
-        nickname: room_nickname.or_else(|| room_info.self_nickname.clone()),
+        nickname: room_nickname.or(local_nickname),
     }
 }
 
@@ -1136,23 +1154,70 @@ mod tests {
         assert_eq!(identity.verifying_key, member_sk.verifying_key());
     }
 
-    /// Source-scrape companion to the test above: it can only stay honest
-    /// while the send paths really do derive `author` from the signing key's
-    /// verifying key. If a send path starts deriving `author` some other way,
-    /// `whoami` must be updated in the same change.
+    /// Structural companion to the test above: `whoami` and every send path
+    /// must derive `author` through the SAME function, not through copies of
+    /// the same expression.
+    ///
+    /// The first version of this test scraped for the literal
+    /// `author: MemberId::from(&signing_key.verifying_key())` and claimed to
+    /// cover "every send path". It did not: `send_message` spelled it with a
+    /// fully-qualified path and `send_message_with_key` derived it via
+    /// `(&sender_vk).into()`, so the scrape was satisfied by the five *action*
+    /// paths alone while the two that send actual chat messages went unpinned
+    /// (caught in review on PR #439). Rather than enumerate spellings, the
+    /// derivation now lives in one function and this pins that.
     #[test]
-    fn message_author_derivation_pinned() {
+    fn message_author_derivation_shared_with_whoami() {
         let api_src = include_str!("api.rs");
+        let storage_src = include_str!("storage.rs");
+
         assert!(
-            api_src.contains("author: MemberId::from(&signing_key.verifying_key())"),
-            "riverctl's message send paths must derive `author` from the \
-             signing key's verifying key. `riverctl identity whoami` \
-             (freenet/river#438) reports `MemberId::from(&verifying_key)` on \
-             the promise that it equals the `author` of messages this identity \
-             sends. If you change how `author` is derived, update \
-             `storage::self_identity_from` in the SAME change or whoami starts \
-             reporting an id that matches no message."
+            api_src.contains("pub(crate) fn author_member_id("),
+            "api::author_member_id must remain the single source of truth for \
+             `MessageV1::author` (freenet/river#438)."
         );
+        assert!(
+            storage_src.contains("crate::api::author_member_id(signing_key)"),
+            "`self_identity_from` must derive the reported member_id via \
+             `api::author_member_id` — the SAME function the send paths use. \
+             Re-inlining the derivation here lets whoami and the send paths \
+             drift, which is the entire bug class this feature must not have."
+        );
+
+        // Every send site must call the helper rather than re-inlining. The
+        // match is on `author: author_member_id(` so it is agnostic to whether
+        // the site passes `signing_key` or `&signing_key` (both spellings
+        // occur, depending on whether the key is owned at that site) — pinning
+        // one spelling would false-fail on a harmless `&`.
+        assert_eq!(
+            api_src
+                .matches("author: MemberId::from(&signing_key")
+                .count(),
+            0,
+            "a send path is hand-inlining the author derivation instead of \
+             calling `author_member_id`. Route it through the helper so \
+             `identity whoami` keeps matching it."
+        );
+        // Production `author:` sites: send_message, edit, delete, react,
+        // unreact, reply (6 direct), plus send_message_with_key and the join
+        // event, which bind the helper's result to a local first.
+        assert!(
+            api_src.matches("author: author_member_id(").count() >= 6,
+            "expected every message-construction site to call \
+             `author_member_id`; found fewer than the known production sites, \
+             so one has been changed to derive `author` some other way."
+        );
+        for binding in [
+            "let sender_member_id = author_member_id(",
+            "let self_id = author_member_id(",
+        ] {
+            assert!(
+                api_src.contains(binding),
+                "`{binding}...` must keep deriving through the shared helper — \
+                 this is `send_message_with_key` / the join event, whose \
+                 `author` a bridge also has to recognise as its own."
+            );
+        }
     }
 
     /// Owner vs non-owner, and the owner's id is derived from their own key.
@@ -1277,6 +1342,61 @@ mod tests {
 
         let identity = self_identity_from(&owner_sk.verifying_key(), &member_sk, &room_info);
         assert_eq!(identity.nickname.as_deref(), Some("Nacho"));
+    }
+
+    /// The `self_nickname` fallback belongs to the PERSISTED identity, so an
+    /// override selecting a DIFFERENT member must not inherit it — that would
+    /// label the override's member ID with another account's name (Codex
+    /// review on PR #439). Reporting no nickname is correct there.
+    #[test]
+    fn self_identity_does_not_inherit_persisted_nickname_under_override() {
+        let owner_sk = create_test_signing_key();
+        let persisted_sk = create_test_signing_key();
+        let override_sk = create_test_signing_key();
+
+        let mut room_info = stored_room_info(create_test_state(&owner_sk), &persisted_sk);
+        room_info.self_nickname = Some("persisted-identity".to_string());
+
+        // Effective key == persisted key: the fallback is genuinely ours.
+        let same = self_identity_from(&owner_sk.verifying_key(), &persisted_sk, &room_info);
+        assert_eq!(same.nickname.as_deref(), Some("persisted-identity"));
+
+        // Effective key is an override for a DIFFERENT member: no nickname,
+        // rather than the persisted identity's.
+        let overridden = self_identity_from(&owner_sk.verifying_key(), &override_sk, &room_info);
+        assert_eq!(
+            overridden.nickname, None,
+            "an override identity must not inherit the persisted identity's \
+             nickname — it belongs to a different member"
+        );
+        assert_eq!(
+            overridden.member_id,
+            MemberId::from(&override_sk.verifying_key())
+        );
+    }
+
+    /// An override that DOES have its own record in the cached state reports
+    /// that record's nickname — the override is a real member here, so the
+    /// room's view of it is correct and must not be suppressed.
+    #[test]
+    fn self_identity_reports_override_own_room_nickname() {
+        use river_core::room_state::privacy::SealedBytes;
+
+        let owner_sk = create_test_signing_key();
+        let persisted_sk = create_test_signing_key();
+        let override_sk = create_test_signing_key();
+
+        let mut state = create_test_state(&owner_sk);
+        push_member_info(
+            &mut state,
+            &override_sk,
+            SealedBytes::public(b"the-override".to_vec()),
+        );
+        let mut room_info = stored_room_info(state, &persisted_sk);
+        room_info.self_nickname = Some("persisted-identity".to_string());
+
+        let identity = self_identity_from(&owner_sk.verifying_key(), &override_sk, &room_info);
+        assert_eq!(identity.nickname.as_deref(), Some("the-override"));
     }
 
     /// `Storage::self_identity` must report the identity that will actually

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -5,7 +5,7 @@ use ed25519_dalek::{SigningKey, VerifyingKey};
 use freenet_stdlib::prelude::ContractKey;
 use fs2::FileExt;
 use river_core::chat_delegate::OutboundDmStore;
-use river_core::room_state::member::AuthorizedMember;
+use river_core::room_state::member::{AuthorizedMember, MemberId};
 use river_core::room_state::ChatRoomStateV1;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -78,6 +78,97 @@ pub struct StoredRoomInfo {
 pub struct RoomStorage {
     /// Map from room owner verifying key (as base58) to room info
     pub rooms: HashMap<String, StoredRoomInfo>,
+}
+
+/// Who the local user is *within one room* (freenet/river#438).
+///
+/// River identities are per-room: each room in `rooms.json` carries its own
+/// signing key, so there is no single global "my member id". Every field here
+/// is derived from local state alone — no network round-trip — so a bridge or
+/// script can resolve its own identity before any message arrives.
+///
+/// [`Self::member_id`] is the value that appears as `author` in the JSON
+/// emitted by `riverctl message list/stream`, which is what makes it usable
+/// for "is this message mine?" filtering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelfIdentity {
+    /// This identity's verifying key for the room (base58-encodable).
+    pub verifying_key: VerifyingKey,
+    /// `MemberId` derived from [`Self::verifying_key`] — matches `author`.
+    pub member_id: MemberId,
+    /// Own nickname, read from the locally-cached room state where possible
+    /// and falling back to `StoredRoomInfo::self_nickname`.
+    ///
+    /// `None` when neither is available — an identity that has never been
+    /// seen in a synced state and never set one locally. Never the
+    /// `[Encrypted: N bytes, vN]` placeholder: an undecryptable private-room
+    /// nickname falls back rather than surfacing ciphertext.
+    pub nickname: Option<String>,
+    /// Whether this identity owns the room.
+    pub is_owner: bool,
+}
+
+/// One entry from [`Storage::list_rooms`] / [`crate::api::ApiClient::list_rooms`].
+#[derive(Debug, Clone)]
+pub struct RoomListing {
+    /// The room owner's verifying key — the room's identifier.
+    pub owner_vk: VerifyingKey,
+    /// Room display name, decrypted for a private room where possible.
+    pub name: String,
+    pub contract_key: String,
+    /// Who the local user is in this room (freenet/river#438).
+    pub self_identity: SelfIdentity,
+}
+
+/// Build a [`SelfIdentity`] from an already-resolved signing key and the
+/// room's stored record.
+///
+/// Pure (no I/O) so the derivation is unit-testable without a node or a data
+/// dir. Callers must pass the key from [`Storage::resolve_signing_key`] so a
+/// `--signing-key-file` override is reflected — reporting the persisted
+/// identity while the override is the one actually signing messages would be
+/// worse than reporting nothing.
+pub(crate) fn self_identity_from(
+    room_owner_vk: &VerifyingKey,
+    signing_key: &SigningKey,
+    room_info: &StoredRoomInfo,
+) -> SelfIdentity {
+    let verifying_key = signing_key.verifying_key();
+    let member_id = MemberId::from(&verifying_key);
+
+    // Prefer the room's own view of the nickname (what other members see),
+    // read from the CACHED state so this never needs the node. `canonical`,
+    // not a bare `.find()`, for the same reason as
+    // `api::resolve_own_member_info_base`: a state may legally carry more than
+    // one `member_info` record for a member and the highest-ranked one wins.
+    let room_nickname = room_info
+        .state
+        .member_info
+        .canonical(member_id)
+        .and_then(|info| {
+            let sealed = &info.member_info.preferred_nickname;
+            let secrets = if sealed.is_private() {
+                crate::private_room::collect_secrets_for_room(
+                    &room_info.state,
+                    signing_key,
+                    &room_info.invitation_secrets,
+                )
+            } else {
+                HashMap::new()
+            };
+            // `.ok()`, so an undecryptable private nickname falls through to
+            // `self_nickname` instead of reporting the sealed placeholder.
+            river_core::ecies::unseal_bytes_with_secrets(sealed, &secrets)
+                .ok()
+                .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
+        });
+
+    SelfIdentity {
+        member_id,
+        is_owner: verifying_key == *room_owner_vk,
+        verifying_key,
+        nickname: room_nickname.or_else(|| room_info.self_nickname.clone()),
+    }
 }
 
 /// Result of [`Storage::import_room_atomic`] (freenet/river#414, Codex round-6
@@ -891,7 +982,7 @@ impl Storage {
         })
     }
 
-    pub fn list_rooms(&self) -> Result<Vec<(VerifyingKey, String, String)>> {
+    pub fn list_rooms(&self) -> Result<Vec<RoomListing>> {
         let storage = self.load_rooms()?;
         let mut rooms = Vec::new();
 
@@ -901,6 +992,7 @@ impl Storage {
                 let mut key_array = [0u8; 32];
                 key_array.copy_from_slice(&owner_key_bytes);
                 if let Ok(owner_vk) = VerifyingKey::from_bytes(&key_array) {
+                    let self_sk = self.resolve_signing_key(&room_info.signing_key_bytes);
                     let sealed_name = &room_info.state.configuration.configuration.display.name;
                     // A private room's name is AES-256-GCM sealed under the room
                     // secret. Decrypt it with the local member's secrets so
@@ -910,7 +1002,6 @@ impl Storage {
                     // when the secret is unavailable (not yet synced / rotated
                     // past); a public name decrypts trivially to its bytes.
                     let room_name = if sealed_name.is_private() {
-                        let self_sk = self.resolve_signing_key(&room_info.signing_key_bytes);
                         let secrets = crate::private_room::collect_secrets_for_room(
                             &room_info.state,
                             &self_sk,
@@ -922,12 +1013,35 @@ impl Storage {
                     } else {
                         sealed_name.to_string_lossy()
                     };
-                    rooms.push((owner_vk, room_name, room_info.contract_key.clone()));
+                    rooms.push(RoomListing {
+                        self_identity: self_identity_from(&owner_vk, &self_sk, room_info),
+                        owner_vk,
+                        name: room_name,
+                        contract_key: room_info.contract_key.clone(),
+                    });
                 }
             }
         }
 
         Ok(rooms)
+    }
+
+    /// Who the local user is in one room, resolved from local storage only
+    /// (freenet/river#438). `None` when the room is not in `rooms.json`.
+    ///
+    /// Deliberately does NOT touch the network: the point is to let a bridge
+    /// learn its own `author` value up front, rather than inferring it from
+    /// messages it observes.
+    pub fn self_identity(&self, room_owner_vk: &VerifyingKey) -> Result<Option<SelfIdentity>> {
+        let storage = self.load_rooms()?;
+        let key_str = bs58::encode(room_owner_vk.as_bytes()).into_string();
+        Ok(storage.rooms.get(&key_str).map(|room_info| {
+            self_identity_from(
+                room_owner_vk,
+                &self.resolve_signing_key(&room_info.signing_key_bytes),
+                room_info,
+            )
+        }))
     }
 }
 
@@ -963,6 +1077,288 @@ mod tests {
         };
         state.configuration = AuthorizedConfigurationV1::new(config, owner_sk);
         state
+    }
+
+    /// Build a `StoredRoomInfo` carrying `state`, with no cached
+    /// `member_info` for anyone unless the caller adds it.
+    fn stored_room_info(state: ChatRoomStateV1, signing_key: &SigningKey) -> StoredRoomInfo {
+        StoredRoomInfo {
+            signing_key_bytes: signing_key.to_bytes(),
+            state,
+            contract_key: "test-contract-key".to_string(),
+            self_authorized_member: None,
+            invite_chain: Vec::new(),
+            previous_contract_key: None,
+            invitation_secrets: HashMap::new(),
+            self_nickname: None,
+        }
+    }
+
+    /// Push an `AuthorizedMemberInfo` for `member_sk` carrying `nickname`.
+    fn push_member_info(
+        state: &mut ChatRoomStateV1,
+        member_sk: &SigningKey,
+        nickname: river_core::room_state::privacy::SealedBytes,
+    ) {
+        use river_core::room_state::member_info::{AuthorizedMemberInfo, MemberInfo};
+        let info = MemberInfo {
+            member_id: MemberId::from(&member_sk.verifying_key()),
+            version: 0,
+            preferred_nickname: nickname,
+            deputies: Vec::new(),
+        };
+        state
+            .member_info
+            .member_info
+            .push(AuthorizedMemberInfo::new_with_member_key(info, member_sk));
+    }
+
+    /// THE contract freenet/river#438 exists to expose: `whoami`'s reported
+    /// `member_id` must be the same value a message this identity sends
+    /// carries as its `author`, so an XMPP/Matrix bridge can filter its own
+    /// echo. Every send path in `api.rs` derives `author` as
+    /// `MemberId::from(&signing_key.verifying_key())`; if `self_identity_from`
+    /// ever derives it differently (e.g. folding in the room key), the whole
+    /// feature silently reports an id that matches nothing.
+    #[test]
+    fn self_identity_member_id_matches_message_author_derivation() {
+        let owner_sk = create_test_signing_key();
+        let member_sk = create_test_signing_key();
+        let room_info = stored_room_info(create_test_state(&owner_sk), &member_sk);
+
+        let identity = self_identity_from(&owner_sk.verifying_key(), &member_sk, &room_info);
+
+        // The exact expression every `author:` field in api.rs is built from.
+        let author_on_send = MemberId::from(&member_sk.verifying_key());
+        assert_eq!(identity.member_id, author_on_send);
+        // JSON output compares the Display form, so pin that too.
+        assert_eq!(identity.member_id.to_string(), author_on_send.to_string());
+        assert_eq!(identity.verifying_key, member_sk.verifying_key());
+    }
+
+    /// Source-scrape companion to the test above: it can only stay honest
+    /// while the send paths really do derive `author` from the signing key's
+    /// verifying key. If a send path starts deriving `author` some other way,
+    /// `whoami` must be updated in the same change.
+    #[test]
+    fn message_author_derivation_pinned() {
+        let api_src = include_str!("api.rs");
+        assert!(
+            api_src.contains("author: MemberId::from(&signing_key.verifying_key())"),
+            "riverctl's message send paths must derive `author` from the \
+             signing key's verifying key. `riverctl identity whoami` \
+             (freenet/river#438) reports `MemberId::from(&verifying_key)` on \
+             the promise that it equals the `author` of messages this identity \
+             sends. If you change how `author` is derived, update \
+             `storage::self_identity_from` in the SAME change or whoami starts \
+             reporting an id that matches no message."
+        );
+    }
+
+    /// Owner vs non-owner, and the owner's id is derived from their own key.
+    #[test]
+    fn self_identity_reports_ownership() {
+        let owner_sk = create_test_signing_key();
+        let owner_vk = owner_sk.verifying_key();
+        let member_sk = create_test_signing_key();
+
+        let as_owner = self_identity_from(
+            &owner_vk,
+            &owner_sk,
+            &stored_room_info(create_test_state(&owner_sk), &owner_sk),
+        );
+        assert!(as_owner.is_owner);
+        assert_eq!(as_owner.member_id, MemberId::from(&owner_vk));
+
+        let as_member = self_identity_from(
+            &owner_vk,
+            &member_sk,
+            &stored_room_info(create_test_state(&owner_sk), &member_sk),
+        );
+        assert!(!as_member.is_owner);
+        assert_ne!(as_member.member_id, as_owner.member_id);
+    }
+
+    /// The nickname comes from the room's own (cached) view when present —
+    /// that is what other members see — rather than the local-only
+    /// `self_nickname`, which can be stale after a rename elsewhere.
+    #[test]
+    fn self_identity_prefers_room_state_nickname_over_local() {
+        use river_core::room_state::privacy::SealedBytes;
+
+        let owner_sk = create_test_signing_key();
+        let member_sk = create_test_signing_key();
+        let mut state = create_test_state(&owner_sk);
+        push_member_info(
+            &mut state,
+            &member_sk,
+            SealedBytes::public(b"from-room".to_vec()),
+        );
+
+        let mut room_info = stored_room_info(state, &member_sk);
+        room_info.self_nickname = Some("stale-local".to_string());
+
+        let identity = self_identity_from(&owner_sk.verifying_key(), &member_sk, &room_info);
+        assert_eq!(identity.nickname.as_deref(), Some("from-room"));
+    }
+
+    /// With no record in the cached state (a just-accepted invitation that has
+    /// not round-tripped yet), fall back to the locally-stored nickname.
+    #[test]
+    fn self_identity_falls_back_to_local_nickname() {
+        let owner_sk = create_test_signing_key();
+        let member_sk = create_test_signing_key();
+        let mut room_info = stored_room_info(create_test_state(&owner_sk), &member_sk);
+        room_info.self_nickname = Some("only-local".to_string());
+
+        let identity = self_identity_from(&owner_sk.verifying_key(), &member_sk, &room_info);
+        assert_eq!(identity.nickname.as_deref(), Some("only-local"));
+
+        // Neither source available → None, not an empty string.
+        let bare = stored_room_info(create_test_state(&owner_sk), &member_sk);
+        assert_eq!(
+            self_identity_from(&owner_sk.verifying_key(), &member_sk, &bare).nickname,
+            None
+        );
+    }
+
+    /// A private-room nickname we cannot decrypt must NOT surface the
+    /// "[Encrypted: N bytes, vN]" placeholder as if it were the nickname —
+    /// fall back to the local one instead.
+    #[test]
+    fn self_identity_undecryptable_private_nickname_falls_back() {
+        use river_core::ecies::seal_bytes;
+        use river_core::room_state::privacy::PrivacyMode;
+
+        let owner_sk = create_test_signing_key();
+        let member_sk = create_test_signing_key();
+        let mut state = create_test_state(&owner_sk);
+        state.configuration.configuration.privacy_mode = PrivacyMode::Private;
+        state.configuration =
+            AuthorizedConfigurationV1::new(state.configuration.configuration.clone(), &owner_sk);
+        // Sealed under a secret this member has no way to obtain.
+        push_member_info(&mut state, &member_sk, seal_bytes(b"hidden", &[9u8; 32], 0));
+
+        let mut room_info = stored_room_info(state, &member_sk);
+        room_info.self_nickname = Some("local-copy".to_string());
+
+        let identity = self_identity_from(&owner_sk.verifying_key(), &member_sk, &room_info);
+        assert_eq!(
+            identity.nickname.as_deref(),
+            Some("local-copy"),
+            "an undecryptable sealed nickname must fall back, not report ciphertext"
+        );
+        assert!(!identity
+            .nickname
+            .as_deref()
+            .unwrap()
+            .contains("[Encrypted:"));
+    }
+
+    /// A private-room nickname we CAN decrypt is reported in plaintext.
+    #[test]
+    fn self_identity_decrypts_private_nickname() {
+        use river_core::ecies::seal_bytes;
+        use river_core::room_state::privacy::PrivacyMode;
+
+        let owner_sk = create_test_signing_key();
+        let member_sk = create_test_signing_key();
+        let secret = [4u8; 32];
+
+        let mut state = create_test_state(&owner_sk);
+        state.configuration.configuration.privacy_mode = PrivacyMode::Private;
+        state.configuration =
+            AuthorizedConfigurationV1::new(state.configuration.configuration.clone(), &owner_sk);
+        push_member_info(&mut state, &member_sk, seal_bytes(b"Nacho", &secret, 0));
+
+        let mut room_info = stored_room_info(state, &member_sk);
+        // The invitation-carried secret, as a just-joined invitee would have.
+        room_info.invitation_secrets.insert(0, secret);
+
+        let identity = self_identity_from(&owner_sk.verifying_key(), &member_sk, &room_info);
+        assert_eq!(identity.nickname.as_deref(), Some("Nacho"));
+    }
+
+    /// `Storage::self_identity` must report the identity that will actually
+    /// SIGN — so a `--signing-key-file` override wins over `rooms.json`.
+    /// Reporting the persisted id while the override signs would hand a bridge
+    /// an id matching none of its own messages: the exact bug whoami exists to
+    /// prevent.
+    #[test]
+    fn self_identity_honors_signing_key_override() {
+        let (storage, _temp_dir) = create_test_storage();
+        let owner_sk = create_test_signing_key();
+        let owner_vk = owner_sk.verifying_key();
+        let stored_sk = create_test_signing_key();
+        let override_sk = create_test_signing_key();
+
+        storage
+            .add_room(
+                &owner_vk,
+                &stored_sk,
+                create_test_state(&owner_sk),
+                &expected_contract_key(&owner_vk),
+            )
+            .unwrap();
+
+        let without = storage.self_identity(&owner_vk).unwrap().unwrap();
+        assert_eq!(
+            without.member_id,
+            MemberId::from(&stored_sk.verifying_key())
+        );
+
+        let overridden = Storage::new_with_override(
+            Some(_temp_dir.path().to_str().unwrap()),
+            Some(override_sk.clone()),
+        )
+        .unwrap();
+        let with = overridden.self_identity(&owner_vk).unwrap().unwrap();
+        assert_eq!(
+            with.member_id,
+            MemberId::from(&override_sk.verifying_key()),
+            "whoami must report the OVERRIDE identity, which is the one signing"
+        );
+        assert_ne!(with.member_id, without.member_id);
+    }
+
+    /// An unknown room reports `None` so the command can print a helpful
+    /// "join it first" error rather than inventing an identity.
+    #[test]
+    fn self_identity_none_for_unknown_room() {
+        let (storage, _temp_dir) = create_test_storage();
+        let unknown = create_test_signing_key().verifying_key();
+        assert!(storage.self_identity(&unknown).unwrap().is_none());
+    }
+
+    /// `room list` carries the same id, so `--format json` consumers can
+    /// resolve every room's self-id in one call (the alternative the reporter
+    /// asked for in freenet/river#438).
+    #[test]
+    fn list_rooms_includes_self_member_id() {
+        let (storage, _temp_dir) = create_test_storage();
+        let owner_sk = create_test_signing_key();
+        let owner_vk = owner_sk.verifying_key();
+        let member_sk = create_test_signing_key();
+
+        storage
+            .add_room(
+                &owner_vk,
+                &member_sk,
+                create_test_state(&owner_sk),
+                &expected_contract_key(&owner_vk),
+            )
+            .unwrap();
+
+        let rooms = storage.list_rooms().unwrap();
+        let room = rooms
+            .iter()
+            .find(|r| r.owner_vk == owner_vk)
+            .expect("room present");
+        assert_eq!(
+            room.self_identity.member_id,
+            MemberId::from(&member_sk.verifying_key())
+        );
+        assert!(!room.self_identity.is_owner);
     }
 
     /// A `room list` on a **private** room must show the decrypted name, not
@@ -1005,11 +1401,11 @@ mod tests {
             .unwrap();
 
         let rooms = storage.list_rooms().unwrap();
-        let (_, name, _) = rooms
+        let room = rooms
             .iter()
-            .find(|(vk, _, _)| *vk == owner_vk)
+            .find(|r| r.owner_vk == owner_vk)
             .expect("room present");
-        assert_eq!(name, "Secret Room");
+        assert_eq!(room.name, "Secret Room");
     }
 
     /// Without the secret, the private name gracefully falls back to the
@@ -1037,11 +1433,11 @@ mod tests {
             .unwrap();
 
         let rooms = storage.list_rooms().unwrap();
-        let (_, name, _) = rooms
+        let room = rooms
             .iter()
-            .find(|(vk, _, _)| *vk == owner_vk)
+            .find(|r| r.owner_vk == owner_vk)
             .expect("room present");
-        assert_eq!(name, "[Encrypted: 11 bytes, v0]");
+        assert_eq!(room.name, "[Encrypted: 11 bytes, v0]");
     }
 
     #[test]

--- a/cli/tests/whoami_offline.rs
+++ b/cli/tests/whoami_offline.rs
@@ -1,0 +1,241 @@
+//! Behavioural tests for `riverctl identity whoami` (freenet/river#438).
+//!
+//! These run the REAL binary with `--node-url` pointed at a closed port, which
+//! is the only way to prove the thing the feature actually promises: that a
+//! bridge can learn its own member ID with the node down, before any message
+//! has arrived.
+//!
+//! The unit tests in `cli/src/` cover the derivation and the JSON payload
+//! shape; the wiring pins in `commands/identity.rs` scrape `main.rs`. Neither
+//! can catch the regression that matters most here — someone routing whoami
+//! back through `ApiClient` (which opens a WebSocket eagerly), or dropping the
+//! `else` so the short-circuit falls through into client construction. Both
+//! leave the source scrapes green and fail here immediately.
+//!
+//! Unlike `message_flow.rs`, these need no Freenet node, so they run in normal
+//! CI rather than being `#[ignore]`d.
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use tempfile::TempDir;
+
+/// A node URL that cannot connect: port 1 is never a Freenet node. Any code
+/// path that tries to reach the node fails fast rather than hanging.
+const DEAD_NODE_URL: &str = "ws://127.0.0.1:1/v1/contract/command?encodingProtocol=native";
+
+fn whoami(config_dir: &TempDir, args: &[&str]) -> std::process::Output {
+    let mut cmd = cargo_bin_cmd!("riverctl");
+    cmd.args(["--config-dir", config_dir.path().to_str().unwrap()])
+        .args(["--node-url", DEAD_NODE_URL])
+        // Keep the once/day crates.io nudge out of a hermetic test.
+        .arg("--no-version-check")
+        .args(["identity", "whoami"])
+        .args(args)
+        // A stale RIVER_SIGNING_KEY* in the developer's environment would
+        // otherwise silently change which identity is reported.
+        .env_remove("RIVER_SIGNING_KEY")
+        .env_remove("RIVER_SIGNING_KEY_FILE")
+        .env_remove("RIVER_CONFIG_DIR");
+    cmd.output().expect("riverctl binary runs")
+}
+
+/// With an inline `--signing-key`, whoami needs no local storage at all — and
+/// must still succeed with the node unreachable. This is the bridge/bot case:
+/// `message send --signing-key` works without local storage, so whoami must
+/// too, or the identity it reports cannot be checked against those messages.
+#[test]
+fn whoami_with_inline_key_succeeds_with_no_node_and_no_storage() {
+    let dir = TempDir::new().unwrap();
+    // Base64 of 32 bytes, the encoding `message send --signing-key` accepts.
+    let key_b64 = base64_32([7u8; 32]);
+    let room = bs58_room_key();
+
+    let out = whoami(
+        &dir,
+        &["--format", "json", &room, "--signing-key", &key_b64],
+    );
+    assert!(
+        out.status.success(),
+        "whoami must succeed offline with an inline key.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout is JSON");
+    assert!(
+        json.is_object(),
+        "a single named room must emit ONE object, not an array — the \
+         documented `| jq -r .member_id` depends on it. Got: {json}"
+    );
+    assert_eq!(json["room"], room);
+    assert_eq!(
+        json["signing_key_source"], "inline",
+        "an inline key must be disclosed as such, so a bridge can tell which \
+         of the three override mechanisms won"
+    );
+    assert!(
+        json["member_id"].as_str().is_some_and(|s| !s.is_empty()),
+        "member_id must be present: it is the whole point"
+    );
+    // Nickname is unknowable without the room's state.
+    assert_eq!(json["nickname"], serde_json::Value::Null);
+}
+
+/// The same key always yields the same member ID — the property a bridge
+/// relies on when it re-runs whoami between restarts.
+#[test]
+fn whoami_inline_key_is_deterministic() {
+    let dir = TempDir::new().unwrap();
+    let key_b64 = base64_32([11u8; 32]);
+    let room = bs58_room_key();
+    let args = ["--format", "json", &room, "--signing-key", &key_b64];
+
+    let first = whoami(&dir, &args);
+    let second = whoami(&dir, &args);
+    assert!(first.status.success() && second.status.success());
+
+    let a: serde_json::Value = serde_json::from_slice(&first.stdout).unwrap();
+    let b: serde_json::Value = serde_json::from_slice(&second.stdout).unwrap();
+    assert_eq!(a["member_id"], b["member_id"]);
+    assert_ne!(a["member_id"], serde_json::Value::Null);
+}
+
+/// A different key must yield a different member ID — otherwise the override
+/// plumbing is silently ignoring the key and reporting something else.
+#[test]
+fn whoami_distinct_keys_yield_distinct_member_ids() {
+    let dir = TempDir::new().unwrap();
+    let room = bs58_room_key();
+
+    let one = whoami(
+        &dir,
+        &[
+            "--format",
+            "json",
+            &room,
+            "--signing-key",
+            &base64_32([1u8; 32]),
+        ],
+    );
+    let two = whoami(
+        &dir,
+        &[
+            "--format",
+            "json",
+            &room,
+            "--signing-key",
+            &base64_32([2u8; 32]),
+        ],
+    );
+    let a: serde_json::Value = serde_json::from_slice(&one.stdout).unwrap();
+    let b: serde_json::Value = serde_json::from_slice(&two.stdout).unwrap();
+    assert_ne!(a["member_id"], b["member_id"]);
+}
+
+/// `RIVER_SIGNING_KEY` must work exactly like `--signing-key`: it is the form
+/// an automation bridge actually uses (exported in a profile or unit file),
+/// and it is what `message send` reads. If whoami ignored it, it would report
+/// an identity matching none of that bridge's own messages.
+#[test]
+fn whoami_reads_river_signing_key_env() {
+    let dir = TempDir::new().unwrap();
+    let key_b64 = base64_32([23u8; 32]);
+    let room = bs58_room_key();
+
+    let mut cmd = cargo_bin_cmd!("riverctl");
+    let out = cmd
+        .args(["--config-dir", dir.path().to_str().unwrap()])
+        .args(["--node-url", DEAD_NODE_URL])
+        .arg("--no-version-check")
+        .args(["identity", "whoami", "--format", "json", &room])
+        .env("RIVER_SIGNING_KEY", &key_b64)
+        .env_remove("RIVER_SIGNING_KEY_FILE")
+        .env_remove("RIVER_CONFIG_DIR")
+        .output()
+        .expect("riverctl binary runs");
+    assert!(
+        out.status.success(),
+        "RIVER_SIGNING_KEY must be honoured.\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let from_env: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(from_env["signing_key_source"], "inline");
+
+    // Identical to passing the same key on the command line.
+    let from_flag = whoami(
+        &dir,
+        &["--format", "json", &room, "--signing-key", &key_b64],
+    );
+    let from_flag: serde_json::Value = serde_json::from_slice(&from_flag.stdout).unwrap();
+    assert_eq!(from_env["member_id"], from_flag["member_id"]);
+}
+
+/// With no rooms and no key, whoami still exits 0 offline and emits an empty
+/// JSON array — a bridge enumerating rooms shouldn't have to special-case a
+/// crash on first run.
+#[test]
+fn whoami_all_rooms_empty_storage_is_empty_array_offline() {
+    let dir = TempDir::new().unwrap();
+    let out = whoami(&dir, &["--format", "json"]);
+    assert!(
+        out.status.success(),
+        "whoami over an empty store must succeed offline.\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(json, serde_json::json!([]));
+}
+
+/// An unknown room with no inline key is a user error, not a crash: exit
+/// non-zero with a message naming the room and the ways forward. It must fail
+/// on the LOOKUP, not on a connection attempt.
+#[test]
+fn whoami_unknown_room_errors_without_contacting_node() {
+    let dir = TempDir::new().unwrap();
+    let room = bs58_room_key();
+    let out = whoami(&dir, &[&room]);
+    assert!(!out.status.success(), "unknown room must exit non-zero");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("not found in local storage"),
+        "error should explain the room is not stored locally, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("WebSocket") && !stderr.contains("Connection refused"),
+        "whoami must not attempt a node connection — it is a local lookup. \
+         Got a connection error instead: {stderr}"
+    );
+}
+
+/// A malformed inline key is rejected with a clear message rather than
+/// silently reporting some other identity.
+#[test]
+fn whoami_rejects_malformed_inline_key() {
+    let dir = TempDir::new().unwrap();
+    let room = bs58_room_key();
+
+    let bad_b64 = whoami(&dir, &[&room, "--signing-key", "not-valid-base64!!"]);
+    assert!(!bad_b64.status.success());
+    assert!(String::from_utf8_lossy(&bad_b64.stderr).contains("base64"));
+
+    // Valid base64, wrong length.
+    let short = whoami(&dir, &[&room, "--signing-key", &base64_of(&[9u8; 16])]);
+    assert!(!short.status.success());
+    assert!(String::from_utf8_lossy(&short.stderr).contains("32 bytes"));
+}
+
+fn base64_32(bytes: [u8; 32]) -> String {
+    base64_of(&bytes)
+}
+
+fn base64_of(bytes: &[u8]) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+/// A syntactically valid base58 room key (32 bytes) that is not in storage.
+fn bs58_room_key() -> String {
+    // A valid Ed25519 verifying key so parsing succeeds and the failure under
+    // test is "not in storage", not "malformed key".
+    let sk = ed25519_dalek::SigningKey::from_bytes(&[42u8; 32]);
+    bs58::encode(sk.verifying_key().as_bytes()).into_string()
+}


### PR DESCRIPTION
## Problem

There was no way to ask riverctl "what is my own member ID in this room?"

`author` in `riverctl message list/stream --format json` is a `MemberId`, but
nothing in the CLI reported the local user's own — so a bridge could not tell
which streamed messages were its own echo. Reported by an XMPP-bridge author
whose sent messages were duplicating in their client's group chat buffer:

> without a way to identify my own MemberId, I am having to use convoluted
> methods to identify which of the incoming messages are the ones I just sent
> from riverctl [...] I need to be able to do this precisely and without first
> waiting for incoming messages from the room and parse the stdout of riverctl.

Everything available today is indirect: `member list` returns every member with
no self marker (and needs a network GET), `identity export` is an armored
private-key blob, and matching on your own nickname is ambiguous.

## Approach

Both shapes the reporter suggested:

```console
$ riverctl identity whoami <room> --format json
{
  "is_owner": true,
  "member_id": "JYFX4AGJ",
  "nickname": "bridge-bot",
  "room": "CEGwowqUhwrfevhNKDyUTvH7YwgdsYcnTzc4iuQ1nxyU",
  "signing_key_source": "stored",
  "verifying_key": "CEGwowqUhwrfevhNKDyUTvH7YwgdsYcnTzc4iuQ1nxyU"
}

$ riverctl room list --format json   # now carries self_member_id + signing_key_source
```

`whoami` with no room reports every room (River identities are per-room, so
there is no single global member ID). A single named room emits one object, not
a one-element array, so `| jq -r .member_id` works without an index.

Three decisions worth review attention:

**The member ID must equal `author`, by construction.** `api::author_member_id`
is the single source of truth for `MessageV1::author`, called by all eight
production send sites *and* by `whoami`'s derivation. The first version of this
PR instead had each site inline the derivation with a source-scrape test holding
them together — review showed that scrape silently missed the two paths that
send actual chat messages (one spelled it fully-qualified, one used `.into()`),
so the guarantee is now structural rather than textual.

**Offline, before the client exists.** `ApiClient::new*` opens a WebSocket
eagerly, so routing whoami through it made a pure local read fail outright when
the node was down — exactly when a bridge most needs its own ID. `main`
short-circuits to `identity::whoami(&storage, ..)` before the client is built
(~8ms, works with the node stopped). `whoami` takes `&Storage` rather than
`&ApiClient` so it cannot acquire a connection by accident.

**It reports the identity that will actually sign — all three overrides.**
riverctl has three: `rooms.json`, `--signing-key-file`/`RIVER_SIGNING_KEY_FILE`,
and `message send --signing-key`/`RIVER_SIGNING_KEY`. whoami initially honoured
only the first two; review found that a bridge exporting `RIVER_SIGNING_KEY`
(the normal way to run one) would send as key B while whoami reported key A —
silently recreating the very bug #438 exists to fix. whoami now takes
`--signing-key` with the same env var and the same precedence `message send`
uses (inline > file > stored), disclosed as `signing_key_source`. With an inline
key the room need not be in local storage, matching `send_message_with_key`'s
documented storage-free bot workflow.

Nickname comes from the cached room state's canonical `member_info` (what other
members see), falling back to the locally-stored nickname *only when the
effective key is the persisted one* — otherwise an override would be labelled
with another account's name (Codex finding). Private-room nicknames decrypt when
the secret is available and fall back rather than surfacing the `[Encrypted: …]`
placeholder.

`Storage::list_rooms` / `ApiClient::list_rooms` now return a `RoomListing`
struct instead of a `(VerifyingKey, String, String)` tuple. Both are `pub` on
the `riverctl` lib crate, so this is a breaking change — hence **0.2.0**, not a
patch bump (for `0.x`, Cargo treats the minor as the breaking axis, so `0.1.81`
would land inside `^0.1.80`). riverctl has zero reverse dependencies on
crates.io, so practical impact is nil.

## Testing

**215 lib tests + 7 new integration tests, all passing.**

`cli/tests/whoami_offline.rs` runs the real binary against a dead node URL —
the only way to prove the offline promise, and it catches what a source scrape
structurally cannot (routing back through `ApiClient`, dropping the `else`).
It needs no Freenet node, so it runs in normal CI rather than being `#[ignore]`d.
Covers: inline key with no storage and no node, `RIVER_SIGNING_KEY` parity with
the flag, determinism, distinct keys → distinct IDs, the single-object JSON
shape, empty-store `[]`, unknown-room error without a connection attempt, and
malformed-key rejection.

Unit tests cover the derivation (`author_member_id` sharing, pinned), the JSON
field names and null-vs-empty nickname, ownership, the override matrix, the
nickname matrix (room-state preferred, local fallback, private decrypt,
undecryptable falls back, empty falls back), and that `whoami <room>` and
`whoami` agree — they run through two independent paths.

Verified end-to-end against a live node: created a room, ran `whoami`
(`JYFX4AGJ`), sent a message, confirmed `message list --format json` reported
`"author": "JYFX4AGJ"`; and that `RIVER_SIGNING_KEY=<key> whoami` reports the
same ID that key signs with.

No WASM touched, so no delegate/contract migration is needed.

Review: Codex plus three independent Claude reviewers (skeptical bug-hunt,
code-first intent, testing/API-compatibility). All findings fixed — see the
[review comment](https://github.com/freenet/river/pull/439#issuecomment-5038299941).

Closes #438

[AI-assisted - Claude]
