### PR TITLE
fix(ui,cli): don't flash "Original message unavailable" while a private room decrypts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,17 @@ jobs:
       # --test target from migration_test, so it needs its own invocation.
       run: cargo test -p river-core --test room_contract_migration_test
 
+    - name: Test ban purges authored content (reply-quote premise)
+      env:
+        RUST_MIN_STACK: 8388608
+        CARGO_TARGET_DIR: ${{ github.workspace }}/target
+      # Pins that an enforced ban purges the banned member's messages AND their
+      # member_info. Both clients' reply-quote suppression keys on that absence
+      # (there is no other link from a reply's quoted-author NAME back to a
+      # MemberId), so if this sweep regressed, a banned member's text would
+      # start rendering again with every client-side test still green.
+      run: cargo test -p river-core --test ban_purges_authored_content_test
+
     - name: Test riverctl (CLI crate unit tests, incl. #292 recovery)
       env:
         RUST_MIN_STACK: 8388608

--- a/cli/README.md
+++ b/cli/README.md
@@ -256,7 +256,9 @@ Run `riverctl <group> --help` or `riverctl <group> <cmd> --help` for full flags.
 | `edit` | A previously-streamed message's content changed | same as `message` (with the new `content` and `edited: true`) |
 | `delete` | A previously-streamed message was deleted | `message_id`, `room`, `author`, `nickname`, `timestamp` (no `content`) |
 
-`reply_to` is `null` for non-replies, otherwise `{ "author", "preview" }`. `edit`/`delete` events are emitted only for messages the stream actually surfaced. Bridges should key off `type` and tolerate unknown future types.
+`reply_to` is `{ "author", "preview" }` only when the quoted message could be read back from live room state. It is `null` both for non-replies **and** for a reply whose quoted message could not be verified — its author was banned (which purges their messages), it was deleted, or it aged out of the room's `max_recent_messages` window. The quoted author and preview stored in a reply are a snapshot written by the *replier* and validated by nothing, so riverctl never emits them unverified; a bridge would otherwise republish a banned member's text after the ban. The human-readable output distinguishes the two cases with a `[reply to an unavailable message]` prefix; the JSON deliberately does not, so no existing consumer breaks on a new shape.
+
+`edit`/`delete` events are emitted only for messages the stream actually surfaced. Bridges should key off `type` and tolerate unknown future types.
 
 The top-level `author` is the sending member's ID; get your own with `riverctl
 identity whoami <room-owner-vk>` and compare against it to recognise your own

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -702,8 +702,14 @@ pub(crate) fn reply_context_display(
 }
 
 /// What a message's reply context should render as, resolved against LIVE room
-/// state. Mirrors the UI's `ReplyStrip` (`ui/src/components/conversation.rs`);
-/// the two must stay in step, since they render the same contract data.
+/// state. Mirrors the UI's `ReplyStrip` (`ui/src/components/conversation.rs`).
+///
+/// The RESOLUTION (which targets are quotable, and when a quote is refused)
+/// must stay in step between the two clients — they read the same contract
+/// data, and a divergence means one client shows text the other suppressed.
+/// The RENDERING deliberately differs: riverctl truncates to 50 chars with a
+/// "..." marker and leaves markdown intact; the UI truncates to 100 and strips
+/// markdown.
 #[derive(Debug, PartialEq)]
 pub(crate) enum ReplyContextDisplay {
     /// Not a reply.
@@ -746,33 +752,36 @@ pub(crate) fn reply_context_display_with_secrets(
     if msg.message.content.content_type() != CONTENT_TYPE_REPLY {
         return ReplyContextDisplay::NotAReply;
     }
-    let reply = match msg.message.content.decode_content() {
+    let decoded = match msg.message.content.decode_content() {
         // Public reply — decoded directly.
-        Some(DecodedContent::Reply(reply)) => reply,
-        // Private reply — decrypt then decode the sealed ReplyContentV1.
-        _ => {
-            let RoomMessageBody::Private {
+        Some(DecodedContent::Reply(reply)) => Some(reply),
+        // Private reply — decrypt then decode the sealed ReplyContentV1. A
+        // PUBLIC body with an undecodable payload also lands here and stays
+        // `None`, which is correct: it is a reply we cannot read.
+        _ => match &msg.message.content {
+            RoomMessageBody::Private {
                 ciphertext,
                 nonce,
                 secret_version,
                 ..
-            } = &msg.message.content
-            else {
-                return ReplyContextDisplay::NotAReply;
-            };
-            let decoded = secrets
+            } => secrets
                 .get(secret_version)
                 .and_then(|secret| {
                     river_core::ecies::decrypt_with_symmetric_key(secret, ciphertext, nonce).ok()
                 })
-                .and_then(|plaintext| ReplyContentV1::decode(&plaintext).ok());
-            match decoded {
-                Some(reply) => reply,
-                // We cannot even tell what this reply quotes, so we certainly
-                // cannot verify it.
-                None => return ReplyContextDisplay::Unavailable,
-            }
+                .and_then(|plaintext| ReplyContentV1::decode(&plaintext).ok()),
+            _ => None,
+        },
+    };
+    let reply = match decoded {
+        Some(reply) => reply,
+        // We cannot even tell what this reply quotes, so we certainly cannot
+        // verify it — unless we simply hold no room secrets yet, which is not
+        // the same thing (see `pending_decryption`). Mirrors the UI.
+        None if pending_decryption(&msg.message.content, secrets) => {
+            return ReplyContextDisplay::NotAReply
         }
+        None => return ReplyContextDisplay::Unavailable,
     };
 
     let messages = &room_state.recent_messages;
@@ -782,6 +791,12 @@ pub(crate) fn reply_context_display_with_secrets(
         .find(|m| m.id() == reply.target_message_id)
         // Soft-deleted messages stay in `messages`, and action / event records
         // are never rendered as message rows. None of them is quotable.
+        //
+        // The event filter is load-bearing: an EVENT is editable by its author,
+        // and `effective_text` consults `edited_content` before any
+        // content-type decode, so without it a member could post a join event,
+        // edit it to arbitrary text, and quote that. Do NOT drop it. Mirrors
+        // the UI's `resolve_reply_context`.
         .filter(|target| {
             !messages.is_deleted(&reply.target_message_id)
                 && !target.message.content.is_action()
@@ -816,12 +831,29 @@ pub(crate) fn reply_context_display_with_secrets(
     }
 }
 
+/// Whether an unreadable private body is merely WAITING on the room secrets
+/// rather than genuinely unreadable — riverctl holds no secrets for a room it
+/// has no local storage for. Mirrors the UI's `pending_decryption`
+/// (`ui/src/components/conversation.rs`); the discriminator is "no secrets AT
+/// ALL", not "this version is missing", because a rotated-past version IS
+/// genuinely unavailable.
+fn pending_decryption(
+    content: &river_core::room_state::message::RoomMessageBody,
+    secrets: &HashMap<u32, [u8; 32]>,
+) -> bool {
+    matches!(
+        content,
+        river_core::room_state::message::RoomMessageBody::Private { .. }
+    ) && secrets.is_empty()
+}
+
 /// A private QUOTE target's plaintext, or `None` when it cannot be read.
 ///
-/// Strict sibling of [`decrypt_private_body_text`]: identical up to the
-/// unrecognised-content-type case, where that one returns the raw decrypted
-/// bytes and this one returns `None`. See the call site for why a quote must
-/// not fall back to raw bytes. Mirrors `target_plaintext` in
+/// Strict sibling of [`decrypt_private_body_text`], which returns the raw
+/// decrypted bytes as lossy UTF-8 in TWO cases this one refuses: an
+/// unrecognised content type, and a recognised one whose payload fails to
+/// decode. See the call site for why a quote must not fall back to raw bytes.
+/// Mirrors `target_plaintext` in
 /// `ui/src/components/conversation.rs`; adding a content type means touching
 /// both.
 fn decrypt_private_quote_text(
@@ -7178,9 +7210,16 @@ mod display_text_tests {
         );
         let (mut state, msg) = state_with_message(body);
 
-        // Opaque without the secret — we cannot even tell what it quotes.
+        // Holding NO secrets at all is the "not loaded yet / no local storage"
+        // case, not a real failure — no prefix, same as the UI renders no strip.
         assert_eq!(
             reply_context_display(&state, &msg),
+            ReplyContextDisplay::NotAReply
+        );
+        // Holding a DIFFERENT version — the room rotated past v0 — is a genuine
+        // failure to read a message we know IS a reply.
+        assert_eq!(
+            reply_context_display_with_secrets(&state, &msg, &HashMap::from([(9u32, [1u8; 32])])),
             ReplyContextDisplay::Unavailable
         );
 
@@ -7270,14 +7309,14 @@ mod display_text_tests {
             "my reply"
         );
 
-        // Same state, same reply, secret removed: the target can no longer be
-        // read, so the quote must disappear rather than fall back to the
-        // snapshot. Asserted against the FINAL state (where the target DOES
+        // Same state, same reply, rotated past the secret: the target can no
+        // longer be read, so the quote must disappear rather than fall back to
+        // the snapshot. Asserted against the FINAL state (where the target DOES
         // exist), so it isolates decryptability rather than target presence.
         assert_eq!(
-            reply_context_display_with_secrets(&state, &msg, &HashMap::new()),
+            reply_context_display_with_secrets(&state, &msg, &HashMap::from([(9u32, [1u8; 32])])),
             ReplyContextDisplay::Unavailable,
-            "without the secret neither the target nor the reply can be read"
+            "without the right secret neither the target nor the reply can be read"
         );
     }
 
@@ -8487,8 +8526,19 @@ mod mention_cli_tests {
                 },
                 &sender,
             );
+            let non_message_id = non_message.id();
             state.recent_messages.messages.push(non_message);
             state.recent_messages.messages.push(reply.clone());
+            // Give the target an EDIT, or the filter is untestable: resolution
+            // would already fail for lack of body text, so deleting the filter
+            // would keep this green. `effective_text` reads `edited_content`
+            // before any content-type decode, and an event IS editable by its
+            // author — post a join event, edit it to arbitrary text, quote it.
+            state
+                .recent_messages
+                .actions_state
+                .edited_content
+                .insert(non_message_id, "attacker-chosen text".to_string());
             assert_eq!(
                 reply_context_display(&state, &reply),
                 ReplyContextDisplay::Unavailable,

--- a/ui/src/components/app/notifications.rs
+++ b/ui/src/components/app/notifications.rs
@@ -484,7 +484,7 @@ fn mentions_or_replies_to_self(
     room_secrets: &std::collections::HashMap<u32, [u8; 32]>,
     recent: &[AuthorizedMessageV1],
 ) -> bool {
-    use crate::components::conversation::{decrypt_message_content, extract_reply_context};
+    use crate::components::conversation::{decrypt_message_content, extract_reply_target_id};
 
     // (a) An @mention of self anywhere in the (decrypted) message text.
     let text = decrypt_message_content(&msg.message.content, room_secrets);
@@ -493,8 +493,7 @@ fn mentions_or_replies_to_self(
     }
 
     // (b) A reply to a message authored by self.
-    let (_, _, target_id) = extract_reply_context(&msg.message.content, room_secrets);
-    if let Some(target_id) = target_id {
+    if let Some(target_id) = extract_reply_target_id(&msg.message.content, room_secrets) {
         return recent
             .iter()
             .any(|m| m.id() == target_id && m.message.author == self_member_id);

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -101,7 +101,7 @@ struct GroupedMessage {
     edited: bool,
     reactions: HashMap<String, Vec<MemberId>>,
     /// What the reply-quote strip should render, already resolved against live
-    /// room state — see [`ReplyStrip`] and [`resolve_reply_context`].
+    /// room state — see [`ReplyStrip`] and [`resolve_reply_strip`].
     reply_strip: ReplyStrip,
     /// Propagation delay in seconds (send → receive), if known and significant
     #[allow(dead_code)]
@@ -163,21 +163,22 @@ enum DisplayRow {
 }
 
 /// What the reply-quote strip should render, resolved against live room state
-/// by [`resolve_reply_context`].
+/// by [`resolve_reply_strip`].
 ///
 /// An enum rather than co-varying `Option` fields plus a flag: the renderer has
 /// two mutually exclusive arms, and the freenet "paired `Option` fields that
 /// must co-occur" bug pattern is exactly the shape where a later edit sets one
-/// half and silently renders both strips at once. Matching on this makes that
-/// unrepresentable.
+/// half and the strip silently renders wrong (or not at all). Matching on this
+/// makes the inconsistent state unrepresentable.
 ///
 /// Distinct from [`ReplyContext`], which is the reply-in-progress the composer
 /// holds while the user is writing a reply.
 #[derive(Clone, Debug, Default, PartialEq)]
 enum ReplyStrip {
-    /// Not a reply — no strip at all.
+    /// Not a reply — no strip at all. Also the "still decrypting" state, which
+    /// must look like nothing rather than like a failure.
     #[default]
-    None,
+    NotAReply,
     /// A reply whose quoted message could not be read back from room state.
     Unavailable,
     /// A quote verified against the message it quotes. Every field is re-read
@@ -234,7 +235,7 @@ enum ReplyStrip {
 /// the target is readable, both its text and its attribution are re-read from
 /// it, so edits and renames propagate and neither half of the replier-supplied
 /// snapshot is ever displayed.
-fn resolve_reply_context(
+fn resolve_reply_strip(
     content: &RoomMessageBody,
     messages_state: &MessagesV1,
     member_info: &MemberInfoV1,
@@ -243,64 +244,98 @@ fn resolve_reply_context(
 ) -> ReplyStrip {
     use river_core::room_state::content::CONTENT_TYPE_REPLY;
 
-    let (_snapshot_author, _snapshot_preview, target_id) = extract_reply_context(content, secrets);
-    let Some(target_id) = target_id else {
-        // A reply we cannot decode — a private one whose secret we do not hold,
-        // or a malformed body — is still a REPLY: `content_type` is cleartext
-        // even on the `Private` variant. Say so rather than silently dropping
-        // the strip, so the two clients agree (riverctl reports the same).
-        return if content.content_type() == CONTENT_TYPE_REPLY {
-            ReplyStrip::Unavailable
+    let Some(target_id) = extract_reply_target_id(content, secrets) else {
+        // We could not decode the reply at all.
+        //
+        // "Still decrypting" is NOT "unavailable" — see `pending_decryption`.
+        // Otherwise this is a REPLY we cannot read (`content_type` is cleartext
+        // even on the `Private` variant, and a public body can carry undecodable
+        // `data`), so say so rather than silently dropping the strip. riverctl
+        // reports the same for the same inputs.
+        return if pending_decryption(content, secrets)
+            || content.content_type() != CONTENT_TYPE_REPLY
+        {
+            ReplyStrip::NotAReply
         } else {
-            ReplyStrip::None
+            ReplyStrip::Unavailable
         };
     };
 
-    let quote = messages_state
+    let target = messages_state
         .messages
         .iter()
         .find(|m| m.id() == target_id)
         // Mirror `display_messages()` and then some: `messages` retains
         // soft-deleted messages and action messages, and events render as a
         // merged summary rather than a `msg-{id}` row. None of those is a
-        // quotable message — resolving one would render machine copy
-        // ("[Reaction 👍 to …]") as if it were the author's words and leave the
-        // scroll-to-original handler pointing at an element that never exists.
+        // quotable message.
+        //
+        // The event filter is load-bearing, not tidiness: an EVENT is editable
+        // by its author (`rebuild_actions_state_with_decrypted` excludes only
+        // `is_action()` from `message_authors`), and `effective_text` consults
+        // `edited_content` BEFORE any content-type decode. So without this a
+        // member could post a join event, edit it to arbitrary text, and quote
+        // it — surfacing text that is rendered nowhere else in the app, since
+        // events render through `format_event_summary`. Do NOT drop this filter.
+        // Quoting an action or event would also aim scroll-to-original at a
+        // `msg-{id}` element that never exists.
         .filter(|target_msg| {
             !messages_state.is_deleted(&target_id)
                 && !target_msg.message.content.is_action()
                 && !target_msg.message.content.is_event()
-        })
-        .and_then(|target_msg| {
-            let text = target_plaintext(messages_state, target_msg, secrets)?;
-            // Attribute to the CURRENT nickname of the message's ACTUAL author
-            // rather than the snapshot's `target_author_name`, which can name
-            // anyone and does not track renames. Routed through the same
-            // `canonical()` lookup the message header uses, so a member with
-            // duplicate `member_info` records cannot be labelled one way in the
-            // quote and another way on their own message.
-            let author = resolve_member_nickname(member_info, target_msg.message.author, secrets);
-            Some((author, text))
         });
+    let Some(target_msg) = target else {
+        return ReplyStrip::Unavailable;
+    };
 
-    match quote {
+    let Some(text) = target_plaintext(messages_state, target_msg, secrets) else {
+        return if pending_decryption(&target_msg.message.content, secrets) {
+            ReplyStrip::NotAReply
+        } else {
+            ReplyStrip::Unavailable
+        };
+    };
+
+    // Attribute to the CURRENT nickname of the message's ACTUAL author rather
+    // than the snapshot's `target_author_name`, which can name anyone and does
+    // not track renames. Routed through the same `canonical()` lookup the
+    // message header uses, so a member with duplicate `member_info` records
+    // cannot be labelled one way in the quote and another way on their own
+    // message.
+    let author = resolve_member_nickname(member_info, target_msg.message.author, secrets);
+
+    ReplyStrip::Quote {
+        author,
         // Clean the preview for display: resolve @mention tokens to plain
         // `@name` (current nickname) and strip markdown, so the quote reads as
         // plain text rather than showing raw `@[name](rv:id)` / `**` /
         // `[text](url)` syntax. Truncate after cleaning.
-        Some((author, text)) => ReplyStrip::Quote {
-            author,
-            preview: clean_reply_preview(&text, member_names)
-                .chars()
-                .take(100)
-                .collect::<String>(),
-            target_id,
-        },
-        // The author name is dropped along with the text: "Alice: [removed]"
-        // still attributes the quoted content to Alice, and the name is exactly
-        // as unverifiable as the text it labels.
-        None => ReplyStrip::Unavailable,
+        preview: clean_reply_preview(&text, member_names)
+            .chars()
+            .take(100)
+            .collect::<String>(),
+        target_id,
     }
+}
+
+/// Whether an unreadable private body is merely WAITING on the room secrets
+/// rather than genuinely unreadable.
+///
+/// `RoomData.secrets` is `#[serde(skip)]`, so every cold start of an
+/// established private room transiently holds NO secrets until
+/// `repopulate_secrets_from_state` rehydrates them from the encrypted blobs.
+/// In that window nothing is verifiable and nothing is being hidden (the
+/// snapshot is unreadable too), so the strip must render as if the message
+/// simply were not a reply — flashing "Original message unavailable" over every
+/// reply on every page load is the alarming-placeholder failure that
+/// freenet/river#284 was filed to remove. The message body itself takes the
+/// same view, rendering a calm "Decrypting messages…".
+///
+/// The discriminator is deliberately "no secrets AT ALL", not "this version is
+/// missing": a rotated-past version is genuinely unavailable and must keep
+/// showing the placeholder.
+fn pending_decryption(content: &RoomMessageBody, secrets: &HashMap<u32, [u8; 32]>) -> bool {
+    matches!(content, RoomMessageBody::Private { .. }) && secrets.is_empty()
 }
 
 /// The quoted message's plaintext, or `None` when it genuinely cannot be read.
@@ -342,9 +377,10 @@ fn target_plaintext(
     let plaintext =
         crate::util::ecies::decrypt_with_symmetric_key(secret, ciphertext.as_slice(), nonce)
             .ok()?;
-    // Adding a content type? Add it here (and to riverctl's
-    // `reply_context_display_with_secrets`) or replies quoting it will render
-    // the "unavailable" placeholder even on a client that supports it.
+    // Adding a content type? Add it here, to riverctl's mirror
+    // `decrypt_private_quote_text`, and (for a public body) to
+    // `DecodedContent::as_text` — otherwise replies quoting it render the
+    // "unavailable" placeholder even on a client that supports it.
     match *content_type {
         CONTENT_TYPE_TEXT => TextContentV1::decode(&plaintext).ok().map(|c| c.text),
         CONTENT_TYPE_REPLY => ReplyContentV1::decode(&plaintext).ok().map(|r| r.text),
@@ -449,7 +485,7 @@ fn group_messages(
             .unwrap_or_default();
 
         // Resolve the reply quote (if any) against live room state.
-        let reply_strip = resolve_reply_context(
+        let reply_strip = resolve_reply_strip(
             &message.message.content,
             messages_state,
             member_info,
@@ -670,26 +706,26 @@ fn collect_mdast_text(node: &markdown::mdast::Node, out: &mut String) {
     }
 }
 
-/// Extract reply context from a message body, if it is a reply.
-/// Returns (author_name, content_preview, target_message_id) or (None, None, None).
-pub(crate) fn extract_reply_context(
+/// The id of the message this reply quotes, or `None` if it is not a reply (or
+/// cannot be decoded).
+///
+/// Deliberately returns ONLY the id. `ReplyContentV1` also carries
+/// `target_author_name` and `target_content_preview` — a snapshot written and
+/// signed by the REPLIER and validated by nothing — and the whole point of
+/// `resolve_reply_strip` is that neither is ever rendered. Not returning them
+/// makes that structural instead of a convention every caller has to honour.
+pub(crate) fn extract_reply_target_id(
     content: &RoomMessageBody,
     secrets: &HashMap<u32, [u8; 32]>,
-) -> (Option<String>, Option<String>, Option<MessageId>) {
+) -> Option<MessageId> {
     use river_core::room_state::content::{ReplyContentV1, CONTENT_TYPE_REPLY};
 
     match content {
         RoomMessageBody::Public {
             content_type, data, ..
-        } if *content_type == CONTENT_TYPE_REPLY => {
-            if let Ok(reply) = ReplyContentV1::decode(data) {
-                return (
-                    Some(reply.target_author_name),
-                    Some(reply.target_content_preview),
-                    Some(reply.target_message_id),
-                );
-            }
-        }
+        } if *content_type == CONTENT_TYPE_REPLY => ReplyContentV1::decode(data)
+            .ok()
+            .map(|r| r.target_message_id),
         RoomMessageBody::Private {
             content_type,
             ciphertext,
@@ -697,24 +733,17 @@ pub(crate) fn extract_reply_context(
             secret_version,
             ..
         } if *content_type == CONTENT_TYPE_REPLY => {
-            if let Some(secret) = secrets.get(secret_version) {
-                use crate::util::ecies::decrypt_with_symmetric_key;
-                if let Ok(decrypted_bytes) =
-                    decrypt_with_symmetric_key(secret, ciphertext.as_slice(), nonce)
-                {
-                    if let Ok(reply) = ReplyContentV1::decode(&decrypted_bytes) {
-                        return (
-                            Some(reply.target_author_name),
-                            Some(reply.target_content_preview),
-                            Some(reply.target_message_id),
-                        );
-                    }
-                }
-            }
+            use crate::util::ecies::decrypt_with_symmetric_key;
+            secrets
+                .get(secret_version)
+                .and_then(|secret| {
+                    decrypt_with_symmetric_key(secret, ciphertext.as_slice(), nonce).ok()
+                })
+                .and_then(|plaintext| ReplyContentV1::decode(&plaintext).ok())
+                .map(|r| r.target_message_id)
         }
-        _ => {}
+        _ => None,
     }
-    (None, None, None)
 }
 
 /// Convert message text to HTML with clickable links that open in new tabs.
@@ -3164,7 +3193,7 @@ fn MessageGroupComponent(
                                                     // composited to the same colour as the bubble.
                                                     {
                                                         match reply_strip_inner {
-                                                            ReplyStrip::None => rsx! {},
+                                                            ReplyStrip::NotAReply => rsx! {},
                                                             // Deliberately inert — no `role`/`tabindex`/
                                                             // `onclick` — because there is no original
                                                             // message to scroll to. It therefore carries
@@ -4703,7 +4732,7 @@ mod tests {
     }
 }
 
-/// Tests for [`resolve_reply_context`] — the rule that a reply's quoted
+/// Tests for [`resolve_reply_strip`] — the rule that a reply's quoted
 /// snapshot is rendered only when it can be re-read from live room state.
 ///
 /// These target the helper rather than `group_messages` because the latter
@@ -4711,7 +4740,7 @@ mod tests {
 /// runtime. The render side (which arm of [`ReplyStrip`] produces what markup)
 /// is covered by `ui/tests/message-layout.spec.ts`.
 #[cfg(test)]
-mod resolve_reply_context_tests {
+mod resolve_reply_strip_tests {
     use super::*;
     use ed25519_dalek::SigningKey;
     use river_core::room_state::content::{TextContentV1, CONTENT_TYPE_TEXT, TEXT_CONTENT_VERSION};
@@ -4769,7 +4798,7 @@ mod resolve_reply_context_tests {
         messages: &MessagesV1,
         member_info: &MemberInfoV1,
     ) -> ReplyStrip {
-        resolve_reply_context(
+        resolve_reply_strip(
             &reply.message.content,
             messages,
             member_info,
@@ -5121,12 +5150,23 @@ mod resolve_reply_context_tests {
                 ),
                 20,
             );
-            let messages = state(vec![
+            let mut messages = state(vec![
                 anchor.clone(),
                 action.clone(),
                 event.clone(),
                 reply.clone(),
             ]);
+            // Give the target an EDIT. Without this the filter is untestable:
+            // resolution would already fail inside `target_plaintext` (an
+            // action/event body has no text), so deleting the filter would keep
+            // the test green. `effective_text` consults `edited_content` BEFORE
+            // any content-type decode, and an event IS editable by its author —
+            // so this is the real attack: post a join event, edit it to
+            // arbitrary text, quote it. The filter is what stops that.
+            messages
+                .actions_state
+                .edited_content
+                .insert(target.id(), "attacker-chosen text".to_string());
             assert_eq!(
                 resolve(&reply, &messages, &member_info),
                 ReplyStrip::Unavailable,
@@ -5184,7 +5224,7 @@ mod resolve_reply_context_tests {
         let messages = state(vec![target, reply.clone()]);
 
         // Holding v1: the target is genuinely re-read.
-        let with_secret = resolve_reply_context(
+        let with_secret = resolve_reply_strip(
             &reply.message.content,
             &messages,
             &member_info,
@@ -5193,25 +5233,37 @@ mod resolve_reply_context_tests {
         );
         assert_eq!(expect_quote(with_secret).1, "private words");
 
-        // Rotated past v1 (holding only v2), and the cold-start case of holding
-        // nothing yet. Both must be `Unavailable`, NOT a quote of the
-        // "[Encrypted message - secret vN unavailable]" / "Decrypting
-        // messages..." diagnostics.
-        for secrets in [HashMap::from([(2u32, [9u8; 32])]), HashMap::new()] {
-            let ctx = resolve_reply_context(
+        // Rotated past v1 (holding only v2): genuinely unavailable. Must NOT
+        // quote the "[Encrypted message - secret vN unavailable]" diagnostic.
+        assert_eq!(
+            resolve_reply_strip(
                 &reply.message.content,
                 &messages,
                 &member_info,
-                &secrets,
+                &HashMap::from([(2u32, [9u8; 32])]),
                 &HashMap::new(),
-            );
-            assert_eq!(
-                ctx,
-                ReplyStrip::Unavailable,
-                "an undecryptable target must not be quoted (secrets held: {:?})",
-                secrets.keys().collect::<Vec<_>>()
-            );
-        }
+            ),
+            ReplyStrip::Unavailable,
+            "a target encrypted under a rotated-past version is unavailable"
+        );
+
+        // Cold start: `RoomData.secrets` is `#[serde(skip)]`, so an established
+        // private room transiently holds NOTHING on every page load. That is
+        // "still decrypting", not "unavailable" — flashing the placeholder over
+        // every reply on every load is the freenet/river#284 alarm class. No
+        // strip at all, matching what the pre-fix code rendered here.
+        assert_eq!(
+            resolve_reply_strip(
+                &reply.message.content,
+                &messages,
+                &member_info,
+                &HashMap::new(),
+                &HashMap::new(),
+            ),
+            ReplyStrip::NotAReply,
+            "a room whose secrets have not rehydrated yet must not flash the \
+             unavailable placeholder over every reply"
+        );
     }
 
     /// A target whose author has no `member_info` record yet (sync lag) still
@@ -5328,7 +5380,7 @@ mod resolve_reply_context_tests {
         let messages = state(vec![target, reply.clone()]);
 
         // With the secret the quote resolves against the live target.
-        let with_secret = resolve_reply_context(
+        let with_secret = resolve_reply_strip(
             &reply.message.content,
             &messages,
             &member_info,
@@ -5337,11 +5389,25 @@ mod resolve_reply_context_tests {
         );
         assert_eq!(expect_quote(with_secret).1, "target text");
 
-        // Without it, we cannot read the reply at all — but we still know it IS
-        // one, so say so rather than rendering nothing.
+        // Holding a DIFFERENT version — the room rotated past v4 — we cannot
+        // read the reply at all, but we still know it IS one, so say so.
+        assert_eq!(
+            resolve_reply_strip(
+                &reply.message.content,
+                &messages,
+                &member_info,
+                &HashMap::from([(5u32, [1u8; 32])]),
+                &HashMap::new(),
+            ),
+            ReplyStrip::Unavailable
+        );
+
+        // Holding NO secrets at all is the cold-start window, not a real
+        // failure: render nothing rather than alarming the user.
         assert_eq!(
             resolve(&reply, &messages, &member_info),
-            ReplyStrip::Unavailable
+            ReplyStrip::NotAReply,
+            "cold start must not flash the placeholder"
         );
     }
 
@@ -5360,6 +5426,6 @@ mod resolve_reply_context_tests {
         );
 
         let ctx = resolve(&plain, &state(vec![plain.clone()]), &info(vec![]));
-        assert_eq!(ctx, ReplyStrip::None);
+        assert_eq!(ctx, ReplyStrip::NotAReply);
     }
 }


### PR DESCRIPTION
## Problem

Follow-up to #471, which merged before this round of review landed. Three findings, one of them a regression #471 introduced.

### 1. Private-room cold start flashes the placeholder over every reply (regression)

#471 made an undecodable reply report "unavailable" rather than rendering no strip, so the UI and riverctl would agree on the same input. That is wrong for one important case.

`RoomData.secrets` is `#[serde(skip)]`, so **every** cold start of an established private room transiently holds no secrets until `repopulate_secrets_from_state` rehydrates them from the encrypted blobs — the comment at `ui/src/components/conversation.rs` says so explicitly, and it is why #284 replaced the alarming body placeholder with a calm "Decrypting messages…". In that window every reply is undecodable, so after #471 every reply in the room renders an italic `↩ Original message unavailable` on every page load before flipping to the real quote.

That is the exact alarm class #284 was filed to remove, and the wording is actively wrong there: the original message is fine, we just have not decrypted it yet. Before #471 no strip rendered at all in that window.

**Fix:** distinguish "still decrypting" from "genuinely unreadable". `pending_decryption` is true only when the body is `Private` **and** we hold *no secrets at all* — deliberately not "this version is missing", because a rotated-past version really is unavailable and must keep showing the placeholder. The pending case renders no strip, matching both the pre-#471 behaviour and what the message body itself does.

The parity argument that motivated #471's change does not apply here: riverctl collects secrets synchronously before any output, so it has no transient window to be in parity with. riverctl gets the same rule anyway, for the case where it holds no local storage for a room.

### 2. riverctl and the UI diverged on a malformed public reply

A `Public` body with `content_type == 3` and undecodable CBOR — postable by any member, since the contract treats content as opaque bytes — got `Unavailable` from the UI and `NotAReply` from riverctl, contradicting the parity the code comments assert. No text leaked either way. Fixed by restructuring the decode so both the private-undecryptable and malformed-public cases flow through one path.

### 3. The action/event target filter was not actually pinned

Both clients' tests passed **with the filter deleted** — resolution already failed inside the text lookup because an action/event body has no text, so the filter was never the thing under test.

That matters because the filter is load-bearing for a real reason, and not the one the comment gave. An **event is editable by its author** (`rebuild_actions_state_with_decrypted` excludes only `is_action()` from `message_authors`), and `effective_text` consults `edited_content` *before* any content-type decode. So a member could post a join event, edit it to arbitrary text, and quote it — surfacing text that is rendered nowhere else in the app, since events render through `format_event_summary`.

Both tests now give the target an edit, which is the actual attack. **Verified by deleting the filter in each client and confirming the corresponding test fails.**

## Also in this round

- **CI gap.** `common/tests/ban_purges_authored_content_test.rs` was added by #471 as the tripwire for the contract behaviour the whole fix rests on — but `build.yml` runs only specific `--test` targets, so it was never executed *or even compiled*. Added as its own step.
- **Structural hardening.** `extract_reply_context` narrowed to `extract_reply_target_id`. It no longer returns the replier-authored snapshot at all, so "the snapshot is never rendered" is enforced by the signature rather than by every caller remembering to discard it. Both callers only ever wanted the id.
- **`cli/README.md`** documented `reply_to` as null only for non-replies. It is now also null for a reply whose quote could not be verified — precisely what a bridge author needs to know, and the PR that changed it did not update the doc.
- **Naming.** `resolve_reply_context` → `resolve_reply_strip` (it returns a `ReplyStrip`); `ReplyStrip::None` → `ReplyStrip::NotAReply`, matching riverctl's clearer variant name.
- **Comment corrections** where a comment overstated what the code does: the strict/lenient decrypt difference is two cases not one; the CLI/UI mirror claim now scopes to *resolution* (rendering deliberately differs — 50 chars with "..." vs 100 chars markdown-stripped); the "add a content type" note pointed at the wrong CLI function and omitted the public decode path; the enum's rationale described a failure mode the old code did not have.

## Testing

`cargo test`: 21 targets green (`river-ui` 516, `riverctl` 259+, `river-core`).

New/changed pins:
- Cold start (no secrets) → no strip; rotated-past version → placeholder. Asserted separately in both clients so the two cases cannot be conflated again.
- Malformed public reply → `Unavailable` in riverctl.
- Action/event filter: tests now fail without the filter (verified by deleting it).
- The `common/tests` premise test now actually runs in CI.

`cargo fmt` and `cargo clippy` clean. Room-contract WASM hash unchanged (`scripts/check-room-contract-migration.sh --ci origin/main HEAD`), so the live Official room's key is untouched.

## Review

Full multi-model review across three rounds on #471 and this follow-up. Round 1 had an external Codex pass plus three Claude lenses. **Codex is unavailable for rounds 2 and 3** — `codex exec` fails with "You've hit your usage limit… try again at Jul 28th 2026 12:14 PM", and the Gemini CLI is deprecated on the individual tier. Per the review policy I used the Claude-subagent fallback with widened perspective diversity instead of dropping independent review: round 2 ran skeptical + testing lenses, round 3 ran skeptical + big-picture + code-first. Every finding in this PR came out of that fallback — including the cold-start regression, which no single lens caught twice.

Worth re-running a real Codex pass on this after Jul 28 if it is still open.

## Known follow-ups (not in this PR)

- The **send path still mints the snapshot**: every new reply persists `target_author_name` / `target_content_preview` into signed contract state, data no current River client reads. Older builds and the currently-published web container still render it, so users only see the fix once the UI is republished.
- `common/src/room_state/content.rs`'s `ReplyContentV1` doc comment still says the snapshot exists "so that the reply remains meaningful even if the target message is later deleted or scrolled out of the recent window" — the design intent this work deliberately reverses. Left alone to keep `common/src/` untouched; a comment-only change cannot move the WASM hash, so it is safe to fix whenever someone is in there.
- The non-self placeholder styling branch has no Playwright coverage: the example fixture is owner-authored so the `is_self` branch is deterministic.

[AI-assisted - Claude]
