### PR TITLE
fix(ui): never offer the Ban action on your own Member Info

### DIFF
--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -639,6 +639,27 @@ pub(crate) fn relevant_deputizer_names(
 /// NOT bare invite-chain ancestry, so a DEPUTY sees the Ban action for members in
 /// their deputizer's subtree. Bare downstream ancestry (`is_downstream`, still
 /// used for the "🔑 Invited by You" relationship tag) would have hidden it.
+///
+/// SELF-BAN IS REFUSED HERE, and that refusal is the UI's own — do NOT
+/// "simplify" it away believing the contract already prevents it, because it
+/// does not (freenet/river#478). `is_ban_authorized(P, P)` genuinely returns
+/// `true` for most deputies: the strict-ancestor walk seeds its visited set with
+/// `target`, so a member is never their own strict ancestor and step 2 never
+/// fires, but step 3 (owner-appointed global moderator) or step 5 (a strict
+/// non-owner ancestor deputized them — the ordinary case, since you usually
+/// deputize someone you invited) does. `validate_single_ban` does not refuse
+/// `banned_by == banned_user` either, and enforcement re-runs the same
+/// predicate, so a self-ban is accepted and then CASCADES:
+/// `MembersV1::check_banned_members` extends removal to
+/// `get_downstream_members(target)`, taking the member's whole invite subtree
+/// with them.
+///
+/// Refusing at the predicate rather than only at the render site means every
+/// caller inherits the guard, and it makes the UI's read path agree with
+/// riverctl's write path, which already refuses self-ban outright
+/// (`ApiClient::ban_member`: "Cannot ban yourself"). Whether the CONTRACT should
+/// reject `banned_by == banned_user` is a separate, wire-format-adjacent
+/// question and is deliberately not decided here.
 pub(crate) fn viewer_can_ban(
     members: &MembersV1,
     member_info: &river_core::room_state::member_info::MemberInfoV1,
@@ -646,6 +667,9 @@ pub(crate) fn viewer_can_ban(
     target: MemberId,
     owner_id: MemberId,
 ) -> bool {
+    if viewer == target {
+        return false;
+    }
     let members_by_id = members.members_by_member_id();
     MembersV1::is_ban_authorized(viewer, target, &members_by_id, member_info, owner_id)
 }
@@ -3947,5 +3971,96 @@ mod tests {
         let decoded =
             Invitation::from_encoded_string(&encoded).expect("legacy invitation should decode");
         assert!(decoded.room_secrets.is_empty());
+    }
+    /// freenet/river#478: a deputy must never be offered the Ban action on
+    /// THEMSELVES. The contract permits that ban — `is_ban_authorized(P, P)` is
+    /// `true` for most deputies — and `MembersV1::check_banned_members` then
+    /// cascades the removal to `get_downstream_members(P)`, so one misclick
+    /// costs the moderator their membership AND their whole invite subtree.
+    ///
+    /// Both self-ban routes are covered, because they reach `true` through
+    /// different branches of `is_ban_authorized`: step 3 (the owner listed you
+    /// in their `deputies`) and step 5 (a strict non-owner ancestor listed you
+    /// — the ordinary case, since you usually deputize someone you invited).
+    ///
+    /// Each case asserts the raw CONTRACT predicate first. Without that
+    /// precondition the test would pass for the wrong reason: if a future
+    /// contract change started refusing self-bans, the UI guard could be
+    /// deleted and this test would stay green while pinning nothing.
+    #[test]
+    fn viewer_can_ban_refuses_self_even_though_the_contract_permits_it() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let global_mod_sk = SigningKey::generate(&mut rng);
+        let parent_sk = SigningKey::generate(&mut rng);
+        let subtree_mod_sk = SigningKey::generate(&mut rng);
+        let bystander_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+
+        // owner -> {global_mod, parent, bystander}; parent -> subtree_mod.
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &global_mod_sk.verifying_key()),
+                authorized_member(&owner_sk, &parent_sk.verifying_key()),
+                authorized_member(&owner_sk, &bystander_sk.verifying_key()),
+                member_invited_by(&parent_sk, owner_id, &subtree_mod_sk.verifying_key()),
+            ],
+        };
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                // Owner appoints a global moderator (step-3 authority).
+                signed_member_info(&owner_sk, "Owner", vec![id(&global_mod_sk)]),
+                signed_member_info(&global_mod_sk, "GlobalMod", vec![]),
+                // Parent deputizes someone they invited (step-5 authority).
+                signed_member_info(&parent_sk, "Parent", vec![id(&subtree_mod_sk)]),
+                signed_member_info(&subtree_mod_sk, "SubtreeMod", vec![]),
+                signed_member_info(&bystander_sk, "Bystander", vec![]),
+            ],
+        };
+        let members_by_id = members.members_by_member_id();
+
+        for (label, sk) in [
+            ("owner-appointed global moderator (step 3)", &global_mod_sk),
+            (
+                "deputy of a strict non-owner ancestor (step 5)",
+                &subtree_mod_sk,
+            ),
+        ] {
+            let who = id(sk);
+            assert!(
+                MembersV1::is_ban_authorized(who, who, &members_by_id, &member_info, owner_id),
+                "precondition: the CONTRACT must permit this self-ban ({label}). \
+                 This test pins a UI-layer guard and is worthless if the \
+                 contract already refuses"
+            );
+            assert!(
+                !viewer_can_ban(&members, &member_info, who, who, owner_id),
+                "the UI must refuse a self-ban ({label}): it is contract-valid \
+                 and cascades to the member's whole invite subtree \
+                 (freenet/river#478)"
+            );
+        }
+
+        // The guard must be exactly `viewer == target` and nothing wider — both
+        // deputies keep the authority they genuinely have over other members.
+        assert!(viewer_can_ban(
+            &members,
+            &member_info,
+            id(&global_mod_sk),
+            id(&bystander_sk),
+            owner_id
+        ));
+        assert!(viewer_can_ban(
+            &members,
+            &member_info,
+            id(&parent_sk),
+            id(&subtree_mod_sk),
+            owner_id
+        ));
     }
 }

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -650,9 +650,16 @@ pub(crate) fn relevant_deputizer_names(
 /// deputize someone you invited) does. `validate_single_ban` does not refuse
 /// `banned_by == banned_user` either, and enforcement re-runs the same
 /// predicate, so a self-ban is accepted and then CASCADES:
-/// `MembersV1::check_banned_members` extends removal to
-/// `get_downstream_members(target)`, taking the member's whole invite subtree
-/// with them.
+/// `MembersV1::banned_member_ids` extends removal to
+/// `get_downstream_members(target)` (`common/src/room_state/member.rs:286-287`),
+/// and `ChatRoomStateV1::post_apply_cleanup` retains that whole set out — taking
+/// the member's entire invite subtree with them. (NOT `check_banned_members`,
+/// which walks invite chains for `has_banned_members` and has no production
+/// caller.)
+///
+/// The OWNER was never affected and this guard is not what protects them:
+/// `is_ban_authorized` denies `target == owner_id` outright before any grant, so
+/// do not later "extend" this refusal to a case that was never broken.
 ///
 /// Refusing at the predicate rather than only at the render site means every
 /// caller inherits the guard, and it makes the UI's read path agree with
@@ -3974,7 +3981,7 @@ mod tests {
     }
     /// freenet/river#478: a deputy must never be offered the Ban action on
     /// THEMSELVES. The contract permits that ban — `is_ban_authorized(P, P)` is
-    /// `true` for most deputies — and `MembersV1::check_banned_members` then
+    /// `true` for most deputies — and `MembersV1::banned_member_ids` then
     /// cascades the removal to `get_downstream_members(P)`, so one misclick
     /// costs the moderator their membership AND their whole invite subtree.
     ///
@@ -3997,6 +4004,7 @@ mod tests {
         let global_mod_sk = SigningKey::generate(&mut rng);
         let parent_sk = SigningKey::generate(&mut rng);
         let subtree_mod_sk = SigningKey::generate(&mut rng);
+        let sibling_sk = SigningKey::generate(&mut rng);
         let bystander_sk = SigningKey::generate(&mut rng);
 
         let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
@@ -4009,6 +4017,7 @@ mod tests {
                 authorized_member(&owner_sk, &parent_sk.verifying_key()),
                 authorized_member(&owner_sk, &bystander_sk.verifying_key()),
                 member_invited_by(&parent_sk, owner_id, &subtree_mod_sk.verifying_key()),
+                member_invited_by(&parent_sk, owner_id, &sibling_sk.verifying_key()),
             ],
         };
         let member_info = MemberInfoV1 {
@@ -4019,6 +4028,7 @@ mod tests {
                 // Parent deputizes someone they invited (step-5 authority).
                 signed_member_info(&parent_sk, "Parent", vec![id(&subtree_mod_sk)]),
                 signed_member_info(&subtree_mod_sk, "SubtreeMod", vec![]),
+                signed_member_info(&sibling_sk, "Sibling", vec![]),
                 signed_member_info(&bystander_sk, "Bystander", vec![]),
             ],
         };
@@ -4046,21 +4056,38 @@ mod tests {
             );
         }
 
-        // The guard must be exactly `viewer == target` and nothing wider — both
-        // deputies keep the authority they genuinely have over other members.
-        assert!(viewer_can_ban(
-            &members,
-            &member_info,
-            id(&global_mod_sk),
-            id(&bystander_sk),
-            owner_id
-        ));
-        assert!(viewer_can_ban(
-            &members,
-            &member_info,
-            id(&parent_sk),
-            id(&subtree_mod_sk),
-            owner_id
-        ));
+        // The guard must be exactly `viewer == target` and nothing wider — every
+        // authority route that reaches a THIRD PARTY must survive it. One case
+        // per route, because a guard widened to something like "the viewer's
+        // relevant-deputizer set contains the target" would leave the step-3 and
+        // step-2 cases passing and only break step 5.
+        for (label, viewer, target) in [
+            // Step 3: owner-appointed global moderator over an unrelated member.
+            (
+                "step 3, global mod -> bystander",
+                id(&global_mod_sk),
+                id(&bystander_sk),
+            ),
+            // Step 2: a genuine strict ancestor over their own invitee.
+            (
+                "step 2, parent -> their invitee",
+                id(&parent_sk),
+                id(&subtree_mod_sk),
+            ),
+            // Step 5: a deputy of a strict non-owner ancestor over another
+            // member of that ancestor's subtree. This is the SAME route the
+            // self-ban case above relies on, so without it the guard could be
+            // widened to swallow step-5 authority entirely and stay green.
+            (
+                "step 5, subtree mod -> sibling in the deputizer's subtree",
+                id(&subtree_mod_sk),
+                id(&sibling_sk),
+            ),
+        ] {
+            assert!(
+                viewer_can_ban(&members, &member_info, viewer, target, owner_id),
+                "the self-ban guard must not block genuine authority ({label})"
+            );
+        }
     }
 }

--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -415,18 +415,18 @@ pub fn MemberInfoModal() -> Element {
                             // Share-invite button row above.
                             div { class: "mt-4 flex items-start gap-3",
                                 // Never offer Ban on your OWN row
-                                // (freenet/river#478). This is the second half of
-                                // a deliberate belt-and-braces pair: the other is
-                                // the `viewer == target` refusal inside
-                                // `viewer_can_ban`, which every caller inherits.
-                                // Keep BOTH. `can_ban` arrives here as a plain
-                                // `bool`, so a future call site that computes it
-                                // some other way (the deputy-badge code calls
-                                // `is_ban_authorized` directly, for instance)
-                                // would bypass the predicate guard entirely.
+                                // (freenet/river#478). Redundant TODAY with the
+                                // `viewer == target` refusal in `viewer_can_ban`,
+                                // and kept deliberately: the asymmetry between a
+                                // guarded Deputize and an unguarded Ban is what
+                                // hid this bug, so the two actions in this row
+                                // read the same way. `can_ban` also arrives as a
+                                // plain `bool`, so a future caller computing it
+                                // another way is still gated here.
                                 // The contract PERMITS a self-ban and cascades it
                                 // to the whole invite subtree — see
-                                // `viewer_can_ban`'s docs.
+                                // `viewer_can_ban`'s docs. `execute_ban` refuses
+                                // it a third time, on the WRITE path.
                                 if member_id != self_member_id {
                                     BanButton {
                                         member_to_ban: member_id,
@@ -578,10 +578,7 @@ mod ban_gate_tests {
     /// here.
     #[test]
     fn modal_renders_deputy_shield_via_shared_helper() {
-        let source = include_str!("member_info_modal.rs");
-        let prod = &source[..source
-            .find("#[cfg(test)]")
-            .expect("member_info_modal.rs should have a #[cfg(test)] block")];
+        let prod = production_source();
 
         assert!(
             prod.contains("🛡 Deputy"),
@@ -599,46 +596,113 @@ mod ban_gate_tests {
              so the wording cannot drift between surfaces (#451)"
         );
     }
-    /// freenet/river#478: the `BanButton` render site must be self-guarded, the
-    /// way `DeputyButton` right beside it already is.
+    /// freenet/river#478: EVERY `BanButton` render site must be self-guarded,
+    /// the way `DeputyButton` right beside it already is.
     ///
-    /// This pins the SECOND half of a deliberate belt-and-braces pair. The
-    /// first half — the `viewer == target` refusal inside `viewer_can_ban` — is
-    /// pinned behaviourally by
-    /// `components::members::tests::viewer_can_ban_refuses_self_even_though_the_contract_permits_it`.
-    /// Because EITHER guard alone hides the button, no behavioural test can
-    /// detect the loss of just one of them; this source pin is what fails when
-    /// the render-site half is deleted.
+    /// This pins the render-site half of a three-layer guard. The other two are
+    /// pinned elsewhere: the `viewer == target` refusal inside `viewer_can_ban`
+    /// behaviourally by
+    /// `components::members::tests::viewer_can_ban_refuses_self_even_though_the_contract_permits_it`,
+    /// and the write-path refusal by `execute_ban_refuses_self_before_building_the_ban`
+    /// below. Any ONE of the three hides or blocks the ban, so no behavioural
+    /// test can detect the loss of just one; that is why the render-site half
+    /// needs a source pin.
+    ///
+    /// Two things this pin does that the obvious version does not:
+    /// * It strips `//` comments before searching, so a future comment that
+    ///   merely QUOTES the guard cannot satisfy it. That is the exact way a
+    ///   source pin dies silently.
+    /// * It checks EVERY occurrence, so adding a second, unguarded render site
+    ///   fails rather than passing on the first one.
     #[test]
     fn ban_button_render_site_is_self_guarded() {
-        let source = include_str!("member_info_modal.rs");
-        // Cut at the FIRST `#[cfg(test)]` so the needle below cannot match
-        // itself — the failure mode where a pin quietly stops pinning.
-        let prod = &source[..source
-            .find("#[cfg(test)]")
-            .expect("member_info_modal.rs should have a #[cfg(test)] block")];
+        let prod = strip_comments(production_source());
 
-        let ban_site = prod
-            .find("BanButton {")
-            .expect("the member-info modal must render `BanButton`");
-        // Only the text immediately preceding the button counts. Wide enough to
-        // survive a comment between the guard and the button, narrow enough
-        // that `DeputyButton`'s own guard — which sits well AFTER the ban site —
-        // can never satisfy it. `char_indices` keeps the slice on a UTF-8
-        // boundary (this file is full of emoji).
-        let head = &prod[..ban_site];
-        let window_start = head
-            .char_indices()
-            .rev()
-            .nth(200)
-            .map(|(i, _)| i)
-            .unwrap_or(0);
+        let sites: Vec<usize> = prod.match_indices("BanButton {").map(|(i, _)| i).collect();
         assert!(
-            head[window_start..].contains("member_id != self_member_id"),
-            "the `BanButton` render site must be guarded by \
-             `member_id != self_member_id` (freenet/river#478): a deputy's \
-             self-ban is contract-VALID and cascades to their entire invite \
-             subtree"
+            !sites.is_empty(),
+            "the member-info modal must render `BanButton`"
         );
+        for site in sites {
+            // Only the text immediately preceding this button counts. With
+            // comments stripped the guard sits ~40 chars back, so 200 is ample
+            // slack while staying far too tight for `DeputyButton`'s own guard
+            // (a separate render site, always AFTER its own `BanButton`) to
+            // satisfy a later occurrence. `char_indices` keeps the slice on a
+            // UTF-8 boundary (this file is full of emoji).
+            let head = &prod[..site];
+            let window_start = head
+                .char_indices()
+                .rev()
+                .nth(200)
+                .map(|(i, _)| i)
+                .unwrap_or(0);
+            assert!(
+                head[window_start..].contains("if member_id != self_member_id {"),
+                "every `BanButton` render site must be guarded by \
+                 `if member_id != self_member_id {{` (freenet/river#478): a \
+                 deputy's self-ban is contract-VALID and cascades to their \
+                 entire invite subtree"
+            );
+        }
+    }
+
+    /// freenet/river#478: `BanButton::execute_ban` must refuse a self-ban
+    /// BEFORE it builds the `UserBan`.
+    ///
+    /// This is the layer every present and future call site inherits, and the
+    /// only one evaluated at click rather than render time. Nothing downstream
+    /// will catch it: the chat delegate signs whatever bytes it is handed,
+    /// `validate_single_ban` does not refuse `banned_by == banned_user`, and
+    /// enforcement re-runs `is_ban_authorized`, which GRANTS a deputy's
+    /// self-ban and then cascades removal to their whole invite subtree.
+    ///
+    /// The ordering assertion is the load-bearing half: a guard that runs after
+    /// the `UserBan` is constructed and dispatched would satisfy a naive
+    /// "contains the check" pin while doing nothing.
+    #[test]
+    fn execute_ban_refuses_self_before_building_the_ban() {
+        let prod = strip_comments(include_str!("member_info_modal/ban_button.rs"));
+
+        let guard = prod.find("if member_to_ban == banned_by {").expect(
+            "`execute_ban` must refuse a self-ban: `if member_to_ban == banned_by {` \
+             (freenet/river#478)",
+        );
+        let construction = prod
+            .find("let ban = UserBan {")
+            .expect("`execute_ban` must build a `UserBan`");
+        assert!(
+            guard < construction,
+            "the self-ban refusal must run BEFORE the `UserBan` is constructed \
+             (freenet/river#478); a check placed after it would let the ban be \
+             built and dispatched"
+        );
+    }
+
+    /// The production half of a source file: everything before the FIRST
+    /// `#[cfg(test)]`, so a pin's needles can never match the test that asserts
+    /// them. Shared by the pins in this module so the cut cannot drift between
+    /// them — moving that cut point is how a pin stops pinning.
+    fn production_source() -> &'static str {
+        let source = include_str!("member_info_modal.rs");
+        &source[..source
+            .find("#[cfg(test)]")
+            .expect("member_info_modal.rs should have a #[cfg(test)] block")]
+    }
+
+    /// `source` with `//` comment bodies removed, so a source pin cannot be
+    /// satisfied by a comment that merely quotes the code it is meant to pin.
+    /// Line-oriented and deliberately simple: it does not need to handle `/*
+    /// */` or `//` inside a string literal, because a false NEGATIVE here is a
+    /// loud test failure, never a silent pass.
+    fn strip_comments(source: &str) -> String {
+        source
+            .lines()
+            .map(|line| match line.find("//") {
+                Some(i) => &line[..i],
+                None => line,
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 }

--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -414,19 +414,34 @@ pub fn MemberInfoModal() -> Element {
                             // Deputize on the right), matching the DM /
                             // Share-invite button row above.
                             div { class: "mt-4 flex items-start gap-3",
-                                BanButton {
-                                    member_to_ban: member_id,
-                                    can_ban: can_ban,
-                                    // The DECRYPTED, sanitised name — the same
-                                    // value `DeputyButton` gets. This used to
-                                    // pass the raw `SealedBytes`, which Dioxus
-                                    // silently coerced through `Display` (i.e.
-                                    // `to_string_lossy`): the ban dialog showed
-                                    // an unsanitised nickname in the one place
-                                    // a moderator is judging authority, and
-                                    // showed "[Encrypted: N bytes, vN]" instead
-                                    // of a name in private rooms.
-                                    nickname: target_nickname.clone()
+                                // Never offer Ban on your OWN row
+                                // (freenet/river#478). This is the second half of
+                                // a deliberate belt-and-braces pair: the other is
+                                // the `viewer == target` refusal inside
+                                // `viewer_can_ban`, which every caller inherits.
+                                // Keep BOTH. `can_ban` arrives here as a plain
+                                // `bool`, so a future call site that computes it
+                                // some other way (the deputy-badge code calls
+                                // `is_ban_authorized` directly, for instance)
+                                // would bypass the predicate guard entirely.
+                                // The contract PERMITS a self-ban and cascades it
+                                // to the whole invite subtree — see
+                                // `viewer_can_ban`'s docs.
+                                if member_id != self_member_id {
+                                    BanButton {
+                                        member_to_ban: member_id,
+                                        can_ban: can_ban,
+                                        // The DECRYPTED, sanitised name — the same
+                                        // value `DeputyButton` gets. This used to
+                                        // pass the raw `SealedBytes`, which Dioxus
+                                        // silently coerced through `Display` (i.e.
+                                        // `to_string_lossy`): the ban dialog showed
+                                        // an unsanitised nickname in the one place
+                                        // a moderator is judging authority, and
+                                        // showed "[Encrypted: N bytes, vN]" instead
+                                        // of a name in private rooms.
+                                        nickname: target_nickname.clone()
+                                    }
                                 }
 
                                 // Deputize / revoke-deputy (#410). Any non-owner
@@ -582,6 +597,48 @@ mod ban_gate_tests {
             prod.contains("DeputyBadge::tooltip"),
             "the deputy chip's tooltip must come from `DeputyBadge::tooltip` \
              so the wording cannot drift between surfaces (#451)"
+        );
+    }
+    /// freenet/river#478: the `BanButton` render site must be self-guarded, the
+    /// way `DeputyButton` right beside it already is.
+    ///
+    /// This pins the SECOND half of a deliberate belt-and-braces pair. The
+    /// first half — the `viewer == target` refusal inside `viewer_can_ban` — is
+    /// pinned behaviourally by
+    /// `components::members::tests::viewer_can_ban_refuses_self_even_though_the_contract_permits_it`.
+    /// Because EITHER guard alone hides the button, no behavioural test can
+    /// detect the loss of just one of them; this source pin is what fails when
+    /// the render-site half is deleted.
+    #[test]
+    fn ban_button_render_site_is_self_guarded() {
+        let source = include_str!("member_info_modal.rs");
+        // Cut at the FIRST `#[cfg(test)]` so the needle below cannot match
+        // itself — the failure mode where a pin quietly stops pinning.
+        let prod = &source[..source
+            .find("#[cfg(test)]")
+            .expect("member_info_modal.rs should have a #[cfg(test)] block")];
+
+        let ban_site = prod
+            .find("BanButton {")
+            .expect("the member-info modal must render `BanButton`");
+        // Only the text immediately preceding the button counts. Wide enough to
+        // survive a comment between the guard and the button, narrow enough
+        // that `DeputyButton`'s own guard — which sits well AFTER the ban site —
+        // can never satisfy it. `char_indices` keeps the slice on a UTF-8
+        // boundary (this file is full of emoji).
+        let head = &prod[..ban_site];
+        let window_start = head
+            .char_indices()
+            .rev()
+            .nth(200)
+            .map(|(i, _)| i)
+            .unwrap_or(0);
+        assert!(
+            head[window_start..].contains("member_id != self_member_id"),
+            "the `BanButton` render site must be guarded by \
+             `member_id != self_member_id` (freenet/river#478): a deputy's \
+             self-ban is contract-VALID and cascades to their entire invite \
+             subtree"
         );
     }
 }

--- a/ui/src/components/members/member_info_modal/ban_button.rs
+++ b/ui/src/components/members/member_info_modal/ban_button.rs
@@ -32,6 +32,28 @@ pub fn BanButton(member_to_ban: MemberId, can_ban: bool, nickname: String) -> El
             let room_state_clone = room_data.room_state.clone();
             let banned_by = MemberId::from(&self_sk.verifying_key());
 
+            // WRITE-PATH refusal of a self-ban (freenet/river#478). The two
+            // guards above this one — `viewer_can_ban` and the render-site
+            // condition in `member_info_modal.rs` — decide whether the button
+            // APPEARS; this one decides whether a `UserBan` is ever built, so it
+            // is the check every present and future call site of `BanButton`
+            // inherits. It is also the only one evaluated at CLICK time: the
+            // render-time guards read `MemberInfoModal`'s own `self_member_id`,
+            // while `banned_by` here comes from a separate memo re-read now, so
+            // an identity re-import between render and click cannot slip past.
+            //
+            // riverctl refuses the same thing at the same layer
+            // (`ApiClient::ban_member`: "Cannot ban yourself"). Nothing below
+            // this point will: the chat delegate signs whatever bytes it is
+            // handed, `validate_single_ban` does not refuse
+            // `banned_by == banned_user`, and enforcement re-runs
+            // `is_ban_authorized`, which GRANTS it for most deputies and then
+            // cascades removal to the member's whole invite subtree.
+            if member_to_ban == banned_by {
+                warn!("Refusing to ban self ({banned_by}) — see freenet/river#478");
+                return;
+            }
+
             let ban = UserBan {
                 owner_member_id: MemberId::from(&current_room),
                 banned_at: get_current_system_time(),


### PR DESCRIPTION
## Problem

A member with deputy authority who opened **their own** Member Info modal saw an enabled "Ban User" button. `member_info_modal.rs` rendered `BanButton` under `if !is_owner` with no `member_id != self_member_id` condition — while `DeputyButton`, a few lines below in the same `div`, already guarded self.

The resulting ban is **contract-valid**, and enforcement cascades removal to `get_downstream_members`, so one misclick removed the moderator **and their entire invite subtree**. (Blast radius figure per #478; not independently re-derived here.)

Only deputies were affected. The owner never was — `is_ban_authorized` denies `target == owner_id` outright before any grant — and neither was an ordinary member with no deputy authority.

## This is contract-PERMITTED behaviour gated at the interaction layer, not a contract fix

Please do not later "simplify" any of these guards away believing the contract prevents self-bans. It does not:

- `is_ban_authorized(P, P)` genuinely returns `true` for most deputies. The strict-ancestor walk seeds its `visited` set with `target`, so a member is never their own strict ancestor and step 2 never fires — but **step 3** (the owner listed them in `deputies`) or **step 5** (a strict non-owner ancestor listed them, the ordinary case since you usually deputize someone you invited) does.
- `validate_single_ban` does not refuse `banned_by == banned_user`, and enforcement re-runs the same predicate, so the ban applies. The cascade is in `MembersV1::banned_member_ids`, retained out by `ChatRoomStateV1::post_apply_cleanup`.

Whether the *contract* should reject `banned_by == banned_user` is a separate, wire-format-adjacent question and is deliberately **not** decided here. This PR is `ui/` only — `git diff origin/main --name-only` is three files, all under `ui/`, so no WASM is re-keyed.

> Note for anyone reading #478: the issue (and this PR's first revision) attributed the cascade to `MembersV1::check_banned_members`. That is wrong. `check_banned_members` walks invite chains for `has_banned_members`, which itself has no production caller. The cascade is `banned_member_ids`. The issue's line citation was right; only the function name was wrong.

## Approach — three layers, each with a distinct job

**1. `viewer_can_ban` refuses `viewer == target`** (`ui/src/components/members.rs`). The primary guard. It is the UI's single definition of "may this viewer ban this target", so every current and future caller inherits it.

**2. The `BanButton` render site is gated on `member_id != self_member_id`**, matching `DeputyButton` beside it. Redundant today, and kept deliberately: the asymmetry between a guarded Deputize and an unguarded Ban is what hid this bug, so the two actions in the row now read the same way.

**3. `BanButton::execute_ban` refuses `member_to_ban == banned_by` before constructing the `UserBan`** (`ui/src/components/members/member_info_modal/ban_button.rs`). Added in review. The first two decide whether the button *appears*; this one decides whether a ban is ever *built*, so it is the layer that does not depend on a caller having asked the right question first. Nothing downstream would catch it: the chat delegate signs whatever bytes it is handed, and `validate_single_ban` does not refuse a self-ban.

That third layer is the one that makes the riverctl argument actually land. `ApiClient::ban_member` (`cli/src/api.rs`) returns `Err("Cannot ban yourself")` — but it refuses at ban *construction*, and the first two guards are on the read/render path. Before this, the UI had no write-path refusal at all.

## Other callers audited

| Site | Verdict |
|---|---|
| `member_info_modal.rs` (`can_ban` → `BanButton`) | **The bug.** Fixed. |
| `members.rs` `badge_for_target` (calls `is_ban_authorized` directly) | **No gap.** `target == self_member_id` is already excluded. The remaining self-evaluation is `is_ban_authorized(A, A)` for `A` a strict ancestor of the viewer — but the same `.any()` also evaluates `is_ban_authorized(A, viewer)`, unconditionally `true` via step 2 for any strict ancestor, so the self path can never decide the result. Confirmed independently by two reviewers, who verified the two ancestor walks use identical semantics. |
| `ui/src/room_data.rs`, `room_synchronizer.rs` `UserBan` constructions | All inside `#[cfg(test)]`. |

`ban_button.rs` is the only production `UserBan` construction in `ui/`, and `BanButton` has one render site.

## Testing

Three tests, one per guard, because **any one guard alone hides or blocks the ban** — so no single behavioural test can detect the loss of just one.

1. `viewer_can_ban_refuses_self_even_though_the_contract_permits_it` — behavioural. Covers both self-ban routes (step 3 and step 5) and asserts the **raw contract predicate first**, so it cannot pass for the wrong reason: if a future contract change starts refusing self-bans, the precondition fails loudly rather than letting the UI guard be deleted under a still-green test. It then asserts one case per authority route (steps 2, 3, 5) reaching a **third party**, so the guard can't be widened. The step-5-over-a-third-party case was added in review — that route was asserted nowhere in `ui/`, despite being the route the second self-ban case depends on.
2. `ban_button_render_site_is_self_guarded` — source pin, line-based: the guard must be on the immediately preceding line of code, at **every** `BanButton {` occurrence.
3. `execute_ban_refuses_self_before_building_the_ban` — source pin asserting the comparison exists, runs before **every** `UserBan` construction, and that its body actually `return`s.

Both pins run over comment-stripped source (`//` and `/* */`), so a comment that merely quotes a guard cannot satisfy them. The `#[cfg(test)]` cut is a shared `production_source()` helper used by every pin in the module, so it cannot drift between them.

### Mutation verification

Every guard was reverted in turn and the suite re-run. Each mutation fails **only** its own test, confirming the three tests are independent:

| Mutation | Result |
|---|---|
| Remove `viewer == target` from `viewer_can_ban` | behavioural test FAILS |
| Remove the render-site `if` | render pin FAILS |
| Add a second, unguarded `BanButton` render site | render pin FAILS |
| Disarm attempt: `/* */` comment quoting the guard, real guard deleted | render pin FAILS |
| Remove the `execute_ban` guard | write-path pin FAILS |
| Drop just the `return;`, keep the `warn!` | write-path pin FAILS |
| Move the guard after the `UserBan` construction | write-path pin FAILS |
| Over-block: require owner-appointment (drops step-2/step-5 authority) | behavioural test FAILS |

`cargo test -p river-ui --bins` 553 passed; `cargo test -p river-core --lib` 205 passed. `cargo fmt --all -- --check` clean; `cargo clippy -p river-ui --bins --all-targets` reports nothing in any changed file.

## Follow-ups deliberately not done here

- **A `common/`-side test that a self-ban cascades.** It would pin the harm at its source, and nothing in `common/` currently tests `banned_by == banned_user`. Out of scope: this change is `ui/`-only because a `common/` change re-keys the live room contract.
- **A Playwright test.** It would be vacuous today: in `ui/src/example_data.rs` the local user is never deputized, so `is_ban_authorized(self, self)` is already `false` and the Ban button is absent with or without all three guards. Making it real needs a fixture change (deputize `(You)` in one example room), which would touch other e2e tests.
- **The empty `mt-4 flex` row** on your own Member Info when both buttons are hidden. Pre-existing — `BanButton` already rendered nothing whenever `can_ban` was false — not a regression from this PR.

Closes #478

[AI-assisted - Claude]
