### PR TITLE
feat(cli): riverctl dm invite — send a clickable invitation via DM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4724,7 +4724,7 @@ dependencies = [
 
 [[package]]
 name = "riverctl"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ cargo install riverctl
 Commands include:
 - `riverctl room` - Room management (create, list, info)
 - `riverctl message` - Send and receive messages
-- `riverctl dm` - End-to-end-encrypted direct messages to a co-member (send, list, purge, accept)
+- `riverctl dm` - End-to-end-encrypted direct messages to a co-member (send, invite, list, purge, accept)
 - `riverctl member` - Member management
 - `riverctl invite` - Create and accept invitations
 - `riverctl identity whoami` - Your own member ID in a room (matches the `author` on your messages)

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riverctl"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["Freenet Project"]
 description = "Command-line interface for River decentralized chat on Freenet"

--- a/cli/README.md
+++ b/cli/README.md
@@ -64,8 +64,29 @@ Only the recipient can decrypt a DM, so `dm list` renders your own sent
 messages from a local plaintext cache. A DM you sent from a different machine
 shows as ciphertext-only there.
 
-The UI can also share an invitation *inside* a DM, which `dm list` shows as
-`[Invitation to room …]`. Accept it with:
+### Inviting someone via DM
+
+You can hand a room invitation to a co-member *as a DM*. The recipient's River
+UI renders it as a clickable **Invitation card** with an Accept button — unlike a
+bare invite code pasted into `dm send`, which just shows up as raw text.
+
+```bash
+# Invite <recipient> (a member of the carrier room) to <target-room>.
+riverctl dm invite <carrier-room-vk> <recipient> --room <target-room-vk> -m "come join!"
+```
+
+- `<carrier-room-vk>` is the room the DM travels in — you and the recipient must
+  both be members of it.
+- `--room <target-room-vk>` is the room you are inviting them to (any room you're
+  a member of, including the carrier room itself). A fresh single-use invite
+  credential is minted, exactly as `invite create` does.
+- `-m/--message` is an optional note shown above the Accept button.
+
+The recipient accepts with `dm accept` (below), or clicks the card in the UI.
+
+### Accepting an invitation that arrived as a DM
+
+`dm list` shows an invite DM as `[Invitation to room …]`. Accept it with:
 
 ```bash
 riverctl dm accept <carrier-room-vk>

--- a/cli/README.md
+++ b/cli/README.md
@@ -77,9 +77,10 @@ riverctl dm invite <carrier-room-vk> <recipient> --room <target-room-vk> -m "com
 
 - `<carrier-room-vk>` is the room the DM travels in — you and the recipient must
   both be members of it.
-- `--room <target-room-vk>` is the room you are inviting them to (any room you're
-  a member of, including the carrier room itself). A fresh single-use invite
-  credential is minted, exactly as `invite create` does.
+- `--room <target-room-vk>` is the room you are inviting them to. It must be a
+  *different* room you're a member of (the recipient is already in the carrier
+  room). A fresh single-use invite credential is minted, exactly as
+  `invite create` does.
 - `-m/--message` is an optional note shown above the Accept button.
 
 The recipient accepts with `dm accept` (below), or clicks the card in the UI.

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -2067,14 +2067,34 @@ impl ApiClient {
     }
 
     pub async fn create_invitation(&self, room_owner_key: &VerifyingKey) -> Result<String> {
+        let invitation = self.build_invitation(room_owner_key)?;
+
+        // Encode as base58
+        let mut data = Vec::new();
+        ciborium::ser::into_writer(&invitation, &mut data)
+            .map_err(|e| anyhow!("Failed to serialize invitation: {}", e))?;
+        let encoded = bs58::encode(data).into_string();
+
+        Ok(encoded)
+    }
+
+    /// Build the [`Invitation`] artifact for `room_owner_key` from local
+    /// storage. Shared by [`Self::create_invitation`] (which base58-encodes it
+    /// into an `?invitation=…` code) and by `dm invite` (which CBOR-encodes it
+    /// into a [`river_core::room_state::dm_body::InvitePayload`]), so both
+    /// entry points produce byte-identical invitation payloads.
+    ///
+    /// The caller must be a member of the room with a stored signing key; the
+    /// generated invitee signing key is a fresh bearer credential.
+    pub(crate) fn build_invitation(&self, room_owner_key: &VerifyingKey) -> Result<Invitation> {
         info!(
-            "Creating invitation for room owned by: {}",
+            "Building invitation for room owned by: {}",
             bs58::encode(room_owner_key.as_bytes()).into_string()
         );
 
         // Get the room info from persistent storage
         let room_data = self.storage.get_room(room_owner_key)?
-            .ok_or_else(|| anyhow!("Room not found in local storage. You must be the room owner to create invitations."))?;
+            .ok_or_else(|| anyhow!("Room not found in local storage. You must be a member of the room to create invitations."))?;
         let (signing_key, state, _contract_key) = room_data;
 
         // Generate a new signing key for the invitee
@@ -2115,20 +2135,12 @@ impl ApiClient {
         let room_secrets = crate::private_room::collect_invitation_secrets(&secrets);
 
         // Create the invitation struct
-        let invitation = Invitation {
+        Ok(Invitation {
             room: *room_owner_key,
             invitee_signing_key,
             invitee: authorized_member,
             room_secrets,
-        };
-
-        // Encode as base58
-        let mut data = Vec::new();
-        ciborium::ser::into_writer(&invitation, &mut data)
-            .map_err(|e| anyhow!("Failed to serialize invitation: {}", e))?;
-        let encoded = bs58::encode(data).into_string();
-
-        Ok(encoded)
+        })
     }
 
     pub async fn accept_invitation(

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -2067,7 +2067,15 @@ impl ApiClient {
     }
 
     pub async fn create_invitation(&self, room_owner_key: &VerifyingKey) -> Result<String> {
-        let invitation = self.build_invitation(room_owner_key)?;
+        // `invite create <room>` honours a `--signing-key-file` override for
+        // the room it targets (that is the override's whole purpose — pick
+        // which of your identities in THIS room mints the invite), so resolve
+        // the inviter key via `get_room`.
+        let (inviter_signing_key, state, _contract_key) = self
+            .storage
+            .get_room(room_owner_key)?
+            .ok_or_else(|| anyhow!("Room not found in local storage. You must be a member of the room to create invitations."))?;
+        let invitation = self.build_invitation(room_owner_key, &inviter_signing_key, &state)?;
 
         // Encode as base58
         let mut data = Vec::new();
@@ -2078,24 +2086,31 @@ impl ApiClient {
         Ok(encoded)
     }
 
-    /// Build the [`Invitation`] artifact for `room_owner_key` from local
-    /// storage. Shared by [`Self::create_invitation`] (which base58-encodes it
-    /// into an `?invitation=…` code) and by `dm invite` (which CBOR-encodes it
-    /// into a [`river_core::room_state::dm_body::InvitePayload`]), so both
-    /// entry points produce byte-identical invitation payloads.
+    /// Build the [`Invitation`] artifact for `room_owner_key`, signed by
+    /// `inviter_signing_key` (which MUST be a member of that room) over the
+    /// local `state`. Shared by [`Self::create_invitation`] (which
+    /// base58-encodes it into an `?invitation=…` code) and by `dm invite`
+    /// (which CBOR-encodes it into a
+    /// [`river_core::room_state::dm_body::InvitePayload`]), so both entry
+    /// points produce byte-identical invitation payloads.
     ///
-    /// The caller must be a member of the room with a stored signing key; the
+    /// The inviter key is passed EXPLICITLY rather than resolved here because
+    /// the two callers resolve it differently: `create_invitation` honours the
+    /// `--signing-key-file` override for its one target room, whereas
+    /// `dm invite` must sign the target-room invitation with the target room's
+    /// OWN stored key (the override, if any, is the carrier-room sender
+    /// identity, not a target member) — see freenet/river#456 / Codex P2. The
     /// generated invitee signing key is a fresh bearer credential.
-    pub(crate) fn build_invitation(&self, room_owner_key: &VerifyingKey) -> Result<Invitation> {
+    pub(crate) fn build_invitation(
+        &self,
+        room_owner_key: &VerifyingKey,
+        inviter_signing_key: &SigningKey,
+        state: &ChatRoomStateV1,
+    ) -> Result<Invitation> {
         info!(
             "Building invitation for room owned by: {}",
             bs58::encode(room_owner_key.as_bytes()).into_string()
         );
-
-        // Get the room info from persistent storage
-        let room_data = self.storage.get_room(room_owner_key)?
-            .ok_or_else(|| anyhow!("Room not found in local storage. You must be a member of the room to create invitations."))?;
-        let (signing_key, state, _contract_key) = room_data;
 
         // Generate a new signing key for the invitee
         let invitee_signing_key =
@@ -2106,11 +2121,11 @@ impl ApiClient {
         let member = Member {
             owner_member_id: (*room_owner_key).into(),
             member_vk: invitee_vk,
-            invited_by: signing_key.verifying_key().into(),
+            invited_by: inviter_signing_key.verifying_key().into(),
         };
 
-        // Sign the member entry with the inviter's key (room owner in this case)
-        let authorized_member = AuthorizedMember::new(member, &signing_key);
+        // Sign the member entry with the inviter's key.
+        let authorized_member = AuthorizedMember::new(member, inviter_signing_key);
 
         // Collect every room secret the CLI holds so the invitee can decrypt
         // the room immediately on join — without waiting for the owner
@@ -2128,8 +2143,8 @@ impl ApiClient {
         // creation is a possible future hardening.
         let invitation_secrets = self.storage.get_invitation_secrets(room_owner_key)?;
         let secrets = crate::private_room::collect_secrets_for_room(
-            &state,
-            &signing_key,
+            state,
+            inviter_signing_key,
             &invitation_secrets,
         );
         let room_secrets = crate::private_room::collect_invitation_secrets(&secrets);

--- a/cli/src/commands/dm.rs
+++ b/cli/src/commands/dm.rs
@@ -67,8 +67,9 @@ pub enum DmCommands {
     ///
     /// `room_id` is the CARRIER room the DM travels in — you and `recipient`
     /// must both be members of it. `--room` is the TARGET room you are inviting
-    /// them to (any room you are a member of, including `room_id` itself). A
-    /// fresh single-use invitee credential is minted, exactly as
+    /// them to; it must be a DIFFERENT room you are a member of (inviting them
+    /// to the carrier room, which they are already in, would be un-acceptable).
+    /// A fresh single-use invitee credential is minted, exactly as
     /// `invite create` does.
     Invite {
         /// Carrier room ID (base58 room owner key) — the room whose DM thread
@@ -78,7 +79,8 @@ pub enum DmCommands {
         /// Recipient member ID (short prefix accepted).
         recipient: String,
         /// Target room ID (base58 room owner key) — the room you are inviting
-        /// the recipient to join. You must be a member of it.
+        /// the recipient to join. You must be a member of it, and it must be
+        /// different from the carrier room.
         #[arg(long)]
         room: String,
         /// Optional personal note shown above the Accept button.
@@ -445,8 +447,22 @@ async fn execute_invite(
     let carrier_room_key = parse_room_id(carrier_room_id)?;
     let target_room_key = parse_room_id(target_room_id)?;
 
+    // Reject a self-invite: the recipient is resolved as a current member of
+    // the carrier room, so inviting them to the carrier room (`--room` ==
+    // carrier) mints an invitation to a room they are ALREADY in. Both the CLI
+    // #308 re-accept guard and the UI's member-aware guard then refuse it, so
+    // the card can never be accepted. Fail loudly instead of "delivering" a
+    // dead invitation (freenet/river#456, Codex P2).
+    if target_room_key == carrier_room_key {
+        return Err(anyhow!(
+            "The target room (--room) is the same as the carrier room. The recipient is already \
+             a member of it, so the invitation could not be accepted. Pick a different --room."
+        ));
+    }
+
     // Signing identity for the carrier room (the DM is signed by, and travels
-    // in, the carrier room).
+    // in, the carrier room). Honours a `--signing-key-file` override — that is
+    // the carrier-room sender identity.
     let (signing_key, _, _) = api.storage().get_room(&carrier_room_key)?.ok_or_else(|| {
         anyhow!("Carrier room not found. You must be a member of it to send an invite DM.")
     })?;
@@ -454,16 +470,29 @@ async fn execute_invite(
     let room_state = api.get_room(&carrier_room_key, false).await?;
     let recipient_vk = resolve_recipient_vk(&room_state, &carrier_room_key, recipient)?;
 
-    // Build the invitation for the TARGET room (requires the target room in
-    // local storage). Byte-identical to what `invite create` produces — same
-    // `build_invitation` — so the recipient's `dm accept` / UI Accept card
-    // decode it the same way as a base58 `?invitation=` code.
-    let invitation = api.build_invitation(&target_room_key).map_err(|e| {
-        anyhow!(
-            "Could not build an invitation for the target room (are you a member of it?): {}",
-            e
-        )
-    })?;
+    // Build the invitation for the TARGET room. Sign it with the target room's
+    // OWN stored member key, NOT a `--signing-key-file` override (which is the
+    // carrier sender identity and is generally not a target-room member —
+    // signing with it mints an invitation the target contract rejects on
+    // accept; freenet/river#456, Codex P2). The target-room local state comes
+    // from storage; `get_invitation_secrets` inside `build_invitation` adds the
+    // private-room secrets. Byte-identical to what `invite create` produces.
+    let target_state = api
+        .storage()
+        .get_room(&target_room_key)?
+        .map(|(_, state, _)| state)
+        .ok_or_else(|| {
+            anyhow!("Target room (--room) not found in local storage. You must be a member of it to invite others to it.")
+        })?;
+    let target_signing_key = api
+        .storage()
+        .stored_signing_key(&target_room_key)?
+        .ok_or_else(|| {
+            anyhow!("Target room (--room) not found in local storage. You must be a member of it to invite others to it.")
+        })?;
+    let invitation = api
+        .build_invitation(&target_room_key, &target_signing_key, &target_state)
+        .map_err(|e| anyhow!("Could not build an invitation for the target room: {}", e))?;
 
     let mut invitation_payload = Vec::new();
     ciborium::ser::into_writer(&invitation, &mut invitation_payload)
@@ -1814,6 +1843,27 @@ mod tests {
         assert!(
             label.starts_with("[Invitation to room ") && label.ends_with("come join"),
             "got: {label}"
+        );
+    }
+
+    /// `dm send` MUST put text DMs on the wire as RAW UTF-8 (the legacy
+    /// no-magic-byte shape) so pre-#243 clients still render them — wrapping a
+    /// `Text` body in `encode_body` would prepend the `0x80` magic and garble
+    /// them on those clients. `execute_send` needs a live `ApiClient` to run,
+    /// so pin the call shape by source-scrape: the send path passes raw bytes,
+    /// and only the invite path opts into `encode_body`.
+    #[test]
+    fn dm_send_uses_legacy_raw_text_wire_shape() {
+        let src = include_str!("dm.rs");
+        let prod = &src[..src.find("#[cfg(test)]").expect("test module marker")];
+        assert!(
+            prod.contains("message.as_bytes(),"),
+            "execute_send must pass raw message bytes to deliver_dm (legacy text wire shape); \
+             wrapping Text in encode_body would break pre-#243 clients"
+        );
+        assert!(
+            prod.contains("encode_body(&body)"),
+            "execute_invite must opt the Invite body into the magic-byte+CBOR encoding"
         );
     }
 

--- a/cli/src/commands/dm.rs
+++ b/cli/src/commands/dm.rs
@@ -422,6 +422,17 @@ async fn deliver_dm(
     Ok(())
 }
 
+/// Whether `member_id` is currently a member of `state` (the room owner always
+/// counts, even without an explicit `AuthorizedMember` entry).
+fn room_has_member(state: &ChatRoomStateV1, owner_id: MemberId, member_id: MemberId) -> bool {
+    member_id == owner_id
+        || state
+            .members
+            .members
+            .iter()
+            .any(|m| m.member.id() == member_id)
+}
+
 /// Normalize the optional `--message` for an invite DM: trim it, and treat a
 /// blank / whitespace-only note as absent so the recipient's UI hides the
 /// message box entirely (per the `InvitePayload::personal_message` contract)
@@ -474,22 +485,41 @@ async fn execute_invite(
     // OWN stored member key, NOT a `--signing-key-file` override (which is the
     // carrier sender identity and is generally not a target-room member —
     // signing with it mints an invitation the target contract rejects on
-    // accept; freenet/river#456, Codex P2). The target-room local state comes
-    // from storage; `get_invitation_secrets` inside `build_invitation` adds the
-    // private-room secrets. Byte-identical to what `invite create` produces.
-    let target_state = api
-        .storage()
-        .get_room(&target_room_key)?
-        .map(|(_, state, _)| state)
-        .ok_or_else(|| {
-            anyhow!("Target room (--room) not found in local storage. You must be a member of it to invite others to it.")
-        })?;
+    // accept; freenet/river#456, Codex P2). Presence in local storage proves
+    // you hold credentials for the room.
     let target_signing_key = api
         .storage()
         .stored_signing_key(&target_room_key)?
         .ok_or_else(|| {
             anyhow!("Target room (--room) not found in local storage. You must be a member of it to invite others to it.")
         })?;
+
+    // Fetch the target room's CURRENT network state, NOT the stale local cache:
+    // (1) it gives the invitee up-to-date `room_secrets` (a rotation since the
+    // last sync would otherwise strand them on `[Encrypted …]`), and (2) it
+    // lets us verify the inviting identity is still a current member. If it was
+    // pruned from the target room (inactivity, or a join that never landed),
+    // an invitation it signs has an `invited_by` that isn't in the room, so the
+    // recipient's accept fails `get_invite_chain` / `MembersV1` verification.
+    // Refuse loudly instead of delivering a dead invitation that reports
+    // success (freenet/river#456, Codex P2 round 2).
+    let target_state = api.get_room(&target_room_key, false).await.map_err(|e| {
+        anyhow!(
+            "Could not fetch the target room (--room) state to build the invitation: {}",
+            e
+        )
+    })?;
+    let target_inviter_id = MemberId::from(&target_signing_key.verifying_key());
+    let target_owner_id = MemberId::from(&target_room_key);
+    if !room_has_member(&target_state, target_owner_id, target_inviter_id) {
+        return Err(anyhow!(
+            "Your identity is not a current member of the target room (--room), so an invitation \
+             signed by it could not be accepted. Re-establish your membership there (send a \
+             message, or re-accept your invitation) before inviting others to it."
+        ));
+    }
+
+    // Byte-identical to what `invite create` produces (same `build_invitation`).
     let invitation = api
         .build_invitation(&target_room_key, &target_signing_key, &target_state)
         .map_err(|e| anyhow!("Could not build an invitation for the target room: {}", e))?;
@@ -1865,6 +1895,43 @@ mod tests {
             prod.contains("encode_body(&body)"),
             "execute_invite must opt the Invite body into the magic-byte+CBOR encoding"
         );
+    }
+
+    /// `room_has_member` gates the `dm invite` target-membership check (a
+    /// non-member target signer produces an un-acceptable invitation). The
+    /// owner counts without an explicit entry; a stranger does not.
+    #[test]
+    fn room_has_member_recognizes_owner_and_members() {
+        let owner = key(1);
+        let member = key(2);
+        let stranger = key(3);
+        let owner_vk = owner.verifying_key();
+        let owner_id = MemberId::from(&owner_vk);
+
+        let mut state = ChatRoomStateV1::default();
+        state.members.members.push(AuthorizedMember::new(
+            Member {
+                owner_member_id: owner_id,
+                member_vk: member.verifying_key(),
+                invited_by: owner_id,
+            },
+            &owner,
+        ));
+
+        // Owner counts even without an explicit AuthorizedMember entry.
+        assert!(room_has_member(&state, owner_id, owner_id));
+        // An enrolled member counts.
+        assert!(room_has_member(
+            &state,
+            owner_id,
+            MemberId::from(&member.verifying_key())
+        ));
+        // A non-member does not.
+        assert!(!room_has_member(
+            &state,
+            owner_id,
+            MemberId::from(&stranger.verifying_key())
+        ));
     }
 
     /// A blank / whitespace-only `--message` becomes `None` so the recipient's

--- a/cli/src/commands/dm.rs
+++ b/cli/src/commands/dm.rs
@@ -20,7 +20,7 @@ use river_core::room_state::direct_messages::{
     advance_recipient_purges, compose_direct_message, open_direct_message, pair_message_count,
     PurgeToken, MAX_DM_MESSAGES_PER_PAIR,
 };
-use river_core::room_state::dm_body::{decode_body, DirectMessageBody, InvitePayload};
+use river_core::room_state::dm_body::{decode_body, encode_body, DirectMessageBody, InvitePayload};
 use river_core::room_state::member::MemberId;
 use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1, ChatRoomStateV1Delta};
 use serde_json::json;
@@ -55,6 +55,35 @@ pub enum DmCommands {
         /// Show only messages from the last N minutes
         #[arg(long)]
         since_minutes: Option<u64>,
+    },
+    /// Send a room invitation AS a direct message, so the recipient's River UI
+    /// renders it as a clickable "Invitation" card (with an Accept button)
+    /// rather than inert text.
+    ///
+    /// This is the send-side counterpart of `dm accept` and the CLI equivalent
+    /// of the UI's "Share invite via DM" button (#252). Pasting a bare invite
+    /// code into `dm send` just shows raw text at the other end — only this
+    /// structured invite DM produces the card.
+    ///
+    /// `room_id` is the CARRIER room the DM travels in — you and `recipient`
+    /// must both be members of it. `--room` is the TARGET room you are inviting
+    /// them to (any room you are a member of, including `room_id` itself). A
+    /// fresh single-use invitee credential is minted, exactly as
+    /// `invite create` does.
+    Invite {
+        /// Carrier room ID (base58 room owner key) — the room whose DM thread
+        /// the invitation is delivered in. You and the recipient must both be
+        /// members.
+        room_id: String,
+        /// Recipient member ID (short prefix accepted).
+        recipient: String,
+        /// Target room ID (base58 room owner key) — the room you are inviting
+        /// the recipient to join. You must be a member of it.
+        #[arg(long)]
+        room: String,
+        /// Optional personal note shown above the Accept button.
+        #[arg(short = 'm', long)]
+        message: Option<String>,
     },
     /// Purge a direct message addressed to you. Builds a recipient purge
     /// envelope listing the message's token; once accepted by the room
@@ -114,6 +143,12 @@ pub async fn execute(command: DmCommands, api: ApiClient, format: OutputFormat) 
             recipient,
             message,
         } => execute_send(api, format, &room_id, &recipient, &message).await,
+        DmCommands::Invite {
+            room_id,
+            recipient,
+            room,
+            message,
+        } => execute_invite(api, format, &room_id, &recipient, &room, message.as_deref()).await,
         DmCommands::List {
             room_id,
             with,
@@ -158,6 +193,60 @@ async fn execute_send(
     let room_state = api.get_room(&room_owner_key, false).await?;
 
     let recipient_vk = resolve_recipient_vk(&room_state, &room_owner_key, recipient)?;
+
+    // Text-variant DMs keep the legacy wire shape (raw UTF-8 bytes, no magic
+    // byte) for backwards compatibility: pre-#243 clients in the wild decode
+    // raw UTF-8 directly via `String::from_utf8_lossy`, and new clients
+    // round-trip cleanly because `decode_body`'s legacy fallback hands raw
+    // UTF-8 back as `DirectMessageBody::Text`. So `dm send` passes the raw
+    // bytes, NOT `encode_body(&Text{..})`. Only NEW variants (`Invite`) opt
+    // into the magic-byte + CBOR shape — see `execute_invite`.
+    deliver_dm(
+        &api,
+        format,
+        room_owner_key,
+        &signing_key,
+        &room_state,
+        recipient_vk,
+        message.as_bytes(),
+        message.to_string(),
+        DmKind::Text,
+    )
+    .await
+}
+
+/// What kind of DM `deliver_dm` is delivering — only affects the
+/// success-message wording, not the wire bytes (the caller has already
+/// encoded those into `body_bytes`).
+#[derive(Clone, Copy)]
+enum DmKind {
+    Text,
+    Invite,
+}
+
+/// Shared delivery core for `dm send` and `dm invite`.
+///
+/// Given an ALREADY-ENCODED DM `body_bytes` (raw UTF-8 for a legacy `Text`
+/// DM, magic-byte+CBOR for a structured `Invite`), this runs the identical
+/// membership / per-pair-cap pre-flight, composes and signs the DM, publishes
+/// the delta (bundling a member-rejoin when the sender was pruned), verifies
+/// the DM actually lands in a local pre-flight `apply_delta`, caches
+/// `cache_label` for the sender's own `dm list` bubble, and prints the result.
+///
+/// Keeping one body means the anti-silent-drop guards (#269) and the rejoin
+/// bundling (#256 / Ivvor Bug #1) are byte-identical for text and invite DMs.
+#[allow(clippy::too_many_arguments)]
+async fn deliver_dm(
+    api: &ApiClient,
+    format: OutputFormat,
+    room_owner_key: VerifyingKey,
+    signing_key: &SigningKey,
+    room_state: &ChatRoomStateV1,
+    recipient_vk: VerifyingKey,
+    body_bytes: &[u8],
+    cache_label: String,
+    kind: DmKind,
+) -> Result<()> {
     let recipient_id = MemberId::from(&recipient_vk);
     let self_id = MemberId::from(&signing_key.verifying_key());
 
@@ -192,7 +281,7 @@ async fn execute_send(
     // Contract-level pin: `pruned_sender_can_dm_when_bundling_rejoin_delta`
     // in `common/tests/direct_messages_test.rs`.
     let (rejoin_members, rejoin_member_info) =
-        api.build_rejoin_delta(&room_state, &room_owner_key, &signing_key);
+        api.build_rejoin_delta(room_state, &room_owner_key, signing_key);
 
     // Codex P2 (PR #269 review): if the sender is pruned AND
     // `build_rejoin_delta` returned no credentials (e.g. older stored
@@ -228,25 +317,13 @@ async fn execute_send(
     }
 
     let now = unix_now()?;
-    // Text-variant DMs keep the legacy wire shape (raw UTF-8 bytes,
-    // no magic byte) for backwards compatibility: pre-this-PR clients
-    // in the wild decode raw UTF-8 directly via
-    // `String::from_utf8_lossy`. A new-format `Text` body would
-    // render a stray `\u{0080}` glyph plus garbled CBOR on those
-    // older clients, with no way for them to know better. New clients
-    // round-trip cleanly because `decode_body`'s legacy fallback path
-    // hands raw UTF-8 back as `DirectMessageBody::Text`.
-    //
-    // Only NEW variants (currently `Invite`) need to opt into the
-    // magic-byte + CBOR wire shape — old clients can't render those
-    // anyway, so the rendering regression is moot.
     let auth = compose_direct_message(
-        &signing_key,
+        signing_key,
         &recipient_vk,
         &room_owner_key,
         now,
         now,
-        message.as_bytes(),
+        body_bytes,
     )
     .map_err(|e| anyhow!("Failed to compose DM: {}", e))?;
 
@@ -270,7 +347,7 @@ async fn execute_send(
     {
         use freenet_scaffold::ComposableState;
         local
-            .apply_delta(&room_state, &params, &Some(delta.clone()))
+            .apply_delta(room_state, &params, &Some(delta.clone()))
             .map_err(|e| anyhow!("Local pre-flight apply_delta failed: {:?}", e))?;
     }
 
@@ -297,26 +374,34 @@ async fn execute_send(
     let token = auth.purge_token();
     let token_hex = hex_token(&token);
 
-    // Persist plaintext in the local outbound-DM cache so a future
-    // `dm list` can render the sender's own bubble as plaintext
-    // instead of `<sent: ciphertext only>`. See issue freenet/river#256.
-    // Failure is logged but not fatal — the DM has already been sent.
+    // Persist a label in the local outbound-DM cache so a future `dm list`
+    // renders the sender's own bubble as text instead of
+    // `<sent: ciphertext only>` (the ciphertext is recipient-sealed, so the
+    // sender can't re-derive it). For a text DM this is the message; for an
+    // invite it's the same `[Invitation to room …]` summary the recipient's
+    // list shows. See issue freenet/river#256. Failure is logged but not
+    // fatal — the DM has already been sent.
     if let Err(e) = persist_outbound_plaintext(
-        &api,
+        api,
         room_owner_key,
         self_id,
         recipient_id,
         token,
         auth.message.timestamp,
-        message.to_string(),
+        cache_label,
     ) {
         tracing::warn!("Failed to persist outbound DM plaintext locally: {}", e);
     }
 
+    let noun = match kind {
+        DmKind::Text => "DM",
+        DmKind::Invite => "Invitation DM",
+    };
     match format {
         OutputFormat::Human => {
             println!(
-                "DM sent to {} (purge token: {})",
+                "{} sent to {} (purge token: {})",
+                noun,
                 short_member_id(&recipient_id),
                 token_hex
             );
@@ -333,6 +418,81 @@ async fn execute_send(
         }
     }
     Ok(())
+}
+
+/// Normalize the optional `--message` for an invite DM: trim it, and treat a
+/// blank / whitespace-only note as absent so the recipient's UI hides the
+/// message box entirely (per the `InvitePayload::personal_message` contract)
+/// rather than rendering an empty line.
+fn normalize_personal_message(message: Option<&str>) -> Option<String> {
+    message
+        .map(str::trim)
+        .filter(|m| !m.is_empty())
+        .map(str::to_string)
+}
+
+/// `dm invite`: send a structured invitation DM so the recipient's UI shows a
+/// clickable Accept card. The CLI counterpart of the UI's "Share invite via
+/// DM" (#252) and the send-side counterpart of `dm accept`.
+async fn execute_invite(
+    api: ApiClient,
+    format: OutputFormat,
+    carrier_room_id: &str,
+    recipient: &str,
+    target_room_id: &str,
+    message: Option<&str>,
+) -> Result<()> {
+    let carrier_room_key = parse_room_id(carrier_room_id)?;
+    let target_room_key = parse_room_id(target_room_id)?;
+
+    // Signing identity for the carrier room (the DM is signed by, and travels
+    // in, the carrier room).
+    let (signing_key, _, _) = api.storage().get_room(&carrier_room_key)?.ok_or_else(|| {
+        anyhow!("Carrier room not found. You must be a member of it to send an invite DM.")
+    })?;
+
+    let room_state = api.get_room(&carrier_room_key, false).await?;
+    let recipient_vk = resolve_recipient_vk(&room_state, &carrier_room_key, recipient)?;
+
+    // Build the invitation for the TARGET room (requires the target room in
+    // local storage). Byte-identical to what `invite create` produces — same
+    // `build_invitation` — so the recipient's `dm accept` / UI Accept card
+    // decode it the same way as a base58 `?invitation=` code.
+    let invitation = api.build_invitation(&target_room_key).map_err(|e| {
+        anyhow!(
+            "Could not build an invitation for the target room (are you a member of it?): {}",
+            e
+        )
+    })?;
+
+    let mut invitation_payload = Vec::new();
+    ciborium::ser::into_writer(&invitation, &mut invitation_payload)
+        .map_err(|e| anyhow!("Failed to serialize invitation: {}", e))?;
+
+    let body = DirectMessageBody::Invite(Box::new(InvitePayload {
+        room_owner_vk: target_room_key,
+        invitation_payload,
+        personal_message: normalize_personal_message(message),
+    }));
+    let body_bytes =
+        encode_body(&body).map_err(|e| anyhow!("Failed to encode invite DM: {}", e))?;
+
+    // Same summary the recipient's `dm list` shows, cached so the sender's own
+    // bubble isn't a bare `<sent: ciphertext only>`.
+    let cache_label = format_dm_body_for_cli(&body, &HashMap::new());
+
+    deliver_dm(
+        &api,
+        format,
+        carrier_room_key,
+        &signing_key,
+        &room_state,
+        recipient_vk,
+        &body_bytes,
+        cache_label,
+        DmKind::Invite,
+    )
+    .await
 }
 
 async fn execute_list(
@@ -1612,6 +1772,62 @@ mod tests {
             personal_message: None,
         };
         assert!(decode_invitation_from_payload(&garbage).is_err());
+    }
+
+    /// The invite DM that `dm invite` builds must decode back — through the
+    /// exact `decode_body` + `decode_invitation_from_payload` path `dm accept`
+    /// and the UI Accept card use — into the same invitation. This pins the
+    /// send/accept wire contract end to end (freenet/river#456).
+    #[test]
+    fn invite_dm_body_round_trips_through_accept_path() {
+        let target = key(30);
+        let target_vk = target.verifying_key();
+        // Same bytes `execute_invite` puts in `invitation_payload` (CBOR of the
+        // `Invitation`, identical to the base58 `invite create` payload).
+        let invitation_payload = encode_invitation(&target);
+
+        let body = DirectMessageBody::Invite(Box::new(InvitePayload {
+            room_owner_vk: target_vk,
+            invitation_payload,
+            personal_message: normalize_personal_message(Some("  come join  ")),
+        }));
+
+        // Wire round-trip: encode_body → decode_body.
+        let wire = encode_body(&body).expect("encode");
+        let decoded = decode_body(&wire).expect("decode");
+        assert_eq!(decoded, body, "invite DM must survive the wire round-trip");
+
+        let DirectMessageBody::Invite(payload) = decoded else {
+            panic!("expected an Invite body");
+        };
+        // Personal message trimmed, not dropped.
+        assert_eq!(payload.personal_message.as_deref(), Some("come join"));
+
+        // The recipient's accept path decodes the embedded invitation and
+        // checks it targets the advertised room.
+        let invitation = decode_invitation_from_payload(&payload)
+            .expect("invite must decode on the accept side");
+        assert_eq!(invitation.room, target_vk);
+
+        // And `dm list` labels it as an invitation to that room.
+        let label = format_dm_body_for_cli(&body, &HashMap::new());
+        assert!(
+            label.starts_with("[Invitation to room ") && label.ends_with("come join"),
+            "got: {label}"
+        );
+    }
+
+    /// A blank / whitespace-only `--message` becomes `None` so the recipient's
+    /// UI hides the message box rather than rendering an empty line.
+    #[test]
+    fn normalize_personal_message_blanks_to_none() {
+        assert_eq!(normalize_personal_message(None), None);
+        assert_eq!(normalize_personal_message(Some("")), None);
+        assert_eq!(normalize_personal_message(Some("   ")), None);
+        assert_eq!(
+            normalize_personal_message(Some("  hi ")).as_deref(),
+            Some("hi")
+        );
     }
 
     /// Build an `InboundInvite` for `select_invite_to_accept` tests. A `valid`

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -418,6 +418,26 @@ impl Storage {
         }
     }
 
+    /// The room's STORED signing key, IGNORING any `--signing-key-file` /
+    /// `RIVER_SIGNING_KEY_FILE` override. Returns `None` if the room isn't in
+    /// local storage.
+    ///
+    /// Use this when you need a room's own persisted member identity
+    /// regardless of a global override that was selected for a DIFFERENT room.
+    /// `dm invite` needs it: the override (if any) is the carrier-room sender
+    /// identity, but the invitation must be signed by the TARGET room's own
+    /// member key — signing it with the carrier override would mint an
+    /// invitation from a non-member that the target contract rejects on accept
+    /// (freenet/river#456, Codex review P2).
+    pub fn stored_signing_key(&self, owner_vk: &VerifyingKey) -> Result<Option<SigningKey>> {
+        let storage = self.load_rooms()?;
+        let owner_key_str = bs58::encode(owner_vk.as_bytes()).into_string();
+        Ok(storage
+            .rooms
+            .get(&owner_key_str)
+            .map(|room_info| SigningKey::from_bytes(&room_info.signing_key_bytes)))
+    }
+
     /// Whether an in-memory signing-key override is active (from
     /// `--signing-key-file` / `RIVER_SIGNING_KEY_FILE`). Lets callers tailor
     /// diagnostics to the override-set vs not-set case without exposing the


### PR DESCRIPTION
## Problem

Reported by Ivvor (#456): sending a bare invite code via `dm send` just shows raw text at the recipient's end. The River UI's "Share invite via DM" (#252) sends a structured `DirectMessageBody::Invite` DM that renders as a clickable **Accept card**, but riverctl could only *accept* such invite DMs (`dm accept`), not *originate* one — `dm send` composes plaintext only.

## Approach

Adds `riverctl dm invite <carrier-room> <recipient> --room <target-room> [-m <msg>]`, the send-side counterpart of `dm accept` and the CLI analog of the UI picker:

- `carrier-room` — the room the DM travels in (you and the recipient are both members).
- `--room target-room` — the room you're inviting them to (any room you're a member of).
- `-m` — optional note shown above the Accept button.

Key correctness point — **byte-identical to what the UI produces**, so a UI recipient gets the real card:

- `build_invitation` is extracted from `create_invitation` (which now calls it, then base58-encodes), so the CBOR `invitation_payload` a `dm invite` embeds is exactly what `invite create` and the UI produce.
- The command wraps it in the same `InvitePayload` / `DirectMessageBody::Invite` and `encode_body`s it — the wire body `dm accept` and the UI Accept card already decode.

`dm send` and `dm invite` now share one delivery core, `deliver_dm`, so the anti-silent-drop guards (#269) and the pruned-sender rejoin bundling (#256 / Ivvor Bug #1) stay byte-identical for both. The only per-kind differences are the wire body (raw UTF-8 for legacy `Text` vs magic-byte+CBOR for `Invite`), the outbound-cache label, and the success noun.

## Scope

**CLI-only.** `git diff origin/main --name-only`: `cli/src/api.rs`, `cli/src/commands/dm.rs`, `cli/README.md`, `README.md`, `cli/Cargo.toml`, `Cargo.lock`. No `common/`, contract, delegate, or `.wasm` change — it only *uses* existing `river-core` DM-body types, so no migration. `river-core` stays 0.1.17; `riverctl` bumped 0.2.1 → 0.2.2 for republish.

## Testing

- `invite_dm_body_round_trips_through_accept_path` — the body `dm invite` builds decodes back through the exact `decode_body` + `decode_invitation_from_payload` path `dm accept` and the UI card use, into the same invitation; `dm list` labels it `[Invitation to room …]`.
- `normalize_personal_message_blanks_to_none` — a blank `--message` becomes `None` so the UI hides the message box.
- **Live end-to-end** (local node, release binary): Alice `dm invite`d Bob to a second room via a carrier room → Bob's `dm list` showed `[Invitation to room 3ena64R7…] come join my other room!` → Bob `dm accept`ed → Bob is now a member of the target room. Alice's own `dm list` shows the same invite label from the outbound cache.

`cargo test -p riverctl` green (226+ lib + integration); `cargo clippy -p riverctl` clean; `cargo fmt` applied.

## Docs

`cli/README.md` gains an "Inviting someone via DM" subsection; the top-level README's `riverctl dm` line now lists `invite`.

Closes #456

[AI-assisted - Claude]
