### PR TITLE
chore(cli): bump riverctl to 0.2.3 for the deputy-read release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4724,7 +4724,7 @@ dependencies = [
 
 [[package]]
 name = "riverctl"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riverctl"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 authors = ["Freenet Project"]
 description = "Command-line interface for River decentralized chat on Freenet"


### PR DESCRIPTION
Version bump only, so the `riverctl-v0.2.3` tag can be cut per `release-riverctl.yml` (the workflow refuses to publish unless the tag version matches `cli/Cargo.toml` and the tagged commit is on main).

Releases the deputy-status read commands from #470:

```
riverctl member deputies <ROOM_ID> [MEMBER_ID]      # who has X deputized
riverctl member deputized-by <ROOM_ID> <MEMBER_ID>  # who deputized X
```

`river-core` is unchanged, so it stays at its current version and the publish step is a no-op for it.

Diff is two lines: `cli/Cargo.toml` and its `Cargo.lock` counterpart. No source change, so no review beyond CI.

[AI-assisted - Claude]