### PR TITLE
chore: bump river-core to 0.1.16 and riverctl to 0.1.80

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4662,7 +4662,7 @@ dependencies = [
 
 [[package]]
 name = "river-core"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -4688,7 +4688,7 @@ dependencies = [
 
 [[package]]
 name = "river-ui"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "aes-gcm",
  "blake3",
@@ -4724,7 +4724,7 @@ dependencies = [
 
 [[package]]
 name = "riverctl"
-version = "0.1.79"
+version = "0.1.80"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ freenet-scaffold-macro = "0.2.2"
 freenet-stdlib = { version = "0.8.3", features = ["contract"] }
 
 [workspace.package]
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 
 [profile.release]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riverctl"
-version = "0.1.79"
+version = "0.1.80"
 edition = "2021"
 authors = ["Freenet Project"]
 description = "Command-line interface for River decentralized chat on Freenet"
@@ -50,7 +50,7 @@ dialoguer = "0.11"
 atty = "0.2"
 
 # Internal dependencies
-river-core = { version = "0.1.15", path = "../common", features = ["ecies", "ecies-randomized", "migration", "mentions"] }
+river-core = { version = "0.1.16", path = "../common", features = ["ecies", "ecies-randomized", "migration", "mentions"] }
 freenet-stdlib = { workspace = true, features = ["net"] }
 freenet-scaffold = "0.2.2"
 # Sans-IO backward-probe decision driver (freenet/river#398 phase 2b): drives


### PR DESCRIPTION
Version bumps for the crates.io release carrying the #398 driver adoption:

- **river-core 0.1.16**: #434 moved the legacy-registry codegen to `freenet-migrate-build` (registry validation now runs at build time in the published crate).
- **riverctl 0.1.80**: #437 drives legacy room recovery through `freenet-migrate`'s decision driver.

Mechanical version bump only (Skip review tier). After merge: tag `riverctl-v0.1.80` to trigger the crates.io + GitHub release workflow (publishes river-core 0.1.16 first, then riverctl).

Part of #398 / freenet-core#2776.

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wJpXbgCrnkSKgkpmnLGwQ