### PR TITLE
fix(ui): close invisible-character and tooltip-injection gaps in the badge work

### DIFF
--- a/ui/src/components/app/notifications.rs
+++ b/ui/src/components/app/notifications.rs
@@ -357,6 +357,32 @@ pub fn request_permission_on_first_message() {
     });
 }
 
+/// Every character a renderer may start a new line on, flattened to a space by
+/// [`notification_body`]: LF, CR, U+0085 NEXT LINE, U+2028 LINE SEPARATOR and
+/// U+2029 PARAGRAPH SEPARATOR.
+const NOTIFICATION_LINE_BREAKS: [char; 5] = ['\n', '\r', '\u{0085}', '\u{2028}', '\u{2029}'];
+
+/// Build the `sender: message` body a notification displays.
+///
+/// The body is ONE flat string, so a message that can start a new line lets its
+/// author paint a second line reading exactly like a notification from someone
+/// else, including a moderator with a 🛡 in it. Every line-break character is
+/// therefore flattened to a space. The sender name needs no such treatment: it
+/// arrives already sanitised from
+/// [`crate::util::display_name::display_nickname`].
+///
+/// BOTH notification paths build their body here (the gateway shell bridge in
+/// [`show_notification`], and the direct Notifications API in
+/// [`create_notification_internal`]), so the guard cannot be half-applied and a
+/// third path cannot ship without it. Pinned by
+/// `both_notification_paths_go_through_notification_body`.
+fn notification_body(sender_name: &str, message_preview: &str) -> String {
+    format!(
+        "{sender_name}: {}",
+        message_preview.replace(NOTIFICATION_LINE_BREAKS, " ")
+    )
+}
+
 /// Show a notification for new messages in a room
 ///
 /// # Arguments
@@ -373,16 +399,7 @@ pub fn show_notification(
     // Gateway iframe: hand the notification to the shell (real origin) over the
     // postMessage bridge — the sandboxed iframe can't use the Notifications API.
     if is_in_shell_iframe() {
-        // Flatten line breaks out of the message text. The body renders as
-        // `sender: message`, so a message starting with a newline lets its author
-        // paint a second line that reads exactly like a notification from someone
-        // else — including a moderator with a 🛡 in it. The sender name itself is
-        // already sanitised.
-        let body = format!(
-            "{}: {}",
-            sender_name,
-            message_preview.replace(['\n', '\r', '\u{2028}', '\u{2029}', '\u{0085}'], " ")
-        );
+        let body = notification_body(sender_name, message_preview);
         post_notification_to_shell(room_key, room_name, &body);
         return;
     }
@@ -424,16 +441,7 @@ fn create_notification_internal(
     sender_name: &str,
     message_preview: &str,
 ) {
-    // Flatten line breaks out of the message text. The body renders as
-    // `sender: message`, so a message starting with a newline lets its author
-    // paint a second line that reads exactly like a notification from someone
-    // else — including a moderator with a 🛡 in it. The sender name itself is
-    // already sanitised.
-    let body = format!(
-        "{}: {}",
-        sender_name,
-        message_preview.replace(['\n', '\r', '\u{2028}', '\u{2029}', '\u{0085}'], " ")
-    );
+    let body = notification_body(sender_name, message_preview);
     info!(
         "Creating notification - title: '{}', body: '{}'",
         room_name, body
@@ -815,6 +823,70 @@ mod notify_gate_tests {
             },
             author_sk,
         )
+    }
+
+    /// A notification body renders as one flat `sender: message` line. Any
+    /// character the renderer breaks on lets a message author paint a second
+    /// line that reads as a notification from someone else, which is the exact
+    /// impersonation this guard exists to stop.
+    #[test]
+    fn notification_body_flattens_every_line_break() {
+        for (label, c) in [
+            ("LINE FEED", '\n'),
+            ("CARRIAGE RETURN", '\r'),
+            ("NEXT LINE", '\u{0085}'),
+            ("LINE SEPARATOR", '\u{2028}'),
+            ("PARAGRAPH SEPARATOR", '\u{2029}'),
+        ] {
+            let forged = format!("hi{c}Ian Clarke \u{1F6E1}: everyone is banned");
+            let body = notification_body("Mallory", &forged);
+            assert!(
+                !body.contains(c),
+                "U+{:04X} {label} survived into a notification body: {body:?}",
+                u32::from(c)
+            );
+            assert!(
+                body.starts_with("Mallory: hi Ian"),
+                "U+{:04X} {label} was not flattened to a space: {body:?}",
+                u32::from(c)
+            );
+        }
+    }
+
+    #[test]
+    fn notification_body_leaves_ordinary_text_alone() {
+        assert_eq!(
+            notification_body("Alice", "hello there"),
+            "Alice: hello there"
+        );
+        // The multi-message summary path passes an empty sender name.
+        assert_eq!(notification_body("", "3 new messages"), ": 3 new messages");
+    }
+
+    /// Both notification paths must build their body through
+    /// [`notification_body`]. They are `wasm`-only, so no behavioural test in
+    /// this crate can reach them: re-inlining the `format!` on either one
+    /// re-opens the hole on that path alone and every other test stays green.
+    #[test]
+    fn both_notification_paths_go_through_notification_body() {
+        let source = include_str!("notifications.rs");
+        let (production, _) = source
+            .split_once("mod notify_gate_tests")
+            .expect("this test module's own declaration marks the end of production code");
+
+        assert_eq!(
+            production
+                .matches("notification_body(sender_name, message_preview)")
+                .count(),
+            2,
+            "expected exactly two call sites (`show_notification` and \
+             `create_notification_internal`); a path stopped delegating"
+        );
+        assert!(
+            !production.contains("\"{}: {}\""),
+            "a notification path re-inlined the `sender: message` join, which \
+             skips the line-break strip that only `notification_body` applies"
+        );
     }
 
     #[test]

--- a/ui/src/components/app/notifications.rs
+++ b/ui/src/components/app/notifications.rs
@@ -381,7 +381,7 @@ pub fn show_notification(
         let body = format!(
             "{}: {}",
             sender_name,
-            message_preview.replace(['\n', '\r'], " ")
+            message_preview.replace(['\n', '\r', '\u{2028}', '\u{2029}', '\u{0085}'], " ")
         );
         post_notification_to_shell(room_key, room_name, &body);
         return;
@@ -432,7 +432,7 @@ fn create_notification_internal(
     let body = format!(
         "{}: {}",
         sender_name,
-        message_preview.replace(['\n', '\r'], " ")
+        message_preview.replace(['\n', '\r', '\u{2028}', '\u{2029}', '\u{0085}'], " ")
     );
     info!(
         "Creating notification - title: '{}', body: '{}'",

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -585,16 +585,35 @@ pub(crate) fn viewer_relevant_deputizer_set(
     set
 }
 
-/// Display names of `target`'s deputizers that are RELEVANT to the viewer,
-/// resolved to `"room owner"` / `"you"` / the appointer's decrypted nickname —
-/// exactly what the member-list 🛡 badge shows. An empty result means the
-/// shield does not show for this viewer.
+/// One appointer behind a 🛡 shield, kept as a TYPE rather than a string so a
+/// surface cannot accidentally treat a nickname as a role label.
+///
+/// `Owner` and `You` are trusted: River decides them, and their wording is a
+/// literal in this file. `Member` carries an attacker-chosen nickname and is
+/// the reason this enum exists — see [`DeputyBadge::tooltip`] for what may and
+/// may not be done with it.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub(crate) enum Appointer {
+    /// The room owner. Rendered as the trusted label `"the room owner"`.
+    Owner,
+    /// The viewer themselves. Rendered as the trusted label `"you"`.
+    You,
+    /// Any other member, named by their decrypted `preferred_nickname`.
+    ///
+    /// **Attacker-controlled.** Never interpolate this into a flat sentence
+    /// alongside a role label.
+    Member(String),
+}
+
+/// `target`'s deputizers that are RELEVANT to the viewer, in the order the
+/// member-list 🛡 badge shows them. An empty result means the shield does not
+/// show for this viewer.
 ///
 /// This is the single definition shared by the member-list row and the
 /// member-info modal legend, so the shield's visibility and its
 /// `Deputy (appointed by …)` tooltip cannot drift between the two
 /// (freenet/river#451).
-pub(crate) fn relevant_deputizer_names(
+pub(crate) fn relevant_appointers(
     member_info: &river_core::room_state::member_info::MemberInfoV1,
     room_secrets: &HashMap<u32, [u8; 32]>,
     deputizers_of: &HashMap<MemberId, Vec<MemberId>>,
@@ -602,48 +621,31 @@ pub(crate) fn relevant_deputizer_names(
     owner_id: MemberId,
     self_member_id: MemberId,
     target: MemberId,
-) -> Vec<String> {
-    // Resolve an appointer's id to a display name (owner -> "the room owner",
-    // self -> "you", else the appointer's decrypted preferred nickname).
-    //
-    // A real nickname is QUOTED and the two role labels are not, because they
-    // share one flat, comma-joined list and a nickname is attacker-chosen.
-    // Without the quotes a member who is a strict ancestor of the viewer can
-    // set their nickname to `room owner`, deputize anyone, and make that
-    // member's shield read `Deputy (appointed by room owner). Can ban you.` —
-    // a forged global-moderator appointment, in the one place the badge
-    // communicates the SCOPE of someone's authority. Sanitising cannot help:
-    // `room owner` is plain ASCII.
-    let name_of = |id: MemberId| -> String {
+) -> Vec<Appointer> {
+    // Classify rather than format. Resolving straight to a display string here
+    // is what made the forgery possible: once an appointer is a `String`, the
+    // difference between "River said this" and "a member typed this" is gone,
+    // and every downstream surface has to remember a rule it cannot see.
+    let appointer_of = |id: MemberId| -> Appointer {
         if id == owner_id {
-            return "the room owner".to_string();
+            return Appointer::Owner;
         }
         if id == self_member_id {
-            return "you".to_string();
+            return Appointer::You;
         }
-        member_info
-            .canonical(id)
-            .map(|mi| {
-                // Strip the quote characters from the nickname before wrapping
-                // it. Without this the quoting is decorative, not protective:
-                // the appointers are joined into ONE flat string, so a
-                // nickname of `Bob\u{201d}, the room owner, \u{201c}Carol`
-                // renders as `appointed by \u{201c}Bob\u{201d}, the room
-                // owner, \u{201c}Carol\u{201d}` — the forged owner
-                // appointment the quotes exist to prevent. Sanitising cannot
-                // help here; the payload IS the quote characters.
-                let name = display_nickname(&mi.member_info.preferred_nickname, room_secrets)
-                    .replace(['\u{201c}', '\u{201d}'], "");
-                format!("\u{201c}{name}\u{201d}")
-            })
-            .unwrap_or_else(|| "an unknown member".to_string())
+        Appointer::Member(
+            member_info
+                .canonical(id)
+                .map(|mi| display_nickname(&mi.member_info.preferred_nickname, room_secrets))
+                .unwrap_or_else(|| "an unknown member".to_string()),
+        )
     };
     relevant_deputizers(
         deputizers_of.get(&target).map(Vec::as_slice).unwrap_or(&[]),
         viewer_relevant,
     )
     .into_iter()
-    .map(name_of)
+    .map(appointer_of)
     .collect()
 }
 
@@ -675,7 +677,7 @@ pub(crate) fn viewer_can_ban(
 ///
 /// * `deputized_by` decides **visibility** — non-empty means show the shield.
 ///   It is the pre-existing viewer-relative predicate the member list and the
-///   member-info modal already use ([`relevant_deputizer_names`]), which never
+///   member-info modal already use ([`relevant_appointers`]), which never
 ///   consults the viewer's own deputy status, so the "still shows when I'm
 ///   immune" half holds by construction.
 /// * `can_ban_viewer` decides only the **tooltip wording**, and is the real
@@ -686,10 +688,9 @@ pub(crate) fn viewer_can_ban(
 ///   `is_ban_authorized` step 4).
 #[derive(Clone, PartialEq, Debug)]
 pub(crate) struct DeputyBadge {
-    /// Viewer-relevant appointer display names — `"room owner"`, `"you"`, or a
-    /// nickname. Never empty: an empty result means no badge at all, which is
-    /// represented by the member being absent from the map.
-    pub deputized_by: Vec<String>,
+    /// Viewer-relevant appointers. Never empty: an empty result means no badge
+    /// at all, which is represented by the member being absent from the map.
+    pub deputized_by: Vec<Appointer>,
     /// Whether this member can currently get the viewer removed from the room,
     /// directly or by a cascading ban of one of the viewer's ancestors. `None`
     /// when the badge is on the VIEWER'S OWN row: "can they ban you" is not a
@@ -699,6 +700,60 @@ pub(crate) struct DeputyBadge {
 }
 
 impl DeputyBadge {
+    /// Who appointed them, as a phrase built ONLY from trusted literals plus a
+    /// count. No nickname reaches this string.
+    ///
+    /// **A `title=` attribute is a flat string, so quoting a nickname inside it
+    /// is not a defense and must not be re-attempted.** The appointers used to
+    /// be joined with `", "`, with the role labels left unquoted so a nickname
+    /// could not pass as one. The forging primitive is the COMMA, not the
+    /// quote: a plain-ASCII nickname of `Bob, the room owner, Carol` produced
+    ///
+    /// ```text
+    /// Deputy (appointed by "Bob, the room owner, Carol"). Can ban you.
+    /// ```
+    ///
+    /// against the legitimate `appointed by "Bob", the room owner, "Carol"`.
+    /// Two quote glyphs shift position; nobody reads that at tooltip size. Any
+    /// quote character works for the decorated variant (`U+201C`, `U+2033`,
+    /// `U+FF02`, `U+00AB`…), and the payload above needs no quote at all, so
+    /// denylisting characters cannot close it. Sanitising cannot either: every
+    /// byte of the payload is a legitimate name character.
+    ///
+    /// So the tooltip names no member. The actual names are surfaced by the
+    /// member-info modal, which renders them as SEPARATE elements where a
+    /// comma inside one of them cannot span two of them.
+    fn appointer_phrase(&self) -> String {
+        let has = |want: &Appointer| self.deputized_by.contains(want);
+        let others = self
+            .deputized_by
+            .iter()
+            .filter(|a| matches!(a, Appointer::Member(_)))
+            .count();
+
+        let mut parts: Vec<String> = Vec::new();
+        if has(&Appointer::Owner) {
+            parts.push("the room owner".to_string());
+        }
+        if has(&Appointer::You) {
+            parts.push("you".to_string());
+        }
+        match others {
+            0 => {}
+            1 => parts.push("another member".to_string()),
+            n => parts.push(format!("{n} other members")),
+        }
+
+        // At most three parts (owner, you, the count), so this covers every
+        // case without a general list-joiner.
+        match parts.len() {
+            0 => "nobody".to_string(),
+            1 => parts.remove(0),
+            2 => format!("{} and {}", parts[0], parts[1]),
+            _ => format!("{}, {} and {}", parts[0], parts[1], parts[2]),
+        }
+    }
+
     /// The `title=` text: who appointed them, and what that means for you.
     ///
     /// One definition for all three surfaces (message author line, member-list
@@ -706,12 +761,29 @@ impl DeputyBadge {
     /// in different places. That is the drift freenet/river#451 fixed for
     /// visibility, applied to the wording too.
     pub fn tooltip(&self) -> String {
-        let appointers = self.deputized_by.join(", ");
+        let appointers = self.appointer_phrase();
         match self.can_ban_viewer {
             Some(true) => format!("Deputy (appointed by {appointers}). Can ban you."),
             Some(false) => format!("Deputy (appointed by {appointers}). Cannot ban you."),
             None => format!("Deputy (appointed by {appointers})"),
         }
+    }
+
+    /// The appointers as individual display strings, for a surface that can
+    /// render them as SEPARATE elements.
+    ///
+    /// Do NOT join these into one string — that reintroduces exactly the
+    /// forgery [`Self::appointer_phrase`] exists to prevent. The only caller is
+    /// the member-info modal, which emits one node per entry.
+    pub fn appointer_names(&self) -> Vec<String> {
+        self.deputized_by
+            .iter()
+            .map(|a| match a {
+                Appointer::Owner => "the room owner".to_string(),
+                Appointer::You => "you".to_string(),
+                Appointer::Member(name) => name.clone(),
+            })
+            .collect()
     }
 }
 
@@ -807,7 +879,7 @@ fn badge_for_target(
     if target == owner_id {
         return None;
     }
-    let deputized_by = relevant_deputizer_names(
+    let deputized_by = relevant_appointers(
         member_info,
         room_secrets,
         deputizers_of,
@@ -2954,7 +3026,7 @@ mod tests {
     /// The 🛡 deputy shield renders exactly when `deputized_by` is non-empty,
     /// and its tooltip names the appointer(s). The member-info modal legend
     /// mirrors this (freenet/river#451) via the shared
-    /// `relevant_deputizer_names` helper, so this pins the row half of the
+    /// `relevant_appointers` helper, so this pins the row half of the
     /// "same shield in both places" contract.
     #[test]
     fn member_display_parts_shows_deputy_shield_with_appointer_tooltip() {
@@ -2968,7 +3040,7 @@ mod tests {
         );
 
         display.deputy_badge = Some(DeputyBadge {
-            deputized_by: vec!["the room owner".to_string()],
+            deputized_by: vec![Appointer::Owner],
             can_ban_viewer: Some(true),
         });
         let parts = member_display_parts(&display);
@@ -2987,7 +3059,7 @@ mod tests {
         // On the viewer's OWN row the ban clause is dropped: "can they ban
         // you" is meaningless about yourself.
         display.deputy_badge = Some(DeputyBadge {
-            deputized_by: vec!["the room owner".to_string()],
+            deputized_by: vec![Appointer::Owner],
             can_ban_viewer: None,
         });
         let parts = member_display_parts(&display);
@@ -3000,7 +3072,7 @@ mod tests {
     /// End-to-end pin of the shared deputy helpers the member row AND the
     /// member-info modal legend both depend on (freenet/river#451): build a
     /// room where the OWNER deputizes `mod_member`, and assert that from an
-    /// unrelated viewer's perspective `relevant_deputizer_names` reports the
+    /// unrelated viewer's perspective `relevant_appointers` reports the
     /// shield named "room owner" (a global moderator is relevant to everyone),
     /// while a member nobody deputized reports no shield.
     #[test]
@@ -3051,7 +3123,7 @@ mod tests {
         // The moderator (a deputy of the owner) shows the shield, named "room
         // owner", even to an unrelated viewer.
         assert_eq!(
-            relevant_deputizer_names(
+            relevant_appointers(
                 &member_info,
                 &secrets,
                 &deputizers_of,
@@ -3060,10 +3132,10 @@ mod tests {
                 viewer_id,
                 mod_id,
             ),
-            vec!["the room owner".to_string()],
+            vec![Appointer::Owner],
         );
         // A member nobody deputized shows no shield.
-        assert!(relevant_deputizer_names(
+        assert!(relevant_appointers(
             &member_info,
             &secrets,
             &deputizers_of,
@@ -3075,58 +3147,153 @@ mod tests {
         .is_empty());
     }
 
-    /// The shield tooltip joins appointer names into ONE flat string, with the
-    /// two role labels (`the room owner`, `you`) left unquoted so a nickname
-    /// cannot masquerade as them. That only works if the nickname cannot
-    /// supply its own quote characters.
+    /// **No nickname content reaches the shield tooltip, at all.**
+    ///
+    /// The tooltip is a `title=` attribute, i.e. one flat string, and the
+    /// forging primitive there is the COMMA, not the quote. A plain-ASCII
+    /// nickname of `Bob, the room owner, Carol` used to render
+    ///
+    /// ```text
+    /// Deputy (appointed by "Bob, the room owner, Carol"). Can ban you.
+    /// ```
+    ///
+    /// against the legitimate `appointed by "Bob", the room owner, "Carol"` —
+    /// two quote glyphs apart, and nobody reads that at tooltip size. Since the
+    /// payload carries no quote character of its own, no denylist of quote
+    /// characters closes it, and sanitising cannot either: every byte is a
+    /// legitimate name character.
+    ///
+    /// So this asserts the only property that actually holds: the tooltip
+    /// contains no attacker-supplied substring. It is checked with a payload
+    /// that has NO Unicode trickery, because that is the case a
+    /// character-denylist fix would silently fail.
     #[test]
-    fn appointer_names_cannot_inject_a_role_label() {
+    fn no_nickname_content_reaches_the_shield_tooltip() {
         use river_core::room_state::member::MembersV1;
         use river_core::room_state::member_info::MemberInfoV1;
 
-        let mut rng = rand::thread_rng();
-        let owner_sk = SigningKey::generate(&mut rng);
-        let liar_sk = SigningKey::generate(&mut rng);
-        let puppet_sk = SigningKey::generate(&mut rng);
-        let viewer_sk = SigningKey::generate(&mut rng);
+        // Each of these is a nickname a member can simply type. The first is
+        // the one that defeats every quote-stripping fix.
+        for payload in [
+            "Bob, the room owner, Carol",
+            "Bob\u{201d}, the room owner, \u{201c}Carol",
+            "Bob\", the room owner, \"Carol",
+            "Bob\u{00BB}, the room owner, \u{00AB}Carol",
+            "Bob\u{FF02}, the room owner, \u{FF02}Carol",
+            "Bob and you and the room owner",
+            ") . Can ban you. Deputy (appointed by the room owner",
+        ] {
+            let mut rng = rand::thread_rng();
+            let owner_sk = SigningKey::generate(&mut rng);
+            let liar_sk = SigningKey::generate(&mut rng);
+            let puppet_sk = SigningKey::generate(&mut rng);
+            let viewer_sk = SigningKey::generate(&mut rng);
 
-        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
-        let owner_id = id(&owner_sk);
+            let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+            let owner_id = id(&owner_sk);
 
-        // The liar invited the viewer, so the liar is a viewer-relevant
-        // appointer and their puppet carries a shield in the viewer's view.
-        let members = MembersV1 {
-            members: vec![
-                authorized_member(&owner_sk, &liar_sk.verifying_key()),
-                authorized_member(&owner_sk, &puppet_sk.verifying_key()),
-                member_invited_by(&liar_sk, owner_id, &viewer_sk.verifying_key()),
-            ],
+            // The liar invited the viewer, so the liar is a viewer-relevant
+            // appointer and their puppet carries a shield in the viewer's view.
+            let members = MembersV1 {
+                members: vec![
+                    authorized_member(&owner_sk, &liar_sk.verifying_key()),
+                    authorized_member(&owner_sk, &puppet_sk.verifying_key()),
+                    member_invited_by(&liar_sk, owner_id, &viewer_sk.verifying_key()),
+                ],
+            };
+            let member_info = MemberInfoV1 {
+                member_info: vec![
+                    signed_member_info(&owner_sk, "Owner", vec![]),
+                    signed_member_info(&liar_sk, payload, vec![id(&puppet_sk)]),
+                    signed_member_info(&puppet_sk, "Puppet", vec![]),
+                    signed_member_info(&viewer_sk, "Viewer", vec![]),
+                ],
+            };
+            let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+            let badges = deputy_badges_for_viewer(
+                &members,
+                &member_info,
+                &secrets,
+                owner_id,
+                id(&viewer_sk),
+            );
+            let badge = badges
+                .get(&id(&puppet_sk))
+                .expect("the puppet carries a shield in this view");
+            let tooltip = badge.tooltip();
+
+            // The payload is the liar's nickname. The liar is ONE appointer, so
+            // the only truthful thing the tooltip can say is "another member".
+            assert_eq!(
+                tooltip, "Deputy (appointed by another member). Can ban you.",
+                "tooltip is not the trusted-literal form for payload {payload:?}"
+            );
+
+            // Belt and braces: no run of the payload long enough to read as a
+            // phrase survives anywhere in the tooltip. A future rewrite that
+            // reintroduces names in some other shape fails here even if it
+            // changes the exact wording asserted above.
+            for window in payload.split(',').map(str::trim).filter(|w| w.len() > 3) {
+                assert!(
+                    !tooltip.contains(window),
+                    "tooltip leaked the nickname fragment {window:?}: {tooltip}"
+                );
+            }
+
+            // The names are still available — as SEPARATE elements, where a
+            // comma inside one cannot span two of them.
+            assert_eq!(
+                badge.appointer_names(),
+                vec![payload.to_string()],
+                "the modal must still be able to show who appointed them"
+            );
+        }
+    }
+
+    /// The trusted-literal wording, across every combination of appointers.
+    /// The counts are the only thing a nickname can influence, and only by
+    /// existing.
+    #[test]
+    fn appointer_phrase_is_built_from_trusted_literals_only() {
+        let phrase = |appointers: Vec<Appointer>| {
+            DeputyBadge {
+                deputized_by: appointers,
+                can_ban_viewer: None,
+            }
+            .tooltip()
         };
-        let payload = "Bob\u{201d}, the room owner, \u{201c}Carol";
-        let member_info = MemberInfoV1 {
-            member_info: vec![
-                signed_member_info(&owner_sk, "Owner", vec![]),
-                signed_member_info(&liar_sk, payload, vec![id(&puppet_sk)]),
-                signed_member_info(&puppet_sk, "Puppet", vec![]),
-                signed_member_info(&viewer_sk, "Viewer", vec![]),
-            ],
-        };
-        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+        let member = |n: &str| Appointer::Member(n.to_string());
 
-        let badges =
-            deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, id(&viewer_sk));
-        let tooltip = badges
-            .get(&id(&puppet_sk))
-            .expect("the puppet carries a shield in this view")
-            .tooltip();
-
-        assert!(
-            !tooltip.contains("\u{201d}, the room owner, \u{201c}"),
-            "a nickname injected an unquoted role label into the tooltip: {tooltip}"
+        assert_eq!(
+            phrase(vec![Appointer::Owner]),
+            "Deputy (appointed by the room owner)"
         );
-        assert!(
-            tooltip.contains("\u{201c}Bob, the room owner, Carol\u{201d}"),
-            "the whole nickname should sit inside one quoted span: {tooltip}"
+        assert_eq!(phrase(vec![Appointer::You]), "Deputy (appointed by you)");
+        assert_eq!(
+            phrase(vec![member("Eve")]),
+            "Deputy (appointed by another member)"
+        );
+        assert_eq!(
+            phrase(vec![member("Eve"), member("Mallory")]),
+            "Deputy (appointed by 2 other members)"
+        );
+        assert_eq!(
+            phrase(vec![Appointer::Owner, member("Eve")]),
+            "Deputy (appointed by the room owner and another member)"
+        );
+        assert_eq!(
+            phrase(vec![Appointer::Owner, Appointer::You]),
+            "Deputy (appointed by the room owner and you)"
+        );
+        assert_eq!(
+            phrase(vec![
+                Appointer::Owner,
+                Appointer::You,
+                member("Eve"),
+                member("Mallory"),
+            ]),
+            "Deputy (appointed by the room owner, you and 2 other members)"
         );
     }
 
@@ -3229,7 +3396,7 @@ mod tests {
         let global = badges
             .get(&id(&global_mod_sk))
             .expect("a deputy of the owner must show the shield to every viewer");
-        assert_eq!(global.deputized_by, vec!["the room owner".to_string()]);
+        assert_eq!(global.deputized_by, vec![Appointer::Owner]);
         assert_eq!(global.can_ban_viewer, Some(true));
         assert_eq!(
             global.tooltip(),
@@ -3241,11 +3408,11 @@ mod tests {
         let by_alpha = badges
             .get(&id(&deputy_alpha_sk))
             .expect("a deputy of the viewer's inviter must show the shield");
-        // A real nickname is quoted so it cannot masquerade as the unquoted
-        // `the room owner` / `you` role labels in the same comma-joined list.
+        // A real nickname is classified as `Member`, never as one of the two
+        // trusted role labels, so it cannot masquerade as either.
         assert_eq!(
             by_alpha.deputized_by,
-            vec!["\u{201c}Alpha\u{201d}".to_string()]
+            vec![Appointer::Member("Alpha".to_string())]
         );
         assert_eq!(by_alpha.can_ban_viewer, Some(true));
 
@@ -3266,7 +3433,7 @@ mod tests {
         let mine = badges
             .get(&id(&my_deputy_sk))
             .expect("a deputy the viewer appointed must still show the shield");
-        assert_eq!(mine.deputized_by, vec!["you".to_string()]);
+        assert_eq!(mine.deputized_by, vec![Appointer::You]);
         assert_eq!(
             mine.can_ban_viewer,
             Some(false),
@@ -3330,7 +3497,7 @@ mod tests {
         let other = badges
             .get(&id(&other_mod_sk))
             .expect("a fellow deputy must still show the shield to a deputy viewer");
-        assert_eq!(other.deputized_by, vec!["the room owner".to_string()]);
+        assert_eq!(other.deputized_by, vec![Appointer::Owner]);
         assert_eq!(
             other.can_ban_viewer,
             Some(true),
@@ -3387,11 +3554,11 @@ mod tests {
         let m = badges
             .get(&id(&mod_sk))
             .expect("the owner must see the shield on their own appointee");
-        // `relevant_deputizer_names` resolves the owner id BEFORE the self id,
+        // `relevant_appointers` resolves the owner id BEFORE the self id,
         // so an owner viewing their own appointee reads "room owner", not
         // "you". Pinned rather than "fixed": the label describes the role that
         // granted the authority, and every other viewer sees the same word.
-        assert_eq!(m.deputized_by, vec!["the room owner".to_string()]);
+        assert_eq!(m.deputized_by, vec![Appointer::Owner]);
         assert_eq!(
             m.can_ban_viewer,
             Some(false),
@@ -3661,7 +3828,10 @@ mod tests {
         let badges =
             deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, id(&viewer_sk));
         let badge = badges.get(&id(&deputy_sk)).expect("shield expected");
-        assert_eq!(badge.deputized_by, vec!["\u{201c}Eve\u{201d}".to_string()]);
+        assert_eq!(
+            badge.deputized_by,
+            vec![Appointer::Member("Eve".to_string())]
+        );
         assert!(!badge.tooltip().contains('🛡'));
 
         // The role labels are unquoted, so a nickname of `room owner` reads as
@@ -3680,12 +3850,20 @@ mod tests {
             owner_id,
             id(&viewer_sk),
         );
+        let badge = liar.get(&id(&deputy_sk)).expect("shield expected");
         assert_eq!(
-            liar.get(&id(&deputy_sk))
-                .expect("shield expected")
-                .deputized_by,
-            vec!["\u{201c}room owner\u{201d}".to_string()],
-            "a nickname of `room owner` must not forge an owner appointment"
+            badge.deputized_by,
+            vec![Appointer::Member("room owner".to_string())],
+            "a nickname of `room owner` must classify as a MEMBER, never as the \
+             trusted `Appointer::Owner` label"
+        );
+        // And the tooltip, which is the flat surface a reader actually sees,
+        // names no member at all.
+        assert!(
+            !badge.tooltip().contains("the room owner"),
+            "a nickname of `room owner` forged an owner appointment in the \
+             tooltip: {}",
+            badge.tooltip()
         );
     }
 

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -533,7 +533,13 @@ pub(crate) fn build_deputizers_of(
             if *deputy == appointer {
                 continue;
             }
-            deputizers_of.entry(*deputy).or_default().push(appointer);
+            // `MAX_DEPUTIES` bounds the LENGTH but nothing rejects repeats, so
+            // `deputies: [sockpuppet; 64]` would otherwise name the same
+            // appointer 64 times in the tooltip and bury the real content.
+            let entry = deputizers_of.entry(*deputy).or_default();
+            if !entry.contains(&appointer) {
+                entry.push(appointer);
+            }
         }
     }
     deputizers_of
@@ -618,10 +624,17 @@ pub(crate) fn relevant_deputizer_names(
         member_info
             .canonical(id)
             .map(|mi| {
-                format!(
-                    "\u{201c}{}\u{201d}",
-                    display_nickname(&mi.member_info.preferred_nickname, room_secrets)
-                )
+                // Strip the quote characters from the nickname before wrapping
+                // it. Without this the quoting is decorative, not protective:
+                // the appointers are joined into ONE flat string, so a
+                // nickname of `Bob\u{201d}, the room owner, \u{201c}Carol`
+                // renders as `appointed by \u{201c}Bob\u{201d}, the room
+                // owner, \u{201c}Carol\u{201d}` — the forged owner
+                // appointment the quotes exist to prevent. Sanitising cannot
+                // help here; the payload IS the quote characters.
+                let name = display_nickname(&mi.member_info.preferred_nickname, room_secrets)
+                    .replace(['\u{201c}', '\u{201d}'], "");
+                format!("\u{201c}{name}\u{201d}")
             })
             .unwrap_or_else(|| "an unknown member".to_string())
     };
@@ -3060,6 +3073,86 @@ mod tests {
             viewer_id,
         )
         .is_empty());
+    }
+
+    /// The shield tooltip joins appointer names into ONE flat string, with the
+    /// two role labels (`the room owner`, `you`) left unquoted so a nickname
+    /// cannot masquerade as them. That only works if the nickname cannot
+    /// supply its own quote characters.
+    #[test]
+    fn appointer_names_cannot_inject_a_role_label() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let liar_sk = SigningKey::generate(&mut rng);
+        let puppet_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+
+        // The liar invited the viewer, so the liar is a viewer-relevant
+        // appointer and their puppet carries a shield in the viewer's view.
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &liar_sk.verifying_key()),
+                authorized_member(&owner_sk, &puppet_sk.verifying_key()),
+                member_invited_by(&liar_sk, owner_id, &viewer_sk.verifying_key()),
+            ],
+        };
+        let payload = "Bob\u{201d}, the room owner, \u{201c}Carol";
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                signed_member_info(&owner_sk, "Owner", vec![]),
+                signed_member_info(&liar_sk, payload, vec![id(&puppet_sk)]),
+                signed_member_info(&puppet_sk, "Puppet", vec![]),
+                signed_member_info(&viewer_sk, "Viewer", vec![]),
+            ],
+        };
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        let badges =
+            deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, id(&viewer_sk));
+        let tooltip = badges
+            .get(&id(&puppet_sk))
+            .expect("the puppet carries a shield in this view")
+            .tooltip();
+
+        assert!(
+            !tooltip.contains("\u{201d}, the room owner, \u{201c}"),
+            "a nickname injected an unquoted role label into the tooltip: {tooltip}"
+        );
+        assert!(
+            tooltip.contains("\u{201c}Bob, the room owner, Carol\u{201d}"),
+            "the whole nickname should sit inside one quoted span: {tooltip}"
+        );
+    }
+
+    /// A repeated deputy entry must not repeat the appointer in the tooltip.
+    #[test]
+    fn duplicate_deputy_entries_are_collapsed() {
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let appointer_sk = SigningKey::generate(&mut rng);
+        let deputy_sk = SigningKey::generate(&mut rng);
+        let deputy_id = MemberId::from(&deputy_sk.verifying_key());
+
+        let member_info = MemberInfoV1 {
+            member_info: vec![signed_member_info(
+                &appointer_sk,
+                "Spammer",
+                vec![deputy_id; 64],
+            )],
+        };
+        let deputizers = build_deputizers_of(&member_info);
+        assert_eq!(
+            deputizers.get(&deputy_id).map(Vec::len),
+            Some(1),
+            "64 repeated grants must collapse to one appointer"
+        );
     }
 
     /// The conversation's 🛡 badge predicate, end to end.

--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -315,7 +315,9 @@ pub fn MemberInfoModal() -> Element {
                             // Deputy shield — mirrors the member-list 🛡 badge
                             // (freenet/river#451). Shown under the same
                             // viewer-relevant condition as the row, with the
-                            // appointer names in the tooltip.
+                            // same tooltip. The tooltip counts the appointers
+                            // rather than naming them; the names themselves are
+                            // listed below.
                             if deputy_badge.is_some() {
                                 span {
                                     "data-testid": "member-info-deputy-tag",
@@ -323,6 +325,32 @@ pub fn MemberInfoModal() -> Element {
                                     title: "{deputy_tooltip}",
                                     "aria-label": "{deputy_tooltip}",
                                     "🛡 Deputy"
+                                }
+                            }
+                        }
+
+                        // The appointers, by name. This is the ONE surface that
+                        // shows them, and it renders each as its own element on
+                        // purpose: a `title=` attribute is a flat string, so a
+                        // nickname of `Bob, the room owner, Carol` inside one
+                        // reads as three appointers including a role label
+                        // River never granted. One node per appointer makes the
+                        // boundaries real rather than punctuation, so a comma
+                        // inside a name cannot span two of them.
+                        //
+                        // Do NOT collapse this into a joined string, and do NOT
+                        // move these names into the tooltip above. See
+                        // `DeputyBadge::appointer_phrase`.
+                        if let Some(badge) = deputy_badge.as_ref() {
+                            div {
+                                "data-testid": "member-info-deputy-appointers",
+                                class: "mb-4 text-sm text-text-muted",
+                                span { class: "mr-1", "Deputized by:" }
+                                for name in badge.appointer_names() {
+                                    span {
+                                        class: "inline-block px-2 py-0.5 mr-1 mb-1 rounded bg-surface border border-border text-text",
+                                        "{name}"
+                                    }
                                 }
                             }
                         }
@@ -583,5 +611,38 @@ mod ban_gate_tests {
             "the deputy chip's tooltip must come from `DeputyBadge::tooltip` \
              so the wording cannot drift between surfaces (#451)"
         );
+    }
+
+    /// This modal is the only surface that shows appointer NAMES, and it must
+    /// render each as its own element.
+    ///
+    /// The tooltip deliberately names nobody, because a `title=` attribute is a
+    /// flat string in which a nickname of `Bob, the room owner, Carol` reads as
+    /// three appointers including a role label River never granted. Joining
+    /// these names — here or anywhere — rebuilds that exact hole with different
+    /// punctuation, so the shape is pinned rather than left to a comment.
+    #[test]
+    fn modal_lists_appointer_names_as_separate_elements() {
+        let source = include_str!("member_info_modal.rs");
+        let prod = &source[..source
+            .find("#[cfg(test)]")
+            .expect("member_info_modal.rs should have a #[cfg(test)] block")];
+
+        assert!(
+            prod.contains("for name in badge.appointer_names()"),
+            "the appointer names must be iterated into one element each; a \
+             single interpolated string reintroduces the role-label forgery"
+        );
+        for joiner in [
+            "appointer_names().join",
+            "appointer_names().concat",
+            "deputized_by.join",
+        ] {
+            assert!(
+                !prod.contains(joiner),
+                "`{joiner}` flattens attacker-controlled nicknames into one \
+                 string, which is the forgery this shape exists to prevent"
+            );
+        }
     }
 }

--- a/ui/src/util/display_name.rs
+++ b/ui/src/util/display_name.rs
@@ -28,7 +28,12 @@
 //!   name. Confusable-script detection is a different problem with a different
 //!   (much worse) false-positive profile.
 //! * Combining marks are preserved, so a "Zalgo" nickname can still be ugly.
-//!   It cannot forge a badge, which is what this module is for.
+//!   It cannot forge a badge, which is what this module is for. The one
+//!   exception is general category **Me** (Enclosing_Mark), all thirteen of
+//!   which are stripped: an Mn mark decorates the preceding character, but an
+//!   Me mark draws a shape *around* it, so `A\u{20DD}` and `A\u{A670}` both
+//!   render a circled A and rebuild by composition the enclosed-alphanumeric
+//!   glyphs this module strips.
 //! * Sanitising can CREATE a collision: `"B⭐ob"` and `"Bob"` render alike, as
 //!   do two nicknames that differ only in stripped characters. Nicknames were
 //!   never unique in River, so this grants no new capability, but identical
@@ -60,6 +65,14 @@
 //!   covers both the orphans the emoji strip leaves behind and the
 //!   `"Bo\u{200D}b"` clone of `"Bob"`. Keeping them is safe because every
 //!   emoji a joiner could assemble is itself removed.
+//!
+//!   The **Ideographic Variation Selectors** (`U+E0100..U+E01EF`) are the same
+//!   kind of special case, from the other direction: they are
+//!   Default_Ignorable by property, but they SELECT A GLYPH rather than
+//!   rendering as nothing, and a Japanese family name routinely needs one
+//!   (`辻󠄀` is `U+8FBB U+E0100`). Blanket-stripping them rewrote real names and
+//!   locked those users out of saving a nickname at all, so they are judged in
+//!   context too: kept directly after an ideograph, dropped everywhere else.
 //! * **Private-use area** codepoints. Fonts are free to map these to any glyph
 //!   at all (Nerd Fonts map a large PUA range to icons, including shields), so
 //!   a PUA nickname renders as a badge on any machine with such a font
@@ -149,6 +162,18 @@ pub fn is_display_hidden(c: char) -> bool {
         // for: `A\u{20DD}` is Ⓐ, `!\u{20E4}` reads as ⚠. The block has no
         // letter content.
         | 0x20D0..=0x20F0
+        // The rest of Unicode general category Me (Enclosing_Mark). Me draws a
+        // shape AROUND the preceding character, so every one of them composes
+        // a badge the same way U+20DD does: `A\u{A670}` renders a circled A,
+        // which is byte-for-byte the `A\u{20DD}` attack above. Me has thirteen
+        // members; the block above covers seven and these are the other six.
+        // U+0488/U+0489 are the Cyrillic hundred-thousands and millions signs,
+        // U+A670..U+A672 the ten-millions family, U+1ABE the parentheses
+        // overlay. Stripping a whole general category is the exception to the
+        // "combining marks are preserved" rule in the module header: Mn marks
+        // decorate a letter, Me marks enclose it, and only the latter can draw
+        // a badge.
+        | 0x0488..=0x0489 | 0x1ABE | 0xA670..=0xA672
         // 〰 〽 and the two emoji-presented enclosed ideographs ㊗ ㊙. The
         // rest of the CJK punctuation and Enclosed CJK blocks is untouched.
         | 0x3030 | 0x303D | 0x3297 | 0x3299
@@ -203,18 +228,64 @@ pub fn is_display_hidden(c: char) -> bool {
         // Pictographs, Emoticons, Transport, Supplemental Symbols and
         // Pictographs, Symbols and Pictographs Extended-A. 🛡 is U+1F6E1.
         | 0x1F000..=0x1FAFF
-        // Plane 14's Default_Ignorable range. `E0000..E0FFF` is the whole set
-        // Unicode marks ignorable in that plane, so every codepoint in it
-        // renders as nothing; the rest of plane 14 (`E1000..EFFFF`) is not
+        // Plane 14's Default_Ignorable range, MINUS the Ideographic Variation
+        // Selectors. `E0000..E0FFF` is the whole set Unicode marks ignorable
+        // in that plane, and the rest of plane 14 (`E1000..EFFFF`) is not
         // ignorable and is left alone. Naming only the tag block
-        // (`E0000..E007F`, the flag-sequence assembler 🏴󠁧󠁢󠁳󠁣󠁴󠁿) and the variation
-        // selectors supplement left ~3,700 invisible characters through, each
-        // of which clones another member's rendered name.
-        | 0xE0000..=0xE0FFF
+        // (`E0000..E007F`, the flag-sequence assembler 🏴󠁧󠁢󠁳󠁣󠁴󠁿) left ~3,700
+        // invisible characters through, each of which clones another member's
+        // rendered name.
+        //
+        // The hole in the middle, `E0100..E01EF`, is deliberate: those DO
+        // select a glyph rather than rendering as nothing, so they are handled
+        // in context by [`sanitize_display_name`] instead. See
+        // [`is_variation_selector_supplement`].
+        | 0xE0000..=0xE00FF | 0xE01F0..=0xE0FFF
         // Supplementary Private Use Areas A and B.
         | 0xF0000..=0xFFFFD
         | 0x100000..=0x10FFFD
     )
+}
+
+/// Whether `c` is an Ideographic Variation Selector (VS17..VS256).
+///
+/// These sit inside plane 14's Default_Ignorable range but are the one part of
+/// it that is NOT invisible: they SELECT A GLYPH. Japanese family names are
+/// routinely spelled with one — `辻` has the variant `辻󠄀` (U+8FBB U+E0100), and
+/// `邊`/`邉`, `﨑`, `髙` work the same way — and any font with an IVS table
+/// (Source Han, Noto CJK) renders the selected form. Stripping them blanket-
+/// wise rewrote real names, and because [`contains_hidden_chars`] gates the
+/// nickname `<input>`, it also told those users their own name "can't contain
+/// emoji" and refused to save it.
+///
+/// So they are judged in context instead, exactly like `U+200C`/`U+200D`: kept
+/// where they can be doing the work they exist for, dropped everywhere else.
+fn is_variation_selector_supplement(c: char) -> bool {
+    matches!(u32::from(c), 0xE0100..=0xE01EF)
+}
+
+/// The ideographs a variation selector may legitimately follow. These are the
+/// blocks the Ideographic Variation Database actually registers sequences for;
+/// after anything else a selector is invisible filler.
+fn is_ideograph(c: char) -> bool {
+    matches!(u32::from(c),
+        // CJK Unified Ideographs Extension A, and the main block.
+        0x3400..=0x4DBF | 0x4E00..=0x9FFF
+        // CJK Compatibility Ideographs (where `﨑` lives).
+        | 0xF900..=0xFAFF
+        // Extensions B onwards, plus the compatibility supplement.
+        | 0x20000..=0x323AF
+    )
+}
+
+/// Whether the variation selector at `chars[i]` can be selecting a glyph, i.e.
+/// it directly follows an ideograph.
+///
+/// Anywhere else it renders as nothing and clones the surrounding name, so it
+/// is dropped for the same reason an orphaned joiner is. `"Ian\u{E0100}"` is a
+/// clone of `"Ian"`; `"辻\u{E0100}"` is a person's name.
+fn selects_an_ideograph_variant(chars: &[char], i: usize) -> bool {
+    i > 0 && chars.get(i - 1).copied().is_some_and(is_ideograph)
 }
 
 /// Whether `s` contains anything [`sanitize_display_name`] would remove.
@@ -222,8 +293,19 @@ pub fn is_display_hidden(c: char) -> bool {
 /// Drives the nickname `<input>`'s "Nicknames can't contain emoji" message —
 /// UX only. Never rely on this for safety: the render-time strip is the
 /// boundary, because `riverctl` never runs this code.
+///
+/// Position-sensitive for the same characters [`sanitize_display_name`] judges
+/// in context, so it cannot reject a name the sanitiser would have kept: a
+/// variation selector after an ideograph is a legitimate Japanese name and is
+/// NOT flagged, while the same selector after `n` is invisible filler and is.
 pub fn contains_hidden_chars(s: &str) -> bool {
-    s.chars().any(is_display_hidden)
+    let chars: Vec<char> = s.chars().collect();
+    chars.iter().enumerate().any(|(i, c)| {
+        if is_variation_selector_supplement(*c) {
+            return !selects_an_ideograph_variant(&chars, i);
+        }
+        is_display_hidden(*c)
+    })
 }
 
 /// Strip everything [`is_display_hidden`] rejects and tidy the result.
@@ -268,6 +350,10 @@ pub fn sanitize_display_name(raw: &str) -> String {
     //    A joiner between two non-ASCII letters is still kept, so a CJK name
     //    can still be cloned this way. That is the residual documented in the
     //    module header, and it is the same shape as the homoglyph problem.
+    //
+    //    The same pass drops a variation selector that is not selecting an
+    //    ideograph variant — same rule, same reason: kept where it does real
+    //    work, dropped where it is invisible filler.
     let is_joiner = |c: char| c == '\u{200C}' || c == '\u{200D}';
     let joins_letters =
         |c: Option<&char>| c.is_some_and(|c| !c.is_ascii() && !c.is_whitespace() && !is_joiner(*c));
@@ -275,13 +361,30 @@ pub fn sanitize_display_name(raw: &str) -> String {
         .iter()
         .enumerate()
         .filter(|(i, c)| {
+            if is_variation_selector_supplement(**c) {
+                return selects_an_ideograph_variant(&stripped, *i);
+            }
             !is_joiner(**c)
                 || (*i > 0
                     && joins_letters(stripped.get(i - 1))
-                    // A trailing joiner is legitimate (Malayalam chillu), so
-                    // "no next character" is allowed; a next character that is
-                    // present must itself be a non-ASCII letter.
-                    && stripped.get(i + 1).is_none_or(|n| joins_letters(Some(n))))
+                    // A joiner is legitimate at the end of a WORD, not just at
+                    // the end of the string: Malayalam legacy chillu is
+                    // consonant + virama + ZWJ, so `"മോഹന\u{0D4D}\u{200D} കുമാർ"`
+                    // (Mohan Kumar) carries one mid-name, and word-final ZWNJ
+                    // does the same in Persian and Kurdish. Requiring
+                    // end-of-string dropped it and degraded the chillu `ൻ` to
+                    // `ന്`, showing a chandrakkala that is not part of the name.
+                    // So: no next character, a non-ASCII letter, or whitespace.
+                    //
+                    // This does not widen the Latin clone surface — the
+                    // PRECEDING character must still be a non-ASCII letter, so
+                    // `"Bo\u{200D}b"` stays closed. It does add word-final
+                    // positions to the non-ASCII residual already documented in
+                    // the module header (an interior joiner in a CJK name), so
+                    // no new capability, just more places for the same one.
+                    && stripped
+                        .get(i + 1)
+                        .is_none_or(|n| joins_letters(Some(n)) || n.is_whitespace()))
         })
         .map(|(_, c)| *c)
         .collect();
@@ -804,8 +907,19 @@ mod tests {
             // Aegean Numbers + Phaistos Disc, 0x10100..=0x101FC.
             ("U+10100 aegean word separator line", '\u{10100}'),
             ("U+101FC phaistos disc sign wavy band", '\u{101FC}'),
-            // Plane 14's Default_Ignorable range, 0xE0000..=0xE0FFF.
+            // Plane 14's Default_Ignorable range, split around the
+            // Ideographic Variation Selectors into 0xE0000..=0xE00FF and
+            // 0xE01F0..=0xE0FFF. All four endpoints, so the carve-out cannot
+            // silently grow to swallow invisible codepoints on either side.
             ("U+E0000 reserved tag codepoint", '\u{E0000}'),
+            (
+                "U+E00FF reserved, just below the IVS carve-out",
+                '\u{E00FF}',
+            ),
+            (
+                "U+E01F0 reserved, just above the IVS carve-out",
+                '\u{E01F0}',
+            ),
             ("U+E0FFF reserved Default_Ignorable", '\u{E0FFF}'),
         ] {
             assert!(
@@ -880,6 +994,156 @@ mod tests {
                 "{label} was stripped out of a name"
             );
         }
+    }
+
+    /// Unicode general category Me (Enclosing_Mark) in FULL.
+    ///
+    /// Every Me character draws a shape around the character before it, so
+    /// each one composes a badge exactly the way `U+20DD` does. Adding the
+    /// `0x20D0..=0x20F0` block caught seven of the thirteen and left six —
+    /// including `U+A670`, which sits immediately before the `U+A673` this
+    /// module already stripped, and which renders `"Mod A\u{A670}"` as a
+    /// circled A: byte-for-byte the attack the block was added to stop.
+    #[test]
+    fn every_enclosing_mark_is_stripped() {
+        // The complete Me category. If Unicode adds a fourteenth, this list is
+        // the thing to update.
+        const ENCLOSING_MARKS: &[(char, &str)] = &[
+            ('\u{0488}', "COMBINING CYRILLIC HUNDRED THOUSANDS SIGN"),
+            ('\u{0489}', "COMBINING CYRILLIC MILLIONS SIGN"),
+            ('\u{1ABE}', "COMBINING PARENTHESES OVERLAY"),
+            ('\u{20DD}', "COMBINING ENCLOSING CIRCLE"),
+            ('\u{20DE}', "COMBINING ENCLOSING SQUARE"),
+            ('\u{20DF}', "COMBINING ENCLOSING DIAMOND"),
+            ('\u{20E0}', "COMBINING ENCLOSING CIRCLE BACKSLASH"),
+            ('\u{20E2}', "COMBINING ENCLOSING SCREEN"),
+            ('\u{20E3}', "COMBINING ENCLOSING KEYCAP"),
+            ('\u{20E4}', "COMBINING ENCLOSING UPWARD POINTING TRIANGLE"),
+            ('\u{A670}', "COMBINING CYRILLIC TEN MILLIONS SIGN"),
+            ('\u{A671}', "COMBINING CYRILLIC HUNDRED MILLIONS SIGN"),
+            ('\u{A672}', "COMBINING CYRILLIC THOUSAND MILLIONS SIGN"),
+        ];
+        for (mark, name) in ENCLOSING_MARKS {
+            assert!(
+                is_display_hidden(*mark),
+                "U+{:04X} {name} is not stripped, so `A{mark}` composes a badge",
+                u32::from(*mark)
+            );
+            // The concrete attack: a circled/enclosed capital, rebuilt from a
+            // letter the strip cannot remove plus a mark it must.
+            assert_eq!(
+                sanitize_display_name(&format!("Mod A{mark}")),
+                "Mod A",
+                "U+{:04X} {name} survived and encloses the letter before it",
+                u32::from(*mark)
+            );
+            assert!(
+                contains_hidden_chars(&format!("Mod A{mark}")),
+                "U+{:04X} {name} is not rejected at the nickname input",
+                u32::from(*mark)
+            );
+        }
+    }
+
+    /// Malayalam legacy chillu is `consonant + virama + ZWJ` and ends a WORD,
+    /// not only a string. Permitting the trailing joiner solely at
+    /// end-of-string kept the single-token name working (which is all the
+    /// original test covered) while silently breaking the ordinary two-word
+    /// form: the ZWJ was dropped, degrading the chillu `ൻ` to `ന്` and showing
+    /// a chandrakkala that is not part of the name.
+    #[test]
+    fn word_final_joiners_survive_in_multi_word_names() {
+        for (label, name) in [
+            (
+                "Malayalam chillu before a space",
+                "മോഹന\u{0D4D}\u{200D} കുമാർ",
+            ),
+            ("Malayalam chillu at end of string", "മോഹന\u{0D4D}\u{200D}"),
+            ("Persian word-final ZWNJ", "علی\u{200C} رضا"),
+            (
+                "two chillus, two words",
+                "മോഹന\u{0D4D}\u{200D} കുമാരന\u{0D4D}\u{200D}",
+            ),
+        ] {
+            assert_eq!(
+                sanitize_display_name(name),
+                name,
+                "{label}: sanitisation dropped a joiner that is part of the name"
+            );
+            assert!(
+                !contains_hidden_chars(name),
+                "{label}: the nickname input rejected a legitimate name"
+            );
+        }
+
+        // The Latin clone surface must stay closed: the PRECEDING character is
+        // still required to be a non-ASCII letter, so a joiner next to ASCII
+        // is dropped no matter what follows it.
+        assert_eq!(sanitize_display_name("Bo\u{200D}b"), "Bob");
+        assert_eq!(sanitize_display_name("Bob\u{200D} Smith"), "Bob Smith");
+        assert_eq!(sanitize_display_name("Alice \u{200D} Bob"), "Alice Bob");
+    }
+
+    /// The Ideographic Variation Selectors are Default_Ignorable by property
+    /// but DO select a glyph, and Japanese family names need them. Blanket-
+    /// stripping them rewrote real names, and because `contains_hidden_chars`
+    /// gates the nickname `<input>`, it also told those users their own name
+    /// "can't contain emoji" and refused to save it.
+    #[test]
+    fn ideographic_variation_sequences_are_preserved() {
+        for (label, name) in [
+            ("辻 with VS17 (the canonical IVS example)", "辻\u{E0100}"),
+            ("邊 variant", "邊\u{E0101}"),
+            ("﨑 (compatibility ideograph) variant", "﨑\u{E0100}"),
+            ("髙 variant in a full name", "髙\u{E0100}橋 太郎"),
+            ("VS256, the top of the range", "辻\u{E01EF}"),
+        ] {
+            assert_eq!(
+                sanitize_display_name(name),
+                name,
+                "{label}: sanitisation rewrote an ideographic variation sequence"
+            );
+            assert!(
+                !contains_hidden_chars(name),
+                "{label}: the nickname input refused a legitimate Japanese name"
+            );
+        }
+    }
+
+    /// The other half of the IVS carve-out. A selector that is NOT after an
+    /// ideograph selects nothing, renders as nothing, and clones the name it
+    /// sits in — so it must still be dropped AND still be rejected at the
+    /// input. Without this the carve-out would just be a hole.
+    #[test]
+    fn variation_selectors_not_after_an_ideograph_are_still_dropped() {
+        for (label, raw, want) in [
+            ("after an ASCII letter", "Ian\u{E0100} Clarke", "Ian Clarke"),
+            ("after a space", "Ian \u{E0100}Clarke", "Ian Clarke"),
+            ("after Cyrillic (not an ideograph)", "Иван\u{E0100}", "Иван"),
+            (
+                "after Hangul (not an ideograph)",
+                "김민준\u{E0100}",
+                "김민준",
+            ),
+            ("at the very start", "\u{E0100}Ian", "Ian"),
+            (
+                "doubled after an ideograph",
+                "辻\u{E0100}\u{E0100}",
+                "辻\u{E0100}",
+            ),
+        ] {
+            assert_eq!(
+                sanitize_display_name(raw),
+                want,
+                "{label}: a non-selecting variation selector survived and clones a name"
+            );
+            assert!(
+                contains_hidden_chars(raw),
+                "{label}: a non-selecting variation selector is not rejected at the input"
+            );
+        }
+        // Alone it is not a name at all.
+        assert_eq!(sanitize_display_name("\u{E0100}"), UNNAMED);
     }
 
     #[test]

--- a/ui/src/util/display_name.rs
+++ b/ui/src/util/display_name.rs
@@ -142,8 +142,13 @@ pub fn is_display_hidden(c: char) -> bool {
         | 0x2900..=0x297F
         // Miscellaneous Symbols and Arrows (⬛ ⭐ …).
         | 0x2B00..=0x2BFF
-        // Combining enclosing keycap (the `1️⃣` assembler).
-        | 0x20E3
+        // Combining Diacritical Marks for Symbols. Includes the keycap
+        // assembler (`1️⃣`) but also the ENCLOSING marks — U+20DD circle,
+        // U+20DE square, U+20E0 circle-backslash, U+20E4 triangle — which
+        // rebuild by composition the very glyphs `0x2460..=0x24FF` is stripped
+        // for: `A\u{20DD}` is Ⓐ, `!\u{20E4}` reads as ⚠. The block has no
+        // letter content.
+        | 0x20D0..=0x20F0
         // 〰 〽 and the two emoji-presented enclosed ideographs ㊗ ㊙. The
         // rest of the CJK punctuation and Enclosed CJK blocks is untouched.
         | 0x3030 | 0x303D | 0x3297 | 0x3299
@@ -158,7 +163,7 @@ pub fn is_display_hidden(c: char) -> bool {
         // U+00AD SOFT HYPHEN and U+180E MONGOLIAN VOWEL SEPARATOR render as
         // nothing; U+FFF9..U+FFFB are interlinear annotation anchors that hide
         // the text between them.
-        | 0x00AD | 0x061C | 0x180E | 0xFFF9..=0xFFFB
+        | 0x00AD | 0x061C | 0x180E | 0xFFF0..=0xFFFB
         // Blank glyphs that are not whitespace, so the space collapse below
         // would not remove them: they let two members share a pixel-identical
         // rendered name (`Alice` vs `Alice\u{3164}`), which undermines the
@@ -175,13 +180,20 @@ pub fn is_display_hidden(c: char) -> bool {
         // Selectors Supplement (U+FE00..FE0F's big brother), and the
         // shorthand-format and musical beam/slur/phrase controls.
         | 0x034F | 0x180B..=0x180D | 0x180F | 0x17B4..=0x17B5 | 0x2065
-        | 0xE0100..=0xE01EF | 0x1BCA0..=0x1BCA3 | 0x1D173..=0x1D17A
+        | 0x1BCA0..=0x1BCA3 | 0x1D173..=0x1D17A
         // Text-presentation symbols that read as a badge in the fonts that
         // carry them: ۞ (ornate star, present wherever Arabic renders), ٭,
         // ꙳, and the Phaistos shield. Plus Symbols for Legacy Computing and
         // its supplement, which contain an inverse check mark and stick
         // figures.
-        | 0x066D | 0x06DE | 0xA673 | 0x101DB
+        | 0x066D | 0x06DE | 0xA673
+        // Aegean/Phaistos: picking out only the shield (U+101DB) left the
+        // helmet, tiara, rosette and — the one that matters — U+10102 AEGEAN
+        // CHECK MARK, which renders as ✓ wherever Noto Sans Symbols is
+        // installed (stock Ubuntu/Fedora).
+        | 0x10100..=0x101FC
+        // Halfwidth clones of the geometric shapes stripped above.
+        | 0xFFED..=0xFFEE
         | 0x1FB00..=0x1FBFF | 0x1CC00..=0x1CEBF
         // Private Use Area (BMP). Font-defined glyphs, and River's own
         // mention sentinels live at U+E000/U+E001.
@@ -191,8 +203,13 @@ pub fn is_display_hidden(c: char) -> bool {
         // Pictographs, Emoticons, Transport, Supplemental Symbols and
         // Pictographs, Symbols and Pictographs Extended-A. 🛡 is U+1F6E1.
         | 0x1F000..=0x1FAFF
-        // Tags — the flag-sequence assembler (🏴󠁧󠁢󠁳󠁣󠁴󠁿).
-        | 0xE0000..=0xE007F
+        // ALL of plane 14. It is Default_Ignorable end to end (HarfBuzz, which
+        // backs Chrome/Firefox/Android, treats the whole plane that way), so
+        // every codepoint in it renders as nothing. Naming only the tag block
+        // (`E0000..E007F`, the flag-sequence assembler 🏴󠁧󠁢󠁳󠁣󠁴󠁿) and the variation
+        // selectors supplement left ~3,700 invisible characters through, each
+        // of which clones another member's rendered name.
+        | 0xE0000..=0xE0FFF
         // Supplementary Private Use Areas A and B.
         | 0xF0000..=0xFFFFD
         | 0x100000..=0x10FFFD
@@ -704,6 +721,59 @@ mod tests {
              nickname can forge a 🛡 deputy badge there:\n  {}",
             offenders.join("\n  ")
         );
+    }
+
+    /// Every Default_Ignorable character renders as nothing, so any one of
+    /// them clones another member's rendered name — the exact capability an
+    /// impersonation campaign wants. The first pass named only the ranges it
+    /// happened to think of and left ~3,700 through, including all of plane 14
+    /// and `U+FFF0..U+FFF8`. These are NOT riverctl-only: `contains_hidden_chars`
+    /// gates the nickname input, so a miss means the UI accepts them too.
+    #[test]
+    fn default_ignorable_characters_cannot_clone_a_name() {
+        for c in [
+            '\u{FFF0}',
+            '\u{FFF4}',
+            '\u{FFF8}', // the FFFx reserved-DI gap
+            '\u{E0001}',
+            '\u{E0080}',
+            '\u{E00FF}', // plane 14 outside the tag block
+            '\u{E01F0}',
+            '\u{E0FFF}', // plane 14 above the variation selectors
+            '\u{E0100}', // variation selectors supplement
+        ] {
+            let cloned = format!("Ian{c} Clarke");
+            assert_eq!(
+                sanitize_display_name(&cloned),
+                "Ian Clarke",
+                "U+{:04X} survived and clones another member's name",
+                u32::from(c)
+            );
+            assert!(
+                contains_hidden_chars(&cloned),
+                "U+{:04X} is not rejected at the nickname input",
+                u32::from(c)
+            );
+            // Alone, it must not pass as a name at all.
+            assert_eq!(sanitize_display_name(&c.to_string()), UNNAMED);
+        }
+    }
+
+    /// Enclosing combining marks rebuild by composition the badge-shaped
+    /// glyphs the enclosed-alphanumeric block is stripped for, and the Aegean
+    /// check mark renders as ✓ on a stock Linux desktop.
+    #[test]
+    fn composed_and_stray_badge_glyphs_are_stripped() {
+        for (label, name, want) in [
+            ("enclosing circle (Ⓐ)", "Mod A\u{20DD}", "Mod A"),
+            ("enclosing square", "Mod A\u{20DE}", "Mod A"),
+            ("enclosing triangle (⚠-ish)", "Mod !\u{20E4}", "Mod !"),
+            ("Aegean check mark", "Mod \u{10102}", "Mod"),
+            ("halfwidth black square", "Mod \u{FFED}", "Mod"),
+        ] {
+            let out = sanitize_display_name(name);
+            assert_eq!(out, want, "{label}: got {out:?}");
+        }
     }
 
     #[test]

--- a/ui/src/util/display_name.rs
+++ b/ui/src/util/display_name.rs
@@ -203,9 +203,10 @@ pub fn is_display_hidden(c: char) -> bool {
         // Pictographs, Emoticons, Transport, Supplemental Symbols and
         // Pictographs, Symbols and Pictographs Extended-A. 🛡 is U+1F6E1.
         | 0x1F000..=0x1FAFF
-        // ALL of plane 14. It is Default_Ignorable end to end (HarfBuzz, which
-        // backs Chrome/Firefox/Android, treats the whole plane that way), so
-        // every codepoint in it renders as nothing. Naming only the tag block
+        // Plane 14's Default_Ignorable range. `E0000..E0FFF` is the whole set
+        // Unicode marks ignorable in that plane, so every codepoint in it
+        // renders as nothing; the rest of plane 14 (`E1000..EFFFF`) is not
+        // ignorable and is left alone. Naming only the tag block
         // (`E0000..E007F`, the flag-sequence assembler 🏴󠁧󠁢󠁳󠁣󠁴󠁿) and the variation
         // selectors supplement left ~3,700 invisible characters through, each
         // of which clones another member's rendered name.
@@ -773,6 +774,111 @@ mod tests {
         ] {
             let out = sanitize_display_name(name);
             assert_eq!(out, want, "{label}: got {out:?}");
+        }
+    }
+
+    /// Both ends of every range widened here, plus the two codepoints the
+    /// widening comments name by hand (`U+20E0`, `U+20E3`).
+    ///
+    /// The tests above sample INTERIOR points, which catches a deleted range
+    /// but not a range narrowed by one, and off-by-one is the likelier edit.
+    /// Every entry below is a codepoint whose loss reopens a real vector: a
+    /// combining mark that rebuilds a badge by composition, an interlinear
+    /// annotation anchor that hides the text between two of them, or an
+    /// invisible plane-14 codepoint that clones another member's name.
+    #[test]
+    fn widened_range_endpoints_are_hidden() {
+        for (label, c) in [
+            // Combining Diacritical Marks for Symbols, 0x20D0..=0x20F0.
+            ("U+20D0 combining left harpoon above", '\u{20D0}'),
+            ("U+20E0 combining enclosing circle backslash", '\u{20E0}'),
+            ("U+20E3 combining enclosing keycap", '\u{20E3}'),
+            ("U+20F0 combining asterisk above", '\u{20F0}'),
+            // Halfwidth geometric shapes, 0xFFED..=0xFFEE.
+            ("U+FFED halfwidth black square", '\u{FFED}'),
+            ("U+FFEE halfwidth white circle", '\u{FFEE}'),
+            // Reserved Default_Ignorables + interlinear annotation,
+            // 0xFFF0..=0xFFFB.
+            ("U+FFF0 reserved Default_Ignorable", '\u{FFF0}'),
+            ("U+FFFB interlinear annotation terminator", '\u{FFFB}'),
+            // Aegean Numbers + Phaistos Disc, 0x10100..=0x101FC.
+            ("U+10100 aegean word separator line", '\u{10100}'),
+            ("U+101FC phaistos disc sign wavy band", '\u{101FC}'),
+            // Plane 14's Default_Ignorable range, 0xE0000..=0xE0FFF.
+            ("U+E0000 reserved tag codepoint", '\u{E0000}'),
+            ("U+E0FFF reserved Default_Ignorable", '\u{E0FFF}'),
+        ] {
+            assert!(
+                is_display_hidden(c),
+                "{label} is not stripped, so it can forge a badge or clone a name"
+            );
+            let cloned = format!("Ian{c} Clarke");
+            assert_eq!(
+                sanitize_display_name(&cloned),
+                "Ian Clarke",
+                "{label} survived sanitisation"
+            );
+            assert!(
+                contains_hidden_chars(&cloned),
+                "{label} is not rejected at the nickname input"
+            );
+        }
+    }
+
+    /// The upper constraint on every range widened here.
+    ///
+    /// Endpoint and interior assertions only pin a range from BELOW: they all
+    /// still pass if a future edit widens it further, which is how a strip rule
+    /// starts mangling real names. Widening `0xFFF0..=0xFFFB` to swallow
+    /// U+FFFD REPLACEMENT CHARACTER, or plane 14 to `0xEFFFF`, passes every
+    /// other test in this module.
+    #[test]
+    fn characters_just_outside_the_widened_ranges_stay_visible() {
+        for (label, c) in [
+            // Either side of 0x20D0..=0x20F0. Reserved codepoints render as a
+            // tofu box, so they are visible and cannot clone a name.
+            (
+                "U+20CF reserved, below the symbol combining marks",
+                '\u{20CF}',
+            ),
+            (
+                "U+20F1 reserved, above the symbol combining marks",
+                '\u{20F1}',
+            ),
+            // Below 0xFFED..=0xFFEE.
+            ("U+FFEC halfwidth downwards arrow", '\u{FFEC}'),
+            // The one-codepoint gap between 0xFFED..=0xFFEE and 0xFFF0..=0xFFFB,
+            // so this pins the top of one range and the bottom of the other.
+            ("U+FFEF reserved", '\u{FFEF}'),
+            // Above 0xFFF0..=0xFFFB. U+FFFD is what `String::from_utf8_lossy`
+            // emits, and `display_nickname`'s undecryptable fallback goes
+            // through it, so stripping it would blank a whole nickname.
+            ("U+FFFC object replacement character", '\u{FFFC}'),
+            ("U+FFFD replacement character", '\u{FFFD}'),
+            // Either side of 0x10100..=0x101FC.
+            ("U+100FF reserved, below Aegean Numbers", '\u{100FF}'),
+            (
+                "U+101FD phaistos disc combining oblique stroke",
+                '\u{101FD}',
+            ),
+            // Either side of 0xE0000..=0xE0FFF. Unicode's Default_Ignorable set
+            // for plane 14 ends at E0FFF; E1000 and up are ordinary reserved
+            // codepoints, and plane 13 below it is unassigned throughout.
+            ("U+DFFFF reserved, below plane 14", '\u{DFFFF}'),
+            ("U+E1000 reserved, above plane 14's ignorables", '\u{E1000}'),
+            ("U+EFFFF reserved, top of plane 14", '\u{EFFFF}'),
+        ] {
+            assert!(
+                !is_display_hidden(c),
+                "{label} is treated as hidden, so a widened range is now \
+                 stripping characters that are not invisible"
+            );
+            let name = format!("Ian{c} Clarke");
+            assert_eq!(
+                sanitize_display_name(&name),
+                name,
+                "{label} was stripped out of a name"
+            );
         }
     }
 

--- a/ui/src/util/display_name.rs
+++ b/ui/src/util/display_name.rs
@@ -228,19 +228,24 @@ pub fn is_display_hidden(c: char) -> bool {
         // Pictographs, Emoticons, Transport, Supplemental Symbols and
         // Pictographs, Symbols and Pictographs Extended-A. 🛡 is U+1F6E1.
         | 0x1F000..=0x1FAFF
-        // Plane 14's Default_Ignorable range, MINUS the Ideographic Variation
-        // Selectors. `E0000..E0FFF` is the whole set Unicode marks ignorable
-        // in that plane, and the rest of plane 14 (`E1000..EFFFF`) is not
-        // ignorable and is left alone. Naming only the tag block
-        // (`E0000..E007F`, the flag-sequence assembler 🏴󠁧󠁢󠁳󠁣󠁴󠁿) left ~3,700
-        // invisible characters through, each of which clones another member's
-        // rendered name.
+        // Plane 14's Default_Ignorable range. `E0000..E0FFF` is the whole set
+        // Unicode marks ignorable in that plane, and the rest of plane 14
+        // (`E1000..EFFFF`) is not ignorable and is left alone. Naming only the
+        // tag block (`E0000..E007F`, the flag-sequence assembler 🏴󠁧󠁢󠁳󠁣󠁴󠁿) left
+        // ~3,700 invisible characters through, each of which clones another
+        // member's rendered name.
         //
-        // The hole in the middle, `E0100..E01EF`, is deliberate: those DO
-        // select a glyph rather than rendering as nothing, so they are handled
-        // in context by [`sanitize_display_name`] instead. See
-        // [`is_variation_selector_supplement`].
-        | 0xE0000..=0xE00FF | 0xE01F0..=0xE0FFF
+        // The Ideographic Variation Selectors (`E0100..E01EF`) are INSIDE this
+        // range on purpose, even though they are the one part of it that is
+        // legitimate in a name. Their exception is applied ON TOP, in context,
+        // by [`sanitize_display_name`] and [`contains_hidden_chars`] — NOT by
+        // punching a hole here. Two complementary hand-written ranges drift:
+        // narrowing the carve-out by one codepoint leaves a character that is
+        // neither stripped nor judged, so it survives verbatim in every name
+        // while rendering as nothing. Layering makes that gap impossible, and
+        // `no_plane_14_codepoint_escapes_both_the_strip_and_the_carve_out`
+        // fails if anyone splits it again.
+        | 0xE0000..=0xE0FFF
         // Supplementary Private Use Areas A and B.
         | 0xF0000..=0xFFFFD
         | 0x100000..=0x10FFFD
@@ -327,12 +332,25 @@ pub fn contains_hidden_chars(s: &str) -> bool {
 pub fn sanitize_display_name(raw: &str) -> String {
     // 1. Remove the hidden characters. A hidden character that was itself
     //    whitespace becomes a space so words don't run together.
-    let stripped: Vec<char> = raw
-        .chars()
-        .filter_map(|c| match (is_display_hidden(c), c.is_whitespace()) {
-            (true, true) => Some(' '),
-            (true, false) => None,
-            (false, _) => Some(c),
+    //
+    //    A variation selector is judged here rather than by the blanket strip,
+    //    because whether it is a Japanese name or invisible filler depends on
+    //    what precedes it. Same decision, same inputs as
+    //    [`contains_hidden_chars`], so the input check and the render strip
+    //    cannot disagree about a given name.
+    let raw_chars: Vec<char> = raw.chars().collect();
+    let stripped: Vec<char> = raw_chars
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &c)| {
+            if is_variation_selector_supplement(c) {
+                return selects_an_ideograph_variant(&raw_chars, i).then_some(c);
+            }
+            match (is_display_hidden(c), c.is_whitespace()) {
+                (true, true) => Some(' '),
+                (true, false) => None,
+                (false, _) => Some(c),
+            }
         })
         .collect();
 
@@ -350,10 +368,6 @@ pub fn sanitize_display_name(raw: &str) -> String {
     //    A joiner between two non-ASCII letters is still kept, so a CJK name
     //    can still be cloned this way. That is the residual documented in the
     //    module header, and it is the same shape as the homoglyph problem.
-    //
-    //    The same pass drops a variation selector that is not selecting an
-    //    ideograph variant — same rule, same reason: kept where it does real
-    //    work, dropped where it is invisible filler.
     let is_joiner = |c: char| c == '\u{200C}' || c == '\u{200D}';
     let joins_letters =
         |c: Option<&char>| c.is_some_and(|c| !c.is_ascii() && !c.is_whitespace() && !is_joiner(*c));
@@ -361,9 +375,6 @@ pub fn sanitize_display_name(raw: &str) -> String {
         .iter()
         .enumerate()
         .filter(|(i, c)| {
-            if is_variation_selector_supplement(**c) {
-                return selects_an_ideograph_variant(&stripped, *i);
-            }
             !is_joiner(**c)
                 || (*i > 0
                     && joins_letters(stripped.get(i - 1))
@@ -907,10 +918,9 @@ mod tests {
             // Aegean Numbers + Phaistos Disc, 0x10100..=0x101FC.
             ("U+10100 aegean word separator line", '\u{10100}'),
             ("U+101FC phaistos disc sign wavy band", '\u{101FC}'),
-            // Plane 14's Default_Ignorable range, split around the
-            // Ideographic Variation Selectors into 0xE0000..=0xE00FF and
-            // 0xE01F0..=0xE0FFF. All four endpoints, so the carve-out cannot
-            // silently grow to swallow invisible codepoints on either side.
+            // Plane 14's Default_Ignorable range, 0xE0000..=0xE0FFF, plus
+            // 0xE01F0..=0xE0FFF, the two codepoints flanking the
+            // variation-selector carve-out layered on top of it.
             ("U+E0000 reserved tag codepoint", '\u{E0000}'),
             (
                 "U+E00FF reserved, just below the IVS carve-out",
@@ -1106,6 +1116,42 @@ mod tests {
             assert!(
                 !contains_hidden_chars(name),
                 "{label}: the nickname input refused a legitimate Japanese name"
+            );
+        }
+    }
+
+    /// No codepoint in plane 14's Default_Ignorable range may fall through BOTH
+    /// the blanket strip and the context-judged variation-selector carve-out.
+    ///
+    /// The two used to be complementary hand-written ranges
+    /// (`E0000..E00FF | E01F0..E0FFF` in [`is_display_hidden`], `E0100..E01EF`
+    /// in [`is_variation_selector_supplement`]). Mutation testing showed that
+    /// narrowing the carve-out by ONE codepoint left `U+E01EF` in neither: not
+    /// stripped, not judged, kept verbatim in every name while rendering as
+    /// nothing — a free clone vector, and every other test still passed. The
+    /// ranges are now layered rather than complementary, so the gap is
+    /// structurally impossible; this sweep is what fails if anyone splits them
+    /// again.
+    #[test]
+    fn no_plane_14_codepoint_escapes_both_the_strip_and_the_carve_out() {
+        for cp in 0xE0000u32..=0xE0FFF {
+            let c = char::from_u32(cp).expect("all of plane 14 is valid scalars");
+            assert!(
+                is_display_hidden(c) || is_variation_selector_supplement(c),
+                "U+{cp:04X} is neither stripped nor context-judged, so it \
+                 survives verbatim while rendering as nothing"
+            );
+            // The decision that matters: after a non-ideograph, every one of
+            // them must go, whichever of the two paths handles it.
+            let cloned = format!("Ian{c} Clarke");
+            assert_eq!(
+                sanitize_display_name(&cloned),
+                "Ian Clarke",
+                "U+{cp:04X} survived after an ASCII letter and clones a name"
+            );
+            assert!(
+                contains_hidden_chars(&cloned),
+                "U+{cp:04X} is not rejected at the nickname input"
             );
         }
     }

--- a/ui/src/util/display_name.rs
+++ b/ui/src/util/display_name.rs
@@ -45,6 +45,26 @@
 //!   `conversation::mention::duplicate_candidate_names` compares name STRINGS,
 //!   so it does not flag a pair that differs only in kept characters.
 //!
+//!   The two characters kept in context — a joiner between non-ASCII letters,
+//!   and an Ideographic Variation Selector after an ideograph — are the whole
+//!   of that residual. `"李\u{E0100}小龍"` and `"李小龍"` render alike on a font
+//!   with no IVD entry for the sequence, exactly as `"李\u{200D}小龍"` does. It
+//!   is bounded: neither survives after an ASCII, Cyrillic or Hangul letter, so
+//!   a Latin name cannot be cloned this way, and a font that DOES carry the IVD
+//!   entry renders the two differently.
+//!
+//!   **This residual is mitigated, and the mitigation is load-bearing on the
+//!   layering below.** `confusable.rs::skeleton` folds a name for
+//!   impersonation detection by dropping every character [`is_display_hidden`]
+//!   reports, and it consults that function DIRECTLY. Because the variation
+//!   selectors stay inside `is_display_hidden`'s plane-14 range and their
+//!   exception is applied on top, `skeleton` still folds `"李\u{E0100}小龍"` and
+//!   `"李小龍"` to the same value, so the confusable warning fires on exactly
+//!   this residual. Anyone tempted to "simplify" by moving the carve-out INTO
+//!   [`is_display_hidden`] — punching a hole in the range rather than layering
+//!   over it — would silently switch that warning off and make the residual
+//!   undetectable. Do not.
+//!
 //! ## What gets removed
 //!
 //! Emoji and pictographic symbols (the badge-forgery vector), plus two classes
@@ -239,7 +259,16 @@ pub fn is_display_hidden(c: char) -> bool {
         // range on purpose, even though they are the one part of it that is
         // legitimate in a name. Their exception is applied ON TOP, in context,
         // by [`sanitize_display_name`] and [`contains_hidden_chars`] — NOT by
-        // punching a hole here. Two complementary hand-written ranges drift:
+        // punching a hole here. TWO separate things depend on that.
+        //
+        // First, `confusable.rs::skeleton` folds names for impersonation
+        // detection by calling THIS function directly. Keeping the selectors
+        // inside the range is what lets it fold `"李\u{E0100}小龍"` and
+        // `"李小龍"` together, so the confusable warning covers the residual
+        // the in-context exception deliberately leaves open (module header).
+        // Punching a hole here would switch that warning off silently.
+        //
+        // Second, two complementary hand-written ranges drift:
         // narrowing the carve-out by one codepoint leaves a character that is
         // neither stripped nor judged, so it survives verbatim in every name
         // while rendering as nothing. Layering makes that gap impossible, and
@@ -1016,8 +1045,10 @@ mod tests {
     /// circled A: byte-for-byte the attack the block was added to stop.
     #[test]
     fn every_enclosing_mark_is_stripped() {
-        // The complete Me category. If Unicode adds a fourteenth, this list is
-        // the thing to update.
+        // The complete Me category, verified against the Unicode 15.0
+        // character database rather than assembled from memory: these thirteen
+        // are every codepoint with `category == "Me"`. If a later revision adds
+        // a fourteenth, this list is the thing to update.
         const ENCLOSING_MARKS: &[(char, &str)] = &[
             ('\u{0488}', "COMBINING CYRILLIC HUNDRED THOUSANDS SIGN"),
             ('\u{0489}', "COMBINING CYRILLIC MILLIONS SIGN"),


### PR DESCRIPTION
## Problem

An adversarial review of the badge/nickname code **#473 already shipped** found four name-impersonation vectors that survived it. They are live (published as 30000357), and the Official room is under an active impersonation campaign, so they are worth closing on their own rather than waiting for the impersonation-marker work.

### 1. ~3,700 invisible characters survived the strip (the important one)

`is_display_hidden` enumerated `U+FFF9..FFFB` and two hand-picked plane-14 sub-ranges, which left `U+FFF0..U+FFF8` and most of plane 14 (`E0080..E00FF`, `E01F0..E0FFF`) through. Every one is Default_Ignorable — HarfBuzz, which backs Chrome, Firefox and Android, treats the whole of plane 14 that way — so it renders as nothing:

```
"Ian\u{FFF0} Clarke"   renders pixel-identical to  "Ian Clarke"
"Ian\u{E0FFF} Clarke"  same
"\u{FFF0}"             a nickname that renders completely blank
```

Two consequences beyond the obvious clone:

- **Not riverctl-only.** `contains_hidden_chars` gates the nickname `<input>`, so it returned `false` for these and the UI accepted them from an ordinary paste-and-save.
- **It defeats the @-mention picker's own anti-collision mechanism.** `duplicate_candidate_names` compares name *strings*, so two members whose names differ only by an invisible character show as two identical `@Ian Clarke` rows with **no** disambiguating member id.

Plane 14 is now covered end to end rather than by enumerated sub-ranges, which is also what stops this recurring the next time someone adds a range.

### 2. Enclosing combining marks rebuilt the glyphs the table strips

`U+2460..U+24FF` (Ⓐ, ①) is stripped, but the enclosing marks that compose the same thing were not:

```
"Mod A\u{20DD}"  → Ⓐ  (enclosing circle)
"Mod !\u{20E4}"  → ! in a triangle, reads as ⚠
"Mod A\u{20E0}"  → 🚫-style prohibition overlay
```

Also `U+10102` AEGEAN CHECK MARK, which renders as ✓ wherever Noto Sans Symbols is installed (stock Ubuntu/Fedora), and the halfwidth clones of the geometric shapes.

### 3. The shield tooltip's appointer quoting was decorative, not protective

The tooltip joins appointers into one flat string and leaves the role labels (`the room owner`, `you`) unquoted precisely so a nickname cannot masquerade as them. But the quote characters were never stripped *from the nickname*, so:

- nickname `Bob”, the room owner, “Carol`
- put a sockpuppet in your `deputies`
- every viewer in your subtree sees `Deputy (appointed by “Bob”, the room owner, “Carol”). Can ban you.`

That unquoted `the room owner` is the forged global-moderator appointment the quoting exists to prevent. Sanitising cannot help — the payload *is* the quote characters. Requires being the victim's invite-ancestor, which an impersonator who invites people satisfies.

### 4. Two smaller ones

- **`deputies` was not deduplicated.** `MAX_DEPUTIES` bounds the length but nothing rejects repeats, so `[sockpuppet; 64]` named the same appointer 64 times and buried the tooltip's real content.
- **Notification previews flattened only `\n`/`\r`,** not `U+2028`, `U+2029` or `U+0085` — leaving exactly the second-line forgery the existing comment describes ("a moderator with a 🛡 in it").

## Testing

`cargo test -p river-ui --bins --all-features` — 555 passed. `cargo fmt` + `clippy` clean.

Five new tests. **Each was verified to fail when its own fix is reverted** — I reverted all four production changes together and confirmed all four tests go red, then restored:

| Test | Reverted → |
|---|---|
| `default_ignorable_characters_cannot_clone_a_name` | FAILED |
| `composed_and_stray_badge_glyphs_are_stripped` | FAILED |
| `appointer_names_cannot_inject_a_role_label` | FAILED |
| `duplicate_deputy_entries_are_collapsed` | FAILED |

The first also asserts `contains_hidden_chars` rejects each character, so the input-side gap is pinned as well as the render-side one.

## What the review could NOT break

Recorded because a clean result is only useful if you know what was tried: every BMP `Emoji=Yes` codepoint is covered; all Nerd Fonts ranges (Pomicons, Powerline, Font Awesome, Codicons, Octicons, Weather, Material Design) are covered via the PUA ranges; bidi cannot detach the badge from its owner because the name and the shield are separate flex items; a member cannot forge the owner's `deputies` because `MemberInfoV1::verify` checks the signature against the key named in `member_id`; and the mention chip escapes both text and attributes.

Known and unchanged: homoglyphs are deliberately not stripped (a Cyrillic `а` is a legitimate letter) — that is what the impersonation *markers* are for, and they follow separately. Mathematical Alphanumeric Symbols (`𝗜𝗮𝗻 𝗖𝗹𝗮𝗿𝗸𝗲`) also survive; they have no legitimate name use and are worth a decision, but stripping them is a behaviour change rather than a gap-closure so I left it out of this PR.

## Scope

UI-only — no `contracts/`, no `common/`, no serialized types, no WASM.

`⚠️ Do not publish from this branch` — the River master agent owns publishing.

[AI-assisted - Claude]
