### PR TITLE
fix(ui,cli): refuse bans whose cascade would remove the banner (#478)

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -4727,9 +4727,15 @@ impl ApiClient {
 
         let banned_member_id = target_member.member_info.member_id;
 
-        // Prevent self-banning
-        if banned_member_id == my_member_id {
-            return Err(anyhow!("Cannot ban yourself"));
+        // Prevent banning yourself out of the room, directly or transitively
+        // (freenet/river#478). ONE rule: refuse when the ban's cascade would
+        // remove US — the target being self, or the target being one of our own
+        // invite ancestors, whose `get_downstream_members` closure contains us.
+        // Both are contract-VALID, so nothing downstream stops them.
+        if let Some(reason) =
+            crate::deputies::self_removing_ban_reason(&room_state, my_member_id, banned_member_id)
+        {
+            return Err(anyhow!(reason));
         }
 
         // Prevent banning the room owner

--- a/cli/src/deputies.rs
+++ b/cli/src/deputies.rs
@@ -307,10 +307,10 @@ impl<'a> RoomDeputies<'a> {
     /// or is an owner-appointed global moderator. An earlier version of this
     /// function approximated the guardrail by hand and undercounted both cases.
     ///
-    /// ONE local narrowing is applied on top: the deputy is not counted against
-    /// themselves (see the filter below). Scope is the grant's: every member for
-    /// an owner grant (whose subtree is the room), otherwise the deputizer's
-    /// invite subtree.
+    /// ONE local narrowing is applied on top: targets whose ban would remove the
+    /// deputy themselves are not counted (see the filter below). Scope is the
+    /// grant's: every member for an owner grant (whose subtree is the room),
+    /// otherwise the deputizer's invite subtree.
     fn reach_of(&self, deputizer: MemberId, deputy: MemberId) -> usize {
         let empty = HashSet::new();
         let targets = if deputizer == self.owner_id {
@@ -321,19 +321,21 @@ impl<'a> RoomDeputies<'a> {
         targets
             .iter()
             .filter(|target| {
-                // Exclude the deputy themselves. `is_ban_authorized` has no
-                // `banner == target` check and self-ban really is contract-
-                // permitted (a deputy whose deputizer is their own invite
-                // ancestor satisfies step 5 against themselves), but counting
-                // it makes the number answer the wrong question: a deputy who
-                // can only "ban" themselves holds no moderation authority.
+                // Exclude every target whose ban would remove the DEPUTY: the
+                // deputy themselves, and the deputy's own invite ancestors
+                // (whose cascade sweeps the deputy up). `is_ban_authorized` has
+                // no such check and both really are contract-permitted (step 3
+                // grants an owner-appointed global moderator authority over
+                // their own ancestors), but counting them makes the number
+                // answer the wrong question: authority you can only spend by
+                // removing yourself is not moderation authority.
                 //
-                // riverctl's own WRITE path already refuses it -- `ban_member`
-                // returns "Cannot ban yourself" (`api.rs`) -- so before this
-                // the read path advertised a capability the CLI will not
-                // exercise. Keep the two in step: if either is relaxed, revisit
-                // the other.
-                **target != deputy
+                // riverctl's own WRITE path refuses exactly this set --
+                // `ban_member` goes through `self_removing_ban_reason` -- so
+                // the read path must not advertise a capability the CLI will
+                // not exercise. Keep the two in step: if either is relaxed,
+                // revisit the other.
+                !self.ban_would_remove(deputy, **target)
                     && MembersV1::is_ban_authorized(
                         deputy,
                         **target,
@@ -343,6 +345,17 @@ impl<'a> RoomDeputies<'a> {
                     )
             })
             .count()
+    }
+
+    /// Whether a ban of `target` would remove `banner` from the room — the same
+    /// question [`self_removing_ban_reason`] answers, off the subtrees this
+    /// struct already built.
+    fn ban_would_remove(&self, banner: MemberId, target: MemberId) -> bool {
+        banner == target
+            || self
+                .subtrees
+                .get(&target)
+                .is_some_and(|downstream| downstream.contains(&banner))
     }
 
     /// Build the resolved view of a single `deputizer -> deputy` grant.
@@ -464,6 +477,58 @@ fn invite_subtrees(state: &ChatRoomStateV1) -> HashMap<MemberId, HashSet<MemberI
         }
     }
     subtrees
+}
+
+/// Everyone a ban of `target` would remove from the room: `target` themselves
+/// PLUS their entire transitive invite subtree — exactly what the contract's
+/// `check_banned_members` inserts (the banned user) and then extends with
+/// (`get_downstream_members`).
+pub fn ban_removal_set(state: &ChatRoomStateV1, target: MemberId) -> HashSet<MemberId> {
+    let mut removed = invite_subtrees(state).remove(&target).unwrap_or_default();
+    removed.insert(target);
+    removed
+}
+
+/// NOBODY MAY BAN THEMSELVES OUT OF THE ROOM (freenet/river#478).
+///
+/// ONE rule, stated once: compute the set the ban would remove
+/// ([`ban_removal_set`]) and refuse if `banner` is in it. That covers the direct
+/// self-ban (`banner == target`) and the transitive one (`target` is a strict
+/// invite ancestor of `banner`, so the cascade sweeps the banner up with them)
+/// as the single case they are — do NOT split this back into two special cases.
+///
+/// The CONTRACT permits both: `MembersV1::is_ban_authorized` has no self-check,
+/// and step 3 (owner-appointed global moderator) fires before anything that
+/// would stop it, so an owner-appointed deputy is authorized to ban themselves
+/// AND their own ancestors. The resulting ban is fully valid and cascades to the
+/// banner's whole invite subtree. So this is a client-side gate, not a contract
+/// fix — and it must be applied to the OUTPUT of `is_ban_authorized`, never
+/// wired into one branch of its priority ladder, or it would miss exactly the
+/// global moderators who can reach the most members.
+///
+/// The UI enforces the identical rule in
+/// `ui/src/components/members.rs::self_removing_ban_reason`; the two clients are
+/// deliberately kept in step (the rule cannot live in `river-core` without
+/// changing the room-contract WASM, and therefore the contract key).
+///
+/// Returns the user-visible reason when the ban is refused, `None` when the rule
+/// does not apply.
+pub fn self_removing_ban_reason(
+    state: &ChatRoomStateV1,
+    banner: MemberId,
+    target: MemberId,
+) -> Option<&'static str> {
+    if !ban_removal_set(state, target).contains(&banner) {
+        return None;
+    }
+    Some(if banner == target {
+        "Cannot ban yourself. The ban would remove you, and everyone you \
+         invited, from the room."
+    } else {
+        "Cannot ban a member you joined the room through. A ban also removes \
+         everyone the banned member invited, so this one would remove you, and \
+         everyone you invited, along with them."
+    })
 }
 
 /// Render a nickname for TERMINAL output: quoted, with every non-printable
@@ -1616,5 +1681,140 @@ mod tests {
         assert_eq!(json["scope"], "invite-subtree");
         assert_eq!(json["active"], false);
         assert!(json["deputy"]["nickname"].is_null());
+    }
+
+    // ------------------------------------------------------------------
+    // freenet/river#478: nobody may ban themselves OUT OF THE ROOM.
+    //
+    // owner -> alpha -> beta -> deputy -> child, plus an unrelated stranger.
+    // `deputy` is an OWNER-APPOINTED GLOBAL MODERATOR, which is the only grant
+    // in `is_ban_authorized` that reaches a member's own ancestors — and it is
+    // granted at step 3, ahead of the step-4 guardrail.
+    // ------------------------------------------------------------------
+
+    /// The chain above, with `deputy` deputized by the owner.
+    fn ban_chain() -> ChatRoomStateV1 {
+        let (owner, alpha, beta, deputy, child, stranger) =
+            (key(1), key(2), key(3), key(4), key(5), key(6));
+        let mut state = ChatRoomStateV1::default();
+        push_member(&mut state, &owner, &owner, &alpha);
+        push_member(&mut state, &owner, &alpha, &beta);
+        push_member(&mut state, &owner, &beta, &deputy);
+        push_member(&mut state, &owner, &deputy, &child);
+        push_member(&mut state, &owner, &owner, &stranger);
+        push_info(&mut state, &owner, 0, "Owner", vec![id(&deputy)]);
+        for (sk, name) in [
+            (&alpha, "Alpha"),
+            (&beta, "Beta"),
+            (&deputy, "Deputy"),
+            (&child, "Child"),
+            (&stranger, "Stranger"),
+        ] {
+            push_info(&mut state, sk, 0, name, vec![]);
+        }
+        state
+    }
+
+    /// riverctl refuses a self-ban AND a ban of any strict ancestor, and keeps
+    /// refusing for the reason the rule states rather than for want of
+    /// authority — the precondition assertions are what prove that.
+    #[test]
+    fn self_removing_bans_are_refused_directly_and_transitively() {
+        let state = ban_chain();
+        let (owner, alpha, beta, deputy) = (key(1), key(2), key(3), key(4));
+        let members_by_id = state.members.members_by_member_id();
+
+        for (label, target) in [
+            ("self", id(&deputy)),
+            ("direct inviter (parent)", id(&beta)),
+            ("grandparent", id(&alpha)),
+        ] {
+            assert!(
+                MembersV1::is_ban_authorized(
+                    id(&deputy),
+                    target,
+                    &members_by_id,
+                    &state.member_info,
+                    id(&owner)
+                ),
+                "precondition ({label}): the contract AUTHORIZES this ban, so a \
+                 refusal below is the #478 rule and not missing authority"
+            );
+            assert!(
+                ban_removal_set(&state, target).contains(&id(&deputy)),
+                "precondition ({label}): the cascade really does remove the banner"
+            );
+            assert!(
+                self_removing_ban_reason(&state, id(&deputy), target).is_some(),
+                "riverctl must refuse a ban of {label} (#478)"
+            );
+        }
+    }
+
+    /// The over-broadness case: legitimate bans stay legitimate.
+    #[test]
+    fn bans_that_do_not_remove_the_banner_are_not_refused() {
+        let state = ban_chain();
+        let (owner, alpha, deputy, child, stranger) = (key(1), key(2), key(4), key(5), key(6));
+
+        for (label, banner, target) in [
+            ("an unrelated member", id(&deputy), id(&stranger)),
+            ("the deputy's own downstream", id(&deputy), id(&child)),
+            ("the owner banning mid-chain", id(&owner), id(&alpha)),
+        ] {
+            assert!(
+                self_removing_ban_reason(&state, banner, target).is_none(),
+                "banning {label} does not remove the banner and must stay \
+                 available (#478 must not be over-broad)"
+            );
+        }
+    }
+
+    /// The reported reach must not advertise authority riverctl's write path
+    /// refuses. Before #478's transitive case, a global moderator's reach
+    /// counted their own ancestors — bans `ban_member` now rejects.
+    #[test]
+    fn reach_excludes_targets_whose_ban_would_remove_the_deputy() {
+        let state = ban_chain();
+        let (owner, deputy) = (key(1), key(4));
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        // Room is alpha, beta, deputy, child, stranger. A global moderator can
+        // ban all of them per the contract, but alpha + beta (their ancestors)
+        // and the deputy themselves would take the deputy down too, leaving
+        // child + stranger.
+        assert_eq!(
+            d.grant(id(&owner), id(&deputy)).members_deputy_can_ban,
+            2,
+            "reach must exclude the deputy AND their own invite ancestors"
+        );
+    }
+
+    /// The write path must go through the shared rule, not re-derive it.
+    /// Source-scraped: `ban_member` needs a live node connection, so the guard
+    /// itself cannot be unit-tested here — this pins the wiring.
+    #[test]
+    fn ban_member_is_wired_to_the_self_removal_rule() {
+        let source = include_str!("api.rs");
+        let prod = source
+            .lines()
+            .map(|line| line.split_once("//").map(|(code, _)| code).unwrap_or(line))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let fn_at = prod
+            .find("pub async fn ban_member(")
+            .expect("api.rs must define ban_member");
+        let build_at = prod[fn_at..]
+            .find("let user_ban = UserBan {")
+            .expect("ban_member must build a UserBan")
+            + fn_at;
+        assert!(
+            prod[fn_at..build_at].contains("self_removing_ban_reason("),
+            "`ban_member` must refuse a self-removing ban BEFORE building the \
+             UserBan, through the shared rule so riverctl and the UI cannot \
+             disagree (#478)"
+        );
     }
 }

--- a/cli/src/deputies.rs
+++ b/cli/src/deputies.rs
@@ -23,7 +23,10 @@
 //! not actually enforce.
 //!
 //! This module is READ-ONLY. It never builds a delta and never touches contract
-//! state.
+//! state. It does own one predicate the WRITE path consults —
+//! [`self_removing_ban_reason`] (freenet/river#478) — because the invite-subtree
+//! walk it needs already lives here as [`invite_subtrees`]; it is still a pure
+//! query over a fetched state.
 
 use ed25519_dalek::VerifyingKey;
 use river_core::room_state::member::{AuthorizedMember, MemberId, MembersV1};
@@ -483,6 +486,11 @@ fn invite_subtrees(state: &ChatRoomStateV1) -> HashMap<MemberId, HashSet<MemberI
 /// PLUS their entire transitive invite subtree — exactly what the contract's
 /// `check_banned_members` inserts (the banned user) and then extends with
 /// (`get_downstream_members`).
+///
+/// Builds every subtree to read one, which is deliberate: [`invite_subtrees`] is
+/// the already-tested walk, carries the cycle guard the contract omits, and a
+/// room is small enough that a one-off single-root variant would only be a
+/// second thing to keep correct.
 pub fn ban_removal_set(state: &ChatRoomStateV1, target: MemberId) -> HashSet<MemberId> {
     let mut removed = invite_subtrees(state).remove(&target).unwrap_or_default();
     removed.insert(target);

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -661,6 +661,23 @@ pub(crate) fn viewer_can_ban(
     target: MemberId,
     owner_id: MemberId,
 ) -> bool {
+    // NOBODY MAY BAN THEMSELVES (freenet/river#478).
+    //
+    // The CONTRACT permits it: `is_ban_authorized` has no self-check, and step
+    // 3 (owner-appointed global moderator) fires before anything that would
+    // stop it, so `is_ban_authorized(d, d)` is `true` for every deputy. Such a
+    // ban is fully valid: `verify` accepts it, and `check_banned_members` then
+    // cascades removal to `get_downstream_members`, taking the deputy's ENTIRE
+    // INVITE SUBTREE with them. On the Official room that is ~105 members for
+    // one misclick on your own profile.
+    //
+    // This is therefore a gate at the interaction layer, not a contract fix.
+    // Do NOT "simplify" it away on the assumption that the contract prevents
+    // self-bans: it does not. Removing it re-arms the misclick, which is why
+    // `viewer_can_ban_refuses_self` pins it.
+    if viewer == target {
+        return false;
+    }
     let members_by_id = members.members_by_member_id();
     MembersV1::is_ban_authorized(viewer, target, &members_by_id, member_info, owner_id)
 }
@@ -3319,6 +3336,113 @@ mod tests {
             deputizers.get(&deputy_id).map(Vec::len),
             Some(1),
             "64 repeated grants must collapse to one appointer"
+        );
+    }
+
+    /// freenet/river#478: nobody may ban themselves.
+    ///
+    /// The precondition assertion is the point. The CONTRACT says yes —
+    /// `is_ban_authorized(deputy, deputy)` returns `true`, because step 3
+    /// (owner-appointed global moderator) fires before anything that would
+    /// stop it — and such a ban cascades to the deputy's whole invite subtree.
+    /// Asserting the contract's answer FIRST proves the guard, and not the
+    /// contract, is what produces `false`.
+    #[test]
+    fn viewer_can_ban_refuses_self() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let deputy_sk = SigningKey::generate(&mut rng);
+        let plain_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+        let deputy_id = id(&deputy_sk);
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &deputy_sk.verifying_key()),
+                authorized_member(&owner_sk, &plain_sk.verifying_key()),
+            ],
+        };
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                signed_member_info(&owner_sk, "Owner", vec![deputy_id]),
+                signed_member_info(&deputy_sk, "Deputy", vec![]),
+                signed_member_info(&plain_sk, "Plain", vec![]),
+            ],
+        };
+
+        // Precondition: the contract really does authorise a self-ban.
+        assert!(
+            MembersV1::is_ban_authorized(
+                deputy_id,
+                deputy_id,
+                &members.members_by_member_id(),
+                &member_info,
+                owner_id
+            ),
+            "precondition: the contract permits a deputy to ban themselves, \
+             which is exactly why the UI must refuse"
+        );
+
+        // The UI gate refuses it.
+        assert!(
+            !viewer_can_ban(&members, &member_info, deputy_id, deputy_id, owner_id),
+            "a deputy must not be able to ban themselves"
+        );
+        // ...without disturbing the ban authority they legitimately hold.
+        assert!(viewer_can_ban(
+            &members,
+            &member_info,
+            deputy_id,
+            id(&plain_sk),
+            owner_id
+        ));
+    }
+
+    /// The second layer of the #478 guard: the Ban action must not even RENDER
+    /// on your own profile. Source-scrape, because the render is a Dioxus
+    /// component tree with no headless harness here — but it fails loudly if
+    /// someone moves `BanButton` back outside the self-check.
+    #[test]
+    fn ban_action_is_not_rendered_for_self() {
+        let source = include_str!("members/member_info_modal.rs");
+        let prod = &source[..source
+            .find("#[cfg(test)]")
+            .expect("member_info_modal.rs should have a #[cfg(test)] block")];
+
+        let ban_at = prod
+            .find("BanButton {")
+            .expect("the modal must render a BanButton");
+        let guard = "if member_id != self_member_id {";
+        let guard_at = prod[..ban_at]
+            .rfind(guard)
+            .unwrap_or_else(|| panic!("no `{guard}` guard above the BanButton render (#478)"));
+
+        // The guard must still be OPEN where the button renders. Track the
+        // MINIMUM running brace depth, not the final depth: the modal has an
+        // earlier `if member_id != self_member_id` block (the DM / Share-invite
+        // row) that closes again, and a final-depth check reads that as
+        // satisfying the guard because a later block re-opens.
+        let between = &prod[guard_at + guard.len()..ban_at];
+        let mut depth = 0i32;
+        let mut min_depth = 0i32;
+        for c in between.chars() {
+            match c {
+                '{' => depth += 1,
+                '}' => depth -= 1,
+                _ => {}
+            }
+            min_depth = min_depth.min(depth);
+        }
+        assert!(
+            min_depth >= 0,
+            "the nearest `{guard}` above `BanButton` closes before the button \
+             renders, so a deputy can still ban themselves from their own \
+             profile (#478)"
         );
     }
 

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -3409,40 +3409,95 @@ mod tests {
     /// someone moves `BanButton` back outside the self-check.
     #[test]
     fn ban_action_is_not_rendered_for_self() {
-        let source = include_str!("members/member_info_modal.rs");
-        let prod = &source[..source
-            .find("#[cfg(test)]")
-            .expect("member_info_modal.rs should have a #[cfg(test)] block")];
-
-        let ban_at = prod
-            .find("BanButton {")
-            .expect("the modal must render a BanButton");
-        let guard = "if member_id != self_member_id {";
-        let guard_at = prod[..ban_at]
-            .rfind(guard)
-            .unwrap_or_else(|| panic!("no `{guard}` guard above the BanButton render (#478)"));
-
-        // The guard must still be OPEN where the button renders. Track the
-        // MINIMUM running brace depth, not the final depth: the modal has an
-        // earlier `if member_id != self_member_id` block (the DM / Share-invite
-        // row) that closes again, and a final-depth check reads that as
-        // satisfying the guard because a later block re-opens.
-        let between = &prod[guard_at + guard.len()..ban_at];
-        let mut depth = 0i32;
-        let mut min_depth = 0i32;
-        for c in between.chars() {
-            match c {
-                '{' => depth += 1,
-                '}' => depth -= 1,
-                _ => {}
-            }
-            min_depth = min_depth.min(depth);
+        // Comments are stripped first. `rfind` matching the guard's text
+        // inside a comment would let a DELETED guard satisfy this test — the
+        // same reason `util::ecies`'s pin strips them.
+        fn strip_line_comments(src: &str) -> String {
+            src.lines()
+                .map(|line| line.split_once("//").map(|(code, _)| code).unwrap_or(line))
+                .collect::<Vec<_>>()
+                .join("\n")
         }
+
+        let source = include_str!("members/member_info_modal.rs");
+        // Cutting at the FIRST `#[cfg(test)]` is the safe direction here: this
+        // assertion requires the button to be PRESENT, so an over-short slice
+        // makes the `expect` below panic loudly rather than pass vacuously.
+        let prod = strip_line_comments(
+            &source[..source
+                .find("#[cfg(test)]")
+                .expect("member_info_modal.rs should have a #[cfg(test)] block")],
+        );
+
+        let guard = "if member_id != self_member_id {";
+        // EVERY render must be guarded, not just the first. A second,
+        // unguarded `BanButton` added later would otherwise slip past.
+        let sites: Vec<usize> = prod.match_indices("BanButton {").map(|(i, _)| i).collect();
         assert!(
-            min_depth >= 0,
-            "the nearest `{guard}` above `BanButton` closes before the button \
-             renders, so a deputy can still ban themselves from their own \
-             profile (#478)"
+            !sites.is_empty(),
+            "the modal must render a BanButton — if it moved to another file, \
+             move this pin with it (#478)"
+        );
+
+        for ban_at in sites {
+            let guard_at = prod[..ban_at]
+                .rfind(guard)
+                .unwrap_or_else(|| panic!("no `{guard}` guard above a BanButton render (#478)"));
+
+            // The guard must still be OPEN where the button renders. Track the
+            // MINIMUM running brace depth, not the final depth: the modal has
+            // an earlier `if member_id != self_member_id` block (the DM /
+            // Share-invite row) that closes again, and a final-depth check
+            // reads that as satisfying the guard because a later block
+            // re-opens.
+            let between = &prod[guard_at + guard.len()..ban_at];
+            let mut depth = 0i32;
+            let mut min_depth = 0i32;
+            for c in between.chars() {
+                match c {
+                    '{' => depth += 1,
+                    '}' => depth -= 1,
+                    _ => {}
+                }
+                min_depth = min_depth.min(depth);
+            }
+            assert!(
+                min_depth >= 0,
+                "the nearest `{guard}` above a `BanButton` closes before the \
+                 button renders, so a deputy can still ban themselves from \
+                 their own profile (#478)"
+            );
+        }
+    }
+
+    /// The THIRD layer of the #478 guard: `execute_ban` must refuse a self-ban
+    /// at the action boundary, not only at render time.
+    ///
+    /// `BanButton::execute_ban` trusts a `member_to_ban` PROP and re-checks
+    /// nothing else, so any future call site passing `can_ban: true` would run
+    /// the cascading ban. Source-scraped because the handler is a Dioxus
+    /// closure needing a runtime; the check is three lines and this pin is
+    /// what stops them being "simplified" away.
+    #[test]
+    fn execute_ban_refuses_self_at_the_action_boundary() {
+        fn strip_line_comments(src: &str) -> String {
+            src.lines()
+                .map(|line| line.split_once("//").map(|(code, _)| code).unwrap_or(line))
+                .collect::<Vec<_>>()
+                .join("\n")
+        }
+        let source = include_str!("members/member_info_modal/ban_button.rs");
+        let prod =
+            strip_line_comments(&source[..source.find("#[cfg(test)]").unwrap_or(source.len())]);
+
+        let build_at = prod
+            .find("let ban = UserBan {")
+            .expect("ban_button.rs must build a UserBan");
+        assert!(
+            prod[..build_at].contains("if member_to_ban == banned_by {"),
+            "`execute_ban` must refuse a self-ban BEFORE building the UserBan \
+             — a self-ban is contract-valid and cascades to the banner's whole \
+             invite subtree (#478)"
         );
     }
 

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -3712,10 +3712,18 @@ mod tests {
             prod.contains("ban_gate("),
             "the modal must gate Ban through `ban_gate` (#478)"
         );
+        // The reason must be RENDERED, not merely computed. Checking only that
+        // the gate is destructured would let someone delete the explanation
+        // element and keep the pin green — a Ban button that vanishes with no
+        // explanation is exactly the bug report this is here to prevent.
+        let reason_at = prod
+            .find("if let Some(reason) = ban_refusal {")
+            .expect("the modal must render the refusal reason when the rule withholds Ban (#478)");
+        let reason_block = &prod[reason_at..];
         assert!(
-            prod.contains("BanGate::WouldRemoveViewer(reason) => Some(reason)"),
-            "the modal must surface the refusal REASON — a Ban button that \
-             vanishes with no explanation is a bug report waiting to happen \
+            reason_block.contains("\"data-testid\": \"ban-withheld-reason\"")
+                && reason_block.contains("\"{reason}\""),
+            "the withheld-Ban explanation must actually display the reason text \
              (#478)"
         );
 

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -649,37 +649,128 @@ pub(crate) fn relevant_appointers(
     .collect()
 }
 
-/// Whether `viewer` may ban `target` — the Ban-button gate (#410 / #411 round 4
-/// D). Uses [`MembersV1::is_ban_authorized`] (owner / invite-ancestor / deputy),
-/// NOT bare invite-chain ancestry, so a DEPUTY sees the Ban action for members in
-/// their deputizer's subtree. Bare downstream ancestry (`is_downstream`, still
-/// used for the "🔑 Invited by You" relationship tag) would have hidden it.
-pub(crate) fn viewer_can_ban(
+/// Everyone a ban of `target` would remove from the room: `target` themselves
+/// PLUS their entire transitive invite subtree.
+///
+/// This mirrors what the contract actually does. `MembersV1::check_banned_members`
+/// inserts the banned user and then extends with `get_downstream_members`, which
+/// is private to the contract crate, so the walk is recomputed here rather than
+/// approximated. (`cli/src/deputies.rs::invite_subtrees` is riverctl's mirror of
+/// the same thing.)
+///
+/// One deliberate difference from the contract's version: a visited-set guard.
+/// The contract can rely on `verify` having rejected circular invite chains; the
+/// UI walks whatever state it currently holds and must not hang on a malformed
+/// one.
+pub(crate) fn ban_removal_set(members: &MembersV1, target: MemberId) -> HashSet<MemberId> {
+    let mut children: HashMap<MemberId, Vec<MemberId>> = HashMap::new();
+    for m in &members.members {
+        children
+            .entry(m.member.invited_by)
+            .or_default()
+            .push(m.member.id());
+    }
+
+    let mut removed = HashSet::new();
+    removed.insert(target);
+    let mut stack = vec![target];
+    while let Some(current) = stack.pop() {
+        for child in children.get(&current).into_iter().flatten() {
+            // `insert` gates the push, so a cycle terminates.
+            if removed.insert(*child) {
+                stack.push(*child);
+            }
+        }
+    }
+    removed
+}
+
+/// NOBODY MAY BAN THEMSELVES OUT OF THE ROOM (freenet/river#478).
+///
+/// ONE rule, stated once: compute the set the ban would remove
+/// ([`ban_removal_set`]) and refuse if `banner` is in it. That covers the direct
+/// self-ban (`banner == target`) and the transitive one (`target` is a strict
+/// invite ancestor of `banner`, so the cascade sweeps the banner up with them)
+/// as the single case they are — do NOT split this back into two special cases.
+///
+/// The CONTRACT permits both: `is_ban_authorized` has no self-check, and step 3
+/// (owner-appointed global moderator) fires before anything that would stop it,
+/// so an owner-appointed deputy is authorized to ban themselves AND to ban their
+/// own ancestors. Such a ban is fully valid: `verify` accepts it, and
+/// `check_banned_members` then cascades removal to `get_downstream_members`,
+/// taking the banner's ENTIRE INVITE SUBTREE with them. On the Official room
+/// that is ~105 members for one misclick.
+///
+/// This is therefore a gate at the interaction layer, not a contract fix. Do NOT
+/// "simplify" it away on the assumption that the contract prevents it: it does
+/// not.
+///
+/// Returns the user-visible reason when the ban is refused, `None` when the rule
+/// does not apply. The wording differs between the two routes because they read
+/// very differently to the user, but the DECISION above is one computation.
+pub(crate) fn self_removing_ban_reason(
+    members: &MembersV1,
+    banner: MemberId,
+    target: MemberId,
+) -> Option<&'static str> {
+    if !ban_removal_set(members, target).contains(&banner) {
+        return None;
+    }
+    Some(if banner == target {
+        "You can't ban yourself. The ban would remove you, and everyone you \
+         invited, from the room."
+    } else {
+        "You can't ban a member you joined the room through. A ban also removes \
+         everyone the banned member invited, so this one would remove you, and \
+         everyone you invited, along with them."
+    })
+}
+
+/// Whether the Ban action is offered for one (viewer, target) pair, and if not,
+/// whether the viewer is owed an explanation.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub(crate) enum BanGate {
+    /// The viewer holds ban authority and the ban is safe to offer.
+    Allowed,
+    /// The viewer holds ban authority, but the ban would remove the VIEWER from
+    /// the room ([`self_removing_ban_reason`]). Carries the user-visible reason:
+    /// the action is withheld from someone who would otherwise have had it, so
+    /// silently hiding it would read as a bug.
+    WouldRemoveViewer(&'static str),
+    /// The viewer has no ban authority over this target. Nothing is owed — the
+    /// action has never been offered here, so an explanation would just be noise
+    /// for a capability they never had.
+    NoAuthority,
+}
+
+/// The Ban-button gate (#410 / #411 round 4 D / #478).
+///
+/// Authority first, via [`MembersV1::is_ban_authorized`] (owner /
+/// invite-ancestor / deputy) rather than bare invite-chain ancestry, so a DEPUTY
+/// sees the Ban action for members in their deputizer's subtree — bare downstream
+/// ancestry (`is_downstream`, still used for the "🔑 Invited by You" relationship
+/// tag) would have hidden it.
+///
+/// Then the self-removal rule, applied to the OUTPUT of `is_ban_authorized`
+/// rather than inside it. That placement is load-bearing: `is_ban_authorized`
+/// grants owner-appointed global moderators authority at step 3, ahead of the
+/// step-4 guardrail, so a check wired into the wrong branch of that ladder would
+/// not fire for exactly the deputies who can reach the most members.
+pub(crate) fn ban_gate(
     members: &MembersV1,
     member_info: &river_core::room_state::member_info::MemberInfoV1,
     viewer: MemberId,
     target: MemberId,
     owner_id: MemberId,
-) -> bool {
-    // NOBODY MAY BAN THEMSELVES (freenet/river#478).
-    //
-    // The CONTRACT permits it: `is_ban_authorized` has no self-check, and step
-    // 3 (owner-appointed global moderator) fires before anything that would
-    // stop it, so `is_ban_authorized(d, d)` is `true` for every deputy. Such a
-    // ban is fully valid: `verify` accepts it, and `check_banned_members` then
-    // cascades removal to `get_downstream_members`, taking the deputy's ENTIRE
-    // INVITE SUBTREE with them. On the Official room that is ~105 members for
-    // one misclick on your own profile.
-    //
-    // This is therefore a gate at the interaction layer, not a contract fix.
-    // Do NOT "simplify" it away on the assumption that the contract prevents
-    // self-bans: it does not. Removing it re-arms the misclick, which is why
-    // `viewer_can_ban_refuses_self` pins it.
-    if viewer == target {
-        return false;
-    }
+) -> BanGate {
     let members_by_id = members.members_by_member_id();
-    MembersV1::is_ban_authorized(viewer, target, &members_by_id, member_info, owner_id)
+    if !MembersV1::is_ban_authorized(viewer, target, &members_by_id, member_info, owner_id) {
+        return BanGate::NoAuthority;
+    }
+    match self_removing_ban_reason(members, viewer, target) {
+        Some(reason) => BanGate::WouldRemoveViewer(reason),
+        None => BanGate::Allowed,
+    }
 }
 
 /// The 🛡 shield one member shows in one viewer's view.
@@ -3339,97 +3430,295 @@ mod tests {
         );
     }
 
-    /// freenet/river#478: nobody may ban themselves.
-    ///
-    /// The precondition assertion is the point. The CONTRACT says yes —
-    /// `is_ban_authorized(deputy, deputy)` returns `true`, because step 3
-    /// (owner-appointed global moderator) fires before anything that would
-    /// stop it — and such a ban cascades to the deputy's whole invite subtree.
-    /// Asserting the contract's answer FIRST proves the guard, and not the
-    /// contract, is what produces `false`.
-    #[test]
-    fn viewer_can_ban_refuses_self() {
-        use river_core::room_state::member::MembersV1;
+    // ------------------------------------------------------------------
+    // freenet/river#478: nobody may ban themselves OUT OF THE ROOM.
+    //
+    // One rule, two routes to the same damage: ban yourself, or ban a member
+    // you joined through (the cascade to `get_downstream_members` sweeps you
+    // and your whole subtree up with them). The fixture below is shared by
+    // every case so the ALLOWED cases are proved against the same room as the
+    // REFUSED ones — an over-broad guard cannot hide behind a friendlier
+    // fixture.
+    // ------------------------------------------------------------------
+
+    /// owner → alpha → beta → deputy → child, plus an unrelated `stranger`
+    /// invited by the owner. `deputy` is an OWNER-APPOINTED GLOBAL MODERATOR,
+    /// which is the whole point: that is the only grant in `is_ban_authorized`
+    /// that reaches a member's own ancestors, and it is granted at step 3,
+    /// ahead of the step-4 guardrail. A guard wired into the wrong branch of
+    /// that ladder would not fire for this deputy.
+    struct BanChain {
+        members: MembersV1,
+        member_info: river_core::room_state::member_info::MemberInfoV1,
+        owner_id: MemberId,
+        alpha_id: MemberId,
+        beta_id: MemberId,
+        deputy_id: MemberId,
+        child_id: MemberId,
+        stranger_id: MemberId,
+        /// A deputy of ALPHA rather than of the owner, used to show the
+        /// ancestor cases are not vacuous: this one is refused for lack of
+        /// authority, not by the #478 rule.
+        alphas_deputy_id: MemberId,
+    }
+
+    fn ban_chain() -> BanChain {
         use river_core::room_state::member_info::MemberInfoV1;
 
         let mut rng = rand::thread_rng();
         let owner_sk = SigningKey::generate(&mut rng);
+        let alpha_sk = SigningKey::generate(&mut rng);
+        let beta_sk = SigningKey::generate(&mut rng);
         let deputy_sk = SigningKey::generate(&mut rng);
-        let plain_sk = SigningKey::generate(&mut rng);
+        let child_sk = SigningKey::generate(&mut rng);
+        let stranger_sk = SigningKey::generate(&mut rng);
+        let alphas_deputy_sk = SigningKey::generate(&mut rng);
 
         let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
         let owner_id = id(&owner_sk);
         let deputy_id = id(&deputy_sk);
+        let alphas_deputy_id = id(&alphas_deputy_sk);
 
         let members = MembersV1 {
             members: vec![
-                authorized_member(&owner_sk, &deputy_sk.verifying_key()),
-                authorized_member(&owner_sk, &plain_sk.verifying_key()),
+                authorized_member(&owner_sk, &alpha_sk.verifying_key()),
+                member_invited_by(&alpha_sk, owner_id, &beta_sk.verifying_key()),
+                member_invited_by(&beta_sk, owner_id, &deputy_sk.verifying_key()),
+                member_invited_by(&deputy_sk, owner_id, &child_sk.verifying_key()),
+                authorized_member(&owner_sk, &stranger_sk.verifying_key()),
+                member_invited_by(&alpha_sk, owner_id, &alphas_deputy_sk.verifying_key()),
             ],
         };
         let member_info = MemberInfoV1 {
             member_info: vec![
+                // The owner deputizes `deputy` — a GLOBAL moderator.
                 signed_member_info(&owner_sk, "Owner", vec![deputy_id]),
+                // Alpha deputizes someone else — a SUBTREE-scoped deputy.
+                signed_member_info(&alpha_sk, "Alpha", vec![alphas_deputy_id]),
+                signed_member_info(&beta_sk, "Beta", vec![]),
                 signed_member_info(&deputy_sk, "Deputy", vec![]),
-                signed_member_info(&plain_sk, "Plain", vec![]),
+                signed_member_info(&child_sk, "Child", vec![]),
+                signed_member_info(&stranger_sk, "Stranger", vec![]),
+                signed_member_info(&alphas_deputy_sk, "AlphasDeputy", vec![]),
             ],
         };
 
-        // Precondition: the contract really does authorise a self-ban.
-        assert!(
-            MembersV1::is_ban_authorized(
-                deputy_id,
-                deputy_id,
-                &members.members_by_member_id(),
-                &member_info,
-                owner_id
-            ),
-            "precondition: the contract permits a deputy to ban themselves, \
-             which is exactly why the UI must refuse"
-        );
-
-        // The UI gate refuses it.
-        assert!(
-            !viewer_can_ban(&members, &member_info, deputy_id, deputy_id, owner_id),
-            "a deputy must not be able to ban themselves"
-        );
-        // ...without disturbing the ban authority they legitimately hold.
-        assert!(viewer_can_ban(
-            &members,
-            &member_info,
+        BanChain {
+            members,
+            member_info,
+            owner_id,
+            alpha_id: id(&alpha_sk),
+            beta_id: id(&beta_sk),
             deputy_id,
-            id(&plain_sk),
-            owner_id
-        ));
+            child_id: id(&child_sk),
+            stranger_id: id(&stranger_sk),
+            alphas_deputy_id,
+        }
     }
 
-    /// The second layer of the #478 guard: the Ban action must not even RENDER
-    /// on your own profile. Source-scrape, because the render is a Dioxus
-    /// component tree with no headless harness here — but it fails loudly if
-    /// someone moves `BanButton` back outside the self-check.
-    #[test]
-    fn ban_action_is_not_rendered_for_self() {
-        // Comments are stripped first. `rfind` matching the guard's text
-        // inside a comment would let a DELETED guard satisfy this test — the
-        // same reason `util::ecies`'s pin strips them.
-        fn strip_line_comments(src: &str) -> String {
-            src.lines()
-                .map(|line| line.split_once("//").map(|(code, _)| code).unwrap_or(line))
-                .collect::<Vec<_>>()
-                .join("\n")
+    impl BanChain {
+        fn gate(&self, viewer: MemberId, target: MemberId) -> BanGate {
+            ban_gate(
+                &self.members,
+                &self.member_info,
+                viewer,
+                target,
+                self.owner_id,
+            )
         }
 
-        let source = include_str!("members/member_info_modal.rs");
-        // Cutting at the FIRST `#[cfg(test)]` is the safe direction here: this
-        // assertion requires the button to be PRESENT, so an over-short slice
-        // makes the `expect` below panic loudly rather than pass vacuously.
-        let prod = strip_line_comments(
-            &source[..source
-                .find("#[cfg(test)]")
-                .expect("member_info_modal.rs should have a #[cfg(test)] block")],
+        /// What the CONTRACT says — asserted as a PRECONDITION everywhere the
+        /// gate refuses, so a refusal can never be credited to the guard when
+        /// the contract would have refused anyway.
+        fn contract_authorizes(&self, banner: MemberId, target: MemberId) -> bool {
+            MembersV1::is_ban_authorized(
+                banner,
+                target,
+                &self.members.members_by_member_id(),
+                &self.member_info,
+                self.owner_id,
+            )
+        }
+    }
+
+    /// The direct route (the original #478): a deputy may not ban themselves.
+    #[test]
+    fn ban_is_refused_for_self() {
+        let c = ban_chain();
+
+        assert!(
+            c.contract_authorizes(c.deputy_id, c.deputy_id),
+            "precondition: the contract permits a deputy to ban THEMSELVES \
+             (step 3 fires before anything that would stop it), which is \
+             exactly why the client must refuse"
+        );
+        assert!(
+            ban_removal_set(&c.members, c.deputy_id).contains(&c.deputy_id),
+            "precondition: the ban's removal set contains the banner"
         );
 
-        let guard = "if member_id != self_member_id {";
+        assert!(
+            matches!(
+                c.gate(c.deputy_id, c.deputy_id),
+                BanGate::WouldRemoveViewer(_)
+            ),
+            "a deputy must not be able to ban themselves (#478)"
+        );
+    }
+
+    /// The transitive route: a deputy may not ban anyone ABOVE them in the
+    /// invite chain, at any depth. Same blast radius as a self-ban, because
+    /// `get_downstream_members` is the full transitive closure.
+    #[test]
+    fn ban_is_refused_for_every_strict_ancestor() {
+        let c = ban_chain();
+
+        for (label, ancestor) in [
+            ("direct inviter (parent)", c.beta_id),
+            ("grandparent", c.alpha_id),
+        ] {
+            assert!(
+                c.contract_authorizes(c.deputy_id, ancestor),
+                "precondition ({label}): the contract AUTHORIZES this ban — an \
+                 owner-appointed global moderator is granted authority at step \
+                 3, over their own ancestors included. Without this the test \
+                 would pass for want of authority, not because of the guard"
+            );
+            assert!(
+                ban_removal_set(&c.members, ancestor).contains(&c.deputy_id),
+                "precondition ({label}): the ban's cascade really does remove \
+                 the banner"
+            );
+
+            assert!(
+                matches!(c.gate(c.deputy_id, ancestor), BanGate::WouldRemoveViewer(_)),
+                "banning a {label} removes the banner and their whole subtree, \
+                 so it must be refused (#478)"
+            );
+        }
+    }
+
+    /// The over-broadness case. A guard that also blocks legitimate bans is a
+    /// failure, so these must still be ALLOWED — from the same room, by the
+    /// same deputy, as the refusals above.
+    #[test]
+    fn bans_that_do_not_remove_the_banner_are_still_allowed() {
+        let c = ban_chain();
+
+        for (label, target) in [
+            ("an unrelated member in another subtree", c.stranger_id),
+            ("a member of the deputy's OWN downstream", c.child_id),
+            (
+                "a deputy scoped to an ancestor's subtree",
+                c.alphas_deputy_id,
+            ),
+        ] {
+            assert!(
+                !ban_removal_set(&c.members, target).contains(&c.deputy_id),
+                "precondition ({label}): this ban does not remove the banner"
+            );
+            assert_eq!(
+                c.gate(c.deputy_id, target),
+                BanGate::Allowed,
+                "banning {label} is legitimate and must stay available (#478 \
+                 must not be over-broad)"
+            );
+        }
+
+        // The OWNER is never in anyone's removal set (they are nobody's
+        // invitee), so their authority is untouched — including over the
+        // members at the top of the deputy's own chain.
+        assert_eq!(c.gate(c.owner_id, c.alpha_id), BanGate::Allowed);
+        assert_eq!(c.gate(c.owner_id, c.deputy_id), BanGate::Allowed);
+    }
+
+    /// Proves the ancestor cases above are about the GUARD and not about
+    /// missing authority: a subtree-scoped deputy (deputized by alpha, not by
+    /// the owner) is refused the very same target for a different reason. If a
+    /// future change made `WouldRemoveViewer` the answer here too, the
+    /// distinction the modal renders on would have silently collapsed.
+    #[test]
+    fn a_non_global_deputy_is_refused_an_ancestor_for_lack_of_authority() {
+        let c = ban_chain();
+
+        assert!(
+            !c.contract_authorizes(c.alphas_deputy_id, c.alpha_id),
+            "precondition: deputy authority is scoped to the DEPUTIZER's \
+             subtree, so alpha's deputy has no grant over alpha themselves"
+        );
+        assert_eq!(
+            c.gate(c.alphas_deputy_id, c.alpha_id),
+            BanGate::NoAuthority,
+            "no authority is a different answer from 'would remove you', and \
+             only the latter is explained to the user"
+        );
+    }
+
+    /// The removal set is the target PLUS their whole transitive subtree —
+    /// the same set `check_banned_members` builds. A one-level-only walk (the
+    /// easy mistake) would miss the grandchild and let the grandparent ban
+    /// through.
+    #[test]
+    fn ban_removal_set_is_the_whole_transitive_subtree() {
+        let c = ban_chain();
+
+        let removed = ban_removal_set(&c.members, c.alpha_id);
+        assert!(removed.contains(&c.alpha_id), "the target themselves");
+        assert!(removed.contains(&c.beta_id), "a direct invitee");
+        assert!(removed.contains(&c.deputy_id), "a grandchild");
+        assert!(removed.contains(&c.child_id), "a great-grandchild");
+        assert!(
+            !removed.contains(&c.stranger_id),
+            "a member in a different subtree is NOT removed"
+        );
+
+        // A leaf removes only themselves.
+        assert_eq!(
+            ban_removal_set(&c.members, c.child_id),
+            HashSet::from([c.child_id])
+        );
+    }
+
+    /// The contract's `get_downstream_members` has no visited guard — it can
+    /// rely on `verify` having rejected circular invite chains. This mirror
+    /// walks whatever state the UI currently holds, including a half-applied
+    /// or hostile one, so it must terminate. (Test hangs rather than fails if
+    /// this regresses, which is still a loud CI signal.)
+    #[test]
+    fn ban_removal_set_terminates_on_a_cycle() {
+        let mut c = ban_chain();
+        // Hand-forge a cycle: alpha claims to have been invited by their own
+        // descendant. `AuthorizedMember::new` would not produce this, so patch
+        // the field directly.
+        c.members.members[0].member.invited_by = c.deputy_id;
+
+        let removed = ban_removal_set(&c.members, c.alpha_id);
+        assert!(removed.contains(&c.alpha_id));
+        assert!(removed.contains(&c.beta_id));
+    }
+
+    /// The RENDER layer. The Ban action must not render when the rule refuses
+    /// it, and the modal must derive that from the shared gate rather than
+    /// re-deciding locally. Source-scrape, because the render is a Dioxus
+    /// component tree with no headless harness here.
+    #[test]
+    fn ban_action_is_not_rendered_when_the_rule_refuses() {
+        let prod = prod_source(include_str!("members/member_info_modal.rs"));
+        assert_prod_only(&prod, "member_info_modal.rs");
+
+        // The modal must ask the SHARED gate. A local re-derivation is how the
+        // render and the action boundary drift apart.
+        assert!(
+            prod.contains("ban_gate("),
+            "the modal must gate Ban through `ban_gate` (#478)"
+        );
+        assert!(
+            prod.contains("BanGate::WouldRemoveViewer(reason) => Some(reason)"),
+            "the modal must surface the refusal REASON — a Ban button that \
+             vanishes with no explanation is a bug report waiting to happen \
+             (#478)"
+        );
+
         // EVERY render must be guarded, not just the first. A second,
         // unguarded `BanButton` added later would otherwise slip past.
         let sites: Vec<usize> = prod.match_indices("BanButton {").map(|(i, _)| i).collect();
@@ -3440,65 +3729,120 @@ mod tests {
         );
 
         for ban_at in sites {
-            let guard_at = prod[..ban_at]
-                .rfind(guard)
-                .unwrap_or_else(|| panic!("no `{guard}` guard above a BanButton render (#478)"));
-
-            // The guard must still be OPEN where the button renders. Track the
-            // MINIMUM running brace depth, not the final depth: the modal has
-            // an earlier `if member_id != self_member_id` block (the DM /
-            // Share-invite row) that closes again, and a final-depth check
-            // reads that as satisfying the guard because a later block
-            // re-opens.
-            let between = &prod[guard_at + guard.len()..ban_at];
-            let mut depth = 0i32;
-            let mut min_depth = 0i32;
-            for c in between.chars() {
-                match c {
-                    '{' => depth += 1,
-                    '}' => depth -= 1,
-                    _ => {}
-                }
-                min_depth = min_depth.min(depth);
+            // Both guards must be open where the button renders: the self
+            // check (which also hides Deputize) and the rule's refusal.
+            for guard in [
+                "if member_id != self_member_id {",
+                "if ban_refusal.is_none() {",
+            ] {
+                let guard_at = prod[..ban_at].rfind(guard).unwrap_or_else(|| {
+                    panic!("no `{guard}` guard above a BanButton render (#478)")
+                });
+                assert!(
+                    guard_is_still_open(&prod[guard_at + guard.len()..ban_at]),
+                    "the nearest `{guard}` above a `BanButton` closes before \
+                     the button renders, so the Ban action is still reachable \
+                     where #478 says it must not be"
+                );
             }
-            assert!(
-                min_depth >= 0,
-                "the nearest `{guard}` above a `BanButton` closes before the \
-                 button renders, so a deputy can still ban themselves from \
-                 their own profile (#478)"
-            );
         }
     }
 
-    /// The THIRD layer of the #478 guard: `execute_ban` must refuse a self-ban
-    /// at the action boundary, not only at render time.
-    ///
-    /// `BanButton::execute_ban` trusts a `member_to_ban` PROP and re-checks
-    /// nothing else, so any future call site passing `can_ban: true` would run
-    /// the cascading ban. Source-scraped because the handler is a Dioxus
-    /// closure needing a runtime; the check is three lines and this pin is
-    /// what stops them being "simplified" away.
+    /// The ACTION BOUNDARY. `BanButton::execute_ban` trusts a `member_to_ban`
+    /// PROP and a `can_ban` PROP; any future call site passing `can_ban: true`
+    /// would run the cascading ban if the only guards were render-time. So the
+    /// check must be inside `execute_ban`, must run BEFORE the `UserBan` is
+    /// built, and must NOT consult the caller's flags. Source-scraped because
+    /// the handler is a Dioxus closure needing a runtime.
     #[test]
-    fn execute_ban_refuses_self_at_the_action_boundary() {
-        fn strip_line_comments(src: &str) -> String {
-            src.lines()
-                .map(|line| line.split_once("//").map(|(code, _)| code).unwrap_or(line))
-                .collect::<Vec<_>>()
-                .join("\n")
-        }
-        let source = include_str!("members/member_info_modal/ban_button.rs");
-        let prod =
-            strip_line_comments(&source[..source.find("#[cfg(test)]").unwrap_or(source.len())]);
+    fn execute_ban_refuses_at_the_action_boundary() {
+        let prod = prod_source(include_str!("members/member_info_modal/ban_button.rs"));
+        assert_prod_only(&prod, "ban_button.rs");
 
+        let handler_at = prod
+            .find("let execute_ban =")
+            .expect("ban_button.rs must define an execute_ban handler");
         let build_at = prod
             .find("let ban = UserBan {")
             .expect("ban_button.rs must build a UserBan");
         assert!(
-            prod[..build_at].contains("if member_to_ban == banned_by {"),
-            "`execute_ban` must refuse a self-ban BEFORE building the UserBan \
-             — a self-ban is contract-valid and cascades to the banner's whole \
-             invite subtree (#478)"
+            handler_at < build_at,
+            "the UserBan must be built inside execute_ban"
         );
+        let guarded_region = &prod[handler_at..build_at];
+
+        assert!(
+            guarded_region.contains("self_removing_ban_reason("),
+            "`execute_ban` must refuse a self-removing ban BEFORE building the \
+             UserBan, using the SAME predicate as the render gate so the two \
+             cannot drift (#478)"
+        );
+        assert!(
+            guarded_region.contains("return;"),
+            "the boundary check must ABORT the ban, not merely log it (#478)"
+        );
+        assert!(
+            !guarded_region.contains("can_ban"),
+            "the boundary check must not be conditioned on the caller's \
+             `can_ban` prop — the whole point is that a caller claiming the \
+             action is permitted cannot make it so (#478)"
+        );
+    }
+
+    /// Production slice of a source file for the pins above: everything before
+    /// the test module (the whole file when it has none), with line comments
+    /// stripped.
+    ///
+    /// Stripping comments matters — a guard that was DELETED but is still
+    /// QUOTED in a comment would otherwise satisfy a `contains`/`rfind`, the
+    /// same reason `util::ecies`'s pin strips them.
+    ///
+    /// Cutting at the FIRST `#[cfg(test)]` is the safe direction here: every
+    /// assertion built on this requires its needle to be PRESENT, so an
+    /// over-short slice panics loudly rather than passing vacuously. The
+    /// dangerous direction is an over-LONG slice, where a needle could match
+    /// inside test code and the pin goes silently vacuous — callers guard
+    /// against that with [`assert_prod_only`].
+    fn prod_source(source: &str) -> String {
+        let end = source.find("#[cfg(test)]").unwrap_or(source.len());
+        source[..end]
+            .lines()
+            .map(|line| line.split_once("//").map(|(code, _)| code).unwrap_or(line))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// Fails if a [`prod_source`] slice still contains test code, which would
+    /// let a pin's needles match themselves. Cheap insurance against the
+    /// failure mode where a rebase moves the cut point and every source-scrape
+    /// in the file quietly stops asserting anything.
+    fn assert_prod_only(prod: &str, what: &str) {
+        assert!(
+            !prod.contains("#[test]"),
+            "{what}: the production slice still contains test code, so the \
+             pins below can match their own needles — fix the cut point"
+        );
+    }
+
+    /// Whether a guard block is still OPEN across `between` (the text from the
+    /// end of the guard's `{` to the site it should be protecting).
+    ///
+    /// Tracks the MINIMUM running brace depth, not the final depth: the modal
+    /// has an earlier `if member_id != self_member_id` block (the DM /
+    /// Share-invite row) that closes again, and a final-depth check reads that
+    /// as satisfying the guard because a later block re-opens.
+    fn guard_is_still_open(between: &str) -> bool {
+        let mut depth = 0i32;
+        let mut min_depth = 0i32;
+        for c in between.chars() {
+            match c {
+                '{' => depth += 1,
+                '}' => depth -= 1,
+                _ => {}
+            }
+            min_depth = min_depth.min(depth);
+        }
+        min_depth >= 0
     }
 
     /// The conversation's 🛡 badge predicate, end to end.

--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -441,6 +441,14 @@ pub fn MemberInfoModal() -> Element {
                             // Ban + Deputize sit in one row (Ban on the left,
                             // Deputize on the right), matching the DM /
                             // Share-invite button row above.
+                            // BOTH actions are gated on the target not being
+                            // yourself. Ban used to sit OUTSIDE this guard, so a
+                            // deputy opening their own profile saw an enabled
+                            // "Ban User" — and the resulting self-ban is
+                            // contract-VALID and cascades to their whole invite
+                            // subtree (freenet/river#478). `viewer_can_ban`
+                            // refuses self as well; this is the second layer.
+                            if member_id != self_member_id {
                             div { class: "mt-4 flex items-start gap-3",
                                 BanButton {
                                     member_to_ban: member_id,
@@ -460,14 +468,13 @@ pub fn MemberInfoModal() -> Element {
                                 // Deputize / revoke-deputy (#410). Any non-owner
                                 // member (except self) may be deputized; the action
                                 // hides itself when the viewer lacks authority.
-                                if member_id != self_member_id {
-                                    DeputyButton {
-                                        target: member_id,
-                                        viewer_has_authority: viewer_has_authority,
-                                        target_is_my_deputy: target_is_my_deputy,
-                                        nickname: target_nickname.clone(),
-                                    }
+                                DeputyButton {
+                                    target: member_id,
+                                    viewer_has_authority: viewer_has_authority,
+                                    target_is_my_deputy: target_is_my_deputy,
+                                    nickname: target_nickname.clone(),
                                 }
+                            }
                             }
                         }
                     }

--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -449,32 +449,32 @@ pub fn MemberInfoModal() -> Element {
                             // subtree (freenet/river#478). `viewer_can_ban`
                             // refuses self as well; this is the second layer.
                             if member_id != self_member_id {
-                            div { class: "mt-4 flex items-start gap-3",
-                                BanButton {
-                                    member_to_ban: member_id,
-                                    can_ban: can_ban,
-                                    // The DECRYPTED, sanitised name — the same
-                                    // value `DeputyButton` gets. This used to
-                                    // pass the raw `SealedBytes`, which Dioxus
-                                    // silently coerced through `Display` (i.e.
-                                    // `to_string_lossy`): the ban dialog showed
-                                    // an unsanitised nickname in the one place
-                                    // a moderator is judging authority, and
-                                    // showed "[Encrypted: N bytes, vN]" instead
-                                    // of a name in private rooms.
-                                    nickname: target_nickname.clone()
-                                }
+                                div { class: "mt-4 flex items-start gap-3",
+                                    BanButton {
+                                        member_to_ban: member_id,
+                                        can_ban: can_ban,
+                                        // The DECRYPTED, sanitised name — the same
+                                        // value `DeputyButton` gets. This used to
+                                        // pass the raw `SealedBytes`, which Dioxus
+                                        // silently coerced through `Display` (i.e.
+                                        // `to_string_lossy`): the ban dialog showed
+                                        // an unsanitised nickname in the one place
+                                        // a moderator is judging authority, and
+                                        // showed "[Encrypted: N bytes, vN]" instead
+                                        // of a name in private rooms.
+                                        nickname: target_nickname.clone()
+                                    }
 
-                                // Deputize / revoke-deputy (#410). Any non-owner
-                                // member (except self) may be deputized; the action
-                                // hides itself when the viewer lacks authority.
-                                DeputyButton {
-                                    target: member_id,
-                                    viewer_has_authority: viewer_has_authority,
-                                    target_is_my_deputy: target_is_my_deputy,
-                                    nickname: target_nickname.clone(),
+                                    // Deputize / revoke-deputy (#410). Any non-owner
+                                    // member (except self) may be deputized; the action
+                                    // hides itself when the viewer lacks authority.
+                                    DeputyButton {
+                                        target: member_id,
+                                        viewer_has_authority: viewer_has_authority,
+                                        target_is_my_deputy: target_is_my_deputy,
+                                        nickname: target_nickname.clone(),
+                                    }
                                 }
-                            }
                             }
                         }
                     }

--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -9,7 +9,7 @@ use crate::components::members::member_info_modal::ban_button::BanButton;
 use crate::components::members::member_info_modal::deputy_button::DeputyButton;
 use crate::components::members::member_info_modal::invited_by_field::InvitedByField;
 use crate::components::members::member_info_modal::nickname_field::NicknameField;
-use crate::components::members::viewer_can_ban;
+use crate::components::members::{ban_gate, BanGate};
 use crate::util::display_name::display_nickname;
 use dioxus::logger::tracing::*;
 use dioxus::prelude::*;
@@ -144,16 +144,22 @@ pub fn MemberInfoModal() -> Element {
             })
             .unwrap_or(false);
 
-        // Ban authority (#410 / #411 round 4 D). The Ban button is gated on REAL
-        // ban authority — owner / invite-ancestor / deputy — via
+        // Ban authority (#410 / #411 round 4 D / #478). The Ban button is gated on
+        // REAL ban authority — owner / invite-ancestor / deputy — via
         // `is_ban_authorized`, NOT bare downstream ancestry (`is_downstream`), so a
         // deputy sees Ban for members in their deputizer's subtree. `is_downstream`
         // is still used above for the "🔑 Invited by You" relationship tag, which
         // is a different meaning and must not change.
-        let can_ban = owner_key_signal
+        //
+        // `ban_gate` folds in the "you may not ban yourself out of the room" rule
+        // and distinguishes its two negative answers, so the ONE case where the
+        // action is taken away from someone who would otherwise have had it —
+        // banning yourself, or banning an ancestor whose cascade sweeps you up —
+        // gets a visible explanation instead of a mysteriously absent button.
+        let gate = owner_key_signal
             .as_ref()
             .map(|owner| {
-                viewer_can_ban(
+                ban_gate(
                     &room_state.room_state.members,
                     &room_state.room_state.member_info,
                     self_member_id,
@@ -161,7 +167,12 @@ pub fn MemberInfoModal() -> Element {
                     MemberId::from(&*owner),
                 )
             })
-            .unwrap_or(false);
+            .unwrap_or(BanGate::NoAuthority);
+        let can_ban = gate == BanGate::Allowed;
+        let ban_refusal = match gate {
+            BanGate::WouldRemoveViewer(reason) => Some(reason),
+            BanGate::Allowed | BanGate::NoAuthority => None,
+        };
 
         info!(
             "Rendering MemberInfoModal for member_id: {:?} is_owner: {:?} is_downstream: {:?} can_ban: {:?}",
@@ -446,23 +457,42 @@ pub fn MemberInfoModal() -> Element {
                             // deputy opening their own profile saw an enabled
                             // "Ban User" — and the resulting self-ban is
                             // contract-VALID and cascades to their whole invite
-                            // subtree (freenet/river#478). `viewer_can_ban`
-                            // refuses self as well; this is the second layer.
+                            // subtree (freenet/river#478).
                             if member_id != self_member_id {
                                 div { class: "mt-4 flex items-start gap-3",
-                                    BanButton {
-                                        member_to_ban: member_id,
-                                        can_ban: can_ban,
-                                        // The DECRYPTED, sanitised name — the same
-                                        // value `DeputyButton` gets. This used to
-                                        // pass the raw `SealedBytes`, which Dioxus
-                                        // silently coerced through `Display` (i.e.
-                                        // `to_string_lossy`): the ban dialog showed
-                                        // an unsanitised nickname in the one place
-                                        // a moderator is judging authority, and
-                                        // showed "[Encrypted: N bytes, vN]" instead
-                                        // of a name in private rooms.
-                                        nickname: target_nickname.clone()
+                                    // #478, transitive case: the Ban action is
+                                    // ALSO withheld when the cascade would sweep
+                                    // the viewer up — i.e. the target is one of
+                                    // the viewer's own invite ancestors. Same
+                                    // damage as a self-ban, different route, so
+                                    // it is the same rule (`ban_gate`), not a
+                                    // second special case. `ban_refusal` is
+                                    // `Some` only when the viewer would OTHERWISE
+                                    // have had the action, which is why it also
+                                    // carries the text: a moderator whose Ban
+                                    // button vanished is owed a reason.
+                                    if ban_refusal.is_none() {
+                                        BanButton {
+                                            member_to_ban: member_id,
+                                            can_ban: can_ban,
+                                            // The DECRYPTED, sanitised name — the same
+                                            // value `DeputyButton` gets. This used to
+                                            // pass the raw `SealedBytes`, which Dioxus
+                                            // silently coerced through `Display` (i.e.
+                                            // `to_string_lossy`): the ban dialog showed
+                                            // an unsanitised nickname in the one place
+                                            // a moderator is judging authority, and
+                                            // showed "[Encrypted: N bytes, vN]" instead
+                                            // of a name in private rooms.
+                                            nickname: target_nickname.clone()
+                                        }
+                                    }
+                                    if let Some(reason) = ban_refusal {
+                                        div {
+                                            "data-testid": "ban-withheld-reason",
+                                            class: "flex-1 px-3 py-2 text-sm text-text-muted bg-surface border border-border rounded-lg",
+                                            "{reason}"
+                                        }
                                     }
 
                                     // Deputize / revoke-deputy (#410). Any non-owner
@@ -497,7 +527,7 @@ pub fn MemberInfoModal() -> Element {
 
 #[cfg(test)]
 mod ban_gate_tests {
-    use super::viewer_can_ban;
+    use crate::components::members::{ban_gate, BanGate};
     use ed25519_dalek::SigningKey;
     use rand::rngs::OsRng;
     use river_core::room_state::member::{AuthorizedMember, Member, MemberId, MembersV1};
@@ -557,32 +587,26 @@ mod ban_gate_tests {
         };
 
         // Owner can ban anyone.
-        assert!(viewer_can_ban(
-            &members,
-            &member_info,
-            owner_id,
-            v_id,
-            owner_id
-        ));
+        assert_eq!(
+            ban_gate(&members, &member_info, owner_id, v_id, owner_id),
+            BanGate::Allowed
+        );
         // D (owner's deputy) can ban V even though D is NOT an ancestor of V, so
         // the old `is_downstream` gate would have hidden the Ban button.
-        assert!(viewer_can_ban(&members, &member_info, d_id, v_id, owner_id));
+        assert_eq!(
+            ban_gate(&members, &member_info, d_id, v_id, owner_id),
+            BanGate::Allowed
+        );
         // An unrelated member cannot ban V.
-        assert!(!viewer_can_ban(
-            &members,
-            &member_info,
-            u_id,
-            v_id,
-            owner_id
-        ));
+        assert_eq!(
+            ban_gate(&members, &member_info, u_id, v_id, owner_id),
+            BanGate::NoAuthority
+        );
         // Nobody can ban the owner.
-        assert!(!viewer_can_ban(
-            &members,
-            &member_info,
-            d_id,
-            owner_id,
-            owner_id
-        ));
+        assert_eq!(
+            ban_gate(&members, &member_info, d_id, owner_id, owner_id),
+            BanGate::NoAuthority
+        );
     }
 
     /// Source-grep pin for freenet/river#451: the modal's icon legend must

--- a/ui/src/components/members/member_info_modal/ban_button.rs
+++ b/ui/src/components/members/member_info_modal/ban_button.rs
@@ -32,17 +32,25 @@ pub fn BanButton(member_to_ban: MemberId, can_ban: bool, nickname: String) -> El
             let room_state_clone = room_data.room_state.clone();
             let banned_by = MemberId::from(&self_sk.verifying_key());
 
-            // THIRD layer of the #478 guard, at the ACTION boundary.
+            // THE ACTION BOUNDARY for "nobody may ban themselves out of the
+            // room" (freenet/river#478, direct AND transitive).
             //
-            // `viewer_can_ban` refuses self and the modal does not render this
-            // button for self, but both are render-time: this function trusts
-            // a `member_to_ban` PROP and re-checks nothing, so any future call
-            // site that passes `can_ban: true` would execute the ban. A
-            // self-ban is contract-valid and cascades to the banner's whole
-            // invite subtree, so the capability should be unreachable rather
-            // than merely un-rendered.
-            if member_to_ban == banned_by {
-                warn!("Refusing to ban yourself (freenet/river#478)");
+            // `ban_gate` refuses it and the modal renders an explanation in
+            // place of this button, but both of those are render-time: this
+            // function trusts a `member_to_ban` PROP and re-checks nothing, so
+            // any future call site that passes `can_ban: true` would execute
+            // the ban. Such a ban is contract-VALID and cascades to the
+            // banner's whole invite subtree, so the capability has to be
+            // unreachable rather than merely un-rendered.
+            //
+            // Same predicate as the render gate — deliberately not a
+            // re-derivation, so the two cannot drift.
+            if let Some(reason) = crate::components::members::self_removing_ban_reason(
+                &room_data.room_state.members,
+                banned_by,
+                member_to_ban,
+            ) {
+                warn!("Refusing a ban that would remove you from the room (freenet/river#478): {reason}");
                 return;
             }
 

--- a/ui/src/components/members/member_info_modal/ban_button.rs
+++ b/ui/src/components/members/member_info_modal/ban_button.rs
@@ -32,6 +32,20 @@ pub fn BanButton(member_to_ban: MemberId, can_ban: bool, nickname: String) -> El
             let room_state_clone = room_data.room_state.clone();
             let banned_by = MemberId::from(&self_sk.verifying_key());
 
+            // THIRD layer of the #478 guard, at the ACTION boundary.
+            //
+            // `viewer_can_ban` refuses self and the modal does not render this
+            // button for self, but both are render-time: this function trusts
+            // a `member_to_ban` PROP and re-checks nothing, so any future call
+            // site that passes `can_ban: true` would execute the ban. A
+            // self-ban is contract-valid and cascades to the banner's whole
+            // invite subtree, so the capability should be unreachable rather
+            // than merely un-rendered.
+            if member_to_ban == banned_by {
+                warn!("Refusing to ban yourself (freenet/river#478)");
+                return;
+            }
+
             let ban = UserBan {
                 owner_member_id: MemberId::from(&current_room),
                 banned_at: get_current_system_time(),


### PR DESCRIPTION
## Problem

Bans **cascade**. `MembersV1::check_banned_members` inserts the banned member and then extends with `get_downstream_members`, the full transitive closure of their invite subtree. That is by design.

The consequence: a deputy who bans anyone **above them in the invite chain** is inside that ancestor's closure, so the cascade removes **the deputy themselves and their entire subtree**. Same blast radius as a direct self-ban, reached by a different route.

It is enabled today, not theoretical. `MembersV1::is_ban_authorized` grants owner-appointed **global moderators** authority at step 3 (`common/src/room_state/member.rs:377`), ahead of the step-4 "cannot ban the member who deputized you" guardrail — so a global mod is authorized over their own ancestors, and over themselves. Nothing downstream rejects it: `verify` accepts the ban, and the cascade runs. On the Official room the Invite Bot's deputies carry roughly 105 members each.

The original PR (#478) closed only the **direct** case (`banned_by == banned_user`). This closes the transitive one, which the review of the first round flagged as still open.

## Approach

Replaces the direct-only self-check with **one rule, stated once**:

> Compute the set the ban would remove — the target **plus** their transitive downstream closure — and refuse if the banning member is in it.

That subsumes the direct case (`banner == target`) rather than sitting beside it as a second special case. A future reader sees a single "you may not ban yourself out of the room" invariant.

Three pieces, in `ui/src/components/members.rs`:

- **`ban_removal_set`** — mirrors what `check_banned_members` actually builds. The contract's `get_downstream_members` is private to the contract crate, so the walk is recomputed rather than approximated (`cli/src/deputies.rs::invite_subtrees` is riverctl's existing mirror of the same thing). It carries a **visited-set guard** the contract omits: the contract can rely on `verify` having rejected circular invite chains, while the UI walks whatever state it currently holds.
- **`self_removing_ban_reason`** — the rule. Returns the user-visible reason, `None` when it does not apply. The *decision* is one computation; only the *wording* branches, because "you can't ban yourself" and "you can't ban someone you joined through" read very differently to a user.
- **`ban_gate`** — applies the rule to the **output** of `is_ban_authorized`, never inside its priority ladder. That placement is the load-bearing part: a check wired into the wrong branch would not fire for exactly the global moderators who can reach the most members. Mutant **M6** pins this.

### Why `viewer_can_ban` became `ban_gate`

The bool predicate could not express *why* the action was withheld, and "silently disable the button" is a bug report waiting to happen. `BanGate` has three answers:

| Answer | Meaning | UI |
|---|---|---|
| `Allowed` | authority held, ban is safe | Ban button renders |
| `WouldRemoveViewer(reason)` | authority held, but the ban removes **you** | button replaced by the reason text |
| `NoAuthority` | never had the action here | nothing (unchanged) |

Distinguishing the last two matters: without it, every ordinary member opening their own inviter's profile would be told they can't do something they never could. `a_non_global_deputy_is_refused_an_ancestor_for_lack_of_authority` pins the distinction.

This is a **replacement, not a removed layer** — `viewer_can_ban` was a thin wrapper with no other callers, and every assertion that used it now asserts on `ban_gate` (strictly stronger: the tests distinguish `NoAuthority` from `WouldRemoveViewer`, so an over-broad guard can no longer hide as "no authority").

### Enforcement points

1. **`ban_gate`** — the predicate. Refuses.
2. **rsx render gate** — the modal renders the explanation in place of `BanButton`, so the UI never offers an action that will be refused.
3. **`execute_ban`** (action boundary) — re-checks the **same** predicate, deliberately not a re-derivation. This is the one that makes the capability *unreachable* rather than merely un-rendered: the handler trusts a `member_to_ban` prop and a `can_ban` prop, so any future call site passing `can_ban: true` would otherwise run the cascading ban. The pin asserts the check does not consult `can_ban` at all (mutant **M10**).

**Cascade semantics are unchanged.** Banning a non-ancestor still cascades exactly as before. This adds a guard; it does not alter who gets removed.

### riverctl

It did **not** refuse the transitive case — only `banned_member_id == my_member_id`. Now fixed:

- `cli/src/deputies.rs` gains `ban_removal_set` + `self_removing_ban_reason` (built on the existing cycle-guarded `invite_subtrees`), and `ban_member` routes through it.
- `RoomDeputies::reach_of` stops counting targets whose ban would remove the deputy. The existing comment there already required this — it said riverctl's read path must not advertise authority the write path refuses, and *"keep the two in step: if either is relaxed, revisit the other."* Before this, a global moderator's reported reach included their own ancestors, which `ban_member` now rejects.

The rule cannot live in `river-core` without changing the room-contract WASM (and therefore the contract key and a migration), so the two clients carry mirrored copies with cross-references in both directions.

## Testing

`cargo test -p river-ui --bins` — 558 passed. `cargo test -p riverctl --lib` — 267 passed. `cargo fmt` clean; `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync` clean.

Every case below is proved against **one shared fixture** (`owner → alpha → beta → deputy → child`, plus an unrelated `stranger`, with `deputy` an owner-appointed global moderator), so the ALLOWED cases and the REFUSED cases come from the same room — an over-broad guard cannot hide behind a friendlier fixture. Every refusal asserts, as a **precondition**, that `is_ban_authorized` returns `true` and that the removal set really contains the banner; without that a test could pass for want of authority rather than because of the guard. (The review of round 1 found exactly this trap in `example_data.rs`, where "(You)" has an empty `deputies` list.)

### Mutation table

Every guard was reverted **individually**, the tests re-run, and the guard restored. 16 mutants, 16 caught.

| # | Mutation | Result |
|---|---|---|
| M1 | rule deleted entirely (UI) | FAILED — self + ancestor |
| M2 | **rule narrowed to the DIRECT case only (UI)** — the exact pre-PR behaviour | FAILED — ancestor (self still passes, as it must) |
| M3 | rule inverted, refuse everything (UI) | FAILED — over-broadness test |
| M4 | removal set walks only ONE level | FAILED — grandparent + closure test |
| M5 | cycle guard removed from the removal set | HANG (caught by timeout) |
| M6 | **rule skipped for owner-appointed global mods** — the ordering trap | FAILED — self + ancestor |
| M7 | render gate deleted from the modal | FAILED — render pin |
| M8 | explanation element deleted from the rsx (button hidden, no reason) | FAILED — render pin |
| M9 | action-boundary check deleted | FAILED — boundary pin |
| M10 | **action boundary gated on the caller's `can_ban` prop** | FAILED — boundary pin |
| M11 | source-scrape cut point disarmed so the prod slice includes test code | FAILED — anti-disarm assertion |
| M12 | rule narrowed to the DIRECT case only (riverctl) | FAILED |
| M13 | rule inverted, refuse everything (riverctl) | FAILED — over-broadness test |
| M14 | `ban_member` reverted to the old direct-only check | FAILED — wiring pin |
| M15 | `reach_of` reverted to excluding only the deputy | FAILED |

M8 was caught only **after** it exposed a real weakness: the first draft of the render pin asserted the modal *destructured* `BanGate::WouldRemoveViewer`, which stays green if someone deletes the element that displays the text. Fixed in `9682cee5` and re-run.

M11 exists because of the failure mode where a rebase moves a source-scrape's cut point and every needle starts matching itself. `assert_prod_only` now fails loudly if a production slice still contains `#[test]`.

### Coverage

- deputy bans direct inviter → refused (M2)
- deputy bans grandparent → refused (M2, M4)
- deputy bans themselves → still refused, #478 not regressed
- deputy bans an unrelated member → **still allowed** (M3/M13)
- deputy bans their own downstream → **still allowed** (M3/M13)
- deputy bans a deputy scoped to an ancestor's subtree → **still allowed**
- owner bans anyone, including mid-chain → **still allowed** (the owner is nobody's invitee, so never in a removal set)
- owner-appointed global moderator path guarded (M6) — and shown non-vacuous by a subtree-scoped deputy getting `NoAuthority` for the same target
- action boundary holds against a caller claiming the action is permitted (M10)
- removal set is the full transitive subtree, and terminates on a forged cycle (M4, M5)

No existing test was weakened, deleted or `#[ignore]`d.

## Scope

UI + CLI only — 5 files, no `common/`, no `contracts/`, no `delegates/`, no serialized types, **no WASM change, so no migration entry needed**.

Pre-existing and **not** touched here: `cargo clippy -D warnings` fails across the workspace on files this branch does not modify (`common/src/room_state/ban.rs` doc-indent lints under rust 1.94, plus dead-code and boolean-simplification lints in `cli/src/version_check.rs`, `cli/src/commands/debug.rs`, `ui/src/components/app/notifications.rs`, and others). CI's clippy workflow is disabled (`clippy.yml.disabled`), which is how the backlog accumulated. Fixing it means editing `common/`, which trips the room-contract migration checks — out of scope for this PR, worth its own.

## Review status

**The previous review is superseded for the changed code.** It reviewed a direct-only guard built on `viewer_can_ban` with a `member_to_ban == banned_by` check at the action boundary; all three of those layers have been rewritten, and the predicate they were built on no longer exists. Its own "Reported, not fixed here" section named this transitive gap as the follow-up — this is it.

Two items from that review remain open and are **not** addressed here:

- **The ban dialog still does not disclose the cascade.** It says only "This action cannot be undone", nothing about the invite subtree going with the target. `get_downstream_members` is computable client-side, so "this will also remove N other members" is cheap.
- **The contract still accepts a self-removing ban.** All four enforcement points (three UI, one CLI) are client-side. A stale web container, an old build, or a custom client can still trigger the cascade.

`⚠️ Do not publish from this branch` — the River master agent owns publishing.

Closes #478

[AI-assisted - Claude]
