### PR TITLE
feat(cli): add deputy-status read commands to riverctl

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -200,11 +200,24 @@ often nobody.
 
 Both accept `--format json`, emitting `{room_id, direction, subject, grants[]}`.
 Each grant carries `deputizer`, `deputy`, `scope` (`room-wide` /
-`invite-subtree`), `reaches_members` (how many members the grant actually
-covers) and `active`. A grant whose deputizer or deputy has left the room is
-reported with `active: false`; the contract does not honour such a grant.
-`in_room` is `true` for the room owner even though the owner never appears in
-the member list.
+`invite-subtree`), `active`, and `reaches_members`.
+
+`reaches_members` is how many members the grant can currently be used against,
+computed from the contract's own rules: `0` for an inactive grant, every member
+for an owner grant, otherwise the deputizer's invite subtree minus anyone in it
+who has themselves deputized this deputy (a member cannot be banned by someone
+they deputized). It is often `0` even for a live grant, because most members
+have invited nobody. `reaches_members > 0` is the check for "this member
+actually has moderation authority here".
+
+A grant whose deputizer or deputy has left the room is reported with
+`active: false`; the contract does not honour such a grant. `in_room` is `true`
+for the room owner even though the owner never appears in the member list.
+
+Nicknames are quoted and escaped in terminal output. They are set by the member
+themselves and are printed next to an authority claim, so an unescaped one could
+forge a line that reads as a real deputy grant. The `-f json` output carries the
+faithful nickname.
 
 `member list --format json` gains `deputies` (who this member deputized) and
 `deputized_by` (who deputized them) alongside the existing `member_id` and

--- a/cli/README.md
+++ b/cli/README.md
@@ -173,13 +173,39 @@ riverctl member set-nickname <room-owner-vk> "New Nickname"
 riverctl member ban          <room-owner-vk> <member-vk>   # Owner only.
 ```
 
+### Deputies
+
+A deputy can ban within their deputizer's invite subtree. Deputies are
+**per-deputizer**, not a room-wide flag: "is X a deputy?" is only meaningful as
+"whose deputy is X?", so both queries name the deputizer explicitly.
+
+```bash
+riverctl member deputize      <room-owner-vk> <member-id>  # Grant.
+riverctl member revoke-deputy <room-owner-vk> <member-id>  # Revoke.
+
+riverctl member deputies      <room-owner-vk> [member-id]  # Who has X deputized?
+riverctl member deputized-by  <room-owner-vk> <member-id>  # Who has deputized X?
+```
+
+`member deputies` defaults to your own identity in the room.
+`member deputized-by` is the one that answers "does this member have moderation
+authority, and from whom?" — the room owner's grant is room-wide, anyone else's
+is limited to their own invite subtree.
+
+Both accept `--format json`, emitting `{room_id, direction, subject, grants[]}`
+where each grant carries `deputizer`, `deputy`, `scope`
+(`room-wide` / `invite-subtree`) and `active`. A grant is inactive when either
+party is no longer in the room, which the contract does not honour. `member
+list` also annotates each member with who deputized them, and `debug room-state`
+reports every grant in the room.
+
 ## Command reference
 
 | Group      | Commands                                                                |
 |------------|-------------------------------------------------------------------------|
 | `room`     | `create`, `list`, `join`, `leave`, `republish`, `config`                |
 | `message`  | `send`, `list`, `stream`, `edit`, `delete`, `react`, `unreact`, `reply` |
-| `member`   | `list`, `set-nickname`, `ban`                                           |
+| `member`   | `list`, `set-nickname`, `ban`, `deputize`, `revoke-deputy`, `deputies`, `deputized-by` |
 | `invite`   | `create`, `accept`                                                      |
 | `dm`       | `send`, `list`, `purge`, `accept`                                       |
 | `identity` | `whoami`, `export`, `import`                                            |

--- a/cli/README.md
+++ b/cli/README.md
@@ -170,8 +170,12 @@ riverctl identity import < my-identity.token     # On another machine.
 ```bash
 riverctl member list         <room-owner-vk>
 riverctl member set-nickname <room-owner-vk> "New Nickname"
-riverctl member ban          <room-owner-vk> <member-vk>   # Owner only.
+riverctl member ban          <room-owner-vk> <member-id>
 ```
+
+`member ban` is not owner-only: the room owner can ban anyone, and so can a
+member banning within their own invite subtree, or a deputy of such a member
+(see below).
 
 ### Deputies
 
@@ -187,17 +191,33 @@ riverctl member deputies      <room-owner-vk> [member-id]  # Who has X deputized
 riverctl member deputized-by  <room-owner-vk> <member-id>  # Who has deputized X?
 ```
 
-`member deputies` defaults to your own identity in the room.
+`member deputies` defaults to your own identity in the room (the identity that
+would sign, so `--signing-key-file` applies).
 `member deputized-by` is the one that answers "does this member have moderation
-authority, and from whom?" — the room owner's grant is room-wide, anyone else's
-is limited to their own invite subtree.
+authority, and from whom?" The room owner's grant covers every member; anyone
+else's covers only the members they invited, directly or indirectly, which is
+often nobody.
 
-Both accept `--format json`, emitting `{room_id, direction, subject, grants[]}`
-where each grant carries `deputizer`, `deputy`, `scope`
-(`room-wide` / `invite-subtree`) and `active`. A grant is inactive when either
-party is no longer in the room, which the contract does not honour. `member
-list` also annotates each member with who deputized them, and `debug room-state`
-reports every grant in the room.
+Both accept `--format json`, emitting `{room_id, direction, subject, grants[]}`.
+Each grant carries `deputizer`, `deputy`, `scope` (`room-wide` /
+`invite-subtree`), `reaches_members` (how many members the grant actually
+covers) and `active`. A grant whose deputizer or deputy has left the room is
+reported with `active: false`; the contract does not honour such a grant.
+`in_room` is `true` for the room owner even though the owner never appears in
+the member list.
+
+`member list --format json` gains `deputies` (who this member deputized) and
+`deputized_by` (who deputized them) alongside the existing `member_id` and
+`nickname`. `debug room-state` gains `deputy_grant_count` and `deputy_grants`.
+
+Two caveats worth knowing:
+
+- The read commands reject an ambiguous partial member ID and list the matches;
+  the write commands (`ban`, `deputize`, `revoke-deputy`) still resolve a
+  partial ID to the first match. Pass the full 8-character ID to be certain.
+- Like every riverctl command that reads a room, these fetch through the
+  standard path, which may PUT migrated state or publish a `member_info` heal
+  for your own identity. They never write deputy state.
 
 ## Command reference
 

--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -1,4 +1,5 @@
 use crate::api::ApiClient;
+use crate::deputies::{grant_status_line, party_label, DeputyGrant, RoomDeputies};
 use crate::output::OutputFormat;
 use anyhow::{anyhow, Result};
 use clap::Subcommand;
@@ -53,6 +54,12 @@ struct RoomStateSummary {
     max_members: usize,
     privacy_mode: String,
     configuration_version: u32,
+    /// Number of `deputizer -> deputy` grants in the room (#410). Deputies are
+    /// per-deputizer, so this counts grants, not "deputy members".
+    deputy_grant_count: usize,
+    /// Every grant, read from the CANONICAL `member_info` record per member so
+    /// a revoked grant lingering in a duplicate record is not reported.
+    deputy_grants: Vec<DeputyGrant>,
 }
 
 #[derive(Serialize)]
@@ -277,7 +284,11 @@ pub async fn execute(command: DebugCommands, api: ApiClient, format: OutputForma
         }
         DebugCommands::RoomState { room_owner_key } => {
             let owner_vk = parse_owner_key(&room_owner_key)?;
-            let room_state = api.get_room(&owner_vk, false).await?;
+            let mut room_state = api.get_room(&owner_vk, false).await?;
+            // Private-room nicknames are sealed; collect the local member's
+            // secrets so deputy grants render names rather than ciphertext.
+            let secrets = api.room_display_secrets(&owner_vk, &mut room_state);
+            let deputy_grants = RoomDeputies::new(&room_state, &owner_vk, &secrets).all_grants();
 
             let config = &room_state.configuration.configuration;
             let summary = RoomStateSummary {
@@ -289,6 +300,8 @@ pub async fn execute(command: DebugCommands, api: ApiClient, format: OutputForma
                 max_members: config.max_members,
                 privacy_mode: format!("{:?}", config.privacy_mode),
                 configuration_version: config.configuration_version,
+                deputy_grant_count: deputy_grants.len(),
+                deputy_grants,
             };
 
             match format {
@@ -305,6 +318,15 @@ pub async fn execute(command: DebugCommands, api: ApiClient, format: OutputForma
                     );
                     println!("Bans: {} / {}", summary.ban_count, summary.max_user_bans);
                     println!("Messages: {}", summary.message_count);
+                    println!("Deputy grants: {}", summary.deputy_grant_count);
+                    for grant in &summary.deputy_grants {
+                        println!(
+                            "  {} -> {}  {}",
+                            party_label(&grant.deputizer),
+                            party_label(&grant.deputy),
+                            grant_status_line(grant)
+                        );
+                    }
                 }
                 OutputFormat::Json => {
                     println!("{}", serde_json::to_string_pretty(&summary)?);

--- a/cli/src/commands/member.rs
+++ b/cli/src/commands/member.rs
@@ -1,8 +1,10 @@
 use crate::api::ApiClient;
+use crate::deputies::{grant_status_line, party_label, ResolveError, RoomDeputies};
 use crate::output::OutputFormat;
 use anyhow::{anyhow, Result};
 use clap::Subcommand;
 use colored::Colorize;
+use river_core::room_state::member::MemberId;
 
 #[derive(Subcommand)]
 pub enum MemberCommands {
@@ -39,6 +41,33 @@ pub enum MemberCommands {
         /// Member ID whose deputy authority to revoke (8-character short ID)
         member_id: String,
     },
+    /// Show the deputies a member has appointed ("who has X deputized?")
+    ///
+    /// Deputies are per-deputizer, not a room-wide flag: this lists only the
+    /// members that MEMBER_ID has deputized, who may ban within MEMBER_ID's own
+    /// invite subtree. Defaults to your own identity in the room.
+    ///
+    /// For the opposite question ("is this member anyone's deputy?") use
+    /// `member deputized-by`.
+    Deputies {
+        /// Room ID (owner key in base58)
+        room_id: String,
+        /// Member ID whose deputies to list (8-character short ID from member
+        /// list). Defaults to your own identity in this room.
+        member_id: Option<String>,
+    },
+    /// Show who has deputized a member ("is X a deputy of anyone?")
+    ///
+    /// The reverse of `member deputies`: scans every member's signed deputy
+    /// list for MEMBER_ID and reports each member who granted them authority,
+    /// including whether that grant is the room owner's (room-wide) or a
+    /// regular member's (limited to that member's invite subtree).
+    DeputizedBy {
+        /// Room ID (owner key in base58)
+        room_id: String,
+        /// Member ID to look up (8-character short ID from member list)
+        member_id: String,
+    },
 }
 
 pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputFormat) -> Result<()> {
@@ -69,6 +98,12 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
             // public room or a room not in local storage.
             let secrets = api.room_display_secrets(&owner_vk, &mut room_state);
 
+            // Deputy grants are attributed per-deputizer (#410), so a member row
+            // carries the members who deputized THEM — never a bare badge, which
+            // in the UI is viewer-scoped and routinely misread as room-wide.
+            let deputies = RoomDeputies::new(&room_state, &owner_vk, &secrets);
+            let deputized_by = deputies.deputizers_by_deputy();
+
             // Collect member info
             let members: Vec<_> = room_state
                 .member_info
@@ -79,8 +114,15 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
                         &info.member_info.preferred_nickname,
                         &secrets,
                     );
-                    let member_id = info.member_info.member_id.to_string();
-                    (member_id, nickname)
+                    let id = info.member_info.member_id;
+                    let granted_by: Vec<MemberId> =
+                        deputized_by.get(&id).cloned().unwrap_or_default();
+                    (
+                        id.to_string(),
+                        nickname,
+                        deputies.deputies_of(id),
+                        granted_by,
+                    )
                 })
                 .collect();
 
@@ -90,8 +132,22 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
                         println!("No members found in room.");
                     } else {
                         println!("\n{} member(s) found:\n", members.len());
-                        for (member_id, nickname) in members {
-                            println!("  {} ({})", nickname.green(), &member_id[..8]);
+                        for (member_id, nickname, _own_deputies, granted_by) in &members {
+                            let suffix = if granted_by.is_empty() {
+                                String::new()
+                            } else {
+                                let names: Vec<String> = granted_by
+                                    .iter()
+                                    .map(|id| party_label(&deputies.party(*id)))
+                                    .collect();
+                                format!("  deputy of: {}", names.join(", "))
+                            };
+                            println!(
+                                "  {} ({}){}",
+                                nickname.green(),
+                                &member_id[..8],
+                                suffix.yellow()
+                            );
                         }
                         println!();
                     }
@@ -99,10 +155,14 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
                 OutputFormat::Json => {
                     let json_members: Vec<_> = members
                         .into_iter()
-                        .map(|(member_id, nickname)| {
+                        .map(|(member_id, nickname, own_deputies, granted_by)| {
                             serde_json::json!({
                                 "member_id": member_id,
                                 "nickname": nickname,
+                                // Members this member has deputized.
+                                "deputies": ids_to_strings(&own_deputies),
+                                // Members who have deputized this member.
+                                "deputized_by": ids_to_strings(&granted_by),
                             })
                         })
                         .collect();
@@ -242,7 +302,164 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
             }
             Ok(())
         }
+        MemberCommands::Deputies { room_id, member_id } => {
+            let owner_vk = parse_room_id(&room_id)?;
+            let mut room_state = api.get_room(&owner_vk, false).await?;
+            let secrets = api.room_display_secrets(&owner_vk, &mut room_state);
+            let deputies = RoomDeputies::new(&room_state, &owner_vk, &secrets);
+
+            // No MEMBER_ID → the identity this CLI joined the room as. Deputy
+            // grants are per-deputizer, so "my deputies" is the only sensible
+            // default; there is no room-wide list to fall back to.
+            let subject_id = match &member_id {
+                Some(short) => resolve_or_explain(&deputies, short)?,
+                None => own_member_id(&api, &owner_vk)?,
+            };
+
+            let subject = deputies.party(subject_id);
+            let grants: Vec<_> = deputies
+                .deputies_of(subject_id)
+                .into_iter()
+                .map(|deputy| deputies.grant(subject_id, deputy))
+                .collect();
+
+            match format {
+                OutputFormat::Human => {
+                    if grants.is_empty() {
+                        println!(
+                            "{} has not deputized anyone in this room.",
+                            party_label(&subject)
+                        );
+                    } else {
+                        println!(
+                            "\nDeputies appointed by {} ({} grant(s)):\n",
+                            party_label(&subject),
+                            grants.len()
+                        );
+                        for grant in &grants {
+                            println!(
+                                "  {}  {}",
+                                party_label(&grant.deputy).green(),
+                                grant_status_line(grant)
+                            );
+                        }
+                        println!();
+                    }
+                    println!(
+                        "{}",
+                        "Deputy authority is per-deputizer: this lists only the members \
+                         the member above deputized."
+                            .dimmed()
+                    );
+                }
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "room_id": room_id,
+                            "direction": "deputies-of",
+                            "subject": subject,
+                            "grants": grants,
+                        }))?
+                    );
+                }
+            }
+            Ok(())
+        }
+        MemberCommands::DeputizedBy { room_id, member_id } => {
+            let owner_vk = parse_room_id(&room_id)?;
+            let mut room_state = api.get_room(&owner_vk, false).await?;
+            let secrets = api.room_display_secrets(&owner_vk, &mut room_state);
+            let deputies = RoomDeputies::new(&room_state, &owner_vk, &secrets);
+
+            let subject_id = resolve_or_explain(&deputies, &member_id)?;
+            let subject = deputies.party(subject_id);
+            let grants: Vec<_> = deputies
+                .deputizers_of(subject_id)
+                .into_iter()
+                .map(|deputizer| deputies.grant(deputizer, subject_id))
+                .collect();
+
+            match format {
+                OutputFormat::Human => {
+                    if grants.is_empty() {
+                        println!(
+                            "No one has deputized {} in this room.",
+                            party_label(&subject)
+                        );
+                    } else {
+                        println!(
+                            "\n{} has been deputized by {} member(s):\n",
+                            party_label(&subject),
+                            grants.len()
+                        );
+                        for grant in &grants {
+                            let owner_tag = if grant.deputizer.is_owner {
+                                "  [room owner]"
+                            } else {
+                                ""
+                            };
+                            println!(
+                                "  {}{}  {}",
+                                party_label(&grant.deputizer).green(),
+                                owner_tag,
+                                grant_status_line(grant)
+                            );
+                        }
+                        println!();
+                    }
+                }
+                OutputFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "room_id": room_id,
+                            "direction": "deputized-by",
+                            "subject": subject,
+                            "grants": grants,
+                        }))?
+                    );
+                }
+            }
+            Ok(())
+        }
     }
+}
+
+/// Render a list of member ids as their short-id strings, for JSON output.
+fn ids_to_strings(ids: &[MemberId]) -> Vec<String> {
+    ids.iter().map(|id| id.to_string()).collect()
+}
+
+/// Resolve a short member id, turning the structured failure into the same
+/// "use member list" guidance the write paths give — and, for an ambiguous
+/// prefix, listing the ids it matched instead of silently picking one.
+fn resolve_or_explain(deputies: &RoomDeputies<'_>, short: &str) -> Result<MemberId> {
+    deputies.resolve_short_id(short).map_err(|err| match err {
+        ResolveError::NotFound => anyhow!(
+            "Member '{}' not found in this room. Use 'member list' to see member IDs.",
+            short
+        ),
+        ResolveError::Ambiguous(ids) => anyhow!(
+            "Member ID '{}' is ambiguous: it matches {}. Pass the full 8-character ID.",
+            short,
+            ids.join(", ")
+        ),
+    })
+}
+
+/// The member id of the identity this CLI joined `room_owner_key` as.
+fn own_member_id(
+    api: &ApiClient,
+    room_owner_key: &ed25519_dalek::VerifyingKey,
+) -> Result<MemberId> {
+    let (signing_key, _, _) = api.storage().get_room(room_owner_key)?.ok_or_else(|| {
+        anyhow!(
+            "Room not found in local storage, so there is no 'your own' identity to \
+             default to. Pass a member ID explicitly."
+        )
+    })?;
+    Ok(MemberId::from(&signing_key.verifying_key()))
 }
 
 /// Decode a base58 room id (owner verifying key) into a `VerifyingKey`.
@@ -257,4 +474,81 @@ fn parse_room_id(room_id: &str) -> Result<ed25519_dalek::VerifyingKey> {
     key_array.copy_from_slice(&owner_key_bytes);
     ed25519_dalek::VerifyingKey::from_bytes(&key_array)
         .map_err(|e| anyhow!("Invalid room ID: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    /// Minimal harness so the `MemberCommands` clap surface can be parsed
+    /// without pulling in the whole binary's global flags.
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(subcommand)]
+        command: MemberCommands,
+    }
+
+    fn parse(args: &[&str]) -> Result<MemberCommands, clap::Error> {
+        let mut argv = vec!["member"];
+        argv.extend_from_slice(args);
+        TestCli::try_parse_from(argv).map(|cli| cli.command)
+    }
+
+    #[test]
+    fn deputies_accepts_an_explicit_member_id() {
+        match parse(&["deputies", "ROOM", "7XSOGJTK"]).expect("must parse") {
+            MemberCommands::Deputies { room_id, member_id } => {
+                assert_eq!(room_id, "ROOM");
+                assert_eq!(member_id.as_deref(), Some("7XSOGJTK"));
+            }
+            other => panic!("wrong subcommand: {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn deputies_member_id_is_optional_and_defaults_to_self() {
+        // The no-MEMBER_ID form is the "what did I deputize?" shorthand; it must
+        // stay optional rather than becoming a required positional.
+        match parse(&["deputies", "ROOM"]).expect("must parse without a member id") {
+            MemberCommands::Deputies { room_id, member_id } => {
+                assert_eq!(room_id, "ROOM");
+                assert_eq!(member_id, None);
+            }
+            other => panic!("wrong subcommand: {:?}", std::mem::discriminant(&other)),
+        }
+    }
+
+    #[test]
+    fn deputized_by_is_spelled_in_kebab_case_and_requires_a_member_id() {
+        match parse(&["deputized-by", "ROOM", "PMAQEUP5"]).expect("must parse") {
+            MemberCommands::DeputizedBy { room_id, member_id } => {
+                assert_eq!(room_id, "ROOM");
+                assert_eq!(member_id, "PMAQEUP5");
+            }
+            other => panic!("wrong subcommand: {:?}", std::mem::discriminant(&other)),
+        }
+
+        // The reverse lookup has no sensible "self" default (asking who
+        // deputized you is a different question from your own grants), so the
+        // member id stays mandatory.
+        assert!(
+            parse(&["deputized-by", "ROOM"]).is_err(),
+            "deputized-by must require a member id"
+        );
+    }
+
+    #[test]
+    fn room_id_is_required_for_both_new_commands() {
+        assert!(parse(&["deputies"]).is_err());
+        assert!(parse(&["deputized-by"]).is_err());
+    }
+
+    #[test]
+    fn ids_to_strings_renders_short_ids() {
+        use ed25519_dalek::SigningKey;
+        let id: MemberId = SigningKey::from_bytes(&[5u8; 32]).verifying_key().into();
+        assert_eq!(ids_to_strings(&[id]), vec![id.to_string()]);
+        assert!(ids_to_strings(&[]).is_empty());
+    }
 }

--- a/cli/src/commands/member.rs
+++ b/cli/src/commands/member.rs
@@ -1,5 +1,7 @@
 use crate::api::ApiClient;
-use crate::deputies::{grant_status_line, party_label, ResolveError, RoomDeputies};
+use crate::deputies::{
+    display_nickname, grant_status_line, party_label, ResolveError, RoomDeputies,
+};
 use crate::output::OutputFormat;
 use anyhow::{anyhow, Result};
 use clap::Subcommand;
@@ -127,7 +129,15 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
                     } else {
                         println!("\n{} member(s) found:\n", members.len());
                         for (party, _own_deputies, granted_by) in &members {
-                            let nickname = party.nickname.as_deref().unwrap_or("(unknown)");
+                            // Escaped and quoted: an unescaped nickname can
+                            // forge a row that reads as a real deputy grant,
+                            // and `colored` drops the colour that would
+                            // distinguish it as soon as output is piped.
+                            let nickname = party
+                                .nickname
+                                .as_deref()
+                                .map(display_nickname)
+                                .unwrap_or_else(|| "(unknown)".to_string());
                             print!("  {} ({})", nickname.green(), party.member_id);
                             if !granted_by.is_empty() {
                                 let names: Vec<String> = granted_by
@@ -318,10 +328,12 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
             let secrets = api.room_display_secrets(&owner_vk, &mut room_state);
             let deputies = RoomDeputies::new(&room_state, &owner_vk, &secrets);
 
-            let subject_id = match (&member_id, own_id) {
-                (Some(short), _) => resolve_or_explain(&deputies, short)?,
-                (None, Some(id)) => id,
-                (None, None) => unreachable!("own_id is set whenever member_id is None"),
+            let subject_id = match member_id.as_deref() {
+                Some(short) => resolve_or_explain(&deputies, short)?,
+                // `own_id` was resolved above on exactly this branch.
+                None => {
+                    own_id.ok_or_else(|| anyhow!("no member ID given and no local identity"))?
+                }
             };
 
             let subject = deputies.party(subject_id);

--- a/cli/src/commands/member.rs
+++ b/cli/src/commands/member.rs
@@ -352,9 +352,9 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
                         );
                     } else {
                         println!(
-                            "\nDeputies appointed by {} ({} grant(s)):\n",
+                            "\nDeputies appointed by {} ({}):\n",
                             party_label(&subject),
-                            grants.len()
+                            count(grants.len(), "grant")
                         );
                         for grant in &grants {
                             println!(
@@ -417,9 +417,9 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
                         );
                     } else {
                         println!(
-                            "\n{} has been deputized by {} member(s):\n",
+                            "\n{} has been deputized by {}:\n",
                             party_label(&subject),
-                            grants.len()
+                            count(grants.len(), "member")
                         );
                         for grant in &grants {
                             let owner_tag = if grant.deputizer.is_owner {
@@ -457,6 +457,16 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
 /// Render a list of member ids as their short-id strings, for JSON output.
 fn ids_to_strings(ids: &[MemberId]) -> Vec<String> {
     ids.iter().map(|id| id.to_string()).collect()
+}
+
+/// `"1 grant"` / `"3 grants"`, so counted output reads as English rather than
+/// as the `N thing(s)` form.
+fn count(n: usize, noun: &str) -> String {
+    if n == 1 {
+        format!("1 {noun}")
+    } else {
+        format!("{n} {noun}s")
+    }
 }
 
 /// Resolve a short member id, turning the structured failure into the same

--- a/cli/src/commands/member.rs
+++ b/cli/src/commands/member.rs
@@ -99,30 +99,24 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
             let secrets = api.room_display_secrets(&owner_vk, &mut room_state);
 
             // Deputy grants are attributed per-deputizer (#410), so a member row
-            // carries the members who deputized THEM — never a bare badge, which
-            // in the UI is viewer-scoped and routinely misread as room-wide.
+            // carries the members who deputized THEM, never a bare badge (the
+            // UI's badge is viewer-scoped and routinely misread as room-wide).
             let deputies = RoomDeputies::new(&room_state, &owner_vk, &secrets);
             let deputized_by = deputies.deputizers_by_deputy();
 
-            // Collect member info
-            let members: Vec<_> = room_state
-                .member_info
-                .member_info
-                .iter()
-                .map(|info| {
-                    let nickname = crate::api::unseal_nickname_display(
-                        &info.member_info.preferred_nickname,
-                        &secrets,
-                    );
-                    let id = info.member_info.member_id;
+            // One row per MEMBER, not per `member_info` record: `verify`
+            // deliberately accepts several records for the same member
+            // (migration-safety), so iterating the raw vector emitted duplicate
+            // rows whose nickname came from a losing record while the deputy
+            // annotation came from the canonical one. `members_with_info` is
+            // deduplicated and `party` reads the canonical record.
+            let members: Vec<_> = deputies
+                .members_with_info()
+                .map(|id| {
+                    let party = deputies.party(id);
                     let granted_by: Vec<MemberId> =
                         deputized_by.get(&id).cloned().unwrap_or_default();
-                    (
-                        id.to_string(),
-                        nickname,
-                        deputies.deputies_of(id),
-                        granted_by,
-                    )
+                    (party, deputies.deputies_of(id).to_vec(), granted_by)
                 })
                 .collect();
 
@@ -132,22 +126,17 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
                         println!("No members found in room.");
                     } else {
                         println!("\n{} member(s) found:\n", members.len());
-                        for (member_id, nickname, _own_deputies, granted_by) in &members {
-                            let suffix = if granted_by.is_empty() {
-                                String::new()
-                            } else {
+                        for (party, _own_deputies, granted_by) in &members {
+                            let nickname = party.nickname.as_deref().unwrap_or("(unknown)");
+                            print!("  {} ({})", nickname.green(), party.member_id);
+                            if !granted_by.is_empty() {
                                 let names: Vec<String> = granted_by
                                     .iter()
                                     .map(|id| party_label(&deputies.party(*id)))
                                     .collect();
-                                format!("  deputy of: {}", names.join(", "))
-                            };
-                            println!(
-                                "  {} ({}){}",
-                                nickname.green(),
-                                &member_id[..8],
-                                suffix.yellow()
-                            );
+                                print!("{}", format!("  deputy of: {}", names.join(", ")).yellow());
+                            }
+                            println!();
                         }
                         println!();
                     }
@@ -155,10 +144,16 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
                 OutputFormat::Json => {
                     let json_members: Vec<_> = members
                         .into_iter()
-                        .map(|(member_id, nickname, own_deputies, granted_by)| {
+                        .map(|(party, own_deputies, granted_by)| {
                             serde_json::json!({
-                                "member_id": member_id,
-                                "nickname": nickname,
+                                "member_id": party.member_id,
+                                // Unchanged shape: the pre-#470 output rendered
+                                // a member with no readable nickname as the
+                                // lossy placeholder string, never null, and
+                                // `party.nickname` is only None for a member
+                                // with no member_info record, which cannot
+                                // appear in this listing.
+                                "nickname": party.nickname.unwrap_or_default(),
                                 // Members this member has deputized.
                                 "deputies": ids_to_strings(&own_deputies),
                                 // Members who have deputized this member.
@@ -304,23 +299,36 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
         }
         MemberCommands::Deputies { room_id, member_id } => {
             let owner_vk = parse_room_id(&room_id)?;
+
+            // No MEMBER_ID means the identity this CLI joined the room as.
+            // Deputy grants are per-deputizer, so "my deputies" is the only
+            // sensible default; there is no room-wide list to fall back to.
+            // Resolved BEFORE the fetch so a caller with no local room record
+            // gets the error immediately instead of after a full GET.
+            let own_id = match &member_id {
+                Some(_) => None,
+                None => Some(own_member_id(&api, &owner_vk)?),
+            };
+
+            if !matches!(format, OutputFormat::Json) {
+                eprintln!("Listing deputies in room: {}", room_id);
+            }
+
             let mut room_state = api.get_room(&owner_vk, false).await?;
             let secrets = api.room_display_secrets(&owner_vk, &mut room_state);
             let deputies = RoomDeputies::new(&room_state, &owner_vk, &secrets);
 
-            // No MEMBER_ID → the identity this CLI joined the room as. Deputy
-            // grants are per-deputizer, so "my deputies" is the only sensible
-            // default; there is no room-wide list to fall back to.
-            let subject_id = match &member_id {
-                Some(short) => resolve_or_explain(&deputies, short)?,
-                None => own_member_id(&api, &owner_vk)?,
+            let subject_id = match (&member_id, own_id) {
+                (Some(short), _) => resolve_or_explain(&deputies, short)?,
+                (None, Some(id)) => id,
+                (None, None) => unreachable!("own_id is set whenever member_id is None"),
             };
 
             let subject = deputies.party(subject_id);
             let grants: Vec<_> = deputies
                 .deputies_of(subject_id)
-                .into_iter()
-                .map(|deputy| deputies.grant(subject_id, deputy))
+                .iter()
+                .map(|deputy| deputies.grant(subject_id, *deputy))
                 .collect();
 
             match format {
@@ -345,7 +353,9 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
                         }
                         println!();
                     }
-                    println!(
+                    // stderr, like every other `member` subcommand's chatter, so
+                    // piping the human output does not mix prose into the data.
+                    eprintln!(
                         "{}",
                         "Deputy authority is per-deputizer: this lists only the members \
                          the member above deputized."
@@ -368,6 +378,12 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
         }
         MemberCommands::DeputizedBy { room_id, member_id } => {
             let owner_vk = parse_room_id(&room_id)?;
+            if !matches!(format, OutputFormat::Json) {
+                eprintln!(
+                    "Looking up who deputized '{}' in room: {}",
+                    member_id, room_id
+                );
+            }
             let mut room_state = api.get_room(&owner_vk, false).await?;
             let secrets = api.room_display_secrets(&owner_vk, &mut room_state);
             let deputies = RoomDeputies::new(&room_state, &owner_vk, &secrets);
@@ -448,18 +464,26 @@ fn resolve_or_explain(deputies: &RoomDeputies<'_>, short: &str) -> Result<Member
     })
 }
 
-/// The member id of the identity this CLI joined `room_owner_key` as.
+/// The member id this CLI would currently sign as in `room_owner_key`.
+///
+/// Routes through `Storage::self_identity`, the same derivation `identity
+/// whoami` and every send path use, rather than re-deriving from a signing key
+/// (see the "do not re-inline" note on `api::author_member_id`). It therefore
+/// honours `--signing-key-file` / `RIVER_SIGNING_KEY_FILE`: with an override in
+/// effect this is the OVERRIDE identity, not the persisted one.
 fn own_member_id(
     api: &ApiClient,
     room_owner_key: &ed25519_dalek::VerifyingKey,
 ) -> Result<MemberId> {
-    let (signing_key, _, _) = api.storage().get_room(room_owner_key)?.ok_or_else(|| {
-        anyhow!(
-            "Room not found in local storage, so there is no 'your own' identity to \
-             default to. Pass a member ID explicitly."
-        )
-    })?;
-    Ok(MemberId::from(&signing_key.verifying_key()))
+    api.storage()
+        .self_identity(room_owner_key)?
+        .map(|identity| identity.member_id)
+        .ok_or_else(|| {
+            anyhow!(
+                "Room not found in local storage, so there is no 'your own' identity to \
+                 default to. Pass a member ID explicitly."
+            )
+        })
 }
 
 /// Decode a base58 room id (owner verifying key) into a `VerifyingKey`.

--- a/cli/src/deputies.rs
+++ b/cli/src/deputies.rs
@@ -1,0 +1,661 @@
+//! Read-side deputy queries (deputy ban authority, freenet/river#410).
+//!
+//! Deputies are **per-deputizer**, never a global flag. Each member's own
+//! signed `MemberInfo` carries a `deputies: Vec<MemberId>` listing the members
+//! *they* have deputized, and that grant only scopes to that deputizer's invite
+//! subtree (the room owner's subtree being everyone). The UI's shield badges are
+//! viewer-scoped — they show who *you* deputized — which is a recurring source
+//! of confusion, so every rendering here names the deputizer explicitly.
+//!
+//! Two directions are supported:
+//!
+//! * **forward** — [`RoomDeputies::deputies_of`]: "who has X deputized?"
+//! * **reverse** — [`RoomDeputies::deputizers_of`]: "who has deputized X?",
+//!   which is what answers "is this member a deputy of anyone (the owner, the
+//!   invite bot, …)?"
+//!
+//! Every read routes through [`MemberInfoV1::deputies_of`], which selects the
+//! CANONICAL (highest-rank) `member_info` record per member. That is
+//! load-bearing: `MemberInfoV1::verify` deliberately accepts a state carrying
+//! more than one record for the same member (migration-safety), so a bare
+//! first-match scan of `member_info.member_info` can read a LOSING — e.g.
+//! already-revoked — record and report deputy authority that the contract does
+//! not actually enforce.
+//!
+//! This module is READ-ONLY. It never builds a delta and never touches contract
+//! state.
+
+use ed25519_dalek::VerifyingKey;
+use river_core::room_state::member::MemberId;
+use river_core::room_state::member_info::MemberInfoV1;
+use river_core::room_state::ChatRoomStateV1;
+use serde::Serialize;
+use std::collections::{BTreeSet, HashMap, HashSet};
+
+/// One party of a deputy grant, resolved for display.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DeputyParty {
+    /// The member's short id, as printed by `member list`.
+    pub member_id: String,
+    /// The member's nickname, or `null` when they have no `member_info` record
+    /// in this room (e.g. a deputy who was pruned for inactivity but is still
+    /// listed in their deputizer's signed record).
+    pub nickname: Option<String>,
+    /// Whether this party is the room owner.
+    pub is_owner: bool,
+    /// Whether this party is currently in the room: present in
+    /// `members.members`, **or** the room owner (who is never in that list —
+    /// see `MembersV1::is_ban_authorized`).
+    pub in_room: bool,
+}
+
+/// How far a grant reaches, when it is active.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DeputyScope {
+    /// Granted by the room owner, whose invite subtree is the whole room.
+    RoomWide,
+    /// Granted by a regular member: authority only within that member's own
+    /// invite subtree, which may be empty.
+    InviteSubtree,
+}
+
+/// A single `deputizer -> deputy` grant, resolved for display.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DeputyGrant {
+    pub deputizer: DeputyParty,
+    pub deputy: DeputyParty,
+    pub scope: DeputyScope,
+    /// Whether the grant is not structurally inert: both parties are currently
+    /// in the room. The contract only honours deputy authority when the deputy
+    /// is a current member, and a non-owner deputizer must be a genuine invite
+    /// ancestor of the ban target — so a grant naming a pruned member on either
+    /// side confers nothing. `true` does NOT mean the deputy can ban any given
+    /// person: a non-owner deputizer's authority is still limited to their own
+    /// invite subtree, which may be empty.
+    pub active: bool,
+}
+
+/// Why a short member id could not be resolved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolveError {
+    /// No member id in the room matched.
+    NotFound,
+    /// The input is a prefix of more than one member id. Carries the matching
+    /// ids, sorted, so the caller can list them.
+    Ambiguous(Vec<String>),
+}
+
+/// Deputy queries over one fetched room state.
+///
+/// Borrows the state; construct one per fetch. `secrets` is the private-room
+/// decryption map from `ApiClient::room_display_secrets` (empty for a public
+/// room), used only to render nicknames.
+pub struct RoomDeputies<'a> {
+    state: &'a ChatRoomStateV1,
+    secrets: &'a HashMap<u32, [u8; 32]>,
+    owner_id: MemberId,
+    current_members: HashSet<MemberId>,
+}
+
+impl<'a> RoomDeputies<'a> {
+    pub fn new(
+        state: &'a ChatRoomStateV1,
+        owner_vk: &VerifyingKey,
+        secrets: &'a HashMap<u32, [u8; 32]>,
+    ) -> Self {
+        let current_members = state
+            .members
+            .members
+            .iter()
+            .map(|m| m.member.id())
+            .collect();
+        Self {
+            state,
+            secrets,
+            owner_id: MemberId::from(owner_vk),
+            current_members,
+        }
+    }
+
+    fn member_info(&self) -> &MemberInfoV1 {
+        &self.state.member_info
+    }
+
+    /// Every member id this room mentions anywhere: the owner, current members,
+    /// members with a `member_info` record, and ids appearing in ANY deputies
+    /// list. The last source matters — a deputy pruned for inactivity keeps no
+    /// `member_info` record but is still named by their deputizer's signed
+    /// record, and "is this (now absent) member still someone's deputy?" is a
+    /// question worth being able to ask.
+    fn known_member_ids(&self) -> BTreeSet<MemberId> {
+        let mut ids: BTreeSet<MemberId> = BTreeSet::new();
+        ids.insert(self.owner_id);
+        ids.extend(self.current_members.iter().copied());
+        for info in &self.member_info().member_info {
+            ids.insert(info.member_info.member_id);
+        }
+        for id in self.deputizer_candidates() {
+            ids.extend(self.member_info().deputies_of(id).iter().copied());
+        }
+        ids
+    }
+
+    /// Ids that could plausibly hold a `deputies` list: every member with a
+    /// `member_info` record (deputies live nowhere else, so a member without a
+    /// record has, by definition, deputized no one).
+    fn deputizer_candidates(&self) -> BTreeSet<MemberId> {
+        self.member_info()
+            .member_info
+            .iter()
+            .map(|info| info.member_info.member_id)
+            .collect()
+    }
+
+    /// Resolve a user-supplied short id against every id the room mentions.
+    ///
+    /// Matching mirrors `ban_member` / `member deputize` — a case-sensitive
+    /// prefix match, or a case-insensitive match against the first 8 characters
+    /// — but, unlike those write paths, an input matching more than one member
+    /// is reported as [`ResolveError::Ambiguous`] rather than silently resolving
+    /// to whichever record happens to come first in the state vector.
+    pub fn resolve_short_id(&self, short: &str) -> Result<MemberId, ResolveError> {
+        if short.is_empty() {
+            return Err(ResolveError::NotFound);
+        }
+        let matches: Vec<MemberId> = self
+            .known_member_ids()
+            .into_iter()
+            .filter(|id| {
+                let s = id.to_string();
+                s.starts_with(short) || s[..8.min(s.len())].eq_ignore_ascii_case(short)
+            })
+            .collect();
+        match matches.len() {
+            0 => Err(ResolveError::NotFound),
+            1 => Ok(matches[0]),
+            _ => Err(ResolveError::Ambiguous(
+                matches.iter().map(|id| id.to_string()).collect(),
+            )),
+        }
+    }
+
+    /// Whether `id` is currently in the room (a member, or the owner).
+    fn in_room(&self, id: MemberId) -> bool {
+        id == self.owner_id || self.current_members.contains(&id)
+    }
+
+    /// Resolve one member for display.
+    pub fn party(&self, id: MemberId) -> DeputyParty {
+        let nickname = self.member_info().canonical(id).map(|info| {
+            crate::api::unseal_nickname_display(&info.member_info.preferred_nickname, self.secrets)
+        });
+        DeputyParty {
+            member_id: id.to_string(),
+            nickname,
+            is_owner: id == self.owner_id,
+            in_room: self.in_room(id),
+        }
+    }
+
+    /// Build the resolved view of a single `deputizer -> deputy` grant.
+    pub fn grant(&self, deputizer: MemberId, deputy: MemberId) -> DeputyGrant {
+        DeputyGrant {
+            scope: if deputizer == self.owner_id {
+                DeputyScope::RoomWide
+            } else {
+                DeputyScope::InviteSubtree
+            },
+            active: self.in_room(deputizer) && self.in_room(deputy),
+            deputizer: self.party(deputizer),
+            deputy: self.party(deputy),
+        }
+    }
+
+    /// Forward lookup: the members `deputizer` has deputized, sorted by id.
+    ///
+    /// Reads the CANONICAL record, so a revoked grant lingering in a duplicate
+    /// lower-rank record is not reported.
+    pub fn deputies_of(&self, deputizer: MemberId) -> Vec<MemberId> {
+        let mut ids: Vec<MemberId> = self.member_info().deputies_of(deputizer).to_vec();
+        ids.sort_by_key(|id| id.to_string());
+        ids.dedup();
+        ids
+    }
+
+    /// Reverse lookup: every member who has deputized `deputy`, sorted by id.
+    pub fn deputizers_of(&self, deputy: MemberId) -> Vec<MemberId> {
+        let mut ids: Vec<MemberId> = self
+            .deputizer_candidates()
+            .into_iter()
+            .filter(|deputizer| self.member_info().deputies_of(*deputizer).contains(&deputy))
+            .collect();
+        ids.sort_by_key(|id| id.to_string());
+        ids
+    }
+
+    /// Every grant in the room, sorted by `(deputizer, deputy)` id.
+    pub fn all_grants(&self) -> Vec<DeputyGrant> {
+        let mut grants = Vec::new();
+        for deputizer in self.deputizer_candidates() {
+            for deputy in self.deputies_of(deputizer) {
+                grants.push(self.grant(deputizer, deputy));
+            }
+        }
+        grants.sort_by(|a, b| {
+            (&a.deputizer.member_id, &a.deputy.member_id)
+                .cmp(&(&b.deputizer.member_id, &b.deputy.member_id))
+        });
+        grants
+    }
+
+    /// `deputy -> [deputizer, …]` for every grant in the room, for annotating a
+    /// full member listing without an O(members²) rescan.
+    pub fn deputizers_by_deputy(&self) -> HashMap<MemberId, Vec<MemberId>> {
+        let mut map: HashMap<MemberId, Vec<MemberId>> = HashMap::new();
+        for deputizer in self.deputizer_candidates() {
+            for deputy in self.deputies_of(deputizer) {
+                map.entry(deputy).or_default().push(deputizer);
+            }
+        }
+        for deputizers in map.values_mut() {
+            deputizers.sort_by_key(|id| id.to_string());
+        }
+        map
+    }
+}
+
+/// Render a party as `Nickname (SHORTID)`, or `(unknown) (SHORTID)` when they
+/// have no `member_info` record in this room.
+pub fn party_label(party: &DeputyParty) -> String {
+    match &party.nickname {
+        Some(nickname) => format!("{} ({})", nickname, party.member_id),
+        None => format!("(unknown) ({})", party.member_id),
+    }
+}
+
+/// One-line explanation of what a grant currently confers, for human output.
+///
+/// Names the DEPUTIZER rather than leaning on the surrounding row, because the
+/// ambiguity this command exists to remove is exactly "a deputy of whom?". The
+/// deputy is left implicit: every call site already prints them, either as the
+/// row label or via the `deputizer -> deputy` arrow in `debug room-state`.
+pub fn grant_status_line(grant: &DeputyGrant) -> String {
+    if !grant.active {
+        let absent = if !grant.deputy.in_room {
+            &grant.deputy
+        } else {
+            &grant.deputizer
+        };
+        return format!(
+            "inactive: {} is not currently in this room",
+            party_label(absent)
+        );
+    }
+    match grant.scope {
+        DeputyScope::RoomWide => {
+            "active: may ban room-wide (granted by the room owner)".to_string()
+        }
+        DeputyScope::InviteSubtree => format!(
+            "active: may ban within {}'s invite subtree",
+            party_label(&grant.deputizer)
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use river_core::room_state::member::{AuthorizedMember, Member};
+    use river_core::room_state::member_info::{AuthorizedMemberInfo, MemberInfo};
+
+    /// The cli crate's dalek build does not enable the `rand` `generate`
+    /// helper, so keys come from fixed seeds (mirrors `api.rs`'s cli tests).
+    fn key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    fn id(sk: &SigningKey) -> MemberId {
+        sk.verifying_key().into()
+    }
+
+    /// A room where `owner` owns it and every listed key is a current member
+    /// invited directly by the owner.
+    fn room(owner: &SigningKey, members: &[&SigningKey]) -> ChatRoomStateV1 {
+        let mut state = ChatRoomStateV1::default();
+        for sk in members {
+            let member = Member {
+                owner_member_id: id(owner),
+                invited_by: id(owner),
+                member_vk: sk.verifying_key(),
+            };
+            state
+                .members
+                .members
+                .push(AuthorizedMember::new(member, owner));
+        }
+        state
+    }
+
+    /// Push a signed `member_info` record for `sk` at `version` with `deputies`.
+    fn push_info(
+        state: &mut ChatRoomStateV1,
+        sk: &SigningKey,
+        version: u32,
+        nickname: &str,
+        deputies: Vec<MemberId>,
+    ) {
+        let mut info = MemberInfo::new_public(id(sk), version, nickname.to_string());
+        info.deputies = deputies;
+        state
+            .member_info
+            .member_info
+            .push(AuthorizedMemberInfo::new_with_member_key(info, sk));
+    }
+
+    fn no_secrets() -> HashMap<u32, [u8; 32]> {
+        HashMap::new()
+    }
+
+    #[test]
+    fn forward_and_reverse_lookup_agree_on_a_grant() {
+        let owner = key(1);
+        let alice = key(2);
+        let bob = key(3);
+        let mut state = room(&owner, &[&alice, &bob]);
+        push_info(&mut state, &owner, 0, "Room Owner", vec![]);
+        push_info(&mut state, &alice, 0, "Alice", vec![id(&bob)]);
+        push_info(&mut state, &bob, 0, "Bob", vec![]);
+
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        assert_eq!(d.deputies_of(id(&alice)), vec![id(&bob)]);
+        assert_eq!(d.deputizers_of(id(&bob)), vec![id(&alice)]);
+
+        // The reverse direction is NOT symmetric: Bob deputized nobody.
+        assert!(d.deputies_of(id(&bob)).is_empty());
+        assert!(d.deputizers_of(id(&alice)).is_empty());
+    }
+
+    #[test]
+    fn reverse_lookup_finds_every_deputizer_of_one_member() {
+        // Ian's use case: "is this member a deputy of anyone — the owner, the
+        // invite bot, …?" Two independent members deputize the same target.
+        let owner = key(1);
+        let alice = key(2);
+        let bot = key(3);
+        let mut state = room(&owner, &[&alice, &bot]);
+        push_info(&mut state, &owner, 0, "Room Owner", vec![id(&bot)]);
+        push_info(&mut state, &alice, 0, "Alice", vec![id(&bot)]);
+        push_info(&mut state, &bot, 0, "Invite Bot", vec![]);
+
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        let mut expected = vec![id(&owner), id(&alice)];
+        expected.sort_by_key(|i| i.to_string());
+        assert_eq!(d.deputizers_of(id(&bot)), expected);
+
+        // The owner's grant is room-wide; a regular member's is subtree-scoped.
+        let owner_grant = d.grant(id(&owner), id(&bot));
+        assert_eq!(owner_grant.scope, DeputyScope::RoomWide);
+        assert!(owner_grant.active);
+        assert!(owner_grant.deputizer.is_owner);
+        assert!(
+            owner_grant.deputizer.in_room,
+            "the owner is never in members.members but is always in the room"
+        );
+
+        let alice_grant = d.grant(id(&alice), id(&bot));
+        assert_eq!(alice_grant.scope, DeputyScope::InviteSubtree);
+        assert!(alice_grant.active);
+        assert!(!alice_grant.deputizer.is_owner);
+    }
+
+    #[test]
+    fn empty_deputies_reports_nothing_in_either_direction() {
+        let owner = key(1);
+        let alice = key(2);
+        let mut state = room(&owner, &[&alice]);
+        push_info(&mut state, &owner, 0, "Room Owner", vec![]);
+        push_info(&mut state, &alice, 0, "Alice", vec![]);
+
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        assert!(d.deputies_of(id(&alice)).is_empty());
+        assert!(d.deputizers_of(id(&alice)).is_empty());
+        assert!(d.all_grants().is_empty());
+        assert!(d.deputizers_by_deputy().is_empty());
+    }
+
+    #[test]
+    fn member_with_no_member_info_record_has_no_deputies() {
+        // A member present in `members` but with no `member_info` entry: the
+        // lookup must return empty rather than panicking or inventing a grant.
+        let owner = key(1);
+        let alice = key(2);
+        let mut state = room(&owner, &[&alice]);
+        push_info(&mut state, &owner, 0, "Room Owner", vec![]);
+
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        assert!(d.deputies_of(id(&alice)).is_empty());
+        let party = d.party(id(&alice));
+        assert_eq!(party.nickname, None, "no member_info → no nickname");
+        assert!(party.in_room, "still a current member");
+    }
+
+    #[test]
+    fn resolve_short_id_matches_case_insensitively_and_rejects_unknown() {
+        let owner = key(1);
+        let alice = key(2);
+        let mut state = room(&owner, &[&alice]);
+        push_info(&mut state, &owner, 0, "Room Owner", vec![]);
+        push_info(&mut state, &alice, 0, "Alice", vec![]);
+
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        let alice_id = id(&alice).to_string();
+        assert_eq!(d.resolve_short_id(&alice_id), Ok(id(&alice)));
+        assert_eq!(
+            d.resolve_short_id(&alice_id.to_lowercase()),
+            Ok(id(&alice)),
+            "member ids are printed uppercase base32; accept a lowercased copy"
+        );
+
+        // A member id that is in no room list at all.
+        assert_eq!(
+            d.resolve_short_id("ZZZZZZZZ"),
+            Err(ResolveError::NotFound),
+            "an id belonging to no member must not resolve"
+        );
+        assert_eq!(d.resolve_short_id(""), Err(ResolveError::NotFound));
+    }
+
+    #[test]
+    fn resolve_short_id_reports_ambiguity_rather_than_guessing() {
+        // A one-character prefix will match several of the room's ids; the read
+        // path must refuse rather than pick whichever comes first in the vector.
+        let owner = key(1);
+        let members: Vec<SigningKey> = (2u8..12).map(key).collect();
+        let refs: Vec<&SigningKey> = members.iter().collect();
+        let mut state = room(&owner, &refs);
+        push_info(&mut state, &owner, 0, "Room Owner", vec![]);
+        for (n, sk) in members.iter().enumerate() {
+            push_info(&mut state, sk, 0, &format!("M{n}"), vec![]);
+        }
+
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        // Find a first character shared by at least two ids.
+        let mut by_first: HashMap<char, usize> = HashMap::new();
+        for sk in &members {
+            *by_first
+                .entry(id(sk).to_string().chars().next().unwrap())
+                .or_default() += 1;
+        }
+        let (shared, _) = by_first
+            .iter()
+            .find(|(_, count)| **count > 1)
+            .expect("10 ids over a 32-symbol alphabet must share a first character");
+
+        match d.resolve_short_id(&shared.to_string()) {
+            Err(ResolveError::Ambiguous(ids)) => assert!(ids.len() > 1),
+            other => panic!("expected an ambiguity error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reads_the_canonical_record_so_a_revoked_grant_is_not_reported() {
+        // `MemberInfoV1::verify` accepts duplicate records for one member, so a
+        // client can hold BOTH a grant (v1) and its revoke (v2). Reporting the
+        // losing record would tell the user a revoked deputy is still active.
+        let owner = key(1);
+        let alice = key(2);
+        let bob = key(3);
+        let mut state = room(&owner, &[&alice, &bob]);
+        push_info(&mut state, &owner, 0, "Room Owner", vec![]);
+        push_info(&mut state, &bob, 0, "Bob", vec![]);
+        // Grant @ v1, then revoke @ v2 — pushed in "wrong" order on purpose.
+        push_info(&mut state, &alice, 2, "Alice", vec![]);
+        push_info(&mut state, &alice, 1, "Alice", vec![id(&bob)]);
+
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        assert!(
+            d.deputies_of(id(&alice)).is_empty(),
+            "the v2 revoke is canonical; the v1 grant must not be reported"
+        );
+        assert!(
+            d.deputizers_of(id(&bob)).is_empty(),
+            "the reverse lookup must honour the same canonical record"
+        );
+        assert!(d.all_grants().is_empty());
+    }
+
+    #[test]
+    fn a_grant_naming_a_pruned_member_is_reported_but_marked_inactive() {
+        // A deputy pruned for inactivity keeps no `member_info` record but is
+        // still named by their deputizer's signed record. The contract honours
+        // deputy authority only for CURRENT members, so the grant is inert —
+        // surface it, but do not claim it confers anything.
+        let owner = key(1);
+        let alice = key(2);
+        let pruned = key(3);
+        let mut state = room(&owner, &[&alice]);
+        push_info(&mut state, &owner, 0, "Room Owner", vec![]);
+        push_info(&mut state, &alice, 0, "Alice", vec![id(&pruned)]);
+
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        assert_eq!(d.deputies_of(id(&alice)), vec![id(&pruned)]);
+        let grant = d.grant(id(&alice), id(&pruned));
+        assert!(!grant.active, "the deputy is no longer a member");
+        assert_eq!(grant.deputy.nickname, None);
+        assert!(!grant.deputy.in_room);
+
+        // The pruned id is still resolvable, so `deputized-by` can answer for
+        // it (mirroring the revoke path's own-deputies fallback).
+        assert_eq!(
+            d.resolve_short_id(&id(&pruned).to_string()),
+            Ok(id(&pruned))
+        );
+        assert_eq!(d.deputizers_of(id(&pruned)), vec![id(&alice)]);
+    }
+
+    #[test]
+    fn a_grant_from_a_pruned_deputizer_is_inactive() {
+        // Mirror image: the DEPUTIZER left the room. A non-owner deputizer must
+        // be a genuine invite ancestor of the ban target, which a non-member
+        // never is, so the grant confers nothing.
+        let owner = key(1);
+        let gone = key(2);
+        let bob = key(3);
+        let mut state = room(&owner, &[&bob]);
+        push_info(&mut state, &owner, 0, "Room Owner", vec![]);
+        push_info(&mut state, &gone, 0, "Gone", vec![id(&bob)]);
+        push_info(&mut state, &bob, 0, "Bob", vec![]);
+
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        let grant = d.grant(id(&gone), id(&bob));
+        assert!(!grant.active);
+        assert!(!grant.deputizer.in_room);
+        assert!(grant.deputy.in_room);
+    }
+
+    #[test]
+    fn all_grants_and_index_cover_every_grant_deterministically() {
+        let owner = key(1);
+        let alice = key(2);
+        let bob = key(3);
+        let carol = key(4);
+        let mut state = room(&owner, &[&alice, &bob, &carol]);
+        push_info(&mut state, &owner, 0, "Room Owner", vec![id(&carol)]);
+        push_info(&mut state, &alice, 0, "Alice", vec![id(&bob), id(&carol)]);
+        push_info(&mut state, &bob, 0, "Bob", vec![]);
+        push_info(&mut state, &carol, 0, "Carol", vec![]);
+
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        let grants = d.all_grants();
+        assert_eq!(grants.len(), 3);
+        let mut sorted = grants.clone();
+        sorted.sort_by(|a, b| {
+            (&a.deputizer.member_id, &a.deputy.member_id)
+                .cmp(&(&b.deputizer.member_id, &b.deputy.member_id))
+        });
+        assert_eq!(
+            grants, sorted,
+            "all_grants must be deterministically ordered"
+        );
+
+        let index = d.deputizers_by_deputy();
+        assert_eq!(index.get(&id(&bob)).unwrap(), &vec![id(&alice)]);
+        let mut carol_deputizers = vec![id(&owner), id(&alice)];
+        carol_deputizers.sort_by_key(|i| i.to_string());
+        assert_eq!(index.get(&id(&carol)).unwrap(), &carol_deputizers);
+        assert!(!index.contains_key(&id(&alice)));
+    }
+
+    #[test]
+    fn human_status_line_names_the_deputizer_not_a_bare_badge() {
+        // The UI's viewer-scoped shield badge is the confusion this command
+        // exists to avoid: every line must say WHOSE authority is in play.
+        let owner = key(1);
+        let alice = key(2);
+        let bob = key(3);
+        let mut state = room(&owner, &[&alice, &bob]);
+        push_info(&mut state, &owner, 0, "Room Owner", vec![]);
+        push_info(&mut state, &alice, 0, "Alice", vec![id(&bob)]);
+        push_info(&mut state, &bob, 0, "Bob", vec![]);
+
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        let line = grant_status_line(&d.grant(id(&alice), id(&bob)));
+        assert!(line.contains("Alice"), "must name the deputizer: {line}");
+        assert!(line.contains("invite subtree"), "must scope it: {line}");
+
+        let owner_line = grant_status_line(&d.grant(id(&owner), id(&bob)));
+        assert!(
+            owner_line.contains("room-wide"),
+            "an owner grant is room-wide: {owner_line}"
+        );
+
+        assert_eq!(
+            party_label(&d.party(id(&alice))),
+            format!("Alice ({})", id(&alice))
+        );
+    }
+}

--- a/cli/src/deputies.rs
+++ b/cli/src/deputies.rs
@@ -26,7 +26,7 @@
 //! state.
 
 use ed25519_dalek::VerifyingKey;
-use river_core::room_state::member::MemberId;
+use river_core::room_state::member::{AuthorizedMember, MemberId, MembersV1};
 use river_core::room_state::member_info::MemberInfoV1;
 use river_core::room_state::ChatRoomStateV1;
 use serde::Serialize;
@@ -129,6 +129,8 @@ pub struct RoomDeputies<'a> {
     /// `member -> the members they invited, directly or indirectly`, for every
     /// member with a non-empty subtree.
     subtrees: HashMap<MemberId, HashSet<MemberId>>,
+    /// Index required by `MembersV1::is_ban_authorized`, built once.
+    members_by_id: HashMap<MemberId, &'a AuthorizedMember>,
 }
 
 impl<'a> RoomDeputies<'a> {
@@ -182,6 +184,7 @@ impl<'a> RoomDeputies<'a> {
         }
 
         let subtrees = invite_subtrees(state);
+        let members_by_id = state.members.members_by_member_id();
 
         Self {
             state,
@@ -191,6 +194,7 @@ impl<'a> RoomDeputies<'a> {
             deputies_by_deputizer,
             known_ids,
             subtrees,
+            members_by_id,
         }
     }
 
@@ -267,30 +271,38 @@ impl<'a> RoomDeputies<'a> {
         }
     }
 
-    /// How many members a `deputizer -> deputy` grant can actually be used
-    /// against, per `MembersV1::is_ban_authorized`.
+    /// How many members within a grant's scope the deputy can actually ban.
     ///
-    /// The owner's grant is absolute (step 3, checked BEFORE the guardrail), so
-    /// it reaches every member. A non-owner's grant reaches only that member's
-    /// invite subtree (step 5), minus any subtree member who has themselves
-    /// deputized this deputy: step 4 denies a ban whose TARGET lists the banner
-    /// in their own `deputies`, so those members are not reachable.
+    /// Delegates the per-target decision to `MembersV1::is_ban_authorized`, the
+    /// contract's OWN public predicate, rather than re-deriving its rules here.
+    /// That matters: the rules do not compose the way a summary would suggest.
+    /// The "you cannot ban the member who deputized you" guardrail is step 4,
+    /// checked AFTER the absolute grants, so a target who deputized this deputy
+    /// is still bannable when the deputy is that target's own invite ancestor,
+    /// or is an owner-appointed global moderator. An earlier version of this
+    /// function approximated the guardrail by hand and undercounted both cases.
+    ///
+    /// Scope is the grant's: every member for an owner grant (whose subtree is
+    /// the room), otherwise the deputizer's invite subtree.
     fn reach_of(&self, deputizer: MemberId, deputy: MemberId) -> usize {
-        if deputizer == self.owner_id {
-            // The owner is never in `members.members`, and `is_ban_authorized`
-            // refuses `target == owner` outright, so the member list is already
-            // exactly the set of valid targets.
-            return self.current_members.len();
-        }
-        self.subtrees
-            .get(&deputizer)
-            .map(|subtree| {
-                subtree
-                    .iter()
-                    .filter(|target| !self.deputies_of(**target).contains(&deputy))
-                    .count()
+        let empty = HashSet::new();
+        let targets = if deputizer == self.owner_id {
+            &self.current_members
+        } else {
+            self.subtrees.get(&deputizer).unwrap_or(&empty)
+        };
+        targets
+            .iter()
+            .filter(|target| {
+                MembersV1::is_ban_authorized(
+                    deputy,
+                    **target,
+                    &self.members_by_id,
+                    self.member_info(),
+                    self.owner_id,
+                )
             })
-            .unwrap_or(0)
+            .count()
     }
 
     /// Build the resolved view of a single `deputizer -> deputy` grant.
@@ -381,8 +393,9 @@ impl<'a> RoomDeputies<'a> {
 /// `verify` having rejected circular invite chains, whereas this reads a fetched
 /// state directly and must not hang on a malformed one.
 ///
-/// The owner is excluded: they are never in `members.members`, and their reach
-/// is the whole room, handled separately.
+/// The owner gets an entry like anyone else (they are the `invited_by` of the
+/// members they invited), but [`RoomDeputies::reach_of`] does not consult it:
+/// an owner grant is scoped to the whole member list, not to a subtree.
 fn invite_subtrees(state: &ChatRoomStateV1) -> HashMap<MemberId, HashSet<MemberId>> {
     let mut children: HashMap<MemberId, Vec<MemberId>> = HashMap::new();
     for member in &state.members.members {
@@ -487,6 +500,10 @@ pub fn grant_status_line(grant: &DeputyGrant) -> String {
     match grant.scope {
         // `is_ban_authorized` refuses `target == owner` outright, so even an
         // owner-appointed deputy cannot ban the owner.
+        DeputyScope::RoomWide if grant.reaches_members == 1 => {
+            "active: may ban the only other member in the room (granted by the room owner)"
+                .to_string()
+        }
         DeputyScope::RoomWide => format!(
             "active: may ban any of the {} in the room (granted by the room owner)",
             members(grant.reaches_members)
@@ -1063,8 +1080,16 @@ mod tests {
         let bidi = "Eve\u{202e} rewonR mooR :fo ytuped";
         // 4. Zero-width characters can hide text inside an apparent name.
         let zero_width = "Ev\u{200b}e\u{feff}";
+        // 5. A carriage return rewrites the line in place; a tab fakes columns.
+        let carriage = "Eve\r  Admin (AAAAAAAA)";
+        let tabbed = "Eve\tAdmin";
+        // 6. The Zl/Zp separators are neither Cc nor Cf, and a terminal or log
+        //    viewer may still break a line on them.
+        let separators = "Eve\u{2028}Admin\u{2029}Mod";
 
-        for hostile in [newline, ansi, bidi, zero_width] {
+        for hostile in [
+            newline, ansi, bidi, zero_width, carriage, tabbed, separators,
+        ] {
             let mut state = room(&owner, &[&evil]);
             push_info(&mut state, &owner, 0, "Room Owner", vec![]);
             push_info(&mut state, &evil, 0, hostile, vec![]);
@@ -1074,7 +1099,8 @@ mod tests {
             let label = party_label(&d.party(id(&evil)));
 
             for forbidden in [
-                '\n', '\r', '\t', '\u{1b}', '\u{202e}', '\u{200b}', '\u{feff}',
+                '\n', '\r', '\t', '\u{1b}', '\u{202e}', '\u{200b}', '\u{feff}', '\u{2028}',
+                '\u{2029}',
             ] {
                 assert!(
                     !label.contains(forbidden),
@@ -1150,11 +1176,71 @@ mod tests {
             "Alice's subtree is {{target, other}}, but target deputized this \
              deputy so only `other` is reachable"
         );
+    }
 
-        // The owner's grant is absolute (step 3 precedes the guardrail), so the
-        // same guardrail must NOT reduce it.
+    #[test]
+    fn the_guardrail_does_not_apply_where_an_absolute_grant_already_does() {
+        // The guardrail is `is_ban_authorized` step 4, checked AFTER the
+        // absolute grants, so it must NOT be applied as a blanket exclusion.
+        // Two cases where a target who deputized the deputy is STILL bannable:
+        //
+        //   (a) the deputy is that target's own invite ancestor (step 2)
+        //   (b) the owner has appointed the deputy globally (step 3)
+        //
+        // Approximating step 4 by hand undercounted both. The reach now routes
+        // through the contract's own predicate, so it cannot drift from it.
+        let owner = key(1);
+        let alice = key(2);
+        let deputy = key(3);
+        let target = key(4);
+
+        // (a) owner -> alice -> deputy -> target, and alice deputizes deputy.
+        let mut state = ChatRoomStateV1::default();
+        push_member(&mut state, &owner, &owner, &alice);
+        push_member(&mut state, &owner, &alice, &deputy);
+        push_member(&mut state, &owner, &deputy, &target);
+        push_info(&mut state, &owner, 0, "Room Owner", vec![]);
+        push_info(&mut state, &alice, 0, "Alice", vec![id(&deputy)]);
+        push_info(&mut state, &deputy, 0, "Deputy", vec![]);
+        // The target deputized the deputy, which would trip a naive guardrail.
+        push_info(&mut state, &target, 0, "Target", vec![id(&deputy)]);
+
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+        assert_eq!(
+            d.grant(id(&alice), id(&deputy)).reaches_members,
+            2,
+            "Alice's subtree is {{deputy, target}}; the deputy is the target's \
+             own invite ancestor, so step 2 authorizes the ban despite the \
+             target having deputized them"
+        );
+
+        // (b) the same shape, but authority comes from the owner appointing the
+        //     deputy as a global moderator.
+        let mut state = ChatRoomStateV1::default();
+        push_member(&mut state, &owner, &owner, &alice);
+        push_member(&mut state, &owner, &alice, &target);
+        push_member(&mut state, &owner, &owner, &deputy);
+        push_info(&mut state, &owner, 0, "Room Owner", vec![id(&deputy)]);
+        push_info(&mut state, &alice, 0, "Alice", vec![id(&deputy)]);
+        push_info(&mut state, &deputy, 0, "Deputy", vec![]);
+        push_info(&mut state, &target, 0, "Target", vec![id(&deputy)]);
+
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+        assert_eq!(
+            d.grant(id(&alice), id(&deputy)).reaches_members,
+            1,
+            "Alice's subtree is {{target}}; the owner's global appointment is \
+             absolute (step 3), so the target's own grant cannot block it"
+        );
+
+        // The owner's own grant reaches every member.
         let owner_grant = d.grant(id(&owner), id(&deputy));
-        assert_eq!(owner_grant.reaches_members, 4, "every member is a target");
+        assert_eq!(owner_grant.scope, DeputyScope::RoomWide);
+        assert_eq!(
+            owner_grant.reaches_members, 3,
+            "alice + target + deputy; the owner is never a valid ban target"
+        );
     }
 
     #[test]
@@ -1230,6 +1316,59 @@ mod tests {
         let line = grant_status_line(&d.grant(id(&alice), id(&deputy)));
         assert!(line.contains("1 member in"), "{line}");
         assert!(!line.contains("member(s)"), "{line}");
+    }
+
+    #[test]
+    fn dedup_survives_two_distinct_ids_that_print_identically() {
+        // A `MemberId` prints as 8 base32 characters, which is only the first 5
+        // of its 8 underlying bytes, so distinct ids CAN print the same. Sorting
+        // by the printed form alone would not necessarily put equal ids
+        // adjacent, and `dedup` would then leave a duplicate behind. Constructed
+        // directly here because grinding a real 40-bit collision is not viable
+        // in a unit test.
+        use freenet_scaffold::util::FastHash;
+
+        // Little-endian: the low 5 bytes drive the printed form, so these two
+        // differ only in bytes the printed id never sees.
+        let twin_a = MemberId(FastHash(0x0000_0000_0000_0001));
+        let twin_b = MemberId(FastHash(0x0100_0000_0000_0001));
+        assert_ne!(twin_a, twin_b, "the two ids must be genuinely distinct");
+        assert_eq!(
+            twin_a.to_string(),
+            twin_b.to_string(),
+            "...but must print identically, or this test proves nothing"
+        );
+
+        // A third entry equal to the first: the duplicate `dedup` has to remove.
+        let mut ids = vec![twin_a, twin_b, twin_a];
+        ids.sort_by_key(|id| (id.to_string(), *id));
+        ids.dedup();
+        assert_eq!(
+            ids.len(),
+            2,
+            "the genuine duplicate must collapse while the twin survives"
+        );
+        assert!(ids.contains(&twin_a) && ids.contains(&twin_b));
+    }
+
+    #[test]
+    fn room_wide_status_reads_correctly_for_a_single_other_member() {
+        // The room-wide branch needed its own singular form: "may ban any of
+        // the 1 member in the room" is not English.
+        let owner = key(1);
+        let deputy = key(2);
+        let mut state = room(&owner, &[&deputy]);
+        push_info(&mut state, &owner, 0, "Room Owner", vec![id(&deputy)]);
+        push_info(&mut state, &deputy, 0, "Deputy", vec![]);
+
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        let grant = d.grant(id(&owner), id(&deputy));
+        assert_eq!(grant.reaches_members, 1);
+        let line = grant_status_line(&grant);
+        assert!(line.contains("the only other member"), "{line}");
+        assert!(!line.contains("1 member in the room"), "{line}");
     }
 
     #[test]

--- a/cli/src/deputies.rs
+++ b/cli/src/deputies.rs
@@ -66,15 +66,21 @@ pub struct DeputyGrant {
     pub deputizer: DeputyParty,
     pub deputy: DeputyParty,
     pub scope: DeputyScope,
-    /// How many members this grant currently reaches: the size of the
-    /// deputizer's invite subtree, or the whole member list for an owner grant.
+    /// How many members this grant can currently be used against.
     ///
-    /// This is what separates "the grant exists" from "the grant does anything".
-    /// Per `MembersV1::is_ban_authorized`, a non-owner deputizer's grant only
-    /// fires where that deputizer is a strict invite ancestor of the ban target,
-    /// so a deputizer who has invited nobody confers nothing even while
-    /// [`Self::active`] is true. Most members have invited nobody, so that is
-    /// the common case, not a corner.
+    /// This is what separates "the grant exists" from "the grant does anything",
+    /// and it is computed from `MembersV1::is_ban_authorized`'s actual rules:
+    ///
+    /// * `0` whenever [`Self::active`] is false, since the contract honours
+    ///   nothing in that case.
+    /// * For an owner grant, every member. That grant is absolute (step 3,
+    ///   checked before the guardrail), and the owner is never a valid target.
+    /// * Otherwise the deputizer's invite subtree (step 5), minus any member of
+    ///   it who has themselves deputized this deputy, since step 4 denies a ban
+    ///   whose target lists the banner in their own `deputies`.
+    ///
+    /// Frequently `0` for a live grant: most members have invited nobody, so a
+    /// grant from them reaches no one. That is the common case, not a corner.
     pub reaches_members: usize,
     /// Whether the grant is structurally live: both parties are currently in the
     /// room. The load-bearing half is the DEPUTY: `is_ban_authorized` gates both
@@ -120,9 +126,9 @@ pub struct RoomDeputies<'a> {
     deputies_by_deputizer: BTreeMap<MemberId, Vec<MemberId>>,
     /// Every id this room mentions anywhere (see [`Self::resolve_short_id`]).
     known_ids: BTreeSet<MemberId>,
-    /// `member -> number of members they invited, directly or indirectly`, for
-    /// every member with a non-empty subtree.
-    subtree_sizes: HashMap<MemberId, usize>,
+    /// `member -> the members they invited, directly or indirectly`, for every
+    /// member with a non-empty subtree.
+    subtrees: HashMap<MemberId, HashSet<MemberId>>,
 }
 
 impl<'a> RoomDeputies<'a> {
@@ -152,7 +158,11 @@ impl<'a> RoomDeputies<'a> {
         let mut deputies_by_deputizer: BTreeMap<MemberId, Vec<MemberId>> = BTreeMap::new();
         for deputizer in candidates {
             let mut ids: Vec<MemberId> = state.member_info.deputies_of(deputizer).to_vec();
-            ids.sort_by_key(|id| id.to_string());
+            // Sort by (printed id, id) rather than printed id alone: the printed
+            // form is 40 bits of a 64-bit hash, so two distinct ids CAN print
+            // the same, and under a printed-id-only sort they need not land
+            // adjacent, which would defeat `dedup`.
+            ids.sort_by_key(|id| (id.to_string(), *id));
             ids.dedup();
             deputies_by_deputizer.insert(deputizer, ids);
         }
@@ -171,7 +181,7 @@ impl<'a> RoomDeputies<'a> {
             known_ids.extend(deputies.iter().copied());
         }
 
-        let subtree_sizes = invite_subtree_sizes(state);
+        let subtrees = invite_subtrees(state);
 
         Self {
             state,
@@ -180,7 +190,7 @@ impl<'a> RoomDeputies<'a> {
             current_members,
             deputies_by_deputizer,
             known_ids,
-            subtree_sizes,
+            subtrees,
         }
     }
 
@@ -240,12 +250,14 @@ impl<'a> RoomDeputies<'a> {
     }
 
     /// Resolve one member for display.
+    ///
+    /// `nickname` is the FAITHFUL decoded value, not an escaped one: it is
+    /// serialized into `-f json`, where a relay or bridge needs the real string
+    /// and JSON escaping already makes it safe. Escaping happens at the terminal
+    /// print sites ([`party_label`] / [`display_nickname`]).
     pub fn party(&self, id: MemberId) -> DeputyParty {
         let nickname = self.member_info().canonical(id).map(|info| {
-            sanitize_for_terminal(&crate::api::unseal_nickname_display(
-                &info.member_info.preferred_nickname,
-                self.secrets,
-            ))
+            crate::api::unseal_nickname_display(&info.member_info.preferred_nickname, self.secrets)
         });
         DeputyParty {
             member_id: id.to_string(),
@@ -255,26 +267,50 @@ impl<'a> RoomDeputies<'a> {
         }
     }
 
-    /// How many members `id`'s grants reach: everyone for the owner, otherwise
-    /// the size of `id`'s invite subtree.
-    fn reach_of(&self, id: MemberId) -> usize {
-        if id == self.owner_id {
-            self.current_members.len()
-        } else {
-            self.subtree_sizes.get(&id).copied().unwrap_or(0)
+    /// How many members a `deputizer -> deputy` grant can actually be used
+    /// against, per `MembersV1::is_ban_authorized`.
+    ///
+    /// The owner's grant is absolute (step 3, checked BEFORE the guardrail), so
+    /// it reaches every member. A non-owner's grant reaches only that member's
+    /// invite subtree (step 5), minus any subtree member who has themselves
+    /// deputized this deputy: step 4 denies a ban whose TARGET lists the banner
+    /// in their own `deputies`, so those members are not reachable.
+    fn reach_of(&self, deputizer: MemberId, deputy: MemberId) -> usize {
+        if deputizer == self.owner_id {
+            // The owner is never in `members.members`, and `is_ban_authorized`
+            // refuses `target == owner` outright, so the member list is already
+            // exactly the set of valid targets.
+            return self.current_members.len();
         }
+        self.subtrees
+            .get(&deputizer)
+            .map(|subtree| {
+                subtree
+                    .iter()
+                    .filter(|target| !self.deputies_of(**target).contains(&deputy))
+                    .count()
+            })
+            .unwrap_or(0)
     }
 
     /// Build the resolved view of a single `deputizer -> deputy` grant.
     pub fn grant(&self, deputizer: MemberId, deputy: MemberId) -> DeputyGrant {
+        let active = self.in_room(deputizer) && self.in_room(deputy);
         DeputyGrant {
             scope: if deputizer == self.owner_id {
                 DeputyScope::RoomWide
             } else {
                 DeputyScope::InviteSubtree
             },
-            active: self.in_room(deputizer) && self.in_room(deputy),
-            reaches_members: self.reach_of(deputizer),
+            // Zero when the grant is inert, so a script filtering
+            // `reaches_members > 0` for real moderation authority cannot get a
+            // false positive from a grant the contract would refuse outright.
+            reaches_members: if active {
+                self.reach_of(deputizer, deputy)
+            } else {
+                0
+            },
+            active,
             deputizer: self.party(deputizer),
             deputy: self.party(deputy),
         }
@@ -335,15 +371,19 @@ impl<'a> RoomDeputies<'a> {
     }
 }
 
-/// `member -> number of members they invited, directly or indirectly`, for every
+/// `member -> the members they invited, directly or indirectly`, for every
 /// member with a non-empty invite subtree.
 ///
-/// Mirrors the traversal `MembersV1::get_downstream_members` performs (which is
-/// private to the contract crate), including its visited-set cycle guard, so the
-/// reach reported here matches the subtree `is_ban_authorized` grants authority
-/// over. The owner is excluded: they are never in `members.members`, and their
-/// reach is the whole room, handled separately.
-fn invite_subtree_sizes(state: &ChatRoomStateV1) -> HashMap<MemberId, usize> {
+/// Computes the same set `MembersV1::get_downstream_members` does (which is
+/// private to the contract crate), so the reach reported here matches the
+/// subtree `is_ban_authorized` grants authority over. It additionally carries a
+/// visited-set guard that the contract's version omits: the contract can rely on
+/// `verify` having rejected circular invite chains, whereas this reads a fetched
+/// state directly and must not hang on a malformed one.
+///
+/// The owner is excluded: they are never in `members.members`, and their reach
+/// is the whole room, handled separately.
+fn invite_subtrees(state: &ChatRoomStateV1) -> HashMap<MemberId, HashSet<MemberId>> {
     let mut children: HashMap<MemberId, Vec<MemberId>> = HashMap::new();
     for member in &state.members.members {
         children
@@ -352,50 +392,67 @@ fn invite_subtree_sizes(state: &ChatRoomStateV1) -> HashMap<MemberId, usize> {
             .push(member.member.id());
     }
 
-    let mut sizes = HashMap::new();
+    let mut subtrees = HashMap::new();
     for root in children.keys().copied() {
         let mut seen: HashSet<MemberId> = HashSet::new();
         let mut stack = vec![root];
         while let Some(current) = stack.pop() {
             for child in children.get(&current).into_iter().flatten() {
-                // A self-invite or an invite cycle would otherwise loop forever;
-                // `seen` also stops a descendant from being counted twice.
+                // `*child != root` keeps a member out of their own subtree (a
+                // strict-ancestor relation, matching `is_ban_authorized`), and
+                // `seen.insert` gates the push so a cycle terminates.
                 if *child != root && seen.insert(*child) {
                     stack.push(*child);
                 }
             }
         }
         if !seen.is_empty() {
-            sizes.insert(root, seen.len());
+            subtrees.insert(root, seen);
         }
     }
-    sizes
+    subtrees
 }
 
-/// Strip C0 control characters from a nickname before it is printed.
+/// Render a nickname for TERMINAL output: quoted, with every non-printable
+/// character escaped to a visible `\u{…}` form.
 ///
 /// Nicknames are attacker-controlled and `unseal_nickname_display` is a lossy
-/// UTF-8 decode with no filtering, so an embedded newline or ANSI escape could
-/// forge an extra output row. That was cosmetic before deputy status was
-/// printed; now a forged row would claim moderation authority, so filter it.
-fn sanitize_for_terminal(raw: &str) -> String {
-    raw.chars()
-        .map(|c| {
-            if c.is_control() && c != '\t' {
-                char::REPLACEMENT_CHARACTER
-            } else {
-                c
-            }
-        })
-        .collect()
+/// UTF-8 decode with no filtering. Unescaped, a nickname could forge an entire
+/// output row: a newline starts one, and a bidi override (U+202E) reverses the
+/// rest of the line including the member id and the deputy annotation. That was
+/// cosmetic before deputy status was printed; a forged row now claims moderation
+/// authority. The quotes matter independently of escaping, because a nickname of
+/// purely printable characters like `Bob (AAAAAAAA)  deputy of: Room Owner`
+/// otherwise renders as a plausible second row, and `colored` drops the colour
+/// that would distinguish it as soon as output is piped.
+///
+/// `str`'s `Debug` is the escape used deliberately: it covers control (Cc),
+/// format (Cf, which is where the bidi overrides and zero-width joiners live)
+/// and separator (Zl/Zp) characters via the standard library's own printability
+/// table, rather than a hand-maintained range list that would silently miss a
+/// category. It escapes `"` and `\` but leaves `'` alone, so ordinary names read
+/// normally.
+pub fn display_nickname(nickname: &str) -> String {
+    format!("{:?}", nickname)
 }
 
-/// Render a party as `Nickname (SHORTID)`, or `(unknown) (SHORTID)` when they
-/// have no `member_info` record in this room.
+/// Render a party as `"Nickname" (SHORTID)`, or `(unknown) (SHORTID)` when they
+/// have no `member_info` record in this room. The nickname is escaped and quoted
+/// by [`display_nickname`]; `(unknown)` is unquoted precisely so it cannot be
+/// confused with a member whose nickname is literally `unknown`.
 pub fn party_label(party: &DeputyParty) -> String {
     match &party.nickname {
-        Some(nickname) => format!("{} ({})", nickname, party.member_id),
+        Some(nickname) => format!("{} ({})", display_nickname(nickname), party.member_id),
         None => format!("(unknown) ({})", party.member_id),
+    }
+}
+
+/// `"1 member"` / `"N members"`.
+fn members(count: usize) -> String {
+    if count == 1 {
+        "1 member".to_string()
+    } else {
+        format!("{count} members")
     }
 }
 
@@ -411,31 +468,37 @@ pub fn party_label(party: &DeputyParty) -> String {
 /// old "may ban within X's invite subtree" phrasing overstated.
 pub fn grant_status_line(grant: &DeputyGrant) -> String {
     if !grant.active {
-        let absent = if !grant.deputy.in_room {
-            &grant.deputy
-        } else {
-            &grant.deputizer
+        return match (grant.deputizer.in_room, grant.deputy.in_room) {
+            (false, false) => format!(
+                "inactive: neither {} nor {} is currently in this room",
+                party_label(&grant.deputizer),
+                party_label(&grant.deputy)
+            ),
+            (_, false) => format!(
+                "inactive: {} is not currently in this room",
+                party_label(&grant.deputy)
+            ),
+            _ => format!(
+                "inactive: {} is not currently in this room",
+                party_label(&grant.deputizer)
+            ),
         };
-        return format!(
-            "inactive: {} is not currently in this room",
-            party_label(absent)
-        );
     }
     match grant.scope {
         // `is_ban_authorized` refuses `target == owner` outright, so even an
         // owner-appointed deputy cannot ban the owner.
         DeputyScope::RoomWide => format!(
-            "active: may ban any of the {} member(s) in the room (granted by the room owner)",
-            grant.reaches_members
+            "active: may ban any of the {} in the room (granted by the room owner)",
+            members(grant.reaches_members)
         ),
         DeputyScope::InviteSubtree if grant.reaches_members == 0 => format!(
-            "active but reaches no one: {} has invited nobody, so this grant currently \
-             confers no ban authority",
+            "active but reaches no one: there is currently nobody in {}'s invite \
+             subtree that this deputy may ban",
             party_label(&grant.deputizer)
         ),
         DeputyScope::InviteSubtree => format!(
-            "active: may ban the {} member(s) {} invited, directly or indirectly",
-            grant.reaches_members,
+            "active: may ban {} in {}'s invite subtree",
+            members(grant.reaches_members),
             party_label(&grant.deputizer)
         ),
     }
@@ -869,7 +932,7 @@ mod tests {
         assert!(from_alice.active);
         assert_eq!(from_alice.reaches_members, 2);
         let line = grant_status_line(&from_alice);
-        assert!(line.contains("2 member(s)"), "{line}");
+        assert!(line.contains("2 members"), "{line}");
         assert!(line.contains("Alice"), "must name the deputizer: {line}");
 
         // Bob invited nobody, so his grant is live but reaches no one. This
@@ -885,10 +948,20 @@ mod tests {
         assert!(bob_line.contains("Bob"), "{bob_line}");
     }
 
+    /// Sizes of every invite subtree, for the tests that only care about counts.
+    fn subtree_sizes(state: &ChatRoomStateV1) -> HashMap<MemberId, usize> {
+        invite_subtrees(state)
+            .into_iter()
+            .map(|(k, v)| (k, v.len()))
+            .collect()
+    }
+
     #[test]
-    fn invite_subtree_sizes_survives_a_cycle_and_a_self_invite() {
-        // `get_downstream_members` carries a visited-set cycle guard; the CLI
-        // mirror must too, or a malformed invite graph hangs the command.
+    fn invite_subtrees_survives_a_cycle_and_a_self_invite() {
+        // The contract's own `get_downstream_members` has NO visited guard (it
+        // relies on `verify` rejecting circular invite chains). This mirror
+        // reads a fetched state directly, so it must not hang on a malformed
+        // one.
         let owner = key(1);
         let alice = key(2);
         let bob = key(3);
@@ -900,7 +973,7 @@ mod tests {
         // descendant). `AuthorizedMember::new` would assert, so build it raw.
         state.members.members[0].member.invited_by = id(&bob);
 
-        let sizes = invite_subtree_sizes(&state);
+        let sizes = subtree_sizes(&state);
         assert_eq!(sizes.get(&id(&alice)).copied().unwrap_or(0), 1);
         assert_eq!(sizes.get(&id(&bob)).copied().unwrap_or(0), 1);
 
@@ -910,9 +983,28 @@ mod tests {
         push_member(&mut selfie, &owner, &owner, &alice);
         selfie.members.members[0].member.invited_by = id(&alice);
         assert_eq!(
-            invite_subtree_sizes(&selfie).get(&id(&alice)).copied(),
+            subtree_sizes(&selfie).get(&id(&alice)).copied(),
             None,
             "self-invite is not a subtree"
+        );
+
+        // A deep chain: each ancestor counts every descendant below them.
+        let carol = key(4);
+        let dave = key(5);
+        let mut chain = ChatRoomStateV1::default();
+        push_member(&mut chain, &owner, &owner, &alice);
+        push_member(&mut chain, &owner, &alice, &bob);
+        push_member(&mut chain, &owner, &bob, &carol);
+        push_member(&mut chain, &owner, &carol, &dave);
+        let sizes = subtree_sizes(&chain);
+        assert_eq!(sizes.get(&id(&alice)).copied(), Some(3));
+        assert_eq!(sizes.get(&id(&bob)).copied(), Some(2));
+        assert_eq!(sizes.get(&id(&carol)).copied(), Some(1));
+        assert_eq!(sizes.get(&id(&dave)).copied(), None);
+        assert_eq!(
+            sizes.get(&id(&owner)).copied(),
+            Some(4),
+            "the owner's own entry counts the whole chain"
         );
     }
 
@@ -935,7 +1027,7 @@ mod tests {
 
         let line = grant_status_line(&d.grant(id(&alice), id(&bob)));
         assert!(line.contains("Alice"), "must name the deputizer: {line}");
-        assert!(line.contains("invited"), "must scope it: {line}");
+        assert!(line.contains("invite subtree"), "must scope it: {line}");
 
         let owner_line = grant_status_line(&d.grant(id(&owner), id(&bob)));
         assert!(
@@ -945,7 +1037,7 @@ mod tests {
 
         assert_eq!(
             party_label(&d.party(id(&alice))),
-            format!("Alice ({})", id(&alice))
+            format!("\"Alice\" ({})", id(&alice))
         );
         assert_eq!(
             party_label(&d.party(id(&key(9)))),
@@ -957,32 +1049,187 @@ mod tests {
     #[test]
     fn a_hostile_nickname_cannot_forge_an_extra_output_row() {
         // Nicknames are attacker-controlled and printed next to an authority
-        // claim, so an embedded newline must not produce a second line that
-        // looks like a real grant.
+        // claim. Three separate forgery vectors must all be neutralised.
         let owner = key(1);
         let evil = key(2);
-        let mut state = room(&owner, &[&evil]);
+
+        // 1. A newline starts a second line that reads as a real row.
+        let newline = "Eve\n  Admin (AAAAAAAA)  deputy of: Room Owner";
+        // 2. An ANSI escape can repaint or erase what follows.
+        let ansi = "Eve\u{1b}[2K\u{1b}[31mAdmin";
+        // 3. A bidi override reverses the rendering of the REST of the line,
+        //    including the member id and the deputy annotation (Trojan Source).
+        //    U+202E is category Cf, which `char::is_control()` does NOT cover.
+        let bidi = "Eve\u{202e} rewonR mooR :fo ytuped";
+        // 4. Zero-width characters can hide text inside an apparent name.
+        let zero_width = "Ev\u{200b}e\u{feff}";
+
+        for hostile in [newline, ansi, bidi, zero_width] {
+            let mut state = room(&owner, &[&evil]);
+            push_info(&mut state, &owner, 0, "Room Owner", vec![]);
+            push_info(&mut state, &evil, 0, hostile, vec![]);
+
+            let secrets = no_secrets();
+            let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+            let label = party_label(&d.party(id(&evil)));
+
+            for forbidden in [
+                '\n', '\r', '\t', '\u{1b}', '\u{202e}', '\u{200b}', '\u{feff}',
+            ] {
+                assert!(
+                    !label.contains(forbidden),
+                    "{forbidden:?} must not survive into terminal output: {label:?}"
+                );
+            }
+            assert!(
+                label.starts_with('"'),
+                "the nickname must be quoted so it cannot be mistaken for \
+                 surrounding structure: {label:?}"
+            );
+            assert!(
+                label.ends_with(&format!("({})", id(&evil))),
+                "the real member id must still terminate the label: {label:?}"
+            );
+
+            // The JSON side keeps the faithful value: JSON escaping already
+            // makes it safe, and a bridge relaying nicknames needs the real
+            // string rather than a mangled one.
+            assert_eq!(
+                d.party(id(&evil)).nickname.as_deref(),
+                Some(hostile),
+                "DeputyParty.nickname must not be lossily rewritten"
+            );
+        }
+
+        // A nickname of purely PRINTABLE characters can forge a row too, which
+        // escaping alone does not stop; the quotes are what close that hole.
+        let plausible = "Bob (AAAAAAAA)  deputy of: Room Owner";
+        assert_eq!(
+            display_nickname(plausible),
+            format!("\"{plausible}\""),
+            "a printable forgery attempt must be visibly delimited"
+        );
+
+        // Ordinary names are untouched apart from the quotes.
+        assert_eq!(display_nickname("Ian Clarke"), "\"Ian Clarke\"");
+        assert_eq!(display_nickname("O'Brien"), "\"O'Brien\"");
+        assert_eq!(display_nickname("emoji \u{1f600}"), "\"emoji \u{1f600}\"");
+    }
+
+    #[test]
+    fn reach_excludes_subtree_members_who_deputized_this_deputy() {
+        // `is_ban_authorized` step 4 denies a ban whose TARGET lists the banner
+        // in their own deputies ("you cannot ban the member who deputized
+        // you"). Those subtree members are not reachable, so counting them
+        // would overstate the authority the grant confers.
+        let owner = key(1);
+        let alice = key(2);
+        let target = key(3);
+        let other = key(4);
+        let deputy = key(5);
+
+        let mut state = ChatRoomStateV1::default();
+        push_member(&mut state, &owner, &owner, &alice);
+        push_member(&mut state, &owner, &alice, &target);
+        push_member(&mut state, &owner, &alice, &other);
+        push_member(&mut state, &owner, &owner, &deputy);
+
+        push_info(&mut state, &owner, 0, "Room Owner", vec![]);
+        push_info(&mut state, &alice, 0, "Alice", vec![id(&deputy)]);
+        // `target` has ALSO deputized `deputy`, so `deputy` cannot ban them.
+        push_info(&mut state, &target, 0, "Target", vec![id(&deputy)]);
+        push_info(&mut state, &other, 0, "Other", vec![]);
+        push_info(&mut state, &deputy, 0, "Deputy", vec![]);
+
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        let grant = d.grant(id(&alice), id(&deputy));
+        assert_eq!(
+            grant.reaches_members, 1,
+            "Alice's subtree is {{target, other}}, but target deputized this \
+             deputy so only `other` is reachable"
+        );
+
+        // The owner's grant is absolute (step 3 precedes the guardrail), so the
+        // same guardrail must NOT reduce it.
+        let owner_grant = d.grant(id(&owner), id(&deputy));
+        assert_eq!(owner_grant.reaches_members, 4, "every member is a target");
+    }
+
+    #[test]
+    fn an_inactive_grant_reaches_nobody() {
+        // A script filtering `reaches_members > 0` for real moderation
+        // authority must not get a false positive from a grant the contract
+        // would refuse outright.
+        let owner = key(1);
+        let alice = key(2);
+        let child = key(3);
+        let pruned = key(4);
+
+        let mut state = ChatRoomStateV1::default();
+        push_member(&mut state, &owner, &owner, &alice);
+        push_member(&mut state, &owner, &alice, &child);
+        push_info(&mut state, &owner, 0, "Room Owner", vec![]);
+        push_info(&mut state, &alice, 0, "Alice", vec![id(&pruned)]);
+        push_info(&mut state, &child, 0, "Child", vec![]);
+
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        let grant = d.grant(id(&alice), id(&pruned));
+        assert!(!grant.active, "the deputy has left the room");
+        assert_eq!(
+            grant.reaches_members, 0,
+            "Alice has a real subtree, but this grant confers nothing"
+        );
+    }
+
+    #[test]
+    fn inactive_line_names_both_parties_when_both_are_absent() {
+        let owner = key(1);
+        let gone_deputizer = key(2);
+        let gone_deputy = key(3);
+        let mut state = ChatRoomStateV1::default();
         push_info(&mut state, &owner, 0, "Room Owner", vec![]);
         push_info(
             &mut state,
-            &evil,
+            &gone_deputizer,
             0,
-            "Eve\n  Admin (AAAAAAAA)  deputy of: Room Owner",
-            vec![],
+            "Gone",
+            vec![id(&gone_deputy)],
         );
 
         let secrets = no_secrets();
         let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
 
-        let label = party_label(&d.party(id(&evil)));
-        assert!(!label.contains('\n'), "newline must be stripped: {label:?}");
-        assert!(!label.contains('\r'));
-        assert!(!label.contains('\u{1b}'), "ANSI escapes must be stripped");
-        assert!(label.starts_with("Eve"), "the readable part survives");
+        let line = grant_status_line(&d.grant(id(&gone_deputizer), id(&gone_deputy)));
+        assert!(line.starts_with("inactive: neither"), "{line}");
+        assert!(line.contains(&id(&gone_deputizer).to_string()), "{line}");
+        assert!(line.contains(&id(&gone_deputy).to_string()), "{line}");
+    }
 
-        assert_eq!(sanitize_for_terminal("plain"), "plain");
-        assert_eq!(sanitize_for_terminal("keep\ttab"), "keep\ttab");
-        assert_eq!(sanitize_for_terminal("emoji \u{1f600}"), "emoji \u{1f600}");
+    #[test]
+    fn status_line_uses_singular_for_a_reach_of_one() {
+        let owner = key(1);
+        let alice = key(2);
+        let child = key(3);
+        let deputy = key(4);
+        let mut state = ChatRoomStateV1::default();
+        push_member(&mut state, &owner, &owner, &alice);
+        push_member(&mut state, &owner, &alice, &child);
+        push_member(&mut state, &owner, &owner, &deputy);
+        push_info(&mut state, &owner, 0, "Room Owner", vec![]);
+        push_info(&mut state, &alice, 0, "Alice", vec![id(&deputy)]);
+        push_info(&mut state, &child, 0, "Child", vec![]);
+        push_info(&mut state, &deputy, 0, "Deputy", vec![]);
+
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        let line = grant_status_line(&d.grant(id(&alice), id(&deputy)));
+        assert!(line.contains("1 member in"), "{line}");
+        assert!(!line.contains("member(s)"), "{line}");
     }
 
     #[test]

--- a/cli/src/deputies.rs
+++ b/cli/src/deputies.rs
@@ -30,7 +30,7 @@ use river_core::room_state::member::MemberId;
 use river_core::room_state::member_info::MemberInfoV1;
 use river_core::room_state::ChatRoomStateV1;
 use serde::Serialize;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 /// One party of a deputy grant, resolved for display.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -66,13 +66,26 @@ pub struct DeputyGrant {
     pub deputizer: DeputyParty,
     pub deputy: DeputyParty,
     pub scope: DeputyScope,
-    /// Whether the grant is not structurally inert: both parties are currently
-    /// in the room. The contract only honours deputy authority when the deputy
-    /// is a current member, and a non-owner deputizer must be a genuine invite
-    /// ancestor of the ban target — so a grant naming a pruned member on either
-    /// side confers nothing. `true` does NOT mean the deputy can ban any given
-    /// person: a non-owner deputizer's authority is still limited to their own
-    /// invite subtree, which may be empty.
+    /// How many members this grant currently reaches: the size of the
+    /// deputizer's invite subtree, or the whole member list for an owner grant.
+    ///
+    /// This is what separates "the grant exists" from "the grant does anything".
+    /// Per `MembersV1::is_ban_authorized`, a non-owner deputizer's grant only
+    /// fires where that deputizer is a strict invite ancestor of the ban target,
+    /// so a deputizer who has invited nobody confers nothing even while
+    /// [`Self::active`] is true. Most members have invited nobody, so that is
+    /// the common case, not a corner.
+    pub reaches_members: usize,
+    /// Whether the grant is structurally live: both parties are currently in the
+    /// room. The load-bearing half is the DEPUTY: `is_ban_authorized` gates both
+    /// deputy branches on the banner being a current member, so a grant naming a
+    /// pruned deputy is honoured by nobody. The deputizer half is
+    /// defence-in-depth: `MemberInfoV1::verify` rejects a `member_info` record
+    /// whose member is neither the owner nor a current member, so a deputizer
+    /// absent from the room cannot occur in a state the contract accepted.
+    ///
+    /// `active` does NOT mean the deputy can ban a given person; see
+    /// [`Self::reaches_members`] and [`Self::scope`] for how far it goes.
     pub active: bool,
 }
 
@@ -81,8 +94,9 @@ pub struct DeputyGrant {
 pub enum ResolveError {
     /// No member id in the room matched.
     NotFound,
-    /// The input is a prefix of more than one member id. Carries the matching
-    /// ids, sorted, so the caller can list them.
+    /// The input matched more than one member id (as a prefix, or as a
+    /// case-insensitive full match). Carries the matching ids sorted by their
+    /// printed form, so the message lists them the way the user sees them.
     Ambiguous(Vec<String>),
 }
 
@@ -91,11 +105,24 @@ pub enum ResolveError {
 /// Borrows the state; construct one per fetch. `secrets` is the private-room
 /// decryption map from `ApiClient::room_display_secrets` (empty for a public
 /// room), used only to render nicknames.
+///
+/// The canonical deputy lists are resolved ONCE in [`Self::new`], so a caller
+/// annotating every row of a member listing does not re-scan `member_info` per
+/// row. Resolution still goes through [`MemberInfoV1::deputies_of`], which stays
+/// the single source of truth for which record wins.
 pub struct RoomDeputies<'a> {
     state: &'a ChatRoomStateV1,
     secrets: &'a HashMap<u32, [u8; 32]>,
     owner_id: MemberId,
     current_members: HashSet<MemberId>,
+    /// Canonical `deputizer -> deputies` for every member holding a
+    /// `member_info` record. Values are sorted by printed id and deduplicated.
+    deputies_by_deputizer: BTreeMap<MemberId, Vec<MemberId>>,
+    /// Every id this room mentions anywhere (see [`Self::resolve_short_id`]).
+    known_ids: BTreeSet<MemberId>,
+    /// `member -> number of members they invited, directly or indirectly`, for
+    /// every member with a non-empty subtree.
+    subtree_sizes: HashMap<MemberId, usize>,
 }
 
 impl<'a> RoomDeputies<'a> {
@@ -104,17 +131,56 @@ impl<'a> RoomDeputies<'a> {
         owner_vk: &VerifyingKey,
         secrets: &'a HashMap<u32, [u8; 32]>,
     ) -> Self {
-        let current_members = state
+        let owner_id = MemberId::from(owner_vk);
+        let current_members: HashSet<MemberId> = state
             .members
             .members
             .iter()
             .map(|m| m.member.id())
             .collect();
+
+        // Ids that could hold a `deputies` list: every member with a
+        // `member_info` record. Deputies live nowhere else, so a member without
+        // a record has, by definition, deputized no one.
+        let candidates: BTreeSet<MemberId> = state
+            .member_info
+            .member_info
+            .iter()
+            .map(|info| info.member_info.member_id)
+            .collect();
+
+        let mut deputies_by_deputizer: BTreeMap<MemberId, Vec<MemberId>> = BTreeMap::new();
+        for deputizer in candidates {
+            let mut ids: Vec<MemberId> = state.member_info.deputies_of(deputizer).to_vec();
+            ids.sort_by_key(|id| id.to_string());
+            ids.dedup();
+            deputies_by_deputizer.insert(deputizer, ids);
+        }
+
+        // Every id the room mentions anywhere: the owner, current members,
+        // members with a `member_info` record, and ids appearing in ANY
+        // deputies list. The last source matters: a deputy pruned for
+        // inactivity keeps no `member_info` record but is still named by their
+        // deputizer's signed record, and "is this (now absent) member still
+        // someone's deputy?" is a question worth being able to ask.
+        let mut known_ids: BTreeSet<MemberId> = BTreeSet::new();
+        known_ids.insert(owner_id);
+        known_ids.extend(current_members.iter().copied());
+        for (deputizer, deputies) in &deputies_by_deputizer {
+            known_ids.insert(*deputizer);
+            known_ids.extend(deputies.iter().copied());
+        }
+
+        let subtree_sizes = invite_subtree_sizes(state);
+
         Self {
             state,
             secrets,
-            owner_id: MemberId::from(owner_vk),
+            owner_id,
             current_members,
+            deputies_by_deputizer,
+            known_ids,
+            subtree_sizes,
         }
     }
 
@@ -122,50 +188,23 @@ impl<'a> RoomDeputies<'a> {
         &self.state.member_info
     }
 
-    /// Every member id this room mentions anywhere: the owner, current members,
-    /// members with a `member_info` record, and ids appearing in ANY deputies
-    /// list. The last source matters — a deputy pruned for inactivity keeps no
-    /// `member_info` record but is still named by their deputizer's signed
-    /// record, and "is this (now absent) member still someone's deputy?" is a
-    /// question worth being able to ask.
-    fn known_member_ids(&self) -> BTreeSet<MemberId> {
-        let mut ids: BTreeSet<MemberId> = BTreeSet::new();
-        ids.insert(self.owner_id);
-        ids.extend(self.current_members.iter().copied());
-        for info in &self.member_info().member_info {
-            ids.insert(info.member_info.member_id);
-        }
-        for id in self.deputizer_candidates() {
-            ids.extend(self.member_info().deputies_of(id).iter().copied());
-        }
-        ids
-    }
-
-    /// Ids that could plausibly hold a `deputies` list: every member with a
-    /// `member_info` record (deputies live nowhere else, so a member without a
-    /// record has, by definition, deputized no one).
-    fn deputizer_candidates(&self) -> BTreeSet<MemberId> {
-        self.member_info()
-            .member_info
-            .iter()
-            .map(|info| info.member_info.member_id)
-            .collect()
-    }
-
     /// Resolve a user-supplied short id against every id the room mentions.
     ///
-    /// Matching mirrors `ban_member` / `member deputize` — a case-sensitive
-    /// prefix match, or a case-insensitive match against the first 8 characters
-    /// — but, unlike those write paths, an input matching more than one member
-    /// is reported as [`ResolveError::Ambiguous`] rather than silently resolving
-    /// to whichever record happens to come first in the state vector.
+    /// Matching mirrors `ban_member` / `member deputize`: a case-sensitive
+    /// prefix match, or a case-insensitive match against the first 8 characters.
+    /// Unlike those write paths, an input matching more than one member is
+    /// reported as [`ResolveError::Ambiguous`] rather than silently resolving to
+    /// whichever record happens to come first in the state vector. (The write
+    /// paths keep their first-match behaviour; converging them would change
+    /// existing commands, so it is deliberately left alone here.)
     pub fn resolve_short_id(&self, short: &str) -> Result<MemberId, ResolveError> {
         if short.is_empty() {
             return Err(ResolveError::NotFound);
         }
         let matches: Vec<MemberId> = self
-            .known_member_ids()
-            .into_iter()
+            .known_ids
+            .iter()
+            .copied()
             .filter(|id| {
                 let s = id.to_string();
                 s.starts_with(short) || s[..8.min(s.len())].eq_ignore_ascii_case(short)
@@ -174,9 +213,14 @@ impl<'a> RoomDeputies<'a> {
         match matches.len() {
             0 => Err(ResolveError::NotFound),
             1 => Ok(matches[0]),
-            _ => Err(ResolveError::Ambiguous(
-                matches.iter().map(|id| id.to_string()).collect(),
-            )),
+            _ => {
+                // `known_ids` is ordered by the underlying hash, which has no
+                // relation to the 8-char base32 the user sees; sort by the
+                // printed form so the message reads in the order they'd expect.
+                let mut ids: Vec<String> = matches.iter().map(|id| id.to_string()).collect();
+                ids.sort();
+                Err(ResolveError::Ambiguous(ids))
+            }
         }
     }
 
@@ -185,16 +229,39 @@ impl<'a> RoomDeputies<'a> {
         id == self.owner_id || self.current_members.contains(&id)
     }
 
+    /// Every member holding a `member_info` record, deduplicated and ordered.
+    ///
+    /// This is the canonical row set for a member listing: the raw
+    /// `member_info.member_info` vector can hold several records for one member
+    /// (`MemberInfoV1::verify` accepts duplicates for migration-safety), so
+    /// iterating it directly yields duplicate rows carrying losing nicknames.
+    pub fn members_with_info(&self) -> impl Iterator<Item = MemberId> + '_ {
+        self.deputies_by_deputizer.keys().copied()
+    }
+
     /// Resolve one member for display.
     pub fn party(&self, id: MemberId) -> DeputyParty {
         let nickname = self.member_info().canonical(id).map(|info| {
-            crate::api::unseal_nickname_display(&info.member_info.preferred_nickname, self.secrets)
+            sanitize_for_terminal(&crate::api::unseal_nickname_display(
+                &info.member_info.preferred_nickname,
+                self.secrets,
+            ))
         });
         DeputyParty {
             member_id: id.to_string(),
             nickname,
             is_owner: id == self.owner_id,
             in_room: self.in_room(id),
+        }
+    }
+
+    /// How many members `id`'s grants reach: everyone for the owner, otherwise
+    /// the size of `id`'s invite subtree.
+    fn reach_of(&self, id: MemberId) -> usize {
+        if id == self.owner_id {
+            self.current_members.len()
+        } else {
+            self.subtree_sizes.get(&id).copied().unwrap_or(0)
         }
     }
 
@@ -207,6 +274,7 @@ impl<'a> RoomDeputies<'a> {
                 DeputyScope::InviteSubtree
             },
             active: self.in_room(deputizer) && self.in_room(deputy),
+            reaches_members: self.reach_of(deputizer),
             deputizer: self.party(deputizer),
             deputy: self.party(deputy),
         }
@@ -216,19 +284,20 @@ impl<'a> RoomDeputies<'a> {
     ///
     /// Reads the CANONICAL record, so a revoked grant lingering in a duplicate
     /// lower-rank record is not reported.
-    pub fn deputies_of(&self, deputizer: MemberId) -> Vec<MemberId> {
-        let mut ids: Vec<MemberId> = self.member_info().deputies_of(deputizer).to_vec();
-        ids.sort_by_key(|id| id.to_string());
-        ids.dedup();
-        ids
+    pub fn deputies_of(&self, deputizer: MemberId) -> &[MemberId] {
+        self.deputies_by_deputizer
+            .get(&deputizer)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
     }
 
     /// Reverse lookup: every member who has deputized `deputy`, sorted by id.
     pub fn deputizers_of(&self, deputy: MemberId) -> Vec<MemberId> {
         let mut ids: Vec<MemberId> = self
-            .deputizer_candidates()
-            .into_iter()
-            .filter(|deputizer| self.member_info().deputies_of(*deputizer).contains(&deputy))
+            .deputies_by_deputizer
+            .iter()
+            .filter(|(_, deputies)| deputies.contains(&deputy))
+            .map(|(deputizer, _)| *deputizer)
             .collect();
         ids.sort_by_key(|id| id.to_string());
         ids
@@ -237,9 +306,9 @@ impl<'a> RoomDeputies<'a> {
     /// Every grant in the room, sorted by `(deputizer, deputy)` id.
     pub fn all_grants(&self) -> Vec<DeputyGrant> {
         let mut grants = Vec::new();
-        for deputizer in self.deputizer_candidates() {
-            for deputy in self.deputies_of(deputizer) {
-                grants.push(self.grant(deputizer, deputy));
+        for (deputizer, deputies) in &self.deputies_by_deputizer {
+            for deputy in deputies {
+                grants.push(self.grant(*deputizer, *deputy));
             }
         }
         grants.sort_by(|a, b| {
@@ -249,13 +318,14 @@ impl<'a> RoomDeputies<'a> {
         grants
     }
 
-    /// `deputy -> [deputizer, …]` for every grant in the room, for annotating a
-    /// full member listing without an O(members²) rescan.
+    /// `deputy -> [deputizer, …]` for every grant in the room, so a full member
+    /// listing can be annotated with one pass instead of a reverse lookup per
+    /// row.
     pub fn deputizers_by_deputy(&self) -> HashMap<MemberId, Vec<MemberId>> {
         let mut map: HashMap<MemberId, Vec<MemberId>> = HashMap::new();
-        for deputizer in self.deputizer_candidates() {
-            for deputy in self.deputies_of(deputizer) {
-                map.entry(deputy).or_default().push(deputizer);
+        for (deputizer, deputies) in &self.deputies_by_deputizer {
+            for deputy in deputies {
+                map.entry(*deputy).or_default().push(*deputizer);
             }
         }
         for deputizers in map.values_mut() {
@@ -263,6 +333,61 @@ impl<'a> RoomDeputies<'a> {
         }
         map
     }
+}
+
+/// `member -> number of members they invited, directly or indirectly`, for every
+/// member with a non-empty invite subtree.
+///
+/// Mirrors the traversal `MembersV1::get_downstream_members` performs (which is
+/// private to the contract crate), including its visited-set cycle guard, so the
+/// reach reported here matches the subtree `is_ban_authorized` grants authority
+/// over. The owner is excluded: they are never in `members.members`, and their
+/// reach is the whole room, handled separately.
+fn invite_subtree_sizes(state: &ChatRoomStateV1) -> HashMap<MemberId, usize> {
+    let mut children: HashMap<MemberId, Vec<MemberId>> = HashMap::new();
+    for member in &state.members.members {
+        children
+            .entry(member.member.invited_by)
+            .or_default()
+            .push(member.member.id());
+    }
+
+    let mut sizes = HashMap::new();
+    for root in children.keys().copied() {
+        let mut seen: HashSet<MemberId> = HashSet::new();
+        let mut stack = vec![root];
+        while let Some(current) = stack.pop() {
+            for child in children.get(&current).into_iter().flatten() {
+                // A self-invite or an invite cycle would otherwise loop forever;
+                // `seen` also stops a descendant from being counted twice.
+                if *child != root && seen.insert(*child) {
+                    stack.push(*child);
+                }
+            }
+        }
+        if !seen.is_empty() {
+            sizes.insert(root, seen.len());
+        }
+    }
+    sizes
+}
+
+/// Strip C0 control characters from a nickname before it is printed.
+///
+/// Nicknames are attacker-controlled and `unseal_nickname_display` is a lossy
+/// UTF-8 decode with no filtering, so an embedded newline or ANSI escape could
+/// forge an extra output row. That was cosmetic before deputy status was
+/// printed; now a forged row would claim moderation authority, so filter it.
+fn sanitize_for_terminal(raw: &str) -> String {
+    raw.chars()
+        .map(|c| {
+            if c.is_control() && c != '\t' {
+                char::REPLACEMENT_CHARACTER
+            } else {
+                c
+            }
+        })
+        .collect()
 }
 
 /// Render a party as `Nickname (SHORTID)`, or `(unknown) (SHORTID)` when they
@@ -280,6 +405,10 @@ pub fn party_label(party: &DeputyParty) -> String {
 /// ambiguity this command exists to remove is exactly "a deputy of whom?". The
 /// deputy is left implicit: every call site already prints them, either as the
 /// row label or via the `deputizer -> deputy` arrow in `debug room-state`.
+///
+/// Reports the grant's actual REACH, not just that it exists. A deputy of
+/// someone who has invited nobody holds authority over an empty set, which the
+/// old "may ban within X's invite subtree" phrasing overstated.
 pub fn grant_status_line(grant: &DeputyGrant) -> String {
     if !grant.active {
         let absent = if !grant.deputy.in_room {
@@ -293,11 +422,20 @@ pub fn grant_status_line(grant: &DeputyGrant) -> String {
         );
     }
     match grant.scope {
-        DeputyScope::RoomWide => {
-            "active: may ban room-wide (granted by the room owner)".to_string()
-        }
+        // `is_ban_authorized` refuses `target == owner` outright, so even an
+        // owner-appointed deputy cannot ban the owner.
+        DeputyScope::RoomWide => format!(
+            "active: may ban any of the {} member(s) in the room (granted by the room owner)",
+            grant.reaches_members
+        ),
+        DeputyScope::InviteSubtree if grant.reaches_members == 0 => format!(
+            "active but reaches no one: {} has invited nobody, so this grant currently \
+             confers no ban authority",
+            party_label(&grant.deputizer)
+        ),
         DeputyScope::InviteSubtree => format!(
-            "active: may ban within {}'s invite subtree",
+            "active: may ban the {} member(s) {} invited, directly or indirectly",
+            grant.reaches_members,
             party_label(&grant.deputizer)
         ),
     }
@@ -325,17 +463,28 @@ mod tests {
     fn room(owner: &SigningKey, members: &[&SigningKey]) -> ChatRoomStateV1 {
         let mut state = ChatRoomStateV1::default();
         for sk in members {
-            let member = Member {
-                owner_member_id: id(owner),
-                invited_by: id(owner),
-                member_vk: sk.verifying_key(),
-            };
-            state
-                .members
-                .members
-                .push(AuthorizedMember::new(member, owner));
+            push_member(&mut state, owner, owner, sk);
         }
         state
+    }
+
+    /// Add `sk` as a member invited by `inviter` (signed by the inviter, as
+    /// `AuthorizedMember::new` asserts).
+    fn push_member(
+        state: &mut ChatRoomStateV1,
+        owner: &SigningKey,
+        inviter: &SigningKey,
+        sk: &SigningKey,
+    ) {
+        let member = Member {
+            owner_member_id: id(owner),
+            invited_by: id(inviter),
+            member_vk: sk.verifying_key(),
+        };
+        state
+            .members
+            .members
+            .push(AuthorizedMember::new(member, inviter));
     }
 
     /// Push a signed `member_info` record for `sk` at `version` with `deputies`.
@@ -371,7 +520,7 @@ mod tests {
         let secrets = no_secrets();
         let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
 
-        assert_eq!(d.deputies_of(id(&alice)), vec![id(&bob)]);
+        assert_eq!(d.deputies_of(id(&alice)), [id(&bob)]);
         assert_eq!(d.deputizers_of(id(&bob)), vec![id(&alice)]);
 
         // The reverse direction is NOT symmetric: Bob deputized nobody.
@@ -381,8 +530,9 @@ mod tests {
 
     #[test]
     fn reverse_lookup_finds_every_deputizer_of_one_member() {
-        // Ian's use case: "is this member a deputy of anyone — the owner, the
-        // invite bot, …?" Two independent members deputize the same target.
+        // The motivating question: "is this member a deputy of anyone (the
+        // owner, the invite bot, ...)?" Two independent members deputize the
+        // same target.
         let owner = key(1);
         let alice = key(2);
         let bot = key(3);
@@ -406,6 +556,10 @@ mod tests {
         assert!(
             owner_grant.deputizer.in_room,
             "the owner is never in members.members but is always in the room"
+        );
+        assert_eq!(
+            owner_grant.reaches_members, 2,
+            "an owner grant reaches every member"
         );
 
         let alice_grant = d.grant(id(&alice), id(&bot));
@@ -445,7 +599,7 @@ mod tests {
 
         assert!(d.deputies_of(id(&alice)).is_empty());
         let party = d.party(id(&alice));
-        assert_eq!(party.nickname, None, "no member_info → no nickname");
+        assert_eq!(party.nickname, None, "no member_info means no nickname");
         assert!(party.in_room, "still a current member");
     }
 
@@ -479,36 +633,63 @@ mod tests {
 
     #[test]
     fn resolve_short_id_reports_ambiguity_rather_than_guessing() {
-        // A one-character prefix will match several of the room's ids; the read
-        // path must refuse rather than pick whichever comes first in the vector.
+        // A prefix shared by two ids must refuse rather than pick whichever
+        // comes first in the state vector.
+        //
+        // The colliding pair is SEARCHED for over a wide seed range rather than
+        // assumed: with 10 random ids over a 32-symbol alphabet there is a ~21%
+        // chance no two share a first character, so asserting a pigeonhole that
+        // does not hold would make this test a latent flake.
         let owner = key(1);
-        let members: Vec<SigningKey> = (2u8..12).map(key).collect();
-        let refs: Vec<&SigningKey> = members.iter().collect();
-        let mut state = room(&owner, &refs);
-        push_info(&mut state, &owner, 0, "Room Owner", vec![]);
-        for (n, sk) in members.iter().enumerate() {
-            push_info(&mut state, sk, 0, &format!("M{n}"), vec![]);
+        let candidates: Vec<SigningKey> = (2u8..=200).map(key).collect();
+        let mut first_seen: HashMap<char, usize> = HashMap::new();
+        let mut pair: Option<(usize, usize)> = None;
+        for (i, sk) in candidates.iter().enumerate() {
+            let c = id(sk).to_string().chars().next().unwrap();
+            match first_seen.get(&c) {
+                Some(j) => {
+                    pair = Some((*j, i));
+                    break;
+                }
+                None => {
+                    first_seen.insert(c, i);
+                }
+            }
         }
+        // 199 ids over a 32-symbol alphabet: a collision is guaranteed.
+        let (a, b) = pair.expect("199 ids over 32 symbols must collide on the first character");
+        let (first, second) = (&candidates[a], &candidates[b]);
+        let shared = id(first).to_string().chars().next().unwrap();
+
+        let mut state = room(&owner, &[first, second]);
+        push_info(&mut state, &owner, 0, "Room Owner", vec![]);
+        push_info(&mut state, first, 0, "First", vec![]);
+        push_info(&mut state, second, 0, "Second", vec![]);
 
         let secrets = no_secrets();
         let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
 
-        // Find a first character shared by at least two ids.
-        let mut by_first: HashMap<char, usize> = HashMap::new();
-        for sk in &members {
-            *by_first
-                .entry(id(sk).to_string().chars().next().unwrap())
-                .or_default() += 1;
-        }
-        let (shared, _) = by_first
-            .iter()
-            .find(|(_, count)| **count > 1)
-            .expect("10 ids over a 32-symbol alphabet must share a first character");
-
         match d.resolve_short_id(&shared.to_string()) {
-            Err(ResolveError::Ambiguous(ids)) => assert!(ids.len() > 1),
+            Err(ResolveError::Ambiguous(ids)) => {
+                assert!(ids.contains(&id(first).to_string()));
+                assert!(ids.contains(&id(second).to_string()));
+                let mut sorted = ids.clone();
+                sorted.sort();
+                assert_eq!(
+                    ids, sorted,
+                    "the matches must be listed in printed-id order, not in \
+                     the underlying hash order the id set is stored in"
+                );
+            }
             other => panic!("expected an ambiguity error, got {other:?}"),
         }
+
+        // The full 8-character id still resolves unambiguously.
+        assert_eq!(
+            d.resolve_short_id(&id(first).to_string()),
+            Ok(id(first)),
+            "a full id must not be reported as ambiguous"
+        );
     }
 
     #[test]
@@ -522,7 +703,7 @@ mod tests {
         let mut state = room(&owner, &[&alice, &bob]);
         push_info(&mut state, &owner, 0, "Room Owner", vec![]);
         push_info(&mut state, &bob, 0, "Bob", vec![]);
-        // Grant @ v1, then revoke @ v2 — pushed in "wrong" order on purpose.
+        // Grant @ v1, then revoke @ v2, pushed in "wrong" order on purpose.
         push_info(&mut state, &alice, 2, "Alice", vec![]);
         push_info(&mut state, &alice, 1, "Alice", vec![id(&bob)]);
 
@@ -541,11 +722,34 @@ mod tests {
     }
 
     #[test]
+    fn duplicate_records_collapse_to_one_row_with_the_canonical_nickname() {
+        // The listing surface must be per-MEMBER, not per-record: two records
+        // for Alice must yield one row, carrying the winning record's nickname.
+        let owner = key(1);
+        let alice = key(2);
+        let mut state = room(&owner, &[&alice]);
+        push_info(&mut state, &owner, 0, "Room Owner", vec![]);
+        push_info(&mut state, &alice, 1, "Old Alice", vec![]);
+        push_info(&mut state, &alice, 2, "New Alice", vec![]);
+
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        let rows: Vec<MemberId> = d.members_with_info().collect();
+        assert_eq!(rows.len(), 2, "owner + alice, not owner + alice + alice");
+        assert_eq!(
+            d.party(id(&alice)).nickname.as_deref(),
+            Some("New Alice"),
+            "the canonical (highest-version) record wins"
+        );
+    }
+
+    #[test]
     fn a_grant_naming_a_pruned_member_is_reported_but_marked_inactive() {
         // A deputy pruned for inactivity keeps no `member_info` record but is
-        // still named by their deputizer's signed record. The contract honours
-        // deputy authority only for CURRENT members, so the grant is inert —
-        // surface it, but do not claim it confers anything.
+        // still named by their deputizer's signed record. `is_ban_authorized`
+        // honours deputy authority only for CURRENT members, so the grant is
+        // inert: surface it, but do not claim it confers anything.
         let owner = key(1);
         let alice = key(2);
         let pruned = key(3);
@@ -556,11 +760,12 @@ mod tests {
         let secrets = no_secrets();
         let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
 
-        assert_eq!(d.deputies_of(id(&alice)), vec![id(&pruned)]);
+        assert_eq!(d.deputies_of(id(&alice)), [id(&pruned)]);
         let grant = d.grant(id(&alice), id(&pruned));
         assert!(!grant.active, "the deputy is no longer a member");
         assert_eq!(grant.deputy.nickname, None);
         assert!(!grant.deputy.in_room);
+        assert!(grant_status_line(&grant).starts_with("inactive:"));
 
         // The pruned id is still resolvable, so `deputized-by` can answer for
         // it (mirroring the revoke path's own-deputies fallback).
@@ -572,10 +777,12 @@ mod tests {
     }
 
     #[test]
-    fn a_grant_from_a_pruned_deputizer_is_inactive() {
-        // Mirror image: the DEPUTIZER left the room. A non-owner deputizer must
-        // be a genuine invite ancestor of the ban target, which a non-member
-        // never is, so the grant confers nothing.
+    fn a_grant_from_an_absent_deputizer_is_inactive() {
+        // Defence-in-depth only: `MemberInfoV1::verify` rejects a `member_info`
+        // record whose member is neither the owner nor a current member, so a
+        // deputizer absent from `members` cannot occur in a state the contract
+        // accepted. Pinned anyway so a hand-built or partially-applied state
+        // cannot make the CLI claim authority for someone who has left.
         let owner = key(1);
         let gone = key(2);
         let bob = key(3);
@@ -629,13 +836,96 @@ mod tests {
     }
 
     #[test]
+    fn reach_is_the_deputizers_invite_subtree_not_merely_that_a_grant_exists() {
+        // The whole point of `reaches_members`: a deputy of someone who invited
+        // nobody has authority over an empty set, and saying "may ban within
+        // their invite subtree" would overstate it. Tree:
+        //   owner -> alice -> carol -> dave
+        //   owner -> bob (invited nobody)
+        let owner = key(1);
+        let alice = key(2);
+        let bob = key(3);
+        let carol = key(4);
+        let dave = key(5);
+        let deputy = key(6);
+
+        let mut state = ChatRoomStateV1::default();
+        push_member(&mut state, &owner, &owner, &alice);
+        push_member(&mut state, &owner, &owner, &bob);
+        push_member(&mut state, &owner, &alice, &carol);
+        push_member(&mut state, &owner, &carol, &dave);
+        push_member(&mut state, &owner, &owner, &deputy);
+
+        push_info(&mut state, &owner, 0, "Room Owner", vec![]);
+        push_info(&mut state, &alice, 0, "Alice", vec![id(&deputy)]);
+        push_info(&mut state, &bob, 0, "Bob", vec![id(&deputy)]);
+        push_info(&mut state, &deputy, 0, "Deputy", vec![]);
+
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        // Alice's subtree is carol + dave (transitive), so 2.
+        let from_alice = d.grant(id(&alice), id(&deputy));
+        assert!(from_alice.active);
+        assert_eq!(from_alice.reaches_members, 2);
+        let line = grant_status_line(&from_alice);
+        assert!(line.contains("2 member(s)"), "{line}");
+        assert!(line.contains("Alice"), "must name the deputizer: {line}");
+
+        // Bob invited nobody, so his grant is live but reaches no one. This
+        // must NOT read as though the deputy can ban within a real subtree.
+        let from_bob = d.grant(id(&bob), id(&deputy));
+        assert!(from_bob.active);
+        assert_eq!(from_bob.reaches_members, 0);
+        let bob_line = grant_status_line(&from_bob);
+        assert!(
+            bob_line.contains("reaches no one"),
+            "an empty subtree must be stated plainly: {bob_line}"
+        );
+        assert!(bob_line.contains("Bob"), "{bob_line}");
+    }
+
+    #[test]
+    fn invite_subtree_sizes_survives_a_cycle_and_a_self_invite() {
+        // `get_downstream_members` carries a visited-set cycle guard; the CLI
+        // mirror must too, or a malformed invite graph hangs the command.
+        let owner = key(1);
+        let alice = key(2);
+        let bob = key(3);
+
+        let mut state = ChatRoomStateV1::default();
+        push_member(&mut state, &owner, &owner, &alice);
+        push_member(&mut state, &owner, &alice, &bob);
+        // Hand-forged cycle: alice claims to have been invited by bob (her own
+        // descendant). `AuthorizedMember::new` would assert, so build it raw.
+        state.members.members[0].member.invited_by = id(&bob);
+
+        let sizes = invite_subtree_sizes(&state);
+        assert_eq!(sizes.get(&id(&alice)).copied().unwrap_or(0), 1);
+        assert_eq!(sizes.get(&id(&bob)).copied().unwrap_or(0), 1);
+
+        // A member who invited themselves must not be counted as their own
+        // descendant, and must not loop.
+        let mut selfie = ChatRoomStateV1::default();
+        push_member(&mut selfie, &owner, &owner, &alice);
+        selfie.members.members[0].member.invited_by = id(&alice);
+        assert_eq!(
+            invite_subtree_sizes(&selfie).get(&id(&alice)).copied(),
+            None,
+            "self-invite is not a subtree"
+        );
+    }
+
+    #[test]
     fn human_status_line_names_the_deputizer_not_a_bare_badge() {
         // The UI's viewer-scoped shield badge is the confusion this command
         // exists to avoid: every line must say WHOSE authority is in play.
         let owner = key(1);
         let alice = key(2);
         let bob = key(3);
+        let carol = key(4);
         let mut state = room(&owner, &[&alice, &bob]);
+        push_member(&mut state, &owner, &alice, &carol);
         push_info(&mut state, &owner, 0, "Room Owner", vec![]);
         push_info(&mut state, &alice, 0, "Alice", vec![id(&bob)]);
         push_info(&mut state, &bob, 0, "Bob", vec![]);
@@ -645,17 +935,96 @@ mod tests {
 
         let line = grant_status_line(&d.grant(id(&alice), id(&bob)));
         assert!(line.contains("Alice"), "must name the deputizer: {line}");
-        assert!(line.contains("invite subtree"), "must scope it: {line}");
+        assert!(line.contains("invited"), "must scope it: {line}");
 
         let owner_line = grant_status_line(&d.grant(id(&owner), id(&bob)));
         assert!(
-            owner_line.contains("room-wide"),
-            "an owner grant is room-wide: {owner_line}"
+            owner_line.contains("room owner"),
+            "an owner grant must be attributed to the owner: {owner_line}"
         );
 
         assert_eq!(
             party_label(&d.party(id(&alice))),
             format!("Alice ({})", id(&alice))
         );
+        assert_eq!(
+            party_label(&d.party(id(&key(9)))),
+            format!("(unknown) ({})", id(&key(9))),
+            "a member with no member_info record renders as (unknown)"
+        );
+    }
+
+    #[test]
+    fn a_hostile_nickname_cannot_forge_an_extra_output_row() {
+        // Nicknames are attacker-controlled and printed next to an authority
+        // claim, so an embedded newline must not produce a second line that
+        // looks like a real grant.
+        let owner = key(1);
+        let evil = key(2);
+        let mut state = room(&owner, &[&evil]);
+        push_info(&mut state, &owner, 0, "Room Owner", vec![]);
+        push_info(
+            &mut state,
+            &evil,
+            0,
+            "Eve\n  Admin (AAAAAAAA)  deputy of: Room Owner",
+            vec![],
+        );
+
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        let label = party_label(&d.party(id(&evil)));
+        assert!(!label.contains('\n'), "newline must be stripped: {label:?}");
+        assert!(!label.contains('\r'));
+        assert!(!label.contains('\u{1b}'), "ANSI escapes must be stripped");
+        assert!(label.starts_with("Eve"), "the readable part survives");
+
+        assert_eq!(sanitize_for_terminal("plain"), "plain");
+        assert_eq!(sanitize_for_terminal("keep\ttab"), "keep\ttab");
+        assert_eq!(sanitize_for_terminal("emoji \u{1f600}"), "emoji \u{1f600}");
+    }
+
+    #[test]
+    fn json_shape_is_pinned_so_scripts_do_not_break_silently() {
+        // These field names and the kebab-case scope values are the CLI's
+        // published contract for `-f json`; renaming one silently breaks every
+        // consumer, so pin them here rather than in a reviewer's memory.
+        let owner = key(1);
+        let alice = key(2);
+        let bob = key(3);
+        let mut state = room(&owner, &[&alice, &bob]);
+        push_info(&mut state, &owner, 0, "Room Owner", vec![id(&bob)]);
+        push_info(&mut state, &alice, 0, "Alice", vec![]);
+        push_info(&mut state, &bob, 0, "Bob", vec![]);
+
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        let grant = d.grant(id(&owner), id(&bob));
+        let json = serde_json::to_value(&grant).unwrap();
+
+        assert_eq!(json["scope"], "room-wide");
+        assert_eq!(json["active"], true);
+        assert_eq!(json["reaches_members"], 2);
+        for side in ["deputizer", "deputy"] {
+            let party = &json[side];
+            assert!(party["member_id"].is_string(), "{side}.member_id");
+            assert!(party["nickname"].is_string(), "{side}.nickname");
+            assert!(party["is_owner"].is_boolean(), "{side}.is_owner");
+            assert!(party["in_room"].is_boolean(), "{side}.in_room");
+        }
+        assert_eq!(json["deputizer"]["is_owner"], true);
+        assert_eq!(
+            json["deputizer"]["in_room"], true,
+            "the owner is in the room even though members.members never lists them"
+        );
+
+        // The other scope value, and the null nickname for an id with no record.
+        let subtree = d.grant(id(&alice), id(&key(9)));
+        let json = serde_json::to_value(&subtree).unwrap();
+        assert_eq!(json["scope"], "invite-subtree");
+        assert_eq!(json["active"], false);
+        assert!(json["deputy"]["nickname"].is_null());
     }
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod commands;
 pub mod config;
+pub mod deputies;
 pub mod error;
 pub mod output;
 pub mod private_room;


### PR DESCRIPTION
## Problem

riverctl can WRITE deputy status (`member deputize`, `member revoke-deputy`) but
has no way to READ it. The data is in each member's own `AuthorizedMemberInfo.deputies`
(`common/src/room_state/member_info.rs`), but `member list` never showed it and
`debug room-state` never included it.

The only way to tell whether a `deputize` had landed was to re-run `deputize` and
look for `Member is already a deputy; nothing to do`. That is a bad API, and it
gives no answer at all to the more useful question: "does this member have
moderation authority, and from whom?"

## Approach

Two read commands, plus deputy annotations on the two existing read surfaces:

| Command | Question it answers |
|---|---|
| `member deputies <ROOM> [MEMBER_ID]` | forward: who has X deputized? (defaults to your own identity) |
| `member deputized-by <ROOM> <MEMBER_ID>` | reverse: who has deputized X? |
| `member list <ROOM>` | each member row now shows who deputized them |
| `debug room-state <ROOM>` | every grant in the room |

All of them support `-f json`. The two new commands emit one consistent shape,
`{room_id, direction, subject, grants[]}`, where each grant carries `deputizer`,
`deputy`, `scope` (`room-wide` / `invite-subtree`) and `active`.

### Why two subcommands rather than one command with a `--of` flag

The two directions have genuinely different subjects and different output, and a
flag that silently swaps which side of the relation the argument refers to is
exactly the ambiguity this feature exists to remove. Two names that read as
English sentences (`X's deputies` / `X is deputized by`) are harder to misread.

### Semantics

- **Per-deputizer, never a global flag.** Every rendering names the deputizer
  explicitly. This deliberately does not reproduce the UI's viewer-scoped green
  shield badge, which is a recurring source of confusion.
- **Canonical records only.** All reads route through `MemberInfoV1::deputies_of`,
  which selects the highest-rank record per member. `MemberInfoV1::verify`
  deliberately accepts a state carrying more than one record per member
  (migration-safety), so a bare first-match scan can read an already-revoked
  record and report authority the contract does not enforce.
- **Inert grants are shown, not hidden.** A grant naming a member who has left
  the room is listed but marked `inactive`, matching `MembersV1::is_ban_authorized`,
  which only honours deputy authority between current members. Hiding it would
  make a lingering grant invisible; claiming it is active would be wrong.
- **Ambiguous prefixes are an error.** Unlike the write paths, which take the
  first `.find()` match, an input matching more than one member id is rejected
  with the list of matches instead of silently picking one.

### Scope

CLI/read-only. No contract, WASM or serialized-state changes:
`git diff origin/main --stat` touches only `cli/`.

## Testing

19 new unit tests (`cargo test -p riverctl`: 244 lib tests pass).

`cli/src/deputies.rs` covers forward lookup, reverse lookup, both directions
agreeing, empty deputies, a member with no `member_info` record, short-id
resolution (case-insensitive, unknown id, ambiguous prefix), canonical-record
selection (a v1 grant superseded by a v2 revoke must not be reported), a grant
naming a pruned deputy, a grant from a pruned deputizer, deterministic ordering
of `all_grants` / `deputizers_by_deputy`, and the human status line naming the
deputizer.

`cli/src/commands/member.rs` covers the clap surface: the optional `MEMBER_ID`
on `deputies`, the required one on `deputized-by`, and the kebab-case spelling.

Also smoke-tested against the live Official room
(`4uNUKFzZQCnzo4K2ecZ16cMsYEEfoaRS35z6exEsbvm4`) on a local node, which
surfaced a real inactive grant to a pruned member:

```
$ riverctl member deputies <room> PMAQEUP5
  (unknown) (3YBS76GA)  inactive: (unknown) (3YBS76GA) is not currently in this room
  Ian Clarke (7XSOGJTK)  active: may ban within Invite Bot (PMAQEUP5)'s invite subtree
  HostFat (DLQVWAIV)  active: may ban within Invite Bot (PMAQEUP5)'s invite subtree
  ...

$ riverctl member deputized-by <room> 7XSOGJTK
Ian Clarke (7XSOGJTK) has been deputized by 1 member(s):
  Invite Bot (PMAQEUP5)  active: may ban within Invite Bot (PMAQEUP5)'s invite subtree
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HP4Xk5kf2FujRiFq7qye38

[AI-assisted - Claude]