### PR TITLE
docs(ui): recommend DM invites in the invite-member modal

### DIFF
--- a/ui/src/components/members/invite_member_modal.rs
+++ b/ui/src/components/members/invite_member_modal.rs
@@ -186,11 +186,32 @@ pub fn InviteMemberModal(is_active: Signal<bool>) -> Element {
                             );
 
                             rsx! {
-                                // Warning
+                                // Recommended path first: ask, then send the
+                                // invitation as a DM via the built-in
+                                // "Share invite" flow (#252, #457). It hands
+                                // the recipient a one-click Accept card and
+                                // never puts a bearer credential through an
+                                // outside channel, so it belongs ABOVE the
+                                // link/code it is meant to displace.
+                                div { class: "mb-4 p-3 bg-accent-soft border-l-4 border-accent rounded-r-lg",
+                                    p { class: "text-sm text-text",
+                                        span { class: "font-medium", "Best way to invite someone: send it in a DM. " }
+                                        "If you already share a room with them, ask whether they'd like to join — then click their name in the member list and choose "
+                                        span { class: "font-medium", "Share invite" }
+                                        ". River builds the invitation and drops it into your DM as a card they accept in one click, with nothing to copy, paste, or leak."
+                                    }
+                                }
+
+                                // Fallback path (no shared room yet): the
+                                // link/code below are bearer credentials — a
+                                // single reusable identity — hence the
+                                // one-person-only warning.
                                 div { class: "mb-4 p-3 bg-warning-bg border-l-4 border-yellow-500 rounded-r-lg",
                                     p { class: "text-sm text-text",
-                                        span { class: "font-medium", "Share privately with one person only. " }
-                                        "Each invitation creates a unique identity. If multiple people use the same link, they will share one identity and cause conflicts. Generate a new invitation for each person."
+                                        span { class: "font-medium", "No DM yet? Share the link or code below privately, with one person only. " }
+                                        "Each invitation creates a unique identity and is good for exactly one person. If two people use the same link or code, they share one identity and neither works correctly. Click "
+                                        span { class: "font-medium", "New Invitation" }
+                                        " for every additional person."
                                     }
                                 }
 

--- a/ui/src/components/members/invite_member_modal.rs
+++ b/ui/src/components/members/invite_member_modal.rs
@@ -195,10 +195,10 @@ pub fn InviteMemberModal(is_active: Signal<bool>) -> Element {
                                 // link/code it is meant to displace.
                                 div { class: "mb-4 p-3 bg-accent-soft border-l-4 border-accent rounded-r-lg",
                                     p { class: "text-sm text-text",
-                                        span { class: "font-medium", "Best way to invite someone: send it in a DM. " }
-                                        "If you already share a room with them, ask whether they'd like to join — then click their name in the member list and choose "
+                                        span { class: "font-medium", "Best way to invite someone: send the invitation in a DM. " }
+                                        "Ask whether they'd like to join first. Then, in any room you already share with them, click their name in the member list, choose "
                                         span { class: "font-medium", "Share invite" }
-                                        ". River builds the invitation and drops it into your DM as a card they accept in one click, with nothing to copy, paste, or leak."
+                                        ", and pick this room. River drops an invitation card into your DM thread that they accept in one click — nothing to copy, paste, or leak."
                                     }
                                 }
 

--- a/ui/src/components/members/invite_member_modal.rs
+++ b/ui/src/components/members/invite_member_modal.rs
@@ -193,7 +193,9 @@ pub fn InviteMemberModal(is_active: Signal<bool>) -> Element {
                                 // never puts a bearer credential through an
                                 // outside channel, so it belongs ABOVE the
                                 // link/code it is meant to displace.
-                                div { class: "mb-4 p-3 bg-accent-soft border-l-4 border-accent rounded-r-lg",
+                                div {
+                                    "data-testid": "invite-dm-recommendation",
+                                    class: "mb-4 p-3 bg-accent-soft border-l-4 border-accent rounded-r-lg",
                                     p { class: "text-sm text-text",
                                         span { class: "font-medium", "Best way to invite someone: send the invitation in a DM. " }
                                         "Ask whether they'd like to join first. Then, in any room you already share with them, click their name in the member list, choose "
@@ -206,7 +208,9 @@ pub fn InviteMemberModal(is_active: Signal<bool>) -> Element {
                                 // link/code below are bearer credentials — a
                                 // single reusable identity — hence the
                                 // one-person-only warning.
-                                div { class: "mb-4 p-3 bg-warning-bg border-l-4 border-yellow-500 rounded-r-lg",
+                                div {
+                                    "data-testid": "invite-share-warning",
+                                    class: "mb-4 p-3 bg-warning-bg border-l-4 border-yellow-500 rounded-r-lg",
                                     p { class: "text-sm text-text",
                                         span { class: "font-medium", "No DM yet? Share the link or code below privately, with one person only. " }
                                         "Each invitation creates a unique identity and is good for exactly one person. If two people use the same link or code, they share one identity and neither works correctly. Click "

--- a/ui/tests/invite-modal-guidance.spec.ts
+++ b/ui/tests/invite-modal-guidance.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect, Page } from "@playwright/test";
+
+// Copy test for the invite-member modal's guidance blocks.
+//
+// The modal used to warn ONLY about the link being single-use, never
+// mentioning that River can send an invitation directly in a DM (#252,
+// #457) — which is the recommended flow: ask the person first, then use
+// "Share invite" from their member card in a room you already share, so
+// no bearer credential travels through an outside channel.
+//
+// These assertions pin BOTH blocks and their order, so a future refactor
+// of this modal can't silently drop the recommendation and leave
+// copy-the-link as the only documented path.
+
+async function waitForApp(page: Page) {
+  await page.waitForSelector(".app-root", { timeout: 30_000 });
+  await expect(page.locator("aside, .app-root button")).not.toHaveCount(0);
+}
+
+// A room where the test user is a member, so "Invite Member" can generate
+// an invitation (matches the portable-invite-code spec).
+const ROOM_NAME = "Public Discussion Room";
+
+async function openInviteModal(page: Page) {
+  const vp = page.viewportSize();
+  if (vp && vp.width < 1024) {
+    await page.setViewportSize({ width: 1280, height: vp.height });
+  }
+  const roomBtn = page.getByRole("button", { name: ROOM_NAME });
+  await expect(roomBtn).toBeVisible({ timeout: 5_000 });
+  await roomBtn.click();
+  await expect(page.getByRole("heading", { name: ROOM_NAME })).toBeVisible({
+    timeout: 5_000,
+  });
+
+  await page.getByTestId("invite-member-button").click();
+  await expect(page.getByTestId("invite-member-modal")).toBeVisible({
+    timeout: 5_000,
+  });
+  // The invitation is generated asynchronously (delegate signing with a
+  // local fallback); the guidance blocks render alongside it.
+  await expect(page.getByTestId("invite-link-input")).not.toHaveValue("", {
+    timeout: 10_000,
+  });
+}
+
+test.describe("Invite-member modal guidance copy", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("recommends sending the invitation via DM, naming Share invite", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await openInviteModal(page);
+
+    const rec = page.getByTestId("invite-dm-recommendation");
+    await expect(rec).toBeVisible();
+    await expect(rec).toContainText(/in a DM/i);
+    await expect(rec).toContainText(/Share invite/);
+  });
+
+  test("still warns that the link or code is for one person only", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await openInviteModal(page);
+
+    const warning = page.getByTestId("invite-share-warning");
+    await expect(warning).toBeVisible();
+    await expect(warning).toContainText(/one person only/i);
+    await expect(warning).toContainText(/New Invitation/);
+  });
+
+  test("shows the DM recommendation above the link-sharing warning", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await openInviteModal(page);
+
+    const recBox = await page
+      .getByTestId("invite-dm-recommendation")
+      .boundingBox();
+    const warnBox = await page
+      .getByTestId("invite-share-warning")
+      .boundingBox();
+    expect(recBox).not.toBeNull();
+    expect(warnBox).not.toBeNull();
+    // Recommended path first — the fallback warning sits below it.
+    expect(recBox!.y).toBeLessThan(warnBox!.y);
+  });
+});


### PR DESCRIPTION
## Problem

The invite-member modal's only guidance was the one-person warning:

> **Share privately with one person only.** Each invitation creates a unique identity. If multiple people use the same link, they will share one identity and cause conflicts. Generate a new invitation for each person.

It says nothing about sending an invitation **via DM** (#252, #457), which is the flow we actually want people to use: ask whether they'd like to join, and once they agree, click their name in the member list → **Share invite** → River drops an invitation card into the DM thread that they accept in one click. Copying a bearer credential into an outside channel is the fallback, not the default.

## Change

Copy-only. Two blocks now, in priority order:

1. **Recommended (accent callout, above the link/code):** "Best way to invite someone: send it in a DM. If you already share a room with them, ask whether they'd like to join — then click their name in the member list and choose **Share invite**. River builds the invitation and drops it into your DM as a card they accept in one click, with nothing to copy, paste, or leak."
2. **Fallback (existing yellow warning, reframed):** "No DM yet? Share the link or code below privately, with one person only. Each invitation creates a unique identity and is good for exactly one person. If two people use the same link or code, they share one identity and neither works correctly. Click **New Invitation** for every additional person."

The warning now names the **New Invitation** button (which is right there in the modal) instead of the vaguer "generate a new invitation".

No logic, no state, no WASM change → no delegate/contract migration needed.

## Test coverage

- `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync` — clean.
- New classes `bg-accent-soft` / `border-accent` / `border-l-4` all verified present in the generated Tailwind CSS (both already used elsewhere in the UI).
- Playwright layout suite run against the example-data build before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)