### PR TITLE
perf(ui): stop re-rendering the whole message history on every state change

### DIFF
--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -4533,9 +4533,41 @@ mod tests {
     // -----------------------------------------------------------------
     // Message-group memoization (over-rendering regression guard)
     // -----------------------------------------------------------------
+    /// The production half of this file, i.e. everything above this test module.
+    ///
+    /// `include_str!("conversation.rs")` pulls in the test module too, so a
+    /// source scrape that searched the whole string would match the literals
+    /// written in the assertions below and pass no matter what the real code
+    /// does. Cutting the file at the test-module header is what makes these
+    /// scrapes able to fail.
+    fn production_src() -> &'static str {
+        let src = include_str!("conversation.rs");
+        let marker = "#[cfg(test)]\nmod tests {";
+        let cut = src
+            .rfind(marker)
+            .expect("conversation.rs must contain the `#[cfg(test)] mod tests {` header");
+        &src[..cut]
+    }
+
+    #[test]
+    fn production_src_excludes_this_test_module() {
+        // Guard for the guard: if the marker ever stops matching (reformat,
+        // renamed module) `production_src` would silently start returning the
+        // whole file and the scrapes below would go back to being self-fulfilling.
+        let prod = production_src();
+        assert!(
+            !prod.contains("fn production_src_excludes_this_test_module"),
+            "production_src() must cut the file before the test module"
+        );
+        assert!(
+            prod.contains("fn MessageGroupComponent"),
+            "production_src() must still contain the production code it scrapes"
+        );
+    }
+
     #[test]
     fn message_group_callbacks_are_stable_handles() {
-        let src = include_str!("conversation.rs");
+        let src = production_src();
 
         // Dioxus decides whether a child component can be skipped by comparing
         // ALL of its props with PartialEq — event handlers included. A closure
@@ -4594,6 +4626,15 @@ mod tests {
             src.contains("_timeFmt") && src.contains("_fullFmt"),
             "format_time_local / format_full_datetime_local must reuse cached \
              Intl.DateTimeFormat instances rather than building one per call."
+        );
+        // A cached formatter pins the timezone it was built with, so the cache
+        // must be invalidated when the device timezone changes mid-session —
+        // otherwise message times drift away from the date separators, which
+        // read the current zone directly.
+        assert!(
+            src.contains("getTimezoneOffset()") && src.contains("_fmtOffset"),
+            "The cached Intl formatters must be rebuilt when the device timezone \
+             changes; otherwise times render in the stale zone until reload."
         );
         assert!(
             !src.contains("date.toLocaleTimeString(") && !src.contains("date.toLocaleString("),

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1991,6 +1991,54 @@ pub fn Conversation() -> Element {
         }
     };
 
+    // Stable handles for the per-message-group callbacks.
+    //
+    // A closure written inline in `rsx!` becomes a fresh `Callback` on every
+    // render, and `Callback`'s `PartialEq` is pointer identity. The props
+    // `PartialEq` that Dioxus uses to decide whether a child can be memoized
+    // compares EVERY prop, callbacks included — so inline closures made
+    // `MessageGroupComponent` un-memoizable: every re-render of `Conversation`
+    // re-rendered all N message groups even when nothing about them changed.
+    // Measured on a 90-message room: one sent message re-rendered every group
+    // 4 times, and merely scrolling past the bottom sentinel re-rendered all of
+    // them once.
+    //
+    // `use_callback` allocates the handle once and swaps the inner closure each
+    // render, so the identity is stable (props compare equal → group memoizes)
+    // while the captured state stays current. Dioxus additionally re-points the
+    // old handle at the newest closure inside `memoize`, so a memoized group
+    // still invokes the latest logic.
+    let on_react_cb = use_callback({
+        let handle_toggle_reaction = handle_toggle_reaction.clone();
+        move |(msg_id, emoji): (MessageId, String)| {
+            let handle_toggle_reaction = handle_toggle_reaction.clone();
+            handle_toggle_reaction(msg_id, emoji);
+        }
+    });
+    let on_request_delete_cb = use_callback(move |msg_id: MessageId| {
+        pending_delete.set(Some(msg_id));
+    });
+    let on_edit_cb = use_callback({
+        let handle_edit_message = handle_edit_message.clone();
+        move |(msg_id, new_text): (MessageId, String)| {
+            let handle_edit_message = handle_edit_message.clone();
+            handle_edit_message(msg_id, new_text);
+        }
+    });
+    let on_reply_cb = use_callback(move |ctx: ReplyContext| {
+        replying_to.set(Some(ctx));
+        #[cfg(target_arch = "wasm32")]
+        if let Some(window) = web_sys::window() {
+            if let Some(doc) = window.document() {
+                if let Some(el) = doc.get_element_by_id("message-input") {
+                    if let Some(el) = el.dyn_ref::<web_sys::HtmlElement>() {
+                        let _ = el.focus();
+                    }
+                }
+            }
+        }
+    });
+
     rsx! {
         div { class: "flex-1 flex flex-col min-w-0 bg-bg",
             // Room header
@@ -2185,12 +2233,9 @@ pub fn Conversation() -> Element {
                                     Some(rsx! {
                                         div { class: "space-y-4",
                                             {rows.into_iter().enumerate().map({
-                                                let handle_toggle_reaction = handle_toggle_reaction.clone();
                                                 let member_names = member_names.clone();
                                                 move |(row_idx, row)| {
                                                 let is_last_group = row_idx == rows_len - 1;
-                                                let handle_toggle_reaction = handle_toggle_reaction.clone();
-                                                let handle_edit_message = handle_edit_message.clone();
                                                 let member_names = member_names.clone();
                                                 match row {
                                                     DisplayRow::DateSeparator { key, label } => rsx! {
@@ -2237,27 +2282,13 @@ pub fn Conversation() -> Element {
                                                                 is_private: edit_is_private,
                                                                 last_chat_element: if is_last_group { Some(last_chat_element) } else { None },
                                                                 edit_trigger: edit_trigger,
-                                                                on_react: move |(msg_id, emoji)| {
-                                                                    handle_toggle_reaction(msg_id, emoji);
-                                                                },
-                                                                on_request_delete: move |msg_id| {
-                                                                    pending_delete.set(Some(msg_id));
-                                                                },
-                                                                on_edit: move |(msg_id, new_text)| {
-                                                                    handle_edit_message(msg_id, new_text);
-                                                                },
-                                                                on_reply: move |ctx: ReplyContext| {
-                                                                    replying_to.set(Some(ctx));
-                                                                    if let Some(window) = web_sys::window() {
-                                                                        if let Some(doc) = window.document() {
-                                                                            if let Some(el) = doc.get_element_by_id("message-input") {
-                                                                                if let Some(el) = el.dyn_ref::<web_sys::HtmlElement>() {
-                                                                                    let _ = el.focus();
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                },
+                                                                // Stable handles (see `use_callback` above): passing
+                                                                // inline closures here would defeat memoization of
+                                                                // every message group.
+                                                                on_react: on_react_cb,
+                                                                on_request_delete: on_request_delete_cb,
+                                                                on_edit: on_edit_cb,
+                                                                on_reply: on_reply_cb,
                                                                 open_action_menu: open_action_menu,
                                                             }
                                                         }
@@ -4496,6 +4527,78 @@ mod tests {
         assert!(
             html.contains("river-mention-self"),
             "legacy self-mention must get the self class: {html}"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Message-group memoization (over-rendering regression guard)
+    // -----------------------------------------------------------------
+    #[test]
+    fn message_group_callbacks_are_stable_handles() {
+        let src = include_str!("conversation.rs");
+
+        // Dioxus decides whether a child component can be skipped by comparing
+        // ALL of its props with PartialEq — event handlers included. A closure
+        // written inline in `rsx!` allocates a fresh `Callback` every render and
+        // `Callback`'s PartialEq is pointer identity, so an inline handler makes
+        // the child permanently un-memoizable.
+        //
+        // Before this was fixed, every re-render of `Conversation` re-rendered
+        // EVERY message group: sending one message into a 90-message room
+        // re-rendered all 85 groups 4 times over (340 group renders), and simply
+        // scrolling past the bottom sentinel re-rendered all 85. That cost ~1.1s
+        // of blocked main thread per sent message on a mid-range phone.
+        //
+        // The four handlers must therefore keep a stable identity via
+        // `use_callback`, which allocates the handle once and swaps the inner
+        // closure each render.
+        for cb in [
+            "let on_react_cb = use_callback(",
+            "let on_request_delete_cb = use_callback(",
+            "let on_edit_cb = use_callback(",
+            "let on_reply_cb = use_callback(",
+        ] {
+            assert!(
+                src.contains(cb),
+                "MessageGroupComponent's handlers must be created with `use_callback` \
+                 so their identity is stable across renders; missing: {cb}"
+            );
+        }
+
+        // ...and the call site must pass those handles, not inline closures.
+        for wiring in [
+            "on_react: on_react_cb",
+            "on_request_delete: on_request_delete_cb",
+            "on_edit: on_edit_cb",
+            "on_reply: on_reply_cb",
+        ] {
+            assert!(
+                src.contains(wiring),
+                "The MessageGroupComponent call site must pass the stable \
+                 use_callback handle. Passing an inline `move |..| {{ .. }}` closure \
+                 here silently un-memoizes every message group. Missing: {wiring}"
+            );
+        }
+    }
+
+    #[test]
+    fn local_date_formatters_are_cached() {
+        let src = include_str!("../util.rs");
+
+        // `toLocaleTimeString`/`toLocaleString` with an options object construct
+        // a new Intl.DateTimeFormat per call (~70us in Chromium, vs ~4.5us for a
+        // cached formatter). These run once per message group per render, so the
+        // uncached form cost ~12ms of pure date formatting per re-render of a
+        // 90-message room.
+        assert!(
+            src.contains("_timeFmt") && src.contains("_fullFmt"),
+            "format_time_local / format_full_datetime_local must reuse cached \
+             Intl.DateTimeFormat instances rather than building one per call."
+        );
+        assert!(
+            !src.contains("date.toLocaleTimeString(") && !src.contains("date.toLocaleString("),
+            "Do not call toLocaleTimeString/toLocaleString with an options object \
+             per message — build the Intl.DateTimeFormat once and reuse it."
         );
     }
 }

--- a/ui/src/util.rs
+++ b/ui/src/util.rs
@@ -98,22 +98,33 @@ pub fn capture_runtime() {
 export function get_current_time() {
     return Date.now();
 }
+// `toLocaleTimeString`/`toLocaleString` with an options object builds a fresh
+// Intl.DateTimeFormat on every call (~70us each, measured in Chromium). These
+// run once per message group per render, so a 90-message room paid ~12ms of
+// pure date formatting per re-render. Constructing each formatter once and
+// reusing it is ~15x cheaper and produces byte-identical output.
+let _timeFmt = null;
+let _fullFmt = null;
 export function format_time_local(timestamp_ms) {
-    const date = new Date(timestamp_ms);
-    return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: false });
+    if (_timeFmt === null) {
+        _timeFmt = new Intl.DateTimeFormat(undefined, { hour: '2-digit', minute: '2-digit', hour12: false });
+    }
+    return _timeFmt.format(new Date(timestamp_ms));
 }
 export function format_full_datetime_local(timestamp_ms) {
-    const date = new Date(timestamp_ms);
-    return date.toLocaleString(undefined, {
-        weekday: 'short',
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit',
-        hour12: false
-    });
+    if (_fullFmt === null) {
+        _fullFmt = new Intl.DateTimeFormat(undefined, {
+            weekday: 'short',
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+            hour12: false
+        });
+    }
+    return _fullFmt.format(new Date(timestamp_ms));
 }
 export function local_date_key(timestamp_ms) {
     // Local calendar date (viewer's timezone) as a zero-padded YYYY-MM-DD

--- a/ui/src/util.rs
+++ b/ui/src/util.rs
@@ -102,17 +102,35 @@ export function get_current_time() {
 // Intl.DateTimeFormat on every call (~70us each, measured in Chromium). These
 // run once per message group per render, so a 90-message room paid ~12ms of
 // pure date formatting per re-render. Constructing each formatter once and
-// reusing it is ~15x cheaper and produces byte-identical output.
+// reusing it is ~15x cheaper end-to-end and produces byte-identical output
+// (verified over a full year of timestamps in 4 timezones).
 let _timeFmt = null;
 let _fullFmt = null;
-export function format_time_local(timestamp_ms) {
-    if (_timeFmt === null) {
+let _fmtOffset = null;
+function ensureFormatters() {
+    // An Intl.DateTimeFormat resolves its timezone once, when it is constructed.
+    // If the device timezone changes while River is open (travel, a system
+    // setting change), a permanently-cached formatter would keep rendering the
+    // old zone while local_date_key below — which reads the Date's local fields
+    // directly — already reflects the new one, so message times and the date
+    // separators above them would disagree. The uncached form we replaced picked
+    // such a change up immediately, so the cache has to as well.
+    //
+    // The check is the current UTC offset: ~0.16us, against ~1.5us to format.
+    // (Re-resolving the zone NAME via `new Intl.DateTimeFormat().resolvedOptions()`
+    // costs ~84us — worse than not caching at all — and asking the cached
+    // formatter for its own resolvedOptions() only ever reports the zone it was
+    // built with, so neither can do this job.)
+    //
+    // Known limitation: a switch between two zones whose current offset is
+    // identical is not detected. Those zones render identically for the current
+    // period; only a message from a period where their DST rules diverge could
+    // format differently. A DST transition while the app is open changes the
+    // offset and so triggers one rebuild, which is the correct outcome.
+    const offset = new Date().getTimezoneOffset();
+    if (_timeFmt === null || offset !== _fmtOffset) {
+        _fmtOffset = offset;
         _timeFmt = new Intl.DateTimeFormat(undefined, { hour: '2-digit', minute: '2-digit', hour12: false });
-    }
-    return _timeFmt.format(new Date(timestamp_ms));
-}
-export function format_full_datetime_local(timestamp_ms) {
-    if (_fullFmt === null) {
         _fullFmt = new Intl.DateTimeFormat(undefined, {
             weekday: 'short',
             year: 'numeric',
@@ -124,6 +142,13 @@ export function format_full_datetime_local(timestamp_ms) {
             hour12: false
         });
     }
+}
+export function format_time_local(timestamp_ms) {
+    ensureFormatters();
+    return _timeFmt.format(new Date(timestamp_ms));
+}
+export function format_full_datetime_local(timestamp_ms) {
+    ensureFormatters();
     return _fullFmt.format(new Date(timestamp_ms));
 }
 export function local_date_key(timestamp_ms) {

--- a/ui/tests/responsive-layout.spec.ts
+++ b/ui/tests/responsive-layout.spec.ts
@@ -294,14 +294,14 @@ test.describe("Sandboxed iframe embedding", () => {
   const sandboxAttrs =
     "allow-scripts allow-forms allow-popups allow-same-origin";
 
-  test("app renders inside a sandboxed iframe", async ({ page }) => {
+  test("app renders inside a sandboxed iframe", async ({ page, baseURL }) => {
     await page.setContent(`
       <!DOCTYPE html>
       <html>
       <body style="margin:0;padding:0;height:100vh;">
         <iframe
           sandbox="${sandboxAttrs}"
-          src="http://localhost:8082"
+          src="${baseURL}"
           style="width:100%;height:100%;border:none;"
         ></iframe>
       </body>
@@ -317,6 +317,7 @@ test.describe("Sandboxed iframe embedding", () => {
 
   test("3-column layout works inside sandboxed iframe at desktop width", async ({
     page,
+    baseURL,
   }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await page.setContent(`
@@ -325,7 +326,7 @@ test.describe("Sandboxed iframe embedding", () => {
       <body style="margin:0;padding:0;height:100vh;">
         <iframe
           sandbox="${sandboxAttrs}"
-          src="http://localhost:8082"
+          src="${baseURL}"
           style="width:100%;height:100%;border:none;"
         ></iframe>
       </body>


### PR DESCRIPTION
## Problem

A River user reported the chat interface has "overactive reactivity" with "a lot of reflow/repaint", and guessed it was a flexbox side effect.

Profiling says the reactivity half of that is right and the layout half is not. On a 90-message room, sending one message costs **1466 ms** of main-thread time at 6x CPU throttle (mid-range phone). Of that, layout + style recalc is **24 ms (1.6%)**. Scripting is **1187 ms (81%)** — and only 2-8 DOM nodes actually change. The browser was doing almost no layout work; the app was computing a render it then threw away.

Measured with Chromium CDP `Performance.getMetrics` + a `MutationObserver`, against an example-data build padded to 90 messages (production caps `max_recent_messages` at 100).

## Root cause

Dioxus decides whether a child component can be skipped by comparing **all** of its props with `PartialEq` — event handlers included. The derive excludes callbacks from the *move* logic, not from the *equality* check:

```rust
let equal = self == new;   // derived PartialEq over every field
#move_event_handlers
if !equal { /* move regular fields */ }
equal
```

A closure written inline in `rsx!` becomes a fresh `Callback` on every render, and `Callback`'s `PartialEq` is pointer identity (`ptr_eq(&other.callback) && origin == origin`). So the four inline handlers passed to `MessageGroupComponent` (`on_react`, `on_request_delete`, `on_edit`, `on_reply`) made it **permanently un-memoizable**: every re-render of `Conversation` re-rendered every message group.

Instrumented call counts on an 85-group room:

| interaction | group renders before | after |
|---|---|---|
| send one message | 340 (4 full passes) | **4** |
| scroll the history | 85 (1 full pass) | **0** |
| type a character | 0 | 0 |
| idle | 0 | 0 |

Scrolling re-rendered the entire history because crossing the bottom sentinel flips `is_at_bottom`, which `Conversation` reads in render.

## Approach

**1. Stable callback identities.** `use_callback` allocates the handle once and swaps the inner closure each render, so identity is stable (props compare equal → the group memoizes) while captured state stays current. Freshness does not depend on the memoize path: `use_callback` itself replaces the inner closure on every `Conversation` render, and Dioxus additionally re-points the old handle at the newest closure inside `memoize` (called unconditionally, before the equality result is used).

Considered and rejected: hand-writing the props struct with a manual `PartialEq` that skips the handler fields. That is the documented opt-out, but it means restating 12 fields and re-deriving `Props` by hand, and it silently breaks if a field is added later.

**2. Cache the `Intl.DateTimeFormat` instances.** `toLocaleTimeString` / `toLocaleString` with an options object construct a new formatter per call — **67-74 µs** each in Chromium, vs **4.4-4.6 µs** for a cached one (~15x). These ran once per message group per render, so a 90-message room paid ~12 ms of pure date formatting per re-render. Output is byte-identical (verified for both formats).

## Results

6x CPU throttle, 94 messages:

| scenario | scripting before → after | longest task before → after |
|---|---|---|
| send a message | 1176 ms → **228 ms** | 1114 ms → **109 ms** |
| send another | 617 ms → **130 ms** | 524 ms → **76 ms** |
| scroll history | 253 ms → **12 ms** | 253 ms → **0** |
| type 26 chars | 120 ms → 120 ms | 0 → 0 |

The ~1.1 s main-thread freeze per sent message becomes ~109 ms.

## Testing

- Two source-scrape pin tests (the idiom this repo already uses) fail CI if either regression returns: handlers must be built with `use_callback` and the call site must pass those handles, and the date formatters must stay cached.
- `cargo test -p river-ui --bins`: 506 passed.
- Full Playwright suite across chromium, firefox, webkit, mobile-chrome, mobile-safari: **425 passed, 0 failed**. This directly exercises the handlers changed here — "Reply from the kebab opens the composer reply preview", "React from the kebab opens the emoji picker and closes the menu", "kebab opens a menu with Reply / Edit / Delete on own messages".
- UI-only change: no delegate, contract, or `common/` code touched, so no WASM migration.

## Drive-by

The two sandboxed-iframe layout tests hardcoded `http://localhost:8082` as the iframe `src` instead of honouring the configured `baseURL`, so they failed against any other port (after 3x30 s retries). They now use `baseURL`, whose default is unchanged. Verified pre-existing by reproducing on the unmodified base commit.

## Not addressed here

Named rather than silently dropped:

- `Conversation` still re-renders **4 times** per sent message. Each pass is now cheap, but 1 would be better.
- The composer's textarea auto-resize (`height: auto` → read `scrollHeight` → set height) forces ~3 layouts per keystroke — 67 ms layout + 108 ms style for 26 characters at 6x throttle. This is the one genuine reflow cost in the app, and it is the part of the original report that was literally about layout.

Neither is a regression from this PR.

[AI-assisted - Claude]