### PR TITLE
docs(cli): document riverctl dm send

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ cargo install riverctl
 Commands include:
 - `riverctl room` - Room management (create, list, info)
 - `riverctl message` - Send and receive messages
+- `riverctl dm` - End-to-end-encrypted direct messages to a co-member (send, list, purge, accept)
 - `riverctl member` - Member management
 - `riverctl invite` - Create and accept invitations
 - `riverctl identity whoami` - Your own member ID in a room (matches the `author` on your messages)

--- a/cli/README.md
+++ b/cli/README.md
@@ -41,6 +41,40 @@ riverctl message edit   <room-owner-vk> <message-id> "Fixed typo."
 riverctl message delete <room-owner-vk> <message-id>
 ```
 
+## Direct messages
+
+End-to-end-encrypted one-to-one messages between two members of the same room.
+They travel inside the room's contract state, so both people must already be
+members — there is no cross-room DM.
+
+The recipient is a member ID: either the short 8-character form that
+`riverctl member list` prints, or the full ID.
+
+```bash
+riverctl member list <room-owner-vk>             # Find the recipient's member ID.
+riverctl dm send  <room-owner-vk> <recipient> "Hello, just between us."
+riverctl dm list  <room-owner-vk>                # Threads to/from you, decrypted.
+riverctl dm purge <room-owner-vk> <purge-token>  # Drop a DM addressed to you.
+```
+
+The purge token is the 32-character hex value `dm list` prints beneath each
+inbound DM as `purge token: …`.
+
+Only the recipient can decrypt a DM, so `dm list` renders your own sent
+messages from a local plaintext cache. A DM you sent from a different machine
+shows as ciphertext-only there.
+
+The UI can also share an invitation *inside* a DM, which `dm list` shows as
+`[Invitation to room …]`. Accept it with:
+
+```bash
+riverctl dm accept <carrier-room-vk>
+```
+
+`<carrier-room-vk>` is the room whose DM thread **contains** the invitation, not
+the room you are joining. If you have invite DMs for several rooms, narrow with
+`--from <sender>` or `--room <target-room>`.
+
 ## Inviting others
 
 ```bash


### PR DESCRIPTION
## Problem

Reported by Ivvor on Matrix:

> I see `riverctl dm accept` to process a DM invite, but no specific DM send, unless you just send the raw code as a message I guess.

`riverctl dm send` **is not missing** — it has existed since v0.1.55 (#243, May 2026) and works. I verified it end-to-end on a live node while triaging: Alice sent, Bob's `dm list` decrypted it.

The gap is documentation:

1. The **top-level `README.md`** riverctl command list omitted `dm` entirely — it listed `room`, `message`, `member`, `invite`, `identity`.
2. **`cli/README.md`** carried DMs only as a single row in the reference table (`dm | send, list, purge, accept`). Every other command family — messages, invites, identity, members — has a worked example section with copy-pasteable commands. DMs had none.

So a reader finds `dm accept` in that table and reasonably concludes there's no send.

## Approach

- Add `riverctl dm` to the top-level README command list.
- Add a "Direct messages" section to `cli/README.md`, in the same style as the neighbouring sections, covering `send` / `list` / `purge` / `accept`.

Beyond the bare commands it documents the three things that actually trip people up:

- the recipient is a **member ID** (the short 8-char form `member list` prints is accepted);
- the **purge token** comes from the `purge token: …` line printed under each inbound DM by `dm list`;
- `dm accept` takes the **carrier** room (the room whose DM thread contains the invitation), *not* the room you're joining.

It also notes the sender-side plaintext cache: only the recipient can decrypt a DM, so your own sent messages render from a local cache and show as ciphertext-only from a different machine.

## Verification

Every command and output format documented here was checked against riverctl 0.2.1 — `--help` signatures for `send`/`list`/`purge`/`accept`, plus a real round trip on a local node (create room → invite → accept → `dm send` → `dm list`), including confirming the `purge token:` line renders as described.

## Scope

Docs only. No code, no WASM, no contract change, no republish. Fixes the discoverability problem behind the report; no behavioural change.

[AI-assisted - Claude]
