### PR TITLE
feat(ui): deputy shield on message authors, and no emoji in nicknames

### DIFF
--- a/ui/src/components/app/notifications.rs
+++ b/ui/src/components/app/notifications.rs
@@ -664,10 +664,10 @@ pub fn notify_new_messages(
     let sender_name = member_info
         .canonical(msg.message.author)
         .map(|ami| {
-            match unseal_bytes_with_secrets(&ami.member_info.preferred_nickname, room_secrets) {
-                Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
-                Err(_) => ami.member_info.preferred_nickname.to_string_lossy(),
-            }
+            crate::util::display_name::display_nickname(
+                &ami.member_info.preferred_nickname,
+                room_secrets,
+            )
         })
         .unwrap_or_else(|| "Someone".to_string());
 

--- a/ui/src/components/app/notifications.rs
+++ b/ui/src/components/app/notifications.rs
@@ -373,7 +373,16 @@ pub fn show_notification(
     // Gateway iframe: hand the notification to the shell (real origin) over the
     // postMessage bridge — the sandboxed iframe can't use the Notifications API.
     if is_in_shell_iframe() {
-        let body = format!("{}: {}", sender_name, message_preview);
+        // Flatten line breaks out of the message text. The body renders as
+        // `sender: message`, so a message starting with a newline lets its author
+        // paint a second line that reads exactly like a notification from someone
+        // else — including a moderator with a 🛡 in it. The sender name itself is
+        // already sanitised.
+        let body = format!(
+            "{}: {}",
+            sender_name,
+            message_preview.replace(['\n', '\r'], " ")
+        );
         post_notification_to_shell(room_key, room_name, &body);
         return;
     }
@@ -415,7 +424,16 @@ fn create_notification_internal(
     sender_name: &str,
     message_preview: &str,
 ) {
-    let body = format!("{}: {}", sender_name, message_preview);
+    // Flatten line breaks out of the message text. The body renders as
+    // `sender: message`, so a message starting with a newline lets its author
+    // paint a second line that reads exactly like a notification from someone
+    // else — including a moderator with a 🛡 in it. The sender name itself is
+    // already sanitised.
+    let body = format!(
+        "{}: {}",
+        sender_name,
+        message_preview.replace(['\n', '\r'], " ")
+    );
     info!(
         "Creating notification - title: '{}', body: '{}'",
         room_name, body

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -2923,18 +2923,18 @@ fn MessageGroupComponent(
                             },
                             "{group.author_name}"
                         }
-                        // Deputy shield. Same glyph and `member-icon` styling
-                        // as the member-list row and the member-info modal, so
-                        // the three surfaces read as one badge. The nickname
-                        // above cannot forge it: nicknames are stripped of
-                        // emoji by `crate::util::display_name`.
+                        // Deputy shield. Same glyph, same visibility rule and
+                        // the same tooltip as the member-list row and the
+                        // member-info modal chip, so the three read as one
+                        // badge. The nickname above cannot forge it: nicknames
+                        // are stripped of emoji by `crate::util::display_name`.
                         if let Some(badge) = group.author_badge.as_ref() {
                             {
                                 let tooltip = badge.tooltip();
                                 rsx! {
                                     span {
                                         "data-testid": "message-author-deputy-badge",
-                                        class: "member-icon text-sm cursor-default",
+                                        class: "text-sm cursor-default",
                                         title: "{tooltip}",
                                         "aria-label": "{tooltip}",
                                         "🛡"
@@ -3853,6 +3853,90 @@ mod tests {
         for spoof in ["Mallory 🛡", "Mallory 👑", "Mallory \u{1F6E1}\u{FE0F}"] {
             assert_eq!(sanitize_display_name(spoof), "Mallory");
         }
+    }
+
+    /// A mention token carries a `[name]` SNAPSHOT written by the sender. When
+    /// the member reference doesn't resolve, that snapshot is what renders —
+    /// so `@[Admin 🛡](rv:<nobody>)` would paint a shield inside a message with
+    /// no nickname involved at all. Any member can type this into any message,
+    /// which makes it a broader vector than the nickname one.
+    #[test]
+    fn unresolved_mention_chip_snapshot_is_sanitised() {
+        let unknown = MemberId(freenet_scaffold::util::FastHash(0xDEAD_BEEF));
+        let me = MemberId(freenet_scaffold::util::FastHash(1));
+        let token = river_core::mention::encode_mention(unknown, "Admin 🛡");
+
+        let html = message_to_html_with_mentions(&token, &HashMap::new(), me);
+        assert!(
+            !html.contains('\u{1F6E1}'),
+            "an unresolved mention rendered a badge glyph from its snapshot: {html}"
+        );
+        assert!(
+            html.contains("Admin"),
+            "the name itself must survive: {html}"
+        );
+    }
+
+    /// Same snapshot, the other renderer: the quoted reply preview resolves
+    /// mention tokens to plain `@name` and falls back to the sender-written
+    /// snapshot for an unknown member.
+    #[test]
+    fn reply_preview_sanitises_an_unresolved_mention_snapshot() {
+        let unknown = MemberId(freenet_scaffold::util::FastHash(0xDEAD_BEEF));
+        let token = river_core::mention::encode_mention(unknown, "Admin 🛡");
+
+        let preview = clean_reply_preview(&token, &HashMap::new());
+        assert!(
+            !preview.contains('\u{1F6E1}'),
+            "reply preview rendered a badge glyph from a mention snapshot: {preview}"
+        );
+        assert!(preview.contains("@Admin"), "got: {preview}");
+    }
+
+    /// `ReplyContentV1.target_author_name` is a name the REPLYING client wrote
+    /// into the message body, never checked against the target message's real
+    /// author. It renders as `↩ @name:` directly under the real author line and
+    /// its badge, so it must be sanitised on BOTH the public and the private
+    /// (encrypted-room) decode paths. Sanitising only one of them is exactly
+    /// the bug this test exists to prevent.
+    #[test]
+    fn reply_context_author_name_is_sanitised_on_both_paths() {
+        use river_core::room_state::content::ReplyContentV1;
+
+        let target_id = MessageId(freenet_scaffold::util::FastHash(7));
+        let spoof = "Admin \u{1F6E1}";
+
+        // Public room.
+        let public = RoomMessageBody::reply(
+            "sure".to_string(),
+            target_id.clone(),
+            spoof.to_string(),
+            "the original".to_string(),
+        );
+        let (author, _, _) = extract_reply_context(&public, &HashMap::new());
+        assert_eq!(author.as_deref(), Some("Admin"), "public reply path");
+
+        // Private room: same payload, encrypted with a known secret.
+        let secret = [42u8; 32];
+        let plaintext = ReplyContentV1::new(
+            "sure".to_string(),
+            target_id,
+            spoof.to_string(),
+            "the original".to_string(),
+        )
+        .encode();
+        let (ciphertext, nonce) =
+            crate::util::ecies::encrypt_with_symmetric_key(&secret, &plaintext);
+        let private = RoomMessageBody::private(
+            river_core::room_state::content::CONTENT_TYPE_REPLY,
+            river_core::room_state::content::REPLY_CONTENT_VERSION,
+            ciphertext,
+            nonce,
+            3,
+        );
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::from([(3u32, secret)]);
+        let (author, _, _) = extract_reply_context(&private, &secrets);
+        assert_eq!(author.as_deref(), Some("Admin"), "private reply path");
     }
 
     /// Issue #315 — pin that the markdown renderer never passes raw HTML

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -3911,51 +3911,13 @@ mod tests {
         assert!(preview.contains("@Admin"), "got: {preview}");
     }
 
-    /// `ReplyContentV1.target_author_name` is a name the REPLYING client wrote
-    /// into the message body, never checked against the target message's real
-    /// author. It renders as `↩ @name:` directly under the real author line and
-    /// its badge, so it must be sanitised on BOTH the public and the private
-    /// (encrypted-room) decode paths. Sanitising only one of them is exactly
-    /// the bug this test exists to prevent.
-    #[test]
-    fn reply_context_author_name_is_sanitised_on_both_paths() {
-        use river_core::room_state::content::ReplyContentV1;
-
-        let target_id = MessageId(freenet_scaffold::util::FastHash(7));
-        let spoof = "Admin \u{1F6E1}";
-
-        // Public room.
-        let public = RoomMessageBody::reply(
-            "sure".to_string(),
-            target_id.clone(),
-            spoof.to_string(),
-            "the original".to_string(),
-        );
-        let (author, _, _) = extract_reply_context(&public, &HashMap::new());
-        assert_eq!(author.as_deref(), Some("Admin"), "public reply path");
-
-        // Private room: same payload, encrypted with a known secret.
-        let secret = [42u8; 32];
-        let plaintext = ReplyContentV1::new(
-            "sure".to_string(),
-            target_id,
-            spoof.to_string(),
-            "the original".to_string(),
-        )
-        .encode();
-        let (ciphertext, nonce) =
-            crate::util::ecies::encrypt_with_symmetric_key(&secret, &plaintext);
-        let private = RoomMessageBody::private(
-            river_core::room_state::content::CONTENT_TYPE_REPLY,
-            river_core::room_state::content::REPLY_CONTENT_VERSION,
-            ciphertext,
-            nonce,
-            3,
-        );
-        let secrets: HashMap<u32, [u8; 32]> = HashMap::from([(3u32, secret)]);
-        let (author, _, _) = extract_reply_context(&private, &secrets);
-        assert_eq!(author.as_deref(), Some("Admin"), "private reply path");
-    }
+    // A previous revision of this branch sanitised
+    // `ReplyContentV1.target_author_name` on both decode paths, because the
+    // reply strip rendered that sender-written snapshot. freenet/river#480
+    // removed the field from the decoder's return type entirely, so there is
+    // no longer a value to sanitise: the quote author comes from
+    // `resolve_member_nickname` on live state, covered by
+    // `resolve_reply_strip_tests::quote_author_label_is_sanitised`.
 
     /// Issue #315 — pin that the markdown renderer never passes raw HTML
     /// through to the DOM. `markdown_to_html` feeds attacker-controlled

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -394,13 +394,18 @@ fn target_plaintext(
     }
 }
 
-/// A member's current nickname, decrypted when the room is private.
+/// A member's current nickname, decrypted when the room is private and
+/// sanitised for display.
 ///
 /// Routes through [`MemberInfoV1::canonical`] rather than a pre-collected
 /// `member_id -> name` map: River accepts duplicate `member_info` records until
 /// `post_apply_cleanup` dedups them, and a raw `.collect()` keeps whichever
 /// record happens to come last. Every by-id read must agree on the canonical
 /// (highest-rank) record.
+///
+/// The sanitisation is [`crate::util::display_name::display_nickname`], which
+/// strips emoji so a nickname cannot forge the 🛡 deputy badge rendered beside
+/// it. Every nickname that reaches the screen goes through it.
 fn resolve_member_nickname(
     member_info: &MemberInfoV1,
     member_id: MemberId,
@@ -3828,9 +3833,17 @@ mod tests {
     #[test]
     fn author_deputy_badge_uses_the_shared_helper() {
         let source = include_str!("conversation.rs");
+        // Cut at THIS test module specifically, by a needle that cannot match
+        // itself (it contains an escaped newline in the source, not a literal
+        // one). Neither `find("#[cfg(test)]")` nor `rfind` works here: the
+        // first lands on the `clear_message_html_cache` helper above and hides
+        // most of the file, and the last lands on whichever test module was
+        // appended most recently — freenet/river#471 added one, which silently
+        // made every assertion below self-satisfying because the needles were
+        // then inside the scanned text.
         let prod = &source[..source
-            .rfind("#[cfg(test)]")
-            .expect("conversation.rs should have a #[cfg(test)] block")];
+            .find("#[cfg(test)]\nmod tests {")
+            .expect("conversation.rs should have a `#[cfg(test)] mod tests` block")];
 
         assert!(
             prod.contains("message-author-deputy-badge"),
@@ -5000,6 +5013,49 @@ mod resolve_reply_strip_tests {
             } => (author, preview),
             other => panic!("expected a rendered quote, got {other:?}"),
         }
+    }
+
+    /// The quote's author label is the target author's CURRENT nickname, so it
+    /// goes through the same sanitiser as the message header above it. Without
+    /// this, `Alice 🛡` would paint a shield into the reply strip — one line
+    /// under the real author line and its real badge.
+    ///
+    /// This covers the LIVE path. `extract_reply_context`'s own sanitisation of
+    /// the sender-written snapshot name is defence in depth: both of its
+    /// callers now discard that field.
+    #[test]
+    fn quote_author_label_is_sanitised() {
+        let owner_sk = signing_key(1);
+        let alice_sk = signing_key(2);
+        let bob_sk = signing_key(3);
+        let owner = member_id_of(&owner_sk);
+
+        let quoted = authored(
+            owner,
+            &alice_sk,
+            RoomMessageBody::public("morning".to_string()),
+            10,
+        );
+        let reply = authored(
+            owner,
+            &bob_sk,
+            RoomMessageBody::reply(
+                "morning!".to_string(),
+                quoted.id(),
+                "whatever the sender claims".to_string(),
+                "morning".to_string(),
+            ),
+            20,
+        );
+        let member_info = info(vec![named(&alice_sk, "Alice \u{1F6E1}")]);
+
+        let (author, preview) = expect_quote(resolve(
+            &reply,
+            &state(vec![quoted, reply.clone()]),
+            &member_info,
+        ));
+        assert_eq!(author, "Alice", "quote author kept a badge glyph");
+        assert_eq!(preview, "morning");
     }
 
     const ABUSE: &str = "you are all worthless, buy my coin at scam.example";

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -7,7 +7,9 @@ use crate::components::app::{
     MobileView, CURRENT_ROOM, EDIT_ROOM_MODAL, MEMBER_INFO_MODAL, MOBILE_VIEW, NOTIFICATION_MODAL,
     ROOMS,
 };
+use crate::components::members::{deputy_badges_for_viewer, DeputyBadge};
 use crate::room_data::{NotificationMode, SendMessageError};
+use crate::util::display_name::{display_nickname, sanitize_display_name};
 use crate::util::ecies::{encrypt_with_symmetric_key, unseal_bytes_with_secrets};
 use crate::util::{
     date_separator_labels, format_utc_as_full_datetime, format_utc_as_local_time,
@@ -78,6 +80,10 @@ struct ReplyContext {
 struct MessageGroup {
     author_id: MemberId,
     author_name: String,
+    /// The 🛡 shield to show next to this author's name, or `None` for none.
+    /// See [`DeputyBadge`] for the predicate and why visibility and the
+    /// "can ban you" wording are separate questions.
+    author_badge: Option<DeputyBadge>,
     is_self: bool,
     first_time: DateTime<Utc>,
     /// True if any message in this group had a future timestamp that was clamped
@@ -402,12 +408,7 @@ fn resolve_member_nickname(
 ) -> String {
     member_info
         .canonical(member_id)
-        .map(
-            |ami| match unseal_bytes_with_secrets(&ami.member_info.preferred_nickname, secrets) {
-                Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
-                Err(_) => ami.member_info.preferred_nickname.to_string_lossy(),
-            },
-        )
+        .map(|ami| display_nickname(&ami.member_info.preferred_nickname, secrets))
         .unwrap_or_else(|| "Unknown".to_string())
 }
 
@@ -419,6 +420,9 @@ fn group_messages(
     self_member_id: MemberId,
     secrets: &HashMap<u32, [u8; 32]>,
     member_names: &HashMap<MemberId, String>,
+    // Which members show a 🛡 shield in THIS viewer's conversation, built once
+    // per render by `deputy_badges_for_viewer`. Absent ⇒ no shield.
+    deputy_badges: &HashMap<MemberId, DeputyBadge>,
 ) -> Vec<DisplayItem> {
     let mut items: Vec<DisplayItem> = Vec::new();
     let group_threshold = Duration::from_secs(5 * 60); // 5 minutes
@@ -533,6 +537,7 @@ fn group_messages(
             items.push(DisplayItem::Messages(MessageGroup {
                 author_id,
                 author_name,
+                author_badge: deputy_badges.get(&author_id).cloned(),
                 is_self,
                 first_time: message_time,
                 time_clamped,
@@ -663,12 +668,29 @@ pub(crate) fn decrypt_message_content(
 /// the token snapshot as fallback) and strip markdown formatting, so the preview
 /// reads as plain text. Caller truncates the result.
 fn clean_reply_preview(text: &str, member_names: &HashMap<MemberId, String>) -> String {
-    let with_mentions = river_core::mention::render_plaintext(text, |r| {
-        member_names
-            .iter()
-            .find(|(id, _)| r.matches(**id))
-            .map(|(_, name)| name.clone())
-    });
+    use river_core::mention::{parse_segments, MentionSegment};
+
+    // Mirrors `river_core::mention::render_plaintext`, except the fallback
+    // display name — the `[name]` snapshot the SENDER embedded in the message
+    // — is sanitised. That snapshot is arbitrary attacker text, so an
+    // unsanitised fallback would let `@[Alice 🛡](rv:…)` paint a shield into a
+    // reply preview for a member id nobody in the room resolves. Names that DO
+    // resolve come from `member_names`, which is already sanitised at source.
+    let mut with_mentions = String::with_capacity(text.len());
+    for seg in parse_segments(text) {
+        match seg {
+            MentionSegment::Text(t) => with_mentions.push_str(&t),
+            MentionSegment::Mention(m) => {
+                let name = member_names
+                    .iter()
+                    .find(|(id, _)| m.member_ref.matches(**id))
+                    .map(|(_, name)| name.clone())
+                    .unwrap_or_else(|| sanitize_display_name(&m.display_name));
+                with_mentions.push('@');
+                with_mentions.push_str(&name);
+            }
+        }
+    }
     strip_markdown(&with_mentions)
 }
 
@@ -824,9 +846,14 @@ pub(crate) fn message_to_html_with_mentions(
                 // known members so the chip stays clickable and self-highlighted.
                 // An unknown member yields `None` -> non-clickable snapshot chip.
                 let resolved = m.member_ref.resolve(member_names.keys().copied());
+                // The `[name]` snapshot is sender-controlled text, so an
+                // unresolved mention must be sanitised before it becomes a
+                // chip — otherwise `@[Admin 🛡](rv:…)` paints a shield inside
+                // a message. Resolved names come from `member_names`, which is
+                // already sanitised at source.
                 let name = resolved
                     .and_then(|id| member_names.get(&id).cloned())
-                    .unwrap_or(m.display_name);
+                    .unwrap_or_else(|| sanitize_display_name(&m.display_name));
                 chips.push(render_mention_chip_html(
                     resolved,
                     &name,
@@ -1354,22 +1381,32 @@ pub fn Conversation() -> Element {
                         .member_info
                         .iter()
                         .map(|ami| {
-                            let name = match unseal_bytes_with_secrets(
-                                &ami.member_info.preferred_nickname,
-                                &room_data.secrets,
-                            ) {
-                                Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
-                                Err(_) => ami.member_info.preferred_nickname.to_string_lossy(),
-                            };
-                            (ami.member_info.member_id, name)
+                            (
+                                ami.member_info.member_id,
+                                display_nickname(
+                                    &ami.member_info.preferred_nickname,
+                                    &room_data.secrets,
+                                ),
+                            )
                         })
                         .collect();
+                    // Which authors show a 🛡 shield in this viewer's view.
+                    // Computed once here, not per message: the maps behind it
+                    // are O(members) to build.
+                    let deputy_badges = deputy_badges_for_viewer(
+                        &room_state.members,
+                        &room_state.member_info,
+                        &room_data.secrets,
+                        MemberId::from(&key),
+                        self_member_id,
+                    );
                     let groups = group_messages(
                         &room_state.recent_messages,
                         &room_state.member_info,
                         self_member_id,
                         &room_data.secrets,
                         &member_names,
+                        &deputy_badges,
                     );
                     return Some((groups, self_member_id, member_names));
                 }
@@ -2610,14 +2647,13 @@ pub fn Conversation() -> Element {
                                     .iter()
                                     .filter(|ami| ami.member_info.member_id != self_id)
                                     .map(|ami| {
-                                        let name = match unseal_bytes_with_secrets(
-                                            &ami.member_info.preferred_nickname,
-                                            &room_data.secrets,
-                                        ) {
-                                            Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
-                                            Err(_) => ami.member_info.preferred_nickname.to_string_lossy(),
-                                        };
-                                        (ami.member_info.member_id, name)
+                                        (
+                                            ami.member_info.member_id,
+                                            display_nickname(
+                                                &ami.member_info.preferred_nickname,
+                                                &room_data.secrets,
+                                            ),
+                                        )
                                     })
                                     .filter(|(_, name)| !name.trim().is_empty())
                                     .collect();
@@ -2886,6 +2922,25 @@ fn MessageGroupComponent(
                                 });
                             },
                             "{group.author_name}"
+                        }
+                        // Deputy shield. Same glyph and `member-icon` styling
+                        // as the member-list row and the member-info modal, so
+                        // the three surfaces read as one badge. The nickname
+                        // above cannot forge it: nicknames are stripped of
+                        // emoji by `crate::util::display_name`.
+                        if let Some(badge) = group.author_badge.as_ref() {
+                            {
+                                let tooltip = badge.tooltip();
+                                rsx! {
+                                    span {
+                                        "data-testid": "message-author-deputy-badge",
+                                        class: "member-icon text-sm cursor-default",
+                                        title: "{tooltip}",
+                                        "aria-label": "{tooltip}",
+                                        "🛡"
+                                    }
+                                }
+                            }
                         }
                         span {
                             class: if time_clamped {

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -3814,6 +3814,47 @@ fn MessageGroupComponent(
 mod tests {
     use super::*;
 
+    /// Source-grep pin, mirroring `member_info_modal`'s: the conversation's
+    /// author line must take BOTH the shield's visibility and its tooltip from
+    /// the shared `DeputyBadge` machinery, never a private copy of the
+    /// viewer-relevance rule. Three surfaces show this shield (author line,
+    /// member-list row, member-info modal); freenet/river#451 is what happens
+    /// when two of them drift.
+    #[test]
+    fn author_deputy_badge_uses_the_shared_helper() {
+        let source = include_str!("conversation.rs");
+        let prod = &source[..source
+            .rfind("#[cfg(test)]")
+            .expect("conversation.rs should have a #[cfg(test)] block")];
+
+        assert!(
+            prod.contains("message-author-deputy-badge"),
+            "the conversation must render the 🛡 author badge"
+        );
+        assert!(
+            prod.contains("deputy_badges_for_viewer"),
+            "author-badge visibility must come from the shared \
+             `deputy_badges_for_viewer` map"
+        );
+        assert!(
+            prod.contains("badge.tooltip()"),
+            "the author badge's tooltip must come from `DeputyBadge::tooltip` \
+             so the wording cannot drift between surfaces"
+        );
+    }
+
+    /// Nicknames reach the author line through `display_nickname`, so an emoji
+    /// nickname cannot render a second, fake shield beside the real one. The
+    /// crate-wide render-path scan lives in `crate::util::display_name`; this
+    /// is the conversation-local statement of the same requirement.
+    #[test]
+    fn author_names_are_stripped_of_badge_glyphs() {
+        use crate::util::display_name::sanitize_display_name;
+        for spoof in ["Mallory 🛡", "Mallory 👑", "Mallory \u{1F6E1}\u{FE0F}"] {
+            assert_eq!(sanitize_display_name(spoof), "Mallory");
+        }
+    }
+
     /// Issue #315 — pin that the markdown renderer never passes raw HTML
     /// through to the DOM. `markdown_to_html` feeds attacker-controlled
     /// message text into `markdown::to_html_with_options(_, Options::gfm())`,

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -2655,7 +2655,10 @@ pub fn Conversation() -> Element {
                                             ),
                                         )
                                     })
-                                    .filter(|(_, name)| !name.trim().is_empty())
+                                    // `display_nickname` never returns an empty
+                                    // string, so the old is-empty filter became
+                                    // dead: the placeholder is what to exclude.
+                                    .filter(|(_, name)| name != crate::util::display_name::UNNAMED)
                                     .collect();
                                 mention_members
                                     .sort_by(|a, b| a.1.to_lowercase().cmp(&b.1.to_lowercase()));
@@ -2877,7 +2880,9 @@ fn MessageGroupComponent(
         let mut v: Vec<(MemberId, String)> = member_names
             .iter()
             .filter(|(id, _)| **id != self_member_id)
-            .filter(|(_, name)| !name.trim().is_empty())
+            // `display_nickname` never returns an empty string, so the old
+            // is-empty filter became dead: the placeholder is what to exclude.
+            .filter(|(_, name)| *name != crate::util::display_name::UNNAMED)
             .map(|(id, name)| (*id, name.clone()))
             .collect();
         v.sort_by(|a, b| a.1.to_lowercase().cmp(&b.1.to_lowercase()));

--- a/ui/src/components/direct_messages/dm_thread_modal.rs
+++ b/ui/src/components/direct_messages/dm_thread_modal.rs
@@ -163,13 +163,10 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                 .map(|info| {
                     (
                         info.member_info.member_id,
-                        match unseal_bytes_with_secrets(
+                        crate::util::display_name::display_nickname(
                             &info.member_info.preferred_nickname,
                             &room_data.secrets,
-                        ) {
-                            Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
-                            Err(_) => info.member_info.preferred_nickname.to_string_lossy(),
-                        },
+                        ),
                     )
                 })
                 .collect::<std::collections::HashMap<_, _>>();

--- a/ui/src/components/direct_messages/invite_via_dm_picker_modal.rs
+++ b/ui/src/components/direct_messages/invite_via_dm_picker_modal.rs
@@ -175,11 +175,10 @@ pub fn InviteViaDmPickerModal() -> Element {
                     .member_info
                     .canonical(target_peer)
                     .map(|mi| {
-                        match unseal_bytes_with_secrets(&mi.member_info.preferred_nickname, secrets)
-                        {
-                            Ok(b) => String::from_utf8_lossy(&b).to_string(),
-                            Err(_) => mi.member_info.preferred_nickname.to_string_lossy(),
-                        }
+                        crate::util::display_name::display_nickname(
+                            &mi.member_info.preferred_nickname,
+                            secrets,
+                        )
                     })
             });
         nickname.unwrap_or_else(|| target_peer.to_string().chars().take(8).collect())

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -597,19 +597,33 @@ pub(crate) fn relevant_deputizer_names(
     self_member_id: MemberId,
     target: MemberId,
 ) -> Vec<String> {
-    // Resolve an appointer's id to a display name (owner -> "room owner",
+    // Resolve an appointer's id to a display name (owner -> "the room owner",
     // self -> "you", else the appointer's decrypted preferred nickname).
+    //
+    // A real nickname is QUOTED and the two role labels are not, because they
+    // share one flat, comma-joined list and a nickname is attacker-chosen.
+    // Without the quotes a member who is a strict ancestor of the viewer can
+    // set their nickname to `room owner`, deputize anyone, and make that
+    // member's shield read `Deputy (appointed by room owner). Can ban you.` —
+    // a forged global-moderator appointment, in the one place the badge
+    // communicates the SCOPE of someone's authority. Sanitising cannot help:
+    // `room owner` is plain ASCII.
     let name_of = |id: MemberId| -> String {
         if id == owner_id {
-            return "room owner".to_string();
+            return "the room owner".to_string();
         }
         if id == self_member_id {
             return "you".to_string();
         }
         member_info
             .canonical(id)
-            .map(|mi| display_nickname(&mi.member_info.preferred_nickname, room_secrets))
-            .unwrap_or_else(|| "Unknown".to_string())
+            .map(|mi| {
+                format!(
+                    "\u{201c}{}\u{201d}",
+                    display_nickname(&mi.member_info.preferred_nickname, room_secrets)
+                )
+            })
+            .unwrap_or_else(|| "an unknown member".to_string())
     };
     relevant_deputizers(
         deputizers_of.get(&target).map(Vec::as_slice).unwrap_or(&[]),
@@ -968,6 +982,10 @@ pub fn MemberList() -> Element {
                                 span {
                                     class: "member-icon",
                                     title: "{tooltip}",
+                                    // The glyph alone means nothing to a
+                                    // screen reader, and the deputy shield is
+                                    // now a security-relevant signal.
+                                    "aria-label": "{tooltip}",
                                     " {icon}"
                                 }
                             }
@@ -2937,7 +2955,7 @@ mod tests {
         );
 
         display.deputy_badge = Some(DeputyBadge {
-            deputized_by: vec!["room owner".to_string()],
+            deputized_by: vec!["the room owner".to_string()],
             can_ban_viewer: Some(true),
         });
         let parts = member_display_parts(&display);
@@ -2948,18 +2966,21 @@ mod tests {
             .expect("a deputy must show the 🛡 shield");
         // Identical wording to the conversation author line and the modal
         // chip — all three call `DeputyBadge::tooltip`.
-        assert_eq!(shield.1, "Deputy (appointed by room owner). Can ban you.");
+        assert_eq!(
+            shield.1,
+            "Deputy (appointed by the room owner). Can ban you."
+        );
 
         // On the viewer's OWN row the ban clause is dropped: "can they ban
         // you" is meaningless about yourself.
         display.deputy_badge = Some(DeputyBadge {
-            deputized_by: vec!["room owner".to_string()],
+            deputized_by: vec!["the room owner".to_string()],
             can_ban_viewer: None,
         });
         let parts = member_display_parts(&display);
         assert_eq!(
             parts.tags.iter().find(|(icon, _)| *icon == "🛡").unwrap().1,
-            "Deputy (appointed by room owner)"
+            "Deputy (appointed by the room owner)"
         );
     }
 
@@ -3026,7 +3047,7 @@ mod tests {
                 viewer_id,
                 mod_id,
             ),
-            vec!["room owner".to_string()],
+            vec!["the room owner".to_string()],
         );
         // A member nobody deputized shows no shield.
         assert!(relevant_deputizer_names(
@@ -3115,11 +3136,11 @@ mod tests {
         let global = badges
             .get(&id(&global_mod_sk))
             .expect("a deputy of the owner must show the shield to every viewer");
-        assert_eq!(global.deputized_by, vec!["room owner".to_string()]);
+        assert_eq!(global.deputized_by, vec!["the room owner".to_string()]);
         assert_eq!(global.can_ban_viewer, Some(true));
         assert_eq!(
             global.tooltip(),
-            "Deputy (appointed by room owner). Can ban you."
+            "Deputy (appointed by the room owner). Can ban you."
         );
 
         // 1b. Deputy of a strict ancestor of the viewer → badge, named after
@@ -3127,7 +3148,12 @@ mod tests {
         let by_alpha = badges
             .get(&id(&deputy_alpha_sk))
             .expect("a deputy of the viewer's inviter must show the shield");
-        assert_eq!(by_alpha.deputized_by, vec!["Alpha".to_string()]);
+        // A real nickname is quoted so it cannot masquerade as the unquoted
+        // `the room owner` / `you` role labels in the same comma-joined list.
+        assert_eq!(
+            by_alpha.deputized_by,
+            vec!["\u{201c}Alpha\u{201d}".to_string()]
+        );
         assert_eq!(by_alpha.can_ban_viewer, Some(true));
 
         // 2. Deputy of a member OUTSIDE the viewer's invite ancestry → NO
@@ -3211,7 +3237,7 @@ mod tests {
         let other = badges
             .get(&id(&other_mod_sk))
             .expect("a fellow deputy must still show the shield to a deputy viewer");
-        assert_eq!(other.deputized_by, vec!["room owner".to_string()]);
+        assert_eq!(other.deputized_by, vec!["the room owner".to_string()]);
         assert_eq!(
             other.can_ban_viewer,
             Some(true),
@@ -3225,7 +3251,7 @@ mod tests {
             .get(&viewer_id)
             .expect("a deputy viewer sees the shield on their own row");
         assert_eq!(own.can_ban_viewer, None);
-        assert_eq!(own.tooltip(), "Deputy (appointed by room owner)");
+        assert_eq!(own.tooltip(), "Deputy (appointed by the room owner)");
     }
 
     /// The room owner's OWN view. `viewer_relevant_deputizer_set` gives the
@@ -3272,7 +3298,7 @@ mod tests {
         // so an owner viewing their own appointee reads "room owner", not
         // "you". Pinned rather than "fixed": the label describes the role that
         // granted the authority, and every other viewer sees the same word.
-        assert_eq!(m.deputized_by, vec!["room owner".to_string()]);
+        assert_eq!(m.deputized_by, vec!["the room owner".to_string()]);
         assert_eq!(
             m.can_ban_viewer,
             Some(false),
@@ -3542,8 +3568,32 @@ mod tests {
         let badges =
             deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, id(&viewer_sk));
         let badge = badges.get(&id(&deputy_sk)).expect("shield expected");
-        assert_eq!(badge.deputized_by, vec!["Eve".to_string()]);
+        assert_eq!(badge.deputized_by, vec!["\u{201c}Eve\u{201d}".to_string()]);
         assert!(!badge.tooltip().contains('🛡'));
+
+        // The role labels are unquoted, so a nickname of `room owner` reads as
+        // the nickname it is rather than as an owner appointment.
+        let liar = deputy_badges_for_viewer(
+            &members,
+            &MemberInfoV1 {
+                member_info: vec![
+                    signed_member_info(&owner_sk, "Owner", vec![]),
+                    signed_member_info(&appointer_sk, "room owner", vec![id(&deputy_sk)]),
+                    signed_member_info(&deputy_sk, "Deputy", vec![]),
+                    signed_member_info(&viewer_sk, "Viewer", vec![]),
+                ],
+            },
+            &secrets,
+            owner_id,
+            id(&viewer_sk),
+        );
+        assert_eq!(
+            liar.get(&id(&deputy_sk))
+                .expect("shield expected")
+                .deputized_by,
+            vec!["\u{201c}room owner\u{201d}".to_string()],
+            "a nickname of `room owner` must not forge an owner appointment"
+        );
     }
 
     /// `build_deputizers_of` must order each deputy's appointers

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -173,10 +173,11 @@ struct MemberDisplay {
     sponsored_you: bool,
     invited_by_you: bool,
     in_your_network: bool,
-    /// Display names of the members who have deputized this member (the owner
-    /// shows as "room owner"). Empty means not a deputy. Drives the 🛡 badge
-    /// and its tooltip (#410).
-    deputized_by: Vec<String>,
+    /// The 🛡 badge to show for this member in the current viewer's view, or
+    /// `None` for no badge (#410). Same value — and therefore the same
+    /// visibility rule and the same tooltip — the conversation's author line
+    /// and the member-info modal use.
+    deputy_badge: Option<DeputyBadge>,
 }
 
 fn is_member_sponsor(
@@ -246,11 +247,8 @@ fn member_display_parts(member: &MemberDisplay) -> MemberDisplayParts {
     } else if member.sponsored_you {
         tags.push(("🔭", "In Your Invite Chain".to_string()));
     }
-    if !member.deputized_by.is_empty() {
-        tags.push((
-            "🛡",
-            format!("Deputy (appointed by {})", member.deputized_by.join(", ")),
-        ));
+    if let Some(badge) = member.deputy_badge.as_ref() {
+        tags.push(("🛡", badge.tooltip()));
     }
 
     MemberDisplayParts {
@@ -652,18 +650,27 @@ pub(crate) struct DeputyBadge {
     /// nickname. Never empty: an empty result means no badge at all, which is
     /// represented by the member being absent from the map.
     pub deputized_by: Vec<String>,
-    /// Whether this member may actually ban the viewer right now.
-    pub can_ban_viewer: bool,
+    /// Whether this member may actually ban the viewer right now, or `None`
+    /// when the badge is on the VIEWER'S OWN row — "can they ban you" is not a
+    /// meaningful thing to say about yourself, and `is_ban_authorized` happily
+    /// answers `true` for a global moderator asked about themselves.
+    pub can_ban_viewer: Option<bool>,
 }
 
 impl DeputyBadge {
     /// The `title=` text: who appointed them, and what that means for you.
+    ///
+    /// One definition for all three surfaces (message author line, member-list
+    /// row, member-info modal chip) so the shield cannot say different things
+    /// in different places — the drift freenet/river#451 fixed for visibility,
+    /// applied to the wording too.
     pub fn tooltip(&self) -> String {
-        format!(
-            "Deputy (appointed by {}) — {} ban you",
-            self.deputized_by.join(", "),
-            if self.can_ban_viewer { "can" } else { "cannot" }
-        )
+        let appointers = self.deputized_by.join(", ");
+        match self.can_ban_viewer {
+            Some(true) => format!("Deputy (appointed by {appointers}) — can ban you"),
+            Some(false) => format!("Deputy (appointed by {appointers}) — cannot ban you"),
+            None => format!("Deputy (appointed by {appointers})"),
+        }
     }
 }
 
@@ -705,13 +712,15 @@ pub(crate) fn deputy_badges_for_viewer(
             if deputized_by.is_empty() {
                 return None;
             }
-            let can_ban_viewer = MembersV1::is_ban_authorized(
-                target,
-                self_member_id,
-                &members_by_id,
-                member_info,
-                owner_id,
-            );
+            let can_ban_viewer = (target != self_member_id).then(|| {
+                MembersV1::is_ban_authorized(
+                    target,
+                    self_member_id,
+                    &members_by_id,
+                    member_info,
+                    owner_id,
+                )
+            });
             Some((
                 target,
                 DeputyBadge {
@@ -758,6 +767,11 @@ pub fn MemberList() -> Element {
         // with the modal legend via `viewer_relevant_deputizer_set` (#451).
         let viewer_relevant = viewer_relevant_deputizer_set(members, owner_id, self_member_id);
 
+        // The badge (visibility + tooltip) for every member, shared verbatim
+        // with the conversation's author lines.
+        let deputy_badges =
+            deputy_badges_for_viewer(members, member_info, room_secrets, owner_id, self_member_id);
+
         // Order the list as a DISPLAY tree, VIEWER-SCOPED: a member renders under
         // a deputizer only if that deputizer is viewer-relevant — so a global mod
         // rises to the top for everyone (including the owner's own view), a
@@ -802,16 +816,10 @@ pub fn MemberList() -> Element {
                 // appointed them). A deputy of the OWNER (global mod) shows in
                 // every view including the owner's own; a mod you appointed
                 // shows in your view; a deputy of an unrelated subtree is hidden.
-                // Same helper the member-info modal legend uses (#451).
-                deputized_by: relevant_deputizer_names(
-                    member_info,
-                    room_secrets,
-                    &deputizers_of,
-                    &viewer_relevant,
-                    owner_id,
-                    self_member_id,
-                    member_id,
-                ),
+                // Same map the conversation's author line uses (#451), so the
+                // shield's visibility AND its tooltip stay identical across
+                // the sidebar, the modal and the conversation.
+                deputy_badge: deputy_badges.get(&member_id).cloned(),
             };
 
             all_members.push((member_display_parts(&member_display), member_id));
@@ -2520,7 +2528,7 @@ mod tests {
             sponsored_you: false,
             invited_by_you: false,
             in_your_network: false,
-            deputized_by: Vec::new(),
+            deputy_badge: None,
         }
     }
 
@@ -2850,14 +2858,31 @@ mod tests {
             "no shield when the member is not a deputy"
         );
 
-        display.deputized_by = vec!["room owner".to_string()];
+        display.deputy_badge = Some(DeputyBadge {
+            deputized_by: vec!["room owner".to_string()],
+            can_ban_viewer: Some(true),
+        });
         let parts = member_display_parts(&display);
         let shield = parts
             .tags
             .iter()
             .find(|(icon, _)| *icon == "🛡")
             .expect("a deputy must show the 🛡 shield");
-        assert_eq!(shield.1, "Deputy (appointed by room owner)");
+        // Identical wording to the conversation author line and the modal
+        // chip — all three call `DeputyBadge::tooltip`.
+        assert_eq!(shield.1, "Deputy (appointed by room owner) — can ban you");
+
+        // On the viewer's OWN row the ban clause is dropped: "can they ban
+        // you" is meaningless about yourself.
+        display.deputy_badge = Some(DeputyBadge {
+            deputized_by: vec!["room owner".to_string()],
+            can_ban_viewer: None,
+        });
+        let parts = member_display_parts(&display);
+        assert_eq!(
+            parts.tags.iter().find(|(icon, _)| *icon == "🛡").unwrap().1,
+            "Deputy (appointed by room owner)"
+        );
     }
 
     /// End-to-end pin of the shared deputy helpers the member row AND the
@@ -3013,7 +3038,7 @@ mod tests {
             .get(&id(&global_mod_sk))
             .expect("a deputy of the owner must show the shield to every viewer");
         assert_eq!(global.deputized_by, vec!["room owner".to_string()]);
-        assert!(global.can_ban_viewer);
+        assert_eq!(global.can_ban_viewer, Some(true));
         assert_eq!(
             global.tooltip(),
             "Deputy (appointed by room owner) — can ban you"
@@ -3025,7 +3050,7 @@ mod tests {
             .get(&id(&deputy_alpha_sk))
             .expect("a deputy of the viewer's inviter must show the shield");
         assert_eq!(by_alpha.deputized_by, vec!["Alpha".to_string()]);
-        assert!(by_alpha.can_ban_viewer);
+        assert_eq!(by_alpha.can_ban_viewer, Some(true));
 
         // 2. Deputy of a member OUTSIDE the viewer's invite ancestry → NO
         //    badge. Deputy authority is scoped to the deputizer's subtree, so
@@ -3045,8 +3070,9 @@ mod tests {
             .get(&id(&my_deputy_sk))
             .expect("a deputy the viewer appointed must still show the shield");
         assert_eq!(mine.deputized_by, vec!["you".to_string()]);
-        assert!(
-            !mine.can_ban_viewer,
+        assert_eq!(
+            mine.can_ban_viewer,
+            Some(false),
             "a deputy cannot ban the member who deputized them"
         );
         assert_eq!(mine.tooltip(), "Deputy (appointed by you) — cannot ban you");
@@ -3108,11 +3134,20 @@ mod tests {
             .get(&id(&other_mod_sk))
             .expect("a fellow deputy must still show the shield to a deputy viewer");
         assert_eq!(other.deputized_by, vec!["room owner".to_string()]);
-        assert!(
+        assert_eq!(
             other.can_ban_viewer,
+            Some(true),
             "owner-appointed moderators have absolute authority, including \
              over other moderators"
         );
+
+        // The viewer is a deputy too, so their OWN row carries a shield — with
+        // the ban clause dropped rather than a nonsensical "can ban you".
+        let own = badges
+            .get(&viewer_id)
+            .expect("a deputy viewer sees the shield on their own row");
+        assert_eq!(own.can_ban_viewer, None);
+        assert_eq!(own.tooltip(), "Deputy (appointed by room owner)");
     }
 
     /// The room owner's OWN view. `viewer_relevant_deputizer_set` gives the
@@ -3160,7 +3195,11 @@ mod tests {
         // "you". Pinned rather than "fixed": the label describes the role that
         // granted the authority, and every other viewer sees the same word.
         assert_eq!(m.deputized_by, vec!["room owner".to_string()]);
-        assert!(!m.can_ban_viewer, "the owner is never a valid ban target");
+        assert_eq!(
+            m.can_ban_viewer,
+            Some(false),
+            "the owner is never a valid ban target"
+        );
         // Someone else's deputy is not relevant to the owner's view.
         assert!(!badges.contains_key(&id(&their_deputy_sk)));
     }

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -520,6 +520,19 @@ pub(crate) fn build_deputizers_of(
             continue;
         };
         for deputy in &canonical.member_info.deputies {
+            // SELF-DEPUTISATION IS NOT A GRANT. `MemberInfoV1::verify` bounds
+            // the list length and checks the signature but never validates who
+            // is in it, so any member can write `deputies: [self]` with a
+            // custom client. Honouring that would let them render a genuine 🛡
+            // on their own messages for their whole subtree — the same
+            // impersonation this file's badge exists to make trustworthy,
+            // achieved with a real badge instead of an emoji. It also grants
+            // nothing: `is_ban_authorized` step 5 only consults a STRICT
+            // ancestor's deputy list, so a self-grant is already inert for
+            // authority. Ignore it for display too.
+            if *deputy == appointer {
+                continue;
+            }
             deputizers_of.entry(*deputy).or_default().push(appointer);
         }
     }
@@ -650,8 +663,9 @@ pub(crate) struct DeputyBadge {
     /// nickname. Never empty: an empty result means no badge at all, which is
     /// represented by the member being absent from the map.
     pub deputized_by: Vec<String>,
-    /// Whether this member may actually ban the viewer right now, or `None`
-    /// when the badge is on the VIEWER'S OWN row — "can they ban you" is not a
+    /// Whether this member can currently get the viewer removed from the room,
+    /// directly or by a cascading ban of one of the viewer's ancestors. `None`
+    /// when the badge is on the VIEWER'S OWN row: "can they ban you" is not a
     /// meaningful thing to say about yourself, and `is_ban_authorized` happily
     /// answers `true` for a global moderator asked about themselves.
     pub can_ban_viewer: Option<bool>,
@@ -662,13 +676,13 @@ impl DeputyBadge {
     ///
     /// One definition for all three surfaces (message author line, member-list
     /// row, member-info modal chip) so the shield cannot say different things
-    /// in different places — the drift freenet/river#451 fixed for visibility,
-    /// applied to the wording too.
+    /// in different places. That is the drift freenet/river#451 fixed for
+    /// visibility, applied to the wording too.
     pub fn tooltip(&self) -> String {
         let appointers = self.deputized_by.join(", ");
         match self.can_ban_viewer {
-            Some(true) => format!("Deputy (appointed by {appointers}) — can ban you"),
-            Some(false) => format!("Deputy (appointed by {appointers}) — cannot ban you"),
+            Some(true) => format!("Deputy (appointed by {appointers}). Can ban you."),
+            Some(false) => format!("Deputy (appointed by {appointers}). Cannot ban you."),
             None => format!("Deputy (appointed by {appointers})"),
         }
     }
@@ -700,7 +714,8 @@ pub(crate) fn deputy_badges_for_viewer(
     deputizers_of
         .keys()
         .filter_map(|&target| {
-            let deputized_by = relevant_deputizer_names(
+            badge_for_target(
+                &members_by_id,
                 member_info,
                 room_secrets,
                 &deputizers_of,
@@ -708,28 +723,91 @@ pub(crate) fn deputy_badges_for_viewer(
                 owner_id,
                 self_member_id,
                 target,
-            );
-            if deputized_by.is_empty() {
-                return None;
-            }
-            let can_ban_viewer = (target != self_member_id).then(|| {
-                MembersV1::is_ban_authorized(
-                    target,
-                    self_member_id,
-                    &members_by_id,
-                    member_info,
-                    owner_id,
-                )
-            });
-            Some((
-                target,
-                DeputyBadge {
-                    deputized_by,
-                    can_ban_viewer,
-                },
-            ))
+            )
+            .map(|badge| (target, badge))
         })
         .collect()
+}
+
+/// [`deputy_badges_for_viewer`] for a SINGLE member.
+///
+/// The member-info modal wants one member's badge and is not memoised, so
+/// building the whole map there would decrypt every deputy's appointer
+/// nicknames on every render — in a private room that is an ECIES unseal per
+/// appointer per keystroke elsewhere in the app. Same predicate, same tooltip;
+/// only the sweep is narrowed.
+pub(crate) fn deputy_badge_for_viewer(
+    members: &MembersV1,
+    member_info: &river_core::room_state::member_info::MemberInfoV1,
+    room_secrets: &HashMap<u32, [u8; 32]>,
+    owner_id: MemberId,
+    self_member_id: MemberId,
+    target: MemberId,
+) -> Option<DeputyBadge> {
+    let deputizers_of = build_deputizers_of(member_info);
+    let viewer_relevant = viewer_relevant_deputizer_set(members, owner_id, self_member_id);
+    badge_for_target(
+        &members.members_by_member_id(),
+        member_info,
+        room_secrets,
+        &deputizers_of,
+        &viewer_relevant,
+        owner_id,
+        self_member_id,
+        target,
+    )
+}
+
+/// The single definition of "does `target` show a shield to this viewer, and
+/// what does its tooltip say". Both public entry points route through here so
+/// the sweep and the single lookup cannot disagree.
+#[allow(clippy::too_many_arguments)]
+fn badge_for_target(
+    members_by_id: &HashMap<MemberId, &AuthorizedMember>,
+    member_info: &river_core::room_state::member_info::MemberInfoV1,
+    room_secrets: &HashMap<u32, [u8; 32]>,
+    deputizers_of: &HashMap<MemberId, Vec<MemberId>>,
+    viewer_relevant: &HashSet<MemberId>,
+    owner_id: MemberId,
+    self_member_id: MemberId,
+    target: MemberId,
+) -> Option<DeputyBadge> {
+    // The OWNER never carries a deputy shield. Their authority is inherent,
+    // not delegated, so "Deputy (appointed by …)" would be false. And nothing
+    // in `MemberInfoV1::verify` stops a member from listing the owner in their
+    // own `deputies`, which would otherwise let anyone in the viewer's invite
+    // chain paint a fabricated appointment onto the owner.
+    if target == owner_id {
+        return None;
+    }
+    let deputized_by = relevant_deputizer_names(
+        member_info,
+        room_secrets,
+        deputizers_of,
+        viewer_relevant,
+        owner_id,
+        self_member_id,
+        target,
+    );
+    if deputized_by.is_empty() {
+        return None;
+    }
+    let can_ban_viewer = (target != self_member_id).then(|| {
+        // A ban CASCADES to the banned member's whole invite subtree
+        // (`MembersV1::get_downstream_members`), so "can they ban you" is not
+        // just `is_ban_authorized(target, viewer)`: someone who can ban anyone
+        // the viewer descends from removes the viewer too. `viewer_relevant`
+        // is exactly {owner} ∪ the viewer's strict ancestors ∪ {viewer}, which
+        // is the full victim set; the owner is never a valid ban target so
+        // that entry always answers `false`.
+        viewer_relevant.iter().any(|&victim| {
+            MembersV1::is_ban_authorized(target, victim, members_by_id, member_info, owner_id)
+        })
+    });
+    Some(DeputyBadge {
+        deputized_by,
+        can_ban_viewer,
+    })
 }
 
 #[component]
@@ -2870,7 +2948,7 @@ mod tests {
             .expect("a deputy must show the 🛡 shield");
         // Identical wording to the conversation author line and the modal
         // chip — all three call `DeputyBadge::tooltip`.
-        assert_eq!(shield.1, "Deputy (appointed by room owner) — can ban you");
+        assert_eq!(shield.1, "Deputy (appointed by room owner). Can ban you.");
 
         // On the viewer's OWN row the ban clause is dropped: "can they ban
         // you" is meaningless about yourself.
@@ -3041,7 +3119,7 @@ mod tests {
         assert_eq!(global.can_ban_viewer, Some(true));
         assert_eq!(
             global.tooltip(),
-            "Deputy (appointed by room owner) — can ban you"
+            "Deputy (appointed by room owner). Can ban you."
         );
 
         // 1b. Deputy of a strict ancestor of the viewer → badge, named after
@@ -3075,7 +3153,7 @@ mod tests {
             Some(false),
             "a deputy cannot ban the member who deputized them"
         );
-        assert_eq!(mine.tooltip(), "Deputy (appointed by you) — cannot ban you");
+        assert_eq!(mine.tooltip(), "Deputy (appointed by you). Cannot ban you.");
 
         // 4. No deputy authority at all → no badge.
         assert!(!badges.contains_key(&id(&plain_sk)));
@@ -3202,6 +3280,230 @@ mod tests {
         );
         // Someone else's deputy is not relevant to the owner's view.
         assert!(!badges.contains_key(&id(&their_deputy_sk)));
+    }
+
+    /// "Cannot ban you" must not lie. A ban cascades to the banned member's
+    /// whole invite subtree, so a deputy who cannot ban the viewer DIRECTLY but
+    /// can ban the viewer's inviter still gets the viewer removed.
+    ///
+    /// Room: `owner -> alpha -> parent -> viewer`. `alpha` deputizes `mod`, and
+    /// the viewer ALSO deputizes `mod` — which is exactly the configuration the
+    /// badge advertises as "you're protected". `is_ban_authorized(mod, viewer)`
+    /// denies (step 4 guardrail), but `is_ban_authorized(mod, parent)` grants
+    /// (step 5, alpha is parent's ancestor), and banning `parent` sweeps the
+    /// viewer out with them.
+    #[test]
+    fn can_ban_viewer_accounts_for_cascading_bans() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let alpha_sk = SigningKey::generate(&mut rng);
+        let parent_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+        let mod_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+        let viewer_id = id(&viewer_sk);
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &alpha_sk.verifying_key()),
+                authorized_member(&owner_sk, &mod_sk.verifying_key()),
+                member_invited_by(&alpha_sk, owner_id, &parent_sk.verifying_key()),
+                member_invited_by(&parent_sk, owner_id, &viewer_sk.verifying_key()),
+            ],
+        };
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                signed_member_info(&owner_sk, "Owner", vec![]),
+                signed_member_info(&alpha_sk, "Alpha", vec![id(&mod_sk)]),
+                signed_member_info(&parent_sk, "Parent", vec![]),
+                // The viewer deputizes the moderator, which under the contract
+                // makes a DIRECT ban of the viewer inert.
+                signed_member_info(&viewer_sk, "Viewer", vec![id(&mod_sk)]),
+                signed_member_info(&mod_sk, "Mod", vec![]),
+            ],
+        };
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+        let members_by_id = members.members_by_member_id();
+
+        // Precondition: the direct ban really is denied. Without this the test
+        // would pass for the wrong reason.
+        assert!(
+            !MembersV1::is_ban_authorized(
+                id(&mod_sk),
+                viewer_id,
+                &members_by_id,
+                &member_info,
+                owner_id
+            ),
+            "precondition: a direct ban of the viewer must be denied here"
+        );
+        // ...but the ancestor ban is not.
+        assert!(MembersV1::is_ban_authorized(
+            id(&mod_sk),
+            id(&parent_sk),
+            &members_by_id,
+            &member_info,
+            owner_id
+        ));
+
+        let badges =
+            deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, viewer_id);
+        let badge = badges.get(&id(&mod_sk)).expect("shield expected");
+        assert_eq!(
+            badge.can_ban_viewer,
+            Some(true),
+            "the tooltip must not promise safety from someone who can remove \
+             the viewer by banning their inviter"
+        );
+    }
+
+    /// A member can write `deputies: [self]` with a custom client — nothing in
+    /// `MemberInfoV1::verify` forbids it. Honouring it would let anyone in the
+    /// viewer's invite chain render a REAL shield on their own messages, which
+    /// is the impersonation this whole feature exists to prevent.
+    #[test]
+    fn self_deputisation_grants_no_badge() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let liar_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &liar_sk.verifying_key()),
+                // The viewer is inside the liar's subtree, so the liar IS a
+                // viewer-relevant appointer — the badge would show if the
+                // self-grant counted.
+                member_invited_by(&liar_sk, owner_id, &viewer_sk.verifying_key()),
+            ],
+        };
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                signed_member_info(&owner_sk, "Owner", vec![]),
+                signed_member_info(&liar_sk, "Liar", vec![id(&liar_sk)]),
+                signed_member_info(&viewer_sk, "Viewer", vec![]),
+            ],
+        };
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        let badges =
+            deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, id(&viewer_sk));
+        assert!(
+            badges.is_empty(),
+            "a self-granted deputy entry must not render a shield: {badges:?}"
+        );
+    }
+
+    /// Symmetrically: a member can list the OWNER in their own `deputies`. The
+    /// owner's authority is inherent, so a fabricated "appointed by …" chip on
+    /// the owner would be both false and a spoof surface.
+    #[test]
+    fn owner_never_carries_a_deputy_badge() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let liar_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &liar_sk.verifying_key()),
+                member_invited_by(&liar_sk, owner_id, &viewer_sk.verifying_key()),
+            ],
+        };
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                signed_member_info(&owner_sk, "Owner", vec![]),
+                // A member "deputizing" the owner.
+                signed_member_info(&liar_sk, "Liar", vec![owner_id]),
+                signed_member_info(&viewer_sk, "Viewer", vec![]),
+            ],
+        };
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        let badges =
+            deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, id(&viewer_sk));
+        assert!(
+            !badges.contains_key(&owner_id),
+            "the owner must never render a deputy shield"
+        );
+    }
+
+    /// The single-target lookup used by the member-info modal must agree with
+    /// the sweep used by the member list and the conversation, member for
+    /// member. If they can disagree the shield drifts between surfaces again.
+    #[test]
+    fn single_target_badge_matches_the_sweep() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let alpha_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+        let mod_sk = SigningKey::generate(&mut rng);
+        let plain_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+        let viewer_id = id(&viewer_sk);
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &alpha_sk.verifying_key()),
+                authorized_member(&owner_sk, &mod_sk.verifying_key()),
+                authorized_member(&owner_sk, &plain_sk.verifying_key()),
+                member_invited_by(&alpha_sk, owner_id, &viewer_sk.verifying_key()),
+            ],
+        };
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                signed_member_info(&owner_sk, "Owner", vec![id(&mod_sk)]),
+                signed_member_info(&alpha_sk, "Alpha", vec![]),
+                signed_member_info(&viewer_sk, "Viewer", vec![]),
+                signed_member_info(&mod_sk, "Mod", vec![]),
+                signed_member_info(&plain_sk, "Plain", vec![]),
+            ],
+        };
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        let sweep = deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, viewer_id);
+        for target in [
+            owner_id,
+            id(&alpha_sk),
+            viewer_id,
+            id(&mod_sk),
+            id(&plain_sk),
+        ] {
+            assert_eq!(
+                deputy_badge_for_viewer(
+                    &members,
+                    &member_info,
+                    &secrets,
+                    owner_id,
+                    viewer_id,
+                    target
+                ),
+                sweep.get(&target).cloned(),
+                "single-target lookup disagrees with the sweep for {target}"
+            );
+        }
     }
 
     /// An emoji nickname must not be able to paint an appointer name that

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -2,6 +2,7 @@ use crate::components::app::freenet_api::freenet_synchronizer::SynchronizerStatu
 use crate::components::app::{
     MobileView, CURRENT_ROOM, MEMBER_INFO_MODAL, MOBILE_VIEW, ROOMS, SYNC_STATUS,
 };
+use crate::util::display_name::display_nickname;
 use crate::util::ecies::unseal_bytes_with_secrets;
 use dioxus::prelude::*;
 use dioxus_free_icons::icons::fa_solid_icons::{FaArrowLeft, FaFileExport, FaUserPlus, FaUsers};
@@ -596,12 +597,7 @@ pub(crate) fn relevant_deputizer_names(
         }
         member_info
             .canonical(id)
-            .map(|mi| {
-                match unseal_bytes_with_secrets(&mi.member_info.preferred_nickname, room_secrets) {
-                    Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
-                    Err(_) => mi.member_info.preferred_nickname.to_string_lossy(),
-                }
-            })
+            .map(|mi| display_nickname(&mi.member_info.preferred_nickname, room_secrets))
             .unwrap_or_else(|| "Unknown".to_string())
     };
     relevant_deputizers(
@@ -611,6 +607,120 @@ pub(crate) fn relevant_deputizer_names(
     .into_iter()
     .map(name_of)
     .collect()
+}
+
+/// Whether `viewer` may ban `target` — the Ban-button gate (#410 / #411 round 4
+/// D). Uses [`MembersV1::is_ban_authorized`] (owner / invite-ancestor / deputy),
+/// NOT bare invite-chain ancestry, so a DEPUTY sees the Ban action for members in
+/// their deputizer's subtree. Bare downstream ancestry (`is_downstream`, still
+/// used for the "🔑 Invited by You" relationship tag) would have hidden it.
+pub(crate) fn viewer_can_ban(
+    members: &MembersV1,
+    member_info: &river_core::room_state::member_info::MemberInfoV1,
+    viewer: MemberId,
+    target: MemberId,
+    owner_id: MemberId,
+) -> bool {
+    let members_by_id = members.members_by_member_id();
+    MembersV1::is_ban_authorized(viewer, target, &members_by_id, member_info, owner_id)
+}
+
+/// The 🛡 shield one member shows in one viewer's view.
+///
+/// Ian's semantics for the shield (2026-07): *"a deputy shield indicates 'this
+/// user has been deputized WHICH ALLOWS THEM TO BAN ME', unless I'm also a
+/// deputy in which case they can't ban me but I can still see that they're a
+/// deputy."* So the shield is about the AUTHOR's authority over the VIEWER, and
+/// it must NOT disappear when the viewer happens to be immune.
+///
+/// Those two halves are deliberately separate fields:
+///
+/// * `deputized_by` decides **visibility** — non-empty means show the shield.
+///   It is the pre-existing viewer-relative predicate the member list and the
+///   member-info modal already use ([`relevant_deputizer_names`]), which never
+///   consults the viewer's own deputy status, so the "still shows when I'm
+///   immune" half holds by construction.
+/// * `can_ban_viewer` decides only the **tooltip wording**, and is the real
+///   contract-level answer from [`MembersV1::is_ban_authorized`] rather than an
+///   approximation of it. The two can legitimately disagree: a deputy the
+///   viewer appointed themselves shows the shield but cannot ban the viewer
+///   (the "cannot ban the member who deputized you" guardrail in
+///   `is_ban_authorized` step 4).
+#[derive(Clone, PartialEq, Debug)]
+pub(crate) struct DeputyBadge {
+    /// Viewer-relevant appointer display names — `"room owner"`, `"you"`, or a
+    /// nickname. Never empty: an empty result means no badge at all, which is
+    /// represented by the member being absent from the map.
+    pub deputized_by: Vec<String>,
+    /// Whether this member may actually ban the viewer right now.
+    pub can_ban_viewer: bool,
+}
+
+impl DeputyBadge {
+    /// The `title=` text: who appointed them, and what that means for you.
+    pub fn tooltip(&self) -> String {
+        format!(
+            "Deputy (appointed by {}) — {} ban you",
+            self.deputized_by.join(", "),
+            if self.can_ban_viewer { "can" } else { "cannot" }
+        )
+    }
+}
+
+/// Every member who shows a 🛡 shield in `self_member_id`'s view, keyed by
+/// member id. Absent from the map ⇒ no shield.
+///
+/// Computed once per render rather than per message: the conversation asks this
+/// for every message author, and the underlying `deputizers_of` /
+/// `viewer_relevant` maps are O(members) to build.
+///
+/// Deliberately built from the SAME helpers as the member-list row and the
+/// member-info modal legend, so the shield cannot mean one thing in the
+/// conversation and another in the sidebar — the drift freenet/river#451 fixed
+/// between the row and the modal.
+pub(crate) fn deputy_badges_for_viewer(
+    members: &MembersV1,
+    member_info: &river_core::room_state::member_info::MemberInfoV1,
+    room_secrets: &HashMap<u32, [u8; 32]>,
+    owner_id: MemberId,
+    self_member_id: MemberId,
+) -> HashMap<MemberId, DeputyBadge> {
+    let deputizers_of = build_deputizers_of(member_info);
+    let viewer_relevant = viewer_relevant_deputizer_set(members, owner_id, self_member_id);
+    // `is_ban_authorized` needs this map; build it once for the whole sweep.
+    let members_by_id = members.members_by_member_id();
+
+    deputizers_of
+        .keys()
+        .filter_map(|&target| {
+            let deputized_by = relevant_deputizer_names(
+                member_info,
+                room_secrets,
+                &deputizers_of,
+                &viewer_relevant,
+                owner_id,
+                self_member_id,
+                target,
+            );
+            if deputized_by.is_empty() {
+                return None;
+            }
+            let can_ban_viewer = MembersV1::is_ban_authorized(
+                target,
+                self_member_id,
+                &members_by_id,
+                member_info,
+                owner_id,
+            );
+            Some((
+                target,
+                DeputyBadge {
+                    deputized_by,
+                    can_ban_viewer,
+                },
+            ))
+        })
+        .collect()
 }
 
 #[component]
@@ -662,15 +772,7 @@ pub fn MemberList() -> Element {
 
             let nickname = member_info
                 .canonical(member_id)
-                .map(|mi| {
-                    match unseal_bytes_with_secrets(
-                        &mi.member_info.preferred_nickname,
-                        room_secrets,
-                    ) {
-                        Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
-                        Err(_) => mi.member_info.preferred_nickname.to_string_lossy(),
-                    }
-                })
+                .map(|mi| display_nickname(&mi.member_info.preferred_nickname, room_secrets))
                 .unwrap_or_else(|| "Unknown".to_string());
 
             let member_display = MemberDisplay {
@@ -1782,6 +1884,40 @@ mod tests {
         AuthorizedMember::new(member, owner_sk)
     }
 
+    /// Like [`authorized_member`] but for a NON-owner inviter, so tests can
+    /// build an invite tree deeper than one level (the deputy badge is scoped
+    /// to invite subtrees, so depth is the whole point).
+    fn member_invited_by(
+        inviter_sk: &SigningKey,
+        owner_id: MemberId,
+        invitee_vk: &VerifyingKey,
+    ) -> AuthorizedMember {
+        let member = Member {
+            owner_member_id: owner_id,
+            invited_by: MemberId::from(&inviter_sk.verifying_key()),
+            member_vk: *invitee_vk,
+        };
+        AuthorizedMember::new(member, inviter_sk)
+    }
+
+    /// A signed `member_info` record with a chosen nickname and deputy list.
+    fn signed_member_info(
+        sk: &SigningKey,
+        nickname: &str,
+        deputies: Vec<MemberId>,
+    ) -> river_core::room_state::member_info::AuthorizedMemberInfo {
+        use river_core::room_state::member_info::{AuthorizedMemberInfo, MemberInfo};
+        let mi = MemberInfo {
+            member_id: MemberId::from(&sk.verifying_key()),
+            version: 0,
+            preferred_nickname: river_core::room_state::privacy::SealedBytes::public(
+                nickname.as_bytes().to_vec(),
+            ),
+            deputies,
+        };
+        AuthorizedMemberInfo::new_with_member_key(mi, sk)
+    }
+
     /// An empty [`Rooms`](crate::room_data::Rooms) for the overwrite-import
     /// tests (`Rooms` derives no `Default`, so build it field-by-field —
     /// mirrors the `empty_rooms` helper in `chat_delegate.rs`).
@@ -2800,6 +2936,273 @@ mod tests {
             viewer_id,
         )
         .is_empty());
+    }
+
+    /// The conversation's 🛡 badge predicate, end to end.
+    ///
+    /// Ian's semantics: the shield means *"this user has been deputized, which
+    /// allows them to ban ME"*, and it stays visible even when the viewer
+    /// happens to be immune. One room exercises every case at once so the
+    /// cases cannot drift apart:
+    ///
+    /// ```text
+    /// owner ──┬── alpha ── viewer      alpha deputizes deputy_alpha
+    ///         ├── unrelated            unrelated deputizes deputy_unrelated
+    ///         ├── global_mod           owner deputizes global_mod
+    ///         ├── my_deputy            viewer deputizes my_deputy
+    ///         ├── deputy_alpha
+    ///         ├── deputy_unrelated
+    ///         └── plain
+    /// ```
+    #[test]
+    fn deputy_badge_is_viewer_relative_and_survives_viewer_immunity() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let alpha_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+        let unrelated_sk = SigningKey::generate(&mut rng);
+        let global_mod_sk = SigningKey::generate(&mut rng);
+        let deputy_alpha_sk = SigningKey::generate(&mut rng);
+        let deputy_unrelated_sk = SigningKey::generate(&mut rng);
+        let my_deputy_sk = SigningKey::generate(&mut rng);
+        let plain_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+        let viewer_id = id(&viewer_sk);
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &alpha_sk.verifying_key()),
+                authorized_member(&owner_sk, &unrelated_sk.verifying_key()),
+                authorized_member(&owner_sk, &global_mod_sk.verifying_key()),
+                authorized_member(&owner_sk, &deputy_alpha_sk.verifying_key()),
+                authorized_member(&owner_sk, &deputy_unrelated_sk.verifying_key()),
+                authorized_member(&owner_sk, &my_deputy_sk.verifying_key()),
+                authorized_member(&owner_sk, &plain_sk.verifying_key()),
+                // The viewer sits INSIDE alpha's subtree, so alpha is a strict
+                // ancestor and alpha's deputies have authority over the viewer.
+                member_invited_by(&alpha_sk, owner_id, &viewer_sk.verifying_key()),
+            ],
+        };
+
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                signed_member_info(&owner_sk, "Owner", vec![id(&global_mod_sk)]),
+                signed_member_info(&alpha_sk, "Alpha", vec![id(&deputy_alpha_sk)]),
+                signed_member_info(&unrelated_sk, "Unrelated", vec![id(&deputy_unrelated_sk)]),
+                signed_member_info(&viewer_sk, "Viewer", vec![id(&my_deputy_sk)]),
+                signed_member_info(&global_mod_sk, "GlobalMod", vec![]),
+                signed_member_info(&deputy_alpha_sk, "DeputyAlpha", vec![]),
+                signed_member_info(&deputy_unrelated_sk, "DeputyUnrelated", vec![]),
+                signed_member_info(&my_deputy_sk, "MyDeputy", vec![]),
+                signed_member_info(&plain_sk, "Plain", vec![]),
+            ],
+        };
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        let badges =
+            deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, viewer_id);
+
+        // 1. Deputy of the room owner, viewer is an ordinary member → badge,
+        //    and they really can ban the viewer (owner-appointed global mod).
+        let global = badges
+            .get(&id(&global_mod_sk))
+            .expect("a deputy of the owner must show the shield to every viewer");
+        assert_eq!(global.deputized_by, vec!["room owner".to_string()]);
+        assert!(global.can_ban_viewer);
+        assert_eq!(
+            global.tooltip(),
+            "Deputy (appointed by room owner) — can ban you"
+        );
+
+        // 1b. Deputy of a strict ancestor of the viewer → badge, named after
+        //     the appointer, and they can ban the viewer (subtree authority).
+        let by_alpha = badges
+            .get(&id(&deputy_alpha_sk))
+            .expect("a deputy of the viewer's inviter must show the shield");
+        assert_eq!(by_alpha.deputized_by, vec!["Alpha".to_string()]);
+        assert!(by_alpha.can_ban_viewer);
+
+        // 2. Deputy of a member OUTSIDE the viewer's invite ancestry → NO
+        //    badge. Deputy authority is scoped to the deputizer's subtree, so
+        //    this member holds no authority that bears on the viewer, and
+        //    Ian's shield means "authority over me". They still show the
+        //    shield in THEIR OWN subtree's views.
+        assert!(
+            !badges.contains_key(&id(&deputy_unrelated_sk)),
+            "a deputy of an unrelated subtree must not show the shield here"
+        );
+
+        // 3. Viewer is immune (they appointed this deputy themselves, so
+        //    `is_ban_authorized` step 4 denies the ban) → the badge STILL
+        //    shows. This is the half Ian called out explicitly; only the
+        //    tooltip reflects the immunity.
+        let mine = badges
+            .get(&id(&my_deputy_sk))
+            .expect("a deputy the viewer appointed must still show the shield");
+        assert_eq!(mine.deputized_by, vec!["you".to_string()]);
+        assert!(
+            !mine.can_ban_viewer,
+            "a deputy cannot ban the member who deputized them"
+        );
+        assert_eq!(mine.tooltip(), "Deputy (appointed by you) — cannot ban you");
+
+        // 4. No deputy authority at all → no badge.
+        assert!(!badges.contains_key(&id(&plain_sk)));
+
+        // 5. The room OWNER gets no deputy shield. Their authority is
+        //    inherent, not delegated, so "Deputy (appointed by …)" would be a
+        //    lie; the member list already marks them with 👑.
+        assert!(
+            !badges.contains_key(&owner_id),
+            "the owner is not a deputy of anyone"
+        );
+
+        // The viewer themselves is not a deputy in this room.
+        assert!(!badges.contains_key(&viewer_id));
+    }
+
+    /// The other reading of "unless I'm also a deputy": the viewer holds
+    /// deputy authority of their own. The badge must not be suppressed — and,
+    /// pinned here because it is counter-intuitive, being a deputy does NOT
+    /// make the viewer immune. Two deputies of the same appointer can ban each
+    /// other, so the tooltip says "can ban you".
+    #[test]
+    fn deputy_viewer_still_sees_the_shield_on_a_fellow_deputy() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+        let other_mod_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+        let viewer_id = id(&viewer_sk);
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &viewer_sk.verifying_key()),
+                authorized_member(&owner_sk, &other_mod_sk.verifying_key()),
+            ],
+        };
+        // The owner deputizes BOTH the viewer and the other moderator.
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                signed_member_info(&owner_sk, "Owner", vec![id(&viewer_sk), id(&other_mod_sk)]),
+                signed_member_info(&viewer_sk, "Viewer", vec![]),
+                signed_member_info(&other_mod_sk, "OtherMod", vec![]),
+            ],
+        };
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        let badges =
+            deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, viewer_id);
+
+        let other = badges
+            .get(&id(&other_mod_sk))
+            .expect("a fellow deputy must still show the shield to a deputy viewer");
+        assert_eq!(other.deputized_by, vec!["room owner".to_string()]);
+        assert!(
+            other.can_ban_viewer,
+            "owner-appointed moderators have absolute authority, including \
+             over other moderators"
+        );
+    }
+
+    /// The room owner's OWN view. `viewer_relevant_deputizer_set` gives the
+    /// owner no strict ancestors, so only deputies the owner appointed are
+    /// relevant — which is every global moderator. Pinned because an
+    /// off-by-one here would blank the owner's whole moderator list.
+    #[test]
+    fn owner_sees_the_shield_on_their_own_appointees() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let mod_sk = SigningKey::generate(&mut rng);
+        let other_sk = SigningKey::generate(&mut rng);
+        let their_deputy_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &mod_sk.verifying_key()),
+                authorized_member(&owner_sk, &other_sk.verifying_key()),
+                member_invited_by(&other_sk, owner_id, &their_deputy_sk.verifying_key()),
+            ],
+        };
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                signed_member_info(&owner_sk, "Owner", vec![id(&mod_sk)]),
+                signed_member_info(&other_sk, "Other", vec![id(&their_deputy_sk)]),
+                signed_member_info(&mod_sk, "Mod", vec![]),
+                signed_member_info(&their_deputy_sk, "TheirDeputy", vec![]),
+            ],
+        };
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        let badges = deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, owner_id);
+
+        let m = badges
+            .get(&id(&mod_sk))
+            .expect("the owner must see the shield on their own appointee");
+        // `relevant_deputizer_names` resolves the owner id BEFORE the self id,
+        // so an owner viewing their own appointee reads "room owner", not
+        // "you". Pinned rather than "fixed": the label describes the role that
+        // granted the authority, and every other viewer sees the same word.
+        assert_eq!(m.deputized_by, vec!["room owner".to_string()]);
+        assert!(!m.can_ban_viewer, "the owner is never a valid ban target");
+        // Someone else's deputy is not relevant to the owner's view.
+        assert!(!badges.contains_key(&id(&their_deputy_sk)));
+    }
+
+    /// An emoji nickname must not be able to paint an appointer name that
+    /// looks like a second badge inside the tooltip.
+    #[test]
+    fn deputizer_names_are_sanitised() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let appointer_sk = SigningKey::generate(&mut rng);
+        let deputy_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &appointer_sk.verifying_key()),
+                authorized_member(&owner_sk, &deputy_sk.verifying_key()),
+                member_invited_by(&appointer_sk, owner_id, &viewer_sk.verifying_key()),
+            ],
+        };
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                signed_member_info(&owner_sk, "Owner", vec![]),
+                signed_member_info(&appointer_sk, "Eve 🛡👑", vec![id(&deputy_sk)]),
+                signed_member_info(&deputy_sk, "Deputy", vec![]),
+                signed_member_info(&viewer_sk, "Viewer", vec![]),
+            ],
+        };
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        let badges =
+            deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, id(&viewer_sk));
+        let badge = badges.get(&id(&deputy_sk)).expect("shield expected");
+        assert_eq!(badge.deputized_by, vec!["Eve".to_string()]);
+        assert!(!badge.tooltip().contains('🛡'));
     }
 
     /// `build_deputizers_of` must order each deputy's appointers

--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -218,21 +218,23 @@ pub fn MemberInfoModal() -> Element {
             .deputies_of(self_member_id)
             .contains(&member_id);
 
-        // Viewer-relevant deputizer names for the target, for the 🛡 legend
-        // chip below (freenet/river#451). Computed with the SAME shared helpers
-        // the member-list row uses, so the modal shows the shield under exactly
-        // the same condition — and with the same "appointed by …" tooltip — as
-        // the row does. Empty ⇒ this member does not show the shield here.
+        // The 🛡 legend chip below (freenet/river#451). Computed with the SAME
+        // shared helper the member-list row and the conversation's author line
+        // use, so the modal shows the shield under exactly the same condition,
+        // and with the same tooltip, as they do. `None` means no shield here.
+        //
+        // Single-target variant: this component is not memoised, and the sweep
+        // decrypts every deputy's appointer nicknames.
         let deputy_badge: Option<super::DeputyBadge> =
             owner_key_signal.as_ref().and_then(|owner| {
-                super::deputy_badges_for_viewer(
+                super::deputy_badge_for_viewer(
                     &room_state.room_state.members,
                     &room_state.room_state.member_info,
                     &room_state.secrets,
                     MemberId::from(&*owner),
                     self_member_id,
+                    member_id,
                 )
-                .remove(&member_id)
             });
         let deputy_tooltip = deputy_badge
             .as_ref()
@@ -414,7 +416,16 @@ pub fn MemberInfoModal() -> Element {
                                 BanButton {
                                     member_to_ban: member_id,
                                     can_ban: can_ban,
-                                    nickname: member_info.member_info.preferred_nickname.clone()
+                                    // The DECRYPTED, sanitised name — the same
+                                    // value `DeputyButton` gets. This used to
+                                    // pass the raw `SealedBytes`, which Dioxus
+                                    // silently coerced through `Display` (i.e.
+                                    // `to_string_lossy`): the ban dialog showed
+                                    // an unsanitised nickname in the one place
+                                    // a moderator is judging authority, and
+                                    // showed "[Encrypted: N bytes, vN]" instead
+                                    // of a name in private rooms.
+                                    nickname: target_nickname.clone()
                                 }
 
                                 // Deputize / revoke-deputy (#410). Any non-owner
@@ -561,9 +572,9 @@ mod ban_gate_tests {
             "the member-info modal must render the 🛡 deputy legend chip (#451)"
         );
         assert!(
-            prod.contains("deputy_badges_for_viewer"),
+            prod.contains("deputy_badge_for_viewer"),
             "the deputy chip's visibility must come from the shared \
-             `deputy_badges_for_viewer` map so it cannot drift from the \
+             `deputy_badge_for_viewer` helper so it cannot drift from the \
              member-list row or the conversation author line (#451)"
         );
         assert!(

--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -223,29 +223,21 @@ pub fn MemberInfoModal() -> Element {
         // the member-list row uses, so the modal shows the shield under exactly
         // the same condition — and with the same "appointed by …" tooltip — as
         // the row does. Empty ⇒ this member does not show the shield here.
-        let deputizer_names: Vec<String> = owner_key_signal
-            .as_ref()
-            .map(|owner| {
-                let owner_id = MemberId::from(&*owner);
-                let member_info_all = &room_state.room_state.member_info;
-                let deputizers_of = super::build_deputizers_of(member_info_all);
-                let viewer_relevant = super::viewer_relevant_deputizer_set(
+        let deputy_badge: Option<super::DeputyBadge> =
+            owner_key_signal.as_ref().and_then(|owner| {
+                super::deputy_badges_for_viewer(
                     &room_state.room_state.members,
-                    owner_id,
-                    self_member_id,
-                );
-                super::relevant_deputizer_names(
-                    member_info_all,
+                    &room_state.room_state.member_info,
                     &room_state.secrets,
-                    &deputizers_of,
-                    &viewer_relevant,
-                    owner_id,
+                    MemberId::from(&*owner),
                     self_member_id,
-                    member_id,
                 )
-            })
+                .remove(&member_id)
+            });
+        let deputy_tooltip = deputy_badge
+            .as_ref()
+            .map(super::DeputyBadge::tooltip)
             .unwrap_or_default();
-        let deputy_tooltip = format!("Deputy (appointed by {})", deputizer_names.join(", "));
         // Decrypted display nickname for the target (for the deputy action copy).
         let target_nickname = display_nickname(
             &member_info.member_info.preferred_nickname,
@@ -322,7 +314,7 @@ pub fn MemberInfoModal() -> Element {
                             // (freenet/river#451). Shown under the same
                             // viewer-relevant condition as the row, with the
                             // appointer names in the tooltip.
-                            if !deputizer_names.is_empty() {
+                            if deputy_badge.is_some() {
                                 span {
                                     "data-testid": "member-info-deputy-tag",
                                     class: "inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium bg-purple-500/20 text-purple-400",
@@ -548,10 +540,15 @@ mod ban_gate_tests {
 
     /// Source-grep pin for freenet/river#451: the modal's icon legend must
     /// render the 🛡 deputy chip, driven by the SAME shared helper the
-    /// member-list row uses. The reported bug was that the row showed the
-    /// shield but this modal did not; without this pin a future refactor could
-    /// silently drop the chip again, or reintroduce a private, drifting copy of
-    /// the viewer-relevance logic instead of the shared helper.
+    /// member-list row and the conversation's author line use. The reported bug
+    /// was that the row showed the shield but this modal did not; without this
+    /// pin a future refactor could silently drop the chip again, or reintroduce
+    /// a private, drifting copy of the viewer-relevance logic.
+    ///
+    /// The pin now covers the TOOLTIP as well as visibility: all three surfaces
+    /// must go through `DeputyBadge::tooltip`, so the shield cannot say
+    /// "appointed by X — can ban you" in the conversation and something else
+    /// here.
     #[test]
     fn modal_renders_deputy_shield_via_shared_helper() {
         let source = include_str!("member_info_modal.rs");
@@ -564,9 +561,15 @@ mod ban_gate_tests {
             "the member-info modal must render the 🛡 deputy legend chip (#451)"
         );
         assert!(
-            prod.contains("relevant_deputizer_names"),
-            "the deputy chip must be driven by the shared `relevant_deputizer_names` \
-             helper so it cannot drift from the member-list row (#451)"
+            prod.contains("deputy_badges_for_viewer"),
+            "the deputy chip's visibility must come from the shared \
+             `deputy_badges_for_viewer` map so it cannot drift from the \
+             member-list row or the conversation author line (#451)"
+        );
+        assert!(
+            prod.contains("DeputyBadge::tooltip"),
+            "the deputy chip's tooltip must come from `DeputyBadge::tooltip` \
+             so the wording cannot drift between surfaces (#451)"
         );
     }
 }

--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -9,33 +9,12 @@ use crate::components::members::member_info_modal::ban_button::BanButton;
 use crate::components::members::member_info_modal::deputy_button::DeputyButton;
 use crate::components::members::member_info_modal::invited_by_field::InvitedByField;
 use crate::components::members::member_info_modal::nickname_field::NicknameField;
-use crate::util::ecies::unseal_bytes_with_secrets;
+use crate::components::members::viewer_can_ban;
+use crate::util::display_name::display_nickname;
 use dioxus::logger::tracing::*;
 use dioxus::prelude::*;
 use river_core::room_state::member::MemberId;
 use river_core::room_state::ChatRoomParametersV1;
-
-/// Whether `viewer` may ban `target` — the Ban-button gate (#410 / #411 round 4
-/// D). Uses [`MembersV1::is_ban_authorized`] (owner / invite-ancestor / deputy),
-/// NOT bare invite-chain ancestry, so a DEPUTY sees the Ban action for members in
-/// their deputizer's subtree. Bare downstream ancestry (`is_downstream`, still
-/// used for the "🔑 Invited by You" relationship tag) would have hidden it.
-fn viewer_can_ban(
-    members: &river_core::room_state::member::MembersV1,
-    member_info: &river_core::room_state::member_info::MemberInfoV1,
-    viewer: MemberId,
-    target: MemberId,
-    owner_id: MemberId,
-) -> bool {
-    let members_by_id = members.members_by_member_id();
-    river_core::room_state::member::MembersV1::is_ban_authorized(
-        viewer,
-        target,
-        &members_by_id,
-        member_info,
-        owner_id,
-    )
-}
 
 #[component]
 pub fn MemberInfoModal() -> Element {
@@ -197,13 +176,7 @@ pub fn MemberInfoModal() -> Element {
                 let nickname = member_info_v1
                     .canonical(inviter_id)
                     .map(|mi| {
-                        match unseal_bytes_with_secrets(
-                            &mi.member_info.preferred_nickname,
-                            &room_state.secrets,
-                        ) {
-                            Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
-                            Err(_) => mi.member_info.preferred_nickname.to_string_lossy(),
-                        }
+                        display_nickname(&mi.member_info.preferred_nickname, &room_state.secrets)
                     })
                     .unwrap_or_else(|| "Unknown".to_string());
                 (nickname, Some(inviter_id))
@@ -274,13 +247,10 @@ pub fn MemberInfoModal() -> Element {
             .unwrap_or_default();
         let deputy_tooltip = format!("Deputy (appointed by {})", deputizer_names.join(", "));
         // Decrypted display nickname for the target (for the deputy action copy).
-        let target_nickname = match unseal_bytes_with_secrets(
+        let target_nickname = display_nickname(
             &member_info.member_info.preferred_nickname,
             &room_state.secrets,
-        ) {
-            Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
-            Err(_) => member_info.member_info.preferred_nickname.to_string_lossy(),
-        };
+        );
 
         // Get the member ID string to display
         let member_id_str = member_id.to_string();

--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -321,6 +321,7 @@ pub fn MemberInfoModal() -> Element {
                                     "data-testid": "member-info-deputy-tag",
                                     class: "inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium bg-purple-500/20 text-purple-400",
                                     title: "{deputy_tooltip}",
+                                    "aria-label": "{deputy_tooltip}",
                                     "🛡 Deputy"
                                 }
                             }

--- a/ui/src/components/members/member_info_modal/nickname_field.rs
+++ b/ui/src/components/members/member_info_modal/nickname_field.rs
@@ -1,5 +1,6 @@
 use crate::components::app::{CURRENT_ROOM, ROOMS};
-use crate::util::ecies::{seal_for_room, unseal_bytes_with_secrets};
+use crate::util::display_name::{contains_hidden_chars, display_nickname, EMOJI_REJECTION_MESSAGE};
+use crate::util::ecies::seal_for_room;
 use dioxus::logger::tracing::*;
 use dioxus::prelude::*;
 use dioxus_free_icons::icons::fa_solid_icons::FaPencil;
@@ -46,13 +47,11 @@ pub fn NicknameField(member_info: AuthorizedMemberInfo) -> Element {
         .map(|smi| smi == &member_id)
         .unwrap_or(false);
 
-    // Decrypt nickname for display (version-aware)
+    // Decrypt nickname for display (version-aware) and sanitise it, so a
+    // nickname written by `riverctl` (which never runs the input validation
+    // below) shows here exactly as it renders everywhere else — no emoji.
     let initial_nickname =
-        match unseal_bytes_with_secrets(&member_info.member_info.preferred_nickname, &room_secrets)
-        {
-            Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
-            Err(_) => member_info.member_info.preferred_nickname.to_string_lossy(),
-        };
+        display_nickname(&member_info.member_info.preferred_nickname, &room_secrets);
     let initial_nickname_for_revert = initial_nickname.clone();
     let mut temp_nickname = use_signal(|| initial_nickname);
     let mut input_element = use_signal(|| None as Option<Rc<MountedData>>);
@@ -67,6 +66,17 @@ pub fn NicknameField(member_info: AuthorizedMemberInfo) -> Element {
         move |new_value: String| {
             if new_value.is_empty() {
                 warn!("Nickname cannot be empty");
+                return;
+            }
+
+            // Input-time rejection (UX, NOT the security boundary — see
+            // `crate::util::display_name`). Emoji in a nickname would be
+            // stripped at render time anyway, so saving one silently loses
+            // characters; refuse the edit and revert the field so the user
+            // gets told why instead.
+            if contains_hidden_chars(&new_value) {
+                warn!("{EMOJI_REJECTION_MESSAGE}");
+                temp_nickname.set(initial_nickname_for_revert.clone());
                 return;
             }
 
@@ -250,7 +260,9 @@ pub fn NicknameField(member_info: AuthorizedMemberInfo) -> Element {
     };
 
     let on_blur = {
-        let save_changes = save_changes.clone();
+        // `mut` because the emoji-rejection branch reverts `temp_nickname`,
+        // which makes the closure `FnMut`.
+        let mut save_changes = save_changes.clone();
         move |_| {
             let new_value = temp_nickname();
             save_changes(new_value);
@@ -258,7 +270,7 @@ pub fn NicknameField(member_info: AuthorizedMemberInfo) -> Element {
     };
 
     let on_keydown = {
-        let save_changes = save_changes.clone();
+        let mut save_changes = save_changes.clone();
         move |evt: dioxus_core::Event<KeyboardData>| {
             if evt.key() == Key::Enter {
                 let new_value = temp_nickname();
@@ -274,6 +286,9 @@ pub fn NicknameField(member_info: AuthorizedMemberInfo) -> Element {
         }
     };
 
+    // Live validity of what is currently typed, for the inline hint below.
+    let has_emoji = contains_hidden_chars(&temp_nickname());
+
     rsx! {
         div {
             class: "mb-4",
@@ -281,7 +296,12 @@ pub fn NicknameField(member_info: AuthorizedMemberInfo) -> Element {
             div {
                 class: "relative",
                 input {
-                    class: "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent",
+                    class: if has_emoji {
+                        "w-full px-3 py-2 bg-surface border border-red-500 rounded-lg text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent"
+                    } else {
+                        "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
+                    },
+                    "aria-invalid": if has_emoji { "true" } else { "false" },
                     value: "{temp_nickname}",
                     readonly: !is_self,
                     oninput: on_input,
@@ -294,6 +314,14 @@ pub fn NicknameField(member_info: AuthorizedMemberInfo) -> Element {
                         class: "absolute right-3 top-1/2 -translate-y-1/2 text-text-muted",
                         Icon { icon: FaPencil, width: 14, height: 14 }
                     }
+                }
+            }
+            if has_emoji {
+                p {
+                    "data-testid": "nickname-emoji-error",
+                    class: "mt-1 text-xs text-red-400",
+                    role: "alert",
+                    "{EMOJI_REJECTION_MESSAGE}"
                 }
             }
         }

--- a/ui/src/components/members/member_info_modal/nickname_field.rs
+++ b/ui/src/components/members/member_info_modal/nickname_field.rs
@@ -69,6 +69,17 @@ pub fn NicknameField(member_info: AuthorizedMemberInfo) -> Element {
                 return;
             }
 
+            // Nothing typed: do not republish. `initial_nickname` is the
+            // SANITISED value, so without this guard merely focusing and
+            // leaving your own nickname field would rewrite a `riverctl`-set
+            // nickname network-wide (a `member_info` republish at version + 1
+            // plus a sync) with no edit and no confirmation. Render-time
+            // stripping deliberately HIDES emoji rather than deleting them;
+            // this keeps that promise.
+            if new_value == initial_nickname_for_revert {
+                return;
+            }
+
             // Input-time rejection (UX, NOT the security boundary — see
             // `crate::util::display_name`). Emoji in a nickname would be
             // stripped at render time anyway, so saving one silently loses

--- a/ui/src/components/room_list/create_room_modal.rs
+++ b/ui/src/components/room_list/create_room_modal.rs
@@ -220,7 +220,10 @@ pub fn CreateRoomModal() -> Element {
                     }
                     button {
                         "data-testid": "create-room-submit-button",
-                        class: "px-4 py-2 bg-accent hover:bg-accent-hover text-white text-sm font-medium rounded-lg transition-colors",
+                        class: "px-4 py-2 bg-accent hover:bg-accent-hover text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed",
+                        // Disabled rather than silently no-op, matching the
+                        // accept-invitation modal's nickname gate.
+                        disabled: nickname_has_emoji,
                         onclick: create_room,
                         "Create Room"
                     }

--- a/ui/src/components/room_list/create_room_modal.rs
+++ b/ui/src/components/room_list/create_room_modal.rs
@@ -1,4 +1,5 @@
 use crate::components::app::{CREATE_ROOM_MODAL, CURRENT_ROOM, ROOMS};
+use crate::util::display_name::{contains_hidden_chars, EMOJI_REJECTION_MESSAGE};
 use dioxus::prelude::*;
 use ed25519_dalek::SigningKey;
 
@@ -14,6 +15,10 @@ pub fn CreateRoomModal() -> Element {
         let name = room_name.read().clone();
         if name.is_empty() {
             info!("🔴 Room name is empty, returning");
+            return;
+        }
+        if contains_hidden_chars(&nickname.read()) {
+            info!("🔴 {EMOJI_REJECTION_MESSAGE} — room creation blocked");
             return;
         }
         info!("🔵 Room name: {}", name);
@@ -122,6 +127,11 @@ pub fn CreateRoomModal() -> Element {
         return rsx! {};
     }
 
+    // Input-time rejection (UX, not the security boundary — see
+    // `crate::util::display_name`). Emoji would be stripped at render time
+    // anyway; telling the user up front beats silently losing characters.
+    let nickname_has_emoji = contains_hidden_chars(&nickname());
+
     rsx! {
         // Backdrop
         div {
@@ -162,10 +172,23 @@ pub fn CreateRoomModal() -> Element {
                         label { class: "block text-sm font-medium text-text mb-1", "Your Nickname" }
                         input {
                             "data-testid": "create-room-nickname-input",
-                            class: "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent",
+                            class: if nickname_has_emoji {
+                                "w-full px-3 py-2 bg-surface border border-red-500 rounded-lg text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-red-500/50 focus:border-red-500"
+                            } else {
+                                "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent"
+                            },
+                            "aria-invalid": if nickname_has_emoji { "true" } else { "false" },
                             value: "{nickname}",
                             placeholder: "Enter your nickname",
-                            onchange: move |evt| nickname.set(evt.value().to_string())
+                            oninput: move |evt| nickname.set(evt.value().to_string())
+                        }
+                        if nickname_has_emoji {
+                            p {
+                                "data-testid": "create-room-nickname-emoji-error",
+                                class: "mt-1 text-xs text-red-400",
+                                role: "alert",
+                                "{EMOJI_REJECTION_MESSAGE}"
+                            }
                         }
                     }
 

--- a/ui/src/components/room_list/dm_rail_section.rs
+++ b/ui/src/components/room_list/dm_rail_section.rs
@@ -545,13 +545,10 @@ fn build_archived_view() -> Option<Vec<ArchivedEntry>> {
             .map(|info| {
                 (
                     info.member_info.member_id,
-                    match unseal_bytes_with_secrets(
+                    crate::util::display_name::display_nickname(
                         &info.member_info.preferred_nickname,
                         &room_data.secrets,
-                    ) {
-                        Ok(b) => String::from_utf8_lossy(&b).to_string(),
-                        Err(_) => info.member_info.preferred_nickname.to_string_lossy(),
-                    },
+                    ),
                 )
             })
             .collect();
@@ -659,13 +656,10 @@ fn build_view() -> Option<Vec<DmRailEntry>> {
             .map(|info| {
                 (
                     info.member_info.member_id,
-                    match unseal_bytes_with_secrets(
+                    crate::util::display_name::display_nickname(
                         &info.member_info.preferred_nickname,
                         &room_data.secrets,
-                    ) {
-                        Ok(b) => String::from_utf8_lossy(&b).to_string(),
-                        Err(_) => info.member_info.preferred_nickname.to_string_lossy(),
-                    },
+                    ),
                 )
             })
             .collect();

--- a/ui/src/components/room_list/receive_invitation_modal.rs
+++ b/ui/src/components/room_list/receive_invitation_modal.rs
@@ -3,6 +3,7 @@ use crate::components::app::{PENDING_INVITES, ROOMS, SYNCHRONIZER};
 use crate::components::members::Invitation;
 use crate::invites::{PendingRoomJoin, PendingRoomStatus};
 use crate::room_data::Rooms;
+use crate::util::display_name::{contains_hidden_chars, EMOJI_REJECTION_MESSAGE};
 use dioxus::logger::tracing::{error, info, warn};
 use dioxus::prelude::*;
 use ed25519_dalek::VerifyingKey;
@@ -833,6 +834,12 @@ fn render_new_invitation(inv: Invitation, invitation: Signal<Option<Invitation>>
     // Create a signal for the nickname
     let mut nickname = use_signal(|| default_nickname);
 
+    // Input-time rejection (UX, not the security boundary — see
+    // `crate::util::display_name`). Emoji would be stripped at render time
+    // anyway; telling the user up front beats silently losing characters.
+    let nickname_has_emoji = contains_hidden_chars(&nickname());
+    let accept_disabled = nickname.read().trim().is_empty() || nickname_has_emoji;
+
     rsx! {
         p { class: "text-text mb-2", "You have been invited to join a new room." }
         p { class: "text-text-muted mb-4", "Choose a nickname to use in this room:" }
@@ -840,7 +847,12 @@ fn render_new_invitation(inv: Invitation, invitation: Signal<Option<Invitation>>
         div { class: "mb-4",
             input {
                 "data-testid": "receive-invitation-nickname-input",
-                class: "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent",
+                class: if nickname_has_emoji {
+                    "w-full px-3 py-2 bg-surface border border-red-500 rounded-lg text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent"
+                } else {
+                    "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
+                },
+                "aria-invalid": if nickname_has_emoji { "true" } else { "false" },
                 r#type: "text",
                 value: "{nickname}",
                 onmounted: move |cx| {
@@ -851,12 +863,20 @@ fn render_new_invitation(inv: Invitation, invitation: Signal<Option<Invitation>>
                 },
                 oninput: move |evt| nickname.set(evt.value().clone()),
                 onkeydown: move |evt: KeyboardEvent| {
-                    if evt.key() == Key::Enter && !nickname.read().trim().is_empty() {
+                    if evt.key() == Key::Enter && !accept_disabled {
                         evt.prevent_default();
                         accept_invitation(inv_for_enter.clone(), nickname.read().clone());
                     }
                 },
                 placeholder: "Your preferred nickname"
+            }
+            if nickname_has_emoji {
+                p {
+                    "data-testid": "receive-invitation-nickname-emoji-error",
+                    class: "mt-1 text-xs text-red-400",
+                    role: "alert",
+                    "{EMOJI_REJECTION_MESSAGE}"
+                }
             }
         }
 
@@ -866,7 +886,7 @@ fn render_new_invitation(inv: Invitation, invitation: Signal<Option<Invitation>>
             button {
                 "data-testid": "receive-invitation-accept-button",
                 class: "px-4 py-2 bg-accent hover:bg-accent-hover text-white font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed",
-                disabled: nickname.read().trim().is_empty(),
+                disabled: accept_disabled,
                 onclick: move |_| {
                     accept_invitation(inv_for_accept.clone(), nickname.read().clone());
                 },

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -116,8 +116,17 @@ fn create_room(room_name: &String, self_is: SelfIs, description: Option<&str>) -
             MemberInfo {
                 member_id: owner_id,
                 version: 0,
+                // The trailing 🛡👑 is a deliberate BADGE-SPOOF attempt baked
+                // into example data: the owner's stored nickname claims the
+                // deputy shield and the owner crown. `display_nickname` strips
+                // both at render time, so the member list must still show
+                // exactly ONE shield (the real deputy's) and the conversation
+                // must show the owner's name with no glyphs. If the strip ever
+                // regresses, `member-info-deputy-tag.spec.ts`'s
+                // `toHaveCount(1)` and `conversation-deputy-badge.spec.ts`
+                // both fail.
                 preferred_nickname: SealedBytes::public(
-                    (random_full_name() + " (Owner)").into_bytes(),
+                    (random_full_name() + " (Owner) \u{1F6E1}\u{1F451}").into_bytes(),
                 ),
                 deputies: vec![other_member_id],
             },
@@ -203,7 +212,13 @@ fn create_room(room_name: &String, self_is: SelfIs, description: Option<&str>) -
     member_keys.insert(other_member_id, other_member_sk);
 
     // Add example messages
-    add_example_messages(&mut room_state, &owner_id, owner_sk, &member_keys);
+    add_example_messages(
+        &mut room_state,
+        &owner_id,
+        owner_sk,
+        &member_keys,
+        other_member_id,
+    );
 
     let verification_result = room_state.verify(
         &room_state,
@@ -253,6 +268,10 @@ fn add_example_messages(
     owner_id: &MemberId,
     owner_key: &SigningKey,
     member_keys: &HashMap<MemberId, SigningKey>,
+    // The owner-appointed deputy. Given one guaranteed message below so the
+    // conversation's 🛡 badge is deterministically present for Playwright —
+    // the random author picks alone leave it to chance.
+    deputy_id: MemberId,
 ) {
     // Use a timestamp 24 hours ago as base time for messages
     let now = crate::util::get_current_system_time()
@@ -333,6 +352,25 @@ fn add_example_messages(
 
         // Add a more natural time gap between messages (30 sec to 15 min)
         current_time_ms += (rand::random::<u64>() % 870 + 30) * 1000;
+    }
+
+    // One guaranteed message from the owner-appointed deputy, so the
+    // conversation always has an author line carrying the 🛡 badge. The random
+    // loop above may or may not pick them.
+    if let Some(deputy_key) = member_keys.get(&deputy_id) {
+        let msg = AuthorizedMessageV1::new(
+            MessageV1 {
+                room_owner: *owner_id,
+                author: deputy_id,
+                time: get_time_from_millis(current_time_ms),
+                content: RoomMessageBody::public(
+                    "Reminder: keep it civil in here, please.".to_string(),
+                ),
+            },
+            deputy_key,
+        );
+        messages.messages.push(msg);
+        current_time_ms += 60_000;
     }
 
     // A message exercising @mention chips. The snapshot name in the token is

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -365,7 +365,15 @@ fn add_example_messages(
             .member_info
             .iter()
             .find(|m| m.member_info.member_id == target_author_id)
-            .map(|m| m.member_info.preferred_nickname.to_string_lossy())
+            .map(|m| {
+                // Example rooms are public, so the secret map is empty. Routed
+                // through the shared helper anyway so the render-path pin test
+                // has no exceptions to carve out.
+                crate::util::display_name::display_nickname(
+                    &m.member_info.preferred_nickname,
+                    &HashMap::new(),
+                )
+            })
             .unwrap_or_else(|| "someone".to_string());
         let target_preview = match &target.message.content {
             RoomMessageBody::Public { data, .. } => {
@@ -460,7 +468,15 @@ fn add_example_messages(
             .member_info
             .iter()
             .find(|m| m.member_info.member_id == target_author_id)
-            .map(|m| m.member_info.preferred_nickname.to_string_lossy())
+            .map(|m| {
+                // Example rooms are public, so the secret map is empty. Routed
+                // through the shared helper anyway so the render-path pin test
+                // has no exceptions to carve out.
+                crate::util::display_name::display_nickname(
+                    &m.member_info.preferred_nickname,
+                    &HashMap::new(),
+                )
+            })
             .unwrap_or_else(|| "someone".to_string());
         let target_preview = match &long_url_msg.message.content {
             RoomMessageBody::Public { data, .. } => {

--- a/ui/src/util.rs
+++ b/ui/src/util.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+pub mod display_name;
 pub mod ecies;
 
 use ed25519_dalek::VerifyingKey;

--- a/ui/src/util/display_name.rs
+++ b/ui/src/util/display_name.rs
@@ -31,8 +31,14 @@
 //!   It cannot forge a badge, which is what this module is for.
 //! * Sanitising can CREATE a collision: `"B⭐ob"` and `"Bob"` render alike, as
 //!   do two nicknames that differ only in stripped characters. Nicknames were
-//!   never unique in River, so this grants no new capability, but it is worth
-//!   knowing that identical rendered names are possible by construction.
+//!   never unique in River, so this grants no new capability, but identical
+//!   rendered names are possible by construction. The specific vectors that
+//!   are cheap to close ARE closed — invisible-but-not-whitespace characters
+//!   are stripped, space-lookalikes are normalised, and a joiner is only kept
+//!   between two non-ASCII letters — but a joiner inside a CJK name still
+//!   clones it, and homoglyphs always will. Note that
+//!   `conversation::mention::duplicate_candidate_names` compares name STRINGS,
+//!   so it does not flag a pair that differs only in kept characters.
 //!
 //! ## What gets removed
 //!
@@ -46,11 +52,14 @@
 //!   which would defeat telling a moderator from an impersonator even with the
 //!   badge itself correct.
 //!
-//!   Deliberately NOT removed: `U+200C` ZWNJ and `U+200D` ZWJ. They look like
-//!   emoji machinery, but they are orthography in Persian, Sinhala and
-//!   Malayalam, and stripping them mangles real names. They are safe to keep
-//!   because every emoji a joiner could assemble is itself removed; a joiner
-//!   left stranded at an edge by that removal is dropped as an orphan.
+//!   `U+200C` ZWNJ and `U+200D` ZWJ are a special case. They look like emoji
+//!   machinery, but they are orthography in Persian, Sinhala and Malayalam,
+//!   and blanket-stripping them mangles real names. They are kept only where
+//!   they can be doing that work — between two non-ASCII letters, or trailing
+//!   one (Malayalam chillu ends a name) — and dropped everywhere else, which
+//!   covers both the orphans the emoji strip leaves behind and the
+//!   `"Bo\u{200D}b"` clone of `"Bob"`. Keeping them is safe because every
+//!   emoji a joiner could assemble is itself removed.
 //! * **Private-use area** codepoints. Fonts are free to map these to any glyph
 //!   at all (Nerd Fonts map a large PUA range to icons, including shields), so
 //!   a PUA nickname renders as a badge on any machine with such a font
@@ -150,12 +159,30 @@ pub fn is_display_hidden(c: char) -> bool {
         // nothing; U+FFF9..U+FFFB are interlinear annotation anchors that hide
         // the text between them.
         | 0x00AD | 0x061C | 0x180E | 0xFFF9..=0xFFFB
-        // Blank glyphs that are not whitespace, so `split_whitespace` would
-        // not collapse them: they let two members share a pixel-identical
+        // Blank glyphs that are not whitespace, so the space collapse below
+        // would not remove them: they let two members share a pixel-identical
         // rendered name (`Alice` vs `Alice\u{3164}`), which undermines the
         // "you can tell members apart by name" assumption the badge sits on.
         // U+2800 BRAILLE PATTERN BLANK, and the Hangul fillers.
         | 0x115F | 0x1160 | 0x2800 | 0x3164 | 0xFFA0
+        // The rest of the Default_Ignorable characters, which render as
+        // nothing. Without these a nickname made ENTIRELY of them is
+        // non-empty (so it never becomes `UNNAMED`) yet renders blank, which
+        // makes a message header look like a continuation of the group above
+        // it — including a badged moderator's group.
+        // U+034F combining grapheme joiner, the Mongolian free variation
+        // selectors, the Khmer inherent vowels, U+2065, the Variation
+        // Selectors Supplement (U+FE00..FE0F's big brother), and the
+        // shorthand-format and musical beam/slur/phrase controls.
+        | 0x034F | 0x180B..=0x180D | 0x180F | 0x17B4..=0x17B5 | 0x2065
+        | 0xE0100..=0xE01EF | 0x1BCA0..=0x1BCA3 | 0x1D173..=0x1D17A
+        // Text-presentation symbols that read as a badge in the fonts that
+        // carry them: ۞ (ornate star, present wherever Arabic renders), ٭,
+        // ꙳, and the Phaistos shield. Plus Symbols for Legacy Computing and
+        // its supplement, which contain an inverse check mark and stick
+        // figures.
+        | 0x066D | 0x06DE | 0xA673 | 0x101DB
+        | 0x1FB00..=0x1FBFF | 0x1CC00..=0x1CEBF
         // Private Use Area (BMP). Font-defined glyphs, and River's own
         // mention sentinels live at U+E000/U+E001.
         | 0xE000..=0xF8FF
@@ -209,32 +236,50 @@ pub fn sanitize_display_name(raw: &str) -> String {
         })
         .collect();
 
-    // 2. Drop ORPHANED joiners. U+200C/U+200D are kept above because they are
-    //    orthography between letters, but step 1 can leave one stranded at an
-    //    edge or beside a space — `"Bob 👮🏽‍♀️"` strips down to `"Bob ‍"`. A
-    //    joiner only means anything between two non-space characters, so drop
-    //    the rest rather than leave an invisible character in a name.
+    // 2. Keep a joiner only where it can be doing orthographic work, which is
+    //    between two NON-ASCII letters (Persian `علی‌رضا`, Sinhala `සූර්‍ය`,
+    //    Malayalam chillu — which is consonant + virama + ZWJ and legitimately
+    //    ENDS a name, so a trailing joiner after a non-ASCII letter is kept
+    //    too). Everywhere else it is dropped, which covers two cases:
+    //
+    //    * Orphans left by step 1: `"Bob 👮🏽‍♀️"` strips down to `"Bob ‍"`.
+    //    * The clone attack `"Bo\u{200D}b"`, which renders exactly like
+    //      `"Bob"` in any Latin font. Latin script never needs a joiner, so
+    //      requiring a non-ASCII neighbour costs nothing and closes it.
+    //
+    //    A joiner between two non-ASCII letters is still kept, so a CJK name
+    //    can still be cloned this way. That is the residual documented in the
+    //    module header, and it is the same shape as the homoglyph problem.
     let is_joiner = |c: char| c == '\u{200C}' || c == '\u{200D}';
+    let joins_letters =
+        |c: Option<&char>| c.is_some_and(|c| !c.is_ascii() && !c.is_whitespace() && !is_joiner(*c));
     let kept: Vec<char> = stripped
         .iter()
         .enumerate()
         .filter(|(i, c)| {
             !is_joiner(**c)
                 || (*i > 0
-                    && !stripped[i - 1].is_whitespace()
-                    && !is_joiner(stripped[i - 1])
-                    && stripped
-                        .get(i + 1)
-                        .is_some_and(|n| !n.is_whitespace() && !is_joiner(*n)))
+                    && joins_letters(stripped.get(i - 1))
+                    // A trailing joiner is legitimate (Malayalam chillu), so
+                    // "no next character" is allowed; a next character that is
+                    // present must itself be a non-ASCII letter.
+                    && stripped.get(i + 1).is_none_or(|n| joins_letters(Some(n))))
         })
         .map(|(_, c)| *c)
         .collect();
 
-    // 3. Collapse the double spaces the removal leaves behind
-    //    ("Alice 🛡 Smith" -> "Alice  Smith").
+    // 3. Normalise the spaces that are visually IDENTICAL to U+0020 (NBSP and
+    //    friends) down to it, then collapse runs. Normalising loses nothing a
+    //    reader can see, and it closes the `"Alice\u{00A0}Smith"` clone of
+    //    `"Alice Smith"`. U+3000 IDEOGRAPHIC SPACE is deliberately NOT in this
+    //    set: it renders double-width, it is visibly different, and it is the
+    //    conventional separator in a Japanese name (`山田　太郎`).
+    let looks_like_a_plain_space =
+        |c: char| matches!(u32::from(c), 0x00A0 | 0x2000..=0x200A | 0x202F | 0x205F);
     let mut collapsed = String::with_capacity(kept.len());
     let mut last_was_space = false;
     for c in kept {
+        let c = if looks_like_a_plain_space(c) { ' ' } else { c };
         let is_space = c == ' ';
         if !(is_space && last_was_space) {
             collapsed.push(c);
@@ -419,7 +464,6 @@ mod tests {
             "user_42",                 // underscores/digits
             "山田\u{3000}太郎",        // U+3000, the Japanese name separator
             "佐々木",                  // U+3005 iteration mark
-            "Jean\u{00A0}Luc",         // non-breaking space
             "สมชาย ใจดี",               // Thai
             "Արամ Խաչատրյան",          // Armenian
             "გიორგი ბერიძე",           // Georgian
@@ -457,11 +501,72 @@ mod tests {
         assert_eq!(sanitize_display_name("  Alice  "), "Alice");
     }
 
+    /// Spaces that render IDENTICALLY to U+0020 are normalised to it, so a
+    /// nickname cannot clone another member's rendered name by swapping one
+    /// in. U+3000 is not one of them: it is double-width, visibly different,
+    /// and the conventional separator in a Japanese name.
+    #[test]
+    fn space_lookalikes_are_normalised_but_ideographic_space_is_not() {
+        for lookalike in ['\u{00A0}', '\u{2002}', '\u{2007}', '\u{202F}', '\u{205F}'] {
+            assert_eq!(
+                sanitize_display_name(&format!("Jean{lookalike}Luc")),
+                "Jean Luc",
+                "U+{:04X} can clone a name that uses a plain space",
+                u32::from(lookalike)
+            );
+        }
+        assert_eq!(
+            sanitize_display_name("山田\u{3000}太郎"),
+            "山田\u{3000}太郎",
+            "the ideographic space is part of the name, not a lookalike"
+        );
+    }
+
+    /// A joiner between two ASCII letters is invisible, so `"Bo\u{200D}b"`
+    /// renders exactly like `"Bob"` — a pixel-perfect clone of another
+    /// member's name that no font distinguishes. Latin script never needs a
+    /// joiner, so it is dropped there; a Malayalam chillu, which legitimately
+    /// ENDS a name as consonant + virama + ZWJ, is kept.
+    #[test]
+    fn joiners_are_dropped_where_they_only_clone() {
+        assert_eq!(sanitize_display_name("Bo\u{200D}b"), "Bob");
+        assert_eq!(sanitize_display_name("Ali\u{200C}ce Smith"), "Alice Smith");
+        // Non-ASCII on one side only is still Latin-adjacent: drop.
+        assert_eq!(sanitize_display_name("Ali\u{200D}سce"), "Aliسce");
+        // Malayalam legacy chillu at the end of a name: keep.
+        let mohan = "മോഹന\u{0D4D}\u{200D}";
+        assert_eq!(sanitize_display_name(mohan), mohan);
+    }
+
     #[test]
     fn all_emoji_nickname_falls_back_to_placeholder() {
         assert_eq!(sanitize_display_name("🛡👑⭐"), UNNAMED);
         assert_eq!(sanitize_display_name(""), UNNAMED);
         assert_eq!(sanitize_display_name("   "), UNNAMED);
+    }
+
+    /// A nickname that renders BLANK but is not whitespace would otherwise
+    /// skip the `UNNAMED` placeholder and produce a nameless message header,
+    /// which reads as a continuation of the group above it — including a
+    /// badged moderator's group.
+    #[test]
+    fn nicknames_that_render_blank_become_unnamed() {
+        for blank in [
+            "\u{1BCA0}",        // shorthand format letter overlap
+            "\u{1D173}",        // musical symbol begin beam
+            "\u{E0100}",        // variation selector-17
+            "\u{180B}",         // Mongolian free variation selector one
+            "\u{034F}",         // combining grapheme joiner
+            "\u{2065}",         // unassigned Default_Ignorable
+            "\u{3164}\u{2800}", // Hangul filler + Braille blank
+            "\u{200D}",         // a lone joiner
+        ] {
+            assert_eq!(
+                sanitize_display_name(blank),
+                UNNAMED,
+                "a nickname rendering blank must not pass as a name: {blank:?}"
+            );
+        }
     }
 
     #[test]
@@ -493,9 +598,17 @@ mod tests {
     /// hand. Walking the tree rather than listing files means a NEW component
     /// is covered the day it is written.
     ///
+    /// Three shapes are flagged. The third exists because the first two missed
+    /// a live bug: `BanButton { nickname: …preferred_nickname.clone() }` handed
+    /// a `SealedBytes` to a `String` prop, which the Dioxus props derive
+    /// silently converts via `Display` (i.e. `to_string_lossy`) — no unseal, no
+    /// sanitise, and neither literal pattern present. That coercion is a
+    /// repeatable footgun in this codebase, so it gets its own check.
+    ///
     /// If this fires on a genuinely non-display use of the field, route it
-    /// through [`display_nickname`] anyway or move it below `#[cfg(test)]` —
-    /// do not weaken the scan.
+    /// through [`display_nickname`] anyway. Do NOT weaken the scan, and note
+    /// that moving code into a test module does not help: the walk reads whole
+    /// files on purpose (see the comment on `source` below).
     #[test]
     fn nickname_render_paths_go_through_display_nickname() {
         use std::path::{Path, PathBuf};
@@ -528,7 +641,8 @@ mod tests {
             // `conversation.rs` has a `#[cfg(test)]` helper at line ~770, so
             // the cut hid 2,800 lines including a real offender. No test
             // fixture in this crate needs the pattern anyway.
-            let production = std::fs::read_to_string(&path).expect("readable source file");
+            let source = std::fs::read_to_string(&path).expect("readable source file");
+            let production = source.as_str();
             let rel = path
                 .strip_prefix(&src)
                 .unwrap_or(&path)
@@ -538,9 +652,37 @@ mod tests {
             if production.contains("preferred_nickname.to_string_lossy()") {
                 offenders.push(format!("{rel}: preferred_nickname.to_string_lossy()"));
             }
+
+            // A `SealedBytes` handed to a name-shaped component prop. Matches
+            // `nickname:` / `name:` / `author:` (but not the struct field
+            // `preferred_nickname:`, which is how a record is BUILT) followed
+            // closely by the field.
+            for prop in ["nickname:", "name:", "author:"] {
+                let mut rest = production;
+                let mut consumed = 0usize;
+                while let Some(idx) = rest.find(prop) {
+                    let abs = consumed + idx;
+                    let preceded_by_ident = production[..abs]
+                        .chars()
+                        .next_back()
+                        .is_some_and(|c| c.is_alphanumeric() || c == '_');
+                    if !preceded_by_ident {
+                        let window: String = production[abs..].chars().take(120).collect();
+                        if window.contains("preferred_nickname") {
+                            offenders.push(format!(
+                                "{rel}: `{prop}` prop fed from preferred_nickname \
+                                 (Dioxus converts a String prop via Display, so this \
+                                 bypasses both the unseal and the sanitiser)"
+                            ));
+                        }
+                    }
+                    rest = &rest[idx + prop.len()..];
+                    consumed = abs + prop.len();
+                }
+            }
             // An unseal whose argument is the nickname field. The window is
             // generous because rustfmt often breaks the call across lines.
-            let mut rest = production.as_str();
+            let mut rest = production;
             while let Some(idx) = rest.find("unseal_bytes_with_secrets(") {
                 let after = &rest[idx..];
                 // Take CHARS, not bytes: these files are full of multi-byte

--- a/ui/src/util/display_name.rs
+++ b/ui/src/util/display_name.rs
@@ -29,16 +29,28 @@
 //!   (much worse) false-positive profile.
 //! * Combining marks are preserved, so a "Zalgo" nickname can still be ugly.
 //!   It cannot forge a badge, which is what this module is for.
+//! * Sanitising can CREATE a collision: `"B⭐ob"` and `"Bob"` render alike, as
+//!   do two nicknames that differ only in stripped characters. Nicknames were
+//!   never unique in River, so this grants no new capability, but it is worth
+//!   knowing that identical rendered names are possible by construction.
 //!
 //! ## What gets removed
 //!
 //! Emoji and pictographic symbols (the badge-forgery vector), plus two classes
 //! that exist purely to deceive the reader:
 //!
-//! * **Invisible formatting** — zero-width joiners/spaces, bidi embedding and
-//!   override controls, word joiners. These let a nickname reorder or hide
-//!   text around itself (`Alice\u{202E}...`), and ZWJ is how multi-codepoint
-//!   emoji sequences are assembled in the first place.
+//! * **Invisible and blank characters** — zero-width space, bidi embedding and
+//!   override controls, soft hyphen, interlinear annotation, the Hangul
+//!   fillers, Braille blank. These either reorder the text around them
+//!   (`Alice\u{202E}...`) or let two members render a pixel-identical name,
+//!   which would defeat telling a moderator from an impersonator even with the
+//!   badge itself correct.
+//!
+//!   Deliberately NOT removed: `U+200C` ZWNJ and `U+200D` ZWJ. They look like
+//!   emoji machinery, but they are orthography in Persian, Sinhala and
+//!   Malayalam, and stripping them mangles real names. They are safe to keep
+//!   because every emoji a joiner could assemble is itself removed; a joiner
+//!   left stranded at an edge by that removal is dropped as an orphan.
 //! * **Private-use area** codepoints. Fonts are free to map these to any glyph
 //!   at all (Nerd Fonts map a large PUA range to icons, including shields), so
 //!   a PUA nickname renders as a badge on any machine with such a font
@@ -88,9 +100,18 @@ pub fn is_display_hidden(c: char) -> bool {
         0x00A9 | 0x00AE
         // ‼ ⁉
         | 0x203C | 0x2049
-        // Zero-width space/non-joiner/joiner, LTR/RTL marks. ZWJ is how
-        // multi-codepoint emoji sequences are built.
-        | 0x200B..=0x200F
+        // Zero-width space, and the LTR/RTL marks.
+        //
+        // NOT U+200C ZWNJ or U+200D ZWJ. Those look like emoji machinery — ZWJ
+        // is what joins 👩 + ZWJ + 💻 — but they are orthography in several
+        // scripts, and stripping them mangles real names: Persian compounds
+        // (`علی‌رضا` Alireza, `حسین‌زاده` Hosseinzadeh) need ZWNJ to keep the
+        // preceding letter in its final form, Sinhala touching letters
+        // (`සූර්‍ය` Surya) need ZWJ, and several Malayalam IMEs emit chillu as
+        // consonant + virama + ZWJ. Keeping them is safe here because every
+        // emoji a ZWJ could join is itself stripped, so the joiner has nothing
+        // left to assemble.
+        | 0x200B | 0x200E | 0x200F
         // Line/paragraph separators.
         | 0x2028..=0x2029
         // Bidi embedding / override controls (the `\u{202E}` reversal trick).
@@ -122,6 +143,19 @@ pub fn is_display_hidden(c: char) -> bool {
         | 0xFE00..=0xFE0F
         // Zero-width no-break space / BOM.
         | 0xFEFF
+        // The remaining invisible `Cf` formatting characters that no range
+        // above covers, and that `char::is_control()` (which is `Cc` only)
+        // misses. U+061C ARABIC LETTER MARK is a bidi control like U+200E/F;
+        // U+00AD SOFT HYPHEN and U+180E MONGOLIAN VOWEL SEPARATOR render as
+        // nothing; U+FFF9..U+FFFB are interlinear annotation anchors that hide
+        // the text between them.
+        | 0x00AD | 0x061C | 0x180E | 0xFFF9..=0xFFFB
+        // Blank glyphs that are not whitespace, so `split_whitespace` would
+        // not collapse them: they let two members share a pixel-identical
+        // rendered name (`Alice` vs `Alice\u{3164}`), which undermines the
+        // "you can tell members apart by name" assumption the badge sits on.
+        // U+2800 BRAILLE PATTERN BLANK, and the Hangul fillers.
+        | 0x115F | 0x1160 | 0x2800 | 0x3164 | 0xFFA0
         // Private Use Area (BMP). Font-defined glyphs, and River's own
         // mention sentinels live at U+E000/U+E001.
         | 0xE000..=0xF8FF
@@ -158,8 +192,15 @@ pub fn contains_hidden_chars(s: &str) -> bool {
 /// separator) becomes a space rather than vanishing, so `"Alice\nBob"` stays
 /// two words instead of collapsing to `"AliceBob"`. Zero-width characters are
 /// not whitespace, so `"A\u{200B}lice"` correctly rejoins as `"Alice"`.
+///
+/// Only runs of ASCII space are collapsed, and only interior ones. Non-ASCII
+/// spaces are left alone: U+3000 IDEOGRAPHIC SPACE is the conventional
+/// separator between a Japanese surname and given name (`山田　太郎`), and
+/// normalising it to `' '` would quietly rewrite a real name.
 pub fn sanitize_display_name(raw: &str) -> String {
-    let stripped: String = raw
+    // 1. Remove the hidden characters. A hidden character that was itself
+    //    whitespace becomes a space so words don't run together.
+    let stripped: Vec<char> = raw
         .chars()
         .filter_map(|c| match (is_display_hidden(c), c.is_whitespace()) {
             (true, true) => Some(' '),
@@ -168,15 +209,44 @@ pub fn sanitize_display_name(raw: &str) -> String {
         })
         .collect();
 
-    // Collapse whitespace runs left behind by the removal. `split_whitespace`
-    // handles every Unicode space, and the join normalises exotic spaces to a
-    // plain one — deliberate, since a nickname has no use for U+2007.
-    let collapsed = stripped.split_whitespace().collect::<Vec<_>>().join(" ");
+    // 2. Drop ORPHANED joiners. U+200C/U+200D are kept above because they are
+    //    orthography between letters, but step 1 can leave one stranded at an
+    //    edge or beside a space — `"Bob 👮🏽‍♀️"` strips down to `"Bob ‍"`. A
+    //    joiner only means anything between two non-space characters, so drop
+    //    the rest rather than leave an invisible character in a name.
+    let is_joiner = |c: char| c == '\u{200C}' || c == '\u{200D}';
+    let kept: Vec<char> = stripped
+        .iter()
+        .enumerate()
+        .filter(|(i, c)| {
+            !is_joiner(**c)
+                || (*i > 0
+                    && !stripped[i - 1].is_whitespace()
+                    && !is_joiner(stripped[i - 1])
+                    && stripped
+                        .get(i + 1)
+                        .is_some_and(|n| !n.is_whitespace() && !is_joiner(*n)))
+        })
+        .map(|(_, c)| *c)
+        .collect();
 
-    if collapsed.is_empty() {
+    // 3. Collapse the double spaces the removal leaves behind
+    //    ("Alice 🛡 Smith" -> "Alice  Smith").
+    let mut collapsed = String::with_capacity(kept.len());
+    let mut last_was_space = false;
+    for c in kept {
+        let is_space = c == ' ';
+        if !(is_space && last_was_space) {
+            collapsed.push(c);
+        }
+        last_was_space = is_space;
+    }
+
+    let trimmed = collapsed.trim();
+    if trimmed.is_empty() {
         UNNAMED.to_string()
     } else {
-        collapsed
+        trimmed.to_string()
     }
 }
 
@@ -231,9 +301,68 @@ mod tests {
 
     #[test]
     fn zwj_sequences_and_skin_tones_are_stripped() {
-        // 👮🏽‍♀️ = U+1F46E U+1F3FD ZWJ U+2640 U+FE0F
+        // 👮🏽‍♀️ = U+1F46E U+1F3FD ZWJ U+2640 U+FE0F. Every component is
+        // hidden; the ZWJ is kept by `is_display_hidden` (it is orthography in
+        // other scripts) and then dropped as an orphan, so nothing is left.
         let officer = "Bob \u{1F46E}\u{1F3FD}\u{200D}\u{2640}\u{FE0F}";
         assert_eq!(sanitize_display_name(officer), "Bob");
+        assert!(!sanitize_display_name(officer).contains('\u{200D}'));
+
+        // A joiner alone, or beside a space, is also an orphan.
+        assert_eq!(sanitize_display_name("\u{200D}Alice"), "Alice");
+        assert_eq!(sanitize_display_name("Alice\u{200D}"), "Alice");
+        assert_eq!(sanitize_display_name("Alice \u{200D} Bob"), "Alice Bob");
+    }
+
+    /// U+200C ZWNJ and U+200D ZWJ look like emoji machinery but are letters in
+    /// effect in Persian, Sinhala and Malayalam. Stripping them mangles real
+    /// names — and, because `contains_hidden_chars` gates three inputs, it
+    /// would have locked those users out of creating a room or accepting an
+    /// invitation while telling them their name contained emoji.
+    #[test]
+    fn joiners_between_letters_are_preserved() {
+        for name in [
+            "علی\u{200C}رضا",   // Alireza (Persian compound given name)
+            "حسین\u{200C}زاده", // Hosseinzadeh
+            "නික\u{200D}නම",     // Sinhala touching letters
+            "മോഹ\u{200D}ൻ",     // Malayalam chillu (consonant + virama + ZWJ)
+        ] {
+            assert_eq!(
+                sanitize_display_name(name),
+                name,
+                "sanitisation broke a name whose joiner is orthography: {name:?}"
+            );
+            assert!(
+                !contains_hidden_chars(name),
+                "a name with an interior joiner must not be rejected at input: {name:?}"
+            );
+        }
+    }
+
+    /// Blank-but-not-whitespace characters let two members render a
+    /// pixel-identical name, which defeats telling a moderator from an
+    /// impersonator even with the badge correct.
+    #[test]
+    fn invisible_and_blank_characters_are_stripped() {
+        for (label, blank) in [
+            ("HANGUL FILLER", '\u{3164}'),
+            ("HANGUL CHOSEONG FILLER", '\u{115F}'),
+            ("HANGUL JUNGSEONG FILLER", '\u{1160}'),
+            ("HALFWIDTH HANGUL FILLER", '\u{FFA0}'),
+            ("BRAILLE PATTERN BLANK", '\u{2800}'),
+            ("SOFT HYPHEN", '\u{00AD}'),
+            ("ARABIC LETTER MARK", '\u{061C}'),
+            ("MONGOLIAN VOWEL SEPARATOR", '\u{180E}'),
+            ("INTERLINEAR ANNOTATION ANCHOR", '\u{FFF9}'),
+        ] {
+            let name = format!("Alice{blank}");
+            assert_eq!(
+                sanitize_display_name(&name),
+                "Alice",
+                "{label} survived and can clone another member's name"
+            );
+            assert!(contains_hidden_chars(&name), "{label} not flagged");
+        }
     }
 
     #[test]
@@ -288,6 +417,14 @@ mod tests {
             "O'Brien-Smith Jr.",       // punctuation
             "Anne-Marie (Ann)",        // more punctuation
             "user_42",                 // underscores/digits
+            "山田\u{3000}太郎",        // U+3000, the Japanese name separator
+            "佐々木",                  // U+3005 iteration mark
+            "Jean\u{00A0}Luc",         // non-breaking space
+            "สมชาย ใจดี",               // Thai
+            "Արամ Խաչատրյան",          // Armenian
+            "გიორგი ბერიძე",           // Georgian
+            "ኃይሌ ገብረሥላሴ",              // Ethiopic
+            "ᏣᎳᎩ ᎠᏰᎵ",                 // Cherokee
             "山田 太郎、はじめまして", // CJK punctuation 、
         ] {
             assert_eq!(
@@ -406,7 +543,11 @@ mod tests {
             let mut rest = production.as_str();
             while let Some(idx) = rest.find("unseal_bytes_with_secrets(") {
                 let after = &rest[idx..];
-                let window = &after[..after.len().min(160)];
+                // Take CHARS, not bytes: these files are full of multi-byte
+                // characters (em-dashes and emoji in comments), and a byte
+                // slice would panic on a char boundary and be blamed on
+                // whichever unrelated change happened to move the text.
+                let window: String = after.chars().take(160).collect();
                 if window.contains("preferred_nickname") {
                     offenders.push(format!("{rel}: unseal of preferred_nickname"));
                 }

--- a/ui/src/util/display_name.rs
+++ b/ui/src/util/display_name.rs
@@ -1,0 +1,435 @@
+//! Display-time sanitisation of member nicknames.
+//!
+//! River shows a 🛡 shield next to members who hold deputy (moderator)
+//! authority over the viewer. A nickname is attacker-controlled bytes from
+//! the member's own signed `MemberInfoV1.preferred_nickname`, so a member who
+//! calls themselves `Alice 🛡` renders a shield that River never granted —
+//! a moderator-impersonation ("fake badge") attack. The same trick works for
+//! `👑` (room owner), `⭐` (you) and every other glyph River uses as a badge.
+//!
+//! The fix is **render-time**, not input-time. `riverctl` writes `member_info`
+//! straight to the contract and never touches the UI's input validation, so
+//! any rule enforced only in the nickname `<input>` is trivially bypassed.
+//! The nickname `<input>` *also* rejects emoji (see
+//! `member_info_modal::nickname_field`), but that is a UX affordance so honest
+//! users get told why their characters vanish — the security boundary is
+//! [`sanitize_display_name`], applied at every point where a nickname becomes
+//! display text.
+//!
+//! ## Scope, honestly stated
+//!
+//! * This **hides** emoji, it does not prevent storage. A CLI user can still
+//!   write `Alice 🛡` into the contract; River just never renders the shield.
+//!   Enforcing the rule in the room contract would change the contract WASM
+//!   and re-key every live room, which is not worth it for a display concern.
+//! * Homoglyphs are **not** addressed and cannot be, without breaking the
+//!   non-Latin names this function deliberately preserves. A Cyrillic `а` is a
+//!   legitimate letter; so is every character in a Chinese, Arabic or Greek
+//!   name. Confusable-script detection is a different problem with a different
+//!   (much worse) false-positive profile.
+//! * Combining marks are preserved, so a "Zalgo" nickname can still be ugly.
+//!   It cannot forge a badge, which is what this module is for.
+//!
+//! ## What gets removed
+//!
+//! Emoji and pictographic symbols (the badge-forgery vector), plus two classes
+//! that exist purely to deceive the reader:
+//!
+//! * **Invisible formatting** — zero-width joiners/spaces, bidi embedding and
+//!   override controls, word joiners. These let a nickname reorder or hide
+//!   text around itself (`Alice\u{202E}...`), and ZWJ is how multi-codepoint
+//!   emoji sequences are assembled in the first place.
+//! * **Private-use area** codepoints. Fonts are free to map these to any glyph
+//!   at all (Nerd Fonts map a large PUA range to icons, including shields), so
+//!   a PUA nickname renders as a badge on any machine with such a font
+//!   installed. River *also* uses `U+E000`/`U+E001` as internal sentinels in
+//!   [`crate::components::conversation::message_to_html_with_mentions`], so
+//!   stripping PUA additionally keeps a nickname from smuggling a sentinel
+//!   into the mention-chip substitution.
+//!
+//! Everything else is kept. Chinese, Japanese, Korean, Arabic, Hebrew,
+//! Cyrillic, Greek, Devanagari and accented Latin names pass through
+//! byte-identical, as do ordinary punctuation and CJK punctuation — see the
+//! `real_names_in_other_scripts_are_untouched` test, which is the guard
+//! against a rule that mangles real people's names (worse than the problem it
+//! solves).
+
+use river_core::room_state::privacy::SealedBytes;
+use std::collections::HashMap;
+
+/// Rendered in place of a nickname that is empty once sanitised (e.g. the
+/// nickname was nothing but emoji). Distinct from `"Unknown"`, which callers
+/// already use for "no `member_info` record at all", so the two cases stay
+/// distinguishable in the UI.
+pub const UNNAMED: &str = "Unnamed";
+
+/// Shown next to a nickname `<input>` whose contents would not survive
+/// [`sanitize_display_name`]. One wording, used by every nickname input, so a
+/// user gets the same explanation wherever they hit it.
+pub const EMOJI_REJECTION_MESSAGE: &str = "Nicknames can't contain emoji";
+
+/// Whether `c` must never appear in rendered display text.
+///
+/// Ranges are Unicode *blocks* rather than the `Emoji` character property:
+/// River has no Unicode-property dependency and the UI's wasm bundle size is
+/// a standing concern, so a table of block ranges is the right trade. Blocks
+/// are slightly broader than the emoji property (they also catch arrows,
+/// geometric shapes and dingbats), which is the safe direction — those are
+/// symbols, not letters, and none of them belong in a person's name.
+pub fn is_display_hidden(c: char) -> bool {
+    // Control characters (C0/C1). A newline or NUL in a nickname is never
+    // legitimate and breaks layout.
+    if c.is_control() {
+        return true;
+    }
+
+    matches!(u32::from(c),
+        // Symbols that Latin-1 inherited and that render as emoji: © ®
+        0x00A9 | 0x00AE
+        // ‼ ⁉
+        | 0x203C | 0x2049
+        // Zero-width space/non-joiner/joiner, LTR/RTL marks. ZWJ is how
+        // multi-codepoint emoji sequences are built.
+        | 0x200B..=0x200F
+        // Line/paragraph separators.
+        | 0x2028..=0x2029
+        // Bidi embedding / override controls (the `\u{202E}` reversal trick).
+        | 0x202A..=0x202E
+        // Word joiner, invisible operators, bidi isolates.
+        | 0x2060..=0x2064 | 0x2066..=0x206F
+        // ™ ℹ
+        | 0x2122 | 0x2139
+        // Arrows.
+        | 0x2190..=0x21FF
+        // Miscellaneous Technical (⌚ ⌛ ⏰ …).
+        | 0x2300..=0x23FF
+        // Enclosed Alphanumerics (① Ⓐ …).
+        | 0x2460..=0x24FF
+        // Geometric Shapes, Miscellaneous Symbols (☀ ⚔ ⛨ …), Dingbats
+        // (✅ ❌ ❤ …) — one contiguous run.
+        | 0x25A0..=0x27BF
+        // Supplemental Arrows-B.
+        | 0x2900..=0x297F
+        // Miscellaneous Symbols and Arrows (⬛ ⭐ …).
+        | 0x2B00..=0x2BFF
+        // Combining enclosing keycap (the `1️⃣` assembler).
+        | 0x20E3
+        // 〰 〽 and the two emoji-presented enclosed ideographs ㊗ ㊙. The
+        // rest of the CJK punctuation and Enclosed CJK blocks is untouched.
+        | 0x3030 | 0x303D | 0x3297 | 0x3299
+        // Variation selectors — VS16 is what turns a text-presentation
+        // character into its emoji glyph.
+        | 0xFE00..=0xFE0F
+        // Zero-width no-break space / BOM.
+        | 0xFEFF
+        // Private Use Area (BMP). Font-defined glyphs, and River's own
+        // mention sentinels live at U+E000/U+E001.
+        | 0xE000..=0xF8FF
+        // The emoji planes: Mahjong/Domino/Cards, Enclosed Alphanumeric
+        // Supplement (regional-indicator flags), Miscellaneous Symbols and
+        // Pictographs, Emoticons, Transport, Supplemental Symbols and
+        // Pictographs, Symbols and Pictographs Extended-A. 🛡 is U+1F6E1.
+        | 0x1F000..=0x1FAFF
+        // Tags — the flag-sequence assembler (🏴󠁧󠁢󠁳󠁣󠁴󠁿).
+        | 0xE0000..=0xE007F
+        // Supplementary Private Use Areas A and B.
+        | 0xF0000..=0xFFFFD
+        | 0x100000..=0x10FFFD
+    )
+}
+
+/// Whether `s` contains anything [`sanitize_display_name`] would remove.
+///
+/// Drives the nickname `<input>`'s "Nicknames can't contain emoji" message —
+/// UX only. Never rely on this for safety: the render-time strip is the
+/// boundary, because `riverctl` never runs this code.
+pub fn contains_hidden_chars(s: &str) -> bool {
+    s.chars().any(is_display_hidden)
+}
+
+/// Strip everything [`is_display_hidden`] rejects and tidy the result.
+///
+/// Removing a character can leave a double space (`"Alice 🛡 Smith"`), so
+/// internal whitespace runs are collapsed to one space and the result is
+/// trimmed. A name that is empty afterwards becomes [`UNNAMED`] rather than a
+/// blank author line.
+///
+/// A removed character that was itself whitespace (a newline, a paragraph
+/// separator) becomes a space rather than vanishing, so `"Alice\nBob"` stays
+/// two words instead of collapsing to `"AliceBob"`. Zero-width characters are
+/// not whitespace, so `"A\u{200B}lice"` correctly rejoins as `"Alice"`.
+pub fn sanitize_display_name(raw: &str) -> String {
+    let stripped: String = raw
+        .chars()
+        .filter_map(|c| match (is_display_hidden(c), c.is_whitespace()) {
+            (true, true) => Some(' '),
+            (true, false) => None,
+            (false, _) => Some(c),
+        })
+        .collect();
+
+    // Collapse whitespace runs left behind by the removal. `split_whitespace`
+    // handles every Unicode space, and the join normalises exotic spaces to a
+    // plain one — deliberate, since a nickname has no use for U+2007.
+    let collapsed = stripped.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    if collapsed.is_empty() {
+        UNNAMED.to_string()
+    } else {
+        collapsed
+    }
+}
+
+/// Decrypt a member's sealed nickname and sanitise it for display.
+///
+/// **The single choke point for turning `preferred_nickname` into display
+/// text.** Every UI surface that shows a nickname — message author lines, the
+/// member list, the member-info modal, reply previews, mention chips, DM
+/// threads and rail, notifications — routes through here, and
+/// [`tests::nickname_render_paths_go_through_display_nickname`] pins that so a
+/// new surface can't quietly reintroduce the hole by inlining the unseal.
+///
+/// Falls back to the sealed value's lossy rendering when decryption fails
+/// (a private room whose secret hasn't synced yet), matching what every call
+/// site did before this helper existed — and sanitising that path too, since
+/// `SealedBytes::Public` returns the raw bytes verbatim.
+pub fn display_nickname(sealed: &SealedBytes, secrets: &HashMap<u32, [u8; 32]>) -> String {
+    let raw = match crate::util::ecies::unseal_bytes_with_secrets(sealed, secrets) {
+        Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
+        Err(_) => sealed.to_string_lossy(),
+    };
+    sanitize_display_name(&raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The badge glyphs River itself renders. A nickname able to display any
+    /// of these can impersonate a moderator, the room owner, or "you".
+    const BADGE_GLYPHS: &[&str] = &["🛡", "👑", "⭐", "🔑", "🎪", "✅", "⚠", "🔰", "⚔"];
+
+    #[test]
+    fn badge_glyphs_cannot_survive_a_nickname() {
+        for glyph in BADGE_GLYPHS {
+            let name = format!("Alice {glyph}");
+            let out = sanitize_display_name(&name);
+            assert_eq!(out, "Alice", "{glyph} survived sanitisation as {out:?}");
+            assert!(
+                contains_hidden_chars(&name),
+                "{glyph} not flagged as hidden"
+            );
+        }
+    }
+
+    #[test]
+    fn shield_with_variation_selector_is_stripped() {
+        // U+1F6E1 U+FE0F — the emoji-presentation form, which is what a
+        // phone keyboard actually inserts.
+        assert_eq!(sanitize_display_name("Mod\u{1F6E1}\u{FE0F}"), "Mod");
+    }
+
+    #[test]
+    fn zwj_sequences_and_skin_tones_are_stripped() {
+        // 👮🏽‍♀️ = U+1F46E U+1F3FD ZWJ U+2640 U+FE0F
+        let officer = "Bob \u{1F46E}\u{1F3FD}\u{200D}\u{2640}\u{FE0F}";
+        assert_eq!(sanitize_display_name(officer), "Bob");
+    }
+
+    #[test]
+    fn flag_sequences_are_stripped() {
+        // Regional indicators (🇬🇧) and tag sequences (🏴󠁧󠁢󠁳󠁣󠁴󠁿).
+        assert_eq!(sanitize_display_name("Kim \u{1F1EC}\u{1F1E7}"), "Kim");
+        let scotland = "Ada \u{1F3F4}\u{E0067}\u{E0062}\u{E0073}\u{E0063}\u{E0074}\u{E007F}";
+        assert_eq!(sanitize_display_name(scotland), "Ada");
+    }
+
+    #[test]
+    fn bidi_overrides_and_zero_width_chars_are_stripped() {
+        // RLO can visually reverse the text that follows it, letting a
+        // nickname reorder the badge/name/timestamp row around itself.
+        assert_eq!(sanitize_display_name("Alice\u{202E}bob"), "Alicebob");
+        assert_eq!(sanitize_display_name("A\u{200B}l\u{FEFF}ice"), "Alice");
+        assert!(contains_hidden_chars("Alice\u{202E}"));
+    }
+
+    #[test]
+    fn private_use_area_is_stripped() {
+        // Nerd Fonts and similar map PUA to icon glyphs (shields included),
+        // and U+E000/U+E001 are River's own mention sentinels.
+        assert_eq!(sanitize_display_name("Eve \u{E000}\u{E001}"), "Eve");
+        assert_eq!(sanitize_display_name("Eve \u{F0FF}"), "Eve");
+        assert_eq!(sanitize_display_name("Eve \u{100001}"), "Eve");
+    }
+
+    #[test]
+    fn control_characters_are_stripped() {
+        assert_eq!(sanitize_display_name("Alice\nBob"), "Alice Bob");
+        assert_eq!(sanitize_display_name("Alice\u{0}"), "Alice");
+    }
+
+    /// The guard against a rule that mangles real people's names. Every name
+    /// here must pass through completely unchanged.
+    #[test]
+    fn real_names_in_other_scripts_are_untouched() {
+        for name in [
+            "李小龍",                  // Chinese
+            "さくら 田中",             // Japanese (kana + kanji)
+            "김민준",                  // Korean
+            "محمد عبد الله",           // Arabic
+            "דָּוִד",                     // Hebrew with niqqud (combining marks)
+            "Иван Петров",             // Cyrillic
+            "Γιώργος Παπαδόπουλος",    // Greek
+            "अमिताभ बच्चन",             // Devanagari
+            "François Müller",         // accented Latin
+            "Ægir Þórsson",            // Icelandic
+            "Nguyễn Thị Hương",        // Vietnamese
+            "José Ñuñez",              // Spanish
+            "O'Brien-Smith Jr.",       // punctuation
+            "Anne-Marie (Ann)",        // more punctuation
+            "user_42",                 // underscores/digits
+            "山田 太郎、はじめまして", // CJK punctuation 、
+        ] {
+            assert_eq!(
+                sanitize_display_name(name),
+                name,
+                "sanitisation altered a legitimate name: {name:?}"
+            );
+            assert!(
+                !contains_hidden_chars(name),
+                "legitimate name flagged as containing emoji: {name:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn generated_default_handles_are_untouched() {
+        // Every handle `crate::nickname` can produce must survive verbatim,
+        // or new members would render as a mangled name.
+        for first in crate::nickname::FIRST_NAMES {
+            for last in crate::nickname::LAST_NAMES {
+                let handle = format!("{first} {last}");
+                assert_eq!(sanitize_display_name(&handle), handle);
+            }
+        }
+    }
+
+    #[test]
+    fn whitespace_left_by_stripping_is_collapsed() {
+        assert_eq!(sanitize_display_name("Alice 🛡 Smith"), "Alice Smith");
+        assert_eq!(sanitize_display_name("  Alice  "), "Alice");
+    }
+
+    #[test]
+    fn all_emoji_nickname_falls_back_to_placeholder() {
+        assert_eq!(sanitize_display_name("🛡👑⭐"), UNNAMED);
+        assert_eq!(sanitize_display_name(""), UNNAMED);
+        assert_eq!(sanitize_display_name("   "), UNNAMED);
+    }
+
+    #[test]
+    fn display_nickname_sanitises_public_and_undecryptable_values() {
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+        let public = SealedBytes::public("Mallory 🛡".as_bytes().to_vec());
+        assert_eq!(display_nickname(&public, &secrets), "Mallory");
+
+        // A private value with no secret available falls back to
+        // `to_string_lossy` — a synthetic placeholder, which must also come
+        // back sanitised rather than bypassing the strip.
+        let private = SealedBytes::private(vec![1, 2, 3], [0u8; 12], 7, 3);
+        let out = display_nickname(&private, &secrets);
+        assert!(
+            !contains_hidden_chars(&out),
+            "fallback path bypassed the strip"
+        );
+    }
+
+    /// **The regression gate.** Render-time stripping only closes the hole if
+    /// EVERY surface goes through [`display_nickname`]; one surface that
+    /// inlines the old `unseal_bytes_with_secrets(&…preferred_nickname)` /
+    /// `preferred_nickname.to_string_lossy()` pattern reopens it, and that is
+    /// exactly the mistake a future feature is most likely to make (it is what
+    /// twelve call sites looked like before this module existed).
+    ///
+    /// So: scan the whole UI source tree and fail if any production code
+    /// outside this module turns `preferred_nickname` into a display string by
+    /// hand. Walking the tree rather than listing files means a NEW component
+    /// is covered the day it is written.
+    ///
+    /// If this fires on a genuinely non-display use of the field, route it
+    /// through [`display_nickname`] anyway or move it below `#[cfg(test)]` —
+    /// do not weaken the scan.
+    #[test]
+    fn nickname_render_paths_go_through_display_nickname() {
+        use std::path::{Path, PathBuf};
+
+        fn rust_files(dir: &Path, out: &mut Vec<PathBuf>) {
+            for entry in std::fs::read_dir(dir).expect("readable source dir") {
+                let path = entry.expect("readable dir entry").path();
+                if path.is_dir() {
+                    rust_files(&path, out);
+                } else if path.extension().is_some_and(|e| e == "rs") {
+                    out.push(path);
+                }
+            }
+        }
+
+        let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut files = Vec::new();
+        rust_files(&src, &mut files);
+        assert!(files.len() > 20, "source walk found suspiciously few files");
+
+        let mut offenders: Vec<String> = Vec::new();
+        for path in files {
+            // This module is the one place allowed to do it.
+            if path.ends_with("util/display_name.rs") {
+                continue;
+            }
+            // Deliberately scans the WHOLE file, test modules included. The
+            // obvious refinement — cut at the first `#[cfg(test)]`, as
+            // `members.rs`'s own pins do — silently disarmed this test:
+            // `conversation.rs` has a `#[cfg(test)]` helper at line ~770, so
+            // the cut hid 2,800 lines including a real offender. No test
+            // fixture in this crate needs the pattern anyway.
+            let production = std::fs::read_to_string(&path).expect("readable source file");
+            let rel = path
+                .strip_prefix(&src)
+                .unwrap_or(&path)
+                .display()
+                .to_string();
+
+            if production.contains("preferred_nickname.to_string_lossy()") {
+                offenders.push(format!("{rel}: preferred_nickname.to_string_lossy()"));
+            }
+            // An unseal whose argument is the nickname field. The window is
+            // generous because rustfmt often breaks the call across lines.
+            let mut rest = production.as_str();
+            while let Some(idx) = rest.find("unseal_bytes_with_secrets(") {
+                let after = &rest[idx..];
+                let window = &after[..after.len().min(160)];
+                if window.contains("preferred_nickname") {
+                    offenders.push(format!("{rel}: unseal of preferred_nickname"));
+                }
+                rest = &after[1..];
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "these UI surfaces turn a nickname into display text without \
+             `crate::util::display_name::display_nickname`, so an emoji \
+             nickname can forge a 🛡 deputy badge there:\n  {}",
+            offenders.join("\n  ")
+        );
+    }
+
+    #[test]
+    fn ascii_is_never_touched() {
+        // Cheap total check that the block table has no accidental hole in
+        // the printable-ASCII range.
+        for byte in 0x20u8..0x7F {
+            let c = byte as char;
+            assert!(!is_display_hidden(c), "ASCII {c:?} treated as hidden");
+        }
+    }
+}

--- a/ui/tests/conversation-deputy-badge.spec.ts
+++ b/ui/tests/conversation-deputy-badge.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect, Page } from "@playwright/test";
+
+// Render coverage for the two halves of the deputy-badge change:
+//
+//  1. A message author who holds deputy authority relevant to the viewer gets
+//     a 🛡 badge next to their name, with a tooltip naming the appointer and
+//     saying whether they can ban you. Authors without that authority don't.
+//
+//  2. That badge cannot be faked by a nickname. Example data deliberately
+//     gives the room OWNER the stored nickname "… (Owner) 🛡👑" — a spoof
+//     attempt — and `crate::util::display_name` strips it at render time, so
+//     the owner's author line shows no glyph at all.
+//
+// Example data (ui/src/example_data.rs): in "Team Chat Room" the owner
+// deputizes the "(Member)" member (a global moderator, relevant to every
+// viewer) and that member is given one guaranteed message so this spec is
+// deterministic. The local user is "(You)" and the owner is "(Owner)".
+//
+// Rust unit tests pin the predicate itself (`deputy_badges_for_viewer`) and
+// the sanitiser; this spec pins that the two are actually wired to the DOM.
+
+const BADGE = '[data-testid="message-author-deputy-badge"]';
+// Every glyph River uses as a badge somewhere in the UI. None may appear in a
+// rendered author NAME.
+const BADGE_GLYPHS = ["🛡", "👑", "⭐", "🔑", "🎪"];
+
+async function waitForApp(page: Page) {
+  await page.waitForSelector(".app-root", { timeout: 30_000 });
+}
+
+async function openTeamChat(page: Page) {
+  await page.goto("/");
+  await waitForApp(page);
+  await page.getByText("Team Chat Room").first().click();
+  // Author lines only render for OTHER people's messages, so wait for one.
+  await page
+    .locator('span[title^="Member ID"]')
+    .first()
+    .waitFor({ state: "visible", timeout: 10_000 });
+}
+
+test.describe("Deputy badge on message authors", () => {
+  // Fixed desktop viewport so the conversation pane is always in view
+  // (mirrors member-info-deputy-tag.spec.ts).
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("the deputy's message author line carries the 🛡 badge", async ({
+    page,
+  }) => {
+    await openTeamChat(page);
+
+    // The deputy authored at least one message, so at least one badge renders.
+    const badges = page.locator(BADGE);
+    await expect(badges.first()).toBeVisible({ timeout: 10_000 });
+
+    // The tooltip names the appointer AND says what it means for the viewer.
+    // The deputy here was appointed by the room owner and can ban the viewer.
+    await expect(badges.first()).toHaveAttribute(
+      "title",
+      /Deputy \(appointed by room owner\) — can ban you/,
+    );
+
+    // Every badge sits next to the SAME author — the one deputy in this room.
+    const badgedNames = new Set<string>();
+    const count = await badges.count();
+    for (let i = 0; i < count; i++) {
+      const header = badges.nth(i).locator("xpath=..");
+      const name = (
+        (await header.locator('span[title^="Member ID"]').textContent()) || ""
+      ).trim();
+      badgedNames.add(name);
+    }
+    expect(badgedNames.size).toBe(1);
+    expect([...badgedNames][0]).toContain("(Member)");
+  });
+
+  test("a non-deputy author has no badge", async ({ page }) => {
+    await openTeamChat(page);
+    await expect(page.locator(BADGE).first()).toBeVisible({ timeout: 10_000 });
+
+    // The owner also posts in example data, and the owner is nobody's deputy,
+    // so their author line must carry no badge.
+    const ownerHeader = page
+      .locator('span[title^="Member ID"]')
+      .filter({ hasText: "(Owner)" })
+      .first();
+    await expect(ownerHeader).toBeVisible();
+    await expect(
+      ownerHeader.locator("xpath=..").locator(BADGE),
+    ).toHaveCount(0);
+  });
+
+  test("an emoji nickname cannot paint a badge into the author line", async ({
+    page,
+  }) => {
+    await openTeamChat(page);
+
+    // The owner's STORED nickname ends with 🛡👑 (see example_data.rs). None
+    // of it may survive into any rendered author name.
+    const names = await page
+      .locator('span[title^="Member ID"]')
+      .allTextContents();
+    expect(names.length).toBeGreaterThan(0);
+    for (const name of names) {
+      for (const glyph of BADGE_GLYPHS) {
+        expect(
+          name,
+          `author name rendered a badge glyph from a nickname: ${JSON.stringify(name)}`,
+        ).not.toContain(glyph);
+      }
+    }
+    // Sanity: the owner really is on screen, so the loop above wasn't vacuous.
+    expect(names.some((n) => n.includes("(Owner)"))).toBe(true);
+  });
+
+  test("the member list still shows exactly one shield", async ({ page }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await page.getByText("Team Chat Room").first().click();
+
+    // The owner's spoofed nickname would add a second 🛡-bearing row if the
+    // render-time strip regressed.
+    const shieldRows = page
+      .locator('button[title^="Member ID"]')
+      .filter({ hasText: "🛡" });
+    await expect(shieldRows).toHaveCount(1);
+  });
+});

--- a/ui/tests/conversation-deputy-badge.spec.ts
+++ b/ui/tests/conversation-deputy-badge.spec.ts
@@ -18,8 +18,13 @@ import { test, expect, Page } from "@playwright/test";
 //
 // Rust unit tests pin the predicate itself (`deputy_badges_for_viewer`) and
 // the sanitiser; this spec pins that the two are actually wired to the DOM.
+// The member-list side of the spoof check lives in member-info-deputy-tag.spec.ts.
 
 const BADGE = '[data-testid="message-author-deputy-badge"]';
+// The author-name span in a message header. Scoped to the chat container so it
+// cannot pick up the @mention autocomplete's disambiguator, which uses the
+// same title prefix.
+const AUTHOR_NAME = '#chat-scroll-container span[title^="Member ID"]';
 // Every glyph River uses as a badge somewhere in the UI. None may appear in a
 // rendered author NAME.
 const BADGE_GLYPHS = ["🛡", "👑", "⭐", "🔑", "🎪"];
@@ -32,11 +37,10 @@ async function openTeamChat(page: Page) {
   await page.goto("/");
   await waitForApp(page);
   await page.getByText("Team Chat Room").first().click();
-  // Author lines only render for OTHER people's messages, so wait for one.
-  await page
-    .locator('span[title^="Member ID"]')
-    .first()
-    .waitFor({ state: "visible", timeout: 10_000 });
+  // Author lines only render for OTHER people's messages, and the deputy is
+  // guaranteed to have posted one, so waiting for the badge also guarantees
+  // the conversation has finished rendering.
+  await page.locator(BADGE).first().waitFor({ state: "visible", timeout: 15_000 });
 }
 
 test.describe("Deputy badge on message authors", () => {
@@ -49,45 +53,38 @@ test.describe("Deputy badge on message authors", () => {
   }) => {
     await openTeamChat(page);
 
-    // The deputy authored at least one message, so at least one badge renders.
-    const badges = page.locator(BADGE);
-    await expect(badges.first()).toBeVisible({ timeout: 10_000 });
-
     // The tooltip names the appointer AND says what it means for the viewer.
     // The deputy here was appointed by the room owner and can ban the viewer.
-    await expect(badges.first()).toHaveAttribute(
+    await expect(page.locator(BADGE).first()).toHaveAttribute(
       "title",
-      /Deputy \(appointed by room owner\) — can ban you/,
+      "Deputy (appointed by room owner). Can ban you.",
     );
 
     // Every badge sits next to the SAME author — the one deputy in this room.
-    const badgedNames = new Set<string>();
-    const count = await badges.count();
-    for (let i = 0; i < count; i++) {
-      const header = badges.nth(i).locator("xpath=..");
-      const name = (
-        (await header.locator('span[title^="Member ID"]').textContent()) || ""
-      ).trim();
-      badgedNames.add(name);
-    }
-    expect(badgedNames.size).toBe(1);
-    expect([...badgedNames][0]).toContain("(Member)");
+    const badgedNames = await page.locator(BADGE).evaluateAll((badges) =>
+      badges.map((b) => {
+        const name = b.parentElement?.querySelector(
+          'span[title^="Member ID"]',
+        );
+        return (name?.textContent || "").trim();
+      }),
+    );
+    expect(badgedNames.length).toBeGreaterThan(0);
+    expect(new Set(badgedNames).size).toBe(1);
+    expect(badgedNames[0]).toContain("(Member)");
   });
 
   test("a non-deputy author has no badge", async ({ page }) => {
     await openTeamChat(page);
-    await expect(page.locator(BADGE).first()).toBeVisible({ timeout: 10_000 });
 
     // The owner also posts in example data, and the owner is nobody's deputy,
     // so their author line must carry no badge.
     const ownerHeader = page
-      .locator('span[title^="Member ID"]')
+      .locator(AUTHOR_NAME)
       .filter({ hasText: "(Owner)" })
       .first();
     await expect(ownerHeader).toBeVisible();
-    await expect(
-      ownerHeader.locator("xpath=..").locator(BADGE),
-    ).toHaveCount(0);
+    await expect(ownerHeader.locator("xpath=..").locator(BADGE)).toHaveCount(0);
   });
 
   test("an emoji nickname cannot paint a badge into the author line", async ({
@@ -97,9 +94,7 @@ test.describe("Deputy badge on message authors", () => {
 
     // The owner's STORED nickname ends with 🛡👑 (see example_data.rs). None
     // of it may survive into any rendered author name.
-    const names = await page
-      .locator('span[title^="Member ID"]')
-      .allTextContents();
+    const names = await page.locator(AUTHOR_NAME).allTextContents();
     expect(names.length).toBeGreaterThan(0);
     for (const name of names) {
       for (const glyph of BADGE_GLYPHS) {
@@ -111,18 +106,5 @@ test.describe("Deputy badge on message authors", () => {
     }
     // Sanity: the owner really is on screen, so the loop above wasn't vacuous.
     expect(names.some((n) => n.includes("(Owner)"))).toBe(true);
-  });
-
-  test("the member list still shows exactly one shield", async ({ page }) => {
-    await page.goto("/");
-    await waitForApp(page);
-    await page.getByText("Team Chat Room").first().click();
-
-    // The owner's spoofed nickname would add a second 🛡-bearing row if the
-    // render-time strip regressed.
-    const shieldRows = page
-      .locator('button[title^="Member ID"]')
-      .filter({ hasText: "🛡" });
-    await expect(shieldRows).toHaveCount(1);
   });
 });

--- a/ui/tests/conversation-deputy-badge.spec.ts
+++ b/ui/tests/conversation-deputy-badge.spec.ts
@@ -57,7 +57,7 @@ test.describe("Deputy badge on message authors", () => {
     // The deputy here was appointed by the room owner and can ban the viewer.
     await expect(page.locator(BADGE).first()).toHaveAttribute(
       "title",
-      "Deputy (appointed by room owner). Can ban you.",
+      "Deputy (appointed by the room owner). Can ban you.",
     );
 
     // Every badge sits next to the SAME author — the one deputy in this room.

--- a/ui/tests/member-info-deputy-tag.spec.ts
+++ b/ui/tests/member-info-deputy-tag.spec.ts
@@ -43,6 +43,11 @@ test.describe("Member-info modal deputy shield legend (#451)", () => {
 
     // The deputy is the one member whose row carries the shield glyph. Exactly
     // one member (the owner-appointed "(Member)") is a deputy in example data.
+    //
+    // This count is ALSO the member-list regression gate for nickname emoji
+    // stripping: example_data.rs deliberately gives the OWNER the stored
+    // nickname "… (Owner) 🛡👑", so if `crate::util::display_name` ever stops
+    // stripping it, the owner's row matches too and this becomes 2.
     const deputyRow = page
       .locator('button[title^="Member ID"]')
       .filter({ hasText: "🛡" });

--- a/ui/tests/nickname-emoji-rejection.spec.ts
+++ b/ui/tests/nickname-emoji-rejection.spec.ts
@@ -48,35 +48,49 @@ test.describe("Nickname inputs reject emoji", () => {
     await expect(nickname).toBeVisible();
     await expect(error).toBeVisible();
 
-    // Clearing the emoji clears the error again.
+    // Clearing the emoji clears the error again, and NOW the same submit
+    // works. Without this positive control the assertion above would also
+    // pass if the button were broken for some unrelated reason.
     await nickname.fill("Alice");
     await expect(
       page.getByTestId("create-room-nickname-emoji-error"),
     ).toHaveCount(0);
+    await page.getByTestId("create-room-submit-button").click();
+    await expect(page.getByTestId("create-room-modal")).toHaveCount(0);
+    await expect(page.getByText("Emoji Test Room").first()).toBeVisible();
   });
 
   test("a non-Latin nickname is NOT rejected", async ({ page }) => {
-    // The rule must not mangle real names. A rule that flags 李小龍 or محمد is
-    // worse than the problem it solves.
+    // The rule must not mangle real names. A rule that flags 李小龍, محمد or
+    // علی‌رضا (whose ZWNJ is orthography, not emoji machinery) is worse than
+    // the problem it solves.
     await page.goto("/");
     await waitForApp(page);
 
     await page.getByTestId("create-room-button").click();
     const nickname = page.getByTestId("create-room-nickname-input");
     await expect(nickname).toBeVisible({ timeout: 10_000 });
+    const error = page.getByTestId("create-room-nickname-emoji-error");
 
     for (const name of [
       "李小龍",
       "محمد عبد الله",
+      "علی\u{200C}رضا", // Persian compound name, contains ZWNJ
+      "සූර්\u{200D}ය", // Sinhala touching letters, contains ZWJ
+      "山田\u{3000}太郎", // ideographic space separator
       "Иван Петров",
       "François Müller",
       "Nguyễn Thị Hương",
     ]) {
+      // Drive the field INVALID first, and wait for the error to appear.
+      // Asserting `toHaveCount(0)` straight after a `fill` would pass
+      // instantly on a render that hasn't happened yet — i.e. the single most
+      // important test here would be unable to fail for the right reason.
+      await nickname.fill("x 🛡");
+      await expect(error).toBeVisible();
+
       await nickname.fill(name);
-      await expect(
-        page.getByTestId("create-room-nickname-emoji-error"),
-        `rejected a legitimate name: ${name}`,
-      ).toHaveCount(0);
+      await expect(error, `rejected a legitimate name: ${name}`).toHaveCount(0);
     }
   });
 });

--- a/ui/tests/nickname-emoji-rejection.spec.ts
+++ b/ui/tests/nickname-emoji-rejection.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect, Page } from "@playwright/test";
+
+// The UX half of the nickname change: a nickname input tells the user why
+// emoji aren't allowed instead of silently dropping the characters at render
+// time.
+//
+// This is NOT the security boundary — riverctl writes member_info directly and
+// never runs this code, which is why the render-time strip
+// (`crate::util::display_name`) exists and is covered by Rust unit tests plus
+// conversation-deputy-badge.spec.ts. This spec only pins that honest users get
+// told.
+
+async function waitForApp(page: Page) {
+  await page.waitForSelector(".app-root", { timeout: 30_000 });
+}
+
+test.describe("Nickname inputs reject emoji", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("the create-room nickname field explains and blocks", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+
+    await page.getByTestId("create-room-button").click();
+    const nickname = page.getByTestId("create-room-nickname-input");
+    await expect(nickname).toBeVisible({ timeout: 10_000 });
+
+    await page.getByTestId("create-room-name-input").fill("Emoji Test Room");
+
+    // A plain name is accepted with no complaint.
+    await nickname.fill("Alice");
+    await expect(
+      page.getByTestId("create-room-nickname-emoji-error"),
+    ).toHaveCount(0);
+    await expect(nickname).toHaveAttribute("aria-invalid", "false");
+
+    // Adding a shield surfaces the message and marks the field invalid.
+    await nickname.fill("Alice 🛡");
+    const error = page.getByTestId("create-room-nickname-emoji-error");
+    await expect(error).toBeVisible();
+    await expect(error).toHaveText("Nicknames can't contain emoji");
+    await expect(nickname).toHaveAttribute("aria-invalid", "true");
+
+    // Submitting is a no-op while invalid — the modal stays open.
+    await page.getByTestId("create-room-submit-button").click();
+    await expect(nickname).toBeVisible();
+    await expect(error).toBeVisible();
+
+    // Clearing the emoji clears the error again.
+    await nickname.fill("Alice");
+    await expect(
+      page.getByTestId("create-room-nickname-emoji-error"),
+    ).toHaveCount(0);
+  });
+
+  test("a non-Latin nickname is NOT rejected", async ({ page }) => {
+    // The rule must not mangle real names. A rule that flags 李小龍 or محمد is
+    // worse than the problem it solves.
+    await page.goto("/");
+    await waitForApp(page);
+
+    await page.getByTestId("create-room-button").click();
+    const nickname = page.getByTestId("create-room-nickname-input");
+    await expect(nickname).toBeVisible({ timeout: 10_000 });
+
+    for (const name of [
+      "李小龍",
+      "محمد عبد الله",
+      "Иван Петров",
+      "François Müller",
+      "Nguyễn Thị Hương",
+    ]) {
+      await nickname.fill(name);
+      await expect(
+        page.getByTestId("create-room-nickname-emoji-error"),
+        `rejected a legitimate name: ${name}`,
+      ).toHaveCount(0);
+    }
+  });
+});

--- a/ui/tests/nickname-emoji-rejection.spec.ts
+++ b/ui/tests/nickname-emoji-rejection.spec.ts
@@ -43,19 +43,19 @@ test.describe("Nickname inputs reject emoji", () => {
     await expect(error).toHaveText("Nicknames can't contain emoji");
     await expect(nickname).toHaveAttribute("aria-invalid", "true");
 
-    // Submitting is a no-op while invalid — the modal stays open.
-    await page.getByTestId("create-room-submit-button").click();
-    await expect(nickname).toBeVisible();
-    await expect(error).toBeVisible();
+    // Submit is disabled while invalid, matching the accept-invitation modal.
+    const submit = page.getByTestId("create-room-submit-button");
+    await expect(submit).toBeDisabled();
 
-    // Clearing the emoji clears the error again, and NOW the same submit
-    // works. Without this positive control the assertion above would also
-    // pass if the button were broken for some unrelated reason.
+    // Clearing the emoji clears the error and re-enables submit, and the room
+    // is really created. Without this positive control the assertion above
+    // would also pass if the button were broken for an unrelated reason.
     await nickname.fill("Alice");
     await expect(
       page.getByTestId("create-room-nickname-emoji-error"),
     ).toHaveCount(0);
-    await page.getByTestId("create-room-submit-button").click();
+    await expect(submit).toBeEnabled();
+    await submit.click();
     await expect(page.getByTestId("create-room-modal")).toHaveCount(0);
     await expect(page.getByText("Emoji Test Room").first()).toBeVisible();
   });


### PR DESCRIPTION
## Problem

Two related gaps in the conversation view.

**Moderators are invisible.** The 🛡 deputy shield exists in the member list and
the member-info modal, but not where moderation actually happens: next to the
name on a message. You cannot tell whether the person telling you to calm down
has the authority to ban you.

**A nickname can fake the badge.** A nickname is attacker-controlled bytes from
the member's own signed `MemberInfoV1.preferred_nickname`. Set it to `Alice 🛡`
and you render a shield River never granted; the same works for `👑` (room
owner) and `⭐` (you). Adding the badge to the conversation without closing this
would ship an impersonation surface.

## One correction to the spec, up front

The brief for this work was, verbatim:

> a deputy shield indicates "this user has been deputized WHICH ALLOWS THEM TO
> BAN ME", unless I'm also a deputy in which case they can't ban me but I can
> still see that they're a deputy.

**Being a deputy does not make you immune.** `MembersV1::is_ban_authorized`
grants owner-appointed moderators *absolute* authority at step 3, which is
checked *before* the step-4 "cannot ban the member who deputized you" guardrail
(`common/src/room_state/member.rs:299-313`). So two owner-appointed moderators
can ban each other, and a moderator looking at a peer moderator's message will
see **"Deputy (appointed by the room owner). Can ban you."** — the tooltip the
premise says should not appear.

This PR implements what the contract actually does and pins it
(`deputy_viewer_still_sees_the_shield_on_a_fellow_deputy`). The visibility half
of the ask is implemented exactly as stated: **the badge never disappears
because the viewer is immune.** Only the wording reflects reality.

If deputies *should* be immune to each other, that is a change to
`is_ban_authorized` — a contract change, which re-keys every live room, and
deliberately out of scope here. Say the word and it can be a separate PR.

## Approach

### The badge predicate

The shield means the author holds deputy authority that **bears on the viewer**.

That predicate already existed. `relevant_deputizer_names` +
`viewer_relevant_deputizer_set` (added for #410/#451) are viewer-relative: a
member shows the shield when one of the people who deputized them is a **strict
invite-ancestor of the viewer**, **the room owner** (a global moderator,
relevant to everyone), or **the viewer themselves** (a deputy you appointed).
It never consults the viewer's own deputy status, so "still shows when I'm
immune" holds by construction.

Note this is *not* `deputies_of(self_member_id)` — that is `target_is_my_deputy`,
which drives the Deputize/Undeputize button and is the opposite ("who I
deputized") direction.

This PR wraps it in a shared `DeputyBadge` / `deputy_badges_for_viewer` used by
**all three** surfaces, so visibility *and* wording cannot drift the way #451
drifted:

| | |
|---|---|
| **Visibility** | non-empty `relevant_deputizer_names` (unchanged rule) |
| **Tooltip** | `Deputy (appointed by the room owner). Can ban you.` |

The ban clause is the real contract answer from `is_ban_authorized`, and it
accounts for **cascading bans**: a ban sweeps the target's whole invite subtree,
so someone who can ban your inviter removes you too. Asking only about a direct
ban would have told a user they were safe from someone who can delete them at
will.

The clause is dropped entirely on your own row ("can they ban you" is
meaningless about yourself, and `is_ban_authorized` answers `true` for a global
moderator asked about themselves).

Decisions the brief asked to be explicit about:

- **Deputy of a subtree outside the viewer's ancestry → no badge.** Their
  authority cannot reach the viewer. They still show it inside their own
  subtree's views.
- **The room owner never gets a shield.** Their authority is inherent, not
  delegated. This is enforced, not incidental: nothing in `MemberInfoV1::verify`
  stops a member listing the owner in their own `deputies`.
- **Self-deputisation grants nothing.** Also contract-legal, also now ignored —
  otherwise anyone in the viewer's invite chain could render a *real* shield on
  their own messages, which is the impersonation this PR exists to prevent, just
  achieved with a real badge instead of an emoji.
- **Self messages have no author line**, so your own badge appears only in the
  sidebar and the modal.

### Emoji in nicknames

Render-time stripping is the security boundary: `riverctl` writes `member_info`
straight to the contract and never runs UI validation. New
`ui/src/util/display_name.rs` owns one `display_nickname(sealed, secrets)` choke
point and **every** nickname render path goes through it — twelve inlined call
sites collapsed into one, covering message author lines, the member list, the
modal, the nickname field, reply-strip authors, mention chips (both renderers),
both @-autocomplete lists, reaction tooltips, DM thread and rail, notifications,
and the deputy tooltip's appointer names.

Three of those are not looked-up nicknames at all — they are name-shaped
strings the SENDER writes, spoofable with no `member_info` involved:

- `ReplyContentV1.target_author_name` (the `↩ @name:` in a reply strip), on both
  the public and the encrypted-room decode paths
- an unresolved mention's `[name]` snapshot in `@[Admin 🛡](rv:…)`
- the tooltip's appointer names

The reply strip additionally now prefers the **real** author of the quoted
message when it is still in the buffer, instead of the sender's claim about who
they were quoting.

**What is stripped:** emoji and pictographic blocks; invisible and blank
characters (zero-width, bidi overrides, soft hyphen, Hangul fillers, Braille
blank, the Default_Ignorable tail) — a nickname made only of those renders blank
while being non-empty, which gives a message a nameless header that reads as a
continuation of the group above it; private-use-area codepoints (Nerd Fonts map
PUA to icon glyphs including shields, and `U+E000`/`U+E001` are River's own
mention-substitution sentinels); and spaces that render identically to `U+0020`.

**What is not:** anything that could be part of a real name. CJK, Arabic,
Hebrew-with-niqqud, Cyrillic, Greek, Devanagari, Thai, Armenian, Georgian,
Ethiopic, Cherokee, accented and Vietnamese Latin, CJK punctuation, `U+3000`
(the Japanese name separator) and ordinary punctuation all pass through
byte-identical.

`U+200C` ZWNJ and `U+200D` ZWJ are the interesting case. They look like emoji
machinery, but they are **orthography**: Persian compounds (`علی‌رضا`), Sinhala
touching letters (`සූර්‍ය`), Malayalam chillu. Blanket-stripping them mangled
those names *and*, because the same predicate gates three inputs, locked those
users out of creating a room or accepting an invitation while telling them their
name contained emoji. They are now kept where they can be doing orthographic
work — between two non-ASCII letters, or trailing one — and dropped elsewhere,
which covers both the orphans the emoji strip leaves behind and the
`"Bo\u{200D}b"` clone of `"Bob"`.

**Input-time rejection is UX, not security.** The three nickname inputs show
"Nicknames can't contain emoji", mark the field `aria-invalid`, and refuse to
submit.

### Stated honestly

- This **hides** emoji, it does not prevent storage. A CLI user can still write
  `Alice 🛡` into the contract; the **River UI** never renders it — but
  `riverctl member list` and `riverctl message stream -f json` still print the
  raw value, so a bot consuming riverctl output sees the unsanitised name.
  Contract-level enforcement was rejected because it re-keys every live room.
- **Homoglyphs are not addressed and cannot be** without breaking the non-Latin
  names above. A Cyrillic `а` is a legitimate letter.
- Sanitising can still **create** a rendered-name collision (a joiner inside a
  CJK name, or a homoglyph). The cheap vectors are closed; the rest is the
  homoglyph problem. `duplicate_candidate_names` in the mention picker compares
  name strings, so it will not flag such a pair.
- Combining marks are preserved, so a "Zalgo" nickname can still be ugly. It
  cannot forge a badge.

### Changes to existing surfaces, called out

- The member-list and modal shield tooltips now carry the same
  `. Can/Cannot ban you.` clause (single-definition tooltip *is* the anti-drift
  mechanism).
- `BanButton` was passing a raw `SealedBytes` into a `String` prop, which Dioxus
  converts via `Display`: the ban dialog showed an unsanitised nickname, and
  `[Encrypted: N bytes, vN]` instead of a name in private rooms. Now fixed.
- Focusing and leaving your own nickname field used to republish `member_info`
  at version + 1 with no edit. Now guarded.
- Notification bodies flatten newlines out of the message text (a leading
  newline let an author paint a second line shaped like a notification from
  someone else).

## Testing

`cargo test -p river-ui --bins --all-features` — **537 passed**.
Playwright chromium, full suite — **86 passed, 6 skipped, 0 failed**. (One
pre-existing flake in `responsive-layout.spec.ts`'s sandboxed-iframe tests,
reproduced on another branch's dev server too — filed as #479.)

Highlights of the new coverage:

- `deputy_badge_is_viewer_relative_and_survives_viewer_immunity` — one room
  covering every case: deputy-of-owner → badge + "can ban you"; deputy of the
  viewer's inviter → badge; deputy of an unrelated subtree → no badge; **a
  deputy the viewer appointed → badge STILL shows, tooltip says "cannot ban
  you"**; no authority → no badge; owner → no badge.
- `can_ban_viewer_accounts_for_cascading_bans` — asserts the precondition (the
  direct ban really is denied) before asserting the tooltip, so it cannot pass
  for the wrong reason.
- `self_deputisation_grants_no_badge`, `owner_never_carries_a_deputy_badge`,
  `single_target_badge_matches_the_sweep`.
- `joiners_between_letters_are_preserved` and
  `joiners_are_dropped_where_they_only_clone` — the two halves of the ZWNJ/ZWJ
  rule.
- `real_names_in_other_scripts_are_untouched` — 24 names across 15 scripts, the
  guard against a rule that mangles real people's names.
- `nicknames_that_render_blank_become_unnamed`,
  `space_lookalikes_are_normalised_but_ideographic_space_is_not`,
  `reply_context_author_name_is_sanitised_on_both_paths`,
  `unresolved_mention_chip_snapshot_is_sanitised`.

**Regression gates:**

- `nickname_render_paths_go_through_display_nickname` walks the whole `ui/src`
  tree and fails on three shapes: the inlined unseal, `to_string_lossy` on the
  field, and a `SealedBytes` reaching a name-shaped component prop. That third
  check exists because the first two missed the live `BanButton` bug. Verified
  to fire by planting each violation.
- Source-grep pins in `conversation.rs` and `member_info_modal.rs` that both
  surfaces take visibility *and* tooltip from the shared helper.
- Example data gives the room owner a deliberately spoofed `… (Owner) 🛡👑`
  nickname, so `member-info-deputy-tag.spec.ts`'s existing `toHaveCount(1)`
  becomes a live regression gate for the strip, and gives the deputy one
  guaranteed message so the badge is deterministically present.

## Scope

UI-only — no `contracts/`, no `common/`, no serialized types, no WASM. The live
Official room's contract key is untouched.

`⚠️ Do not publish from this branch` — the River master agent owns publishing.

[AI-assisted - Claude]
