### PR TITLE
feat(ui): expand randomized name suggestions

### DIFF
--- a/ui/src/nickname.rs
+++ b/ui/src/nickname.rs
@@ -116,7 +116,7 @@ pub const LAST_NAMES: [&str; 100] = [
     "Mantis",
     "Panther",
     "Jaguar",
-    "Cougar",
+    "Ocelot",
     "Wolfhound",
     "Serpent",
     "Foundry",
@@ -179,7 +179,7 @@ pub fn generate_default_nickname(vk: &VerifyingKey) -> String {
 mod tests {
     use super::*;
     use ed25519_dalek::SigningKey;
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
 
     /// Every handle the generator can emit, for the exhaustive checks.
     fn all_handles() -> impl Iterator<Item = String> {
@@ -316,35 +316,55 @@ mod tests {
         );
     }
 
+    /// The point of the bigger pools is variety, which only materializes if
+    /// the fold indexes evenly across the whole of each one.
+    ///
+    /// A reachability floor alone is NOT enough, and it is worth being precise
+    /// about why: a "how many words were reached" check is a total-COLLAPSE
+    /// detector only. Degenerate multipliers (2, 32, even 100 — one sharing
+    /// factors with the pool size) still reach all 100 buckets over 2,000
+    /// keys, and so does a synthetic distribution putting 90% of its mass on
+    /// 10 words. So this test also bounds the SHARE any single word may take,
+    /// which is what actually catches skew.
     #[test]
-    fn fold_reaches_most_of_both_pools() {
-        // The point of the bigger pools is variety, which only materializes
-        // if the fold indexes across the whole of each one. With 2,000 keys
-        // a uniform fold hits all 100 words in each pool with overwhelming
-        // probability; 80 is a loose floor that still catches a fold that
-        // has collapsed onto a subset (e.g. a pool size sharing factors
-        // with the hash multiplier).
+    fn fold_spreads_evenly_across_both_pools() {
         let mut rng = rand::thread_rng();
-        let mut firsts = HashSet::new();
-        let mut lasts = HashSet::new();
-        for _ in 0..2_000 {
+        const KEYS: usize = 2_000;
+        let mut firsts: HashMap<String, usize> = HashMap::new();
+        let mut lasts: HashMap<String, usize> = HashMap::new();
+        for _ in 0..KEYS {
             let sk = SigningKey::generate(&mut rng);
             let name = generate_default_nickname(&sk.verifying_key());
             let (first, last) = name.split_once(' ').unwrap();
-            firsts.insert(first.to_string());
-            lasts.insert(last.to_string());
+            *firsts.entry(first.to_string()).or_default() += 1;
+            *lasts.entry(last.to_string()).or_default() += 1;
         }
-        assert!(
-            firsts.len() >= 80,
-            "only {} of {} first words reachable",
-            firsts.len(),
-            FIRST_NAMES.len()
-        );
-        assert!(
-            lasts.len() >= 80,
-            "only {} of {} last words reachable",
-            lasts.len(),
-            LAST_NAMES.len()
-        );
+
+        for (label, counts, pool) in [
+            ("first", &firsts, FIRST_NAMES.len()),
+            ("last", &lasts, LAST_NAMES.len()),
+        ] {
+            // Reachability: catches a fold collapsed onto a subset.
+            assert!(
+                counts.len() >= 80,
+                "{label}: only {} of {pool} words reachable",
+                counts.len()
+            );
+
+            // Evenness: expected share is KEYS/pool (20). Allow 4x headroom
+            // for sampling noise — the observed max is ~2x — while still
+            // failing the 90%-on-10-words case a reachability floor waves
+            // through.
+            let expected = KEYS / pool;
+            let (worst_word, worst_count) = counts
+                .iter()
+                .max_by_key(|(_, c)| **c)
+                .expect("non-empty pool");
+            assert!(
+                *worst_count <= expected * 4,
+                "{label}: \"{worst_word}\" took {worst_count} of {KEYS} draws \
+                 (expected ~{expected}) — the fold is skewed, not uniform"
+            );
+        }
     }
 }

--- a/ui/src/nickname.rs
+++ b/ui/src/nickname.rs
@@ -12,18 +12,43 @@
 //! handle, with no stored state and no RNG. That property matters: the
 //! member-info self-heal path regenerates this name and must land on the
 //! same value every time.
+//!
+//! The pools started at 30x30 = 900 combinations, which users reported as
+//! "samey" — a room of a few dozen people saw the same words over and over.
+//! They are now 100x100 = 10,000 combinations. Keep the two pools disjoint
+//! (so no handle reads "Echo Echo"), keep every word short, ASCII and
+//! inoffensive, and keep them the same length as the constants below claim —
+//! the tests at the bottom of this file pin all of that.
 
 use ed25519_dalek::VerifyingKey;
 
-/// First half of the handle. Exactly 30 entries — see `pools_are_30` test.
-pub const FIRST_NAMES: [&str; 30] = [
+/// Upper bound on the length of any handle this module can produce.
+///
+/// Every combination must fit a room's `max_nickname_size`, which defaults
+/// to 50 bytes. `handles_fit_the_default_nickname_limit` checks the real
+/// default rather than trusting this number, and
+/// `handles_are_within_max_handle_len` checks this one, so a future word
+/// that blows the budget fails CI instead of producing a nickname the
+/// room contract rejects.
+pub const MAX_HANDLE_LEN: usize = 20;
+
+/// First half of the handle. Exactly 100 entries — see `pools_are_100`.
+pub const FIRST_NAMES: [&str; 100] = [
     "Acid", "Zero", "Crash", "Cyber", "Ghost", "Neon", "Razor", "Static", "Phantom", "Chrome",
     "Glitch", "Cipher", "Daemon", "Null", "Hex", "Rogue", "Vapor", "Plasma", "Volt", "Frost",
     "Quantum", "Binary", "Proxy", "Logic", "Echo", "Pixel", "Neural", "Photon", "Onyx", "Cobalt",
+    "Nitro", "Turbo", "Solar", "Lunar", "Cosmic", "Astro", "Argon", "Xenon", "Neutron", "Proton",
+    "Flux", "Prism", "Laser", "Lumen", "Nova", "Pulsar", "Quasar", "Comet", "Meteor", "Orbit",
+    "Zenith", "Nebula", "Aurora", "Halcyon", "Obsidian", "Titanium", "Iridium", "Mercury",
+    "Silicon", "Carbon", "Crystal", "Granite", "Velvet", "Indigo", "Violet", "Crimson", "Scarlet",
+    "Azure", "Magenta", "Amber", "Copper", "Silver", "Ember", "Cinder", "Blaze", "Tempest",
+    "Thunder", "Monsoon", "Zephyr", "Glacier", "Tundra", "Midnight", "Twilight", "Umbra",
+    "Eclipse", "Stellar", "Astral", "Lucid", "Silent", "Hollow", "Feral", "Wired", "Analog",
+    "Digital", "Modular", "Fractal", "Syntax", "Bitwise", "Cache", "Packet",
 ];
 
-/// Second half of the handle. Exactly 30 entries — see `pools_are_30` test.
-pub const LAST_NAMES: [&str; 30] = [
+/// Second half of the handle. Exactly 100 entries — see `pools_are_100`.
+pub const LAST_NAMES: [&str; 100] = [
     "Override",
     "Phreak",
     "Wraith",
@@ -54,13 +79,88 @@ pub const LAST_NAMES: [&str; 30] = [
     "Vertex",
     "Payload",
     "Mainframe",
+    "Runner",
+    "Prowler",
+    "Seeker",
+    "Voyager",
+    "Corsair",
+    "Ronin",
+    "Vagabond",
+    "Wanderer",
+    "Pilgrim",
+    "Courier",
+    "Beacon",
+    "Lantern",
+    "Compass",
+    "Anchor",
+    "Harbor",
+    "Keystone",
+    "Bastion",
+    "Citadel",
+    "Rampart",
+    "Bulwark",
+    "Talon",
+    "Osprey",
+    "Kestrel",
+    "Condor",
+    "Harrier",
+    "Albatross",
+    "Skylark",
+    "Nightjar",
+    "Peregrine",
+    "Corvid",
+    "Lynx",
+    "Jackal",
+    "Viper",
+    "Cobra",
+    "Mantis",
+    "Panther",
+    "Jaguar",
+    "Cougar",
+    "Wolfhound",
+    "Serpent",
+    "Foundry",
+    "Forge",
+    "Anvil",
+    "Crucible",
+    "Furnace",
+    "Bellows",
+    "Piston",
+    "Turbine",
+    "Dynamo",
+    "Flywheel",
+    "Lattice",
+    "Matrix",
+    "Nexus",
+    "Conduit",
+    "Junction",
+    "Gateway",
+    "Bridge",
+    "Tunnel",
+    "Terminal",
+    "Console",
+    "Sigil",
+    "Rune",
+    "Glyph",
+    "Token",
+    "Ledger",
+    "Archive",
+    "Codex",
+    "Almanac",
+    "Manifest",
+    "Protocol",
 ];
 
 /// Fold a byte slice into a stable index seed (simple polynomial hash).
-fn fold(bytes: &[u8]) -> usize {
-    bytes.iter().fold(0usize, |acc, &b| {
-        acc.wrapping_mul(31).wrapping_add(b as usize)
-    })
+///
+/// Deliberately `u64` rather than `usize`: `usize` is 32-bit on the wasm32
+/// build that ships and 64-bit natively, so a `usize` accumulator would
+/// give the two different index values for the same key (and the native
+/// unit tests would not be testing what the browser actually produces).
+fn fold(bytes: &[u8]) -> u64 {
+    bytes
+        .iter()
+        .fold(0u64, |acc, &b| acc.wrapping_mul(31).wrapping_add(b as u64))
 }
 
 /// Derive a deterministic default handle (e.g. "Cipher Daylight") from a
@@ -70,8 +170,8 @@ pub fn generate_default_nickname(vk: &VerifyingKey) -> String {
     let bytes = vk.as_bytes();
     // Use disjoint key halves for the two indices so the first and last
     // word vary independently.
-    let first = FIRST_NAMES[fold(&bytes[0..16]) % FIRST_NAMES.len()];
-    let last = LAST_NAMES[fold(&bytes[16..32]) % LAST_NAMES.len()];
+    let first = FIRST_NAMES[(fold(&bytes[0..16]) % FIRST_NAMES.len() as u64) as usize];
+    let last = LAST_NAMES[(fold(&bytes[16..32]) % LAST_NAMES.len() as u64) as usize];
     format!("{first} {last}")
 }
 
@@ -79,13 +179,93 @@ pub fn generate_default_nickname(vk: &VerifyingKey) -> String {
 mod tests {
     use super::*;
     use ed25519_dalek::SigningKey;
+    use std::collections::HashSet;
+
+    /// Every handle the generator can emit, for the exhaustive checks.
+    fn all_handles() -> impl Iterator<Item = String> {
+        FIRST_NAMES
+            .iter()
+            .flat_map(|first| LAST_NAMES.iter().map(move |last| format!("{first} {last}")))
+    }
 
     #[test]
-    fn pools_are_30() {
+    fn pools_are_100() {
         // The doc-comments and the deterministic-distribution reasoning
-        // both assume 30x30 = 900 combinations.
-        assert_eq!(FIRST_NAMES.len(), 30);
-        assert_eq!(LAST_NAMES.len(), 30);
+        // both assume 100x100 = 10,000 combinations.
+        assert_eq!(FIRST_NAMES.len(), 100);
+        assert_eq!(LAST_NAMES.len(), 100);
+        assert_eq!(FIRST_NAMES.len() * LAST_NAMES.len(), 10_000);
+    }
+
+    #[test]
+    fn pools_have_no_duplicates() {
+        for (label, pool) in [
+            ("FIRST_NAMES", &FIRST_NAMES[..]),
+            ("LAST_NAMES", &LAST_NAMES[..]),
+        ] {
+            let unique: HashSet<&&str> = pool.iter().collect();
+            assert_eq!(
+                unique.len(),
+                pool.len(),
+                "{label} contains a duplicate — it wastes a slot and skews the distribution"
+            );
+        }
+    }
+
+    #[test]
+    fn pools_are_disjoint() {
+        let first: HashSet<&&str> = FIRST_NAMES.iter().collect();
+        let overlap: Vec<&&str> = LAST_NAMES.iter().filter(|w| first.contains(w)).collect();
+        assert!(
+            overlap.is_empty(),
+            "a word in both pools can produce a doubled handle (e.g. \"Echo Echo\"): {overlap:?}"
+        );
+    }
+
+    #[test]
+    fn words_are_short_ascii_and_capitalized() {
+        for word in FIRST_NAMES.iter().chain(LAST_NAMES.iter()) {
+            assert!(
+                word.chars().all(|c| c.is_ascii_alphabetic()),
+                "{word} must be plain ASCII letters"
+            );
+            assert!(
+                word.starts_with(|c: char| c.is_ascii_uppercase()),
+                "{word} must be capitalized"
+            );
+            assert!(
+                (3..=9).contains(&word.len()),
+                "{word} is {} chars — keep pool words between 3 and 9 so every handle stays chat-sized",
+                word.len()
+            );
+        }
+    }
+
+    #[test]
+    fn handles_are_within_max_handle_len() {
+        let longest = all_handles().max_by_key(String::len).unwrap();
+        assert!(
+            longest.len() <= MAX_HANDLE_LEN,
+            "longest handle {longest:?} is {} bytes, over MAX_HANDLE_LEN ({MAX_HANDLE_LEN})",
+            longest.len()
+        );
+    }
+
+    #[test]
+    fn handles_fit_the_default_nickname_limit() {
+        // The room contract rejects a member_info whose nickname exceeds the
+        // room's `max_nickname_size`, so a generated default that does not
+        // fit would make the join / self-heal UPDATE fail outright. Check
+        // against the real default rather than a hardcoded copy of it.
+        let limit =
+            river_core::room_state::configuration::Configuration::default().max_nickname_size;
+        for handle in all_handles() {
+            assert!(
+                handle.len() <= limit,
+                "{handle:?} is {} bytes, over the default max_nickname_size of {limit}",
+                handle.len()
+            );
+        }
     }
 
     #[test]
@@ -120,19 +300,51 @@ mod tests {
 
     #[test]
     fn distinct_keys_mostly_distinct_handles() {
-        // Not a guarantee (900 combos, birthday paradox), but a sanity
-        // check that the fold actually spreads keys around.
+        // Not a guarantee (10,000 combos, birthday paradox), but a sanity
+        // check that the fold actually spreads keys around. 200 keys into
+        // 10,000 buckets: ~198 unique expected, so 180 leaves ample slack.
         let mut rng = rand::thread_rng();
-        let mut seen = std::collections::HashSet::new();
-        for _ in 0..50 {
+        let mut seen = HashSet::new();
+        for _ in 0..200 {
             let sk = SigningKey::generate(&mut rng);
             seen.insert(generate_default_nickname(&sk.verifying_key()));
         }
-        // 50 keys into 900 buckets: expect well over half unique.
         assert!(
-            seen.len() > 30,
-            "fold barely spread keys: {} unique",
+            seen.len() > 180,
+            "fold barely spread keys: {} unique out of 200",
             seen.len()
+        );
+    }
+
+    #[test]
+    fn fold_reaches_most_of_both_pools() {
+        // The point of the bigger pools is variety, which only materializes
+        // if the fold indexes across the whole of each one. With 2,000 keys
+        // a uniform fold hits all 100 words in each pool with overwhelming
+        // probability; 80 is a loose floor that still catches a fold that
+        // has collapsed onto a subset (e.g. a pool size sharing factors
+        // with the hash multiplier).
+        let mut rng = rand::thread_rng();
+        let mut firsts = HashSet::new();
+        let mut lasts = HashSet::new();
+        for _ in 0..2_000 {
+            let sk = SigningKey::generate(&mut rng);
+            let name = generate_default_nickname(&sk.verifying_key());
+            let (first, last) = name.split_once(' ').unwrap();
+            firsts.insert(first.to_string());
+            lasts.insert(last.to_string());
+        }
+        assert!(
+            firsts.len() >= 80,
+            "only {} of {} first words reachable",
+            firsts.len(),
+            FIRST_NAMES.len()
+        );
+        assert!(
+            lasts.len() >= 80,
+            "only {} of {} last words reachable",
+            lasts.len(),
+            LAST_NAMES.len()
         );
     }
 }


### PR DESCRIPTION
## Problem

Users reported that the nickname River suggests when you join a room feels "samey" — different people keep getting handles built from the same handful of words.

The generator (`ui/src/nickname.rs`) derives a two-word handle deterministically from the member's verifying key, one word from `FIRST_NAMES` and one from `LAST_NAMES`. Both pools held 30 words, so the whole space was 30 x 30 = **900 combinations**. In a room with a few dozen members, repeated words (and occasionally repeated full handles) are common at that size.

## Approach

Grow both pools to 100 words, giving **10,000 combinations** (11x more). All 60 original words are kept and the existing 90s-hacker-culture tone is matched — the new words are the same kind of thing (`Halcyon`, `Obsidian`, `Bitwise`, `Peregrine`, `Crucible`, `Almanac`). Sample output:

```
Lumen Vector      Chrome Nightjar    Xenon Nightjar     Neural Corsair
Eclipse Glider    Titanium Gateway   Chrome Storm       Crash Peregrine
Scarlet Peregrine Phantom Gateway    Bitwise Override   Hollow Osprey
Nitro Lattice     Phantom Bellows    Digital Cobra
```

Every word is ASCII, capitalized, 3-9 characters and inoffensive, so the longest possible handle is 19 bytes — comfortably inside the 50-byte default `max_nickname_size` (a generated default that exceeded a room's limit would make the join / self-heal UPDATE fail outright, so this is checked exhaustively in a test against the real `Configuration::default()`).

Two smaller things came along with it:

- The two pools are now **disjoint**, so no handle can read "Echo Echo". A test pins this.
- `fold` accumulates in `u64` instead of `usize`. `usize` is 32-bit on the wasm32 build that actually ships and 64-bit natively, so `accumulator % pool_len` gave *different* words in the browser than in the native unit tests. `u64` makes both agree, so the tests measure what users actually get.

**Note on determinism:** the derivation stays a pure function of the key (the member-info self-heal path depends on that and is unaffected). But because the pool lengths change, a given key now maps to a different handle than it did before. That is cosmetic only — a stored `member_info` nickname always wins; the generated handle is a fallback used when no entry exists. The visible effect is that a member who never set a nickname and has no published `member_info` may show a different default handle after upgrading.

Scope is client-only: this touches `ui/src/nickname.rs` and nothing under `common/`, `contracts/` or `delegates/`, so no WASM bytes and no contract/delegate key change.

## Testing

`cargo test -p river-ui --bins` — 496 passed, 0 failed (this is the same command CI runs for the UI crate). New / updated tests in `ui/src/nickname.rs`:

- `pools_are_100` — both pools are exactly 100 entries, 10,000 combinations (replaces `pools_are_30`)
- `pools_have_no_duplicates` — no repeated word within either pool
- `pools_are_disjoint` — no word in both pools, so no doubled handle
- `words_are_short_ascii_and_capitalized` — ASCII-alphabetic, capitalized, 3-9 chars
- `handles_are_within_max_handle_len` — exhaustive over all 10,000 handles vs `MAX_HANDLE_LEN`
- `handles_fit_the_default_nickname_limit` — exhaustive over all 10,000 handles vs the real `Configuration::default().max_nickname_size`, rather than a hardcoded copy of it
- `fold_reaches_most_of_both_pools` — 2,000 keys must reach at least 80 of the 100 words in each pool (measured: 100/100 for both, so the floor has plenty of slack)
- `distinct_keys_mostly_distinct_handles` — tightened from >30/50 unique to >180/200 unique now that the space is 10,000

Also ran `cargo fmt --all` and `cargo clippy -p river-ui --bins` (clean). Deliberately did not run `cargo make build` — it rebuilds the WASMs.

[AI-assisted - Claude]
