### PR TITLE
feat(ui): warn on names visually confusable with a moderator's

### DIFF
--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -7,8 +7,12 @@ use crate::components::app::{
     MobileView, CURRENT_ROOM, EDIT_ROOM_MODAL, MEMBER_INFO_MODAL, MOBILE_VIEW, NOTIFICATION_MODAL,
     ROOMS,
 };
-use crate::components::members::{deputy_badges_for_viewer, DeputyBadge};
+use crate::components::members::{
+    deputy_badges_for_viewer, impersonation_checker_for_viewer, impersonation_warning_for_display,
+    DeputyBadge,
+};
 use crate::room_data::{NotificationMode, SendMessageError};
+use crate::util::confusable::{ImpersonationChecker, ImpersonationWarning};
 use crate::util::display_name::{display_nickname, sanitize_display_name};
 use crate::util::ecies::{encrypt_with_symmetric_key, unseal_bytes_with_secrets};
 use crate::util::{
@@ -84,6 +88,14 @@ struct MessageGroup {
     /// See [`DeputyBadge`] for the predicate and why visibility and the
     /// "can ban you" wording are separate questions.
     author_badge: Option<DeputyBadge>,
+    /// The ⚠ impersonation warning for this author, or `None`. Same value, and
+    /// therefore the same tier rule and tooltip, the member-list row shows —
+    /// both go through
+    /// [`crate::components::members::impersonation_warning_for_display`].
+    ///
+    /// Mutually exclusive with `author_badge`: a shielded author is a deputy,
+    /// and a deputy is never warned about.
+    author_impersonation: Option<ImpersonationWarning>,
     is_self: bool,
     first_time: DateTime<Utc>,
     /// True if any message in this group had a future timestamp that was clamped
@@ -433,6 +445,10 @@ fn group_messages(
     // Which members show a 🛡 shield in THIS viewer's conversation, built once
     // per render by `deputy_badges_for_viewer`. Absent ⇒ no shield.
     deputy_badges: &HashMap<MemberId, DeputyBadge>,
+    // The ⚠ impersonation checker for this viewer, built once per render by
+    // `impersonation_checker_for_viewer` — passed in rather than built here so
+    // the protected set is folded once, not once per call.
+    impersonation: &ImpersonationChecker,
 ) -> Vec<DisplayItem> {
     let mut items: Vec<DisplayItem> = Vec::new();
     let group_threshold = Duration::from_secs(5 * 60); // 5 minutes
@@ -544,10 +560,16 @@ fn group_messages(
                 group.messages.push(grouped_message);
             }
         } else {
+            // Once per GROUP, not once per message: consecutive messages from
+            // one author share a header, so the warning is a property of the
+            // group.
+            let author_impersonation =
+                impersonation_warning_for_display(impersonation, author_id, &author_name);
             items.push(DisplayItem::Messages(MessageGroup {
                 author_id,
                 author_name,
                 author_badge: deputy_badges.get(&author_id).cloned(),
+                author_impersonation,
                 is_self,
                 first_time: message_time,
                 time_clamped,
@@ -1410,6 +1432,15 @@ pub fn Conversation() -> Element {
                         MemberId::from(&key),
                         self_member_id,
                     );
+                    // The ⚠ impersonation checker, from the SAME badge map, so
+                    // "who is a deputy" has one answer across the conversation
+                    // and the member list. Built once here, like the badges.
+                    let impersonation = impersonation_checker_for_viewer(
+                        &room_state.member_info,
+                        &room_data.secrets,
+                        MemberId::from(&key),
+                        &deputy_badges,
+                    );
                     let groups = group_messages(
                         &room_state.recent_messages,
                         &room_state.member_info,
@@ -1417,6 +1448,7 @@ pub fn Conversation() -> Element {
                         &room_data.secrets,
                         &member_names,
                         &deputy_badges,
+                        &impersonation,
                     );
                     return Some((groups, self_member_id, member_names));
                 }
@@ -2937,6 +2969,31 @@ fn MessageGroupComponent(
                                 });
                             },
                             "{group.author_name}"
+                        }
+                        // Impersonation warning. Sits immediately after the
+                        // name, before the shield slot — the two are mutually
+                        // exclusive (a shielded author is a deputy, and a
+                        // deputy is never warned about), so this is a single
+                        // badge position in practice.
+                        //
+                        // The nickname above cannot forge this glyph: U+26A0 is
+                        // inside the range `display_name::is_display_hidden`
+                        // strips, so it can never survive into a rendered
+                        // nickname. `the_warning_glyph_cannot_appear_in_a_nickname`
+                        // pins that.
+                        if let Some(warning) = group.author_impersonation.as_ref() {
+                            {
+                                let tooltip = warning.tooltip();
+                                rsx! {
+                                    span {
+                                        "data-testid": "message-author-impersonation-warning",
+                                        class: "text-sm cursor-default",
+                                        title: "{tooltip}",
+                                        "aria-label": "{tooltip}",
+                                        {crate::util::confusable::WARNING_GLYPH}
+                                    }
+                                }
+                            }
                         }
                         // Deputy shield. Same glyph, same visibility rule and
                         // the same tooltip as the member-list row and the

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -9,7 +9,7 @@ use crate::components::app::{
 };
 use crate::components::members::{
     deputy_badges_for_viewer, impersonation_checker_for_viewer, impersonation_warning_for_display,
-    DeputyBadge,
+    privilege_in_view, DeputyBadge,
 };
 use crate::room_data::{NotificationMode, SendMessageError};
 use crate::util::confusable::{ImpersonationChecker, ImpersonationWarning};
@@ -93,8 +93,14 @@ struct MessageGroup {
     /// both go through
     /// [`crate::components::members::impersonation_warning_for_display`].
     ///
-    /// Mutually exclusive with `author_badge`: a shielded author is a deputy,
-    /// and a deputy is never warned about.
+    /// **NOT mutually exclusive with `author_badge`.** A deputy IS warned about
+    /// when their name collides with another protected name — two deputies
+    /// sharing a name each render 🛡 *and* ⚠ — so both slots can be occupied at
+    /// once and the layout must handle it. The warning renders FIRST, and its
+    /// tooltip switches wording when the flagged member holds privilege (see
+    /// [`ImpersonationWarning::flagged_privilege`]) rather than being
+    /// suppressed: suppression is what a deputised sockpuppet wants.
+    /// `a_shield_and_a_warning_can_both_render` pins the co-occurrence.
     author_impersonation: Option<ImpersonationWarning>,
     is_self: bool,
     first_time: DateTime<Utc>,
@@ -431,7 +437,7 @@ fn resolve_member_nickname(
     member_info
         .canonical(member_id)
         .map(|ami| display_nickname(&ami.member_info.preferred_nickname, secrets))
-        .unwrap_or_else(|| "Unknown".to_string())
+        .unwrap_or_else(|| crate::util::display_name::UNKNOWN_MEMBER.to_string())
 }
 
 /// Group consecutive messages from the same sender within 5 minutes,
@@ -449,6 +455,9 @@ fn group_messages(
     // `impersonation_checker_for_viewer` — passed in rather than built here so
     // the protected set is folded once, not once per call.
     impersonation: &ImpersonationChecker,
+    // The room owner, so an author line can tell whether the member it is
+    // flagging holds privilege themselves — see `privilege_in_view`.
+    owner_id: MemberId,
 ) -> Vec<DisplayItem> {
     let mut items: Vec<DisplayItem> = Vec::new();
     let group_threshold = Duration::from_secs(5 * 60); // 5 minutes
@@ -563,8 +572,18 @@ fn group_messages(
             // Once per GROUP, not once per message: consecutive messages from
             // one author share a header, so the warning is a property of the
             // group.
-            let author_impersonation =
-                impersonation_warning_for_display(impersonation, author_id, &author_name);
+            //
+            // `author_id` is the id of the member whose NAME is on this line.
+            // Passing `self_member_id` compiles and passes every behavioural
+            // test while putting ⚠ on the genuine owner and every genuine
+            // moderator; the argument is pinned by
+            // `impersonation_warning_is_wired_into_both_render_surfaces`.
+            let author_impersonation = impersonation_warning_for_display(
+                impersonation,
+                author_id,
+                &author_name,
+                privilege_in_view(author_id, owner_id, deputy_badges),
+            );
             items.push(DisplayItem::Messages(MessageGroup {
                 author_id,
                 author_name,
@@ -1449,6 +1468,7 @@ pub fn Conversation() -> Element {
                         &member_names,
                         &deputy_badges,
                         &impersonation,
+                        MemberId::from(&key),
                     );
                     return Some((groups, self_member_id, member_names));
                 }
@@ -2971,10 +2991,16 @@ fn MessageGroupComponent(
                             "{group.author_name}"
                         }
                         // Impersonation warning. Sits immediately after the
-                        // name, before the shield slot — the two are mutually
-                        // exclusive (a shielded author is a deputy, and a
-                        // deputy is never warned about), so this is a single
-                        // badge position in practice.
+                        // name, before the shield slot. The two are NOT
+                        // mutually exclusive — two deputies whose names collide
+                        // each carry a shield AND a warning — so these really
+                        // are two badge positions and both can be filled at
+                        // once. Do not collapse them into one slot, and do not
+                        // suppress the warning when a shield is present: a
+                        // deputised sockpuppet carries a genuine shield, and
+                        // suppressing on it is the exact immunity
+                        // `a_deputised_sockpuppet_cannot_suppress_its_own_warning`
+                        // denies.
                         //
                         // The nickname above cannot forge this glyph: U+26A0 is
                         // inside the range `display_name::is_display_hidden`

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -994,9 +994,6 @@ pub(crate) fn impersonation_checker_for_viewer(
     owner_id: MemberId,
     deputy_badges: &HashMap<MemberId, DeputyBadge>,
 ) -> ImpersonationChecker {
-    let mut privileged_ids: HashSet<MemberId> = deputy_badges.keys().copied().collect();
-    privileged_ids.insert(owner_id);
-
     // The name this member has CLAIMED, or `None` if they have not claimed one.
     //
     // `display_nickname` can return three strings the member never chose, and
@@ -1033,7 +1030,7 @@ pub(crate) fn impersonation_checker_for_viewer(
 
     let mut protected = Vec::new();
     if let Some(name) = claimed_name(owner_id) {
-        protected.push(ProtectedName::new(ProtectedRole::Owner, name));
+        protected.push(ProtectedName::new(ProtectedRole::Owner, name, owner_id));
     }
     // Sorted, because `deputy_badges` is a `HashMap` and two deputies can share
     // a skeleton (a sockpuppet deputised under a real deputy's name). Raw map
@@ -1042,12 +1039,39 @@ pub(crate) fn impersonation_checker_for_viewer(
     let mut deputies: Vec<MemberId> = deputy_badges.keys().copied().collect();
     deputies.sort_unstable();
     for id in deputies {
+        // **The protected set must not be attacker-WRITABLE.**
+        //
+        // `deputy_badges` badges anyone deputised by a viewer-relevant
+        // appointer, and `viewer_relevant_deputizer_set` is "the viewer's
+        // strict ancestors ∪ the viewer". Self-deputisation is already
+        // ignored, but a TWO-ACCOUNT attacker is not: any strict ancestor of
+        // the viewer — in a room where invites get reshared, that is a large
+        // set — can deputise a sockpuppet and choose its nickname freely.
+        //
+        // Without this gate that nickname became a protected NAME, so an
+        // attacker could type an innocent member's display name into a
+        // sockpuppet and have the innocent member render with
+        // "this member is NOT a moderator" across the attacker's whole invite
+        // subtree, on demand, invisibly to the victim. That is precisely the
+        // false-accusation harm the tier-1-only decision exists to avoid,
+        // except aimed rather than accidental.
+        //
+        // So only a deputy appointed by the OWNER (or by the viewer
+        // themselves, who is trusting their own grant) contributes a name.
+        // That matches the real topology — Ian appoints the moderators — and
+        // makes the protected set unwritable by anyone else.
+        let badge = &deputy_badges[&id];
+        let trusted_grant = badge.deputized_by.contains(&Appointer::Owner)
+            || badge.deputized_by.contains(&Appointer::You);
+        if !trusted_grant {
+            continue;
+        }
         if let Some(name) = claimed_name(id) {
-            protected.push(ProtectedName::new(ProtectedRole::Deputy, name));
+            protected.push(ProtectedName::new(ProtectedRole::Deputy, name, id));
         }
     }
 
-    ImpersonationChecker::new(protected, privileged_ids)
+    ImpersonationChecker::new(protected)
 }
 
 /// The impersonation warning a surface actually RENDERS for one member, if any.
@@ -5262,6 +5286,211 @@ mod tests {
         assert!(impersonation_warning_for_display(&checker, id(&other_sk), "R00m 0wner").is_some());
     }
 
+    /// A room where an ATTACKER (a strict ancestor of the viewer, so a
+    /// viewer-relevant appointer) deputises a sockpuppet and names it whatever
+    /// the caller asks. Returns the checker as the viewer sees it, plus the
+    /// sockpuppet's id, an innocent bystander's id, and the real moderator's id.
+    fn attacker_sockpuppet_fixture(
+        puppet_nickname: &str,
+    ) -> (ImpersonationChecker, MemberId, MemberId, MemberId) {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let mod_sk = SigningKey::generate(&mut rng);
+        let attacker_sk = SigningKey::generate(&mut rng);
+        let puppet_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+        let innocent_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        // The attacker invited the viewer, making the attacker a STRICT
+        // ANCESTOR — which is all `viewer_relevant_deputizer_set` requires.
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &mod_sk.verifying_key()),
+                authorized_member(&owner_sk, &attacker_sk.verifying_key()),
+                authorized_member(&owner_sk, &puppet_sk.verifying_key()),
+                authorized_member(&owner_sk, &innocent_sk.verifying_key()),
+                member_invited_by(&attacker_sk, owner_id, &viewer_sk.verifying_key()),
+            ],
+        };
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                // The owner appoints the REAL moderator.
+                signed_member_info(&owner_sk, "Room Owner", vec![id(&mod_sk)]),
+                signed_member_info(&mod_sk, "Ian Clarke", vec![]),
+                // The attacker appoints their sockpuppet. Nothing in
+                // `MemberInfoV1::verify` stops this.
+                signed_member_info(&attacker_sk, "Attacker", vec![id(&puppet_sk)]),
+                signed_member_info(&puppet_sk, puppet_nickname, vec![]),
+                signed_member_info(&viewer_sk, "Viewer", vec![]),
+                signed_member_info(&innocent_sk, "Bob Smith", vec![]),
+            ],
+        };
+
+        let badges =
+            deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, id(&viewer_sk));
+        // Precondition: the attack primitive works — the sockpuppet really does
+        // carry a shield in the viewer's view. If this ever stops holding, the
+        // tests below would pass for the wrong reason.
+        assert!(
+            badges.contains_key(&id(&puppet_sk)),
+            "precondition: an ancestor's sockpuppet IS badged to the viewer, \
+             which is exactly why the protected set must not follow the badge"
+        );
+        assert!(badges.contains_key(&id(&mod_sk)));
+
+        let checker = impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges);
+        (checker, id(&puppet_sk), id(&innocent_sk), id(&mod_sk))
+    }
+
+    /// **BLOCKING A1 — warning INJECTION.** An attacker must not be able to aim
+    /// the badge at an innocent member.
+    ///
+    /// The primitive: any strict ancestor of the viewer deputises a sockpuppet
+    /// and names it after an innocent member. If the protected set followed the
+    /// badge map, that name became protected and the innocent member rendered
+    /// "this member is NOT a moderator" across the attacker's whole invite
+    /// subtree — remotely, on demand, and invisibly to the victim.
+    #[test]
+    fn an_attacker_cannot_aim_the_warning_at_an_innocent_member() {
+        // The sockpuppet is named after the innocent member.
+        let (checker, _puppet, innocent, _mod_id) = attacker_sockpuppet_fixture("Bob Smith");
+
+        assert_eq!(
+            impersonation_warning_for_display(&checker, innocent, "Bob Smith"),
+            None,
+            "an innocent member was accused because an ancestor deputised a \
+             sockpuppet wearing their name — the protected set must not be \
+             writable by anyone but the owner (or the viewer)"
+        );
+
+        // And the room's REAL protected names still work, so this is not
+        // vacuous: the owner-appointed moderator's name is still protected.
+        assert!(
+            impersonation_warning_for_display(&checker, innocent, "\u{0399}an Clarke").is_some(),
+            "the owner-appointed moderator's name must still be protected"
+        );
+    }
+
+    /// **BLOCKING A2 — warning SUPPRESSION.** Being deputised must not buy
+    /// immunity from impersonating someone else.
+    ///
+    /// The same primitive, aimed the other way: the sockpuppet names itself
+    /// after the REAL moderator. Under a room-wide "privileged ⇒ never warned"
+    /// exemption it rendered a genuine 🛡 and no ⚠ — and on the message author
+    /// line that is worse than shipping nothing, because the real Ian is the
+    /// OWNER and 👑 renders only in the member list, so the fake visually
+    /// outranked the real one in the conversation.
+    #[test]
+    fn a_deputised_sockpuppet_cannot_suppress_its_own_warning() {
+        let (checker, puppet, _innocent, mod_id) = attacker_sockpuppet_fixture("Ian Clarke");
+
+        let warning = impersonation_warning_for_display(&checker, puppet, "Ian Clarke")
+            .expect("a sockpuppet wearing the moderator's name MUST be flagged");
+        assert_eq!(warning.impersonated.display_name, "Ian Clarke");
+        assert_eq!(warning.impersonated.role, ProtectedRole::Deputy);
+
+        // Homoglyph variants too, not just the literal string.
+        assert!(impersonation_warning_for_display(&checker, puppet, "\u{0399}an Clarke").is_some());
+
+        // The REAL moderator, under the same name, is still exempt — the
+        // exemption is keyed on the identity the name was taken from.
+        assert_eq!(
+            impersonation_warning_for_display(&checker, mod_id, "Ian Clarke"),
+            None
+        );
+    }
+
+    /// The gate is on WHO APPOINTED the deputy, not on the badge existing. A
+    /// deputy the VIEWER appointed is trusted (the viewer is trusting their own
+    /// grant), so their name is protected; a deputy some other ancestor
+    /// appointed is not.
+    #[test]
+    fn only_owner_or_viewer_appointed_deputies_contribute_a_protected_name() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+        let mine_sk = SigningKey::generate(&mut rng);
+        let ancestor_sk = SigningKey::generate(&mut rng);
+        let theirs_sk = SigningKey::generate(&mut rng);
+        let stranger_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &ancestor_sk.verifying_key()),
+                authorized_member(&owner_sk, &theirs_sk.verifying_key()),
+                authorized_member(&owner_sk, &stranger_sk.verifying_key()),
+                member_invited_by(&ancestor_sk, owner_id, &viewer_sk.verifying_key()),
+                member_invited_by(&viewer_sk, owner_id, &mine_sk.verifying_key()),
+            ],
+        };
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                signed_member_info(&owner_sk, "Room Owner", vec![]),
+                // The viewer appoints `mine`; an unrelated ancestor appoints
+                // `theirs`. Both are badged to the viewer.
+                signed_member_info(&viewer_sk, "Viewer", vec![id(&mine_sk)]),
+                signed_member_info(&ancestor_sk, "Ancestor", vec![id(&theirs_sk)]),
+                signed_member_info(&mine_sk, "Trusted Mod", vec![]),
+                signed_member_info(&theirs_sk, "Untrusted Mod", vec![]),
+                signed_member_info(&stranger_sk, "Stranger", vec![]),
+            ],
+        };
+        let badges =
+            deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, id(&viewer_sk));
+        assert!(
+            badges.contains_key(&id(&mine_sk)) && badges.contains_key(&id(&theirs_sk)),
+            "precondition: BOTH deputies are badged to this viewer"
+        );
+
+        let checker = impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges);
+        assert!(
+            impersonation_warning_for_display(&checker, id(&stranger_sk), "Trusted Mod").is_some(),
+            "a deputy the VIEWER appointed is trusted, so their name is protected"
+        );
+        assert_eq!(
+            impersonation_warning_for_display(&checker, id(&stranger_sk), "Untrusted Mod"),
+            None,
+            "a deputy appointed by some other ancestor must NOT contribute a \
+             protected name — that is the attacker-writable path"
+        );
+    }
+
+    /// **Wiring pin for the gate.** Source-scrape, because the gate is a single
+    /// `continue` that a refactor could drop while every behavioural test still
+    /// passes in a room that happens to have only owner-appointed deputies.
+    #[test]
+    fn the_protected_set_is_gated_on_the_appointer() {
+        let src = include_str!("members.rs");
+        let start = src
+            .find("pub(crate) fn impersonation_checker_for_viewer")
+            .expect("the builder must exist");
+        let end = src[start..]
+            .find("\n/// The impersonation warning a surface actually RENDERS")
+            .expect("the builder is followed by the render boundary")
+            + start;
+        let body = &src[start..end];
+        assert!(
+            body.contains("Appointer::Owner"),
+            "`impersonation_checker_for_viewer` no longer gates the protected \
+             set on the appointer, so any strict ancestor of the viewer can \
+             deputise a sockpuppet and inject a protected name"
+        );
+    }
+
     /// **The motivating attack.** `Ιan Clarke` with a Greek capital iota
     /// (U+0399) renders identically to the moderator's `Ian Clarke` and walks
     /// past every character-blocking rule River has: U+0399 is a letter, and
@@ -5319,26 +5548,32 @@ mod tests {
             "the owner must never be flagged for their own name"
         );
 
-        // And under each OTHER's names, and under a homoglyph of one: a
-        // privileged member is exempt whatever they are called. The owner
-        // renaming themselves after a moderator is not impersonation.
-        for name in [
-            "Ian Clarke",
-            "\u{0399}an Clarke",
-            "Room Owner",
-            "R00m 0wner",
-        ] {
-            assert_eq!(
-                impersonation_warning_for_display(&checker, owner_id, name),
-                None,
-                "the owner was flagged while called {name:?}"
-            );
+        // Including under FOLDED variants of their own name — the exemption is
+        // per-identity, not per-literal-string.
+        for name in ["\u{0399}an Clarke", "lan Clarke", "IAN CLARKE"] {
             assert_eq!(
                 impersonation_warning_for_display(&checker, mod_id, name),
                 None,
-                "the moderator was flagged while called {name:?}"
+                "the real moderator was flagged for a variant of their OWN name: {name:?}"
             );
         }
+        assert_eq!(
+            impersonation_warning_for_display(&checker, owner_id, "R00m 0wner"),
+            None
+        );
+
+        // **The invariant is narrow, and deliberately so.** Taking a name that
+        // is NOT yours is flagged even when you hold privilege: the exemption
+        // is keyed on the member a protected name was TAKEN FROM, not on a
+        // room-wide "privileged" set. The broad version was attacker-extendable
+        // — a strict ancestor of the viewer can deputise a sockpuppet, which
+        // put the sockpuppet in that set and let it wear `"Ian Clarke"` with a
+        // genuine shield and no warning.
+        assert!(
+            impersonation_warning_for_display(&checker, owner_id, "Ian Clarke").is_some(),
+            "the owner renaming themselves after a moderator IS impersonating \
+             that moderator, and must be flagged"
+        );
 
         // The exemption is identity-scoped, not name-scoped: the SAME names on
         // an unprivileged member are flagged. Without this half the test above
@@ -5634,13 +5869,18 @@ mod tests {
         );
     }
 
-    /// The 🛡 and the ⚠ can never appear on the same member: a shielded member is
-    /// a deputy, deputies are in the checker's privileged set, and a privileged
-    /// member is never warned about. Worth pinning because the two badges render
-    /// in adjacent slots and a future refactor that built the checker from
-    /// something other than the badge map would break it silently.
+    /// A shielded deputy with a name of their own shows no ⚠, and two
+    /// owner-appointed deputies whose names COLLIDE both do.
+    ///
+    /// **This used to claim the two badges are mutually exclusive, which is no
+    /// longer true and should not be restored.** That held only because a
+    /// privileged member was exempt from every protected name — the broad rule
+    /// an attacker extended by deputising a sockpuppet. With the exemption
+    /// keyed per-name, two genuine deputies with confusable names warn about
+    /// each other, which is the honest answer: the owner appointed two people a
+    /// reader cannot tell apart, and surfacing that is the feature working.
     #[test]
-    fn shield_and_warning_are_mutually_exclusive() {
+    fn a_deputy_shows_no_warning_unless_a_protected_name_collides() {
         use river_core::room_state::member::MembersV1;
         use river_core::room_state::member_info::MemberInfoV1;
 
@@ -5661,9 +5901,36 @@ mod tests {
                 authorized_member(&owner_sk, &viewer_sk.verifying_key()),
             ],
         };
-        // TWO moderators with confusable names — the worst case for this
-        // property, because each one's name is protected against the other.
-        let member_info = MemberInfoV1 {
+        // Case 1: two owner-appointed deputies with DISTINCT names. Neither
+        // shows a warning — the common case, and the one that matters for not
+        // badging the people the shield is meant to vouch for.
+        let distinct = MemberInfoV1 {
+            member_info: vec![
+                signed_member_info(&owner_sk, "Room Owner", vec![id(&mod_a_sk), id(&mod_b_sk)]),
+                signed_member_info(&mod_a_sk, "Ian Clarke", vec![]),
+                signed_member_info(&mod_b_sk, "Nacho Duart", vec![]),
+                signed_member_info(&viewer_sk, "Viewer", vec![]),
+            ],
+        };
+        let badges =
+            deputy_badges_for_viewer(&members, &distinct, &secrets, owner_id, id(&viewer_sk));
+        let checker = impersonation_checker_for_viewer(&distinct, &secrets, owner_id, &badges);
+        for (sk, name) in [(&mod_a_sk, "Ian Clarke"), (&mod_b_sk, "Nacho Duart")] {
+            assert!(
+                badges.contains_key(&id(sk)),
+                "precondition: {name:?} carries a shield"
+            );
+            assert_eq!(
+                impersonation_warning_for_display(&checker, id(sk), name),
+                None,
+                "a shielded deputy with a name of their own must show no warning"
+            );
+        }
+
+        // Case 2: two owner-appointed deputies whose names COLLIDE. Both are
+        // flagged, each naming the other — the exemption covers only your own
+        // identity.
+        let colliding = MemberInfoV1 {
             member_info: vec![
                 signed_member_info(&owner_sk, "Room Owner", vec![id(&mod_a_sk), id(&mod_b_sk)]),
                 signed_member_info(&mod_a_sk, "Ian Clarke", vec![]),
@@ -5672,18 +5939,13 @@ mod tests {
             ],
         };
         let badges =
-            deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, id(&viewer_sk));
-        let checker = impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges);
-
+            deputy_badges_for_viewer(&members, &colliding, &secrets, owner_id, id(&viewer_sk));
+        let checker = impersonation_checker_for_viewer(&colliding, &secrets, owner_id, &badges);
         for (sk, name) in [(&mod_a_sk, "Ian Clarke"), (&mod_b_sk, "\u{0399}an Clarke")] {
             assert!(
-                badges.contains_key(&id(sk)),
-                "precondition: {name:?} carries a shield"
-            );
-            assert_eq!(
-                impersonation_warning_for_display(&checker, id(sk), name),
-                None,
-                "{name:?} shows a shield, so it must never also show a warning"
+                impersonation_warning_for_display(&checker, id(sk), name).is_some(),
+                "two deputies a reader cannot tell apart must BOTH be flagged; \
+                 exempting them is the broad rule an attacker extended"
             );
         }
     }
@@ -5765,7 +6027,11 @@ mod tests {
         display.is_self = true;
         display.invited_by_you = true;
         display.impersonation = Some(ImpersonationWarning {
-            impersonated: ProtectedName::new(ProtectedRole::Deputy, "Ian Clarke"),
+            impersonated: ProtectedName::new(
+                ProtectedRole::Deputy,
+                "Ian Clarke",
+                MemberId(freenet_scaffold::util::FastHash(1)),
+            ),
             tier: ConfusableTier::Identical,
         });
 

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -186,10 +186,12 @@ struct MemberDisplay {
     /// uses — both go through
     /// [`impersonation_warning_for_display`].
     ///
-    /// Mutually exclusive with `deputy_badge` by construction: a member who
-    /// shows a shield is a deputy, deputies are in the checker's privileged set,
-    /// and a privileged member is never warned about. Pinned by
-    /// `shield_and_warning_are_mutually_exclusive`.
+    /// **NOT mutually exclusive with `deputy_badge`.** The exemption is keyed on
+    /// the name's SOURCE, not on the flagged member's privilege, so a deputy
+    /// whose name collides with another protected name carries both badges.
+    /// `a_shield_and_a_warning_can_both_render` pins it, and
+    /// [`ImpersonationWarning::flagged_privilege`] is why the tooltip stays
+    /// truthful in that case.
     impersonation: Option<ImpersonationWarning>,
 }
 
@@ -971,11 +973,19 @@ pub(crate) fn deputy_badges_for_viewer(
 /// protected name is one whose authority this viewer would be fooled by, which
 /// is precisely the set whose shield they can see.
 ///
-/// ## Two filters on which names get protected
+/// ## Which names get protected: the filters in `claimed_name`
 ///
-/// * **No `member_info` record ⇒ not protected.** Such a member renders as
-///   `"Unknown"`, and `"Unknown"` is what EVERY member without a record renders
-///   as — protecting it would flag all of them for impersonating each other.
+/// A privileged member contributes a name only if they CHOSE it. Four ways a
+/// rendered name is not a chosen one, and all four are filtered:
+///
+/// * **No `member_info` record, or a nickname that fails to decrypt ⇒ not
+///   protected.** The unseal is tested directly, so a change to the
+///   `"[Encrypted: …]"` placeholder's wording cannot reopen it.
+/// * **`"Unknown"` ⇒ not protected.** That is the fallback both render surfaces
+///   use for a member with no record yet, so protecting it would flag every
+///   such member at once during a sync gap.
+/// * **`UNNAMED` ⇒ not protected.** The placeholder for a nickname that
+///   sanitises to nothing, shared by a whole class of members.
 /// * **A generated handle ⇒ not protected.** A member who never typed a
 ///   nickname wears one of the 10,000 handles River derived from their key
 ///   ([`crate::nickname::is_generated_handle`]). Two members can be assigned the
@@ -984,9 +994,20 @@ pub(crate) fn deputy_badges_for_viewer(
 ///   than not that some pair shares a handle. Protecting an unclaimed name would
 ///   turn that birthday collision into an accusation.
 ///
-/// `privileged_ids` is deliberately WIDER than `protected`: it holds every
-/// deputy and the owner, including the ones whose names are filtered out above.
-/// The identity exemption must never depend on a name — see
+/// **The last three are compared by SKELETON, not by string equality**, because
+/// the matcher they gate compares skeletons. An exact-string filter is a guard
+/// that is weaker than the thing it guards: `amber worm`, `AmberWorm` and
+/// `Arnber Worm` are all "not a generated handle" to `==`, yet all three tier-1
+/// match the member River assigned `Amber Worm`. No attacker is needed — a
+/// moderator who simply styles their own name in lower case would otherwise put
+/// "this member is NOT a moderator" on every member holding that handle.
+/// `a_lowercased_generated_handle_is_not_protected` and
+/// `an_unknown_named_deputy_is_not_protected` pin it.
+///
+/// The identity exemption must never depend on a name: a member filtered out
+/// here is still exempt from being accused of impersonating *themselves*,
+/// because the exemption is keyed on [`ProtectedName::source`] and a name that
+/// never enters the set can never accuse anyone. See
 /// [`ImpersonationChecker::check`].
 pub(crate) fn impersonation_checker_for_viewer(
     member_info: &river_core::room_state::member_info::MemberInfoV1,
@@ -1016,16 +1037,29 @@ pub(crate) fn impersonation_checker_for_viewer(
     // prefix, so a future change to the placeholder's wording cannot silently
     // reopen this. (`conversation.rs` filters `UNNAMED` out of mention
     // autocomplete for the same reason.)
+    //
+    // **The placeholder and handle checks compare SKELETONS, not strings.** The
+    // matcher these filters gate compares folds, so an `==` filter is weaker
+    // than the thing it guards and is simply walked around: `unknown`,
+    // `Unkn0wn` and `Unknovvn` are all `!= "Unknown"` yet all three tier-1 match
+    // every member rendering as `Unknown`, and the whole `Amber Worm` family
+    // (`amber worm`, `AmberWorm`, `Arnber Worm`, ...) does the same to a
+    // generated handle. See [`crate::nickname::folds_to_generated_handle`].
     let claimed_name = |id: MemberId| -> Option<String> {
         let sealed = &member_info.canonical(id)?.member_info.preferred_nickname;
         if unseal_bytes_with_secrets(sealed, room_secrets).is_err() {
             return None;
         }
         let name = display_nickname(sealed, room_secrets);
-        if name == crate::util::display_name::UNNAMED {
-            return None;
+        for placeholder in [
+            crate::util::display_name::UNNAMED,
+            crate::util::display_name::UNKNOWN_MEMBER,
+        ] {
+            if crate::util::confusable::folds_together(&name, placeholder) {
+                return None;
+            }
         }
-        (!crate::nickname::is_generated_handle(&name)).then_some(name)
+        (!crate::nickname::folds_to_generated_handle(&name)).then_some(name)
     };
 
     let mut protected = Vec::new();
@@ -1039,33 +1073,37 @@ pub(crate) fn impersonation_checker_for_viewer(
     let mut deputies: Vec<MemberId> = deputy_badges.keys().copied().collect();
     deputies.sort_unstable();
     for id in deputies {
-        // **The protected set must not be attacker-WRITABLE.**
+        // **EVERY badged deputy contributes a name, whoever appointed them.**
         //
-        // `deputy_badges` badges anyone deputised by a viewer-relevant
-        // appointer, and `viewer_relevant_deputizer_set` is "the viewer's
-        // strict ancestors ∪ the viewer". Self-deputisation is already
-        // ignored, but a TWO-ACCOUNT attacker is not: any strict ancestor of
-        // the viewer — in a room where invites get reshared, that is a large
-        // set — can deputise a sockpuppet and choose its nickname freely.
+        // There was a gate here that admitted only deputies appointed by the
+        // OWNER or by the viewer themselves. It was removed deliberately, and
+        // it must not come back — see
+        // `the_protected_set_is_not_gated_on_the_appointer`, which pins its
+        // absence.
         //
-        // Without this gate that nickname became a protected NAME, so an
-        // attacker could type an innocent member's display name into a
-        // sockpuppet and have the innocent member render with
-        // "this member is NOT a moderator" across the attacker's whole invite
-        // subtree, on demand, invisibly to the victim. That is precisely the
-        // false-accusation harm the tier-1-only decision exists to avoid,
-        // except aimed rather than accidental.
+        // The gate was written on the assumption that the owner appoints the
+        // moderators. In the live Freenet Official room that is simply false:
+        // all five deputy grants are issued by `Invite Bot`, not by the owner.
+        // So the gate protected exactly one name — the owner's own — and left
+        // every actual moderator's name unprotected, which is the impersonation
+        // this feature exists to catch. A gate that switches the feature off in
+        // the only room that has ever needed it is worse than no gate.
         //
-        // So only a deputy appointed by the OWNER (or by the viewer
-        // themselves, who is trusting their own grant) contributes a name.
-        // That matches the real topology — Ian appoints the moderators — and
-        // makes the protected set unwritable by anyone else.
-        let badge = &deputy_badges[&id];
-        let trusted_grant = badge.deputized_by.contains(&Appointer::Owner)
-            || badge.deputized_by.contains(&Appointer::You);
-        if !trusted_grant {
-            continue;
-        }
+        // **The accepted cost, stated plainly.** `MemberInfoV1::verify`
+        // validates only the LENGTH of a `deputies` list and the signer's own
+        // signature — never who is in it. So any strict ancestor of the viewer
+        // can deputise a sockpuppet, name it after an innocent member, and have
+        // that innocent member render "this member is NOT a moderator" across
+        // the attacker's invite subtree. That is a real harm and it is now
+        // reachable; `a_sockpuppet_can_inject_a_protected_name` pins it as an
+        // accepted cost rather than letting it be rediscovered by an accused
+        // member. It is bounded by the three filters below (`claimed_name`),
+        // which are skeleton-based precisely because an exact-string filter is
+        // trivially side-stepped by the same attacker.
+        //
+        // Self-deputisation is still ignored, upstream in
+        // `viewer_relevant_deputizer_set` — a member cannot bootstrap
+        // themselves into the badge map, so they cannot reach this loop alone.
         if let Some(name) = claimed_name(id) {
             protected.push(ProtectedName::new(ProtectedRole::Deputy, name, id));
         }
@@ -1108,6 +1146,11 @@ pub(crate) fn impersonation_warning_for_display(
     checker: &ImpersonationChecker,
     member_id: MemberId,
     display_name: &str,
+    // The privilege the FLAGGED member holds in this viewer's view, from
+    // [`privilege_in_view`]. Not derivable from the checker: it is the badge
+    // map's answer, not the protected set's. Drives the tooltip only — it never
+    // suppresses the badge.
+    flagged_privilege: Option<ProtectedRole>,
 ) -> Option<ImpersonationWarning> {
     // `check_identical` rather than `check(..).filter(..)`: the filtered form
     // still ran the full Damerau sweep for every NON-matching member on every
@@ -1119,7 +1162,32 @@ pub(crate) fn impersonation_warning_for_display(
             .is_none_or(|w| w.tier == ConfusableTier::Identical),
         "only the Identical tier may reach a render surface"
     );
-    warning
+    warning.map(|w| ImpersonationWarning {
+        flagged_privilege,
+        ..w
+    })
+}
+
+/// The privilege `member_id` holds in this viewer's view, if any.
+///
+/// One definition for every surface, from the same badge map the 🛡 and the
+/// protected set come from, so "does this member hold privilege" cannot get
+/// three answers in three places.
+///
+/// The owner outranks a deputy grant: a room owner who is also somehow in
+/// `deputy_badges` is described as the owner.
+pub(crate) fn privilege_in_view(
+    member_id: MemberId,
+    owner_id: MemberId,
+    deputy_badges: &HashMap<MemberId, DeputyBadge>,
+) -> Option<ProtectedRole> {
+    if member_id == owner_id {
+        Some(ProtectedRole::Owner)
+    } else if deputy_badges.contains_key(&member_id) {
+        Some(ProtectedRole::Deputy)
+    } else {
+        None
+    }
 }
 
 /// [`deputy_badges_for_viewer`] for a SINGLE member.
@@ -1265,14 +1333,24 @@ pub fn MemberList() -> Element {
             let nickname = member_info
                 .canonical(member_id)
                 .map(|mi| display_nickname(&mi.member_info.preferred_nickname, room_secrets))
-                .unwrap_or_else(|| "Unknown".to_string());
+                .unwrap_or_else(|| crate::util::display_name::UNKNOWN_MEMBER.to_string());
 
             // Computed from the RENDERED `nickname` above, not the raw sealed
             // bytes: the checker compares what the reader actually sees, so it
             // must be fed post-`display_nickname` text. Feeding it the raw
             // nickname would compare a string nobody is shown.
-            let impersonation_warning =
-                impersonation_warning_for_display(&impersonation, member_id, &nickname);
+            //
+            // `member_id` is the id of the member this ROW is for. Passing
+            // `self_member_id` here compiles, passes every behavioural test, and
+            // puts ⚠ on the genuine owner and every genuine moderator — the
+            // argument is pinned by
+            // `impersonation_warning_is_wired_into_both_render_surfaces`.
+            let impersonation_warning = impersonation_warning_for_display(
+                &impersonation,
+                member_id,
+                &nickname,
+                privilege_in_view(member_id, owner_id, &deputy_badges),
+            );
 
             let member_display = MemberDisplay {
                 nickname,
@@ -5147,11 +5225,11 @@ mod tests {
         // Latin `T`-lookalike is not reachable, but the reverse IS — an
         // attacker who copies the name verbatim collides by construction.
         assert!(
-            impersonation_warning_for_display(&checker, stranger, "Дмитрий Волков").is_some(),
+            impersonation_warning_for_display(&checker, stranger, "Дмитрий Волков", None).is_some(),
             "a verbatim copy of the owner's Cyrillic name must be flagged"
         );
         assert!(
-            impersonation_warning_for_display(&checker, stranger, "李小龍").is_some(),
+            impersonation_warning_for_display(&checker, stranger, "李小龍", None).is_some(),
             "a verbatim copy of the deputy's CJK name must be flagged"
         );
 
@@ -5166,7 +5244,7 @@ mod tests {
             "Γιώργος Παπαδόπουλος",
         ] {
             assert_eq!(
-                impersonation_warning_for_display(&checker, stranger, name),
+                impersonation_warning_for_display(&checker, stranger, name, None),
                 None,
                 "{name:?} is an unrelated name in a protected script and must \
                  not be flagged"
@@ -5291,7 +5369,7 @@ mod tests {
         );
         for sk in [&a_sk, &b_sk] {
             assert_eq!(
-                impersonation_warning_for_display(&checker, id(sk), &rendered(sk)),
+                impersonation_warning_for_display(&checker, id(sk), &rendered(sk), None),
                 None,
                 "an ordinary member must not be accused of impersonating an \
                  owner whose name merely failed to decrypt"
@@ -5353,13 +5431,27 @@ mod tests {
         let checker = impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges);
 
         assert_eq!(
-            impersonation_warning_for_display(&checker, id(&other_sk), &unnamed),
+            impersonation_warning_for_display(&checker, id(&other_sk), &unnamed, None),
             None,
             "`UNNAMED` is the placeholder for EVERY blank nickname, so it must \
              not be a protected name"
         );
-        // The owner's real name is still protected, so this is not vacuous.
-        assert!(impersonation_warning_for_display(&checker, id(&other_sk), "R00m 0wner").is_some());
+        // The owner's real name is still protected, so this is not vacuous —
+        // and it is protected AS THE OWNER. Mutating `ProtectedRole::Owner` to
+        // `Deputy` in the builder survives every other test in this file, and
+        // then the tooltip tells readers to hunt for a shield the owner does
+        // not have.
+        let owner_hit =
+            impersonation_warning_for_display(&checker, id(&other_sk), "R00m 0wner", None)
+                .expect("the owner's name must still be protected");
+        assert_eq!(
+            owner_hit.impersonated.role,
+            ProtectedRole::Owner,
+            "the owner's name must be protected as the OWNER — the tooltip's \
+             remedy clause (a crown in the member list, not a shield) is \
+             chosen from this role"
+        );
+        assert!(owner_hit.tooltip().contains("is NOT the room owner"));
     }
 
     /// A room where an ATTACKER (a strict ancestor of the viewer, so a
@@ -5425,31 +5517,43 @@ mod tests {
         (checker, id(&puppet_sk), id(&innocent_sk), id(&mod_sk))
     }
 
-    /// **BLOCKING A1 — warning INJECTION.** An attacker must not be able to aim
-    /// the badge at an innocent member.
+    /// **The accepted cost of protecting every deputy, pinned so it stays
+    /// deliberate.**
     ///
-    /// The primitive: any strict ancestor of the viewer deputises a sockpuppet
-    /// and names it after an innocent member. If the protected set followed the
-    /// badge map, that name became protected and the innocent member rendered
-    /// "this member is NOT a moderator" across the attacker's whole invite
-    /// subtree — remotely, on demand, and invisibly to the victim.
+    /// The protected set IS attacker-writable: any strict ancestor of the viewer
+    /// can deputise a sockpuppet and name it after an innocent member, and the
+    /// innocent member then renders "this member is NOT a moderator" across the
+    /// attacker's invite subtree, invisibly to the victim. `MemberInfoV1::verify`
+    /// validates only the LENGTH of a `deputies` list, never who is in it, so
+    /// nothing below the UI stops it.
+    ///
+    /// There was a gate here that admitted only owner- or viewer-appointed
+    /// deputies. It closed this hole and, in the process, switched the feature
+    /// off in the one room that has needed it: every deputy grant in the live
+    /// Freenet Official room is issued by `Invite Bot`, not by the owner, so the
+    /// gate protected the owner's name and nobody else's. The owner chose the
+    /// wider set with this cost known.
+    ///
+    /// This test asserts the CURRENT behaviour rather than the desirable one. If
+    /// it starts failing because someone re-narrowed the set, that is a policy
+    /// change and needs the same sign-off — do not "fix" it by re-adding a gate.
     #[test]
-    fn an_attacker_cannot_aim_the_warning_at_an_innocent_member() {
+    fn a_sockpuppet_can_inject_a_protected_name() {
         // The sockpuppet is named after the innocent member.
         let (checker, _puppet, innocent, _mod_id) = attacker_sockpuppet_fixture("Bob Smith");
 
-        assert_eq!(
-            impersonation_warning_for_display(&checker, innocent, "Bob Smith"),
-            None,
-            "an innocent member was accused because an ancestor deputised a \
-             sockpuppet wearing their name — the protected set must not be \
-             writable by anyone but the owner (or the viewer)"
+        assert!(
+            impersonation_warning_for_display(&checker, innocent, "Bob Smith", None).is_some(),
+            "ACCEPTED COST: an ancestor's sockpuppet CAN aim the badge at an \
+             innocent member. If this now returns None the protected set was \
+             re-narrowed — see the doc comment before changing this assertion"
         );
 
         // And the room's REAL protected names still work, so this is not
         // vacuous: the owner-appointed moderator's name is still protected.
         assert!(
-            impersonation_warning_for_display(&checker, innocent, "\u{0399}an Clarke").is_some(),
+            impersonation_warning_for_display(&checker, innocent, "\u{0399}an Clarke", None)
+                .is_some(),
             "the owner-appointed moderator's name must still be protected"
         );
     }
@@ -5467,28 +5571,66 @@ mod tests {
     fn a_deputised_sockpuppet_cannot_suppress_its_own_warning() {
         let (checker, puppet, _innocent, mod_id) = attacker_sockpuppet_fixture("Ian Clarke");
 
-        let warning = impersonation_warning_for_display(&checker, puppet, "Ian Clarke")
-            .expect("a sockpuppet wearing the moderator's name MUST be flagged");
+        // The sockpuppet carries a GENUINE 🛡 in this viewer's view — that is
+        // the whole primitive — so this is the case where a
+        // "privileged ⇒ suppress" rule would hand it immunity. It must not.
+        let warning = impersonation_warning_for_display(
+            &checker,
+            puppet,
+            "Ian Clarke",
+            Some(ProtectedRole::Deputy),
+        )
+        .expect("a sockpuppet wearing the moderator's name MUST be flagged");
         assert_eq!(warning.impersonated.display_name, "Ian Clarke");
         assert_eq!(warning.impersonated.role, ProtectedRole::Deputy);
 
         // Homoglyph variants too, not just the literal string.
-        assert!(impersonation_warning_for_display(&checker, puppet, "\u{0399}an Clarke").is_some());
+        assert!(impersonation_warning_for_display(
+            &checker,
+            puppet,
+            "\u{0399}an Clarke",
+            Some(ProtectedRole::Deputy)
+        )
+        .is_some());
 
-        // The REAL moderator, under the same name, is still exempt — the
-        // exemption is keyed on the identity the name was taken from.
-        assert_eq!(
-            impersonation_warning_for_display(&checker, mod_id, "Ian Clarke"),
-            None
-        );
+        // The REAL moderator is now flagged TOO, and that is the honest
+        // outcome: the room genuinely contains two shielded members with the
+        // same name, and the viewer genuinely cannot tell them apart. What must
+        // NOT happen is the badge asserting something false about either of
+        // them — neither is "NOT a moderator", because both hold a grant.
+        let real = impersonation_warning_for_display(
+            &checker,
+            mod_id,
+            "Ian Clarke",
+            Some(ProtectedRole::Deputy),
+        )
+        .expect("the collision is symmetric: both shielded members are marked");
+        for tip in [warning.tooltip(), real.tooltip()] {
+            assert!(
+                !tip.contains("is NOT"),
+                "the tooltip asserts something false about a member who does \
+                 hold a grant: {tip}"
+            );
+            assert!(tip.contains("Name conflict"), "{tip}");
+            assert!(tip.contains("member ID"), "{tip}");
+        }
+
+        // The identity exemption is still keyed on the name's SOURCE, so the
+        // real moderator is not accused of impersonating THEMSELVES: the
+        // warning they get names the sockpuppet's entry, not their own.
+        assert_ne!(real.impersonated.source, mod_id);
     }
 
-    /// The gate is on WHO APPOINTED the deputy, not on the badge existing. A
-    /// deputy the VIEWER appointed is trusted (the viewer is trusting their own
-    /// grant), so their name is protected; a deputy some other ancestor
-    /// appointed is not.
+    /// **Every deputy the viewer can see a shield for contributes a name**,
+    /// whoever appointed them — owner, the viewer, or any other ancestor.
+    ///
+    /// The scope is deliberately the same set as the shield: a protected name is
+    /// one whose authority this viewer would be fooled by, which is precisely
+    /// the set whose 🛡 they can see. Narrowing it to owner-appointed grants
+    /// protects nobody in the live Freenet Official room, where every grant
+    /// comes from `Invite Bot`.
     #[test]
-    fn only_owner_or_viewer_appointed_deputies_contribute_a_protected_name() {
+    fn every_badged_deputy_contributes_a_protected_name() {
         use river_core::room_state::member::MembersV1;
         use river_core::room_state::member_info::MemberInfoV1;
 
@@ -5534,22 +5676,31 @@ mod tests {
 
         let checker = impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges);
         assert!(
-            impersonation_warning_for_display(&checker, id(&stranger_sk), "Trusted Mod").is_some(),
+            impersonation_warning_for_display(&checker, id(&stranger_sk), "Trusted Mod", None)
+                .is_some(),
             "a deputy the VIEWER appointed is trusted, so their name is protected"
         );
-        assert_eq!(
-            impersonation_warning_for_display(&checker, id(&stranger_sk), "Untrusted Mod"),
-            None,
-            "a deputy appointed by some other ancestor must NOT contribute a \
-             protected name — that is the attacker-writable path"
+        assert!(
+            impersonation_warning_for_display(&checker, id(&stranger_sk), "Untrusted Mod", None)
+                .is_some(),
+            "a deputy appointed by ANOTHER ancestor is badged to this viewer, so \
+             their name must be protected too — this is the case the live \
+             Freenet Official room is entirely made of (every grant there comes \
+             from `Invite Bot`, not the owner)"
         );
     }
 
-    /// **Wiring pin for the gate.** Source-scrape, because the gate is a single
-    /// `continue` that a refactor could drop while every behavioural test still
-    /// passes in a room that happens to have only owner-appointed deputies.
+    /// **Wiring pin for the ABSENCE of the appointer gate.**
+    ///
+    /// Source-scrape, because the gate this replaces was a single `continue`,
+    /// and re-adding one is the obvious "fix" for
+    /// `a_sockpuppet_can_inject_a_protected_name`. It is not a fix, it is a
+    /// policy reversal: it switches the feature off for every real moderator in
+    /// the Freenet Official room. Behavioural tests would not catch it either,
+    /// because a fixture whose deputies happen to be owner-appointed passes
+    /// under both policies.
     #[test]
-    fn the_protected_set_is_gated_on_the_appointer() {
+    fn the_protected_set_is_not_gated_on_the_appointer() {
         let src = include_str!("members.rs");
         let start = src
             .find("pub(crate) fn impersonation_checker_for_viewer")
@@ -5558,13 +5709,162 @@ mod tests {
             .find("\n/// The impersonation warning a surface actually RENDERS")
             .expect("the builder is followed by the render boundary")
             + start;
-        let body = &src[start..end];
+        // Comments in the body legitimately NAME the removed gate, so strip
+        // them: the scrape must see code, not the explanation of why the code
+        // is gone.
+        let body: String = src[start..end]
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
         assert!(
-            body.contains("Appointer::Owner"),
-            "`impersonation_checker_for_viewer` no longer gates the protected \
-             set on the appointer, so any strict ancestor of the viewer can \
-             deputise a sockpuppet and inject a protected name"
+            !body.contains("Appointer::"),
+            "`impersonation_checker_for_viewer` gates the protected set on the \
+             appointer again. That is a POLICY REVERSAL, not a bug fix — it \
+             leaves every moderator in the Freenet Official room unprotected, \
+             because every deputy grant there is issued by `Invite Bot` rather \
+             than by the owner. See the doc on \
+             `a_sockpuppet_can_inject_a_protected_name`."
         );
+    }
+
+    /// **P3.5 — the guards must be as wide as the matcher they gate.**
+    ///
+    /// `is_generated_handle` is exact-string; the matcher compares folds. So a
+    /// moderator who merely styles their own name in lower case used to inject
+    /// a protected name that tier-1 matches the handle River assigned to
+    /// somebody else — putting "this member is NOT a moderator" on a member who
+    /// never typed anything. No attacker required.
+    #[test]
+    fn a_confusable_variant_of_a_generated_handle_is_not_protected() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        // Every one of these is `!= "Amber Worm"`, so the old exact filter let
+        // it through, and every one is a tier-1 match for `Amber Worm`.
+        for styled in [
+            "amber worm",
+            "AMBER WORM",
+            "AmberWorm",
+            "Amber\u{3000}Worm",
+            "Arnber Worm",
+            "Amber W0rm",
+            "Amber Worrn",
+        ] {
+            assert!(
+                !crate::nickname::is_generated_handle(styled),
+                "precondition: `{styled}` is NOT an exact generated handle, \
+                 which is why the exact filter passed it"
+            );
+
+            let mut rng = rand::thread_rng();
+            let owner_sk = SigningKey::generate(&mut rng);
+            let mod_sk = SigningKey::generate(&mut rng);
+            let holder_sk = SigningKey::generate(&mut rng);
+
+            let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+            let owner_id = id(&owner_sk);
+            let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+            let members = MembersV1 {
+                members: vec![
+                    authorized_member(&owner_sk, &mod_sk.verifying_key()),
+                    authorized_member(&owner_sk, &holder_sk.verifying_key()),
+                ],
+            };
+            let member_info = MemberInfoV1 {
+                member_info: vec![
+                    signed_member_info(&owner_sk, "Room Owner", vec![id(&mod_sk)]),
+                    signed_member_info(&mod_sk, styled, vec![]),
+                    signed_member_info(&holder_sk, "Amber Worm", vec![]),
+                ],
+            };
+            let badges = deputy_badges_for_viewer(
+                &members,
+                &member_info,
+                &secrets,
+                owner_id,
+                id(&holder_sk),
+            );
+            assert!(
+                badges.contains_key(&id(&mod_sk)),
+                "precondition: the styled moderator is badged"
+            );
+
+            let checker =
+                impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges);
+            assert_eq!(
+                impersonation_warning_for_display(&checker, id(&holder_sk), "Amber Worm", None),
+                None,
+                "the member River ASSIGNED `Amber Worm` was accused because a \
+                 moderator styled their own name `{styled}` — the handle filter \
+                 must compare skeletons, not strings"
+            );
+        }
+    }
+
+    /// **P3.6 — `"Unknown"` is the no-record fallback and must be filtered.**
+    ///
+    /// A deputy whose `member_info` record literally SAYS `Unknown` (or any
+    /// fold of it) would flag every member whose record has not synced yet —
+    /// simultaneously, with no attacker, during an ordinary sync gap. The
+    /// existing `a_member_without_member_info_is_not_protected` covers a deputy
+    /// with NO record; this covers one whose record carries the placeholder.
+    #[test]
+    fn an_unknown_named_deputy_is_not_protected() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        for spelled in ["Unknown", "unknown", "UNKNOWN", "Unkn0wn", "Unknovvn"] {
+            let mut rng = rand::thread_rng();
+            let owner_sk = SigningKey::generate(&mut rng);
+            let mod_sk = SigningKey::generate(&mut rng);
+            let viewer_sk = SigningKey::generate(&mut rng);
+            let nameless_sk = SigningKey::generate(&mut rng);
+
+            let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+            let owner_id = id(&owner_sk);
+            let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+            let members = MembersV1 {
+                members: vec![
+                    authorized_member(&owner_sk, &mod_sk.verifying_key()),
+                    authorized_member(&owner_sk, &viewer_sk.verifying_key()),
+                    authorized_member(&owner_sk, &nameless_sk.verifying_key()),
+                ],
+            };
+            // `nameless` deliberately has NO member_info record, so both render
+            // surfaces fall back to `UNKNOWN_MEMBER` for them.
+            let member_info = MemberInfoV1 {
+                member_info: vec![
+                    signed_member_info(&owner_sk, "Room Owner", vec![id(&mod_sk)]),
+                    signed_member_info(&mod_sk, spelled, vec![]),
+                    signed_member_info(&viewer_sk, "Viewer", vec![]),
+                ],
+            };
+            let badges = deputy_badges_for_viewer(
+                &members,
+                &member_info,
+                &secrets,
+                owner_id,
+                id(&viewer_sk),
+            );
+            assert!(badges.contains_key(&id(&mod_sk)), "precondition: badged");
+
+            let checker =
+                impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges);
+            assert_eq!(
+                impersonation_warning_for_display(
+                    &checker,
+                    id(&nameless_sk),
+                    crate::util::display_name::UNKNOWN_MEMBER,
+                    None,
+                ),
+                None,
+                "a deputy whose record says `{spelled}` accused every member \
+                 waiting for their member_info to sync"
+            );
+        }
     }
 
     /// **The motivating attack.** `Ιan Clarke` with a Greek capital iota
@@ -5582,7 +5882,7 @@ mod tests {
         );
 
         let (checker, _owner, mod_id, stranger) = impersonation_fixture(homoglyph);
-        let warning = impersonation_warning_for_display(&checker, stranger, homoglyph)
+        let warning = impersonation_warning_for_display(&checker, stranger, homoglyph, None)
             .expect("a Greek-iota homoglyph of a moderator's name must be flagged");
 
         assert_eq!(warning.tier, ConfusableTier::Identical);
@@ -5600,7 +5900,7 @@ mod tests {
 
         // ...and the real moderator, under the real name, is untouched.
         assert_eq!(
-            impersonation_warning_for_display(&checker, mod_id, "Ian Clarke"),
+            impersonation_warning_for_display(&checker, mod_id, "Ian Clarke", None),
             None
         );
     }
@@ -5614,12 +5914,12 @@ mod tests {
 
         // Each under their own name.
         assert_eq!(
-            impersonation_warning_for_display(&checker, mod_id, "Ian Clarke"),
+            impersonation_warning_for_display(&checker, mod_id, "Ian Clarke", None),
             None,
             "the real moderator must never be flagged for their own name"
         );
         assert_eq!(
-            impersonation_warning_for_display(&checker, owner_id, "Room Owner"),
+            impersonation_warning_for_display(&checker, owner_id, "Room Owner", None),
             None,
             "the owner must never be flagged for their own name"
         );
@@ -5628,13 +5928,13 @@ mod tests {
         // per-identity, not per-literal-string.
         for name in ["\u{0399}an Clarke", "lan Clarke", "IAN CLARKE"] {
             assert_eq!(
-                impersonation_warning_for_display(&checker, mod_id, name),
+                impersonation_warning_for_display(&checker, mod_id, name, None),
                 None,
                 "the real moderator was flagged for a variant of their OWN name: {name:?}"
             );
         }
         assert_eq!(
-            impersonation_warning_for_display(&checker, owner_id, "R00m 0wner"),
+            impersonation_warning_for_display(&checker, owner_id, "R00m 0wner", None),
             None
         );
 
@@ -5646,7 +5946,7 @@ mod tests {
         // put the sockpuppet in that set and let it wear `"Ian Clarke"` with a
         // genuine shield and no warning.
         assert!(
-            impersonation_warning_for_display(&checker, owner_id, "Ian Clarke").is_some(),
+            impersonation_warning_for_display(&checker, owner_id, "Ian Clarke", None).is_some(),
             "the owner renaming themselves after a moderator IS impersonating \
              that moderator, and must be flagged"
         );
@@ -5655,11 +5955,12 @@ mod tests {
         // an unprivileged member are flagged. Without this half the test above
         // would pass against a checker that never flags anything.
         assert!(
-            impersonation_warning_for_display(&checker, stranger, "\u{0399}an Clarke").is_some(),
+            impersonation_warning_for_display(&checker, stranger, "\u{0399}an Clarke", None)
+                .is_some(),
             "an unprivileged member using the moderator's name must be flagged"
         );
         assert!(
-            impersonation_warning_for_display(&checker, stranger, "R00m 0wner").is_some(),
+            impersonation_warning_for_display(&checker, stranger, "R00m 0wner", None).is_some(),
             "an unprivileged member using the owner's name must be flagged"
         );
     }
@@ -5679,7 +5980,7 @@ mod tests {
             "Bob Smith",
         ] {
             assert_eq!(
-                impersonation_warning_for_display(&checker, stranger, name),
+                impersonation_warning_for_display(&checker, stranger, name, None),
                 None,
                 "{name:?} is an ordinary name and must not be accused"
             );
@@ -5710,7 +6011,7 @@ mod tests {
             "François Müller",      // accented Latin
         ] {
             assert_eq!(
-                impersonation_warning_for_display(&checker, stranger, name),
+                impersonation_warning_for_display(&checker, stranger, name, None),
                 None,
                 "a legitimate name was accused of impersonation: {name:?}"
             );
@@ -5741,7 +6042,7 @@ mod tests {
             );
             // ...and the render boundary drops it.
             assert_eq!(
-                impersonation_warning_for_display(&checker, stranger, name),
+                impersonation_warning_for_display(&checker, stranger, name, None),
                 None,
                 "{name:?} ({why}) is a near-miss and must not render a badge"
             );
@@ -5797,8 +6098,13 @@ mod tests {
         // Deputised: the moderator's name is protected, so the homoglyph warns.
         let deputised = build(vec![id(&mod_sk)]);
         assert!(
-            impersonation_warning_for_display(&deputised, id(&impostor_sk), "\u{0399}an Clarke")
-                .is_some(),
+            impersonation_warning_for_display(
+                &deputised,
+                id(&impostor_sk),
+                "\u{0399}an Clarke",
+                None
+            )
+            .is_some(),
             "while the moderator is deputised their name must be protected"
         );
 
@@ -5806,7 +6112,12 @@ mod tests {
         // no warning, because `Ian Clarke` is now an ordinary member's name.
         let revoked = build(vec![]);
         assert_eq!(
-            impersonation_warning_for_display(&revoked, id(&impostor_sk), "\u{0399}an Clarke"),
+            impersonation_warning_for_display(
+                &revoked,
+                id(&impostor_sk),
+                "\u{0399}an Clarke",
+                None
+            ),
             None,
             "after the deputy grant is revoked the name is no longer protected"
         );
@@ -5815,7 +6126,7 @@ mod tests {
         // from being the owner, not from any deputy grant.
         for (label, checker) in [("deputised", &deputised), ("revoked", &revoked)] {
             assert!(
-                impersonation_warning_for_display(checker, id(&impostor_sk), "R00m 0wner")
+                impersonation_warning_for_display(checker, id(&impostor_sk), "R00m 0wner", None)
                     .is_some(),
                 "the owner must stay protected in the {label} state"
             );
@@ -5880,7 +6191,7 @@ mod tests {
 
         let checker = impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges);
         assert_eq!(
-            impersonation_warning_for_display(&checker, id(&twin_sk), &handle),
+            impersonation_warning_for_display(&checker, id(&twin_sk), &handle, None),
             None,
             "an assigned handle is not a claimed identity; colliding with one \
              must not put an impersonation badge on a member who did nothing"
@@ -5890,7 +6201,7 @@ mod tests {
         // owner's CHOSEN name stays protected in the same room, so this test
         // cannot pass by producing an empty checker.
         assert!(
-            impersonation_warning_for_display(&checker, id(&twin_sk), "R00m 0wner").is_some(),
+            impersonation_warning_for_display(&checker, id(&twin_sk), "R00m 0wner", None).is_some(),
             "the owner's chosen name must still be protected"
         );
     }
@@ -5934,14 +6245,15 @@ mod tests {
         // `"Unknown"` is what the member list renders for a member with no
         // record; it must not be a protected name.
         assert_eq!(
-            impersonation_warning_for_display(&checker, id(&nameless_sk), "Unknown"),
+            impersonation_warning_for_display(&checker, id(&nameless_sk), "Unknown", None),
             None,
             "`Unknown` is the placeholder for EVERY record-less member, so \
              protecting it would accuse all of them"
         );
         // The owner's real name is still protected.
         assert!(
-            impersonation_warning_for_display(&checker, id(&nameless_sk), "R00m 0wner").is_some()
+            impersonation_warning_for_display(&checker, id(&nameless_sk), "R00m 0wner", None)
+                .is_some()
         );
     }
 
@@ -5997,7 +6309,7 @@ mod tests {
                 "precondition: {name:?} carries a shield"
             );
             assert_eq!(
-                impersonation_warning_for_display(&checker, id(sk), name),
+                impersonation_warning_for_display(&checker, id(sk), name, None),
                 None,
                 "a shielded deputy with a name of their own must show no warning"
             );
@@ -6019,11 +6331,95 @@ mod tests {
         let checker = impersonation_checker_for_viewer(&colliding, &secrets, owner_id, &badges);
         for (sk, name) in [(&mod_a_sk, "Ian Clarke"), (&mod_b_sk, "\u{0399}an Clarke")] {
             assert!(
-                impersonation_warning_for_display(&checker, id(sk), name).is_some(),
+                impersonation_warning_for_display(&checker, id(sk), name, None).is_some(),
                 "two deputies a reader cannot tell apart must BOTH be flagged; \
                  exempting them is the broad rule an attacker extended"
             );
         }
+    }
+
+    /// **A shield and a warning CAN both render**, and the tooltip must not
+    /// then assert something false.
+    ///
+    /// Three comments in this codebase used to claim the two badges were
+    /// mutually exclusive, citing a pin test that was never written; one of
+    /// them went on to describe the pair as "a single badge position in
+    /// practice", which invites a refactor that collapses the slots. Case 2 of
+    /// `a_deputy_shows_no_warning_unless_a_protected_name_collides` disproves
+    /// the claim, so this is the pin the comments should always have had.
+    #[test]
+    fn a_shield_and_a_warning_can_both_render() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let mod_a_sk = SigningKey::generate(&mut rng);
+        let mod_b_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &mod_a_sk.verifying_key()),
+                authorized_member(&owner_sk, &mod_b_sk.verifying_key()),
+                authorized_member(&owner_sk, &viewer_sk.verifying_key()),
+            ],
+        };
+        // Two deputies a reader cannot tell apart, plus an OWNER whose name
+        // collides with them — the second reachable case, and the one where the
+        // old tooltip told the room owner they were not a moderator.
+        let colliding = MemberInfoV1 {
+            member_info: vec![
+                signed_member_info(&owner_sk, "lan Clarke", vec![id(&mod_a_sk), id(&mod_b_sk)]),
+                signed_member_info(&mod_a_sk, "Ian Clarke", vec![]),
+                signed_member_info(&mod_b_sk, "\u{0399}an Clarke", vec![]),
+                signed_member_info(&viewer_sk, "Viewer", vec![]),
+            ],
+        };
+        let badges =
+            deputy_badges_for_viewer(&members, &colliding, &secrets, owner_id, id(&viewer_sk));
+        let checker = impersonation_checker_for_viewer(&colliding, &secrets, owner_id, &badges);
+
+        for (member, name) in [
+            (id(&mod_a_sk), "Ian Clarke"),
+            (id(&mod_b_sk), "\u{0399}an Clarke"),
+            (owner_id, "lan Clarke"),
+        ] {
+            let privilege = privilege_in_view(member, owner_id, &badges);
+            assert!(
+                privilege.is_some(),
+                "precondition: {name:?} holds privilege, so a badge renders"
+            );
+            let warning = impersonation_warning_for_display(&checker, member, name, privilege)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{name:?} shares a skeleton with another protected name, so it is flagged"
+                    )
+                });
+            assert_eq!(warning.flagged_privilege, privilege);
+
+            // The badge is NOT suppressed — suppression is the immunity a
+            // deputised sockpuppet wants — but the sentence is true of a
+            // member who does hold a grant.
+            let tip = warning.tooltip();
+            assert!(
+                !tip.contains("is NOT"),
+                "a privileged member was told they are not privileged: {tip}"
+            );
+            assert!(tip.contains("Name conflict"), "{tip}");
+        }
+
+        // ...and an ordinary member colliding with the same names still gets
+        // the accusing wording, so the rewrite is scoped, not blanket.
+        let stranger = MemberId::from(&SigningKey::generate(&mut rng).verifying_key());
+        let tip = impersonation_warning_for_display(&checker, stranger, "Ian Clarke", None)
+            .expect("an unprivileged impostor is still flagged")
+            .tooltip();
+        assert!(tip.contains("is NOT"), "{tip}");
     }
 
     /// The protected set is built from a `HashMap`, so its iteration order is
@@ -6076,7 +6472,7 @@ mod tests {
             );
             let checker =
                 impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges);
-            impersonation_warning_for_display(&checker, id(&impostor_sk), "1an Clarke")
+            impersonation_warning_for_display(&checker, id(&impostor_sk), "1an Clarke", None)
                 .expect("the impostor is flagged")
                 .impersonated
                 .display_name
@@ -6109,6 +6505,7 @@ mod tests {
                 MemberId(freenet_scaffold::util::FastHash(1)),
             ),
             tier: ConfusableTier::Identical,
+            flagged_privilege: None,
         });
 
         let parts = member_display_parts(&display);
@@ -6227,7 +6624,7 @@ mod tests {
         );
         let checker = impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges);
 
-        let warning = impersonation_warning_for_display(&checker, id(&impostor_sk), &clone)
+        let warning = impersonation_warning_for_display(&checker, id(&impostor_sk), &clone, None)
             .expect("an IVS clone of a moderator's name must be flagged");
         assert_eq!(
             warning.tier,
@@ -6240,11 +6637,11 @@ mod tests {
         // And the real moderator is untouched, so the fold has not simply made
         // everything match.
         assert_eq!(
-            impersonation_warning_for_display(&checker, id(&mod_sk), real),
+            impersonation_warning_for_display(&checker, id(&mod_sk), real, None),
             None
         );
         assert_eq!(
-            impersonation_warning_for_display(&checker, id(&viewer_sk), "Viewer"),
+            impersonation_warning_for_display(&checker, id(&viewer_sk), "Viewer", None),
             None
         );
     }
@@ -6273,6 +6670,13 @@ mod tests {
         /// deleted the `MemberList` call site, because `members.rs` also
         /// contains the function's own DEFINITION and its tests. Scoping is
         /// the entire point — do not widen these ranges.
+        /// Whitespace-insensitive form, so an argument-list pin survives
+        /// `cargo fmt` rewrapping a call across different line breaks while
+        /// still failing if an ARGUMENT changes.
+        fn squashed(src: &str) -> String {
+            src.split_whitespace().collect::<Vec<_>>().join(" ")
+        }
+
         fn between<'a>(src: &'a str, from: &str, to: &str, what: &str) -> &'a str {
             let start = src
                 .find(from)
@@ -6295,6 +6699,20 @@ mod tests {
             member_memo.contains("impersonation_warning_for_display("),
             "MemberList no longer computes an impersonation warning, so the \
              member list shows no warning however confusable a name is"
+        );
+        // **The ARGUMENTS, not just the call.** Swapping `member_id` for
+        // `self_member_id` here compiles and passes every behavioural test in
+        // this file, and puts ⚠ on the genuine owner and every genuine
+        // moderator — the worst mutation this feature has, and the one a
+        // bare `contains("impersonation_warning_for_display(")` cannot see.
+        assert!(
+            squashed(member_memo).contains(
+                "impersonation_warning_for_display( &impersonation, member_id, &nickname, \
+                 privilege_in_view(member_id, owner_id, &deputy_badges), )"
+            ),
+            "the member row no longer passes `member_id` (and that row's own \
+             privilege) to `impersonation_warning_for_display`. Passing any \
+             other id flags the genuine owner and every genuine moderator"
         );
         assert!(
             member_memo.contains("impersonation_checker_for_viewer("),
@@ -6338,6 +6756,17 @@ mod tests {
             group_fn.contains("impersonation_warning_for_display("),
             "`group_messages` no longer computes an impersonation warning, so \
              message author lines show no warning"
+        );
+        // Same mutation, same blast radius: `author_id` -> `self_member_id`
+        // compiles, passes, and brands the real owner and every real
+        // moderator across the whole conversation.
+        assert!(
+            squashed(group_fn).contains(
+                "impersonation_warning_for_display( impersonation, author_id, &author_name, \
+                 privilege_in_view(author_id, owner_id, deputy_badges), )"
+            ),
+            "the author line no longer passes `author_id` (and that author's \
+             own privilege) to `impersonation_warning_for_display`"
         );
         assert!(
             !group_fn.contains("impersonation_checker_for_viewer("),

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -240,36 +240,89 @@ fn did_you_invite_member(member_id: MemberId, members: &MembersV1, self_id: Memb
 #[derive(Clone, PartialEq)]
 struct MemberDisplayParts {
     nickname: String,
-    tags: Vec<(&'static str, String)>,
+    tags: Vec<MemberTag>,
+}
+
+/// One badge in a member row.
+///
+/// `test_id` is what makes a badge addressable from a browser test. Every badge
+/// carries one rather than only the ⚠, because they all share a single
+/// anonymous render loop: giving one of them a handle and leaving the rest
+/// glyph-matched just moves the brittleness. The ⚠ is the reason this exists —
+/// the clipping bug it has already had once is exactly the class a browser test
+/// catches and a unit test structurally cannot.
+#[derive(Clone, PartialEq)]
+struct MemberTag {
+    glyph: &'static str,
+    tooltip: String,
+    test_id: &'static str,
+}
+
+impl MemberTag {
+    fn new(glyph: &'static str, test_id: &'static str, tooltip: String) -> Self {
+        Self {
+            glyph,
+            tooltip,
+            test_id,
+        }
+    }
 }
 
 fn member_display_parts(member: &MemberDisplay) -> MemberDisplayParts {
-    let mut tags: Vec<(&'static str, String)> = Vec::new();
+    let mut tags: Vec<MemberTag> = Vec::new();
 
     // FIRST, so the warning sits immediately after the name it is about rather
     // than at the end of a run of relationship tags. A reader scanning the list
     // for an impostor should not have to parse "🔑 🌐 🎪" before reaching it.
+    //
+    // The test id mirrors the conversation side's
+    // `message-author-impersonation-warning`, so one spec can address the same
+    // badge on both surfaces.
     if let Some(warning) = member.impersonation.as_ref() {
-        tags.push((crate::util::confusable::WARNING_GLYPH, warning.tooltip()));
+        tags.push(MemberTag::new(
+            crate::util::confusable::WARNING_GLYPH,
+            "member-list-impersonation-warning",
+            warning.tooltip(),
+        ));
     }
     if member.is_owner {
-        tags.push(("👑", "Room Owner".to_string()));
+        tags.push(MemberTag::new(
+            "👑",
+            "member-list-owner",
+            "Room Owner".into(),
+        ));
     }
     if member.is_self {
-        tags.push(("⭐", "You".to_string()));
+        tags.push(MemberTag::new("⭐", "member-list-self", "You".into()));
     }
     if member.invited_by_you {
-        tags.push(("🔑", "Invited by You".to_string()));
+        tags.push(MemberTag::new(
+            "🔑",
+            "member-list-invited-by-you",
+            "Invited by You".into(),
+        ));
     } else if member.in_your_network {
-        tags.push(("🌐", "In Your Network".to_string()));
+        tags.push(MemberTag::new(
+            "🌐",
+            "member-list-in-your-network",
+            "In Your Network".into(),
+        ));
     }
     if member.invited_you {
-        tags.push(("🎪", "Invited You".to_string()));
+        tags.push(MemberTag::new(
+            "🎪",
+            "member-list-invited-you",
+            "Invited You".into(),
+        ));
     } else if member.sponsored_you {
-        tags.push(("🔭", "In Your Invite Chain".to_string()));
+        tags.push(MemberTag::new(
+            "🔭",
+            "member-list-invite-chain",
+            "In Your Invite Chain".into(),
+        ));
     }
     if let Some(badge) = member.deputy_badge.as_ref() {
-        tags.push(("🛡", badge.tooltip()));
+        tags.push(MemberTag::new("🛡", "member-list-deputy", badge.tooltip()));
     }
 
     MemberDisplayParts {
@@ -1488,15 +1541,22 @@ pub fn MemberList() -> Element {
                             // bytes from `MemberInfoV1.preferred_nickname` MUST NOT be
                             // routed through `dangerous_inner_html` (freenet/river#227).
                             span { class: "truncate min-w-0", "{parts.nickname}" }
-                            for (icon, tooltip) in parts.tags {
+                            for tag in parts.tags {
                                 span {
+                                    // Addressable from a browser test — see
+                                    // `MemberTag`. `title=` does not fire on
+                                    // touch, so the badge's explanation is
+                                    // unreachable on a phone and a spec is the
+                                    // only thing that can check it renders at
+                                    // all at narrow widths.
+                                    "data-testid": "{tag.test_id}",
                                     class: "member-icon flex-shrink-0",
-                                    title: "{tooltip}",
+                                    title: "{tag.tooltip}",
                                     // The glyph alone means nothing to a
                                     // screen reader, and the deputy shield is
                                     // now a security-relevant signal.
-                                    "aria-label": "{tooltip}",
-                                    " {icon}"
+                                    "aria-label": "{tag.tooltip}",
+                                    " {tag.glyph}"
                                 }
                             }
                         }
@@ -3444,7 +3504,7 @@ mod tests {
         let parts = member_display_parts(&display);
 
         assert_eq!(parts.nickname, "alice");
-        let icons: Vec<&str> = parts.tags.iter().map(|(icon, _)| *icon).collect();
+        let icons: Vec<&str> = parts.tags.iter().map(|t| t.glyph).collect();
         assert!(icons.contains(&"👑"));
         assert!(icons.contains(&"⭐"));
     }
@@ -3461,7 +3521,7 @@ mod tests {
             !member_display_parts(&display)
                 .tags
                 .iter()
-                .any(|(icon, _)| *icon == "🛡"),
+                .any(|t| t.glyph == "🛡"),
             "no shield when the member is not a deputy"
         );
 
@@ -3473,12 +3533,12 @@ mod tests {
         let shield = parts
             .tags
             .iter()
-            .find(|(icon, _)| *icon == "🛡")
+            .find(|t| t.glyph == "🛡")
             .expect("a deputy must show the 🛡 shield");
         // Identical wording to the conversation author line and the modal
         // chip — all three call `DeputyBadge::tooltip`.
         assert_eq!(
-            shield.1,
+            shield.tooltip,
             "Deputy (appointed by the room owner). Can ban you."
         );
 
@@ -3490,7 +3550,7 @@ mod tests {
         });
         let parts = member_display_parts(&display);
         assert_eq!(
-            parts.tags.iter().find(|(icon, _)| *icon == "🛡").unwrap().1,
+            parts.tags.iter().find(|t| t.glyph == "🛡").unwrap().tooltip,
             "Deputy (appointed by the room owner)"
         );
     }
@@ -6683,13 +6743,14 @@ mod tests {
         });
 
         let parts = member_display_parts(&display);
-        let (glyph, tooltip) = parts.tags.first().expect("at least one tag");
+        let first = parts.tags.first().expect("at least one tag");
+        let (glyph, tooltip) = (&first.glyph, &first.tooltip);
         assert_eq!(
             *glyph,
             crate::util::confusable::WARNING_GLYPH,
             "the impersonation warning must be the FIRST tag, next to the name; \
              tags were {:?}",
-            parts.tags.iter().map(|(g, _)| *g).collect::<Vec<_>>()
+            parts.tags.iter().map(|t| t.glyph).collect::<Vec<_>>()
         );
         assert!(tooltip.contains("is NOT a moderator"), "{tooltip}");
         // The row's tooltip is flat hover text, so it must carry no nickname —
@@ -6704,7 +6765,7 @@ mod tests {
         assert!(!member_display_parts(&display)
             .tags
             .iter()
-            .any(|(g, _)| *g == crate::util::confusable::WARNING_GLYPH));
+            .any(|t| t.glyph == crate::util::confusable::WARNING_GLYPH));
     }
 
     /// **The residual #488 knowingly left open, and this warning is its only
@@ -6917,6 +6978,34 @@ mod tests {
             )
             .contains("WARNING_GLYPH"),
             "the member row no longer renders the warning glyph"
+        );
+        // ...and it must stay ADDRESSABLE. Without a test id the only handle a
+        // browser spec has on this badge is glyph-matching ⚠ inside
+        // `member-item-{id}`, which rots the moment the row gains any other
+        // symbol. Mirrors the conversation side's
+        // `message-author-impersonation-warning`, asserted below.
+        assert!(
+            between(
+                members_src,
+                "fn member_display_parts(",
+                "\n/// Order member IDs",
+                "member_display_parts",
+            )
+            .contains("\"member-list-impersonation-warning\""),
+            "the member-list warning lost its `data-testid`, so a Playwright \
+             spec can only reach it by glyph-matching. The id must be on the \
+             WARNING tag specifically — on the wrong badge it is worse than \
+             none, because the spec then passes against the shield"
+        );
+        assert!(
+            between(
+                members_src,
+                "pub fn MemberList()",
+                "// Action buttons",
+                "MemberList render",
+            )
+            .contains("\"data-testid\": \"{tag.test_id}\""),
+            "the member row no longer emits each tag's `data-testid`"
         );
 
         // --- Message author line ------------------------------------------

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -5790,6 +5790,118 @@ mod tests {
         );
     }
 
+    /// **The live Freenet Official topology, end to end.**
+    ///
+    /// This is the configuration the removed appointer gate broke, and the
+    /// reason it was removed: in the real room every deputy grant is issued by
+    /// `Invite Bot` (`PMAQEUP5`), not by the owner (`NRKA4WVX`) — verified
+    /// 2026-07-25 with `riverctl debug room-state`. Under the gate the
+    /// protected set was `{"Room Owner"}` and every actual moderator's name was
+    /// unprotected, which is exactly the impersonation this feature exists to
+    /// catch.
+    ///
+    /// Named after the real room on purpose: a fixture of anonymous `mod_a` /
+    /// `mod_b` deputised by the owner passes under BOTH policies, which is why
+    /// the gate survived review in the first place.
+    #[test]
+    fn the_live_freenet_official_topology_protects_every_moderator() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let bot_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+        let mods: Vec<(SigningKey, &str)> =
+            ["Ian Clarke", "HostFat", "Ivvor", "ofansifkapital-xmpp"]
+                .into_iter()
+                .map(|name| (SigningKey::generate(&mut rng), name))
+                .collect();
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        // The bot invited the viewer, so it is a strict ancestor and its grants
+        // are viewer-relevant — the real room's shape.
+        let mut members = vec![
+            authorized_member(&owner_sk, &bot_sk.verifying_key()),
+            member_invited_by(&bot_sk, owner_id, &viewer_sk.verifying_key()),
+        ];
+        let mut records = vec![
+            // The owner deputizes NOBODY. Every grant comes from the bot.
+            signed_member_info(&owner_sk, "Room Owner", vec![]),
+            signed_member_info(
+                &bot_sk,
+                "Invite Bot",
+                mods.iter().map(|(sk, _)| id(sk)).collect(),
+            ),
+            signed_member_info(&viewer_sk, "Viewer", vec![]),
+        ];
+        for (sk, name) in &mods {
+            members.push(member_invited_by(&bot_sk, owner_id, &sk.verifying_key()));
+            records.push(signed_member_info(sk, name, vec![]));
+        }
+        let members = MembersV1 { members };
+        let member_info = MemberInfoV1 {
+            member_info: records,
+        };
+
+        let badges =
+            deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, id(&viewer_sk));
+        for (sk, name) in &mods {
+            assert!(
+                badges.contains_key(&id(sk)),
+                "precondition: {name} carries a shield in the viewer's view"
+            );
+        }
+        let checker = impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges);
+
+        // An impostor joins under a homoglyph of each moderator's name and of
+        // the owner's. Every one must be flagged.
+        let impostor = MemberId::from(&SigningKey::generate(&mut rng).verifying_key());
+        for spoof in [
+            "\u{0399}an Clarke",          // Greek capital iota — the live attack
+            "lan Clarke",                 // lowercase L
+            "IAN CLARKE",                 // case
+            "Ian Clarke",                 // exact
+            "H0stFat",                    // zero for O
+            "lvvor",                      // lowercase L for capital I
+            "IVVOR",                      // case, through the second fold
+            "\u{2C9E}fansifkapital-xmpp", // Coptic O
+            "R00m 0wner",
+        ] {
+            assert!(
+                impersonation_warning_for_display(&checker, impostor, spoof, None).is_some(),
+                "an impostor wearing {spoof:?} must be flagged — this is the \
+                 exact room the feature was built for"
+            );
+        }
+
+        // ...and every genuine moderator, under their own name, is untouched.
+        for (sk, name) in &mods {
+            assert_eq!(
+                impersonation_warning_for_display(
+                    &checker,
+                    id(sk),
+                    name,
+                    Some(ProtectedRole::Deputy)
+                ),
+                None,
+                "the real {name} must never be badged for their own name"
+            );
+        }
+        assert_eq!(
+            impersonation_warning_for_display(
+                &checker,
+                owner_id,
+                "Room Owner",
+                Some(ProtectedRole::Owner)
+            ),
+            None
+        );
+    }
+
     /// **P3.5 — the guards must be as wide as the matcher they gate.**
     ///
     /// `is_generated_handle` is exact-string; the matcher compares folds. So a

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -4973,7 +4973,15 @@ mod tests {
         assert_eq!(warning.tier, ConfusableTier::Identical);
         assert_eq!(warning.impersonated.role, ProtectedRole::Deputy);
         assert_eq!(warning.impersonated.display_name, "Ian Clarke");
-        assert!(warning.tooltip().contains("Ian Clarke"));
+        // The identified victim is on the WARNING, for a surface that can render
+        // it as its own DOM node. It is deliberately NOT in the flat tooltip —
+        // see `ImpersonationWarning::tooltip`, which names the role instead.
+        assert!(
+            !warning.tooltip().contains("Ian Clarke"),
+            "no nickname may reach the flat tooltip: {}",
+            warning.tooltip()
+        );
+        assert!(warning.tooltip().contains("is NOT a moderator"));
 
         // ...and the real moderator, under the real name, is untouched.
         assert_eq!(
@@ -5460,8 +5468,11 @@ mod tests {
              tags were {:?}",
             parts.tags.iter().map(|(g, _)| *g).collect::<Vec<_>>()
         );
-        assert!(tooltip.contains("Ian Clarke"), "{tooltip}");
         assert!(tooltip.contains("is NOT a moderator"), "{tooltip}");
+        // The row's tooltip is flat hover text, so it must carry no nickname —
+        // the member row is one of the surfaces that cannot render separate
+        // nodes for it.
+        assert!(!tooltip.contains("Ian Clarke"), "{tooltip}");
         // The relationship tags are still rendered, after it.
         assert!(parts.tags.len() > 1);
 

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1141,7 +1141,13 @@ pub(crate) fn impersonation_checker_for_viewer(
 /// the member ID, on hover, next to every name.
 ///
 /// So the rendered signal means something narrow and checkable: **these two
-/// names fold to the same skeleton — they are visually the same string.**
+/// names fold to the same skeleton.** That is *almost* "they are visually the
+/// same string", and the difference matters enough to state: the fold also
+/// drops spaces, so `Host Fat` matches `HostFat` and `Jo Anna` matches
+/// `Joanna` — names a reader can plainly tell apart. That rule earns its place
+/// by catching `IanClarke`, and its cost is enumerated in
+/// [`crate::util::confusable`]'s "Honest limits" and pinned row by row in
+/// `documented_accepted_collisions`.
 pub(crate) fn impersonation_warning_for_display(
     checker: &ImpersonationChecker,
     member_id: MemberId,
@@ -4812,33 +4818,69 @@ mod tests {
     #[test]
     fn the_warning_badge_cannot_be_clipped_by_a_long_nickname() {
         let src = include_str!("members.rs");
-        let start = src
-            .find("\"data-testid\": \"member-item-")
+        // LINE-scoped, not byte-offset-scoped. The previous version sliced
+        // `src[start..start + 2600]`, which lands on a char boundary today only
+        // by luck: this file is full of multibyte glyphs (⚠ 🛡 👑 and the
+        // homoglyph literals in the tests), and any edit that shifts one into
+        // the cut panics the test with a slice error instead of a finding.
+        let lines: Vec<&str> = src.lines().collect();
+        let row_start = lines
+            .iter()
+            .position(|l| l.contains("\"data-testid\": \"member-item-"))
             .expect("the row");
-        let row = &src[start..start + 2600];
+        let row_lines = &lines[row_start..(row_start + 40).min(lines.len())];
 
-        let button = row.find("button {").expect("the row is a button");
-        let button_class_end = row[button..].find('\n').unwrap_or(0) + button;
-        let button_line = &row[button..button_class_end + 200];
+        let button_line = row_lines
+            .iter()
+            .skip_while(|l| !l.contains("button {"))
+            .nth(1)
+            .expect("the row button's class line");
         assert!(
-            !button_line.contains("transition-colors truncate"),
-            "`truncate` must not sit on the row BUTTON — it clips the badges \
-             along with the name, so a long nickname hides the warning"
+            button_line.contains("class:"),
+            "expected the class attribute on the line after `button {{`, got \
+             {button_line:?}"
+        );
+        // `!contains("transition-colors truncate")` was strictly weaker than
+        // the revert it blocks: `class: "truncate w-full ... transition-colors"`
+        // reintroduces the bug and passes. The button carries no `truncate` at
+        // all today, so assert exactly that.
+        assert!(
+            !button_line.contains("truncate"),
+            "`truncate` must not sit on the row BUTTON in any position — it \
+             clips the badge spans along with the name, so a long nickname \
+             hides the warning: {button_line:?}"
+        );
+        // `min-w-0` is load-bearing for the same behaviour: without it the
+        // flex item refuses to shrink below its content width, the row
+        // overflows instead of truncating, and the badges go off the edge.
+        assert!(
+            button_line.contains("min-w-0"),
+            "the row button must be `min-w-0` so the name can shrink instead \
+             of pushing the badges out of the row: {button_line:?}"
         );
 
-        let name = row
-            .find("\"{parts.nickname}\"")
+        let name_line = row_lines
+            .iter()
+            .find(|l| l.contains("\"{parts.nickname}\""))
             .expect("the nickname span exists");
         assert!(
-            row[name.saturating_sub(120)..name].contains("truncate"),
-            "the NAME span must be the thing that truncates"
+            name_line.contains("truncate"),
+            "the NAME span must be the thing that truncates: {name_line:?}"
+        );
+        assert!(
+            name_line.contains("min-w-0"),
+            "the name span must be `min-w-0`, or `truncate` has nothing to \
+             shrink against and the badges are pushed out: {name_line:?}"
         );
 
-        let tag = row.find("member-icon").expect("the tag span exists");
+        let tag_line = row_lines
+            .iter()
+            .find(|l| l.contains("member-icon"))
+            .expect("the tag span exists");
         assert!(
-            row[tag..tag + 60].contains("flex-shrink-0"),
+            tag_line.contains("flex-shrink-0"),
             "every badge span must be `flex-shrink-0` so it can never be \
-             clipped, whatever the nickname's length"
+             clipped, whatever the nickname's length: {tag_line:?}"
         );
     }
 

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1001,7 +1001,7 @@ pub(crate) fn deputy_badges_for_viewer(
 /// match the member River assigned `Amber Worm`. No attacker is needed — a
 /// moderator who simply styles their own name in lower case would otherwise put
 /// "this member is NOT a moderator" on every member holding that handle.
-/// `a_lowercased_generated_handle_is_not_protected` and
+/// `a_confusable_variant_of_a_generated_handle_is_not_protected` and
 /// `an_unknown_named_deputy_is_not_protected` pin it.
 ///
 /// The identity exemption must never depend on a name: a member filtered out
@@ -5982,7 +5982,7 @@ mod tests {
     /// A deputy whose `member_info` record literally SAYS `Unknown` (or any
     /// fold of it) would flag every member whose record has not synced yet —
     /// simultaneously, with no attacker, during an ordinary sync gap. The
-    /// existing `a_member_without_member_info_is_not_protected` covers a deputy
+    /// existing `a_privileged_member_without_member_info_is_not_protected` covers a deputy
     /// with NO record; this covers one whose record carries the placeholder.
     #[test]
     fn an_unknown_named_deputy_is_not_protected() {

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -2,6 +2,9 @@ use crate::components::app::freenet_api::freenet_synchronizer::SynchronizerStatu
 use crate::components::app::{
     MobileView, CURRENT_ROOM, MEMBER_INFO_MODAL, MOBILE_VIEW, ROOMS, SYNC_STATUS,
 };
+use crate::util::confusable::{
+    ConfusableTier, ImpersonationChecker, ImpersonationWarning, ProtectedName, ProtectedRole,
+};
 use crate::util::display_name::display_nickname;
 use crate::util::ecies::unseal_bytes_with_secrets;
 use dioxus::prelude::*;
@@ -178,6 +181,16 @@ struct MemberDisplay {
     /// visibility rule and the same tooltip — the conversation's author line
     /// and the member-info modal use.
     deputy_badge: Option<DeputyBadge>,
+    /// The ⚠ impersonation warning for this member, or `None`. Same value, and
+    /// therefore the same tier rule and tooltip, the conversation's author line
+    /// uses — both go through
+    /// [`impersonation_warning_for_display`].
+    ///
+    /// Mutually exclusive with `deputy_badge` by construction: a member who
+    /// shows a shield is a deputy, deputies are in the checker's privileged set,
+    /// and a privileged member is never warned about. Pinned by
+    /// `shield_and_warning_are_mutually_exclusive`.
+    impersonation: Option<ImpersonationWarning>,
 }
 
 fn is_member_sponsor(
@@ -231,6 +244,12 @@ struct MemberDisplayParts {
 fn member_display_parts(member: &MemberDisplay) -> MemberDisplayParts {
     let mut tags: Vec<(&'static str, String)> = Vec::new();
 
+    // FIRST, so the warning sits immediately after the name it is about rather
+    // than at the end of a run of relationship tags. A reader scanning the list
+    // for an impostor should not have to parse "🔑 🌐 🎪" before reaching it.
+    if let Some(warning) = member.impersonation.as_ref() {
+        tags.push((crate::util::confusable::WARNING_GLYPH, warning.tooltip()));
+    }
     if member.is_owner {
         tags.push(("👑", "Room Owner".to_string()));
     }
@@ -936,6 +955,116 @@ pub(crate) fn deputy_badges_for_viewer(
         .collect()
 }
 
+/// The impersonation checker for one viewer's view of one room (#488 follow-up).
+///
+/// ## The protected set is derived from room state, never hard-coded
+///
+/// It is exactly **the room owner, plus every member who shows a 🛡 shield in
+/// this viewer's view**, each under whatever nickname they currently hold. That
+/// is deliberately the SAME notion of "deputy" the shield uses — this takes
+/// `deputy_badges` as a parameter rather than recomputing it, so there is
+/// physically only one answer to "who is a deputy" and a deputize/revoke moves
+/// the protected set with it on the next render. No list to maintain, and no
+/// second definition to drift.
+///
+/// Reusing the viewer-relative badge map also makes the *scope* right: a
+/// protected name is one whose authority this viewer would be fooled by, which
+/// is precisely the set whose shield they can see.
+///
+/// ## Two filters on which names get protected
+///
+/// * **No `member_info` record ⇒ not protected.** Such a member renders as
+///   `"Unknown"`, and `"Unknown"` is what EVERY member without a record renders
+///   as — protecting it would flag all of them for impersonating each other.
+/// * **A generated handle ⇒ not protected.** A member who never typed a
+///   nickname wears one of the 10,000 handles River derived from their key
+///   ([`crate::nickname::is_generated_handle`]). Two members can be assigned the
+///   same one, which is a collision River created rather than an imitation
+///   either of them performed; with ~120 members in a room it is more likely
+///   than not that some pair shares a handle. Protecting an unclaimed name would
+///   turn that birthday collision into an accusation.
+///
+/// `privileged_ids` is deliberately WIDER than `protected`: it holds every
+/// deputy and the owner, including the ones whose names are filtered out above.
+/// The identity exemption must never depend on a name — see
+/// [`ImpersonationChecker::check`].
+pub(crate) fn impersonation_checker_for_viewer(
+    member_info: &river_core::room_state::member_info::MemberInfoV1,
+    room_secrets: &HashMap<u32, [u8; 32]>,
+    owner_id: MemberId,
+    deputy_badges: &HashMap<MemberId, DeputyBadge>,
+) -> ImpersonationChecker {
+    let mut privileged_ids: HashSet<MemberId> = deputy_badges.keys().copied().collect();
+    privileged_ids.insert(owner_id);
+
+    // The name this member has CLAIMED, or `None` if they have not claimed one.
+    let claimed_name = |id: MemberId| -> Option<String> {
+        let name = display_nickname(
+            &member_info.canonical(id)?.member_info.preferred_nickname,
+            room_secrets,
+        );
+        (!crate::nickname::is_generated_handle(&name)).then_some(name)
+    };
+
+    let mut protected = Vec::new();
+    if let Some(name) = claimed_name(owner_id) {
+        protected.push(ProtectedName::new(ProtectedRole::Owner, name));
+    }
+    // Sorted, because `deputy_badges` is a `HashMap` and two deputies can share
+    // a skeleton (a sockpuppet deputised under a real deputy's name). Raw map
+    // order would let the tooltip name a different victim between renders — the
+    // same nondeterminism `build_deputizers_of` sorts away for the shield.
+    let mut deputies: Vec<MemberId> = deputy_badges.keys().copied().collect();
+    deputies.sort_unstable();
+    for id in deputies {
+        if let Some(name) = claimed_name(id) {
+            protected.push(ProtectedName::new(ProtectedRole::Deputy, name));
+        }
+    }
+
+    ImpersonationChecker::new(protected, privileged_ids)
+}
+
+/// The impersonation warning a surface actually RENDERS for one member, if any.
+///
+/// **Every render surface must go through this**, not
+/// [`ImpersonationChecker::check`] directly, because it carries the tier
+/// decision — and a surface that skipped it would show a badge the other
+/// surfaces do not, which is exactly the cross-surface drift freenet/river#451
+/// fixed for the shield.
+///
+/// ## Only [`ConfusableTier::Identical`] is rendered
+///
+/// The engine also reports [`ConfusableTier::NearMiss`] (within a small,
+/// length-scaled edit distance). This UI drops it, on measured evidence rather
+/// than taste: River assigns every member one of 10,000 generated handles, and
+/// `Amber Worm` / `Ember Worm` are one edit apart, so the near-miss tier accuses
+/// a pair of members River itself created — before any attacker acts. Tier 1 is
+/// clean on the same population (no two handles share a skeleton). Both facts
+/// are pinned in [`crate::util::confusable`] by
+/// `generated_handles_never_fold_to_the_same_skeleton` and
+/// `generated_handles_are_within_the_near_miss_budget`.
+///
+/// The cost is real and accepted: `Ian Clark` no longer warns for the moderator
+/// `Ian Clarke`. That is the right trade here, because a false accusation is
+/// not a symmetric error — it lands on an innocent member, it is visible to the
+/// whole room, and a badge that fires on ordinary near-duplicates trains people
+/// to ignore the badge that catches the real thing. What remains for the
+/// near-miss case is the disambiguator River already shows on both surfaces:
+/// the member ID, on hover, next to every name.
+///
+/// So the rendered signal means something narrow and checkable: **these two
+/// names fold to the same skeleton — they are visually the same string.**
+pub(crate) fn impersonation_warning_for_display(
+    checker: &ImpersonationChecker,
+    member_id: MemberId,
+    display_name: &str,
+) -> Option<ImpersonationWarning> {
+    checker
+        .check(member_id, display_name)
+        .filter(|w| w.tier == ConfusableTier::Identical)
+}
+
 /// [`deputy_badges_for_viewer`] for a SINGLE member.
 ///
 /// The member-info modal wants one member's badge and is not memoised, so
@@ -1057,6 +1186,13 @@ pub fn MemberList() -> Element {
         let deputy_badges =
             deputy_badges_for_viewer(members, member_info, room_secrets, owner_id, self_member_id);
 
+        // The ⚠ impersonation checker, built ONCE here from the badge map above
+        // — never inside the per-member loop below, which would re-fold every
+        // protected name (and, in a private room, re-unseal every protected
+        // nickname) once per member. `check` is the per-member hot path.
+        let impersonation =
+            impersonation_checker_for_viewer(member_info, room_secrets, owner_id, &deputy_badges);
+
         // Order the list as a DISPLAY tree, VIEWER-SCOPED: a member renders under
         // a deputizer only if that deputizer is viewer-relevant — so a global mod
         // rises to the top for everyone (including the owner's own view), a
@@ -1073,6 +1209,13 @@ pub fn MemberList() -> Element {
                 .canonical(member_id)
                 .map(|mi| display_nickname(&mi.member_info.preferred_nickname, room_secrets))
                 .unwrap_or_else(|| "Unknown".to_string());
+
+            // Computed from the RENDERED `nickname` above, not the raw sealed
+            // bytes: the checker compares what the reader actually sees, so it
+            // must be fed post-`display_nickname` text. Feeding it the raw
+            // nickname would compare a string nobody is shown.
+            let impersonation_warning =
+                impersonation_warning_for_display(&impersonation, member_id, &nickname);
 
             let member_display = MemberDisplay {
                 nickname,
@@ -1105,6 +1248,7 @@ pub fn MemberList() -> Element {
                 // shield's visibility AND its tooltip stay identical across
                 // the sidebar, the modal and the conversation.
                 deputy_badge: deputy_badges.get(&member_id).cloned(),
+                impersonation: impersonation_warning,
             };
 
             all_members.push((member_display_parts(&member_display), member_id));
@@ -2818,6 +2962,7 @@ mod tests {
             invited_by_you: false,
             in_your_network: false,
             deputy_badge: None,
+            impersonation: None,
         }
     }
 
@@ -4749,5 +4894,644 @@ mod tests {
         let decoded =
             Invitation::from_encoded_string(&encoded).expect("legacy invitation should decode");
         assert!(decoded.room_secrets.is_empty());
+    }
+
+    // ---------------------------------------------------------------
+    // Impersonation warning (⚠) — wiring of `crate::util::confusable`
+    // ---------------------------------------------------------------
+
+    /// A room with `owner` (nickname `Room Owner`), a global moderator `mod`
+    /// (nickname `Ian Clarke`, deputised by the owner), the `viewer`, and one
+    /// extra member whose nickname the caller chooses.
+    ///
+    /// Returns the checker as the VIEWER sees it, plus the extra member's id —
+    /// which is the shape every test below wants.
+    fn impersonation_fixture(
+        stranger_nickname: &str,
+    ) -> (ImpersonationChecker, MemberId, MemberId, MemberId) {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let mod_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+        let stranger_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &mod_sk.verifying_key()),
+                authorized_member(&owner_sk, &viewer_sk.verifying_key()),
+                authorized_member(&owner_sk, &stranger_sk.verifying_key()),
+            ],
+        };
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                signed_member_info(&owner_sk, "Room Owner", vec![id(&mod_sk)]),
+                signed_member_info(&mod_sk, "Ian Clarke", vec![]),
+                signed_member_info(&viewer_sk, "Viewer", vec![]),
+                signed_member_info(&stranger_sk, stranger_nickname, vec![]),
+            ],
+        };
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        let badges =
+            deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, id(&viewer_sk));
+        // Precondition: the moderator really does carry a shield in this view,
+        // so a later "not flagged" assertion cannot pass merely because the
+        // protected set came out empty.
+        assert!(
+            badges.contains_key(&id(&mod_sk)),
+            "fixture precondition: the moderator must show a shield to the viewer"
+        );
+
+        let checker = impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges);
+        (checker, owner_id, id(&mod_sk), id(&stranger_sk))
+    }
+
+    /// **The motivating attack.** `Ιan Clarke` with a Greek capital iota
+    /// (U+0399) renders identically to the moderator's `Ian Clarke` and walks
+    /// past every character-blocking rule River has: U+0399 is a letter, and
+    /// rejecting it would break real Greek names.
+    #[test]
+    fn a_greek_homoglyph_of_a_deputys_name_is_flagged() {
+        let homoglyph = "\u{0399}an Clarke";
+        assert_ne!(homoglyph, "Ian Clarke", "precondition: different bytes");
+        assert!(
+            !crate::util::display_name::contains_hidden_chars(homoglyph),
+            "precondition: the existing invisible-character defence does NOT \
+             catch this, which is why the confusable check exists"
+        );
+
+        let (checker, _owner, mod_id, stranger) = impersonation_fixture(homoglyph);
+        let warning = impersonation_warning_for_display(&checker, stranger, homoglyph)
+            .expect("a Greek-iota homoglyph of a moderator's name must be flagged");
+
+        assert_eq!(warning.tier, ConfusableTier::Identical);
+        assert_eq!(warning.impersonated.role, ProtectedRole::Deputy);
+        assert_eq!(warning.impersonated.display_name, "Ian Clarke");
+        assert!(warning.tooltip().contains("Ian Clarke"));
+
+        // ...and the real moderator, under the real name, is untouched.
+        assert_eq!(
+            impersonation_warning_for_display(&checker, mod_id, "Ian Clarke"),
+            None
+        );
+    }
+
+    /// Requirement one: identity beats name. The genuine article is resolved by
+    /// `MemberId`, which is derived from a keypair and cannot be chosen, so no
+    /// nickname can make a real moderator or the owner look like an impostor.
+    #[test]
+    fn the_genuine_owner_and_deputy_are_never_flagged() {
+        let (checker, owner_id, mod_id, stranger) = impersonation_fixture("Bystander");
+
+        // Each under their own name.
+        assert_eq!(
+            impersonation_warning_for_display(&checker, mod_id, "Ian Clarke"),
+            None,
+            "the real moderator must never be flagged for their own name"
+        );
+        assert_eq!(
+            impersonation_warning_for_display(&checker, owner_id, "Room Owner"),
+            None,
+            "the owner must never be flagged for their own name"
+        );
+
+        // And under each OTHER's names, and under a homoglyph of one: a
+        // privileged member is exempt whatever they are called. The owner
+        // renaming themselves after a moderator is not impersonation.
+        for name in [
+            "Ian Clarke",
+            "\u{0399}an Clarke",
+            "Room Owner",
+            "R00m 0wner",
+        ] {
+            assert_eq!(
+                impersonation_warning_for_display(&checker, owner_id, name),
+                None,
+                "the owner was flagged while called {name:?}"
+            );
+            assert_eq!(
+                impersonation_warning_for_display(&checker, mod_id, name),
+                None,
+                "the moderator was flagged while called {name:?}"
+            );
+        }
+
+        // The exemption is identity-scoped, not name-scoped: the SAME names on
+        // an unprivileged member are flagged. Without this half the test above
+        // would pass against a checker that never flags anything.
+        assert!(
+            impersonation_warning_for_display(&checker, stranger, "\u{0399}an Clarke").is_some(),
+            "an unprivileged member using the moderator's name must be flagged"
+        );
+        assert!(
+            impersonation_warning_for_display(&checker, stranger, "R00m 0wner").is_some(),
+            "an unprivileged member using the owner's name must be flagged"
+        );
+    }
+
+    /// The other half of the bargain: ordinary members must not be accused.
+    #[test]
+    fn plainly_different_names_are_not_flagged() {
+        let (checker, _owner, _mod, stranger) = impersonation_fixture("Bystander");
+        for name in [
+            "Bystander",
+            "Alice",
+            "HostFat",
+            "Clark Kent",
+            "Linus Clarke",
+            "Ian Clarke's Dad",
+            "zorolin",
+            "Bob Smith",
+        ] {
+            assert_eq!(
+                impersonation_warning_for_display(&checker, stranger, name),
+                None,
+                "{name:?} is an ordinary name and must not be accused"
+            );
+        }
+    }
+
+    /// A confusable check that flags real people's names is worse than the
+    /// problem it solves — and it would land hardest on the users least able to
+    /// argue with it. Same guard `display_name::real_names_in_other_scripts_are_untouched`
+    /// provides for sanitisation, applied to the rendered warning.
+    #[test]
+    fn legitimate_non_latin_names_are_not_flagged() {
+        let (checker, _owner, _mod, stranger) = impersonation_fixture("Bystander");
+        for name in [
+            "Иван Петров",          // Russian
+            "Ольга Иванова",        // Russian
+            "Γιώργος Παπαδόπουλος", // Greek
+            "Νίκος Παπαδόπουλος",   // Greek
+            "さくら 田中",          // Japanese
+            "山田\u{3000}太郎",     // Japanese, ideographic space
+            "李小龍",               // Chinese
+            "김민준",               // Korean
+            "محمد عبد الله",        // Arabic
+            "علی\u{200C}رضا",       // Persian, ZWNJ as orthography
+            "דָּוִד",                  // Hebrew with niqqud
+            "अमिताभ बच्चन",          // Devanagari
+            "Nguyễn Thị Hương",     // Vietnamese
+            "François Müller",      // accented Latin
+        ] {
+            assert_eq!(
+                impersonation_warning_for_display(&checker, stranger, name),
+                None,
+                "a legitimate name was accused of impersonation: {name:?}"
+            );
+        }
+    }
+
+    /// **The tier decision.** The engine reports near-misses; this UI does not
+    /// render them. Asserting the engine still FINDS the near-miss is the point
+    /// — otherwise this passes for the wrong reason (an engine that stopped
+    /// detecting it) and the tier rule would be untested.
+    #[test]
+    fn near_miss_is_never_rendered() {
+        let (checker, _owner, _mod, stranger) = impersonation_fixture("Bystander");
+
+        for (name, why) in [
+            ("Ian Clark", "one character short"),
+            ("Ian Clrake", "transposition"),
+            ("Ian Clarkee", "one character long"),
+        ] {
+            // The engine finds it...
+            let raw = checker
+                .check(stranger, name)
+                .unwrap_or_else(|| panic!("engine should still detect {name:?} ({why})"));
+            assert_eq!(
+                raw.tier,
+                ConfusableTier::NearMiss,
+                "{name:?} should be a near-miss, not an identical skeleton"
+            );
+            // ...and the render boundary drops it.
+            assert_eq!(
+                impersonation_warning_for_display(&checker, stranger, name),
+                None,
+                "{name:?} ({why}) is a near-miss and must not render a badge"
+            );
+        }
+    }
+
+    /// The protected set is DERIVED from room state, so it tracks a deputize and
+    /// a revoke with no hand-maintained list anywhere.
+    #[test]
+    fn the_protected_set_follows_deputize_and_revoke() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let mod_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+        let impostor_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &mod_sk.verifying_key()),
+                authorized_member(&owner_sk, &viewer_sk.verifying_key()),
+                authorized_member(&owner_sk, &impostor_sk.verifying_key()),
+            ],
+        };
+
+        // The one thing that varies between the two states: whether the owner's
+        // signed `deputies` list names the moderator.
+        let build = |deputies: Vec<MemberId>| {
+            let member_info = MemberInfoV1 {
+                member_info: vec![
+                    signed_member_info(&owner_sk, "Room Owner", deputies),
+                    signed_member_info(&mod_sk, "Ian Clarke", vec![]),
+                    signed_member_info(&viewer_sk, "Viewer", vec![]),
+                    signed_member_info(&impostor_sk, "\u{0399}an Clarke", vec![]),
+                ],
+            };
+            let badges = deputy_badges_for_viewer(
+                &members,
+                &member_info,
+                &secrets,
+                owner_id,
+                id(&viewer_sk),
+            );
+            impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges)
+        };
+
+        // Deputised: the moderator's name is protected, so the homoglyph warns.
+        let deputised = build(vec![id(&mod_sk)]);
+        assert!(
+            impersonation_warning_for_display(&deputised, id(&impostor_sk), "\u{0399}an Clarke")
+                .is_some(),
+            "while the moderator is deputised their name must be protected"
+        );
+
+        // Revoked: the same room, the same nicknames, the same impostor — and
+        // no warning, because `Ian Clarke` is now an ordinary member's name.
+        let revoked = build(vec![]);
+        assert_eq!(
+            impersonation_warning_for_display(&revoked, id(&impostor_sk), "\u{0399}an Clarke"),
+            None,
+            "after the deputy grant is revoked the name is no longer protected"
+        );
+
+        // The owner is protected in BOTH states — the owner's protection comes
+        // from being the owner, not from any deputy grant.
+        for (label, checker) in [("deputised", &deputised), ("revoked", &revoked)] {
+            assert!(
+                impersonation_warning_for_display(checker, id(&impostor_sk), "R00m 0wner")
+                    .is_some(),
+                "the owner must stay protected in the {label} state"
+            );
+        }
+    }
+
+    /// A member who never typed a nickname wears a handle River derived from
+    /// their key. Two members can be assigned the same one — with ~120 members
+    /// in a room, more likely than not — and that collision is River's doing,
+    /// not an imitation either of them performed. Protecting an unclaimed name
+    /// would turn it into an accusation.
+    #[test]
+    fn a_deputys_generated_handle_is_not_protected() {
+        // A real assignable handle, so this cannot pass because the string
+        // happens not to match.
+        let handle = format!(
+            "{} {}",
+            crate::nickname::FIRST_NAMES[0],
+            crate::nickname::LAST_NAMES[0]
+        );
+        assert!(
+            crate::nickname::is_generated_handle(&handle),
+            "precondition: {handle:?} must be a handle River can assign"
+        );
+
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let mod_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+        let twin_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &mod_sk.verifying_key()),
+                authorized_member(&owner_sk, &viewer_sk.verifying_key()),
+                authorized_member(&owner_sk, &twin_sk.verifying_key()),
+            ],
+        };
+        // The moderator never chose a nickname; an unrelated member drew the
+        // same handle.
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                signed_member_info(&owner_sk, "Room Owner", vec![id(&mod_sk)]),
+                signed_member_info(&mod_sk, &handle, vec![]),
+                signed_member_info(&viewer_sk, "Viewer", vec![]),
+                signed_member_info(&twin_sk, &handle, vec![]),
+            ],
+        };
+        let badges =
+            deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, id(&viewer_sk));
+        assert!(
+            badges.contains_key(&id(&mod_sk)),
+            "precondition: the moderator still carries a shield"
+        );
+
+        let checker = impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges);
+        assert_eq!(
+            impersonation_warning_for_display(&checker, id(&twin_sk), &handle),
+            None,
+            "an assigned handle is not a claimed identity; colliding with one \
+             must not put an impersonation badge on a member who did nothing"
+        );
+
+        // But the identity exemption is still wider than the protected set: the
+        // owner's CHOSEN name stays protected in the same room, so this test
+        // cannot pass by producing an empty checker.
+        assert!(
+            impersonation_warning_for_display(&checker, id(&twin_sk), "R00m 0wner").is_some(),
+            "the owner's chosen name must still be protected"
+        );
+    }
+
+    /// A member with no `member_info` record renders as `"Unknown"`, and so does
+    /// every other member without one. Protecting that string would flag all of
+    /// them for impersonating each other.
+    #[test]
+    fn a_privileged_member_without_member_info_is_not_protected() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let mod_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+        let nameless_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &mod_sk.verifying_key()),
+                authorized_member(&owner_sk, &viewer_sk.verifying_key()),
+                authorized_member(&owner_sk, &nameless_sk.verifying_key()),
+            ],
+        };
+        // The moderator is deputised but has NO member_info record at all.
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                signed_member_info(&owner_sk, "Room Owner", vec![id(&mod_sk)]),
+                signed_member_info(&viewer_sk, "Viewer", vec![]),
+            ],
+        };
+        let badges =
+            deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, id(&viewer_sk));
+        let checker = impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges);
+
+        // `"Unknown"` is what the member list renders for a member with no
+        // record; it must not be a protected name.
+        assert_eq!(
+            impersonation_warning_for_display(&checker, id(&nameless_sk), "Unknown"),
+            None,
+            "`Unknown` is the placeholder for EVERY record-less member, so \
+             protecting it would accuse all of them"
+        );
+        // The owner's real name is still protected.
+        assert!(
+            impersonation_warning_for_display(&checker, id(&nameless_sk), "R00m 0wner").is_some()
+        );
+    }
+
+    /// The 🛡 and the ⚠ can never appear on the same member: a shielded member is
+    /// a deputy, deputies are in the checker's privileged set, and a privileged
+    /// member is never warned about. Worth pinning because the two badges render
+    /// in adjacent slots and a future refactor that built the checker from
+    /// something other than the badge map would break it silently.
+    #[test]
+    fn shield_and_warning_are_mutually_exclusive() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let mod_a_sk = SigningKey::generate(&mut rng);
+        let mod_b_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &mod_a_sk.verifying_key()),
+                authorized_member(&owner_sk, &mod_b_sk.verifying_key()),
+                authorized_member(&owner_sk, &viewer_sk.verifying_key()),
+            ],
+        };
+        // TWO moderators with confusable names — the worst case for this
+        // property, because each one's name is protected against the other.
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                signed_member_info(&owner_sk, "Room Owner", vec![id(&mod_a_sk), id(&mod_b_sk)]),
+                signed_member_info(&mod_a_sk, "Ian Clarke", vec![]),
+                signed_member_info(&mod_b_sk, "\u{0399}an Clarke", vec![]),
+                signed_member_info(&viewer_sk, "Viewer", vec![]),
+            ],
+        };
+        let badges =
+            deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, id(&viewer_sk));
+        let checker = impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges);
+
+        for (sk, name) in [(&mod_a_sk, "Ian Clarke"), (&mod_b_sk, "\u{0399}an Clarke")] {
+            assert!(
+                badges.contains_key(&id(sk)),
+                "precondition: {name:?} carries a shield"
+            );
+            assert_eq!(
+                impersonation_warning_for_display(&checker, id(sk), name),
+                None,
+                "{name:?} shows a shield, so it must never also show a warning"
+            );
+        }
+    }
+
+    /// The protected set is built from a `HashMap`, so its iteration order is
+    /// per-process random. Two protected members CAN share a skeleton (a
+    /// sockpuppet deputised under a real moderator's name), and without the sort
+    /// in `impersonation_checker_for_viewer` the tooltip would name a different
+    /// victim between renders of the same room.
+    #[test]
+    fn the_named_victim_is_stable_across_rebuilds() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let mod_a_sk = SigningKey::generate(&mut rng);
+        let mod_b_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+        let impostor_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &mod_a_sk.verifying_key()),
+                authorized_member(&owner_sk, &mod_b_sk.verifying_key()),
+                authorized_member(&owner_sk, &viewer_sk.verifying_key()),
+                authorized_member(&owner_sk, &impostor_sk.verifying_key()),
+            ],
+        };
+        // Two deputies whose names fold to the SAME skeleton.
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                signed_member_info(&owner_sk, "Room Owner", vec![id(&mod_a_sk), id(&mod_b_sk)]),
+                signed_member_info(&mod_a_sk, "Ian Clarke", vec![]),
+                signed_member_info(&mod_b_sk, "lan Clarke", vec![]),
+                signed_member_info(&viewer_sk, "Viewer", vec![]),
+                signed_member_info(&impostor_sk, "1an Clarke", vec![]),
+            ],
+        };
+
+        let named = || {
+            let badges = deputy_badges_for_viewer(
+                &members,
+                &member_info,
+                &secrets,
+                owner_id,
+                id(&viewer_sk),
+            );
+            let checker =
+                impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges);
+            impersonation_warning_for_display(&checker, id(&impostor_sk), "1an Clarke")
+                .expect("the impostor is flagged")
+                .impersonated
+                .display_name
+        };
+
+        let first = named();
+        for _ in 0..24 {
+            assert_eq!(
+                named(),
+                first,
+                "the tooltip named a different victim on a rebuild of the same \
+                 room state; the protected set is not deterministically ordered"
+            );
+        }
+    }
+
+    /// The member row renders the warning as its own tag, FIRST, carrying the
+    /// unforgeable glyph and the full tooltip.
+    #[test]
+    fn the_member_row_renders_the_warning_first() {
+        let mut display = make_member_display("\u{0399}an Clarke");
+        // A member wearing several relationship tags, so "first" is a real
+        // assertion rather than the only possibility.
+        display.is_self = true;
+        display.invited_by_you = true;
+        display.impersonation = Some(ImpersonationWarning {
+            impersonated: ProtectedName::new(ProtectedRole::Deputy, "Ian Clarke"),
+            tier: ConfusableTier::Identical,
+        });
+
+        let parts = member_display_parts(&display);
+        let (glyph, tooltip) = parts.tags.first().expect("at least one tag");
+        assert_eq!(
+            *glyph,
+            crate::util::confusable::WARNING_GLYPH,
+            "the impersonation warning must be the FIRST tag, next to the name; \
+             tags were {:?}",
+            parts.tags.iter().map(|(g, _)| *g).collect::<Vec<_>>()
+        );
+        assert!(tooltip.contains("Ian Clarke"), "{tooltip}");
+        assert!(tooltip.contains("is NOT a moderator"), "{tooltip}");
+        // The relationship tags are still rendered, after it.
+        assert!(parts.tags.len() > 1);
+
+        // And no warning ⇒ no tag.
+        display.impersonation = None;
+        assert!(!member_display_parts(&display)
+            .tags
+            .iter()
+            .any(|(g, _)| *g == crate::util::confusable::WARNING_GLYPH));
+    }
+
+    /// **Wiring pin.** The warning only protects anyone if the surfaces actually
+    /// render it. Both go through `impersonation_warning_for_display`, and both
+    /// must build the checker OUTSIDE their per-member loop — rebuilding it per
+    /// member re-folds every protected name (and, in a private room, re-unseals
+    /// every protected nickname) once per row.
+    ///
+    /// Source-scrape, because these are Dioxus component trees with no headless
+    /// harness in this crate. Scans the WHOLE file rather than cutting at
+    /// `#[cfg(test)]`: `conversation.rs` has an earlier `#[cfg(test)]` block, so
+    /// a cut would silently skip the code this pins (the mistake
+    /// `display_name::nickname_render_paths_go_through_display_nickname`
+    /// documents).
+    #[test]
+    fn impersonation_warning_is_wired_into_both_render_surfaces() {
+        for (label, source) in [
+            ("member list", include_str!("members.rs")),
+            ("message author line", include_str!("conversation.rs")),
+        ] {
+            assert!(
+                source.contains("impersonation_warning_for_display("),
+                "{label} no longer renders the impersonation warning"
+            );
+            let built = source.matches("impersonation_checker_for_viewer(").count();
+            assert!(
+                built >= 1,
+                "{label} no longer builds an impersonation checker"
+            );
+        }
+
+        // The conversation must compute the warning per GROUP and the checker
+        // once per render — never inside `group_messages`, which would rebuild
+        // the protected set for every message.
+        let conversation = include_str!("conversation.rs");
+        let group_fn = conversation
+            .find("fn group_messages(")
+            .expect("group_messages must exist");
+        let body_end = conversation[group_fn..]
+            .find("\n/// Format an event summary")
+            .expect("group_messages is followed by format_event_summary")
+            + group_fn;
+        assert!(
+            !conversation[group_fn..body_end].contains("impersonation_checker_for_viewer("),
+            "`group_messages` builds the checker itself; it must receive one \
+             built once per render (see `impersonation_warning_for_display`)"
+        );
+
+        // The member list must build the checker outside the per-member loop.
+        let members_src = include_str!("members.rs");
+        let memo = members_src
+            .find("pub fn MemberList()")
+            .expect("MemberList must exist");
+        let loop_at = members_src[memo..]
+            .find("for &member_id in &ordered_ids")
+            .expect("the per-member loop must exist")
+            + memo;
+        assert!(
+            members_src[memo..loop_at].contains("impersonation_checker_for_viewer("),
+            "MemberList must build the impersonation checker BEFORE the \
+             per-member loop, not inside it"
+        );
     }
 }

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1364,17 +1364,29 @@ pub fn MemberList() -> Element {
                         // Stable per-member hook for automation (freenet/river#25).
                         // Entity-ID pattern: `member-item-{member_id}`.
                         "data-testid": "member-item-{member_id}",
+                        // `truncate` used to sit on the BUTTON, which clipped
+                        // the badge spans along with the name: a long enough
+                        // nickname pushed the ⚠ (and its `title`/`aria-label`)
+                        // out of view entirely. That is reachable well inside
+                        // the nickname limit, because the sanitiser
+                        // deliberately does NOT normalise `U+3000` IDEOGRAPHIC
+                        // SPACE — `"Ian Clarke" + "\u{3000}".repeat(13) + "."`
+                        // renders as `Ian Clarke…` with the warning clipped off.
+                        //
+                        // Now the row is a flex line: only the NAME truncates,
+                        // and every badge is `flex-shrink-0` so it can never be
+                        // clipped, whatever the name's length.
                         button {
-                            class: "w-full text-left px-3 py-1.5 rounded-lg text-sm text-text hover:bg-surface transition-colors truncate",
+                            class: "w-full text-left px-3 py-1.5 rounded-lg text-sm text-text hover:bg-surface transition-colors flex items-center min-w-0",
                             title: "Member ID: {member_id}",
                             onclick: move |_| handle_member_click(member_id),
                             // Nickname rendered as a plain text node — attacker-controlled
                             // bytes from `MemberInfoV1.preferred_nickname` MUST NOT be
                             // routed through `dangerous_inner_html` (freenet/river#227).
-                            span { "{parts.nickname}" }
+                            span { class: "truncate min-w-0", "{parts.nickname}" }
                             for (icon, tooltip) in parts.tags {
                                 span {
-                                    class: "member-icon",
+                                    class: "member-icon flex-shrink-0",
                                     title: "{tooltip}",
                                     // The glyph alone means nothing to a
                                     // screen reader, and the deputy shield is
@@ -4707,6 +4719,51 @@ mod tests {
         }
     }
 
+    /// **SHOULD-FIX E — the warning must not be clippable.**
+    ///
+    /// `truncate` used to sit on the member-row BUTTON, which clipped the badge
+    /// spans along with the name. Two consequences: a long nickname pushed the
+    /// ⚠ and its `title`/`aria-label` out of view entirely, and because the
+    /// sanitiser deliberately does NOT normalise `U+3000` IDEOGRAPHIC SPACE, a
+    /// nickname like `"Ian Clarke" + "\u{3000}".repeat(13) + "."` rendered as
+    /// `Ian Clarke…` — a visual clone whose warning was clipped off, well
+    /// inside the nickname length limit.
+    ///
+    /// Source-scrape: this is a Dioxus tree with no headless harness here, and
+    /// the property is a class on a specific element.
+    #[test]
+    fn the_warning_badge_cannot_be_clipped_by_a_long_nickname() {
+        let src = include_str!("members.rs");
+        let start = src
+            .find("\"data-testid\": \"member-item-")
+            .expect("the row");
+        let row = &src[start..start + 2600];
+
+        let button = row.find("button {").expect("the row is a button");
+        let button_class_end = row[button..].find('\n').unwrap_or(0) + button;
+        let button_line = &row[button..button_class_end + 200];
+        assert!(
+            !button_line.contains("transition-colors truncate"),
+            "`truncate` must not sit on the row BUTTON — it clips the badges \
+             along with the name, so a long nickname hides the warning"
+        );
+
+        let name = row
+            .find("\"{parts.nickname}\"")
+            .expect("the nickname span exists");
+        assert!(
+            row[name.saturating_sub(120)..name].contains("truncate"),
+            "the NAME span must be the thing that truncates"
+        );
+
+        let tag = row.find("member-icon").expect("the tag span exists");
+        assert!(
+            row[tag..tag + 60].contains("flex-shrink-0"),
+            "every badge span must be `flex-shrink-0` so it can never be \
+             clipped, whatever the nickname's length"
+        );
+    }
+
     /// Source-grep pin: the member-row render MUST keep `parts.nickname`
     /// as a Dioxus text-node interpolation — `span { "{parts.nickname}" }`
     /// — not pass it through any string concatenation or attribute that
@@ -4715,11 +4772,30 @@ mod tests {
     #[test]
     fn member_row_renders_nickname_as_text_node() {
         let prod = production_source();
+        let needle = "\"{parts.nickname}\"";
+        let at = prod
+            .find(needle)
+            .expect("MemberList must still render `parts.nickname`");
+        // Check the interpolation's POSITION, not the whole element literally.
+        // The literal form broke the moment the span gained a `class` — and it
+        // would have passed unchanged for `dangerous_inner_html:
+        // "{parts.nickname}"` had the element otherwise matched. In rsx a text
+        // node follows `{` or `,`; an attribute value follows `:`.
+        let preceding = prod[..at]
+            .trim_end()
+            .chars()
+            .next_back()
+            .expect("something precedes the interpolation");
         assert!(
-            prod.contains("span { \"{parts.nickname}\" }"),
-            "MemberList must render the nickname as a Dioxus text node \
-             (`span {{ \"{{parts.nickname}}\" }}`). Concatenating it into \
-             an HTML string reopens freenet/river#227."
+            preceding == '{' || preceding == ',',
+            "`parts.nickname` must be a Dioxus TEXT NODE (preceded by `{{` or \
+             `,`), but it is preceded by {preceding:?} — an attribute-value \
+             position. If that attribute is `dangerous_inner_html`, this \
+             reopens freenet/river#227."
+        );
+        assert!(
+            prod[at.saturating_sub(200)..at].contains("span {"),
+            "`parts.nickname` is no longer rendered inside a `span`"
         );
     }
 

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -998,11 +998,36 @@ pub(crate) fn impersonation_checker_for_viewer(
     privileged_ids.insert(owner_id);
 
     // The name this member has CLAIMED, or `None` if they have not claimed one.
+    //
+    // `display_nickname` can return three strings the member never chose, and
+    // ALL THREE must be filtered — each is a pure function of something other
+    // than the nickname, so it is shared by a whole CLASS of members, and
+    // protecting it accuses every one of them at once:
+    //
+    //   * no `member_info` record  -> `"Unknown"`   (the `?` below)
+    //   * sanitises to empty       -> `UNNAMED`
+    //   * decryption failed        -> `"[Encrypted: {len} bytes, v{version}]"`
+    //
+    // The third is the worst. In a private room the viewer's `secrets` map is
+    // `#[serde(skip)]` and rebuilt after every ingestion, so there is a real
+    // window where it is empty or missing a version. During it the owner's name
+    // becomes e.g. `"[Encrypted: 12 bytes, v0]"` — and so does the name of
+    // EVERY member whose nickname is also 12 bytes at v0. In a large room that
+    // is a dozen simultaneous false accusations with no attacker present.
+    //
+    // The unseal is tested DIRECTLY rather than by matching the `"[Encrypted:"`
+    // prefix, so a future change to the placeholder's wording cannot silently
+    // reopen this. (`conversation.rs` filters `UNNAMED` out of mention
+    // autocomplete for the same reason.)
     let claimed_name = |id: MemberId| -> Option<String> {
-        let name = display_nickname(
-            &member_info.canonical(id)?.member_info.preferred_nickname,
-            room_secrets,
-        );
+        let sealed = &member_info.canonical(id)?.member_info.preferred_nickname;
+        if unseal_bytes_with_secrets(sealed, room_secrets).is_err() {
+            return None;
+        }
+        let name = display_nickname(sealed, room_secrets);
+        if name == crate::util::display_name::UNNAMED {
+            return None;
+        }
         (!crate::nickname::is_generated_handle(&name)).then_some(name)
     };
 
@@ -1060,9 +1085,17 @@ pub(crate) fn impersonation_warning_for_display(
     member_id: MemberId,
     display_name: &str,
 ) -> Option<ImpersonationWarning> {
-    checker
-        .check(member_id, display_name)
-        .filter(|w| w.tier == ConfusableTier::Identical)
+    // `check_identical` rather than `check(..).filter(..)`: the filtered form
+    // still ran the full Damerau sweep for every NON-matching member on every
+    // render, in both surfaces, only to throw the result away.
+    let warning = checker.check_identical(member_id, display_name);
+    debug_assert!(
+        warning
+            .as_ref()
+            .is_none_or(|w| w.tier == ConfusableTier::Identical),
+        "only the Identical tier may reach a render surface"
+    );
+    warning
 }
 
 /// [`deputy_badges_for_viewer`] for a SINGLE member.
@@ -4940,16 +4973,293 @@ mod tests {
 
         let badges =
             deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, id(&viewer_sk));
-        // Precondition: the moderator really does carry a shield in this view,
-        // so a later "not flagged" assertion cannot pass merely because the
-        // protected set came out empty.
+        // Precondition: the moderator really does carry a shield in this view.
         assert!(
             badges.contains_key(&id(&mod_sk)),
             "fixture precondition: the moderator must show a shield to the viewer"
         );
 
         let checker = impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges);
+        // **Precondition, and the one that matters for every "is NOT flagged"
+        // test below.** A non-empty shield map does not imply a non-empty
+        // PROTECTED set — `claimed_name` filters placeholder and generated
+        // names, so the checker can come out empty while badges are populated.
+        // Without this, `plainly_different_names_are_not_flagged` and
+        // `legitimate_non_latin_names_are_not_flagged` would both pass against
+        // a checker that can never flag anything.
+        assert!(
+            !checker.is_empty(),
+            "fixture precondition: the protected set must be non-empty, or the \
+             negative assertions below prove nothing"
+        );
         (checker, owner_id, id(&mod_sk), id(&stranger_sk))
+    }
+
+    /// A room whose OWNER and DEPUTY both carry non-Latin names, so the
+    /// cross-script folds are exercised against a non-Latin protected name —
+    /// the direction that actually bites. Every other test protects a Latin
+    /// name, where a Cyrillic candidate can only ever fold *toward* Latin.
+    fn non_latin_fixture() -> (ImpersonationChecker, MemberId) {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let mod_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+        let stranger_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &mod_sk.verifying_key()),
+                authorized_member(&owner_sk, &viewer_sk.verifying_key()),
+                authorized_member(&owner_sk, &stranger_sk.verifying_key()),
+            ],
+        };
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                // Cyrillic owner, CJK deputy.
+                signed_member_info(&owner_sk, "Дмитрий Волков", vec![id(&mod_sk)]),
+                signed_member_info(&mod_sk, "李小龍", vec![]),
+                signed_member_info(&viewer_sk, "Viewer", vec![]),
+                signed_member_info(&stranger_sk, "Stranger", vec![]),
+            ],
+        };
+        let badges =
+            deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, id(&viewer_sk));
+        assert!(badges.contains_key(&id(&mod_sk)));
+        let checker = impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges);
+        assert!(!checker.is_empty(), "non-Latin names must be protectable");
+        (checker, id(&stranger_sk))
+    }
+
+    /// A protected name in a non-Latin script is still protected, and still does
+    /// not swallow unrelated names in the same script.
+    #[test]
+    fn a_non_latin_protected_name_is_protected_without_over_matching() {
+        let (checker, stranger) = non_latin_fixture();
+
+        // A Latin-homoglyph attack on the Cyrillic owner: `Дмитрий` with a
+        // Latin `T`-lookalike is not reachable, but the reverse IS — an
+        // attacker who copies the name verbatim collides by construction.
+        assert!(
+            impersonation_warning_for_display(&checker, stranger, "Дмитрий Волков").is_some(),
+            "a verbatim copy of the owner's Cyrillic name must be flagged"
+        );
+        assert!(
+            impersonation_warning_for_display(&checker, stranger, "李小龍").is_some(),
+            "a verbatim copy of the deputy's CJK name must be flagged"
+        );
+
+        // Other real names in the SAME scripts must not be caught.
+        for name in [
+            "Иван Петров",
+            "Ольга Иванова",
+            "Дмитрий Соколов", // shares a given name with the owner only
+            "王小明",
+            "李連杰",
+            "さくら 田中",
+            "Γιώργος Παπαδόπουλος",
+        ] {
+            assert_eq!(
+                impersonation_warning_for_display(&checker, stranger, name),
+                None,
+                "{name:?} is an unrelated name in a protected script and must \
+                 not be flagged"
+            );
+        }
+    }
+
+    /// **Regression: placeholder display names must never be protected.**
+    ///
+    /// `display_nickname` returns `"[Encrypted: {len} bytes, v{version}]"` when
+    /// the unseal fails, which it does whenever the viewer's in-memory
+    /// `secrets` map is missing the version — a real window, because `secrets`
+    /// is `#[serde(skip)]` and rebuilt after every state ingestion.
+    ///
+    /// That string is a pure function of (nickname LENGTH, secret version), so
+    /// it is shared by every member whose nickname is the same length. If it
+    /// entered the protected set, one un-decryptable owner would flag a whole
+    /// CLASS of innocent members at once, with no attacker present.
+    #[test]
+    fn undecryptable_and_placeholder_names_are_never_protected() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+        use river_core::room_state::privacy::SealedBytes;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let mod_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+        let a_sk = SigningKey::generate(&mut rng);
+        let b_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+
+        // A private room whose secret this viewer does not hold.
+        let sealed =
+            |len: usize, version: u32| SealedBytes::private(vec![7u8; len], [0u8; 12], version, 3);
+        let signed_sealed = |sk: &SigningKey, nickname: SealedBytes| {
+            use river_core::room_state::member_info::{AuthorizedMemberInfo, MemberInfo};
+            AuthorizedMemberInfo::new_with_member_key(
+                MemberInfo {
+                    member_id: MemberId::from(&sk.verifying_key()),
+                    version: 0,
+                    preferred_nickname: nickname,
+                    deputies: vec![],
+                },
+                sk,
+            )
+        };
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &mod_sk.verifying_key()),
+                authorized_member(&owner_sk, &viewer_sk.verifying_key()),
+                authorized_member(&owner_sk, &a_sk.verifying_key()),
+                authorized_member(&owner_sk, &b_sk.verifying_key()),
+            ],
+        };
+        // The owner, the deputy and two ordinary members ALL have 12-byte
+        // nicknames at v0, so all four render the identical placeholder.
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                {
+                    use river_core::room_state::member_info::{AuthorizedMemberInfo, MemberInfo};
+                    AuthorizedMemberInfo::new_with_member_key(
+                        MemberInfo {
+                            member_id: owner_id,
+                            version: 0,
+                            preferred_nickname: sealed(12, 0),
+                            deputies: vec![id(&mod_sk)],
+                        },
+                        &owner_sk,
+                    )
+                },
+                signed_sealed(&mod_sk, sealed(12, 0)),
+                signed_member_info(&viewer_sk, "Viewer", vec![]),
+                signed_sealed(&a_sk, sealed(12, 0)),
+                signed_sealed(&b_sk, sealed(12, 0)),
+            ],
+        };
+        let no_secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        // Precondition: they really do all render the same placeholder string,
+        // so a name-based protected set WOULD flag them all.
+        let rendered = |sk: &SigningKey| {
+            display_nickname(
+                &member_info
+                    .canonical(MemberId::from(&sk.verifying_key()))
+                    .expect("record")
+                    .member_info
+                    .preferred_nickname,
+                &no_secrets,
+            )
+        };
+        assert_eq!(rendered(&a_sk), rendered(&mod_sk));
+        assert_eq!(rendered(&a_sk), rendered(&b_sk));
+        assert!(
+            rendered(&a_sk).contains("Encrypted"),
+            "precondition: the undecryptable placeholder is what renders, got {:?}",
+            rendered(&a_sk)
+        );
+
+        let badges = deputy_badges_for_viewer(
+            &members,
+            &member_info,
+            &no_secrets,
+            owner_id,
+            id(&viewer_sk),
+        );
+        assert!(
+            badges.contains_key(&id(&mod_sk)),
+            "precondition: the deputy still carries a shield"
+        );
+        let checker =
+            impersonation_checker_for_viewer(&member_info, &no_secrets, owner_id, &badges);
+
+        // Nothing is protected, so nobody is accused.
+        assert!(
+            checker.is_empty(),
+            "no name in this room is a CLAIMED name, so the protected set must \
+             be empty"
+        );
+        for sk in [&a_sk, &b_sk] {
+            assert_eq!(
+                impersonation_warning_for_display(&checker, id(sk), &rendered(sk)),
+                None,
+                "an ordinary member must not be accused of impersonating an \
+                 owner whose name merely failed to decrypt"
+            );
+        }
+    }
+
+    /// The `UNNAMED` placeholder is the same shape: a deputy whose nickname
+    /// sanitises to nothing would otherwise flag every other member whose
+    /// nickname also sanitises to nothing. `riverctl` writes `member_info`
+    /// directly, so the nickname input's emoji rejection is not a boundary here.
+    #[test]
+    fn an_unnamed_deputy_is_not_protected() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let mod_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+        let other_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &mod_sk.verifying_key()),
+                authorized_member(&owner_sk, &viewer_sk.verifying_key()),
+                authorized_member(&owner_sk, &other_sk.verifying_key()),
+            ],
+        };
+        // Emoji-only nicknames sanitise to `UNNAMED`.
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                signed_member_info(&owner_sk, "Room Owner", vec![id(&mod_sk)]),
+                signed_member_info(&mod_sk, "\u{1F6E1}\u{1F451}", vec![]),
+                signed_member_info(&viewer_sk, "Viewer", vec![]),
+                signed_member_info(&other_sk, "\u{2B50}\u{1F3AA}", vec![]),
+            ],
+        };
+        let unnamed = display_nickname(
+            &member_info
+                .canonical(id(&other_sk))
+                .expect("record")
+                .member_info
+                .preferred_nickname,
+            &secrets,
+        );
+        assert_eq!(
+            unnamed,
+            crate::util::display_name::UNNAMED,
+            "precondition: an emoji-only nickname renders as the placeholder"
+        );
+
+        let badges =
+            deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, id(&viewer_sk));
+        let checker = impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges);
+
+        assert_eq!(
+            impersonation_warning_for_display(&checker, id(&other_sk), &unnamed),
+            None,
+            "`UNNAMED` is the placeholder for EVERY blank nickname, so it must \
+             not be a protected name"
+        );
+        // The owner's real name is still protected, so this is not vacuous.
+        assert!(impersonation_warning_for_display(&checker, id(&other_sk), "R00m 0wner").is_some());
     }
 
     /// **The motivating attack.** `Ιan Clarke` with a Greek capital iota

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1114,11 +1114,31 @@ pub(crate) fn impersonation_checker_for_viewer(
 
 /// The impersonation warning a surface actually RENDERS for one member, if any.
 ///
-/// **Every render surface must go through this**, not
+/// **Any surface that renders the warning must go through this**, not
 /// [`ImpersonationChecker::check`] directly, because it carries the tier
-/// decision — and a surface that skipped it would show a badge the other
-/// surfaces do not, which is exactly the cross-surface drift freenet/river#451
-/// fixed for the shield.
+/// decision and the truthful-tooltip decision — and a surface that skipped it
+/// would show a badge the other surfaces do not, which is exactly the
+/// cross-surface drift freenet/river#451 fixed for the shield.
+///
+/// ## Which surfaces render it, and which do NOT
+///
+/// This used to claim "every render surface must go through this", which was
+/// false and is the class of stale comment this file's credibility depends on
+/// not having. The warning is rendered on **two** surfaces today:
+///
+/// * the member-list row ([`MemberList`]), and
+/// * the conversation's message author line.
+///
+/// It is NOT rendered on the member-info modal, the DM thread and DM rail,
+/// @mention chips and autocomplete, notifications, or reaction tooltips. Those
+/// show a nickname with no warning beside it. The DM thread is the most
+/// consequential of the gaps: it is a 1:1 surface, which is where a victim is
+/// most likely to act on perceived authority.
+///
+/// Adding a surface is a one-line call to this function plus the glyph; the
+/// reason not to do it blindly is that each surface needs its own
+/// [`privilege_in_view`] answer and its own layout for a badge that must not
+/// be clipped.
 ///
 /// ## Only [`ConfusableTier::Identical`] is rendered
 ///

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -5484,6 +5484,119 @@ mod tests {
             .any(|(g, _)| *g == crate::util::confusable::WARNING_GLYPH));
     }
 
+    /// **The residual #488 knowingly left open, and this warning is its only
+    /// mitigation.**
+    ///
+    /// An Ideographic Variation Selector is legitimate orthography — `辻` has
+    /// the registered variant `辻\u{E0100}` — so #488 deliberately KEEPS one
+    /// after an ideograph rather than stripping it. The cost is that
+    /// `"李\u{E0100}小龍"` and `"李小龍"` render identically on any font without
+    /// an IVD entry for the sequence, which is a clone of another member's
+    /// rendered name that `sanitize_display_name` will not remove.
+    ///
+    /// The layering is what closes it. `is_display_hidden` keeps the selectors
+    /// INSIDE its plane-14 range and the in-context exception is applied ON TOP
+    /// by `sanitize_display_name` / `contains_hidden_chars`, so
+    /// `confusable::skeleton` — which calls `is_display_hidden` DIRECTLY — still
+    /// folds the two names together and this warning fires.
+    ///
+    /// That makes the dependency mutual and easy to break from either side:
+    /// moving the carve-out INTO `is_display_hidden` (punching a hole in the
+    /// range instead of layering over it) would silently switch this warning
+    /// off and leave the residual undetectable. #488 documents that at the call
+    /// site; this test is the CI gate on our side of it.
+    #[test]
+    fn an_ideographic_variation_selector_clone_is_flagged() {
+        use river_core::room_state::member::MembersV1;
+        use river_core::room_state::member_info::MemberInfoV1;
+
+        const IVS: char = '\u{E0100}';
+        let real = "李小龍";
+        let clone = format!("李{IVS}小龍");
+
+        // Preconditions, and the reason this test has to exist.
+        //
+        // 1. The IVS SURVIVES sanitisation, so the two members really do render
+        //    a pixel-identical name — the existing invisible-character defence
+        //    does not catch this one, by design.
+        assert_eq!(
+            crate::util::display_name::sanitize_display_name(&clone),
+            clone,
+            "#488 keeps an IVS after an ideograph; if that changed, this \
+             residual is closed elsewhere and this test should be revisited"
+        );
+        assert!(
+            !crate::util::display_name::contains_hidden_chars(&clone),
+            "the nickname input accepts it too — the residual is real"
+        );
+        assert_ne!(clone, real, "different strings, identical rendering");
+
+        // 2. But `skeleton` folds them together, because it consults
+        //    `is_display_hidden` directly and the selectors are still inside
+        //    its plane-14 range.
+        assert_eq!(
+            crate::util::confusable::skeleton(&clone),
+            crate::util::confusable::skeleton(real),
+            "the confusable fold must see through an IVS, or the warning \
+             cannot fire on this residual"
+        );
+
+        // End to end, through the real protected-set derivation.
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let mod_sk = SigningKey::generate(&mut rng);
+        let viewer_sk = SigningKey::generate(&mut rng);
+        let impostor_sk = SigningKey::generate(&mut rng);
+
+        let id = |sk: &SigningKey| MemberId::from(&sk.verifying_key());
+        let owner_id = id(&owner_sk);
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        let members = MembersV1 {
+            members: vec![
+                authorized_member(&owner_sk, &mod_sk.verifying_key()),
+                authorized_member(&owner_sk, &viewer_sk.verifying_key()),
+                authorized_member(&owner_sk, &impostor_sk.verifying_key()),
+            ],
+        };
+        let member_info = MemberInfoV1 {
+            member_info: vec![
+                signed_member_info(&owner_sk, "Room Owner", vec![id(&mod_sk)]),
+                signed_member_info(&mod_sk, real, vec![]),
+                signed_member_info(&viewer_sk, "Viewer", vec![]),
+                signed_member_info(&impostor_sk, &clone, vec![]),
+            ],
+        };
+        let badges =
+            deputy_badges_for_viewer(&members, &member_info, &secrets, owner_id, id(&viewer_sk));
+        assert!(
+            badges.contains_key(&id(&mod_sk)),
+            "precondition: the CJK-named moderator carries a shield"
+        );
+        let checker = impersonation_checker_for_viewer(&member_info, &secrets, owner_id, &badges);
+
+        let warning = impersonation_warning_for_display(&checker, id(&impostor_sk), &clone)
+            .expect("an IVS clone of a moderator's name must be flagged");
+        assert_eq!(
+            warning.tier,
+            ConfusableTier::Identical,
+            "an IVS clone renders as the SAME string, so it is a tier-1 match, \
+             not a near-miss (which this UI does not render)"
+        );
+        assert_eq!(warning.impersonated.display_name, real);
+
+        // And the real moderator is untouched, so the fold has not simply made
+        // everything match.
+        assert_eq!(
+            impersonation_warning_for_display(&checker, id(&mod_sk), real),
+            None
+        );
+        assert_eq!(
+            impersonation_warning_for_display(&checker, id(&viewer_sk), "Viewer"),
+            None
+        );
+    }
+
     /// **Wiring pin.** The warning only protects anyone if the surfaces actually
     /// render it. Both go through `impersonation_warning_for_display`, and both
     /// must build the checker OUTSIDE their per-member loop — rebuilding it per

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -5487,51 +5487,106 @@ mod tests {
     /// documents).
     #[test]
     fn impersonation_warning_is_wired_into_both_render_surfaces() {
-        for (label, source) in [
-            ("member list", include_str!("members.rs")),
-            ("message author line", include_str!("conversation.rs")),
-        ] {
-            assert!(
-                source.contains("impersonation_warning_for_display("),
-                "{label} no longer renders the impersonation warning"
-            );
-            let built = source.matches("impersonation_checker_for_viewer(").count();
-            assert!(
-                built >= 1,
-                "{label} no longer builds an impersonation checker"
-            );
+        let members_src = include_str!("members.rs");
+        let conversation = include_str!("conversation.rs");
+
+        /// The source between two anchors, so a check is scoped to ONE
+        /// function rather than the whole file.
+        ///
+        /// The whole-file version of this test PASSED against a mutation that
+        /// deleted the `MemberList` call site, because `members.rs` also
+        /// contains the function's own DEFINITION and its tests. Scoping is
+        /// the entire point — do not widen these ranges.
+        fn between<'a>(src: &'a str, from: &str, to: &str, what: &str) -> &'a str {
+            let start = src
+                .find(from)
+                .unwrap_or_else(|| panic!("anchor {from:?} not found ({what})"));
+            let end = src[start..]
+                .find(to)
+                .unwrap_or_else(|| panic!("anchor {to:?} not found after {from:?} ({what})"))
+                + start;
+            &src[start..end]
         }
 
-        // The conversation must compute the warning per GROUP and the checker
-        // once per render — never inside `group_messages`, which would rebuild
-        // the protected set for every message.
-        let conversation = include_str!("conversation.rs");
-        let group_fn = conversation
-            .find("fn group_messages(")
-            .expect("group_messages must exist");
-        let body_end = conversation[group_fn..]
-            .find("\n/// Format an event summary")
-            .expect("group_messages is followed by format_event_summary")
-            + group_fn;
-        assert!(
-            !conversation[group_fn..body_end].contains("impersonation_checker_for_viewer("),
-            "`group_messages` builds the checker itself; it must receive one \
-             built once per render (see `impersonation_warning_for_display`)"
+        // --- Member list -------------------------------------------------
+        let member_memo = between(
+            members_src,
+            "pub fn MemberList()",
+            "let handle_member_click",
+            "MemberList memo",
         );
-
-        // The member list must build the checker outside the per-member loop.
-        let members_src = include_str!("members.rs");
-        let memo = members_src
-            .find("pub fn MemberList()")
-            .expect("MemberList must exist");
-        let loop_at = members_src[memo..]
-            .find("for &member_id in &ordered_ids")
-            .expect("the per-member loop must exist")
-            + memo;
         assert!(
-            members_src[memo..loop_at].contains("impersonation_checker_for_viewer("),
+            member_memo.contains("impersonation_warning_for_display("),
+            "MemberList no longer computes an impersonation warning, so the \
+             member list shows no warning however confusable a name is"
+        );
+        assert!(
+            member_memo.contains("impersonation_checker_for_viewer("),
+            "MemberList no longer builds an impersonation checker"
+        );
+        // Built ONCE, before the per-member loop — not per row, which would
+        // re-fold every protected name (and re-unseal every protected
+        // nickname in a private room) for each member.
+        assert!(
+            between(
+                member_memo,
+                "pub fn MemberList()",
+                "for &member_id in &ordered_ids",
+                "MemberList per-member loop",
+            )
+            .contains("impersonation_checker_for_viewer("),
             "MemberList must build the impersonation checker BEFORE the \
              per-member loop, not inside it"
+        );
+        // ...and the row must actually RENDER it. A warning computed but not
+        // rendered protects nobody.
+        assert!(
+            between(
+                members_src,
+                "fn member_display_parts(",
+                "\n/// Order member IDs",
+                "member_display_parts",
+            )
+            .contains("WARNING_GLYPH"),
+            "the member row no longer renders the warning glyph"
+        );
+
+        // --- Message author line ------------------------------------------
+        let group_fn = between(
+            conversation,
+            "fn group_messages(",
+            "\n/// Format an event summary",
+            "group_messages",
+        );
+        assert!(
+            group_fn.contains("impersonation_warning_for_display("),
+            "`group_messages` no longer computes an impersonation warning, so \
+             message author lines show no warning"
+        );
+        assert!(
+            !group_fn.contains("impersonation_checker_for_viewer("),
+            "`group_messages` builds the checker itself; it must receive one \
+             built once per render, or the protected set is refolded for \
+             every message"
+        );
+        assert!(
+            conversation.contains("impersonation_checker_for_viewer("),
+            "the conversation no longer builds an impersonation checker"
+        );
+        // The rendered element, anchored on its test id.
+        assert!(
+            conversation.contains("\"data-testid\": \"message-author-impersonation-warning\""),
+            "the message author line no longer renders the warning element"
+        );
+        assert!(
+            between(
+                conversation,
+                "\"data-testid\": \"message-author-impersonation-warning\"",
+                "// Deputy shield.",
+                "author-line warning element",
+            )
+            .contains("WARNING_GLYPH"),
+            "the author-line warning element no longer renders the warning glyph"
         );
     }
 }

--- a/ui/src/nickname.rs
+++ b/ui/src/nickname.rs
@@ -185,13 +185,104 @@ pub fn generate_default_nickname(vk: &VerifyingKey) -> String {
 /// badge on someone who did nothing.
 ///
 /// Deliberately case- and spacing-exact: this answers "could River have
-/// assigned this exact string", not "does this look like a handle". A member
-/// who types `amber worm` chose that name, and is treated as having chosen it.
+/// assigned this exact string", not "does this look like a handle".
+///
+/// **That makes it the wrong function for the impersonation guard.** Use
+/// [`folds_to_generated_handle`] there — see its doc for why an exact-string
+/// answer is not a usable guard on a fold-based matcher.
 pub fn is_generated_handle(name: &str) -> bool {
     let Some((first, last)) = name.split_once(' ') else {
         return false;
     };
     FIRST_NAMES.contains(&first) && LAST_NAMES.contains(&last)
+}
+
+/// Whether `name` could be a tier-1 confusable match for one of the 10,000
+/// handles this module can assign.
+///
+/// **A guard must be at least as wide as the thing it guards.**
+/// [`is_generated_handle`] compares exact strings; the impersonation matcher it
+/// used to gate compares [`crate::util::confusable::comparison_folds`]. Every
+/// one of `amber worm`, `AMBER WORM`, `AmberWorm`, `Amber\u{3000}Worm`,
+/// `Arnber Worm`, `Amber W0rm` and `Amber Worrn` is "not a generated handle" to
+/// `==`, and every one of them is a tier-1 match for the member River assigned
+/// `Amber Worm`. Letting any of them into the protected set puts "this member is
+/// NOT a moderator" on a member who did nothing at all.
+///
+/// **No attacker is required.** A moderator who styles their own name in lower
+/// case — `cipher daylight` — is enough to accuse every member holding the
+/// handle `Cipher Daylight`. That is exactly the birthday-collision harm the
+/// original exact filter was written to prevent, arriving through the filter.
+///
+/// ## Why this is a per-word split rather than 10,000 skeletons
+///
+/// The space-stripped fold of `"First Last"` is the space-stripped fold of
+/// `"First"` followed by that of `"Last"`: the multi-character confusables
+/// (`rn -> m`, `vv -> w`) run BEFORE spaces are removed, so none of them can
+/// span the word boundary, and no word folds to leading or trailing space. So a
+/// name matches some handle exactly when its fold splits into a folded
+/// FIRST_NAME and a folded LAST_NAME — 200 skeletons to build instead of 20,000,
+/// and a linear scan of split points instead of a 10,000-entry set probe.
+///
+/// `every_generated_handle_is_rejected_by_the_fold_guard` proves the equivalence
+/// the cheap way round: it sweeps all 10,000 handles and requires each to be
+/// rejected.
+pub fn folds_to_generated_handle(name: &str) -> bool {
+    let pools = handle_skeletons();
+    for (fold_index, candidate) in crate::util::confusable::comparison_folds(name)
+        .iter()
+        .enumerate()
+    {
+        if candidate.is_empty() {
+            continue;
+        }
+        let chars: Vec<char> = candidate.chars().collect();
+        for split in 1..chars.len() {
+            let head: String = chars[..split].iter().collect();
+            if !pools.first[fold_index].contains(&head) {
+                continue;
+            }
+            let tail: String = chars[split..].iter().collect();
+            if pools.last[fold_index].contains(&tail) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// The folded word pools backing [`folds_to_generated_handle`], built once.
+///
+/// Indexed by fold: `[0]` is the visual fold, `[1]` the case-insensitive one,
+/// matching the order [`crate::util::confusable::comparison_folds`] returns.
+struct HandleSkeletons {
+    first: [std::collections::HashSet<String>; 2],
+    last: [std::collections::HashSet<String>; 2],
+}
+
+fn handle_skeletons() -> &'static HandleSkeletons {
+    static POOLS: std::sync::OnceLock<HandleSkeletons> = std::sync::OnceLock::new();
+    POOLS.get_or_init(|| {
+        let fold_pool = |words: &[&str]| {
+            let mut sets = [
+                std::collections::HashSet::new(),
+                std::collections::HashSet::new(),
+            ];
+            for word in words {
+                for (i, folded) in crate::util::confusable::comparison_folds(word)
+                    .into_iter()
+                    .enumerate()
+                {
+                    sets[i].insert(folded);
+                }
+            }
+            sets
+        };
+        HandleSkeletons {
+            first: fold_pool(&FIRST_NAMES),
+            last: fold_pool(&LAST_NAMES),
+        }
+    })
 }
 
 #[cfg(test)]
@@ -205,6 +296,71 @@ mod tests {
         FIRST_NAMES
             .iter()
             .flat_map(|first| LAST_NAMES.iter().map(move |last| format!("{first} {last}")))
+    }
+
+    /// The per-word split in [`folds_to_generated_handle`] must agree with the
+    /// 10,000-skeleton set it stands in for. Proved the cheap way round: every
+    /// handle River can assign is rejected.
+    #[test]
+    fn every_generated_handle_is_rejected_by_the_fold_guard() {
+        for handle in all_handles() {
+            assert!(
+                folds_to_generated_handle(&handle),
+                "River can assign `{handle}`, so it must never enter the \
+                 protected set"
+            );
+        }
+    }
+
+    /// The guard has to be WIDER than [`is_generated_handle`], not merely
+    /// different: every variant here is a tier-1 confusable match for a handle
+    /// River assigns, and every one of them is `!= ` that handle.
+    #[test]
+    fn confusable_variants_of_a_handle_are_rejected_by_the_fold_guard() {
+        for styled in [
+            "amber worm",
+            "AMBER WORM",
+            "AmberWorm",
+            "Amber\u{3000}Worm",
+            "Arnber Worm",
+            "Amber W0rm",
+            "Amber Worrn",
+            "\u{0410}mber Worm", // Cyrillic А
+            "cipher daylight",
+        ] {
+            assert!(
+                !is_generated_handle(styled),
+                "precondition: `{styled}` is not an EXACT handle, which is why \
+                 the exact filter passed it"
+            );
+            assert!(
+                folds_to_generated_handle(styled),
+                "`{styled}` tier-1 matches a handle River assigns, so it must \
+                 not enter the protected set"
+            );
+        }
+    }
+
+    /// ...and not so wide that ordinary chosen names are swallowed. A guard
+    /// that rejects everything protects nobody, which is the failure mode the
+    /// appointer gate had.
+    #[test]
+    fn ordinary_names_are_not_rejected_by_the_fold_guard() {
+        for chosen in [
+            "Ian Clarke",
+            "Invite Bot",
+            "Room Owner",
+            "HostFat",
+            "Ivvor",
+            "Bob Smith",
+            "Nacho Duart",
+            "Hector Santos",
+        ] {
+            assert!(
+                !folds_to_generated_handle(chosen),
+                "`{chosen}` is a chosen name and must stay protectable"
+            );
+        }
     }
 
     #[test]

--- a/ui/src/nickname.rs
+++ b/ui/src/nickname.rs
@@ -175,6 +175,25 @@ pub fn generate_default_nickname(vk: &VerifyingKey) -> String {
     format!("{first} {last}")
 }
 
+/// Whether `name` is one of the 10,000 handles this module can assign.
+///
+/// Used by [`crate::util::confusable`] to tell an *assigned* name from a
+/// *chosen* one. A member who never typed a nickname is wearing a handle River
+/// derived from their key, so two members holding neighbouring assignments
+/// (`Amber Worm` / `Ember Worm`) is a collision River created, not an imitation
+/// either of them performed — and warning about it would put an impersonation
+/// badge on someone who did nothing.
+///
+/// Deliberately case- and spacing-exact: this answers "could River have
+/// assigned this exact string", not "does this look like a handle". A member
+/// who types `amber worm` chose that name, and is treated as having chosen it.
+pub fn is_generated_handle(name: &str) -> bool {
+    let Some((first, last)) = name.split_once(' ') else {
+        return false;
+    };
+    FIRST_NAMES.contains(&first) && LAST_NAMES.contains(&last)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/ui/src/nickname.rs
+++ b/ui/src/nickname.rs
@@ -352,6 +352,7 @@ mod tests {
             "Room Owner",
             "HostFat",
             "Ivvor",
+            "ofansifkapital-xmpp",
             "Bob Smith",
             "Nacho Duart",
             "Hector Santos",

--- a/ui/src/util.rs
+++ b/ui/src/util.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+pub mod confusable;
 pub mod display_name;
 pub mod ecies;
 

--- a/ui/src/util/confusable.rs
+++ b/ui/src/util/confusable.rs
@@ -901,68 +901,76 @@ fn fold_presentation_form(c: char) -> Option<char> {
 fn fold_nfkc_letter(c: char) -> Option<char> {
     Some(match u32::from(c) {
         // 88 characters, generated from Unicode NFKC data.
-        0x00AA => 'a',  // FEMININE ORDINAL INDICATOR
-        0x00BA => 'o',  // MASCULINE ORDINAL INDICATOR
-        0x02B0 => 'h',  // MODIFIER LETTER SMALL H
-        0x02B2 => 'j',  // MODIFIER LETTER SMALL J
-        0x02B3 => 'r',  // MODIFIER LETTER SMALL R
-        0x02B7 => 'w',  // MODIFIER LETTER SMALL W
-        0x02B8 => 'y',  // MODIFIER LETTER SMALL Y
-        0x02E1 => 'l',  // MODIFIER LETTER SMALL L
-        0x02E2 => 's',  // MODIFIER LETTER SMALL S
-        0x02E3 => 'x',  // MODIFIER LETTER SMALL X
-        0x1D2C => 'A',  // MODIFIER LETTER CAPITAL A
-        0x1D2E => 'B',  // MODIFIER LETTER CAPITAL B
-        0x1D30 => 'D',  // MODIFIER LETTER CAPITAL D
-        0x1D31 => 'E',  // MODIFIER LETTER CAPITAL E
-        0x1D33 => 'G',  // MODIFIER LETTER CAPITAL G
-        0x1D34 => 'H',  // MODIFIER LETTER CAPITAL H
-        0x1D35 => 'I',  // MODIFIER LETTER CAPITAL I
-        0x1D36 => 'J',  // MODIFIER LETTER CAPITAL J
-        0x1D37 => 'K',  // MODIFIER LETTER CAPITAL K
-        0x1D38 => 'L',  // MODIFIER LETTER CAPITAL L
-        0x1D39 => 'M',  // MODIFIER LETTER CAPITAL M
-        0x1D3A => 'N',  // MODIFIER LETTER CAPITAL N
-        0x1D3C => 'O',  // MODIFIER LETTER CAPITAL O
-        0x1D3E => 'P',  // MODIFIER LETTER CAPITAL P
-        0x1D3F => 'R',  // MODIFIER LETTER CAPITAL R
-        0x1D40 => 'T',  // MODIFIER LETTER CAPITAL T
-        0x1D41 => 'U',  // MODIFIER LETTER CAPITAL U
-        0x1D42 => 'W',  // MODIFIER LETTER CAPITAL W
-        0x1D43 => 'a',  // MODIFIER LETTER SMALL A
-        0x1D47 => 'b',  // MODIFIER LETTER SMALL B
-        0x1D48 => 'd',  // MODIFIER LETTER SMALL D
-        0x1D49 => 'e',  // MODIFIER LETTER SMALL E
-        0x1D4D => 'g',  // MODIFIER LETTER SMALL G
-        0x1D4F => 'k',  // MODIFIER LETTER SMALL K
-        0x1D50 => 'm',  // MODIFIER LETTER SMALL M
-        0x1D52 => 'o',  // MODIFIER LETTER SMALL O
-        0x1D56 => 'p',  // MODIFIER LETTER SMALL P
-        0x1D57 => 't',  // MODIFIER LETTER SMALL T
-        0x1D58 => 'u',  // MODIFIER LETTER SMALL U
-        0x1D5B => 'v',  // MODIFIER LETTER SMALL V
-        0x1D62 => 'i',  // LATIN SUBSCRIPT SMALL LETTER I
-        0x1D63 => 'r',  // LATIN SUBSCRIPT SMALL LETTER R
-        0x1D64 => 'u',  // LATIN SUBSCRIPT SMALL LETTER U
-        0x1D65 => 'v',  // LATIN SUBSCRIPT SMALL LETTER V
-        0x1D9C => 'c',  // MODIFIER LETTER SMALL C
-        0x1DA0 => 'f',  // MODIFIER LETTER SMALL F
-        0x1DBB => 'z',  // MODIFIER LETTER SMALL Z
-        0x2071 => 'i',  // SUPERSCRIPT LATIN SMALL LETTER I
-        0x207F => 'n',  // SUPERSCRIPT LATIN SMALL LETTER N
-        0x2090 => 'a',  // LATIN SUBSCRIPT SMALL LETTER A
-        0x2091 => 'e',  // LATIN SUBSCRIPT SMALL LETTER E
-        0x2092 => 'o',  // LATIN SUBSCRIPT SMALL LETTER O
-        0x2093 => 'x',  // LATIN SUBSCRIPT SMALL LETTER X
-        0x2095 => 'h',  // LATIN SUBSCRIPT SMALL LETTER H
-        0x2096 => 'k',  // LATIN SUBSCRIPT SMALL LETTER K
-        0x2097 => 'l',  // LATIN SUBSCRIPT SMALL LETTER L
-        0x2098 => 'm',  // LATIN SUBSCRIPT SMALL LETTER M
-        0x2099 => 'n',  // LATIN SUBSCRIPT SMALL LETTER N
-        0x209A => 'p',  // LATIN SUBSCRIPT SMALL LETTER P
-        0x209B => 's',  // LATIN SUBSCRIPT SMALL LETTER S
-        0x209C => 't',  // LATIN SUBSCRIPT SMALL LETTER T
-        0x212A => 'K',  // KELVIN SIGN
+        0x00AA => 'a', // FEMININE ORDINAL INDICATOR
+        0x00BA => 'o', // MASCULINE ORDINAL INDICATOR
+        0x02B0 => 'h', // MODIFIER LETTER SMALL H
+        0x02B2 => 'j', // MODIFIER LETTER SMALL J
+        0x02B3 => 'r', // MODIFIER LETTER SMALL R
+        0x02B7 => 'w', // MODIFIER LETTER SMALL W
+        0x02B8 => 'y', // MODIFIER LETTER SMALL Y
+        0x02E1 => 'l', // MODIFIER LETTER SMALL L
+        0x02E2 => 's', // MODIFIER LETTER SMALL S
+        0x02E3 => 'x', // MODIFIER LETTER SMALL X
+        0x1D2C => 'A', // MODIFIER LETTER CAPITAL A
+        0x1D2E => 'B', // MODIFIER LETTER CAPITAL B
+        0x1D30 => 'D', // MODIFIER LETTER CAPITAL D
+        0x1D31 => 'E', // MODIFIER LETTER CAPITAL E
+        0x1D33 => 'G', // MODIFIER LETTER CAPITAL G
+        0x1D34 => 'H', // MODIFIER LETTER CAPITAL H
+        0x1D35 => 'I', // MODIFIER LETTER CAPITAL I
+        0x1D36 => 'J', // MODIFIER LETTER CAPITAL J
+        0x1D37 => 'K', // MODIFIER LETTER CAPITAL K
+        0x1D38 => 'L', // MODIFIER LETTER CAPITAL L
+        0x1D39 => 'M', // MODIFIER LETTER CAPITAL M
+        0x1D3A => 'N', // MODIFIER LETTER CAPITAL N
+        0x1D3C => 'O', // MODIFIER LETTER CAPITAL O
+        0x1D3E => 'P', // MODIFIER LETTER CAPITAL P
+        0x1D3F => 'R', // MODIFIER LETTER CAPITAL R
+        0x1D40 => 'T', // MODIFIER LETTER CAPITAL T
+        0x1D41 => 'U', // MODIFIER LETTER CAPITAL U
+        0x1D42 => 'W', // MODIFIER LETTER CAPITAL W
+        0x1D43 => 'a', // MODIFIER LETTER SMALL A
+        0x1D47 => 'b', // MODIFIER LETTER SMALL B
+        0x1D48 => 'd', // MODIFIER LETTER SMALL D
+        0x1D49 => 'e', // MODIFIER LETTER SMALL E
+        0x1D4D => 'g', // MODIFIER LETTER SMALL G
+        0x1D4F => 'k', // MODIFIER LETTER SMALL K
+        0x1D50 => 'm', // MODIFIER LETTER SMALL M
+        0x1D52 => 'o', // MODIFIER LETTER SMALL O
+        0x1D56 => 'p', // MODIFIER LETTER SMALL P
+        0x1D57 => 't', // MODIFIER LETTER SMALL T
+        0x1D58 => 'u', // MODIFIER LETTER SMALL U
+        0x1D5B => 'v', // MODIFIER LETTER SMALL V
+        0x1D62 => 'i', // LATIN SUBSCRIPT SMALL LETTER I
+        0x1D63 => 'r', // LATIN SUBSCRIPT SMALL LETTER R
+        0x1D64 => 'u', // LATIN SUBSCRIPT SMALL LETTER U
+        0x1D65 => 'v', // LATIN SUBSCRIPT SMALL LETTER V
+        0x1D9C => 'c', // MODIFIER LETTER SMALL C
+        0x1DA0 => 'f', // MODIFIER LETTER SMALL F
+        0x1DBB => 'z', // MODIFIER LETTER SMALL Z
+        0x2071 => 'i', // SUPERSCRIPT LATIN SMALL LETTER I
+        0x207F => 'n', // SUPERSCRIPT LATIN SMALL LETTER N
+        0x2090 => 'a', // LATIN SUBSCRIPT SMALL LETTER A
+        0x2091 => 'e', // LATIN SUBSCRIPT SMALL LETTER E
+        0x2092 => 'o', // LATIN SUBSCRIPT SMALL LETTER O
+        0x2093 => 'x', // LATIN SUBSCRIPT SMALL LETTER X
+        0x2095 => 'h', // LATIN SUBSCRIPT SMALL LETTER H
+        0x2096 => 'k', // LATIN SUBSCRIPT SMALL LETTER K
+        0x2097 => 'l', // LATIN SUBSCRIPT SMALL LETTER L
+        0x2098 => 'm', // LATIN SUBSCRIPT SMALL LETTER M
+        0x2099 => 'n', // LATIN SUBSCRIPT SMALL LETTER N
+        0x209A => 'p', // LATIN SUBSCRIPT SMALL LETTER P
+        0x209B => 's', // LATIN SUBSCRIPT SMALL LETTER S
+        0x209C => 't', // LATIN SUBSCRIPT SMALL LETTER T
+        0x212A => 'K', // KELVIN SIGN
+        // ANGSTROM SIGN. NFKC gives `\u{00C5}` (A-with-ring), NOT an ASCII
+        // letter, so the generated sweep correctly skipped it — but that is one
+        // more step, not a different answer: `\u{00C5}` is then accent-stripped
+        // to `A` like any other ring-A. Added by hand so the two-step path
+        // lands where the one-step path does. Found by requiring tier 1 in
+        // `roman_numerals_and_nfkc_letters_fold`; under the weaker `is_some()`
+        // assertion it read as a match at NearMiss.
+        0x212B => 'A',  // ANGSTROM SIGN
         0x2139 => 'i',  // INFORMATION SOURCE
         0x2145 => 'D',  // DOUBLE-STRUCK ITALIC CAPITAL D
         0x2146 => 'd',  // DOUBLE-STRUCK ITALIC SMALL D
@@ -1646,9 +1654,19 @@ mod tests {
                 real,
                 mid(1),
             )]);
-            assert!(
-                checker.check(mid(2), attacker).is_some(),
-                "{label}: {attacker:?} must be flagged against {real:?}"
+            // Must be TIER 1. Asserting only `is_some()` was too weak:
+            // a missing fold entry leaves a one-character difference, which
+            // still matches at NearMiss — a tier this UI does not render. Two
+            // mutants (dropping the lunate-sigma and Cyrillic-combining
+            // entries) survived against the weaker assertion.
+            let w = checker.check(mid(2), attacker).unwrap_or_else(|| {
+                panic!("{label}: {attacker:?} must be flagged against {real:?}")
+            });
+            assert_eq!(
+                w.tier,
+                ConfusableTier::Identical,
+                "{label}: {attacker:?} must fold to the SAME skeleton as \
+                 {real:?}, not merely land within the edit budget"
             );
         }
     }
@@ -1676,9 +1694,19 @@ mod tests {
                 real,
                 mid(1),
             )]);
-            assert!(
-                checker.check(mid(2), attacker).is_some(),
-                "{label}: {attacker:?} must be flagged against {real:?}"
+            // Must be TIER 1. Asserting only `is_some()` was too weak:
+            // a missing fold entry leaves a one-character difference, which
+            // still matches at NearMiss — a tier this UI does not render. Two
+            // mutants (dropping the lunate-sigma and Cyrillic-combining
+            // entries) survived against the weaker assertion.
+            let w = checker.check(mid(2), attacker).unwrap_or_else(|| {
+                panic!("{label}: {attacker:?} must be flagged against {real:?}")
+            });
+            assert_eq!(
+                w.tier,
+                ConfusableTier::Identical,
+                "{label}: {attacker:?} must fold to the SAME skeleton as \
+                 {real:?}, not merely land within the edit budget"
             );
         }
     }

--- a/ui/src/util/confusable.rs
+++ b/ui/src/util/confusable.rs
@@ -752,6 +752,60 @@ fn fold_homoglyph(c: char) -> char {
         '\u{03A4}' => 'T', // Τ
         '\u{03A5}' => 'Y', // Υ
         '\u{03A7}' => 'X', // Χ
+        // ---- Shape homoglyphs that NFKC does NOT equate ----
+        //
+        // Unlike `fold_nfkc_letter`, these are NOT normalisation-equal to their
+        // Latin counterparts — they are separate letters that happen to be
+        // drawn the same. So they carry REAL false-positive surface and each is
+        // a judgement, not a lookup. Every script here is covered by
+        // `real_names_in_other_scripts_are_not_flagged` and by the corpus sweep
+        // in `foldable_scripts_do_not_collide_with_latin_names`.
+        //
+        // Greek lunate sigma: the epigraphic forms of sigma, drawn exactly as
+        // Latin C/c.
+        '\u{03F9}' => 'C',
+        '\u{03F2}' => 'c',
+        // Coptic. These capitals are drawn as their Latin lookalikes in every
+        // Coptic font; the lowercase forms sit at +1.
+        '\u{2C80}' => 'A',
+        '\u{2C81}' => 'a',
+        '\u{2C88}' => 'E',
+        '\u{2C8E}' => 'H',
+        '\u{2C92}' => 'I',
+        '\u{2C94}' => 'K',
+        '\u{2C98}' => 'M',
+        '\u{2C9A}' => 'N',
+        '\u{2C9E}' => 'O',
+        '\u{2C9F}' => 'o',
+        '\u{2CA2}' => 'P',
+        '\u{2CA4}' => 'C',
+        '\u{2CA5}' => 'c',
+        '\u{2CA6}' => 'T',
+        '\u{2CAC}' => 'X',
+        // Armenian. ONLY these two: `\u{0585}` and `\u{0578}` are drawn as
+        // Latin `o`/`n`, and BOTH occur in real Armenian names
+        // (`\u{0540}\u{578}\u{57E}\u{570}\u{561}\u{576}\u{576}\u{565}\u{57D}`,
+        // `\u{0533}\u{578}\u{057C}`), which makes this the highest-risk entry
+        // in the file. It is safe only because a collision needs the WHOLE name
+        // to fold and every other Armenian letter stays itself — pinned by the
+        // corpus sweep, not by assertion.
+        '\u{0585}' => 'o',
+        '\u{0578}' => 'n',
+        // Cherokee, and Lisu — which was designed FROM Latin capitals, so its
+        // letters are Latin letterforms outright.
+        '\u{13DF}' => 'C',
+        '\u{A4F2}' => 'I',
+        '\u{A4EA}' => 'W',
+        // Latin-block letters that are not the ASCII letter they resemble:
+        // `\u{01C0}` is a click consonant, `\u{0251}` the IPA script-a, and
+        // `\u{0131}` is Turkish dotless i — a REAL letter in Turkish names,
+        // folded anyway because a reader outside Turkish sees one glyph minus a
+        // dot. That cost is recorded in `documented_accepted_collisions`.
+        '\u{01C0}' => 'l',
+        '\u{0251}' => 'a',
+        '\u{0131}' => 'i',
+        // Mathematical DIVIDES: a bare vertical stroke.
+        '\u{2223}' => 'l',
         // Greek, lowercase — only the three that are genuinely
         // indistinguishable.
         '\u{03BF}' => 'o', // ο
@@ -764,7 +818,18 @@ fn fold_homoglyph(c: char) -> char {
 /// Combining marks, dropped so `"I" + U+0300` folds like `"Ì"`.
 fn is_combining_mark(c: char) -> bool {
     matches!(u32::from(c),
-        0x0300..=0x036F   // Combining Diacritical Marks
+        // Cyrillic combining marks (titlo, palatalisation, psili...). Added
+        // because `"Ian Cla\u{0483}rke"` otherwise EVADED while `U+0300` was
+        // caught — a mark a reader barely registers must not defeat the fold.
+        // These are historic/liturgical ornaments, not part of how any modern
+        // Cyrillic name is spelled, so folding them is safe.
+        //
+        // Hebrew niqqud, Arabic harakat and Indic/Thai vowel signs are still
+        // NOT here, deliberately: in those scripts marks are far more often
+        // meaning-bearing, and widening the strip would start flagging real
+        // people in scripts this repo has no corpus for. See the module header.
+        0x0483..=0x0489
+        | 0x0300..=0x036F   // Combining Diacritical Marks
         | 0x1AB0..=0x1AFF // Combining Diacritical Marks Extended
         | 0x1DC0..=0x1DFF // Combining Diacritical Marks Supplement
         | 0x20D0..=0x20F0 // Combining Diacritical Marks for Symbols
@@ -787,6 +852,9 @@ fn fold_presentation_form(c: char) -> Option<char> {
     if let Some(letter) = fold_letterlike(cp) {
         return Some(letter);
     }
+    if let Some(letter) = fold_nfkc_letter(c) {
+        return Some(letter);
+    }
     // Mathematical Alphanumeric Symbols: consecutive 52-letter (A-Z then a-z)
     // blocks.
     //
@@ -807,6 +875,122 @@ fn fold_presentation_form(c: char) -> Option<char> {
         return Some((b'0' + ((cp - 0x1D7CE) % 10) as u8) as char);
     }
     None
+}
+
+/// Characters whose Unicode NFKC normalisation IS a single ASCII letter, and
+/// which survive [`is_display_hidden`].
+///
+/// **This is the low-risk half of the confusable table and it is GENERATED, not
+/// curated.** Every entry is one a conforming NFKC implementation already
+/// treats as equal to its ASCII letter, so folding them adds no false-positive
+/// surface: none is a letter in any living orthography's normal spelling of a
+/// personal name. They are modifier letters (linguistics/IPA), super/subscripts,
+/// Roman numerals, ordinal indicators, the Kelvin and Angstrom signs, and the
+/// double-struck italics.
+///
+/// Without them the bypasses are trivial and total — Roman numerals render as
+/// plain Latin, so `U+2160 U+216D U+217C` spells `Ian Clarke` to any reader.
+///
+/// Produced by sweeping `0x80..0x30000` for `NFKC(c)` being one ASCII letter
+/// and subtracting what the other tables already fold; regenerate the same way
+/// if those ranges change. `roman_numerals_and_nfkc_letters_fold` pins a
+/// representative of each family.
+///
+/// Contrast [`fold_homoglyph`]'s shape entries, which NFKC does NOT equate and
+/// which therefore carry real false-positive risk.
+fn fold_nfkc_letter(c: char) -> Option<char> {
+    Some(match u32::from(c) {
+        // 88 characters, generated from Unicode NFKC data.
+        0x00AA => 'a',  // FEMININE ORDINAL INDICATOR
+        0x00BA => 'o',  // MASCULINE ORDINAL INDICATOR
+        0x02B0 => 'h',  // MODIFIER LETTER SMALL H
+        0x02B2 => 'j',  // MODIFIER LETTER SMALL J
+        0x02B3 => 'r',  // MODIFIER LETTER SMALL R
+        0x02B7 => 'w',  // MODIFIER LETTER SMALL W
+        0x02B8 => 'y',  // MODIFIER LETTER SMALL Y
+        0x02E1 => 'l',  // MODIFIER LETTER SMALL L
+        0x02E2 => 's',  // MODIFIER LETTER SMALL S
+        0x02E3 => 'x',  // MODIFIER LETTER SMALL X
+        0x1D2C => 'A',  // MODIFIER LETTER CAPITAL A
+        0x1D2E => 'B',  // MODIFIER LETTER CAPITAL B
+        0x1D30 => 'D',  // MODIFIER LETTER CAPITAL D
+        0x1D31 => 'E',  // MODIFIER LETTER CAPITAL E
+        0x1D33 => 'G',  // MODIFIER LETTER CAPITAL G
+        0x1D34 => 'H',  // MODIFIER LETTER CAPITAL H
+        0x1D35 => 'I',  // MODIFIER LETTER CAPITAL I
+        0x1D36 => 'J',  // MODIFIER LETTER CAPITAL J
+        0x1D37 => 'K',  // MODIFIER LETTER CAPITAL K
+        0x1D38 => 'L',  // MODIFIER LETTER CAPITAL L
+        0x1D39 => 'M',  // MODIFIER LETTER CAPITAL M
+        0x1D3A => 'N',  // MODIFIER LETTER CAPITAL N
+        0x1D3C => 'O',  // MODIFIER LETTER CAPITAL O
+        0x1D3E => 'P',  // MODIFIER LETTER CAPITAL P
+        0x1D3F => 'R',  // MODIFIER LETTER CAPITAL R
+        0x1D40 => 'T',  // MODIFIER LETTER CAPITAL T
+        0x1D41 => 'U',  // MODIFIER LETTER CAPITAL U
+        0x1D42 => 'W',  // MODIFIER LETTER CAPITAL W
+        0x1D43 => 'a',  // MODIFIER LETTER SMALL A
+        0x1D47 => 'b',  // MODIFIER LETTER SMALL B
+        0x1D48 => 'd',  // MODIFIER LETTER SMALL D
+        0x1D49 => 'e',  // MODIFIER LETTER SMALL E
+        0x1D4D => 'g',  // MODIFIER LETTER SMALL G
+        0x1D4F => 'k',  // MODIFIER LETTER SMALL K
+        0x1D50 => 'm',  // MODIFIER LETTER SMALL M
+        0x1D52 => 'o',  // MODIFIER LETTER SMALL O
+        0x1D56 => 'p',  // MODIFIER LETTER SMALL P
+        0x1D57 => 't',  // MODIFIER LETTER SMALL T
+        0x1D58 => 'u',  // MODIFIER LETTER SMALL U
+        0x1D5B => 'v',  // MODIFIER LETTER SMALL V
+        0x1D62 => 'i',  // LATIN SUBSCRIPT SMALL LETTER I
+        0x1D63 => 'r',  // LATIN SUBSCRIPT SMALL LETTER R
+        0x1D64 => 'u',  // LATIN SUBSCRIPT SMALL LETTER U
+        0x1D65 => 'v',  // LATIN SUBSCRIPT SMALL LETTER V
+        0x1D9C => 'c',  // MODIFIER LETTER SMALL C
+        0x1DA0 => 'f',  // MODIFIER LETTER SMALL F
+        0x1DBB => 'z',  // MODIFIER LETTER SMALL Z
+        0x2071 => 'i',  // SUPERSCRIPT LATIN SMALL LETTER I
+        0x207F => 'n',  // SUPERSCRIPT LATIN SMALL LETTER N
+        0x2090 => 'a',  // LATIN SUBSCRIPT SMALL LETTER A
+        0x2091 => 'e',  // LATIN SUBSCRIPT SMALL LETTER E
+        0x2092 => 'o',  // LATIN SUBSCRIPT SMALL LETTER O
+        0x2093 => 'x',  // LATIN SUBSCRIPT SMALL LETTER X
+        0x2095 => 'h',  // LATIN SUBSCRIPT SMALL LETTER H
+        0x2096 => 'k',  // LATIN SUBSCRIPT SMALL LETTER K
+        0x2097 => 'l',  // LATIN SUBSCRIPT SMALL LETTER L
+        0x2098 => 'm',  // LATIN SUBSCRIPT SMALL LETTER M
+        0x2099 => 'n',  // LATIN SUBSCRIPT SMALL LETTER N
+        0x209A => 'p',  // LATIN SUBSCRIPT SMALL LETTER P
+        0x209B => 's',  // LATIN SUBSCRIPT SMALL LETTER S
+        0x209C => 't',  // LATIN SUBSCRIPT SMALL LETTER T
+        0x212A => 'K',  // KELVIN SIGN
+        0x2139 => 'i',  // INFORMATION SOURCE
+        0x2145 => 'D',  // DOUBLE-STRUCK ITALIC CAPITAL D
+        0x2146 => 'd',  // DOUBLE-STRUCK ITALIC SMALL D
+        0x2147 => 'e',  // DOUBLE-STRUCK ITALIC SMALL E
+        0x2148 => 'i',  // DOUBLE-STRUCK ITALIC SMALL I
+        0x2149 => 'j',  // DOUBLE-STRUCK ITALIC SMALL J
+        0x2160 => 'I',  // ROMAN NUMERAL ONE
+        0x2164 => 'V',  // ROMAN NUMERAL FIVE
+        0x2169 => 'X',  // ROMAN NUMERAL TEN
+        0x216C => 'L',  // ROMAN NUMERAL FIFTY
+        0x216D => 'C',  // ROMAN NUMERAL ONE HUNDRED
+        0x216E => 'D',  // ROMAN NUMERAL FIVE HUNDRED
+        0x216F => 'M',  // ROMAN NUMERAL ONE THOUSAND
+        0x2170 => 'i',  // SMALL ROMAN NUMERAL ONE
+        0x2174 => 'v',  // SMALL ROMAN NUMERAL FIVE
+        0x2179 => 'x',  // SMALL ROMAN NUMERAL TEN
+        0x217C => 'l',  // SMALL ROMAN NUMERAL FIFTY
+        0x217D => 'c',  // SMALL ROMAN NUMERAL ONE HUNDRED
+        0x217E => 'd',  // SMALL ROMAN NUMERAL FIVE HUNDRED
+        0x217F => 'm',  // SMALL ROMAN NUMERAL ONE THOUSAND
+        0x2C7C => 'j',  // LATIN SUBSCRIPT SMALL LETTER J
+        0x2C7D => 'V',  // MODIFIER LETTER CAPITAL V
+        0xA7F2 => 'C',  // MODIFIER LETTER CAPITAL C
+        0xA7F3 => 'F',  // MODIFIER LETTER CAPITAL F
+        0xA7F4 => 'Q',  // MODIFIER LETTER CAPITAL Q
+        0x107A5 => 'q', // MODIFIER LETTER SMALL Q
+        _ => return None,
+    })
 }
 
 /// Letterlike Symbols (U+2100..U+214F) that NFKC folds to a plain letter.
@@ -1436,6 +1620,150 @@ mod tests {
         );
     }
 
+    /// **BLOCKING C — whole NFKC-equivalent blocks were missing.** A sweep for
+    /// "NFKC yields one ASCII letter, survives `is_display_hidden`, but the fold
+    /// does not fold it" returned ~87 characters. Roman numerals are the
+    /// cleanest bypass: they are letterforms and render as plain Latin.
+    #[test]
+    fn roman_numerals_and_nfkc_letters_fold() {
+        for (label, attacker, real) in [
+            (
+                "Roman numerals",
+                "\u{2160}an \u{216D}\u{217C}arke",
+                "Ian Clarke",
+            ),
+            ("Roman numeral V", "\u{2164}era Voss", "Vera Voss"),
+            ("Roman numeral X", "\u{2169}ander Doe", "Xander Doe"),
+            ("KELVIN SIGN", "\u{212A}ai Chen", "Kai Chen"),
+            ("ANGSTROM SIGN", "\u{212B}da Lovelace", "Ada Lovelace"),
+            ("ordinal indicators", "B\u{00BA}b", "Bob"),
+            ("modifier letters", "\u{1D2C}da", "Ada"),
+            ("double-struck italic", "\u{2145}an", "Dan"),
+            ("subscript letters", "B\u{2092}b", "Bob"),
+        ] {
+            let checker = ImpersonationChecker::new(vec![ProtectedName::new(
+                ProtectedRole::Deputy,
+                real,
+                mid(1),
+            )]);
+            assert!(
+                checker.check(mid(2), attacker).is_some(),
+                "{label}: {attacker:?} must be flagged against {real:?}"
+            );
+        }
+    }
+
+    /// The shape homoglyphs — the half NFKC does NOT equate, so each is a
+    /// judgement rather than a lookup.
+    #[test]
+    fn shape_homoglyphs_fold() {
+        for (label, attacker, real) in [
+            ("Greek lunate sigma", "\u{03F9}larke", "Clarke"),
+            ("Coptic O", "\u{2C9E}wner", "Owner"),
+            ("Coptic C+A", "\u{2CA4}\u{2C80}rl", "Carl"),
+            ("Armenian o", "B\u{0585}b", "Bob"),
+            ("Armenian vo", "Da\u{0578}", "Dan"),
+            ("Cherokee C", "\u{13DF}arl", "Carl"),
+            ("Lisu I", "\u{A4F2}an Clarke", "Ian Clarke"),
+            ("dental click", "\u{01C0}an Clarke", "Ian Clarke"),
+            ("DIVIDES", "\u{2223}an Clarke", "Ian Clarke"),
+            ("IPA alpha", "\u{0251}da", "Ada"),
+            ("dotless i", "\u{0131}an Clarke", "Ian Clarke"),
+            ("Cyrillic titlo", "Ian Cla\u{0483}rke", "Ian Clarke"),
+        ] {
+            let checker = ImpersonationChecker::new(vec![ProtectedName::new(
+                ProtectedRole::Deputy,
+                real,
+                mid(1),
+            )]);
+            assert!(
+                checker.check(mid(2), attacker).is_some(),
+                "{label}: {attacker:?} must be flagged against {real:?}"
+            );
+        }
+    }
+
+    /// **The false-positive sweep for the shape homoglyphs, and the reason the
+    /// C table could not just be pasted in.**
+    ///
+    /// `fold_nfkc_letter` is safe by construction — NFKC already equates its
+    /// entries, and none is a letter in a living orthography. The SHAPE table is
+    /// different: Armenian `ո`/`օ`, the Coptic letters and Cherokee `Ꮯ` are real
+    /// letters in real names, and folding them moves those names toward Latin.
+    ///
+    /// The property that makes it safe is that a collision needs the WHOLE name
+    /// to fold, and every other letter in those scripts stays itself. This
+    /// asserts it directly: no name in the corpus collides with a Latin
+    /// protected name, and no two corpus names collide with each other.
+    #[test]
+    fn foldable_scripts_do_not_collide_with_latin_names() {
+        // Real names in every script the shape table touches, chosen to CONTAIN
+        // the folded letters where possible — `Հովհաննես` and `Գոռ` both carry
+        // Armenian `ո`, which is the highest-risk entry in the table.
+        let corpus = [
+            "Հովհաննես",
+            "Գոռ",
+            "Նոր Օհան",
+            "Արամ Խաչատրյան",
+            "Օհան",
+            "ⲡⲁⲡⲛⲟⲩⲧⲉ",
+            "Ⲡⲉⲧⲣⲟⲥ",
+            "ᏣᎳᎩ ᎠᏰᎵ",
+            "Γιώργος Παπαδόπουλος",
+            "Νίκος Παπαδόπουλος",
+            "Иван Петров",
+            "Ольга Иванова",
+            "Işık Yılmaz",
+            "Cılız Demir",
+        ];
+        let latin_protected = [
+            "Ian Clarke",
+            "Room Owner",
+            "Bob",
+            "Owner",
+            "Carl",
+            "Dan",
+            "Ada",
+            "Nora",
+            "Ohan",
+        ];
+
+        for name in corpus {
+            for protected in latin_protected {
+                let checker = ImpersonationChecker::new(vec![ProtectedName::new(
+                    ProtectedRole::Deputy,
+                    protected,
+                    mid(1),
+                )]);
+                assert_eq!(
+                    checker.check(mid(2), name),
+                    None,
+                    "a legitimate name folded onto a Latin protected name: \
+                     {name:?} vs {protected:?} — the shape table is too \
+                     aggressive and the offending entry must come back out"
+                );
+            }
+        }
+
+        // And no two DIFFERENT corpus names may fold together either, which is
+        // the same harm one level down (a deputy holding one would flag the
+        // other).
+        for (i, a) in corpus.iter().enumerate() {
+            for b in corpus.iter().skip(i + 1) {
+                let checker = ImpersonationChecker::new(vec![ProtectedName::new(
+                    ProtectedRole::Deputy,
+                    *a,
+                    mid(1),
+                )]);
+                assert_eq!(
+                    checker.check(mid(2), b),
+                    None,
+                    "two distinct real names now fold together: {a:?} / {b:?}"
+                );
+            }
+        }
+    }
+
     /// **BLOCKING B — uppercase homoglyphs whose LOWERCASE is in the table.**
     ///
     /// `fold_homoglyph` originally ran only before `to_lowercase`. Any uppercase
@@ -1722,6 +2050,9 @@ mod tests {
             ("Muller", "M\u{00FC}ller", "accent stripping"),
             ("Boll", "B\u{00F6}ll", "accent stripping"),
             ("Moller", "M\u{00F6}ller", "accent stripping"),
+            // Turkish dotless i: a REAL letter in Turkish names, but a reader
+            // outside Turkish sees one glyph minus a dot.
+            ("Isik", "Is\u{0131}k", "Turkish dotless i"),
         ] {
             let checker = ImpersonationChecker::new(vec![ProtectedName::new(
                 ProtectedRole::Deputy,

--- a/ui/src/util/confusable.rs
+++ b/ui/src/util/confusable.rs
@@ -98,7 +98,7 @@
 use crate::util::display_name::is_display_hidden;
 use river_core::room_state::member::MemberId;
 
-/// A `MemberId` no real member can hold, used by [`check_name`] so a test that
+/// A `MemberId` no real member can hold, used by `check_name` so a test that
 /// does not care about identity still routes through the same per-name
 /// exemption logic production uses.
 ///
@@ -107,6 +107,7 @@ use river_core::room_state::member::MemberId;
 /// it being unreachable for CORRECTNESS — the worst case is that a test's
 /// candidate is exempted from one protected name — but keeping it out of band
 /// keeps the tests honest.
+#[cfg(test)]
 const NO_SUCH_MEMBER: MemberId = MemberId(freenet_scaffold::util::FastHash(i64::MIN));
 
 /// How close a name is to a protected one.
@@ -144,7 +145,7 @@ pub enum ProtectedRole {
 /// A privileged name that must not be impersonated.
 ///
 /// Carries BOTH folds (see [`Fold`]) plus their space-stripped forms, computed
-/// once at construction. `check_name` is the per-member hot path and must not
+/// once at construction. `check` is the per-member hot path and must not
 /// re-fold or re-allocate per candidate.
 #[derive(Clone, PartialEq, Debug)]
 pub struct ProtectedName {
@@ -226,6 +227,20 @@ pub struct ImpersonationWarning {
     /// [`crate::components::members::impersonation_warning_for_display`], which
     /// applies the tier decision (only `Identical` is shown).
     pub tier: ConfusableTier,
+    /// The privilege the **FLAGGED** member themselves holds in this viewer's
+    /// view, if any.
+    ///
+    /// [`ImpersonationChecker`] cannot know this — it is asked about a name and
+    /// an id, not about the room's badge map — so it always leaves this `None`.
+    /// [`crate::components::members::impersonation_warning_for_display`] fills
+    /// it in, from the same badge map the 🛡 comes from.
+    ///
+    /// It exists because [`tooltip`](Self::tooltip) used to switch on the
+    /// IMPERSONATED role alone and therefore stated as fact something that is
+    /// provably false in two reachable cases: two deputies with colliding names
+    /// each render 🛡 **and** "this member is NOT a moderator", and the room
+    /// owner can render 👑 alongside the same sentence. See the tooltip.
+    pub flagged_privilege: Option<ProtectedRole>,
 }
 
 /// The glyph rendered for a warning.
@@ -277,8 +292,35 @@ impl ImpersonationWarning {
     /// inside one node cannot span two — the approach `DeputyBadge::appointer_names`
     /// takes for the member-info modal. Never join it into this string.
     ///
+    /// ## It must not assert something that is false
+    ///
+    /// The two role sentences below say "this member is NOT a moderator" / "NOT
+    /// the room owner". Both are FALSE whenever the flagged member holds
+    /// privilege themselves, and both cases are reachable without any bug:
+    ///
+    /// * Two deputies whose names collide. Each is in the other's protected set
+    ///   and neither is exempt from the other, so both render 🛡 **and** ⚠.
+    /// * The room owner. `tier_one_for` skips only the protected name whose
+    ///   `source` is the owner, so an owner whose name collides with a deputy's
+    ///   renders 👑 and "this member is NOT a moderator".
+    ///
+    /// Suppressing the badge in those cases is NOT the fix, and must not be
+    /// attempted: a deputised sockpuppet carries a genuine 🛡, so suppression
+    /// hands it exactly the immunity
+    /// `a_deputised_sockpuppet_cannot_suppress_its_own_warning` exists to deny.
+    /// The badge stays; the SENTENCE changes to one that is true of both
+    /// members, and points at the disambiguator that actually works (the member
+    /// ID River shows on hover). Pinned by
+    /// `a_privileged_member_is_never_told_they_are_not_privileged`.
+    ///
     /// Pinned by `tooltip_contains_no_nickname_content`.
     pub fn tooltip(&self) -> String {
+        if self.flagged_privilege.is_some() {
+            return "Name conflict: this member's name is visually the same as \
+                 another member's who also has privileges in this room. Both are \
+                 real; check the member ID shown on hover to tell them apart."
+                .to_string();
+        }
         match self.impersonated.role {
             ProtectedRole::Owner => "Impersonation warning: this member is NOT the room owner, \
                  but their name closely resembles the owner's. The real owner is marked \
@@ -375,9 +417,15 @@ impl ImpersonationChecker {
     /// The name half of [`check`](Self::check), for a member whose id is not
     /// among any protected name's source.
     ///
-    /// Exposed for tests only. Production callers must use `check` or
-    /// `check_identical`, so the per-name exemption cannot be skipped —
-    /// `impersonation_checker_uses_the_identity_aware_entry_points` pins that.
+    /// **`#[cfg(test)]`, and it must stay that way.** It routes through
+    /// [`NO_SUCH_MEMBER`], which matches no real member, so it skips the
+    /// per-name identity exemption entirely: a production caller would flag the
+    /// REAL owner and every REAL deputy for wearing their own names. This used
+    /// to be `pub` with a doc comment asking callers not to use it and a
+    /// citation to a pin test that was never written, in a module carrying
+    /// `#![allow(dead_code)]` — three layers of nothing. A `cfg` attribute is
+    /// the one form of "do not call this from production" the compiler enforces.
+    #[cfg(test)]
     pub fn check_name(&self, display_name: &str) -> Option<ImpersonationWarning> {
         self.check(NO_SUCH_MEMBER, display_name)
     }
@@ -418,6 +466,10 @@ impl ImpersonationChecker {
                 return Some(ImpersonationWarning {
                     impersonated: p.clone(),
                     tier: ConfusableTier::Identical,
+                    // The checker is asked about a name and an id; it has no
+                    // view of the room's badge map, so only the render boundary
+                    // can fill this in. See `flagged_privilege`.
+                    flagged_privilege: None,
                 });
             }
         }
@@ -448,6 +500,7 @@ impl ImpersonationChecker {
                     best = Some(ImpersonationWarning {
                         impersonated: p.clone(),
                         tier: ConfusableTier::NearMiss,
+                        flagged_privilege: None,
                     });
                 }
             }
@@ -495,6 +548,42 @@ fn edit_budget(len: usize) -> usize {
 /// faithful copy of the engine these results were validated against.
 pub fn skeleton(name: &str) -> String {
     skeleton_with(name, Fold::Visual)
+}
+
+/// The space-stripped form of BOTH folds of `name`.
+///
+/// This is the pair a *guard* must compare when it wants to answer "could this
+/// name ever tier-1 match that one?". [`ImpersonationChecker::tier_one_for`]
+/// accepts a hit under any of four comparisons, and the two space-stripped ones
+/// subsume the other two: equality WITH spaces implies equality without them.
+/// So two names that disagree on both of these can never be a tier-1 match, and
+/// two that agree on either always are.
+///
+/// It exists because the filters deciding which names ENTER the protected set
+/// used to compare exact strings while the matcher they gate compares folds — a
+/// guard weaker than the thing it guards, which is not a guard. See
+/// [`crate::components::members::impersonation_checker_for_viewer`].
+pub fn comparison_folds(name: &str) -> [String; 2] {
+    [
+        strip_spaces(&skeleton_with(name, Fold::Visual)),
+        strip_spaces(&skeleton_with(name, Fold::CaseInsensitive)),
+    ]
+}
+
+/// Whether `a` and `b` are a tier-1 (same-skeleton) match under either fold.
+///
+/// The identity-free form of [`ImpersonationChecker::check_identical`], for
+/// guards that compare a candidate against a fixed literal rather than against
+/// the room's protected set.
+pub fn folds_together(a: &str, b: &str) -> bool {
+    let [a_visual, a_case] = comparison_folds(a);
+    if a_visual.is_empty() {
+        // A name that folds to nothing can never match: `candidate_folds`
+        // rejects it before any comparison runs.
+        return false;
+    }
+    let [b_visual, b_case] = comparison_folds(b);
+    a_visual == b_visual || a_case == b_case
 }
 
 /// [`skeleton`] under a chosen [`Fold`]. See that type for why there are two.
@@ -2103,6 +2192,7 @@ mod tests {
         let deputy = ImpersonationWarning {
             impersonated: ProtectedName::new(ProtectedRole::Deputy, "Ian Clarke", mid(119)),
             tier: ConfusableTier::Identical,
+            flagged_privilege: None,
         }
         .tooltip();
         assert!(deputy.contains("is NOT a moderator"), "{deputy}");
@@ -2114,6 +2204,7 @@ mod tests {
         let owner = ImpersonationWarning {
             impersonated: ProtectedName::new(ProtectedRole::Owner, "Room Owner", mid(120)),
             tier: ConfusableTier::NearMiss,
+            flagged_privilege: None,
         }
         .tooltip();
         assert!(owner.contains("is NOT the room owner"), "{owner}");
@@ -2154,6 +2245,7 @@ mod tests {
             let baseline = ImpersonationWarning {
                 impersonated: ProtectedName::new(role, "Anodyne", mid(1)),
                 tier: ConfusableTier::Identical,
+                flagged_privilege: None,
             }
             .tooltip();
 
@@ -2161,6 +2253,7 @@ mod tests {
                 let tip = ImpersonationWarning {
                     impersonated: ProtectedName::new(role, payload, mid(1)),
                     tier: ConfusableTier::Identical,
+                    flagged_privilege: None,
                 }
                 .tooltip();
                 assert_eq!(

--- a/ui/src/util/confusable.rs
+++ b/ui/src/util/confusable.rs
@@ -75,6 +75,23 @@
 //!   the set of ordinary names that fold onto a moderator's — tiny. The
 //!   `no_false_positives_on_ordinary_names` and
 //!   `generated_handles_never_fold_to_the_same_skeleton` tests are the guard.
+//! * **Latin accents are stripped, which is more aggressive than TR39** and is
+//!   an accepted trade rather than an oversight. `Müller`/`Muller`,
+//!   `Böll`/`Boll` and `Möller`/`Moller` are distinct family names and DO
+//!   collide; stripping is what catches `Ìan Clarke`. Likewise `rn -> m` is a
+//!   real confusable that also collides `Marnie`/`Mamie` and `Lorna`/`Loma`.
+//!   Both are listed in `documented_accepted_collisions`, which fails if either
+//!   silently stops holding — the point is that the accepted list is short,
+//!   named, and testable rather than discovered by an accused member.
+//! * **The accent strip is Latin-only.** `is_combining_mark` covers the Latin
+//!   combining ranges but NOT Hebrew niqqud (U+0591..U+05C7), Arabic harakat
+//!   (U+064B..U+065F), or Devanagari/Thai vowel signs. So a Hebrew or Arabic
+//!   name is compared with its marks intact. That is inconsistent, and it is
+//!   also a bypass in principle (marks a reader barely sees are not folded
+//!   away). It is left as-is deliberately: those marks are far more often
+//!   meaning-bearing than the Latin ones, and widening the strip is exactly the
+//!   kind of change that starts flagging real people in scripts this codebase
+//!   has no test corpus for. Revisit only with a corpus.
 //! * This module compares names. It does not, and cannot, tell you whether the
 //!   person behind an unflagged name is who they say they are.
 
@@ -115,26 +132,73 @@ pub enum ProtectedRole {
 }
 
 /// A privileged name that must not be impersonated.
+///
+/// Carries BOTH folds (see [`Fold`]) plus their space-stripped forms, computed
+/// once at construction. `check_name` is the per-member hot path and must not
+/// re-fold or re-allocate per candidate.
 #[derive(Clone, PartialEq, Debug)]
 pub struct ProtectedName {
     pub role: ProtectedRole,
-    /// The privileged member's display name, already sanitised. Quoted back to
-    /// the reader in the tooltip so the warning names who is being imitated.
+    /// The privileged member's display name, already sanitised.
     pub display_name: String,
-    /// Cached [`skeleton`] of `display_name`.
-    skeleton: String,
+    visual: String,
+    visual_no_space: String,
+    case_insensitive: String,
+    case_insensitive_no_space: String,
 }
 
 impl ProtectedName {
     pub fn new(role: ProtectedRole, display_name: impl Into<String>) -> Self {
         let display_name = display_name.into();
-        let skeleton = skeleton(&display_name);
+        let visual = skeleton_with(&display_name, Fold::Visual);
+        let case_insensitive = skeleton_with(&display_name, Fold::CaseInsensitive);
         Self {
             role,
+            visual_no_space: strip_spaces(&visual),
+            case_insensitive_no_space: strip_spaces(&case_insensitive),
+            visual,
+            case_insensitive,
             display_name,
-            skeleton,
         }
     }
+}
+
+fn strip_spaces(s: &str) -> String {
+    s.chars().filter(|c| *c != ' ').collect()
+}
+
+/// The two skeletons a name folds to. **Both are needed, and neither alone is
+/// sufficient** — this is the fix for a false-positive class found in review.
+///
+/// The bar-shaped characters (`I`, `l`, `1`, `|`, `!`) render identically, and
+/// lowercase `i` does NOT (it has a dot). But case-insensitivity says `I` ≡ `i`.
+/// Composing the two transitively gives `i` ≡ `l`, and then any two names
+/// differing only in `i` vs `l` collide:
+///
+/// * `Ilan` (Hebrew) / `Lian` (Chinese)
+/// * `Alia` (Arabic) / `Alla` (Russian), `Ilya` / `Liya`, `Ila` / `Lia`
+///
+/// That transitive collapse is unavoidable in ONE skeleton: `Ian` ≡ `ian` (case)
+/// and `Ian` ≡ `lan` (the live attack) force `i` ≡ `l`. Verified exhaustively —
+/// every single-skeleton variant either keeps those false positives or breaks a
+/// row of the validated table (moving the fold before the case step drops
+/// `IAN CLARKE`, because capital `L` is then no longer folded).
+///
+/// So the collapse is split across two skeletons and a name matches if EITHER
+/// agrees. Each keeps the bar class as a `'1'` sentinel that never merges with
+/// the letter `i`, so neither one alone equates them:
+///
+/// * [`Fold::Visual`] folds the bar class BEFORE case, so `I` and `l` merge and
+///   lowercase `i` stays distinct. Catches `lan Clarke`, `1an Clarke`,
+///   `Ian CIarke`.
+/// * [`Fold::CaseInsensitive`] folds it AFTER case, so `L`/`l` and `I`/`i` merge
+///   as letters. Catches `IAN CLARKE`, `ian clarke`.
+///
+/// `Ilan`/`Lian` agree under neither, so they are no longer flagged.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Fold {
+    Visual,
+    CaseInsensitive,
 }
 
 /// The warning shown next to an impersonating member's name.
@@ -263,41 +327,92 @@ impl ImpersonationChecker {
         self.check_name(display_name)
     }
 
+    /// [`check`](Self::check) restricted to [`ConfusableTier::Identical`].
+    ///
+    /// **This is what the UI renders** (see
+    /// [`crate::components::members::impersonation_warning_for_display`]), and
+    /// it exists so the render path never pays for the tier it discards: it
+    /// returns before the Damerau-Levenshtein sweep, which is `O(protected x
+    /// len^2)` with a `Vec` allocation per DP row and runs for every
+    /// NON-matching member on every render — i.e. almost all of them.
+    pub fn check_identical(
+        &self,
+        id: MemberId,
+        display_name: &str,
+    ) -> Option<ImpersonationWarning> {
+        if self.privileged_ids.contains(&id) {
+            return None;
+        }
+        let folds = self.candidate_folds(display_name)?;
+        self.tier_one(&folds)
+    }
+
     /// The name half of [`check`](Self::check), with no identity check.
     ///
-    /// Exposed for tests. Production callers must use `check`, so the
-    /// identity-first rule cannot be skipped.
+    /// Exposed for tests. Production callers must use `check` or
+    /// `check_identical`, so the identity-first rule cannot be skipped.
     pub fn check_name(&self, display_name: &str) -> Option<ImpersonationWarning> {
-        if self.protected.is_empty() {
+        let Some(folds) = self.candidate_folds(display_name) else {
             return None;
-        }
-        let sk = skeleton(display_name);
-        if sk.is_empty() {
-            return None;
-        }
-        let sk_chars: Vec<char> = sk.chars().collect();
-        let sk_no_space: String = sk.chars().filter(|c| *c != ' ').collect();
-
+        };
         // Tier 1 across the WHOLE protected set before tier 2, so an exact
         // skeleton match is always reported as `Identical` even when some other
         // protected name is a near-miss. Otherwise the reported tier would
         // depend on the order the protected set happened to be built in.
+        if let Some(hit) = self.tier_one(&folds) {
+            return Some(hit);
+        }
+        self.tier_two(&folds)
+    }
+
+    /// Both folds of a candidate name, or `None` when no match is possible.
+    fn candidate_folds(&self, display_name: &str) -> Option<CandidateFolds> {
+        if self.protected.is_empty() {
+            return None;
+        }
+        let visual = skeleton_with(display_name, Fold::Visual);
+        if visual.is_empty() {
+            return None;
+        }
+        let case_insensitive = skeleton_with(display_name, Fold::CaseInsensitive);
+        Some(CandidateFolds {
+            visual_no_space: strip_spaces(&visual),
+            case_insensitive_no_space: strip_spaces(&case_insensitive),
+            visual_chars: visual.chars().collect(),
+            visual,
+            case_insensitive,
+        })
+    }
+
+    /// An exact match under EITHER fold. See [`Fold`] for why one is not enough.
+    fn tier_one(&self, c: &CandidateFolds) -> Option<ImpersonationWarning> {
         for p in &self.protected {
-            if sk == p.skeleton || sk_no_space == p.skeleton.replace(' ', "") {
+            let hit = c.visual == p.visual
+                || c.visual_no_space == p.visual_no_space
+                || c.case_insensitive == p.case_insensitive
+                || c.case_insensitive_no_space == p.case_insensitive_no_space;
+            if hit {
                 return Some(ImpersonationWarning {
                     impersonated: p.clone(),
                     tier: ConfusableTier::Identical,
                 });
             }
         }
-        let budget = edit_budget(sk_chars.len());
+        None
+    }
+
+    /// A near-miss under the VISUAL fold. Not rendered by this UI — see
+    /// [`check_identical`](Self::check_identical) — but kept, computed and
+    /// tested so the tier decision stays reversible and measurable.
+    fn tier_two(&self, c: &CandidateFolds) -> Option<ImpersonationWarning> {
+        let budget = edit_budget(c.visual_chars.len());
         if budget == 0 {
             return None;
         }
         let mut best: Option<ImpersonationWarning> = None;
         for p in &self.protected {
-            let p_chars: Vec<char> = p.skeleton.chars().collect();
-            if damerau_within(&sk_chars, &p_chars, budget) <= budget {
+            let p_chars: Vec<char> = p.visual.chars().collect();
+            if damerau_within(&c.visual_chars, &p_chars, budget) <= budget {
                 // Owner outranks deputy so the more severe impersonation is the
                 // one named, and the result does not depend on set order.
                 let better = best.as_ref().is_none_or(|b| {
@@ -313,6 +428,15 @@ impl ImpersonationChecker {
         }
         best
     }
+}
+
+/// A candidate name's folds, computed once per `check`.
+struct CandidateFolds {
+    visual: String,
+    visual_no_space: String,
+    visual_chars: Vec<char>,
+    case_insensitive: String,
+    case_insensitive_no_space: String,
 }
 
 /// How many edits away a name may be and still count as a near-miss.
@@ -344,6 +468,11 @@ fn edit_budget(len: usize) -> usize {
 /// considered; that rule is inert, and is kept only so the fold table stays a
 /// faithful copy of the engine these results were validated against.
 pub fn skeleton(name: &str) -> String {
+    skeleton_with(name, Fold::Visual)
+}
+
+/// [`skeleton`] under a chosen [`Fold`]. See that type for why there are two.
+fn skeleton_with(name: &str, fold: Fold) -> String {
     // 1. Drop what a reader cannot see, and fold presentation-only variants of
     //    ASCII. The invisible set is reused from the display-name table rather
     //    than re-listed here, so the two cannot drift. A hidden character that
@@ -386,13 +515,25 @@ pub fn skeleton(name: &str) -> String {
     //    which are all Latin or Cyrillic.)
     let out: String = out.chars().map(fold_homoglyph).collect();
 
-    // 6. Case.
-    let out = out.to_lowercase();
+    // 6/7. The bar class and case, in the order this [`Fold`] calls for.
+    //
+    //   * `Visual` folds bars FIRST, so capital `I` joins lowercase `l` (both
+    //     are a plain vertical stroke) while lowercase `i` — which has a dot —
+    //     stays a separate letter.
+    //   * `CaseInsensitive` lowercases first, so capital `L` has become `l` and
+    //     capital `I` has become `i` before the bar fold runs; that gives the
+    //     case-variant match without ever equating `i` with `l`.
+    //
+    // Both map the bar class to the SENTINEL `'1'`, never to the letter `i`.
+    // That is the whole point: folding to `i` is what made `Alia` and `Alla`
+    // collide. See [`Fold`].
+    let out = match fold {
+        Fold::Visual => fold_bar_class(&out).to_lowercase(),
+        Fold::CaseInsensitive => fold_bar_class(&out.to_lowercase()),
+    };
 
-    // 7. ASCII confusables. `l`/`1`/`|`/`!` all render as `i` in a sans-serif
-    //    UI font, which is the fold that catches `lan Clarke`. Note both sides
-    //    of a comparison are folded, so `"Clarke"` becomes `"ciarke"` for the
-    //    real moderator too and the match still holds.
+    // 7b. The remaining ASCII confusables, which are case-agnostic (they all
+    //     produce a lowercase letter, which the case step above leaves alone).
     let out: String = out.chars().map(fold_ascii_confusable).collect();
 
     // 8. Multi-character confusables: `rn` reads as `m`, `vv` as `w`.
@@ -423,16 +564,40 @@ pub fn skeleton(name: &str) -> String {
 
 /// Multi-character confusables, applied after the single-character map.
 ///
-/// `cl -> d` is inert: the ASCII map has already rewritten `l` to `i`. It is
-/// retained for fidelity with the upstream engine, and
-/// `skeleton_folds_in_reference_order` pins that it stays inert — reordering
-/// the two steps would change which ordinary names fold onto a moderator's.
-const MULTI_CONFUSABLES: [(&str, &str); 4] = [("rn", "m"), ("cl", "d"), ("vv", "w"), ("nn", "m")];
+/// `cl -> d` is inert: the bar fold has already rewritten `l`. It is retained
+/// for fidelity with the upstream engine, and `skeleton_folds_in_reference_order`
+/// pins that it stays inert.
+///
+/// **`nn -> m` was here and was REMOVED.** `rn` and `vv` are genuine visual
+/// confusables — `rn` really does read as `m` at UI sizes, which is what catches
+/// `Roorn Owner`. `nn` does not: `nn` and `m` are different shapes in every
+/// font, joined at the shoulder or not. And doubled-n is one of the commonest
+/// pairs in given names, so the rule accused a long tail of real people —
+/// `Annie`/`Amie`, `Anna`/`Ama` (Akan), `Hanna`/`Hama`, `Donna`/`Doma`,
+/// `Jenna`/`Jema`. It was a straight loss: no attack needs it, and it fired on
+/// names nobody chose to make confusable. Do not re-add it.
+const MULTI_CONFUSABLES: [(&str, &str); 3] = [("rn", "m"), ("cl", "d"), ("vv", "w")];
 
-/// Single-character ASCII lookalikes.
+/// The bar-shaped characters, folded to a `'1'` sentinel.
+///
+/// Deliberately NOT folded to the letter `i`: `i` has a dot and is a different
+/// shape, and merging them is what made `Alia`/`Alla` and `Ilan`/`Lian` collide.
+/// See [`Fold`]. Which characters are in the class depends on whether the case
+/// step has already run — the caller decides by choosing the [`Fold`].
+fn fold_bar_class(s: &str) -> String {
+    s.chars()
+        .map(|c| match c {
+            // `I` is here for the pre-case pass; after `to_lowercase` it can no
+            // longer appear, so the same table serves both directions.
+            'l' | 'I' | '1' | '|' | '!' => '1',
+            other => other,
+        })
+        .collect()
+}
+
+/// Single-character ASCII lookalikes OTHER than the bar class.
 fn fold_ascii_confusable(c: char) -> char {
     match c {
-        'l' | '1' | '|' | '!' => 'i',
         '0' => 'o',
         '5' | '$' => 's',
         '3' => 'e',
@@ -903,21 +1068,60 @@ mod tests {
     /// `"d"` and change which ordinary names land on a moderator's skeleton.
     #[test]
     fn skeleton_folds_in_reference_order() {
-        assert_eq!(skeleton("Clarke"), "ciarke");
+        // The bar class folds to the `'1'` SENTINEL, never to the letter `i` —
+        // folding to `i` is what made `Alia`/`Alla` collide. See [`Fold`].
+        assert_eq!(skeleton("Clarke"), "c1arke");
         assert_ne!(skeleton("Clarke"), "darke");
         // `rn -> m` is still live, because no earlier rule rewrites r or n.
         assert_eq!(skeleton("Roorn"), "room");
-        assert_eq!(skeleton("Ivvor"), "iwor");
-        assert_eq!(skeleton("Annie"), "amie");
+        assert_eq!(skeleton("Ivvor"), "1wor");
+        // `nn -> m` is GONE: `nn` and `m` are different shapes, and doubled-n is
+        // everywhere in real given names. See `MULTI_CONFUSABLES`.
+        assert_eq!(skeleton("Annie"), "annie");
+        assert_ne!(skeleton("Annie"), skeleton("Amie"));
+    }
+
+    /// The two folds differ exactly where they are supposed to: the visual one
+    /// merges `I` with `l`, the case-insensitive one merges the letter cases.
+    /// Neither equates lowercase `i` with `l`.
+    #[test]
+    fn the_two_folds_split_the_bar_class_from_case() {
+        // Visual: capital I and lowercase l both become the sentinel.
+        assert_eq!(skeleton_with("Ian", Fold::Visual), "1an");
+        assert_eq!(skeleton_with("lan", Fold::Visual), "1an");
+        // ...and lowercase `i` does NOT, so `Ilan` and `Lian` stay apart.
+        assert_eq!(skeleton_with("Ilan", Fold::Visual), "11an");
+        assert_eq!(skeleton_with("Lian", Fold::Visual), "lian");
+        assert_ne!(
+            skeleton_with("Ilan", Fold::Visual),
+            skeleton_with("Lian", Fold::Visual)
+        );
+
+        // Case-insensitive: the case row of the validated table.
+        assert_eq!(
+            skeleton_with("IAN CLARKE", Fold::CaseInsensitive),
+            skeleton_with("Ian Clarke", Fold::CaseInsensitive)
+        );
+        assert_eq!(
+            skeleton_with("ian clarke", Fold::CaseInsensitive),
+            skeleton_with("Ian Clarke", Fold::CaseInsensitive)
+        );
+        // ...and it also keeps `i` and `l` apart.
+        assert_ne!(
+            skeleton_with("Alia", Fold::CaseInsensitive),
+            skeleton_with("Alla", Fold::CaseInsensitive)
+        );
     }
 
     #[test]
-    fn skeleton_normalises_case_space_and_invisibles() {
-        assert_eq!(skeleton("  Ian   Clarke  "), "ian ciarke");
-        assert_eq!(skeleton("IAN CLARKE"), "ian ciarke");
-        assert_eq!(skeleton("Ian\u{00A0}Clarke"), "ian ciarke");
-        assert_eq!(skeleton("Ian\u{3000}Clarke"), "ian ciarke");
-        assert_eq!(skeleton("Ian\u{200B}Clarke"), "ianciarke");
+    fn skeleton_normalises_space_and_invisibles() {
+        assert_eq!(skeleton("  Ian   Clarke  "), "1an c1arke");
+        assert_eq!(skeleton("Ian\u{00A0}Clarke"), "1an c1arke");
+        assert_eq!(skeleton("Ian\u{3000}Clarke"), "1an c1arke");
+        assert_eq!(skeleton("Ian\u{200B}Clarke"), "1anc1arke");
+        // Case is the OTHER fold's job now (see the test above), so the visual
+        // skeleton deliberately does not equate these two.
+        assert_ne!(skeleton("IAN CLARKE"), skeleton("Ian Clarke"));
     }
 
     /// Damerau, not Levenshtein: a swap is one edit.
@@ -1005,16 +1209,18 @@ mod tests {
 
     #[test]
     fn presentation_forms_fold_to_ascii() {
-        // Mathematical bold / sans-serif / italic "Ian".
-        assert_eq!(skeleton("\u{1D408}\u{1D41A}\u{1D427}"), "ian");
-        assert_eq!(skeleton("\u{1D5DC}\u{1D5EE}\u{1D5FB}"), "ian");
-        assert_eq!(skeleton("\u{1D470}\u{1D482}\u{1D48F}"), "ian");
+        // Mathematical bold / sans-serif / italic "Ian". The capital I is in
+        // the bar class, so these fold to the sentinel like any other `I`.
+        assert_eq!(skeleton("\u{1D408}\u{1D41A}\u{1D427}"), "1an");
+        assert_eq!(skeleton("\u{1D5DC}\u{1D5EE}\u{1D5FB}"), "1an");
+        assert_eq!(skeleton("\u{1D470}\u{1D482}\u{1D48F}"), "1an");
+        assert_eq!(skeleton("\u{1D408}\u{1D41A}\u{1D427}"), skeleton("Ian"));
         // Fullwidth.
-        assert_eq!(skeleton("\u{FF29}\u{FF41}\u{FF4E}"), "ian");
+        assert_eq!(skeleton("\u{FF29}\u{FF41}\u{FF4E}"), "1an");
         // Letterlike symbols. U+2113 SCRIPT SMALL L folds to `l`, which the
-        // ASCII map then folds to `i` like any other `l`.
+        // bar fold then folds to the sentinel like any other `l`.
         assert_eq!(skeleton("\u{2115}"), "n");
-        assert_eq!(skeleton("\u{2113}"), "i");
+        assert_eq!(skeleton("\u{2113}"), "1");
     }
 
     /// Real names in other scripts must not fold onto a Latin moderator's name.
@@ -1130,6 +1336,143 @@ mod tests {
              justifies rendering tier 1 only no longer holds — re-examine \
              `members::impersonation_warning_for_display`"
         );
+    }
+
+    /// **Regression: the `nn -> m` fold (removed).** Doubled-n is one of the
+    /// commonest pairs in given names, and `nn` is not visually confusable with
+    /// `m`, so the fold accused a long tail of real people. A deputy named
+    /// `Amie` used to flag every `Annie` in the room.
+    #[test]
+    fn doubled_n_names_are_not_flagged_against_m_names() {
+        for (deputy, innocent) in [
+            ("Amie", "Annie"),
+            ("Ama", "Anna"),
+            ("Hama", "Hanna"),
+            ("Doma", "Donna"),
+            ("Jema", "Jenna"),
+            ("Ame", "Anne"),
+        ] {
+            let checker = ImpersonationChecker::new(
+                vec![ProtectedName::new(ProtectedRole::Deputy, deputy)],
+                HashSet::new(),
+            );
+            assert_eq!(
+                checker.check_name(innocent),
+                None,
+                "{innocent:?} must not be flagged against the deputy {deputy:?}: \
+                 `nn` and `m` are different shapes, and this fired on real names"
+            );
+        }
+        // `rn -> m` and `vv -> w` stay — they ARE confusable at UI sizes, and
+        // `rn` is what catches `Roorn Owner`.
+        let checker = ImpersonationChecker::new(
+            vec![ProtectedName::new(ProtectedRole::Owner, "Room Owner")],
+            HashSet::new(),
+        );
+        assert!(checker.check_name("Roorn Owner").is_some());
+    }
+
+    /// **Regression: the `i`/`l` transitive collapse.** The bar-shaped
+    /// characters render alike and lowercase `i` does not, but case-folding says
+    /// `I` = `i`. Composing them in ONE skeleton equated `i` with `l` and
+    /// collided names from several different languages.
+    ///
+    /// Each pair below is two distinct real names. None may be flagged against
+    /// the other, in EITHER direction (which one is the deputy is arbitrary).
+    #[test]
+    fn bar_and_dotted_i_names_are_not_confused() {
+        for (a, b) in [
+            ("Ilan", "Lian"), // Hebrew / Chinese
+            ("Alia", "Alla"), // Arabic / Russian
+            ("Ilya", "Liya"), // Russian / Chinese
+            ("Ila", "Lia"),   // Sanskrit / Italian
+            ("Lisa", "Iisa"), // English / Finnish
+            ("Lina", "Iina"), // Arabic / Finnish
+        ] {
+            for (deputy, innocent) in [(a, b), (b, a)] {
+                let checker = ImpersonationChecker::new(
+                    vec![ProtectedName::new(ProtectedRole::Deputy, deputy)],
+                    HashSet::new(),
+                );
+                assert_eq!(
+                    checker.check_name(innocent),
+                    None,
+                    "{innocent:?} must not be flagged against the deputy \
+                     {deputy:?} — these are different names, and the collapse \
+                     that equated them is what [`Fold`] splits apart"
+                );
+            }
+        }
+    }
+
+    /// The whole validated table still matches after the two-fold split. This
+    /// is the other half of the bargain: fixing the false positives must not
+    /// cost a single true positive.
+    #[test]
+    fn the_validated_table_survives_the_two_fold_split() {
+        let checker = fixture();
+        for name in [
+            "lan Clarke",
+            "1an Clarke",
+            "|an Clarke",
+            "!an Clarke",
+            "Ian CIarke",
+            "Ian C1arke",
+            "IAN CLARKE",
+            "ian clarke",
+            "iAN cLARKE",
+            "Ian Clark\u{0435}",
+            "Ian\u{200B} Clarke",
+            "I\u{00E0}n Clarke",
+            "Ia\u{0300}n Clarke",
+            "Ian  Clarke",
+            "IanClarke",
+            "\u{0399}an Clarke",
+            "Roorn Owner",
+            "lnvite Bot",
+        ] {
+            assert_eq!(
+                checker.check_name(name).map(|w| w.tier),
+                Some(ConfusableTier::Identical),
+                "{name:?} must still be caught after the fold split"
+            );
+        }
+    }
+
+    /// **Accepted collisions, stated explicitly.** These pairs DO fold together
+    /// and a deputy holding one flags a member holding the other. Each is a
+    /// deliberate trade, recorded here so the cost is visible rather than
+    /// discovered by an accused member:
+    ///
+    /// * `rn` really does read as `m` at UI sizes — this is what catches
+    ///   `Roorn Owner`, and the price is `Marnie`/`Mamie`, `Lorna`/`Loma`.
+    /// * Latin accents are stripped, which is more aggressive than TR39
+    ///   (`Müller`/`Muller`, `Böll`/`Boll` are distinct family names). Stripping
+    ///   is what catches `I\u{00E0}n Clarke`.
+    ///
+    /// If one of these ever stops colliding, this test fails and the trade can
+    /// be re-examined — the point is that the list is short, known and
+    /// deliberate.
+    #[test]
+    fn documented_accepted_collisions() {
+        for (deputy, other, why) in [
+            ("Mamie", "Marnie", "rn reads as m"),
+            ("Loma", "Lorna", "rn reads as m"),
+            ("Muller", "M\u{00FC}ller", "accent stripping"),
+            ("Boll", "B\u{00F6}ll", "accent stripping"),
+            ("Moller", "M\u{00F6}ller", "accent stripping"),
+        ] {
+            let checker = ImpersonationChecker::new(
+                vec![ProtectedName::new(ProtectedRole::Deputy, deputy)],
+                HashSet::new(),
+            );
+            assert!(
+                checker.check_name(other).is_some(),
+                "{other:?} vs {deputy:?} ({why}) is a KNOWN accepted collision; \
+                 if it no longer collides, update this list and the module \
+                 header rather than deleting the row"
+            );
+        }
     }
 
     /// The tooltip must name the remedy, not merely alarm. A bare warning

--- a/ui/src/util/confusable.rs
+++ b/ui/src/util/confusable.rs
@@ -2047,6 +2047,8 @@ mod tests {
             "ኃይሌ ገብረሥላሴ",
             "Νίκος Παπαδόπουλος",
             "Ольга Иванова",
+            "ᏣᎳᎩ",
+            "ꓡꓲꓢꓴ",
         ] {
             assert_eq!(
                 checker.check_name(name),
@@ -2628,6 +2630,15 @@ mod tests {
             "ⲡⲁⲡⲛⲟⲩⲧⲉ",
             "Ⲡⲉⲧⲣⲟⲥ",
             "ᏣᎳᎩ ᎠᏰᎵ",
+            // Cherokee went from 1-of-35 folded to the whole block and Lisu
+            // from 2-of-26, which is the largest new false-positive surface in
+            // this file — so both need corpus entries that CONTAIN the newly
+            // folded letters, not just the one letter that was there before.
+            // `ᏣᎳᎩ` (Tsalagi, the nation's own name) carries Ꮃ and Ꭹ; `ꓡꓲꓢꓴ`
+            // (Li-Su, the people's own name) carries all four of ꓡ ꓲ ꓢ ꓴ.
+            "ᏣᎳᎩ",
+            "ᎠᏂᏴᏫᏯ",
+            "ꓡꓲꓢꓴ",
             "Γιώργος Παπαδόπουλος",
             "Νίκος Παπαδόπουλος",
             "Иван Петров",

--- a/ui/src/util/confusable.rs
+++ b/ui/src/util/confusable.rs
@@ -343,7 +343,7 @@ impl ImpersonationWarning {
     /// The badge stays; the SENTENCE changes to one that is true of both
     /// members, and points at the disambiguator that actually works (the member
     /// ID River shows on hover). Pinned by
-    /// `a_privileged_member_is_never_told_they_are_not_privileged`.
+    /// `crate::components::members::a_shield_and_a_warning_can_both_render`.
     ///
     /// Pinned by `tooltip_contains_no_nickname_content`.
     pub fn tooltip(&self) -> String {
@@ -3118,6 +3118,63 @@ mod tests {
     /// protect different entry points: `sanitize_display_name` is the render-time
     /// strip that `riverctl`-written nicknames go through, and
     /// `contains_hidden_chars` is what the nickname `<input>` rejects.
+    #[test]
+    fn every_cited_pin_test_exists() {
+        // `a_`/`an_`/`the_`/`no_`/`every_`/`only_` plus at least ten more
+        // characters is a sentence-style TEST name in this codebase, never a
+        // field or an ordinary function — verified against the whole tree when
+        // this was written. Anything else in backticks is left alone, so this
+        // cannot start failing on a normal identifier.
+        let sources: [(&str, &str); 5] = [
+            ("confusable.rs", include_str!("confusable.rs")),
+            ("display_name.rs", include_str!("display_name.rs")),
+            ("members.rs", include_str!("../components/members.rs")),
+            (
+                "conversation.rs",
+                include_str!("../components/conversation.rs"),
+            ),
+            ("nickname.rs", include_str!("../nickname.rs")),
+        ];
+        let all: String = sources.iter().map(|(_, s)| *s).collect();
+
+        let mut missing = Vec::new();
+        for (file, src) in sources {
+            for cited in cited_test_names(src) {
+                if !all.contains(&format!("fn {cited}(")) {
+                    missing.push(format!("{file} cites `{cited}`"));
+                }
+            }
+        }
+        assert!(
+            missing.is_empty(),
+            "these comments cite a pin test that does not exist. That is the \
+             most repeated defect in this feature's history: three separate \
+             comments claimed a mutual-exclusivity pin that was never written, \
+             and the invariant they described was false. Write the test or fix \
+             the citation:\n  {}",
+            missing.join("\n  ")
+        );
+    }
+
+    /// Backticked identifiers in `src` that are sentence-style test names.
+    fn cited_test_names(src: &str) -> Vec<String> {
+        const PREFIXES: [&str; 6] = ["a_", "an_", "the_", "no_", "every_", "only_"];
+        let mut out = Vec::new();
+        for chunk in src.split('`').skip(1).step_by(2) {
+            let looks_like_a_test = chunk.len() > 12
+                && PREFIXES.iter().any(|p| chunk.starts_with(p))
+                && chunk
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_');
+            if looks_like_a_test {
+                out.push(chunk.to_string());
+            }
+        }
+        out.sort();
+        out.dedup();
+        out
+    }
+
     #[test]
     fn the_warning_glyph_cannot_appear_in_a_nickname() {
         let glyph = WARNING_GLYPH.chars().next().expect("one char");

--- a/ui/src/util/confusable.rs
+++ b/ui/src/util/confusable.rs
@@ -83,6 +83,29 @@
 //!   Both are listed in `documented_accepted_collisions`, which fails if either
 //!   silently stops holding — the point is that the accepted list is short,
 //!   named, and testable rather than discovered by an accused member.
+//! * **A REMOVED SPACE still counts as a match, so the signal is not literally
+//!   "visually the same string".** Both folds are compared with all spaces
+//!   dropped. That is what catches `IanClarke` for `Ian Clarke`, a validated
+//!   row, so the rule stays — but it collides genuinely different names wherever
+//!   a surname particle can be joined or split. LIVE INSTANCE against the real
+//!   moderator list: `Host Fat` collides with `HostFat`. Also
+//!   `Mac Donald`/`Macdonald`, `Le Roy`/`Leroy`, `Di Marco`/`DiMarco`,
+//!   `Jo Anna`/`Joanna`, `Mary Ann`/`Maryann`. All are rows in
+//!   `documented_accepted_collisions`.
+//! * **Greek and Cyrillic ALL-CAPS names fold onto Latin.** `ΑΝΝΑ` folds to
+//!   `Anna`, `ΝΙΝΑ` to `Nina`, `ТОМ` to `Tom`. Every letter involved is in the
+//!   uppercase homoglyph table, and the whole point of that table is that those
+//!   letters are drawn identically — so a reader really cannot tell `ΑΝΝΑ` from
+//!   `ANNA`. Mixed-case Greek does NOT fold, because the lowercase letters are
+//!   deliberately absent from the table.
+//! * **The fold is not normalisation-stable.** Combining marks U+0300..U+036F
+//!   are stripped and precomposed letters are decomposed by table, so `Nguyễn`
+//!   reaches the same skeleton either way — but only for the ranges the tables
+//!   cover. Outside them (Hebrew, Arabic, Indic; see the next bullet) an NFC
+//!   spelling and an NFD spelling of the SAME name can fold differently,
+//!   depending on nothing more than which keyboard the person used. There is no
+//!   normalisation pass here because the crate carries no Unicode dependency;
+//!   `latin_names_fold_the_same_in_nfc_and_nfd` pins the ranges that do work.
 //! * **The accent strip is Latin-only.** `is_combining_mark` covers the Latin
 //!   combining ranges but NOT Hebrew niqqud (U+0591..U+05C7), Arabic harakat
 //!   (U+064B..U+065F), or Devanagari/Thai vowel signs. So a Hebrew or Arabic
@@ -443,7 +466,6 @@ impl ImpersonationChecker {
         Some(CandidateFolds {
             visual_no_space: strip_spaces(&visual),
             case_insensitive_no_space: strip_spaces(&case_insensitive),
-            visual_chars: visual.chars().collect(),
             visual,
             case_insensitive,
         })
@@ -480,7 +502,12 @@ impl ImpersonationChecker {
     /// [`check_identical`](Self::check_identical) — but kept, computed and
     /// tested so the tier decision stays reversible and measurable.
     fn tier_two_for(&self, id: MemberId, c: &CandidateFolds) -> Option<ImpersonationWarning> {
-        let budget = edit_budget(c.visual_chars.len());
+        // Allocated HERE rather than in `candidate_folds`, because
+        // `check_identical` — the only production entry point — returns before
+        // this function and would otherwise pay for a `Vec<char>` of every
+        // NON-matching member's name on every render, in both surfaces.
+        let visual_chars: Vec<char> = c.visual.chars().collect();
+        let budget = edit_budget(visual_chars.len());
         if budget == 0 {
             return None;
         }
@@ -490,7 +517,7 @@ impl ImpersonationChecker {
                 continue;
             }
             let p_chars: Vec<char> = p.visual.chars().collect();
-            if damerau_within(&c.visual_chars, &p_chars, budget) <= budget {
+            if damerau_within(&visual_chars, &p_chars, budget) <= budget {
                 // Owner outranks deputy so the more severe impersonation is the
                 // one named, and the result does not depend on set order.
                 let better = best.as_ref().is_none_or(|b| {
@@ -513,7 +540,6 @@ impl ImpersonationChecker {
 struct CandidateFolds {
     visual: String,
     visual_no_space: String,
-    visual_chars: Vec<char>,
     case_insensitive: String,
     case_insensitive_no_space: String,
 }
@@ -1110,7 +1136,6 @@ fn fold_nfkc_letter(c: char) -> Option<char> {
         // `roman_numerals_and_nfkc_letters_fold`; under the weaker `is_some()`
         // assertion it read as a match at NearMiss.
         0x212B => 'A',  // ANGSTROM SIGN
-        0x2139 => 'i',  // INFORMATION SOURCE
         0x2145 => 'D',  // DOUBLE-STRUCK ITALIC CAPITAL D
         0x2146 => 'd',  // DOUBLE-STRUCK ITALIC SMALL D
         0x2147 => 'e',  // DOUBLE-STRUCK ITALIC SMALL E
@@ -1266,6 +1291,8 @@ fn strip_latin_accent(c: char) -> Option<char> {
     match cp {
         0x00C0..=0x00FF => table_char(LATIN1_FOLD, 0x00C0),
         0x0100..=0x017F => table_char(LATIN_EXT_A_FOLD, 0x0100),
+        0x0180..=0x024F => table_char(LATIN_EXT_B_FOLD, 0x0180),
+        0x1E00..=0x1EFF => table_char(LATIN_EXT_ADD_FOLD, 0x1E00),
         _ => None,
     }
 }
@@ -1304,6 +1331,101 @@ const LATIN_EXT_A_FOLD: &str = concat!(
     "UuUuUuUu",    // Ũ ũ Ū ū Ŭ ŭ Ů ů
     "UuUuWwYy",    // Ű ű Ų ų Ŵ ŵ Ŷ ŷ
     "YZzZzZzs",    // Ÿ Ź ź Ż ż Ž ž ſ
+);
+
+/// U+0180..U+024F (Latin Extended-B), in order. `\0` = leave the character
+/// alone.
+///
+/// **Generated, not curated**, by the same sweep that produced
+/// [`fold_nfkc_letter`]: a slot folds exactly when the codepoint's NFD is one
+/// ASCII letter followed only by combining marks. That is the definition the
+/// two tables above already implement by hand for their ranges, so this simply
+/// stops the coverage ending at U+017F for no reason.
+///
+/// 83 of the 208 slots fold. The rest are letters in their own right, exactly
+/// as NFD leaves them.
+///
+/// This range carries the Vietnamese horn letters, which is why
+/// `H\u{01B0}\u{01A1}ng` needs it.
+const LATIN_EXT_B_FOLD: &str = concat!(
+    "\0\0\0\0\0\0\0\0", // U+0180 ƀ Ɓ Ƃ ƃ Ƅ ƅ Ɔ Ƈ
+    "\0\0\0\0\0\0\0\0", // U+0188 ƈ Ɖ Ɗ Ƌ ƌ ƍ Ǝ Ə
+    "\0\0\0\0\0\0\0\0", // U+0190 Ɛ Ƒ ƒ Ɠ Ɣ ƕ Ɩ Ɨ
+    "\0\0\0\0\0\0\0\0", // U+0198 Ƙ ƙ ƚ ƛ Ɯ Ɲ ƞ Ɵ
+    "Oo\0\0\0\0\0\0",   // U+01A0 Ơ ơ Ƣ ƣ Ƥ ƥ Ʀ Ƨ
+    "\0\0\0\0\0\0\0U",  // U+01A8 ƨ Ʃ ƪ ƫ Ƭ ƭ Ʈ Ư
+    "u\0\0\0\0\0\0\0",  // U+01B0 ư Ʊ Ʋ Ƴ ƴ Ƶ ƶ Ʒ
+    "\0\0\0\0\0\0\0\0", // U+01B8 Ƹ ƹ ƺ ƻ Ƽ ƽ ƾ ƿ
+    "\0\0\0\0\0\0\0\0", // U+01C0 ǀ ǁ ǂ ǃ Ǆ ǅ ǆ Ǉ
+    "\0\0\0\0\0AaI",    // U+01C8 ǈ ǉ Ǌ ǋ ǌ Ǎ ǎ Ǐ
+    "iOoUuUuU",         // U+01D0 ǐ Ǒ ǒ Ǔ ǔ Ǖ ǖ Ǘ
+    "uUuUu\0Aa",        // U+01D8 ǘ Ǚ ǚ Ǜ ǜ ǝ Ǟ ǟ
+    "Aa\0\0\0\0Gg",     // U+01E0 Ǡ ǡ Ǣ ǣ Ǥ ǥ Ǧ ǧ
+    "KkOoOo\0\0",       // U+01E8 Ǩ ǩ Ǫ ǫ Ǭ ǭ Ǯ ǯ
+    "j\0\0\0Gg\0\0",    // U+01F0 ǰ Ǳ ǲ ǳ Ǵ ǵ Ƕ Ƿ
+    "NnAa\0\0\0\0",     // U+01F8 Ǹ ǹ Ǻ ǻ Ǽ ǽ Ǿ ǿ
+    "AaAaEeEe",         // U+0200 Ȁ ȁ Ȃ ȃ Ȅ ȅ Ȇ ȇ
+    "IiIiOoOo",         // U+0208 Ȉ ȉ Ȋ ȋ Ȍ ȍ Ȏ ȏ
+    "RrRrUuUu",         // U+0210 Ȑ ȑ Ȓ ȓ Ȕ ȕ Ȗ ȗ
+    "SsTt\0\0Hh",       // U+0218 Ș ș Ț ț Ȝ ȝ Ȟ ȟ
+    "\0\0\0\0\0\0Aa",   // U+0220 Ƞ ȡ Ȣ ȣ Ȥ ȥ Ȧ ȧ
+    "EeOoOoOo",         // U+0228 Ȩ ȩ Ȫ ȫ Ȭ ȭ Ȯ ȯ
+    "OoYy\0\0\0\0",     // U+0230 Ȱ ȱ Ȳ ȳ ȴ ȵ ȶ ȷ
+    "\0\0\0\0\0\0\0\0", // U+0238 ȸ ȹ Ⱥ Ȼ ȼ Ƚ Ⱦ ȿ
+    "\0\0\0\0\0\0\0\0", // U+0240 ɀ Ɂ ɂ Ƀ Ʉ Ʌ Ɇ ɇ
+    "\0\0\0\0\0\0\0\0", // U+0248 Ɉ ɉ Ɋ ɋ Ɍ ɍ Ɏ ɏ
+);
+
+/// U+1E00..U+1EFF (Latin Extended Additional), in order. `\0` = leave the
+/// character alone.
+///
+/// Generated the same way as [`LATIN_EXT_B_FOLD`]. 244 of the 256 slots fold,
+/// which makes this by far the largest gap the accent strip had: the block is
+/// **all of Vietnamese**, plus the Latin dot-above/dot-below letters. Every one
+/// of them was an evasion — `I\u{1EA1}n Clarke`, an `a` with a dot below that
+/// at member-list size is a speck, folded to itself and never came near
+/// `Ian Clarke`.
+///
+/// The cost is the accent-stripping cost already accepted for `Muller`, scaled
+/// up: Vietnamese tone marks are meaning-bearing, so `Nguy\u{1EC5}n`,
+/// `Nguy\u{00EA}n` and `Nguyen` all reach one skeleton. Recorded in
+/// `documented_accepted_collisions`; the surface that matters is bounded,
+/// because a collision only produces a badge when it lands on a PROTECTED name,
+/// and `real_names_in_other_scripts_are_not_flagged` sweeps a Vietnamese corpus
+/// against the real moderator list.
+const LATIN_EXT_ADD_FOLD: &str = concat!(
+    "AaBbBbBb",       // U+1E00 Ḁ ḁ Ḃ ḃ Ḅ ḅ Ḇ ḇ
+    "CcDdDdDd",       // U+1E08 Ḉ ḉ Ḋ ḋ Ḍ ḍ Ḏ ḏ
+    "DdDdEeEe",       // U+1E10 Ḑ ḑ Ḓ ḓ Ḕ ḕ Ḗ ḗ
+    "EeEeEeFf",       // U+1E18 Ḙ ḙ Ḛ ḛ Ḝ ḝ Ḟ ḟ
+    "GgHhHhHh",       // U+1E20 Ḡ ḡ Ḣ ḣ Ḥ ḥ Ḧ ḧ
+    "HhHhIiIi",       // U+1E28 Ḩ ḩ Ḫ ḫ Ḭ ḭ Ḯ ḯ
+    "KkKkKkLl",       // U+1E30 Ḱ ḱ Ḳ ḳ Ḵ ḵ Ḷ ḷ
+    "LlLlLlMm",       // U+1E38 Ḹ ḹ Ḻ ḻ Ḽ ḽ Ḿ ḿ
+    "MmMmNnNn",       // U+1E40 Ṁ ṁ Ṃ ṃ Ṅ ṅ Ṇ ṇ
+    "NnNnOoOo",       // U+1E48 Ṉ ṉ Ṋ ṋ Ṍ ṍ Ṏ ṏ
+    "OoOoPpPp",       // U+1E50 Ṑ ṑ Ṓ ṓ Ṕ ṕ Ṗ ṗ
+    "RrRrRrRr",       // U+1E58 Ṙ ṙ Ṛ ṛ Ṝ ṝ Ṟ ṟ
+    "SsSsSsSs",       // U+1E60 Ṡ ṡ Ṣ ṣ Ṥ ṥ Ṧ ṧ
+    "SsTtTtTt",       // U+1E68 Ṩ ṩ Ṫ ṫ Ṭ ṭ Ṯ ṯ
+    "TtUuUuUu",       // U+1E70 Ṱ ṱ Ṳ ṳ Ṵ ṵ Ṷ ṷ
+    "UuUuVvVv",       // U+1E78 Ṹ ṹ Ṻ ṻ Ṽ ṽ Ṿ ṿ
+    "WwWwWwWw",       // U+1E80 Ẁ ẁ Ẃ ẃ Ẅ ẅ Ẇ ẇ
+    "WwXxXxYy",       // U+1E88 Ẉ ẉ Ẋ ẋ Ẍ ẍ Ẏ ẏ
+    "ZzZzZzht",       // U+1E90 Ẑ ẑ Ẓ ẓ Ẕ ẕ ẖ ẗ
+    "wy\0\0\0\0\0\0", // U+1E98 ẘ ẙ ẚ ẛ ẜ ẝ ẞ ẟ
+    "AaAaAaAa",       // U+1EA0 Ạ ạ Ả ả Ấ ấ Ầ ầ
+    "AaAaAaAa",       // U+1EA8 Ẩ ẩ Ẫ ẫ Ậ ậ Ắ ắ
+    "AaAaAaAa",       // U+1EB0 Ằ ằ Ẳ ẳ Ẵ ẵ Ặ ặ
+    "EeEeEeEe",       // U+1EB8 Ẹ ẹ Ẻ ẻ Ẽ ẽ Ế ế
+    "EeEeEeEe",       // U+1EC0 Ề ề Ể ể Ễ ễ Ệ ệ
+    "IiIiOoOo",       // U+1EC8 Ỉ ỉ Ị ị Ọ ọ Ỏ ỏ
+    "OoOoOoOo",       // U+1ED0 Ố ố Ồ ồ Ổ ổ Ỗ ỗ
+    "OoOoOoOo",       // U+1ED8 Ộ ộ Ớ ớ Ờ ờ Ở ở
+    "OoOoUuUu",       // U+1EE0 Ỡ ỡ Ợ ợ Ụ ụ Ủ ủ
+    "UuUuUuUu",       // U+1EE8 Ứ ứ Ừ ừ Ử ử Ữ ữ
+    "UuYyYyYy",       // U+1EF0 Ự ự Ỳ ỳ Ỵ ỵ Ỷ ỷ
+    "Yy\0\0\0\0\0\0", // U+1EF8 Ỹ ỹ Ỻ ỻ Ỽ ỽ Ỿ ỿ
 );
 
 /// Damerau-Levenshtein distance between `a` and `b`, giving up once it exceeds
@@ -1660,6 +1782,8 @@ mod tests {
     fn latin_fold_tables_are_aligned() {
         assert_eq!(LATIN1_FOLD.chars().count(), 64);
         assert_eq!(LATIN_EXT_A_FOLD.chars().count(), 128);
+        assert_eq!(LATIN_EXT_B_FOLD.chars().count(), 208);
+        assert_eq!(LATIN_EXT_ADD_FOLD.chars().count(), 256);
         for (input, want) in [
             ('\u{00C0}', Some('A')), // À
             ('\u{00C7}', Some('C')), // Ç
@@ -1691,6 +1815,27 @@ mod tests {
             ('\u{010F}', Some('d')), // ď
             ('\u{0119}', Some('e')), // ę
             ('\u{0121}', Some('g')), // ġ
+            // Latin Extended-B: the Vietnamese horn letters and the caron
+            // vowels, plus the letters that are their own thing.
+            ('\u{01A0}', Some('O')), // Ơ O with horn
+            ('\u{01B0}', Some('u')), // ư u with horn
+            ('\u{01CE}', Some('a')), // ǎ a with caron
+            ('\u{0201}', Some('a')), // ȁ a with double grave
+            ('\u{021B}', Some('t')), // ț t with comma below
+            ('\u{0233}', Some('y')), // ȳ y with macron
+            ('\u{0180}', None),      // ƀ b with stroke is its own letter
+            ('\u{0186}', None),      // Ɔ open O
+            ('\u{01C4}', None),      // Ǆ DZ with caron is a digraph
+            ('\u{01E2}', None),      // Ǣ AE with macron: base is not ASCII
+            // Latin Extended Additional: all of Vietnamese.
+            ('\u{1E00}', Some('A')), // Ḁ A with ring below
+            ('\u{1EA1}', Some('a')), // ạ a with dot below
+            ('\u{1EC5}', Some('e')), // ễ e with circumflex and tilde
+            ('\u{1ECA}', Some('I')), // Ị I with dot below
+            ('\u{1EE9}', Some('u')), // ứ u with horn and acute
+            ('\u{1EF9}', Some('y')), // ỹ y with tilde
+            ('\u{1E9E}', None),      // ẞ capital sharp s is its own letter
+            ('\u{1EFA}', None),      // Ỻ middle-Welsh LL is a digraph
             ('\u{0130}', Some('I')), // İ
             ('\u{0135}', Some('j')), // ĵ
             ('\u{0136}', Some('K')), // Ķ
@@ -1763,6 +1908,16 @@ mod tests {
             "François Müller",
             "Ægir Þórsson",
             "Nguyễn Thị Hương",
+            // The Latin Extended Additional block is now stripped, so the
+            // Vietnamese corpus is where a false positive would land first.
+            "Trần Văn Bảy",
+            "Lê Thị Ngọc Ánh",
+            "Phạm Hoàng Đức",
+            "Đặng Quốc Việt",
+            "Vũ Thị Mỹ Hạnh",
+            "Bùi Thanh Tùng",
+            "Hồ Chí Cường",
+            "Ngô Bảo Châu",
             "José Ñuñez",
             "O'Brien-Smith Jr.",
             "山田\u{3000}太郎",
@@ -1793,24 +1948,104 @@ mod tests {
     /// is why the UI renders tier 1 only.
     #[test]
     fn generated_handles_never_fold_to_the_same_skeleton() {
-        let mut seen: std::collections::HashMap<String, (&str, &str)> =
-            std::collections::HashMap::new();
+        // ALL FOUR comparisons `tier_one_for` makes, not just the visual fold.
+        // Pinning one of four left three quarters of the property unmeasured:
+        // two handles could disagree on `visual` and still collide under
+        // `case_insensitive_no_space`, and the check that is supposed to prove
+        // "River never accuses its own members" would not have noticed.
+        let folds: [(&str, fn(&ProtectedName) -> &String); 4] = [
+            ("visual", |p| &p.visual),
+            ("visual_no_space", |p| &p.visual_no_space),
+            ("case_insensitive", |p| &p.case_insensitive),
+            ("case_insensitive_no_space", |p| {
+                &p.case_insensitive_no_space
+            }),
+        ];
         let mut count = 0usize;
+        let mut seen: Vec<std::collections::HashMap<String, (&str, &str)>> =
+            vec![std::collections::HashMap::new(); folds.len()];
         for first in crate::nickname::FIRST_NAMES {
             for last in crate::nickname::LAST_NAMES {
                 let handle = format!("{first} {last}");
-                let sk = skeleton(&handle);
-                if let Some(prev) = seen.insert(sk.clone(), (first, last)) {
-                    panic!(
-                        "generated handles {prev:?} and {:?} fold to the same skeleton {sk:?}; \
-                         a deputy holding one would make the other look like an impostor",
-                        (first, last)
-                    );
+                let folded = ProtectedName::new(ProtectedRole::Deputy, &handle, mid(1));
+                for (i, (label, get)) in folds.iter().enumerate() {
+                    let sk = get(&folded).clone();
+                    if let Some(prev) = seen[i].insert(sk.clone(), (first, last)) {
+                        panic!(
+                            "generated handles {prev:?} and {:?} collide under the {label} fold \
+                             ({sk:?}); a deputy holding one would make the other look like an \
+                             impostor",
+                            (first, last)
+                        );
+                    }
                 }
                 count += 1;
             }
         }
         assert_eq!(count, 10_000);
+    }
+
+    /// **Named rows for names that are ONE step from being flagged**, so a
+    /// future change that renders tier 2, or widens a fold, cannot make that
+    /// change without seeing whose name it lands on.
+    ///
+    /// `Ivvor2` is a real member of the Freenet Official room and the
+    /// moderator is `Ivvor`. Tier 1 is clean (`1wor2` vs `1wor`) — but the two
+    /// are at Damerau distance exactly 1, so the moment tier 2 renders, a real
+    /// member gets an impersonation badge on day one.
+    #[test]
+    fn near_miss_rows_that_would_accuse_a_real_member() {
+        for (deputy, member) in [("Ivvor", "Ivvor2")] {
+            let checker = ImpersonationChecker::new(vec![ProtectedName::new(
+                ProtectedRole::Deputy,
+                deputy,
+                mid(1),
+            )]);
+            assert_eq!(
+                checker.check_identical(mid(2), member),
+                None,
+                "{member:?} must stay CLEAN at tier 1 against the moderator \
+                 {deputy:?} — it is a real member of the Freenet Official room"
+            );
+            let near = checker
+                .check(mid(2), member)
+                .expect("...but it IS a tier-2 near miss");
+            assert_eq!(
+                near.tier,
+                ConfusableTier::NearMiss,
+                "{member:?} is one edit from {deputy:?}. If this UI ever renders \
+                 tier 2, this real member is badged as an impostor on day one — \
+                 that is the cost of the change, decide it deliberately"
+            );
+        }
+    }
+
+    /// The fold must not depend on which normalisation form the person's
+    /// keyboard produced. Two spellings of one name are one name.
+    ///
+    /// This holds for the ranges the tables cover — Latin combining marks are
+    /// stripped, and precomposed Latin letters are decomposed by table — and
+    /// NOT outside them. The module header records the gap; this pins what
+    /// does work, so a future table change cannot quietly shrink it.
+    #[test]
+    fn latin_names_fold_the_same_in_nfc_and_nfd() {
+        for (nfc, nfd) in [
+            // Vietnamese, the case with the most precomposed letters.
+            ("Nguy\u{1EC5}n", "Nguy\u{0065}\u{0302}\u{0303}n"),
+            ("Th\u{1ECB}", "Th\u{0069}\u{0323}"),
+            ("H\u{01B0}\u{01A1}ng", "H\u{0075}\u{031B}\u{006F}\u{031B}ng"),
+            // Latin-1 and Latin Extended-A.
+            ("M\u{00FC}ller", "M\u{0075}\u{0308}ller"),
+            ("\u{010C}apek", "\u{0043}\u{030C}apek"),
+            ("Ian Clark\u{00E9}", "Ian Clark\u{0065}\u{0301}"),
+        ] {
+            assert_eq!(
+                skeleton(nfc),
+                skeleton(nfd),
+                "{nfc:?} and {nfd:?} are the same name typed two ways and must \
+                 fold identically"
+            );
+        }
     }
 
     /// **The measurement behind the tier decision.** The near-miss tier flags a
@@ -2059,6 +2294,64 @@ mod tests {
         assert_ne!(skeleton("\u{1D26}"), skeleton("G"));
         assert_eq!(skeleton("\u{1D2B}"), skeleton("\u{041B}")); // Cyrillic el
         assert_ne!(skeleton("\u{1D2B}"), skeleton("L"));
+    }
+
+    /// **Precomposed Latin outside U+00C0..U+017F.** The accent strip stopped
+    /// at Latin Extended-A for no stated reason, leaving 327 letters that carry
+    /// a diacritic and no separate combining mark to drop: 83 in Latin
+    /// Extended-B and 244 in Latin Extended Additional, which is all of
+    /// Vietnamese.
+    ///
+    /// The dot-below letters are the sharpest of these — at member-list size
+    /// `\u{1EA1}` is `a` with a speck under it — but every row here folded to
+    /// ITSELF before, so none came anywhere near the protected name.
+    #[test]
+    fn precomposed_latin_outside_the_first_two_blocks_folds() {
+        for (label, attacker, real) in [
+            ("a with dot below", "I\u{1EA1}n Clarke", "Ian Clarke"),
+            ("a with caron", "I\u{01CE}n Clarke", "Ian Clarke"),
+            ("e with dot below", "Ian Clark\u{1EB9}", "Ian Clarke"),
+            ("I with dot below", "\u{1ECA}an Clarke", "Ian Clarke"),
+            ("a with double grave", "I\u{0201}n Clarke", "Ian Clarke"),
+            ("o with horn", "R\u{01A1}om Owner", "Room Owner"),
+            ("u with horn and acute", "I\u{1EE9}an", "Iuan"),
+            ("A with ring below", "\u{1E00}da", "Ada"),
+            ("t with comma below", "Ma\u{021B}ei", "Matei"),
+            ("y with macron", "Br\u{0233}an", "Bryan"),
+        ] {
+            let checker = ImpersonationChecker::new(vec![ProtectedName::new(
+                ProtectedRole::Deputy,
+                real,
+                mid(1),
+            )]);
+            let w = checker
+                .check(mid(2), attacker)
+                .unwrap_or_else(|| panic!("{label}: {attacker:?} vs {real:?}"));
+            assert_eq!(
+                w.tier,
+                ConfusableTier::Identical,
+                "{label}: {attacker:?} must fold to the SAME skeleton as {real:?}"
+            );
+        }
+
+        // The letters in these ranges that are NOT an accented ASCII base must
+        // stay themselves, exactly as NFD leaves them. Folding them would be
+        // inventing an equivalence rather than recording one.
+        for own_letter in [
+            '\u{0180}', // b with stroke
+            '\u{0186}', // open O
+            '\u{0189}', // African D
+            '\u{01C4}', // DZ with caron
+            '\u{01E2}', // AE with macron
+            '\u{1E9E}', // capital sharp s
+            '\u{1EFA}', // middle-Welsh LL
+        ] {
+            assert_eq!(
+                strip_latin_accent(own_letter),
+                None,
+                "{own_letter:?} is a letter in its own right"
+            );
+        }
     }
 
     /// The shape homoglyphs — the half NFKC does NOT equate, so each is a
@@ -2471,6 +2764,44 @@ mod tests {
             // Turkish dotless i: a REAL letter in Turkish names, but a reader
             // outside Turkish sees one glyph minus a dot.
             ("Isik", "Is\u{0131}k", "Turkish dotless i"),
+            // Vietnamese tone marks are meaning-bearing and are stripped, so
+            // distinct names reach one skeleton. This is the accent-stripping
+            // trade already accepted for German, at Vietnamese scale; it
+            // arrived with the Latin Extended Additional table.
+            ("Nguyen", "Nguy\u{1EC5}n", "Vietnamese tone marks"),
+            ("Nguyen", "Nguy\u{00EA}n", "Vietnamese tone marks"),
+            ("Le", "L\u{00EA}", "Vietnamese tone marks"),
+            ("Ha", "H\u{1EA1}", "Vietnamese tone marks"),
+            // `vv -> w`. `Iwor` is an attested Welsh name and collides with the
+            // Freenet Official moderator `Ivvor`. Nobody in the room holds it
+            // today; recorded so it is a known cost rather than a surprise.
+            ("Ivvor", "Iwor", "vv reads as w"),
+            // **Space REMOVAL.** `strip_spaces` compares both folds with all
+            // spaces dropped, which is what catches `IanClarke` for
+            // `Ian Clarke` — a validated row, so the rule stays. The cost is
+            // that a deleted space is not "visually the same string", and
+            // surname particles collide freely. LIVE INSTANCE: the moderator
+            // `HostFat` collides with anyone calling themselves `Host Fat`.
+            ("HostFat", "Host Fat", "space removal"),
+            ("Macdonald", "Mac Donald", "space removal"),
+            ("Leroy", "Le Roy", "space removal"),
+            ("DiMarco", "Di Marco", "space removal"),
+            ("Vandyke", "Van Dyke", "space removal"),
+            ("Delacruz", "De La Cruz", "space removal"),
+            ("StJohn", "St John", "space removal"),
+            ("Joanna", "Jo Anna", "space removal"),
+            ("Maryann", "Mary Ann", "space removal"),
+            ("Annmarie", "Ann Marie", "space removal"),
+            ("Kimberly", "Kim Berly", "space removal"),
+            // **Greek and Cyrillic ALL-CAPS.** Every letter in these names is
+            // in the uppercase homoglyph table, so the whole name folds onto
+            // its Latin twin. The corpus otherwise carries only MIXED-case
+            // Greek, which cannot fold (the lowercase letters are not in the
+            // table), so this class was real, undocumented and untested.
+            ("Anna", "\u{0391}\u{039D}\u{039D}\u{0391}", "Greek all-caps"),
+            ("Nina", "\u{039D}\u{0399}\u{039D}\u{0391}", "Greek all-caps"),
+            ("Emma", "\u{0395}\u{039C}\u{039C}\u{0391}", "Greek all-caps"),
+            ("Tom", "\u{0422}\u{041E}\u{041C}", "Cyrillic all-caps"),
         ] {
             let checker = ImpersonationChecker::new(vec![ProtectedName::new(
                 ProtectedRole::Deputy,

--- a/ui/src/util/confusable.rs
+++ b/ui/src/util/confusable.rs
@@ -628,6 +628,13 @@ fn skeleton_with(name: &str, fold: Fold) -> String {
             out.push(ascii);
             continue;
         }
+        // 2b. Small capitals — the single commonest fancy-text style on chat
+        //     platforms after the mathematical blocks, and one NFKC does NOT
+        //     touch, so it needs its own judgement. See [`fold_small_capital`].
+        if let Some(folded) = fold_small_capital(c) {
+            out.push(folded);
+            continue;
+        }
         // 3. Combining marks. `"I" + U+0300 + "n"` must fold like `"Ìn"`.
         if is_combining_mark(c) {
             continue;
@@ -944,20 +951,63 @@ fn fold_presentation_form(c: char) -> Option<char> {
     if let Some(letter) = fold_nfkc_letter(c) {
         return Some(letter);
     }
-    // Mathematical Alphanumeric Symbols: consecutive 52-letter (A-Z then a-z)
-    // blocks.
+    // Mathematical Alphanumeric Symbols, LATIN half: thirteen consecutive
+    // 52-letter (A-Z then a-z) blocks, ending at U+1D6A3.
     //
-    // The range contains reserved holes (e.g. U+1D455, whose letter lives in
-    // Letterlike Symbols above). A hole maps to a letter here, which is
+    // **The upper bound is load-bearing.** This used to run to U+1D7CB, and the
+    // 52-alignment simply is not true past U+1D6A3: what follows is two dotless
+    // letters and then FIVE GREEK blocks of 58, so `% 52` walked out of phase
+    // and emitted an arbitrary letter. U+1D75E MATH SANS BOLD CAPITAL IOTA came
+    // out as `e`, which meant `𝝞𝗮𝗻 𝗖𝗹𝗮𝗿𝗸𝗲` — pixel-identical to the
+    // `𝗜𝗮𝗻 𝗖𝗹𝗮𝗿𝗸𝗲` the test corpus already caught, one codepoint different —
+    // walked straight past the check. It was wrong in the other direction too:
+    // bold capital Alpha folded to `E`, a false positive on a real Greek name
+    // rendered in a fancy-text generator.
+    //
+    // The range still contains reserved holes (e.g. U+1D455, whose letter lives
+    // in Letterlike Symbols above). A hole maps to a letter here, which is
     // harmless: an unassigned codepoint renders as tofu and cannot appear in a
     // name a reader would mistake for anything.
-    if (0x1D400..=0x1D7CB).contains(&cp) {
+    if (0x1D400..=0x1D6A3).contains(&cp) {
         let idx = (cp - 0x1D400) % 52;
         return Some(if idx < 26 {
             (b'A' + idx as u8) as char
         } else {
             (b'a' + (idx - 26) as u8) as char
         });
+    }
+    // The two dotless letters that sit between the Latin and Greek halves.
+    // U+0131 is the Turkish dotless i the homoglyph table already carries (with
+    // its cost recorded in `documented_accepted_collisions`), so routing through
+    // it keeps one decision in one place.
+    if cp == 0x1D6A4 {
+        return Some('\u{0131}');
+    }
+    if cp == 0x1D6A5 {
+        return Some('j');
+    }
+    // Mathematical Alphanumeric Symbols, GREEK half: five consecutive blocks of
+    // 58, all with the identical slot layout (24 capitals, nabla, 25 lowercase,
+    // partial differential, then six variant symbols).
+    //
+    // Each slot folds to the PLAIN GREEK letter, not to a Latin one. Whether
+    // that letter then becomes Latin is `fold_homoglyph`'s decision, made once
+    // for Greek as a whole and already case-aware — so `𝝞` reaches `Ι` reaches
+    // `I`, while `𝝘` reaches `Γ` and stays Greek, because Gamma is not a Latin
+    // lookalike. Mapping these to Latin here instead would duplicate that
+    // judgement in a second place and let the two drift.
+    if (0x1D6A8..=0x1D7C9).contains(&cp) {
+        let slot = ((cp - 0x1D6A8) % 58) as usize;
+        return MATH_GREEK_FOLD.chars().nth(slot);
+    }
+    // The two bold digammas that close the block. Folded to plain digamma,
+    // which no table turns into Latin `F` — the letterform differs enough, and
+    // nothing in a name needs it.
+    if cp == 0x1D7CA {
+        return Some('\u{03DC}');
+    }
+    if cp == 0x1D7CB {
+        return Some('\u{03DD}');
     }
     // Mathematical digits: five consecutive blocks of ten.
     if (0x1D7CE..=0x1D7FF).contains(&cp) {
@@ -1089,6 +1139,90 @@ fn fold_nfkc_letter(c: char) -> Option<char> {
         _ => return None,
     })
 }
+
+/// Small-capital letters, folded to the capital they are drawn as.
+///
+/// `ɪᴀɴ ᴄʟᴀʀᴋᴇ` reads as `IAN CLARKE` to anyone looking at it, and the module
+/// already asserts that `IAN CLARKE` is an identical skeleton of `Ian Clarke`,
+/// so by its own standard these have to fold too. Every one of them survived
+/// both folds verbatim before this: they are general category `Ll`, so the case
+/// step leaves them alone, and the result was edit distance 8 from the real
+/// name — not even a tier-2 near miss. Small-caps generators are one click away
+/// on any "fancy text" page, and every one of these renders in DejaVu Sans,
+/// Noto Sans, Segoe UI and the macOS system fonts.
+///
+/// ## What is deliberately NOT here
+///
+/// Only the letters whose base is a plain ASCII capital. Everything with a
+/// stroke, hook, belt, leg, or a turned/reversed/inverted orientation
+/// (`ᴃ ᴌ ᴎ ʁ ᴙ ᴚ ᵻ ᵾ`), and the digraphs (`ᴁ ᴓ ꝶ`), are separate letterforms a
+/// reader does not see as the plain capital, so folding them would be inventing
+/// a confusable rather than recording one. There is no small capital X in
+/// Unicode; generators emit plain `x`, which needs nothing here.
+///
+/// The Greek and Cyrillic small capitals fold to their PLAIN Greek/Cyrillic
+/// letter, not to Latin — whether Greek `Ρ` becomes Latin `P` is
+/// [`fold_homoglyph`]'s decision, made once, and duplicating it here is how the
+/// two tables drift apart.
+///
+/// False-positive surface is small by construction: these are IPA and phonetic
+/// notation, not letters any living orthography spells a personal name with.
+/// The corpus sweeps cover them like everything else.
+fn fold_small_capital(c: char) -> Option<char> {
+    Some(match u32::from(c) {
+        0x0262 => 'G',
+        0x026A => 'I',
+        0x0274 => 'N',
+        0x0280 => 'R',
+        0x028F => 'Y',
+        0x0299 => 'B',
+        0x029C => 'H',
+        0x029F => 'L',
+        0x1D00 => 'A',
+        0x1D04 => 'C',
+        0x1D05 => 'D',
+        0x1D07 => 'E',
+        0x1D0A => 'J',
+        0x1D0B => 'K',
+        0x1D0D => 'M',
+        0x1D0F => 'O',
+        0x1D18 => 'P',
+        0x1D1B => 'T',
+        0x1D1C => 'U',
+        0x1D20 => 'V',
+        0x1D21 => 'W',
+        0x1D22 => 'Z',
+        0xA730 => 'F',
+        0xA731 => 'S',
+        0xA7AE => 'I', // LATIN CAPITAL LETTER SMALL CAPITAL I
+        0xA7AF => 'Q',
+        // Greek and Cyrillic small capitals, to their own script's capital.
+        0x1D26 => '\u{0393}', // Γ
+        0x1D27 => '\u{039B}', // Λ
+        0x1D28 => '\u{03A0}', // Π
+        0x1D29 => '\u{03A1}', // Ρ — becomes Latin P via `fold_homoglyph`
+        0x1D2A => '\u{03A8}', // Ψ
+        0xAB65 => '\u{03A9}', // Ω
+        0x1D2B => '\u{041B}', // Л
+        _ => return None,
+    })
+}
+
+/// One Mathematical-Greek block's 58 slots, in order, as their plain Greek
+/// (or plain mathematical) equivalents.
+///
+/// Generated from Unicode NFKD; all five blocks share this layout, which
+/// `the_five_math_greek_blocks_share_one_layout` re-derives rather than trusts.
+const MATH_GREEK_FOLD: &str = concat!(
+    "\u{0391}\u{0392}\u{0393}\u{0394}\u{0395}\u{0396}\u{0397}\u{0398}", // Α Β Γ Δ Ε Ζ Η Θ
+    "\u{0399}\u{039A}\u{039B}\u{039C}\u{039D}\u{039E}\u{039F}\u{03A0}", // Ι Κ Λ Μ Ν Ξ Ο Π
+    "\u{03A1}\u{0398}\u{03A3}\u{03A4}\u{03A5}\u{03A6}\u{03A7}\u{03A8}", // Ρ Θsym Σ Τ Υ Φ Χ Ψ
+    "\u{03A9}\u{2207}\u{03B1}\u{03B2}\u{03B3}\u{03B4}\u{03B5}\u{03B6}", // Ω ∇ α β γ δ ε ζ
+    "\u{03B7}\u{03B8}\u{03B9}\u{03BA}\u{03BB}\u{03BC}\u{03BD}\u{03BE}", // η θ ι κ λ μ ν ξ
+    "\u{03BF}\u{03C0}\u{03C1}\u{03C2}\u{03C3}\u{03C4}\u{03C5}\u{03C6}", // ο π ρ ς σ τ υ φ
+    "\u{03C7}\u{03C8}\u{03C9}\u{2202}\u{03B5}\u{03B8}\u{03BA}\u{03C6}", // χ ψ ω ∂ εsym θsym κsym φsym
+    "\u{03C1}\u{03C0}",                                                 // ρsym πsym
+);
 
 /// Letterlike Symbols (U+2100..U+214F) that NFKC folds to a plain letter.
 fn fold_letterlike(cp: u32) -> Option<char> {
@@ -1758,6 +1892,173 @@ mod tests {
                  {real:?}, not merely land within the edit budget"
             );
         }
+    }
+
+    /// **The mathematical-alphanumeric blocks past the Latin half.**
+    ///
+    /// The sweep used to run `(cp - 0x1D400) % 52` over the whole range to
+    /// U+1D7CB. The 52-alignment holds only to U+1D6A3 (13 blocks x 52 = 676);
+    /// after it come two dotless letters and five GREEK blocks of 58, so the
+    /// modulo walked out of phase and emitted an arbitrary letter.
+    ///
+    /// The evading name below is the corpus's own passing sans-bold case with
+    /// ONE codepoint swapped, `𝗜` for the identically-drawn `𝝞` — and the
+    /// broken modulo turned that one into `e`, so `𝝞𝗮𝗻 𝗖𝗹𝗮𝗿𝗸𝗲` folded to
+    /// `ean clarke` and walked past a check that caught the pixel-identical
+    /// string beside it.
+    #[test]
+    fn the_math_greek_blocks_fold_to_greek_not_to_garbage() {
+        let checker = ImpersonationChecker::new(vec![ProtectedName::new(
+            ProtectedRole::Deputy,
+            "Ian Clarke",
+            mid(1),
+        )]);
+        // Sans-serif bold Latin capital I — the case that always worked.
+        let latin =
+            "\u{1D5DC}\u{1D5EE}\u{1D5FB} \u{1D5D6}\u{1D5F9}\u{1D5EE}\u{1D5FF}\u{1D5F8}\u{1D5F2}";
+        // Sans-serif bold Greek capital IOTA — drawn identically, and the one
+        // that evaded.
+        let greek =
+            "\u{1D75E}\u{1D5EE}\u{1D5FB} \u{1D5D6}\u{1D5F9}\u{1D5EE}\u{1D5FF}\u{1D5F8}\u{1D5F2}";
+        for (label, name) in [("math Latin I", latin), ("math Greek IOTA", greek)] {
+            let w = checker
+                .check(mid(2), name)
+                .unwrap_or_else(|| panic!("{label}: {name:?} must be flagged"));
+            assert_eq!(w.tier, ConfusableTier::Identical, "{label}");
+        }
+
+        // Every capital the plain-Greek homoglyph table carries must arrive
+        // there through the math blocks too, in all five of them.
+        for block in [0x1D6A8u32, 0x1D6E2, 0x1D71C, 0x1D756, 0x1D790] {
+            for (slot, plain, latin) in [
+                (8usize, '\u{0399}', 'i'), // IOTA -> I -> bar sentinel is '1'
+                (0, '\u{0391}', 'a'),      // ALPHA -> A
+                (11, '\u{039C}', 'm'),     // MU -> M
+                (14, '\u{039F}', 'o'),     // OMICRON -> O
+            ] {
+                let math = char::from_u32(block + slot as u32).expect("assigned");
+                assert_eq!(
+                    skeleton(&math.to_string()),
+                    skeleton(&plain.to_string()),
+                    "math Greek at block {block:#X} slot {slot} must fold like \
+                     the plain Greek letter"
+                );
+                let _ = latin;
+            }
+        }
+
+        // ...and the false-positive direction the broken modulo also had:
+        // bold capital Alpha came out as `E`. It must fold like plain Alpha.
+        assert_eq!(skeleton("\u{1D6A8}"), skeleton("\u{0391}"));
+        assert_eq!(skeleton("\u{1D6A8}"), skeleton("A"));
+        // Bold capital IOTA is an `I`, not the `M` the broken modulo made of it.
+        assert_eq!(skeleton("\u{1D6B0}"), skeleton("\u{0399}"));
+        assert_eq!(skeleton("\u{1D6B0}"), skeleton("I"));
+        assert_ne!(skeleton("\u{1D6B0}"), skeleton("M"));
+        // A Greek letter with NO Latin lookalike must stay unfolded rather than
+        // acquiring one: bold capital Gamma stays Greek.
+        assert_eq!(skeleton("\u{1D6AA}"), skeleton("\u{0393}"));
+        assert_ne!(skeleton("\u{1D6AA}"), skeleton("G"));
+        // Italic small dotless i is a dotless i, not `A`.
+        assert_eq!(skeleton("\u{1D6A4}"), skeleton("\u{0131}"));
+        assert_ne!(skeleton("\u{1D6A4}"), skeleton("A"));
+        // Bold capital digamma is a digamma, not `i`.
+        assert_eq!(skeleton("\u{1D7CA}"), skeleton("\u{03DC}"));
+        assert_ne!(skeleton("\u{1D7CA}"), skeleton("i"));
+    }
+
+    /// The five Mathematical-Greek blocks are asserted to share one 58-slot
+    /// layout. Re-derive it rather than trusting the comment: if a future
+    /// Unicode version breaks the alignment, [`MATH_GREEK_FOLD`] silently
+    /// starts emitting the wrong letter for four blocks out of five.
+    #[test]
+    fn the_five_math_greek_blocks_share_one_layout() {
+        let table: Vec<char> = MATH_GREEK_FOLD.chars().collect();
+        assert_eq!(table.len(), 58, "one Greek block is 58 slots");
+        for block in [0x1D6A8u32, 0x1D6E2, 0x1D71C, 0x1D756, 0x1D790] {
+            for (slot, expected) in table.iter().enumerate() {
+                let math = char::from_u32(block + slot as u32)
+                    .unwrap_or_else(|| panic!("{block:#X}+{slot} is a valid codepoint"));
+                assert_eq!(
+                    fold_presentation_form(math),
+                    Some(*expected),
+                    "block {block:#X} slot {slot} disagrees with the table"
+                );
+            }
+        }
+        // The Latin sweep must STOP before the Greek half. U+1D6A3 is the last
+        // monospace small z; U+1D6A8 is bold capital Alpha.
+        assert_eq!(fold_presentation_form('\u{1D6A3}'), Some('z'));
+        assert_eq!(fold_presentation_form('\u{1D6A8}'), Some('\u{0391}'));
+    }
+
+    /// **Latin small capitals.** `ɪᴀɴ ᴄʟᴀʀᴋᴇ` reads as `IAN CLARKE`, and the
+    /// corpus already treats `IAN CLARKE` as an identical skeleton of
+    /// `Ian Clarke` — so these had to fold and did not. They are `Ll`, so both
+    /// folds left them verbatim and the result was edit distance 8: not even a
+    /// near miss.
+    #[test]
+    fn small_capitals_fold() {
+        for (label, attacker, real) in [
+            (
+                "all small caps",
+                "\u{026A}\u{1D00}\u{0274} \u{1D04}\u{029F}\u{1D00}\u{0280}\u{1D0B}\u{1D07}",
+                "Ian Clarke",
+            ),
+            ("one small cap", "\u{026A}an Clarke", "Ian Clarke"),
+            ("small capital F/S", "\u{A730}\u{A731}mith", "FSmith"),
+            ("small capital G/H", "\u{0262}\u{029C}osh", "GHosh"),
+            ("small capital B/Y", "\u{0299}\u{028F}rne", "BYrne"),
+            ("small capital Q", "\u{A7AF}uinn", "Quinn"),
+            ("small capital V/W/Z", "\u{1D20}\u{1D21}\u{1D22}ed", "VWZed"),
+            ("small capital J/M/P", "\u{1D0A}\u{1D0D}\u{1D18}od", "JMPod"),
+            (
+                "small capital D/E/T/U",
+                "\u{1D05}\u{1D07}\u{1D1B}\u{1D1C}",
+                "DETU",
+            ),
+            ("small capital O", "B\u{1D0F}b", "BOb"),
+        ] {
+            let checker = ImpersonationChecker::new(vec![ProtectedName::new(
+                ProtectedRole::Deputy,
+                real,
+                mid(1),
+            )]);
+            let w = checker
+                .check(mid(2), attacker)
+                .unwrap_or_else(|| panic!("{label}: {attacker:?} vs {real:?}"));
+            assert_eq!(w.tier, ConfusableTier::Identical, "{label}");
+        }
+
+        // The letterforms that are NOT the plain capital stay unfolded — a
+        // stroke, hook or turned orientation is a different glyph, and folding
+        // it would be inventing a confusable rather than recording one.
+        for not_folded in [
+            '\u{1D03}', // SMALL CAPITAL BARRED B
+            '\u{1D0C}', // SMALL CAPITAL L WITH STROKE
+            '\u{1D0E}', // SMALL CAPITAL REVERSED N
+            '\u{1D19}', // SMALL CAPITAL REVERSED R
+            '\u{1D1A}', // SMALL CAPITAL TURNED R
+            '\u{0281}', // SMALL CAPITAL INVERTED R
+            '\u{029B}', // SMALL CAPITAL G WITH HOOK
+            '\u{1D01}', // SMALL CAPITAL AE
+            '\u{1D06}', // SMALL CAPITAL ETH
+        ] {
+            assert_eq!(
+                fold_small_capital(not_folded),
+                None,
+                "{not_folded:?} is not drawn as a plain capital"
+            );
+        }
+
+        // Greek and Cyrillic small capitals go to their OWN script's capital,
+        // so whether they then become Latin is `fold_homoglyph`'s single
+        // decision rather than a second one made here.
+        assert_eq!(skeleton("\u{1D29}"), skeleton("\u{03A1}")); // Greek rho
+        assert_eq!(skeleton("\u{1D26}"), skeleton("\u{0393}")); // Greek gamma
+        assert_ne!(skeleton("\u{1D26}"), skeleton("G"));
+        assert_eq!(skeleton("\u{1D2B}"), skeleton("\u{041B}")); // Cyrillic el
+        assert_ne!(skeleton("\u{1D2B}"), skeleton("L"));
     }
 
     /// The shape homoglyphs — the half NFKC does NOT equate, so each is a

--- a/ui/src/util/confusable.rs
+++ b/ui/src/util/confusable.rs
@@ -515,6 +515,22 @@ fn skeleton_with(name: &str, fold: Fold) -> String {
             }
             continue;
         }
+        // 1b. **Joiners, dropped unconditionally** — the OTHER half of #488's
+        //     kept-in-context residual.
+        //
+        //     `is_display_hidden` deliberately does NOT report U+200C/U+200D,
+        //     because they are orthography in Persian, Sinhala and Malayalam and
+        //     blanket-stripping them mangles real names at RENDER time. But this
+        //     is not render, it is comparison, and a joiner never distinguishes
+        //     two people's names to a reader — which is the entire premise of
+        //     the residual `display_name.rs`'s header documents. So dropping
+        //     them here has zero false-positive cost and closes the clone:
+        //     without it `"李\u{200D}小龍"` and `"李小龍"` fold apart and the
+        //     impostor is unflagged, leaving every CJK, Persian, Sinhala and
+        //     Malayalam deputy name cloneable.
+        if c == '\u{200C}' || c == '\u{200D}' {
+            continue;
+        }
         // 2. Fullwidth forms, and the "mathematical alphanumeric" blocks that
         //    every online fancy-text generator emits (`𝐈𝐚𝐧`, `𝗜𝗮𝗻`, `𝙸𝚊𝚗` all
         //    read as "Ian"). NFKC does this in the reference; these are the
@@ -1374,6 +1390,80 @@ mod tests {
              justifies rendering tier 1 only no longer holds — re-examine \
              `members::impersonation_warning_for_display`"
         );
+    }
+
+    /// **SHOULD-FIX D — the joiner half of #488's residual.**
+    ///
+    /// `display_name.rs` keeps TWO characters in context: an IVS after an
+    /// ideograph, and a joiner between two non-ASCII letters. The IVS half was
+    /// already covered (`an_ideographic_variation_selector_clone_is_flagged`);
+    /// this is the other half, which used to EVADE.
+    ///
+    /// A joiner is orthography at render time — Persian `علی‌رضا`, Sinhala
+    /// touching letters, Malayalam chillu — which is why `is_display_hidden`
+    /// does not report it. But it never distinguishes two people's names to a
+    /// READER, so dropping it for comparison has no false-positive cost.
+    #[test]
+    fn a_joiner_clone_is_flagged() {
+        for (real, clone, script) in [
+            (
+                "\u{674E}\u{5C0F}\u{9F8D}",
+                "\u{674E}\u{200D}\u{5C0F}\u{9F8D}",
+                "CJK, ZWJ",
+            ),
+            (
+                "\u{674E}\u{5C0F}\u{9F8D}",
+                "\u{674E}\u{200C}\u{5C0F}\u{9F8D}",
+                "CJK, ZWNJ",
+            ),
+            (
+                "\u{639}\u{644}\u{6CC}\u{631}\u{636}\u{627}",
+                "\u{639}\u{644}\u{6CC}\u{200C}\u{631}\u{636}\u{627}",
+                "Persian",
+            ),
+        ] {
+            // Precondition: sanitisation KEEPS the joiner, so the two members
+            // really do render alike and the existing defence does not catch it.
+            assert_eq!(
+                crate::util::display_name::sanitize_display_name(clone),
+                clone,
+                "{script}: precondition — #488 keeps an interior joiner"
+            );
+            assert_ne!(real, clone, "{script}: different strings");
+
+            let checker = ImpersonationChecker::new(vec![ProtectedName::new(
+                ProtectedRole::Deputy,
+                real,
+                mid(1),
+            )]);
+            let w = checker
+                .check(mid(2), clone)
+                .unwrap_or_else(|| panic!("{script}: a joiner clone must be flagged"));
+            assert_eq!(w.tier, ConfusableTier::Identical);
+        }
+    }
+
+    /// The joiner drop must not disturb names that legitimately CONTAIN one:
+    /// they still fold to themselves-minus-the-joiner, so two DIFFERENT real
+    /// names remain different.
+    #[test]
+    fn dropping_joiners_does_not_merge_distinct_names() {
+        let checker = ImpersonationChecker::new(vec![ProtectedName::new(
+            ProtectedRole::Deputy,
+            "\u{639}\u{644}\u{6CC}\u{200C}\u{631}\u{636}\u{627}",
+            mid(1),
+        )]);
+        for other in [
+            "\u{645}\u{62D}\u{645}\u{62F}",
+            "\u{62D}\u{633}\u{6CC}\u{646}\u{200C}\u{632}\u{627}\u{62F}\u{647}",
+            "\u{674E}\u{5C0F}\u{9F8D}",
+        ] {
+            assert_eq!(
+                checker.check(mid(2), other),
+                None,
+                "{other:?} is a different name and must not be flagged"
+            );
+        }
     }
 
     /// **Regression: the `nn -> m` fold (removed).** Doubled-n is one of the

--- a/ui/src/util/confusable.rs
+++ b/ui/src/util/confusable.rs
@@ -574,6 +574,47 @@ fn skeleton_with(name: &str, fold: Fold) -> String {
         Fold::CaseInsensitive => fold_bar_class(&out.to_lowercase()),
     };
 
+    // 7a. **Homoglyphs, AGAIN, after the case fold.**
+    //
+    // The pass at step 5 runs before `to_lowercase`, which is correct for the
+    // uppercase entries (`Η` looks like `H` but its lowercase `η` looks like
+    // `n`, so one case-insensitive rule would be wrong for both). But it left a
+    // whole class through: any UPPERCASE codepoint absent from the table whose
+    // Unicode lowercase IS in the table survived as the raw codepoint, because
+    // nothing folded it after the case step. The lowercase forms were caught;
+    // the uppercase ones were not.
+    //
+    //   * `Ӏ` U+04C0 CYRILLIC PALOCHKA — a bare vertical stroke, pixel-identical
+    //     to Latin capital I, and the single most-used I-spoof in IDN attacks.
+    //   * `Ԁ` U+0500 CYRILLIC KOMI DE, `Ѵ` U+0474 CYRILLIC IZHITSA.
+    //
+    // Running the same table a second time closes the class rather than the
+    // three instances: `to_lowercase` has already mapped each of them onto its
+    // lowercase form (`ӏ`, `ԁ`, `ѵ`), all of which the table already carried.
+    //
+    // **A character this pass rewrites must then go through the bar fold too,
+    // and ONLY such a character.** The palochka lowercases to `ӏ`, which this
+    // table maps to `l` — a bar — but the bar fold at step 6/7 has already run,
+    // so without this it stayed a literal `l` and `"Ӏan Clarke"` folded to
+    // `"lan c1arke"` against the real `"1an c1arke"`. It still evaded.
+    //
+    // Re-running the bar fold over the WHOLE string instead would be wrong: in
+    // the visual fold a capital `L` legitimately reaches this point as `l` (it
+    // is not a bar — it has a foot), and folding it here would re-merge
+    // `Lisa`/`Iisa`, undoing the split [`Fold`] exists to make. So the bar fold
+    // is applied per character, conditional on this pass having changed it.
+    let out: String = out
+        .chars()
+        .map(|c| {
+            let folded = fold_homoglyph(c);
+            if folded == c {
+                c
+            } else {
+                fold_bar_char(folded)
+            }
+        })
+        .collect();
+
     // 7b. The remaining ASCII confusables, which are case-agnostic (they all
     //     produce a lowercase letter, which the case step above leaves alone).
     let out: String = out.chars().map(fold_ascii_confusable).collect();
@@ -627,14 +668,17 @@ const MULTI_CONFUSABLES: [(&str, &str); 3] = [("rn", "m"), ("cl", "d"), ("vv", "
 /// See [`Fold`]. Which characters are in the class depends on whether the case
 /// step has already run — the caller decides by choosing the [`Fold`].
 fn fold_bar_class(s: &str) -> String {
-    s.chars()
-        .map(|c| match c {
-            // `I` is here for the pre-case pass; after `to_lowercase` it can no
-            // longer appear, so the same table serves both directions.
-            'l' | 'I' | '1' | '|' | '!' => '1',
-            other => other,
-        })
-        .collect()
+    s.chars().map(fold_bar_char).collect()
+}
+
+/// [`fold_bar_class`] for one character.
+fn fold_bar_char(c: char) -> char {
+    match c {
+        // `I` is here for the pre-case pass; after `to_lowercase` it can no
+        // longer appear, so the same table serves both directions.
+        'l' | 'I' | '1' | '|' | '!' => '1',
+        other => other,
+    }
 }
 
 /// Single-character ASCII lookalikes OTHER than the bar class.
@@ -1389,6 +1433,92 @@ mod tests {
              budget ({a:?} vs {b:?}, budget {budget}); the measurement that \
              justifies rendering tier 1 only no longer holds — re-examine \
              `members::impersonation_warning_for_display`"
+        );
+    }
+
+    /// **BLOCKING B — uppercase homoglyphs whose LOWERCASE is in the table.**
+    ///
+    /// `fold_homoglyph` originally ran only before `to_lowercase`. Any uppercase
+    /// codepoint absent from the table whose Unicode lowercase IS in the table
+    /// therefore survived as the raw codepoint: the lowercase form was caught,
+    /// the uppercase one walked straight through. `Ӏ` U+04C0 CYRILLIC PALOCHKA
+    /// is the single most-used I-spoof in IDN attacks — a bare vertical stroke,
+    /// pixel-identical to Latin capital I.
+    #[test]
+    fn uppercase_cyrillic_homoglyphs_are_flagged() {
+        for (label, attacker, real) in [
+            ("U+04C0 PALOCHKA", "\u{04C0}an Clarke", "Ian Clarke"),
+            ("U+0500 KOMI DE", "\u{0500}eputy Dan", "Deputy Dan"),
+            ("U+0474 IZHITSA", "\u{0474}era Voss", "Vera Voss"),
+            ("U+04CF palochka (lower)", "\u{04CF}an Clarke", "Ian Clarke"),
+        ] {
+            let checker = ImpersonationChecker::new(vec![ProtectedName::new(
+                ProtectedRole::Deputy,
+                real,
+                mid(1),
+            )]);
+            let w = checker.check(mid(2), attacker).unwrap_or_else(|| {
+                panic!("{label}: {attacker:?} must be flagged against {real:?}")
+            });
+            assert_eq!(w.tier, ConfusableTier::Identical, "{label}");
+        }
+    }
+
+    /// **The class, not the instances.** Every key in the homoglyph table whose
+    /// uppercase differs from itself must fold the same way from EITHER case.
+    /// This is what makes the second pass a class fix rather than three
+    /// hand-patched characters — it fails for any future table entry added in
+    /// lowercase only.
+    #[test]
+    fn every_lowercase_homoglyph_is_also_caught_uppercased() {
+        // Sweep the ranges the table draws from rather than restating it.
+        let mut checked = 0usize;
+        for cp in (0x0370..=0x058Fu32).chain(0x2C80..=0x2CFF) {
+            let Some(c) = char::from_u32(cp) else {
+                continue;
+            };
+            let folded = fold_homoglyph(c);
+            if folded == c {
+                continue; // not a table key
+            }
+            // An uppercase form that lowercases back onto this key must fold to
+            // the same ASCII letter, in both directions — UNLESS the uppercase
+            // is itself a table key, in which case the table has deliberately
+            // given it a different answer and that answer is correct.
+            //
+            // Greek is the reason this carve-out exists and it is not a
+            // loophole: `ν` (nu) looks like Latin `v` while its uppercase `Ν`
+            // looks like Latin `N`. They are different shapes, so they get
+            // different folds. The bug class this test targets is narrower —
+            // an uppercase codepoint the table does NOT mention, whose
+            // lowercase it does.
+            for upper in c.to_uppercase() {
+                if upper == c || fold_homoglyph(upper) != upper {
+                    continue;
+                }
+                checked += 1;
+                let via_upper = skeleton_with(&upper.to_string(), Fold::CaseInsensitive);
+                let via_lower = skeleton_with(&c.to_string(), Fold::CaseInsensitive);
+                assert_eq!(
+                    via_upper,
+                    via_lower,
+                    "U+{cp:04X}: the lowercase form folds to {via_lower:?} but \
+                     its uppercase U+{:04X} folds to {via_upper:?} — an \
+                     uppercase homoglyph is walking through the fold",
+                    u32::from(upper)
+                );
+            }
+        }
+        // The floor is the size of the bug class for the CURRENT table: the
+        // palochka, komi de and izhitsa, whose uppercase forms the table does
+        // not mention. It is a guard against the sweep silently matching
+        // nothing (a wrong range, a `continue` that swallows everything), not a
+        // target — adding table entries only raises it.
+        assert!(
+            checked >= 3,
+            "the sweep found only {checked} uppercase-not-in-table pairs; it \
+             should find at least the palochka, komi de and izhitsa, so the \
+             ranges are wrong and this test is not testing anything"
         );
     }
 

--- a/ui/src/util/confusable.rs
+++ b/ui/src/util/confusable.rs
@@ -1,0 +1,1244 @@
+//! Detecting display names that are visually confusable with a privileged
+//! member's.
+//!
+//! ## Why this exists
+//!
+//! [`crate::util::display_name`] stops a nickname from *forging* the 🛡 shield,
+//! and its module header states plainly that homoglyphs are out of scope for
+//! it. That leaves the other half of the same attack: a member who cannot draw
+//! a shield can still call themselves `lan Clarke` (lowercase L for capital i)
+//! and be taken for the moderator `Ian Clarke` by every reader who does not
+//! notice the shield is missing.
+//!
+//! **Absence of a shield is a weak signal.** Most legitimate members have no
+//! shield either, so an unbadged `Ian Clarke` reads as an ordinary member
+//! unless the viewer already knows that Ian should be badged. This module
+//! inverts that: instead of relying on the reader to notice something missing,
+//! the impostor is marked with something present.
+//!
+//! This is not hypothetical. On 2026-07-25 the Freenet Official room banned
+//! nine `Ian Clarke` impersonators, and then a tenth joined as `lan Clarke`,
+//! which walked straight past the exact-match check that caught the first nine.
+//!
+//! ## Two tiers
+//!
+//! Ported from the Python engine in `~/bin/river-official-autoban.sh`, which
+//! was validated against a live impersonation fixture before this port existed.
+//! The tiering is the load-bearing part:
+//!
+//! * [`ConfusableTier::Identical`] — the two names fold to the same
+//!   [`skeleton`]. They are visually the *same string*, in the spirit of
+//!   Unicode TR39 skeletons.
+//! * [`ConfusableTier::NearMiss`] — the skeletons are within a small,
+//!   length-scaled Damerau-Levenshtein distance (transpositions count as one
+//!   edit). Catches `Ian Clark`, `Ian Clrake`, `Ian Clarkee`, which no skeleton
+//!   can.
+//!
+//! In the autoban script the tiers have wildly different error budgets: tier 1
+//! *bans* (a false positive removes an innocent person) and tier 2 only
+//! *reports*.
+//!
+//! **This UI renders tier 1 only.** Tier 2 is computed, returned and tested, but
+//! [`crate::components::members::impersonation_warning_for_display`] — the one
+//! function every render surface goes through — drops it. The reason is
+//! measured, not assumed: River assigns every member one of 10,000 generated
+//! handles ([`crate::nickname`]), and two of them, `Amber Worm` and
+//! `Ember Worm`, are one edit apart. No two generated handles share a skeleton
+//! (tier 1 is clean on them, and
+//! `generated_handles_never_fold_to_the_same_skeleton` pins that), but the tier-2
+//! sweep flags a pair River itself hands out. A tier that accuses innocent
+//! members *by default*, before any attacker does anything, is not a tier this
+//! UI can render — so the badge fires only when two names fold to the **same**
+//! skeleton, i.e. when they are visually the same string.
+//!
+//! ## Deciding who is warned about
+//!
+//! The check is **identity-first, name-second**: [`ImpersonationChecker`] holds
+//! the set of member IDs that legitimately hold privilege, and a member whose
+//! own ID is in that set is *never* warned about, whatever they are called.
+//! Member IDs are derived from a keypair, so they cannot be chosen or forged.
+//! Flagging the real moderator instead of the impostor would be worse than
+//! shipping nothing, and that ordering is what makes it impossible.
+//!
+//! ## Honest limits
+//!
+//! * Only collisions with *privileged* names fire (the room owner, and deputies
+//!   the viewer would see a shield for). Two ordinary members with similar names
+//!   are not flagged, because a warning on every near-duplicate would train
+//!   people to ignore the warning — and only the privileged names carry the
+//!   authority worth stealing.
+//! * A member who legitimately shares a moderator's name **is** warned about.
+//!   That is intended: the viewer genuinely cannot tell the two apart on sight,
+//!   which is the fact the warning exists to convey.
+//! * The folds are deliberately small. A fold only matters when the result
+//!   lands on (or very near) a protected name, so the false-positive surface is
+//!   the set of ordinary names that fold onto a moderator's — tiny. The
+//!   `no_false_positives_on_ordinary_names` and
+//!   `generated_handles_never_fold_to_the_same_skeleton` tests are the guard.
+//! * This module compares names. It does not, and cannot, tell you whether the
+//!   person behind an unflagged name is who they say they are.
+
+use crate::util::display_name::is_display_hidden;
+use river_core::room_state::member::MemberId;
+use std::collections::HashSet;
+
+/// How close a name is to a protected one.
+///
+/// **The UI renders [`Identical`](ConfusableTier::Identical) only** — see the
+/// module header, and
+/// [`crate::components::members::impersonation_warning_for_display`], which is
+/// where that decision lives. Both tiers are computed and returned so the
+/// distinction stays testable: a future change that silently promoted every
+/// near-miss to an identical match (or the reverse) would otherwise be
+/// invisible, and reversing the tier decision needs the measurement to still be
+/// there.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ConfusableTier {
+    /// Folds to the identical skeleton — visually the same string.
+    Identical,
+    /// Within a small, length-scaled edit distance of the skeleton.
+    NearMiss,
+}
+
+/// What kind of privilege a protected name carries.
+///
+/// Drives the tooltip's remedy clause, because the two roles are marked with
+/// different glyphs in different places: a deputy shows 🛡 next to their name
+/// everywhere, whereas the room owner's 👑 appears only in the member list.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ProtectedRole {
+    /// The room owner.
+    Owner,
+    /// A member holding a deputy (moderator) grant the viewer would see a
+    /// shield for.
+    Deputy,
+}
+
+/// A privileged name that must not be impersonated.
+#[derive(Clone, PartialEq, Debug)]
+pub struct ProtectedName {
+    pub role: ProtectedRole,
+    /// The privileged member's display name, already sanitised. Quoted back to
+    /// the reader in the tooltip so the warning names who is being imitated.
+    pub display_name: String,
+    /// Cached [`skeleton`] of `display_name`.
+    skeleton: String,
+}
+
+impl ProtectedName {
+    pub fn new(role: ProtectedRole, display_name: impl Into<String>) -> Self {
+        let display_name = display_name.into();
+        let skeleton = skeleton(&display_name);
+        Self {
+            role,
+            display_name,
+            skeleton,
+        }
+    }
+}
+
+/// The warning shown next to an impersonating member's name.
+#[derive(Clone, PartialEq, Debug)]
+pub struct ImpersonationWarning {
+    /// Who is being imitated.
+    pub impersonated: ProtectedName,
+    /// How close the resemblance is. **Callers must not render a warning
+    /// straight from this value** — go through
+    /// [`crate::components::members::impersonation_warning_for_display`], which
+    /// applies the tier decision (only `Identical` is shown).
+    pub tier: ConfusableTier,
+}
+
+/// The glyph rendered for a warning.
+///
+/// U+26A0 sits inside the Miscellaneous Symbols range that
+/// [`crate::util::display_name::is_display_hidden`] strips, so a nickname can
+/// never contain this character — the warning cannot be forged, and an impostor
+/// cannot pre-empt it by putting one in their own name to make the real signal
+/// look like decoration. `badge_glyphs_cannot_survive_a_nickname` in that
+/// module pins the strip; `the_warning_glyph_cannot_appear_in_a_nickname`
+/// below pins that this constant is one of them.
+pub const WARNING_GLYPH: &str = "\u{26a0}";
+
+impl ImpersonationWarning {
+    /// The `title=` / `aria-label` text.
+    ///
+    /// Three things, because a bare ⚠ teaches nobody anything: what is wrong,
+    /// that this member is *not* the person they resemble, and what to look for
+    /// instead. One definition for every surface, so the warning cannot say
+    /// different things in different places — the same rule
+    /// [`crate::components::members::DeputyBadge::tooltip`] follows for the
+    /// shield.
+    ///
+    /// ## The interpolated name is attacker-controlled, and its position is a
+    /// security property
+    ///
+    /// `display_name` is a *protected* member's nickname, which sounds
+    /// trustworthy and is not. Nothing in `MemberInfoV1::verify` validates a
+    /// `deputies` list, so any member who is a strict ancestor of the viewer can
+    /// deputise a sockpuppet and choose its nickname freely — and that
+    /// sockpuppet is then a protected name in the viewer's view. So this string
+    /// is written as though the name were chosen by an attacker, because it can
+    /// be.
+    ///
+    /// Two rules, both load-bearing, pinned by
+    /// `tooltip_cannot_be_forged_by_a_crafted_protected_name`:
+    ///
+    /// * **The name goes LAST.** Every claim this tooltip makes is already made
+    ///   before the attacker's text begins, so no nickname content can be read
+    ///   as one of our own role labels. `DeputyBadge::tooltip` had the opposite
+    ///   shape — attacker names `join(", ")`-ed into the middle of a sentence —
+    ///   and a member called `Bob, the room owner, Carol` turned it into a
+    ///   forged appointment. Do not move the name earlier.
+    /// * **The quote characters are stripped from the name**, so the closing
+    ///   `\u{201d}` is always ours. Without this the quoting is decorative
+    ///   rather than protective: the payload IS the quote character. Same fix,
+    ///   for the same reason, as `relevant_deputizer_names`.
+    pub fn tooltip(&self) -> String {
+        let name = self
+            .impersonated
+            .display_name
+            .replace(['\u{201c}', '\u{201d}'], "");
+        match self.impersonated.role {
+            ProtectedRole::Owner => format!(
+                "Impersonation warning: this member is NOT the room owner, but their \
+                 name closely resembles the owner's. The real owner is marked \
+                 \u{1f451} in the member list. Name imitated: \u{201c}{name}\u{201d}"
+            ),
+            ProtectedRole::Deputy => format!(
+                "Impersonation warning: this member is NOT a moderator, but their name \
+                 closely resembles one. A real moderator shows a \u{1f6e1} shield next \
+                 to their name. Name imitated: \u{201c}{name}\u{201d}"
+            ),
+        }
+    }
+}
+
+/// Decides which members' names are confusable with a privileged member's.
+///
+/// Built once per render pass from the viewer's room state (see
+/// [`crate::components::members::impersonation_checker_for_viewer`]) and then
+/// asked about each rendered name. Construction folds the protected names once;
+/// [`ImpersonationChecker::check`] is the per-name hot path.
+#[derive(Clone, PartialEq, Debug, Default)]
+pub struct ImpersonationChecker {
+    protected: Vec<ProtectedName>,
+    /// IDs that legitimately hold privilege. A member in this set is never
+    /// warned about — see the module header on why identity comes first.
+    privileged_ids: HashSet<MemberId>,
+}
+
+impl ImpersonationChecker {
+    pub fn new(protected: Vec<ProtectedName>, privileged_ids: HashSet<MemberId>) -> Self {
+        Self {
+            protected,
+            privileged_ids,
+        }
+    }
+
+    /// Whether this checker can ever produce a warning.
+    ///
+    /// Lets a caller skip a per-member sweep in a room with no protected names
+    /// at all.
+    pub fn is_empty(&self) -> bool {
+        self.protected.is_empty()
+    }
+
+    /// Whether `id` legitimately holds privilege, and so is never warned about.
+    pub fn is_privileged(&self, id: MemberId) -> bool {
+        self.privileged_ids.contains(&id)
+    }
+
+    /// The warning for `display_name` as shown for member `id`, if any.
+    ///
+    /// `display_name` must be the text actually rendered — i.e. the output of
+    /// [`crate::util::display_name::display_nickname`]. Checking the raw
+    /// nickname instead would compare something the reader never sees.
+    pub fn check(&self, id: MemberId, display_name: &str) -> Option<ImpersonationWarning> {
+        // Identity first. A real moderator must never be flagged, and the only
+        // way to guarantee that is to answer "is this actually them?" before
+        // looking at the name at all.
+        if self.privileged_ids.contains(&id) {
+            return None;
+        }
+        self.check_name(display_name)
+    }
+
+    /// The name half of [`check`](Self::check), with no identity check.
+    ///
+    /// Exposed for tests. Production callers must use `check`, so the
+    /// identity-first rule cannot be skipped.
+    pub fn check_name(&self, display_name: &str) -> Option<ImpersonationWarning> {
+        if self.protected.is_empty() {
+            return None;
+        }
+        let sk = skeleton(display_name);
+        if sk.is_empty() {
+            return None;
+        }
+        let sk_chars: Vec<char> = sk.chars().collect();
+        let sk_no_space: String = sk.chars().filter(|c| *c != ' ').collect();
+
+        // Tier 1 across the WHOLE protected set before tier 2, so an exact
+        // skeleton match is always reported as `Identical` even when some other
+        // protected name is a near-miss. Otherwise the reported tier would
+        // depend on the order the protected set happened to be built in.
+        for p in &self.protected {
+            if sk == p.skeleton || sk_no_space == p.skeleton.replace(' ', "") {
+                return Some(ImpersonationWarning {
+                    impersonated: p.clone(),
+                    tier: ConfusableTier::Identical,
+                });
+            }
+        }
+        let budget = edit_budget(sk_chars.len());
+        if budget == 0 {
+            return None;
+        }
+        let mut best: Option<ImpersonationWarning> = None;
+        for p in &self.protected {
+            let p_chars: Vec<char> = p.skeleton.chars().collect();
+            if damerau_within(&sk_chars, &p_chars, budget) <= budget {
+                // Owner outranks deputy so the more severe impersonation is the
+                // one named, and the result does not depend on set order.
+                let better = best.as_ref().is_none_or(|b| {
+                    p.role == ProtectedRole::Owner && b.impersonated.role != ProtectedRole::Owner
+                });
+                if better {
+                    best = Some(ImpersonationWarning {
+                        impersonated: p.clone(),
+                        tier: ConfusableTier::NearMiss,
+                    });
+                }
+            }
+        }
+        best
+    }
+}
+
+/// How many edits away a name may be and still count as a near-miss.
+///
+/// Scaled by length so short names do not over-match: at four characters or
+/// fewer, one edit turns most names into most other names, so tier 2 is
+/// switched off entirely and only an identical skeleton counts.
+fn edit_budget(len: usize) -> usize {
+    match len {
+        0..=4 => 0,
+        5..=12 => 1,
+        _ => 2,
+    }
+}
+
+/// Fold a display name to its visual skeleton.
+///
+/// Two names with the same skeleton render as the same string to a reader.
+/// The pipeline mirrors the validated Python engine
+/// (`~/bin/river-official-autoban.sh`), with the Unicode normalisation steps
+/// replaced by explicit tables — this crate deliberately carries no Unicode
+/// property or normalisation dependency (the wasm bundle size is a standing
+/// concern, and [`crate::util::display_name`] made the same trade for the same
+/// reason).
+///
+/// Order is load-bearing and is pinned by `skeleton_folds_in_reference_order`.
+/// In particular the single-character ASCII map runs BEFORE the multi-character
+/// one, so `"cl"` has already become `"ci"` by the time `cl -> d` is
+/// considered; that rule is inert, and is kept only so the fold table stays a
+/// faithful copy of the engine these results were validated against.
+pub fn skeleton(name: &str) -> String {
+    // 1. Drop what a reader cannot see, and fold presentation-only variants of
+    //    ASCII. The invisible set is reused from the display-name table rather
+    //    than re-listed here, so the two cannot drift. A hidden character that
+    //    WAS whitespace becomes a space, matching `sanitize_display_name`.
+    //
+    //    In practice the input is already sanitised (callers pass rendered
+    //    text), so the invisible strip is defence in depth — and it is what
+    //    lets the unit tests feed raw attacker strings.
+    let mut out = String::with_capacity(name.len());
+    for c in name.chars() {
+        if is_display_hidden(c) {
+            if c.is_whitespace() {
+                out.push(' ');
+            }
+            continue;
+        }
+        // 2. Fullwidth forms, and the "mathematical alphanumeric" blocks that
+        //    every online fancy-text generator emits (`𝐈𝐚𝐧`, `𝗜𝗮𝗻`, `𝙸𝚊𝚗` all
+        //    read as "Ian"). NFKC does this in the reference; these are the
+        //    ranges that matter for names.
+        if let Some(ascii) = fold_presentation_form(c) {
+            out.push(ascii);
+            continue;
+        }
+        // 3. Combining marks. `"I" + U+0300 + "n"` must fold like `"Ìn"`.
+        if is_combining_mark(c) {
+            continue;
+        }
+        // 4. Precomposed Latin letters, which carry no combining mark to strip
+        //    (`à` is one codepoint). This is the NFD-then-drop-marks step.
+        out.push(strip_latin_accent(c).unwrap_or(c));
+    }
+
+    // 5. Cross-script homoglyphs, BEFORE case folding. Case matters here: `Η`
+    //    (Greek capital eta) looks like `H`, but its lowercase `η` looks like
+    //    `n`, so one case-insensitive rule would be wrong for both. (The Python
+    //    engine case-folds first, which silently disables its Greek entries;
+    //    handling case properly is the one place this port deliberately
+    //    improves on it, and it cannot affect that engine's validated results,
+    //    which are all Latin or Cyrillic.)
+    let out: String = out.chars().map(fold_homoglyph).collect();
+
+    // 6. Case.
+    let out = out.to_lowercase();
+
+    // 7. ASCII confusables. `l`/`1`/`|`/`!` all render as `i` in a sans-serif
+    //    UI font, which is the fold that catches `lan Clarke`. Note both sides
+    //    of a comparison are folded, so `"Clarke"` becomes `"ciarke"` for the
+    //    real moderator too and the match still holds.
+    let out: String = out.chars().map(fold_ascii_confusable).collect();
+
+    // 8. Multi-character confusables: `rn` reads as `m`, `vv` as `w`.
+    let mut out = out;
+    for (from, to) in MULTI_CONFUSABLES {
+        if out.contains(from) {
+            out = out.replace(from, to);
+        }
+    }
+
+    // 9. Collapse whitespace runs and trim, so `"Ian  Clarke"` folds onto
+    //    `"Ian Clarke"`. Every whitespace character becomes a plain space
+    //    first: an impostor who separates the words with U+3000 renders a
+    //    visibly different name, but is one keystroke from the real thing and
+    //    is worth catching.
+    let mut collapsed = String::with_capacity(out.len());
+    let mut last_was_space = false;
+    for c in out.chars() {
+        let c = if c.is_whitespace() { ' ' } else { c };
+        let is_space = c == ' ';
+        if !(is_space && last_was_space) {
+            collapsed.push(c);
+        }
+        last_was_space = is_space;
+    }
+    collapsed.trim().to_string()
+}
+
+/// Multi-character confusables, applied after the single-character map.
+///
+/// `cl -> d` is inert: the ASCII map has already rewritten `l` to `i`. It is
+/// retained for fidelity with the upstream engine, and
+/// `skeleton_folds_in_reference_order` pins that it stays inert — reordering
+/// the two steps would change which ordinary names fold onto a moderator's.
+const MULTI_CONFUSABLES: [(&str, &str); 4] = [("rn", "m"), ("cl", "d"), ("vv", "w"), ("nn", "m")];
+
+/// Single-character ASCII lookalikes.
+fn fold_ascii_confusable(c: char) -> char {
+    match c {
+        'l' | '1' | '|' | '!' => 'i',
+        '0' => 'o',
+        '5' | '$' => 's',
+        '3' => 'e',
+        '@' | '4' => 'a',
+        '7' => 't',
+        other => other,
+    }
+}
+
+/// Cyrillic and Greek letters that are pixel-identical (or near enough) to a
+/// Latin letter in a normal UI font.
+///
+/// Deliberately conservative, and deliberately case-aware. Adding a letter that
+/// merely *resembles* a Latin one (Greek `α`, `η`, `ι`) would start folding
+/// real Greek and Cyrillic names toward Latin skeletons, which is how a
+/// confusable check acquires false positives on exactly the users least able to
+/// argue with it.
+fn fold_homoglyph(c: char) -> char {
+    match c {
+        // Cyrillic, uppercase.
+        '\u{0410}' => 'A', // А
+        '\u{0412}' => 'B', // В
+        '\u{0415}' => 'E', // Е
+        '\u{041A}' => 'K', // К
+        '\u{041C}' => 'M', // М
+        '\u{041D}' => 'H', // Н
+        '\u{041E}' => 'O', // О
+        '\u{0420}' => 'P', // Р
+        '\u{0421}' => 'C', // С
+        '\u{0422}' => 'T', // Т
+        '\u{0423}' => 'Y', // У
+        '\u{0425}' => 'X', // Х
+        '\u{0405}' => 'S', // Ѕ
+        '\u{0406}' => 'I', // І
+        '\u{0408}' => 'J', // Ј
+        '\u{04AE}' => 'Y', // Ү
+        '\u{04BA}' => 'H', // Һ
+        // Cyrillic, lowercase.
+        '\u{0430}' => 'a', // а
+        '\u{0435}' => 'e', // е
+        '\u{043E}' => 'o', // о
+        '\u{0440}' => 'p', // р
+        '\u{0441}' => 'c', // с
+        '\u{0443}' => 'y', // у
+        '\u{0445}' => 'x', // х
+        '\u{0455}' => 's', // ѕ
+        '\u{0456}' => 'i', // і
+        '\u{0458}' => 'j', // ј
+        '\u{04BB}' => 'h', // һ
+        '\u{04CF}' => 'l', // ӏ
+        '\u{0501}' => 'd', // ԁ
+        '\u{0475}' => 'v', // ѵ
+        // Greek, uppercase — identical to the Latin capital in every common
+        // font.
+        '\u{0391}' => 'A', // Α
+        '\u{0392}' => 'B', // Β
+        '\u{0395}' => 'E', // Ε
+        '\u{0396}' => 'Z', // Ζ
+        '\u{0397}' => 'H', // Η
+        '\u{0399}' => 'I', // Ι
+        '\u{039A}' => 'K', // Κ
+        '\u{039C}' => 'M', // Μ
+        '\u{039D}' => 'N', // Ν
+        '\u{039F}' => 'O', // Ο
+        '\u{03A1}' => 'P', // Ρ
+        '\u{03A4}' => 'T', // Τ
+        '\u{03A5}' => 'Y', // Υ
+        '\u{03A7}' => 'X', // Χ
+        // Greek, lowercase — only the three that are genuinely
+        // indistinguishable.
+        '\u{03BF}' => 'o', // ο
+        '\u{03C1}' => 'p', // ρ
+        '\u{03BD}' => 'v', // ν
+        other => other,
+    }
+}
+
+/// Combining marks, dropped so `"I" + U+0300` folds like `"Ì"`.
+fn is_combining_mark(c: char) -> bool {
+    matches!(u32::from(c),
+        0x0300..=0x036F   // Combining Diacritical Marks
+        | 0x1AB0..=0x1AFF // Combining Diacritical Marks Extended
+        | 0x1DC0..=0x1DFF // Combining Diacritical Marks Supplement
+        | 0x20D0..=0x20F0 // Combining Diacritical Marks for Symbols
+        | 0xFE20..=0xFE2F // Combining Half Marks
+    )
+}
+
+/// Presentation-only variants of ASCII: fullwidth forms, the Letterlike
+/// Symbols, and the mathematical alphanumeric blocks.
+///
+/// All are what NFKC folds, and all are trivially reachable — a "fancy text"
+/// web page turns `Ian Clarke` into `𝗜𝗮𝗻 𝗖𝗹𝗮𝗿𝗸𝗲` in one click, and the result is
+/// legible as the original to any reader.
+fn fold_presentation_form(c: char) -> Option<char> {
+    let cp = u32::from(c);
+    // Fullwidth ASCII: U+FF01..U+FF5E maps to U+0021..U+007E.
+    if (0xFF01..=0xFF5E).contains(&cp) {
+        return char::from_u32(cp - 0xFEE0);
+    }
+    if let Some(letter) = fold_letterlike(cp) {
+        return Some(letter);
+    }
+    // Mathematical Alphanumeric Symbols: consecutive 52-letter (A-Z then a-z)
+    // blocks.
+    //
+    // The range contains reserved holes (e.g. U+1D455, whose letter lives in
+    // Letterlike Symbols above). A hole maps to a letter here, which is
+    // harmless: an unassigned codepoint renders as tofu and cannot appear in a
+    // name a reader would mistake for anything.
+    if (0x1D400..=0x1D7CB).contains(&cp) {
+        let idx = (cp - 0x1D400) % 52;
+        return Some(if idx < 26 {
+            (b'A' + idx as u8) as char
+        } else {
+            (b'a' + (idx - 26) as u8) as char
+        });
+    }
+    // Mathematical digits: five consecutive blocks of ten.
+    if (0x1D7CE..=0x1D7FF).contains(&cp) {
+        return Some((b'0' + ((cp - 0x1D7CE) % 10) as u8) as char);
+    }
+    None
+}
+
+/// Letterlike Symbols (U+2100..U+214F) that NFKC folds to a plain letter.
+fn fold_letterlike(cp: u32) -> Option<char> {
+    Some(match cp {
+        0x2102 | 0x212D => 'C',
+        0x2107 => 'E',
+        0x210A => 'g',
+        0x210B | 0x210C | 0x210D => 'H',
+        0x210E | 0x210F => 'h',
+        0x2110 | 0x2111 => 'I',
+        0x2112 => 'L',
+        0x2113 => 'l',
+        0x2115 => 'N',
+        0x2119 => 'P',
+        0x211A => 'Q',
+        0x211B | 0x211C | 0x211D => 'R',
+        0x2124 | 0x2128 => 'Z',
+        0x212C => 'B',
+        0x212F | 0x2130 => 'E',
+        0x2131 => 'F',
+        0x2133 => 'M',
+        0x2134 => 'o',
+        _ => return None,
+    })
+}
+
+/// Latin-1 Supplement and Latin Extended-A, folded to their unaccented base.
+///
+/// This is the NFD-then-drop-combining-marks step for the precomposed letters,
+/// which carry no separate mark to strip. `'\0'` in the tables means "no
+/// decomposition" — `Æ`, `Ø`, `Þ`, `ß`, `Đ`, `Ł` and friends are letters in
+/// their own right and are left alone, exactly as NFD leaves them.
+fn strip_latin_accent(c: char) -> Option<char> {
+    let cp = u32::from(c);
+    let table_char = |table: &str, offset: u32| -> Option<char> {
+        table
+            .chars()
+            .nth((cp - offset) as usize)
+            .filter(|f| *f != '\0')
+    };
+    match cp {
+        0x00C0..=0x00FF => table_char(LATIN1_FOLD, 0x00C0),
+        0x0100..=0x017F => table_char(LATIN_EXT_A_FOLD, 0x0100),
+        _ => None,
+    }
+}
+
+/// U+00C0..U+00FF, in order. `\0` = leave the character alone.
+///
+/// The tables are positional, so `latin_fold_tables_are_aligned` checks both
+/// their length and a spread of individual entries — a miscounted `\0` would
+/// otherwise shift every later letter onto the wrong base.
+const LATIN1_FOLD: &str = concat!(
+    "AAAAAA\0C",   // À Á Â Ã Ä Å Æ Ç
+    "EEEEIIII",    // È É Ê Ë Ì Í Î Ï
+    "\0NOOOOO\0",  // Ð Ñ Ò Ó Ô Õ Ö ×
+    "\0UUUUY\0\0", // Ø Ù Ú Û Ü Ý Þ ß
+    "aaaaaa\0c",   // à á â ã ä å æ ç
+    "eeeeiiii",    // è é ê ë ì í î ï
+    "\0nooooo\0",  // ð ñ ò ó ô õ ö ÷
+    "\0uuuuy\0y",  // ø ù ú û ü ý þ ÿ
+);
+
+/// U+0100..U+017F, in order. `\0` = leave the character alone.
+const LATIN_EXT_A_FOLD: &str = concat!(
+    "AaAaAaCc",    // Ā ā Ă ă Ą ą Ć ć
+    "CcCcCcDd",    // Ĉ ĉ Ċ ċ Č č Ď ď
+    "\0\0EeEeEe",  // Đ đ Ē ē Ĕ ĕ Ė ė
+    "EeEeGgGg",    // Ę ę Ě ě Ĝ ĝ Ğ ğ
+    "GgGgHh\0\0",  // Ġ ġ Ģ ģ Ĥ ĥ Ħ ħ
+    "IiIiIiIi",    // Ĩ ĩ Ī ī Ĭ ĭ Į į
+    "I\0\0\0JjKk", // İ ı Ĳ ĳ Ĵ ĵ Ķ ķ
+    "\0LlLlLlL",   // ĸ Ĺ ĺ Ļ ļ Ľ ľ Ŀ
+    "l\0\0NnNnN",  // ŀ Ł ł Ń ń Ņ ņ Ň
+    "n\0\0\0OoOo", // ň ŉ Ŋ ŋ Ō ō Ŏ ŏ
+    "Oo\0\0RrRr",  // Ő ő Œ œ Ŕ ŕ Ŗ ŗ
+    "RrSsSsSs",    // Ř ř Ś ś Ŝ ŝ Ş ş
+    "SsTtTt\0\0",  // Š š Ţ ţ Ť ť Ŧ ŧ
+    "UuUuUuUu",    // Ũ ũ Ū ū Ŭ ŭ Ů ů
+    "UuUuWwYy",    // Ű ű Ų ų Ŵ ŵ Ŷ ŷ
+    "YZzZzZzs",    // Ÿ Ź ź Ż ż Ž ž ſ
+);
+
+/// Damerau-Levenshtein distance between `a` and `b`, giving up once it exceeds
+/// `cap`.
+///
+/// Damerau rather than plain Levenshtein so a transposition (`Clrake` for
+/// `Clarke`) counts as one edit rather than two — a typo-squat is far more
+/// often a swap than two independent substitutions.
+///
+/// Returns `cap + 1` for "further away than `cap`", which is all a caller with
+/// a budget needs to know.
+fn damerau_within(a: &[char], b: &[char], cap: usize) -> usize {
+    if a.len().abs_diff(b.len()) > cap {
+        return cap + 1;
+    }
+    let mut prev2: Option<Vec<usize>> = None;
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    for i in 1..=a.len() {
+        let mut cur = vec![0usize; b.len() + 1];
+        cur[0] = i;
+        let mut best = cur[0];
+        for j in 1..=b.len() {
+            let cost = usize::from(a[i - 1] != b[j - 1]);
+            let mut v = (prev[j] + 1).min(cur[j - 1] + 1).min(prev[j - 1] + cost);
+            if let Some(p2) = prev2.as_ref() {
+                if i > 1 && j > 1 && a[i - 1] == b[j - 2] && a[i - 2] == b[j - 1] {
+                    v = v.min(p2[j - 2] + 1);
+                }
+            }
+            cur[j] = v;
+            best = best.min(v);
+        }
+        if best > cap {
+            // Every cell in this row already exceeds the budget, and no later
+            // row can lower it.
+            return cap + 1;
+        }
+        prev2 = Some(prev);
+        prev = cur;
+    }
+    prev[b.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mid(n: i64) -> MemberId {
+        MemberId(freenet_scaffold::util::FastHash(n))
+    }
+
+    /// The protected set used by the upstream engine's validation fixture.
+    fn fixture() -> ImpersonationChecker {
+        ImpersonationChecker::new(
+            vec![
+                ProtectedName::new(ProtectedRole::Deputy, "Ian Clarke"),
+                ProtectedName::new(ProtectedRole::Owner, "Room Owner"),
+                ProtectedName::new(ProtectedRole::Deputy, "Invite Bot"),
+            ],
+            HashSet::new(),
+        )
+    }
+
+    /// **The ported test table.** Every row was validated against the live
+    /// impersonation fixture by the Python engine in
+    /// `~/bin/river-official-autoban.sh` before this port existed; a
+    /// disagreement here means the port is wrong, not the table.
+    #[test]
+    fn tier_one_catches_identical_skeletons() {
+        let checker = fixture();
+        for (name, why) in [
+            (
+                "lan Clarke",
+                "lowercase L for capital i (the live 2026-07-25 attack)",
+            ),
+            ("1an Clarke", "digit one for capital i"),
+            ("Ian CIarke", "capital i for lowercase L"),
+            ("IAN CLARKE", "case"),
+            ("Ian Clark\u{0435}", "Cyrillic small ie"),
+            ("Ian\u{200B} Clarke", "zero-width space"),
+            ("I\u{00E0}n Clarke", "precomposed accented a"),
+            ("Ia\u{0300}n Clarke", "combining grave accent"),
+            ("Roorn Owner", "rn reads as m"),
+            ("lnvite Bot", "lowercase L for capital i"),
+            ("Ian  Clarke", "doubled space"),
+            ("IanClarke", "no space at all"),
+            ("!an Clarke", "exclamation mark for capital i"),
+            ("\u{1D408}\u{1D41A}\u{1D427} Clarke", "mathematical bold"),
+            ("\u{FF29}\u{FF41}\u{FF4E} Clarke", "fullwidth forms"),
+        ] {
+            let got = checker.check_name(name);
+            assert_eq!(
+                got.as_ref().map(|w| w.tier),
+                Some(ConfusableTier::Identical),
+                "{name:?} ({why}) should fold to an identical skeleton, got {got:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn tier_two_catches_near_misses() {
+        let checker = fixture();
+        for (name, why) in [
+            ("Ian Clark", "one character short"),
+            ("Ian Clrake", "transposition"),
+            ("Ian Clarkee", "one character long"),
+        ] {
+            let got = checker.check_name(name);
+            assert_eq!(
+                got.as_ref().map(|w| w.tier),
+                Some(ConfusableTier::NearMiss),
+                "{name:?} ({why}) should be a near-miss, got {got:?}"
+            );
+        }
+    }
+
+    /// The other half of the table, and the half that matters most: a warning
+    /// on an ordinary name is what trains people to ignore warnings.
+    #[test]
+    fn no_false_positives_on_ordinary_names() {
+        let checker = fixture();
+        for name in [
+            "Linus Clarke",
+            "Ian",
+            "HostFat",
+            "Alice",
+            "Ivvor",
+            "ofansifkapital-xmpp",
+            "Ian Clarke's Dad",
+            "Bob",
+            "Clark Kent",
+            "Owner",
+            "Bot",
+            "Invited",
+        ] {
+            assert_eq!(
+                checker.check_name(name),
+                None,
+                "{name:?} is an ordinary name and must not be flagged"
+            );
+        }
+    }
+
+    /// Requirement one, and the thing that would be worse to get wrong than to
+    /// ship nothing: the real moderator is resolved by member ID and is never
+    /// the one flagged.
+    #[test]
+    fn the_real_privileged_member_is_never_flagged() {
+        let real_ian = mid(1);
+        let real_owner = mid(2);
+        let impostor = mid(3);
+        let checker = ImpersonationChecker::new(
+            vec![
+                ProtectedName::new(ProtectedRole::Deputy, "Ian Clarke"),
+                ProtectedName::new(ProtectedRole::Owner, "Room Owner"),
+            ],
+            HashSet::from([real_ian, real_owner]),
+        );
+
+        // The real moderator, under their own exact name.
+        assert_eq!(checker.check(real_ian, "Ian Clarke"), None);
+        assert_eq!(checker.check(real_owner, "Room Owner"), None);
+        // A privileged member is safe whatever they call themselves, including
+        // a name that collides with a DIFFERENT protected name — the room owner
+        // renaming themselves "Ian Clarke" is not impersonation.
+        assert_eq!(checker.check(real_owner, "Ian Clarke"), None);
+        assert_eq!(checker.check(real_ian, "lan Clarke"), None);
+        assert!(checker.is_privileged(real_ian));
+        assert!(!checker.is_privileged(impostor));
+        // The impostor, under the same names, IS flagged.
+        assert!(checker.check(impostor, "Ian Clarke").is_some());
+        assert!(checker.check(impostor, "lan Clarke").is_some());
+    }
+
+    /// Two members with confusable ORDINARY names must not warn about each
+    /// other: only privileged names are protected, or the warning becomes
+    /// noise.
+    #[test]
+    fn only_privileged_names_are_protected() {
+        let checker = fixture();
+        assert_eq!(checker.check(mid(9), "Dave Smith"), None);
+        assert_eq!(checker.check(mid(10), "Dave Srnith"), None);
+    }
+
+    #[test]
+    fn an_empty_protected_set_never_warns() {
+        let checker = ImpersonationChecker::new(Vec::new(), HashSet::new());
+        assert!(checker.is_empty());
+        assert_eq!(checker.check(mid(1), "Ian Clarke"), None);
+        assert_eq!(checker.check_name("lan Clarke"), None);
+    }
+
+    /// A protected name that folds to nothing (a nickname of nothing but emoji)
+    /// must not match every name in the room.
+    #[test]
+    fn an_empty_skeleton_matches_nothing() {
+        let checker = ImpersonationChecker::new(
+            vec![ProtectedName::new(ProtectedRole::Deputy, "\u{1F6E1}")],
+            HashSet::new(),
+        );
+        assert_eq!(skeleton("\u{1F6E1}"), "");
+        assert_eq!(checker.check_name("Alice"), None);
+        assert_eq!(checker.check_name(""), None);
+        assert_eq!(checker.check_name("\u{1F451}"), None);
+    }
+
+    /// An exact skeleton match anywhere in the protected set outranks a
+    /// near-miss elsewhere, whatever order the set was built in.
+    #[test]
+    fn identical_outranks_near_miss_regardless_of_order() {
+        let names = [
+            ProtectedName::new(ProtectedRole::Deputy, "Ian Clarke"),
+            ProtectedName::new(ProtectedRole::Deputy, "lan Clarkes"),
+        ];
+        for order in [[0, 1], [1, 0]] {
+            let checker = ImpersonationChecker::new(
+                order.iter().map(|i| names[*i].clone()).collect(),
+                HashSet::new(),
+            );
+            let w = checker.check_name("Ian Clarke").expect("flagged");
+            assert_eq!(w.tier, ConfusableTier::Identical);
+            assert_eq!(w.impersonated.display_name, "Ian Clarke");
+        }
+    }
+
+    /// The owner is the more severe impersonation, so a name that near-misses
+    /// both roles names the owner — deterministically, not by set order.
+    #[test]
+    fn owner_outranks_deputy_for_a_near_miss() {
+        let owner = ProtectedName::new(ProtectedRole::Owner, "Alexander Doe");
+        let deputy = ProtectedName::new(ProtectedRole::Deputy, "Alexandra Doe");
+        for order in [
+            vec![owner.clone(), deputy.clone()],
+            vec![deputy.clone(), owner.clone()],
+        ] {
+            let checker = ImpersonationChecker::new(order, HashSet::new());
+            let w = checker.check_name("Alexanderr Doe").expect("flagged");
+            assert_eq!(w.tier, ConfusableTier::NearMiss);
+            assert_eq!(w.impersonated.role, ProtectedRole::Owner);
+        }
+    }
+
+    /// Short names switch tier 2 off: at four characters or fewer a single edit
+    /// turns most names into most other names.
+    #[test]
+    fn short_names_require_an_identical_skeleton() {
+        let checker = ImpersonationChecker::new(
+            vec![ProtectedName::new(ProtectedRole::Deputy, "Ada")],
+            HashSet::new(),
+        );
+        assert_eq!(checker.check_name("Ida"), None, "one edit, but too short");
+        assert_eq!(checker.check_name("Adam"), None);
+        // The identical-skeleton path still fires.
+        assert!(checker.check_name("Ad@").is_some());
+        assert_eq!(edit_budget(4), 0);
+        assert_eq!(edit_budget(5), 1);
+        assert_eq!(edit_budget(12), 1);
+        assert_eq!(edit_budget(13), 2);
+    }
+
+    /// The fold order is part of the validated behaviour, not an implementation
+    /// detail: running the multi-character map first would rewrite `"cl"` to
+    /// `"d"` and change which ordinary names land on a moderator's skeleton.
+    #[test]
+    fn skeleton_folds_in_reference_order() {
+        assert_eq!(skeleton("Clarke"), "ciarke");
+        assert_ne!(skeleton("Clarke"), "darke");
+        // `rn -> m` is still live, because no earlier rule rewrites r or n.
+        assert_eq!(skeleton("Roorn"), "room");
+        assert_eq!(skeleton("Ivvor"), "iwor");
+        assert_eq!(skeleton("Annie"), "amie");
+    }
+
+    #[test]
+    fn skeleton_normalises_case_space_and_invisibles() {
+        assert_eq!(skeleton("  Ian   Clarke  "), "ian ciarke");
+        assert_eq!(skeleton("IAN CLARKE"), "ian ciarke");
+        assert_eq!(skeleton("Ian\u{00A0}Clarke"), "ian ciarke");
+        assert_eq!(skeleton("Ian\u{3000}Clarke"), "ian ciarke");
+        assert_eq!(skeleton("Ian\u{200B}Clarke"), "ianciarke");
+    }
+
+    /// Damerau, not Levenshtein: a swap is one edit.
+    #[test]
+    fn transposition_costs_one_edit() {
+        let ab: Vec<char> = "abcd".chars().collect();
+        let ba: Vec<char> = "abdc".chars().collect();
+        assert_eq!(damerau_within(&ab, &ba, 2), 1);
+        let far: Vec<char> = "zzzz".chars().collect();
+        assert_eq!(damerau_within(&ab, &far, 1), 2, "capped, not exact");
+        assert_eq!(damerau_within(&ab, &ab, 0), 0);
+        // The length shortcut must not under-report a reachable distance.
+        let long: Vec<char> = "abcdefgh".chars().collect();
+        assert_eq!(damerau_within(&ab, &long, 2), 3);
+    }
+
+    /// The Latin fold tables are positional, so a miscounted `\0` would
+    /// silently shift every later letter onto the wrong base.
+    #[test]
+    fn latin_fold_tables_are_aligned() {
+        assert_eq!(LATIN1_FOLD.chars().count(), 64);
+        assert_eq!(LATIN_EXT_A_FOLD.chars().count(), 128);
+        for (input, want) in [
+            ('\u{00C0}', Some('A')), // À
+            ('\u{00C7}', Some('C')), // Ç
+            ('\u{00CF}', Some('I')), // Ï
+            ('\u{00D1}', Some('N')), // Ñ
+            ('\u{00D6}', Some('O')), // Ö
+            ('\u{00DC}', Some('U')), // Ü
+            ('\u{00DD}', Some('Y')), // Ý
+            ('\u{00E0}', Some('a')), // à
+            ('\u{00E9}', Some('e')), // é
+            ('\u{00F1}', Some('n')), // ñ
+            ('\u{00F6}', Some('o')), // ö
+            ('\u{00FC}', Some('u')), // ü
+            ('\u{00FD}', Some('y')), // ý
+            ('\u{00FF}', Some('y')), // ÿ
+            ('\u{00C6}', None),      // Æ has no decomposition
+            ('\u{00D0}', None),      // Ð
+            ('\u{00D7}', None),      // × is not a letter
+            ('\u{00D8}', None),      // Ø
+            ('\u{00DE}', None),      // Þ
+            ('\u{00DF}', None),      // ß
+            ('\u{00E6}', None),      // æ
+            ('\u{00F0}', None),      // ð
+            ('\u{00F7}', None),      // ÷
+            ('\u{00F8}', None),      // ø
+            ('\u{00FE}', None),      // þ
+            ('\u{0100}', Some('A')), // Ā
+            ('\u{0107}', Some('c')), // ć
+            ('\u{010F}', Some('d')), // ď
+            ('\u{0119}', Some('e')), // ę
+            ('\u{0121}', Some('g')), // ġ
+            ('\u{0130}', Some('I')), // İ
+            ('\u{0135}', Some('j')), // ĵ
+            ('\u{0136}', Some('K')), // Ķ
+            ('\u{013E}', Some('l')), // ľ
+            ('\u{0144}', Some('n')), // ń
+            ('\u{014D}', Some('o')), // ō
+            ('\u{0159}', Some('r')), // ř
+            ('\u{0160}', Some('S')), // Š
+            ('\u{0165}', Some('t')), // ť
+            ('\u{016F}', Some('u')), // ů
+            ('\u{0175}', Some('w')), // ŵ
+            ('\u{0178}', Some('Y')), // Ÿ
+            ('\u{017E}', Some('z')), // ž
+            ('\u{017F}', Some('s')), // ſ
+            ('\u{0110}', None),      // Đ
+            ('\u{0126}', None),      // Ħ
+            ('\u{0131}', None),      // ı, a letter in its own right
+            ('\u{0138}', None),      // ĸ
+            ('\u{0141}', None),      // Ł
+            ('\u{0149}', None),      // ŉ
+            ('\u{0152}', None),      // Œ
+            ('\u{0166}', None),      // Ŧ
+        ] {
+            assert_eq!(
+                strip_latin_accent(input),
+                want,
+                "U+{:04X} folded wrong",
+                u32::from(input)
+            );
+        }
+    }
+
+    #[test]
+    fn presentation_forms_fold_to_ascii() {
+        // Mathematical bold / sans-serif / italic "Ian".
+        assert_eq!(skeleton("\u{1D408}\u{1D41A}\u{1D427}"), "ian");
+        assert_eq!(skeleton("\u{1D5DC}\u{1D5EE}\u{1D5FB}"), "ian");
+        assert_eq!(skeleton("\u{1D470}\u{1D482}\u{1D48F}"), "ian");
+        // Fullwidth.
+        assert_eq!(skeleton("\u{FF29}\u{FF41}\u{FF4E}"), "ian");
+        // Letterlike symbols. U+2113 SCRIPT SMALL L folds to `l`, which the
+        // ASCII map then folds to `i` like any other `l`.
+        assert_eq!(skeleton("\u{2115}"), "n");
+        assert_eq!(skeleton("\u{2113}"), "i");
+    }
+
+    /// Real names in other scripts must not fold onto a Latin moderator's name.
+    /// This is the same guard
+    /// `display_name::real_names_in_other_scripts_are_untouched` provides for
+    /// sanitisation, applied to the confusable fold — a rule that warns on real
+    /// people's names is worse than the problem it solves.
+    #[test]
+    fn real_names_in_other_scripts_are_not_flagged() {
+        let checker = ImpersonationChecker::new(
+            vec![
+                ProtectedName::new(ProtectedRole::Deputy, "Ian Clarke"),
+                ProtectedName::new(ProtectedRole::Owner, "Room Owner"),
+                ProtectedName::new(ProtectedRole::Deputy, "Alice Chen"),
+            ],
+            HashSet::new(),
+        );
+        for name in [
+            "李小龍",
+            "さくら 田中",
+            "김민준",
+            "محمد عبد الله",
+            "דָּוִד",
+            "Иван Петров",
+            "Γιώργος Παπαδόπουλος",
+            "अमिताभ बच्चन",
+            "François Müller",
+            "Ægir Þórsson",
+            "Nguyễn Thị Hương",
+            "José Ñuñez",
+            "O'Brien-Smith Jr.",
+            "山田\u{3000}太郎",
+            "สมชาย ใจดี",
+            "Արամ Խաչատրյան",
+            "გიორგი ბერიძე",
+            "ኃይሌ ገብረሥላሴ",
+            "Νίκος Παπαδόπουλος",
+            "Ольга Иванова",
+        ] {
+            assert_eq!(
+                checker.check_name(name),
+                None,
+                "a legitimate name was flagged as impersonation: {name:?}"
+            );
+        }
+    }
+
+    /// River hands every member an auto-generated handle
+    /// (`crate::nickname::FIRST_NAMES` x `LAST_NAMES`, 10,000 combinations). If
+    /// two of those folded to the same skeleton, a room where a deputy holds a
+    /// generated handle would warn about an innocent member who was simply
+    /// assigned a neighbouring one — the exact warning-fatigue failure this
+    /// feature must avoid, arriving by default rather than by attack.
+    ///
+    /// **This is the tier-1 guarantee, and it holds.** The tier-2 equivalent
+    /// does NOT — see `generated_handles_are_within_the_near_miss_budget`, which
+    /// is why the UI renders tier 1 only.
+    #[test]
+    fn generated_handles_never_fold_to_the_same_skeleton() {
+        let mut seen: std::collections::HashMap<String, (&str, &str)> =
+            std::collections::HashMap::new();
+        let mut count = 0usize;
+        for first in crate::nickname::FIRST_NAMES {
+            for last in crate::nickname::LAST_NAMES {
+                let handle = format!("{first} {last}");
+                let sk = skeleton(&handle);
+                if let Some(prev) = seen.insert(sk.clone(), (first, last)) {
+                    panic!(
+                        "generated handles {prev:?} and {:?} fold to the same skeleton {sk:?}; \
+                         a deputy holding one would make the other look like an impostor",
+                        (first, last)
+                    );
+                }
+                count += 1;
+            }
+        }
+        assert_eq!(count, 10_000);
+    }
+
+    /// **The measurement behind the tier decision.** The near-miss tier flags a
+    /// pair of names River itself assigns, so rendering it would put an
+    /// impersonation badge on a member who did nothing but accept the handle
+    /// they were given.
+    ///
+    /// This test asserts the collision EXISTS. That reads backwards for a test,
+    /// and is deliberate: the original version of it asserted the opposite —
+    /// that no two generated handles are within the edit budget — and shipped
+    /// red, because the property is simply false of River's word lists and no
+    /// reasonable code change makes it true (you would have to change the
+    /// 10,000 handles, renaming every member who never chose a nickname). The
+    /// honest fix is to record the fact and let it drive the design, so:
+    ///
+    /// * this test pins that the fact is still true, and
+    /// * `members::near_miss_is_never_rendered` pins that the UI does not act
+    ///   on it.
+    ///
+    /// If a future change to `FIRST_NAMES`/`LAST_NAMES` or to [`edit_budget`]
+    /// makes generated handles tier-2-clean, this test fails — and reversing the
+    /// tier decision becomes a live option rather than a guess.
+    #[test]
+    fn generated_handles_are_within_the_near_miss_budget() {
+        // The concrete pair, spelled out rather than swept for, so the failure
+        // message names the problem instead of describing it.
+        let a = skeleton("Amber Worm");
+        let b = skeleton("Ember Worm");
+        assert_ne!(a, b, "different skeletons, so tier 1 does not fire");
+        let (ac, bc): (Vec<char>, Vec<char>) = (a.chars().collect(), b.chars().collect());
+        let budget = edit_budget(ac.len());
+        assert!(
+            budget > 0 && damerau_within(&ac, &bc, budget) <= budget,
+            "`Amber Worm` and `Ember Worm` are no longer within the near-miss \
+             budget ({a:?} vs {b:?}, budget {budget}); the measurement that \
+             justifies rendering tier 1 only no longer holds — re-examine \
+             `members::impersonation_warning_for_display`"
+        );
+    }
+
+    /// The tooltip must name the remedy, not merely alarm. A bare warning
+    /// glyph teaches nobody what to do about it.
+    #[test]
+    fn tooltip_names_the_remedy() {
+        let deputy = ImpersonationWarning {
+            impersonated: ProtectedName::new(ProtectedRole::Deputy, "Ian Clarke"),
+            tier: ConfusableTier::Identical,
+        }
+        .tooltip();
+        assert!(deputy.contains("Ian Clarke"), "{deputy}");
+        assert!(deputy.contains("is NOT a moderator"), "{deputy}");
+        assert!(
+            deputy.contains('\u{1f6e1}'),
+            "must point at the shield: {deputy}"
+        );
+
+        let owner = ImpersonationWarning {
+            impersonated: ProtectedName::new(ProtectedRole::Owner, "Room Owner"),
+            tier: ConfusableTier::NearMiss,
+        }
+        .tooltip();
+        assert!(owner.contains("is NOT the room owner"), "{owner}");
+        assert!(
+            owner.contains('\u{1f451}'),
+            "the owner is marked with a crown, not a shield: {owner}"
+        );
+        // The shield is NOT the remedy for an owner collision: the owner never
+        // carries a deputy shield, so telling the reader to look for one would
+        // send them hunting for something that is correctly absent.
+        assert!(!owner.contains('\u{1f6e1}'), "{owner}");
+    }
+
+    /// **The tooltip-injection guard.** A protected name is attacker-choosable
+    /// (any strict ancestor of the viewer can deputise a sockpuppet and name it
+    /// whatever they like), so the tooltip is built as though it were.
+    ///
+    /// The payload here is the one that broke `DeputyBadge::tooltip`: a nickname
+    /// carrying its own quote characters and role-shaped prose. Two properties
+    /// must hold — the name is TERMINAL (so nothing we assert can appear after
+    /// attacker text), and the closing quote is OURS (so the attacker cannot
+    /// break out of the brackets).
+    #[test]
+    fn tooltip_cannot_be_forged_by_a_crafted_protected_name() {
+        let payload = "Bob\u{201d}, the room owner, \u{201c}Carol";
+        for role in [ProtectedRole::Deputy, ProtectedRole::Owner] {
+            let tip = ImpersonationWarning {
+                impersonated: ProtectedName::new(role, payload),
+                tier: ConfusableTier::Identical,
+            }
+            .tooltip();
+
+            // The attacker's quote characters are gone, so the brackets around
+            // the name are ours and cannot be escaped.
+            assert_eq!(
+                tip.matches('\u{201c}').count(),
+                1,
+                "exactly one opening quote, ours: {tip}"
+            );
+            assert_eq!(
+                tip.matches('\u{201d}').count(),
+                1,
+                "exactly one closing quote, ours: {tip}"
+            );
+
+            // The name is TERMINAL: the tooltip ends with the quoted name, so
+            // no attacker text can be followed by prose the reader would take
+            // as ours.
+            assert!(
+                tip.ends_with('\u{201d}'),
+                "the imitated name must be last: {tip}"
+            );
+            let opened = tip.find('\u{201c}').expect("an opening quote");
+            assert!(
+                !tip[..opened].contains("Bob") && !tip[..opened].contains("Carol"),
+                "no attacker text may appear before the quoted name: {tip}"
+            );
+        }
+    }
+
+    /// The warning glyph must be one a nickname can never contain, or an
+    /// impostor could paint a warning onto their own name and make the real
+    /// signal look like decoration.
+    ///
+    /// Checked against BOTH halves of the display-name boundary, because they
+    /// protect different entry points: `sanitize_display_name` is the render-time
+    /// strip that `riverctl`-written nicknames go through, and
+    /// `contains_hidden_chars` is what the nickname `<input>` rejects.
+    #[test]
+    fn the_warning_glyph_cannot_appear_in_a_nickname() {
+        let glyph = WARNING_GLYPH.chars().next().expect("one char");
+        assert_eq!(WARNING_GLYPH.chars().count(), 1, "one codepoint, no VS16");
+        assert!(is_display_hidden(glyph));
+        assert!(crate::util::display_name::contains_hidden_chars(
+            WARNING_GLYPH
+        ));
+        assert_eq!(
+            crate::util::display_name::sanitize_display_name(&format!("Eve {WARNING_GLYPH}")),
+            "Eve"
+        );
+        // Also in its emoji-presentation form, which is what a phone keyboard
+        // inserts and what a copy-paste from most web pages carries.
+        assert_eq!(
+            crate::util::display_name::sanitize_display_name(&format!(
+                "Eve {WARNING_GLYPH}\u{FE0F}"
+            )),
+            "Eve"
+        );
+    }
+}

--- a/ui/src/util/confusable.rs
+++ b/ui/src/util/confusable.rs
@@ -115,6 +115,15 @@
 //!   meaning-bearing than the Latin ones, and widening the strip is exactly the
 //!   kind of change that starts flagging real people in scripts this codebase
 //!   has no test corpus for. Revisit only with a corpus.
+//! * **The shape-homoglyph blocks (Lisu, Cherokee, Coptic) are taken from
+//!   UTR39 `confusables.txt`, not eyeballed.** That is deliberate: several
+//!   Lisu letters are ROTATED or mirrored Latin capitals rather than upright
+//!   ones, and reading them off a chart gets it wrong in both directions. The
+//!   letters those blocks contain that UTR39 does not list stay unfolded.
+//!   Cherokee is the widest false-positive surface in the file — it is a
+//!   living script — but its letters are SYLLABLES, so what a Cherokee name
+//!   folds to is not a word in any language and cannot land on a moderator by
+//!   accident.
 //! * This module compares names. It does not, and cannot, tell you whether the
 //!   person behind an unflagged name is who they say they are.
 
@@ -888,22 +897,45 @@ fn fold_homoglyph(c: char) -> char {
         '\u{03F9}' => 'C',
         '\u{03F2}' => 'c',
         // Coptic. These capitals are drawn as their Latin lookalikes in every
-        // Coptic font; the lowercase forms sit at +1.
+        // Coptic font, and the lowercase form sits at +1 — so the two are
+        // folded as PAIRS. Four lowercase letters were missing while their
+        // capitals were folded (`\u{2C89}`, `\u{2C93}`, `\u{2C95}`,
+        // `\u{2C9B}`), which is a half-closed block rather than a decision.
+        // The entries UTR39 lists and this table did not are here too.
         '\u{2C80}' => 'A',
         '\u{2C81}' => 'a',
+        '\u{2C82}' => 'B',
+        '\u{2C83}' => 'b',
+        '\u{2C85}' => 'r', // small gamma; the CAPITAL is Γ-shaped and is not here
         '\u{2C88}' => 'E',
+        '\u{2C89}' => 'e',
         '\u{2C8E}' => 'H',
+        '\u{2C8F}' => 'h',
         '\u{2C92}' => 'I',
+        '\u{2C93}' => 'i',
         '\u{2C94}' => 'K',
+        '\u{2C95}' => 'k',
         '\u{2C98}' => 'M',
+        '\u{2C99}' => 'm',
         '\u{2C9A}' => 'N',
+        '\u{2C9B}' => 'n',
         '\u{2C9E}' => 'O',
         '\u{2C9F}' => 'o',
         '\u{2CA2}' => 'P',
+        '\u{2CA3}' => 'p',
         '\u{2CA4}' => 'C',
         '\u{2CA5}' => 'c',
         '\u{2CA6}' => 'T',
+        '\u{2CA7}' => 't',
+        '\u{2CA8}' => 'Y',
+        '\u{2CA9}' => 'y',
         '\u{2CAC}' => 'X',
+        '\u{2CAD}' => 'x',
+        '\u{2CBD}' => 'w',
+        '\u{2CCE}' => 'P',
+        '\u{2CCF}' => 'p',
+        '\u{2CD0}' => 'L',
+        '\u{2CD1}' => 'l',
         // Armenian. ONLY these two: `\u{0585}` and `\u{0578}` are drawn as
         // Latin `o`/`n`, and BOTH occur in real Armenian names
         // (`\u{0540}\u{578}\u{57E}\u{570}\u{561}\u{576}\u{576}\u{565}\u{57D}`,
@@ -913,11 +945,89 @@ fn fold_homoglyph(c: char) -> char {
         // corpus sweep, not by assertion.
         '\u{0585}' => 'o',
         '\u{0578}' => 'n',
-        // Cherokee, and Lisu — which was designed FROM Latin capitals, so its
-        // letters are Latin letterforms outright.
-        '\u{13DF}' => 'C',
-        '\u{A4F2}' => 'I',
+        // ---- Lisu (the Fraser alphabet) ----
+        //
+        // Designed FROM Latin capitals, so its letters are Latin letterforms
+        // outright — which is why folding two of them (`I` and `W`) and
+        // leaving the other 24 made no sense: the justification applied to the
+        // whole block, and `ꓲꓮꓠ ꓚꓡꓮꓣꓗꓰ` spelled the moderator's name in
+        // characters nothing folded.
+        //
+        // **Every mapping below is UTR39 `confusables.txt` (17.0), not a
+        // guess.** That matters here: several Fraser letters are ROTATED or
+        // MIRRORED Latin capitals rather than upright ones, and eyeballing the
+        // chart gets those wrong in both directions. UTR39 lists the upright
+        // ones; the rotated forms (`ꓒ ꓕ ꓘ ꓛ ꓞ ꓤ ꓥ ꓨ ꓩ ꓭ ꓯ ꓱ ꓵ ꓶ ꓷ`) are
+        // absent from it and stay unfolded here.
+        '\u{A4D0}' => 'B',
+        '\u{A4D1}' => 'P',
+        '\u{A4D2}' => 'd',
+        '\u{A4D3}' => 'D',
+        '\u{A4D4}' => 'T',
+        '\u{A4D6}' => 'G',
+        '\u{A4D7}' => 'K',
+        '\u{A4D9}' => 'J',
+        '\u{A4DA}' => 'C',
+        '\u{A4DC}' => 'Z',
+        '\u{A4DD}' => 'F',
+        '\u{A4DF}' => 'M',
+        '\u{A4E0}' => 'N',
+        '\u{A4E1}' => 'L',
+        '\u{A4E2}' => 'S',
+        '\u{A4E3}' => 'R',
+        '\u{A4E6}' => 'V',
+        '\u{A4E7}' => 'H',
         '\u{A4EA}' => 'W',
+        '\u{A4EB}' => 'X',
+        '\u{A4EC}' => 'Y',
+        '\u{A4EE}' => 'A',
+        '\u{A4F0}' => 'E',
+        '\u{A4F2}' => 'I',
+        '\u{A4F3}' => 'O',
+        '\u{A4F4}' => 'U',
+        // ---- Cherokee ----
+        //
+        // Same story: one letter was folded and the other 34 were not. The
+        // syllabary is a living script, so this is the widest false-positive
+        // surface added here — but a Cherokee name is written in SYLLABLES, so
+        // the Latin string it folds to is not a name in any language, and a
+        // badge needs the whole thing to land on a protected name. Sourced
+        // from UTR39; the letters absent from that file stay unfolded.
+        '\u{13A0}' => 'D',
+        '\u{13A1}' => 'R',
+        '\u{13A2}' => 'T',
+        '\u{13A5}' => 'i',
+        '\u{13A9}' => 'Y',
+        '\u{13AA}' => 'A',
+        '\u{13AB}' => 'J',
+        '\u{13AC}' => 'E',
+        '\u{13B3}' => 'W',
+        '\u{13B7}' => 'M',
+        '\u{13BB}' => 'H',
+        '\u{13BD}' => 'Y',
+        '\u{13C0}' => 'G',
+        '\u{13C2}' => 'h',
+        '\u{13C3}' => 'Z',
+        '\u{13CF}' => 'b',
+        '\u{13D2}' => 'R',
+        '\u{13D4}' => 'W',
+        '\u{13D5}' => 'S',
+        '\u{13D9}' => 'V',
+        '\u{13DA}' => 'S',
+        '\u{13DE}' => 'L',
+        '\u{13DF}' => 'C',
+        '\u{13E2}' => 'P',
+        '\u{13E6}' => 'K',
+        '\u{13E7}' => 'd',
+        '\u{13F3}' => 'G',
+        '\u{13F4}' => 'B',
+        '\u{AB75}' => 'i',
+        '\u{AB81}' => 'r',
+        '\u{AB83}' => 'w',
+        '\u{AB93}' => 'z',
+        '\u{ABA9}' => 'v',
+        '\u{ABAA}' => 's',
+        '\u{ABAF}' => 'c',
         // Latin-block letters that are not the ASCII letter they resemble:
         // `\u{01C0}` is a click consonant, `\u{0251}` the IPA script-a, and
         // `\u{0131}` is Turkish dotless i — a REAL letter in Turkish names,
@@ -940,17 +1050,27 @@ fn fold_homoglyph(c: char) -> char {
 /// Combining marks, dropped so `"I" + U+0300` folds like `"Ì"`.
 fn is_combining_mark(c: char) -> bool {
     matches!(u32::from(c),
-        // Cyrillic combining marks (titlo, palatalisation, psili...). Added
-        // because `"Ian Cla\u{0483}rke"` otherwise EVADED while `U+0300` was
-        // caught — a mark a reader barely registers must not defeat the fold.
-        // These are historic/liturgical ornaments, not part of how any modern
-        // Cyrillic name is spelled, so folding them is safe.
+        // **The Cyrillic combining marks, ALL of them.** U+0483..U+0489 was
+        // added because `"Ian Cla\u{0483}rke"` EVADED while `U+0300` was
+        // caught, and the rest of the same family was left behind — so
+        // `"Ian Cla\u{A66F}rke"` (VZMET, which sits immediately before the
+        // U+A670 range `is_display_hidden` already strips) evaded in exactly
+        // the same way. Closing a family one codepoint at a time is how the
+        // hole reopens; these are now the complete Mn/Me Cyrillic set:
+        // U+0483..U+0489, the Combining Cyrillic Letters block
+        // (U+2DE0..U+2DFF), and U+A66F plus U+A674..U+A67D.
+        //
+        // They are historic and liturgical ornaments and superscript letters,
+        // not part of how any modern Cyrillic name is spelled, so folding them
+        // is safe.
         //
         // Hebrew niqqud, Arabic harakat and Indic/Thai vowel signs are still
         // NOT here, deliberately: in those scripts marks are far more often
         // meaning-bearing, and widening the strip would start flagging real
         // people in scripts this repo has no corpus for. See the module header.
         0x0483..=0x0489
+        | 0x2DE0..=0x2DFF // Combining Cyrillic Letters
+        | 0xA66F | 0xA674..=0xA67D // vzmet, combining Cyrillic letters, kavyka, payerok
         | 0x0300..=0x036F   // Combining Diacritical Marks
         | 0x1AB0..=0x1AFF // Combining Diacritical Marks Extended
         | 0x1DC0..=0x1DFF // Combining Diacritical Marks Supplement
@@ -2350,6 +2470,94 @@ mod tests {
                 strip_latin_accent(own_letter),
                 None,
                 "{own_letter:?} is a letter in its own right"
+            );
+        }
+    }
+
+    /// **Whole-block coverage where the file previously folded one or two
+    /// letters out of a block.** Lisu had 2 of 26, Cherokee 1 of 35, and four
+    /// Coptic lowercase letters were missing while their capitals folded.
+    ///
+    /// Partial coverage reads like a judgement and is not one: the comment
+    /// justifying the two Lisu entries ("designed FROM Latin capitals, so its
+    /// letters are Latin letterforms outright") applies to the whole block, so
+    /// the other 24 were an oversight that spelled a moderator's name in
+    /// characters nothing folded.
+    #[test]
+    fn partially_covered_blocks_are_now_complete() {
+        for (label, attacker, real) in [
+            (
+                "Lisu, whole name",
+                "\u{A4F2}\u{A4EE}\u{A4E0} \u{A4DA}\u{A4E1}\u{A4EE}\u{A4E3}\u{A4D7}\u{A4F0}",
+                "Ian Clarke",
+            ),
+            ("Lisu R", "Ian Cla\u{A4E3}ke", "Ian Clarke"),
+            ("Lisu N", "Ia\u{A4E0} Clarke", "Ian Clarke"),
+            (
+                "Cherokee, whole name",
+                "\u{13A2}\u{13AA}\u{13C0} \u{13DF}\u{13DE}\u{13AA}\u{13D2}\u{13E6}\u{13AC}",
+                "Tag Clarke",
+            ),
+            ("Cherokee R", "Ian Cla\u{13D2}ke", "Ian Clarke"),
+            ("Cherokee W", "\u{13B3}illiam", "William"),
+            ("Coptic small eie", "Ian Clark\u{2C89}", "Ian Clarke"),
+            ("Coptic small kapa", "Ian Clar\u{2C95}e", "Ian Clarke"),
+            ("Coptic small ni", "Ia\u{2C9B} Clarke", "Ian Clarke"),
+            ("Coptic small iauda", "\u{2C93}nvite Bot", "invite Bot"),
+        ] {
+            let checker = ImpersonationChecker::new(vec![ProtectedName::new(
+                ProtectedRole::Deputy,
+                real,
+                mid(1),
+            )]);
+            let w = checker
+                .check(mid(2), attacker)
+                .unwrap_or_else(|| panic!("{label}: {attacker:?} vs {real:?}"));
+            assert_eq!(w.tier, ConfusableTier::Identical, "{label}");
+        }
+
+        // The Lisu letters UTR39 does NOT list are ROTATED or MIRRORED Latin
+        // capitals, not upright ones. They stay unfolded — folding them would
+        // be inventing a confusable from a chart glance.
+        for rotated in [
+            '\u{A4D5}', // THA
+            '\u{A4D8}', // KHA
+            '\u{A4DB}', // CHA
+            '\u{A4E5}', // NGA
+            '\u{A4EF}', // AE
+            '\u{A4F1}', // EU
+        ] {
+            assert_eq!(
+                fold_homoglyph(rotated),
+                rotated,
+                "{rotated:?} is a rotated Latin form and is absent from UTR39"
+            );
+        }
+    }
+
+    /// **The Cyrillic combining family, closed.** `0x0483..=0x0489` was added
+    /// when `"Ian Cla\u{0483}rke"` evaded; the rest of the same family was
+    /// left, so `"Ian Cla\u{A66F}rke"` evaded in exactly the same way —
+    /// U+A66F sits immediately before the U+A670..A672 range
+    /// `is_display_hidden` already strips.
+    #[test]
+    fn the_whole_cyrillic_combining_family_is_stripped() {
+        for mark in [
+            '\u{0483}', // titlo
+            '\u{0487}', // pokrytie
+            '\u{A66F}', // vzmet
+            '\u{A674}', // combining Ukrainian ie
+            '\u{A67C}', // kavyka
+            '\u{A67D}', // payerok
+            '\u{2DE0}', // combining Cyrillic be
+            '\u{2DFF}', // combining iotified big yus
+        ] {
+            let spoofed = format!("Ian Cla{mark}rke");
+            assert_eq!(
+                skeleton(&spoofed),
+                skeleton("Ian Clarke"),
+                "a combining mark a reader barely registers defeated the fold: \
+                 {mark:?}"
             );
         }
     }

--- a/ui/src/util/confusable.rs
+++ b/ui/src/util/confusable.rs
@@ -161,55 +161,54 @@ pub struct ImpersonationWarning {
 pub const WARNING_GLYPH: &str = "\u{26a0}";
 
 impl ImpersonationWarning {
-    /// The `title=` / `aria-label` text.
+    /// The `title=` / `aria-label` text, built **ONLY from trusted literals**.
     ///
     /// Three things, because a bare ⚠ teaches nobody anything: what is wrong,
-    /// that this member is *not* the person they resemble, and what to look for
+    /// that this member is *not* who they resemble, and what to look for
     /// instead. One definition for every surface, so the warning cannot say
     /// different things in different places — the same rule
     /// [`crate::components::members::DeputyBadge::tooltip`] follows for the
     /// shield.
     ///
-    /// ## The interpolated name is attacker-controlled, and its position is a
-    /// security property
+    /// ## No nickname reaches this string, and none may be added
     ///
-    /// `display_name` is a *protected* member's nickname, which sounds
-    /// trustworthy and is not. Nothing in `MemberInfoV1::verify` validates a
-    /// `deputies` list, so any member who is a strict ancestor of the viewer can
-    /// deputise a sockpuppet and choose its nickname freely — and that
-    /// sockpuppet is then a protected name in the viewer's view. So this string
-    /// is written as though the name were chosen by an attacker, because it can
-    /// be.
+    /// `impersonated.display_name` is right there on the struct and naming the
+    /// imitated member reads like an improvement. It is not, and it must not be
+    /// re-attempted:
     ///
-    /// Two rules, both load-bearing, pinned by
-    /// `tooltip_cannot_be_forged_by_a_crafted_protected_name`:
+    /// * **The name is attacker-choosable.** Nothing in `MemberInfoV1::verify`
+    ///   validates a `deputies` list, so any member who is a strict ancestor of
+    ///   the viewer can deputise a sockpuppet and name it whatever they like.
+    ///   That sockpuppet is then a protected name in the viewer's view.
+    /// * **A `title=` attribute is a flat string, so quoting is not a defense.**
+    ///   `DeputyBadge::tooltip` learned this the hard way (#488): the forging
+    ///   primitive is the COMMA, not the quote, and a payload like
+    ///   `Bob, the room owner, Carol` needs no quote character at all. Putting
+    ///   the name last and stripping its quotes narrows the hole but does not
+    ///   close it — the reader still cannot tell our sentence from theirs at
+    ///   tooltip size.
+    /// * **Naming it buys almost nothing here.** Only
+    ///   [`ConfusableTier::Identical`] is rendered, which means the imitated
+    ///   name folds to the *same skeleton* as the name beside the badge — the
+    ///   reader is already looking at it. What they cannot see, and what this
+    ///   string supplies, is the ROLE being imitated and the badge to check for.
     ///
-    /// * **The name goes LAST.** Every claim this tooltip makes is already made
-    ///   before the attacker's text begins, so no nickname content can be read
-    ///   as one of our own role labels. `DeputyBadge::tooltip` had the opposite
-    ///   shape — attacker names `join(", ")`-ed into the middle of a sentence —
-    ///   and a member called `Bob, the room owner, Carol` turned it into a
-    ///   forged appointment. Do not move the name earlier.
-    /// * **The quote characters are stripped from the name**, so the closing
-    ///   `\u{201d}` is always ours. Without this the quoting is decorative
-    ///   rather than protective: the payload IS the quote character. Same fix,
-    ///   for the same reason, as `relevant_deputizer_names`.
+    /// If a surface can render separate DOM nodes, it may show the name from
+    /// [`ImpersonationWarning::impersonated`] as its own element, where a comma
+    /// inside one node cannot span two — the approach `DeputyBadge::appointer_names`
+    /// takes for the member-info modal. Never join it into this string.
+    ///
+    /// Pinned by `tooltip_contains_no_nickname_content`.
     pub fn tooltip(&self) -> String {
-        let name = self
-            .impersonated
-            .display_name
-            .replace(['\u{201c}', '\u{201d}'], "");
         match self.impersonated.role {
-            ProtectedRole::Owner => format!(
-                "Impersonation warning: this member is NOT the room owner, but their \
-                 name closely resembles the owner's. The real owner is marked \
-                 \u{1f451} in the member list. Name imitated: \u{201c}{name}\u{201d}"
-            ),
-            ProtectedRole::Deputy => format!(
-                "Impersonation warning: this member is NOT a moderator, but their name \
-                 closely resembles one. A real moderator shows a \u{1f6e1} shield next \
-                 to their name. Name imitated: \u{201c}{name}\u{201d}"
-            ),
+            ProtectedRole::Owner => "Impersonation warning: this member is NOT the room owner, \
+                 but their name closely resembles the owner's. The real owner is marked \
+                 \u{1f451} in the member list."
+                .to_string(),
+            ProtectedRole::Deputy => "Impersonation warning: this member is NOT a moderator, \
+                 but their name closely resembles one. A real moderator shows a \u{1f6e1} \
+                 shield next to their name."
+                .to_string(),
         }
     }
 }
@@ -1142,7 +1141,6 @@ mod tests {
             tier: ConfusableTier::Identical,
         }
         .tooltip();
-        assert!(deputy.contains("Ian Clarke"), "{deputy}");
         assert!(deputy.contains("is NOT a moderator"), "{deputy}");
         assert!(
             deputy.contains('\u{1f6e1}'),
@@ -1167,48 +1165,51 @@ mod tests {
 
     /// **The tooltip-injection guard.** A protected name is attacker-choosable
     /// (any strict ancestor of the viewer can deputise a sockpuppet and name it
-    /// whatever they like), so the tooltip is built as though it were.
+    /// whatever they like), and a `title=` attribute is a flat string in which
+    /// quoting is not a defense — the forging primitive is the COMMA, as
+    /// `DeputyBadge::tooltip` established in #488.
     ///
-    /// The payload here is the one that broke `DeputyBadge::tooltip`: a nickname
-    /// carrying its own quote characters and role-shaped prose. Two properties
-    /// must hold — the name is TERMINAL (so nothing we assert can appear after
-    /// attacker text), and the closing quote is OURS (so the attacker cannot
-    /// break out of the brackets).
+    /// So the property is not "the name is positioned safely", it is **no
+    /// nickname content reaches the tooltip at all**. Asserted the strong way:
+    /// the tooltip for a wildly hostile name must be byte-identical to the
+    /// tooltip for an innocuous one. Any interpolation whatsoever fails that,
+    /// including a future "clever" escaping scheme.
     #[test]
-    fn tooltip_cannot_be_forged_by_a_crafted_protected_name() {
-        let payload = "Bob\u{201d}, the room owner, \u{201c}Carol";
+    fn tooltip_contains_no_nickname_content() {
+        // The payload that broke the deputy tooltip, plus a few other shapes a
+        // future interpolation might be tempted to think it had handled.
+        let payloads = [
+            "Bob\u{201d}, the room owner, \u{201c}Carol",
+            "Bob, the room owner, Carol",
+            "Alice\". This member is verified. \"",
+            "\u{202e}redlo mooR",
+            "Ian Clarke",
+            "",
+        ];
         for role in [ProtectedRole::Deputy, ProtectedRole::Owner] {
-            let tip = ImpersonationWarning {
-                impersonated: ProtectedName::new(role, payload),
+            let baseline = ImpersonationWarning {
+                impersonated: ProtectedName::new(role, "Anodyne"),
                 tier: ConfusableTier::Identical,
             }
             .tooltip();
 
-            // The attacker's quote characters are gone, so the brackets around
-            // the name are ours and cannot be escaped.
-            assert_eq!(
-                tip.matches('\u{201c}').count(),
-                1,
-                "exactly one opening quote, ours: {tip}"
-            );
-            assert_eq!(
-                tip.matches('\u{201d}').count(),
-                1,
-                "exactly one closing quote, ours: {tip}"
-            );
+            for payload in payloads {
+                let tip = ImpersonationWarning {
+                    impersonated: ProtectedName::new(role, payload),
+                    tier: ConfusableTier::Identical,
+                }
+                .tooltip();
+                assert_eq!(
+                    tip, baseline,
+                    "the tooltip changed with the protected name, so nickname \
+                     content is reaching it: {payload:?}"
+                );
+            }
 
-            // The name is TERMINAL: the tooltip ends with the quoted name, so
-            // no attacker text can be followed by prose the reader would take
-            // as ours.
-            assert!(
-                tip.ends_with('\u{201d}'),
-                "the imitated name must be last: {tip}"
-            );
-            let opened = tip.find('\u{201c}').expect("an opening quote");
-            assert!(
-                !tip[..opened].contains("Bob") && !tip[..opened].contains("Carol"),
-                "no attacker text may appear before the quoted name: {tip}"
-            );
+            // And it still says something useful without any name in it: which
+            // ROLE is being imitated, and the badge to look for.
+            assert!(baseline.contains("Impersonation warning"), "{baseline}");
+            assert!(baseline.contains("is NOT"), "{baseline}");
         }
     }
 

--- a/ui/src/util/confusable.rs
+++ b/ui/src/util/confusable.rs
@@ -97,7 +97,17 @@
 
 use crate::util::display_name::is_display_hidden;
 use river_core::room_state::member::MemberId;
-use std::collections::HashSet;
+
+/// A `MemberId` no real member can hold, used by [`check_name`] so a test that
+/// does not care about identity still routes through the same per-name
+/// exemption logic production uses.
+///
+/// `MemberId` wraps a `FastHash(i64)`; production ids are BLAKE3-derived from a
+/// verifying key, so `i64::MIN` is not reachable in practice. Nothing depends on
+/// it being unreachable for CORRECTNESS — the worst case is that a test's
+/// candidate is exempted from one protected name — but keeping it out of band
+/// keeps the tests honest.
+const NO_SUCH_MEMBER: MemberId = MemberId(freenet_scaffold::util::FastHash(i64::MIN));
 
 /// How close a name is to a protected one.
 ///
@@ -141,6 +151,10 @@ pub struct ProtectedName {
     pub role: ProtectedRole,
     /// The privileged member's display name, already sanitised.
     pub display_name: String,
+    /// **The member this name was taken from.** The exemption is keyed on this
+    /// rather than on a room-wide "privileged" set: see
+    /// [`ImpersonationChecker::check`].
+    pub source: MemberId,
     visual: String,
     visual_no_space: String,
     case_insensitive: String,
@@ -148,12 +162,13 @@ pub struct ProtectedName {
 }
 
 impl ProtectedName {
-    pub fn new(role: ProtectedRole, display_name: impl Into<String>) -> Self {
+    pub fn new(role: ProtectedRole, display_name: impl Into<String>, source: MemberId) -> Self {
         let display_name = display_name.into();
         let visual = skeleton_with(&display_name, Fold::Visual);
         let case_insensitive = skeleton_with(&display_name, Fold::CaseInsensitive);
         Self {
             role,
+            source,
             visual_no_space: strip_spaces(&visual),
             case_insensitive_no_space: strip_spaces(&case_insensitive),
             visual,
@@ -286,17 +301,11 @@ impl ImpersonationWarning {
 #[derive(Clone, PartialEq, Debug, Default)]
 pub struct ImpersonationChecker {
     protected: Vec<ProtectedName>,
-    /// IDs that legitimately hold privilege. A member in this set is never
-    /// warned about — see the module header on why identity comes first.
-    privileged_ids: HashSet<MemberId>,
 }
 
 impl ImpersonationChecker {
-    pub fn new(protected: Vec<ProtectedName>, privileged_ids: HashSet<MemberId>) -> Self {
-        Self {
-            protected,
-            privileged_ids,
-        }
+    pub fn new(protected: Vec<ProtectedName>) -> Self {
+        Self { protected }
     }
 
     /// Whether this checker can ever produce a warning.
@@ -307,24 +316,43 @@ impl ImpersonationChecker {
         self.protected.is_empty()
     }
 
-    /// Whether `id` legitimately holds privilege, and so is never warned about.
-    pub fn is_privileged(&self, id: MemberId) -> bool {
-        self.privileged_ids.contains(&id)
-    }
-
     /// The warning for `display_name` as shown for member `id`, if any.
     ///
     /// `display_name` must be the text actually rendered — i.e. the output of
     /// [`crate::util::display_name::display_nickname`]. Checking the raw
     /// nickname instead would compare something the reader never sees.
+    ///
+    /// ## The exemption is PER-NAME, not per-member
+    ///
+    /// A protected name is skipped only for the member it was **taken from**
+    /// ([`ProtectedName::source`], a `MemberId`, which is derived from a keypair
+    /// and cannot be chosen). The property this guarantees is the narrow, true
+    /// one:
+    ///
+    /// > **A member is never accused of impersonating an identity that is
+    /// > genuinely theirs.**
+    ///
+    /// It is deliberately NOT the broader "anyone privileged is immune from all
+    /// accusations", which is what this used to do and what an attacker
+    /// exploited. Because a room-wide privileged set was built from
+    /// `deputy_badges`, and a member who is a strict ancestor of the viewer can
+    /// deputise a sockpuppet, an attacker could put their sockpuppet INTO that
+    /// set and then name it exactly `"Ian Clarke"` — earning a genuine 🛡 and
+    /// suppressing the ⚠. On the message author line that is worse than shipping
+    /// nothing: the real Ian is the OWNER, whose 👑 renders only in the member
+    /// list, so the fake visually outranked the real one in the conversation.
+    ///
+    /// A consequence worth stating plainly: the room owner who renames
+    /// themselves to a moderator's name IS now flagged, and that is correct —
+    /// the name is not theirs.
     pub fn check(&self, id: MemberId, display_name: &str) -> Option<ImpersonationWarning> {
-        // Identity first. A real moderator must never be flagged, and the only
-        // way to guarantee that is to answer "is this actually them?" before
-        // looking at the name at all.
-        if self.privileged_ids.contains(&id) {
+        let Some(folds) = self.candidate_folds(display_name) else {
             return None;
+        };
+        if let Some(hit) = self.tier_one_for(id, &folds) {
+            return Some(hit);
         }
-        self.check_name(display_name)
+        self.tier_two_for(id, &folds)
     }
 
     /// [`check`](Self::check) restricted to [`ConfusableTier::Identical`].
@@ -340,29 +368,18 @@ impl ImpersonationChecker {
         id: MemberId,
         display_name: &str,
     ) -> Option<ImpersonationWarning> {
-        if self.privileged_ids.contains(&id) {
-            return None;
-        }
         let folds = self.candidate_folds(display_name)?;
-        self.tier_one(&folds)
+        self.tier_one_for(id, &folds)
     }
 
-    /// The name half of [`check`](Self::check), with no identity check.
+    /// The name half of [`check`](Self::check), for a member whose id is not
+    /// among any protected name's source.
     ///
-    /// Exposed for tests. Production callers must use `check` or
-    /// `check_identical`, so the identity-first rule cannot be skipped.
+    /// Exposed for tests only. Production callers must use `check` or
+    /// `check_identical`, so the per-name exemption cannot be skipped —
+    /// `impersonation_checker_uses_the_identity_aware_entry_points` pins that.
     pub fn check_name(&self, display_name: &str) -> Option<ImpersonationWarning> {
-        let Some(folds) = self.candidate_folds(display_name) else {
-            return None;
-        };
-        // Tier 1 across the WHOLE protected set before tier 2, so an exact
-        // skeleton match is always reported as `Identical` even when some other
-        // protected name is a near-miss. Otherwise the reported tier would
-        // depend on the order the protected set happened to be built in.
-        if let Some(hit) = self.tier_one(&folds) {
-            return Some(hit);
-        }
-        self.tier_two(&folds)
+        self.check(NO_SUCH_MEMBER, display_name)
     }
 
     /// Both folds of a candidate name, or `None` when no match is possible.
@@ -385,8 +402,14 @@ impl ImpersonationChecker {
     }
 
     /// An exact match under EITHER fold. See [`Fold`] for why one is not enough.
-    fn tier_one(&self, c: &CandidateFolds) -> Option<ImpersonationWarning> {
+    ///
+    /// Skips any protected name whose `source` is `id` — the per-name exemption
+    /// described on [`check`](Self::check).
+    fn tier_one_for(&self, id: MemberId, c: &CandidateFolds) -> Option<ImpersonationWarning> {
         for p in &self.protected {
+            if p.source == id {
+                continue;
+            }
             let hit = c.visual == p.visual
                 || c.visual_no_space == p.visual_no_space
                 || c.case_insensitive == p.case_insensitive
@@ -404,13 +427,16 @@ impl ImpersonationChecker {
     /// A near-miss under the VISUAL fold. Not rendered by this UI — see
     /// [`check_identical`](Self::check_identical) — but kept, computed and
     /// tested so the tier decision stays reversible and measurable.
-    fn tier_two(&self, c: &CandidateFolds) -> Option<ImpersonationWarning> {
+    fn tier_two_for(&self, id: MemberId, c: &CandidateFolds) -> Option<ImpersonationWarning> {
         let budget = edit_budget(c.visual_chars.len());
         if budget == 0 {
             return None;
         }
         let mut best: Option<ImpersonationWarning> = None;
         for p in &self.protected {
+            if p.source == id {
+                continue;
+            }
             let p_chars: Vec<char> = p.visual.chars().collect();
             if damerau_within(&c.visual_chars, &p_chars, budget) <= budget {
                 // Owner outranks deputy so the more severe impersonation is the
@@ -856,14 +882,11 @@ mod tests {
 
     /// The protected set used by the upstream engine's validation fixture.
     fn fixture() -> ImpersonationChecker {
-        ImpersonationChecker::new(
-            vec![
-                ProtectedName::new(ProtectedRole::Deputy, "Ian Clarke"),
-                ProtectedName::new(ProtectedRole::Owner, "Room Owner"),
-                ProtectedName::new(ProtectedRole::Deputy, "Invite Bot"),
-            ],
-            HashSet::new(),
-        )
+        ImpersonationChecker::new(vec![
+            ProtectedName::new(ProtectedRole::Deputy, "Ian Clarke", mid(101)),
+            ProtectedName::new(ProtectedRole::Owner, "Room Owner", mid(102)),
+            ProtectedName::new(ProtectedRole::Deputy, "Invite Bot", mid(103)),
+        ])
     }
 
     /// **The ported test table.** Every row was validated against the live
@@ -947,34 +970,52 @@ mod tests {
     }
 
     /// Requirement one, and the thing that would be worse to get wrong than to
-    /// ship nothing: the real moderator is resolved by member ID and is never
-    /// the one flagged.
+    /// ship nothing — but stated NARROWLY.
+    ///
+    /// **The invariant changed.** It used to be "a privileged member is never
+    /// warned about, whatever they are called", which an attacker exploited: a
+    /// strict ancestor of the viewer can deputise a sockpuppet, putting it in
+    /// the privileged set, and then name it `"Ian Clarke"` to suppress the
+    /// warning while earning a genuine 🛡. It is now the property that is
+    /// actually true and actually needed:
+    ///
+    /// > A member is never accused of impersonating an identity that is
+    /// > genuinely THEIRS — keyed on `MemberId`, which is unforgeable.
     #[test]
-    fn the_real_privileged_member_is_never_flagged() {
+    fn a_member_is_never_flagged_for_their_own_identity() {
         let real_ian = mid(1);
         let real_owner = mid(2);
         let impostor = mid(3);
-        let checker = ImpersonationChecker::new(
-            vec![
-                ProtectedName::new(ProtectedRole::Deputy, "Ian Clarke"),
-                ProtectedName::new(ProtectedRole::Owner, "Room Owner"),
-            ],
-            HashSet::from([real_ian, real_owner]),
-        );
+        let checker = ImpersonationChecker::new(vec![
+            ProtectedName::new(ProtectedRole::Deputy, "Ian Clarke", real_ian),
+            ProtectedName::new(ProtectedRole::Owner, "Room Owner", real_owner),
+        ]);
 
-        // The real moderator, under their own exact name.
+        // Each under their OWN name, and under folded variants of it.
         assert_eq!(checker.check(real_ian, "Ian Clarke"), None);
-        assert_eq!(checker.check(real_owner, "Room Owner"), None);
-        // A privileged member is safe whatever they call themselves, including
-        // a name that collides with a DIFFERENT protected name — the room owner
-        // renaming themselves "Ian Clarke" is not impersonation.
-        assert_eq!(checker.check(real_owner, "Ian Clarke"), None);
         assert_eq!(checker.check(real_ian, "lan Clarke"), None);
-        assert!(checker.is_privileged(real_ian));
-        assert!(!checker.is_privileged(impostor));
+        assert_eq!(checker.check(real_ian, "IAN CLARKE"), None);
+        assert_eq!(checker.check(real_owner, "Room Owner"), None);
+        assert_eq!(checker.check(real_owner, "R00m 0wner"), None);
+
         // The impostor, under the same names, IS flagged.
         assert!(checker.check(impostor, "Ian Clarke").is_some());
         assert!(checker.check(impostor, "lan Clarke").is_some());
+        assert!(checker.check(impostor, "R00m 0wner").is_some());
+
+        // **The changed half.** Taking a name that is NOT yours is flagged even
+        // when you hold privilege yourself: the owner renaming themselves after
+        // a moderator is impersonation of that moderator, and a deputy renaming
+        // themselves after the owner is impersonation of the owner. Under the
+        // old global exemption both returned `None`, which is the hole.
+        let w = checker
+            .check(real_owner, "Ian Clarke")
+            .expect("the owner taking a moderator's name is flagged");
+        assert_eq!(w.impersonated.display_name, "Ian Clarke");
+        let w = checker
+            .check(real_ian, "Room Owner")
+            .expect("a moderator taking the owner's name is flagged");
+        assert_eq!(w.impersonated.display_name, "Room Owner");
     }
 
     /// Two members with confusable ORDINARY names must not warn about each
@@ -989,7 +1030,7 @@ mod tests {
 
     #[test]
     fn an_empty_protected_set_never_warns() {
-        let checker = ImpersonationChecker::new(Vec::new(), HashSet::new());
+        let checker = ImpersonationChecker::new(Vec::new());
         assert!(checker.is_empty());
         assert_eq!(checker.check(mid(1), "Ian Clarke"), None);
         assert_eq!(checker.check_name("lan Clarke"), None);
@@ -999,10 +1040,11 @@ mod tests {
     /// must not match every name in the room.
     #[test]
     fn an_empty_skeleton_matches_nothing() {
-        let checker = ImpersonationChecker::new(
-            vec![ProtectedName::new(ProtectedRole::Deputy, "\u{1F6E1}")],
-            HashSet::new(),
-        );
+        let checker = ImpersonationChecker::new(vec![ProtectedName::new(
+            ProtectedRole::Deputy,
+            "\u{1F6E1}",
+            mid(106),
+        )]);
         assert_eq!(skeleton("\u{1F6E1}"), "");
         assert_eq!(checker.check_name("Alice"), None);
         assert_eq!(checker.check_name(""), None);
@@ -1014,14 +1056,12 @@ mod tests {
     #[test]
     fn identical_outranks_near_miss_regardless_of_order() {
         let names = [
-            ProtectedName::new(ProtectedRole::Deputy, "Ian Clarke"),
-            ProtectedName::new(ProtectedRole::Deputy, "lan Clarkes"),
+            ProtectedName::new(ProtectedRole::Deputy, "Ian Clarke", mid(107)),
+            ProtectedName::new(ProtectedRole::Deputy, "lan Clarkes", mid(108)),
         ];
         for order in [[0, 1], [1, 0]] {
-            let checker = ImpersonationChecker::new(
-                order.iter().map(|i| names[*i].clone()).collect(),
-                HashSet::new(),
-            );
+            let checker =
+                ImpersonationChecker::new(order.iter().map(|i| names[*i].clone()).collect());
             let w = checker.check_name("Ian Clarke").expect("flagged");
             assert_eq!(w.tier, ConfusableTier::Identical);
             assert_eq!(w.impersonated.display_name, "Ian Clarke");
@@ -1032,13 +1072,13 @@ mod tests {
     /// both roles names the owner — deterministically, not by set order.
     #[test]
     fn owner_outranks_deputy_for_a_near_miss() {
-        let owner = ProtectedName::new(ProtectedRole::Owner, "Alexander Doe");
-        let deputy = ProtectedName::new(ProtectedRole::Deputy, "Alexandra Doe");
+        let owner = ProtectedName::new(ProtectedRole::Owner, "Alexander Doe", mid(109));
+        let deputy = ProtectedName::new(ProtectedRole::Deputy, "Alexandra Doe", mid(110));
         for order in [
             vec![owner.clone(), deputy.clone()],
             vec![deputy.clone(), owner.clone()],
         ] {
-            let checker = ImpersonationChecker::new(order, HashSet::new());
+            let checker = ImpersonationChecker::new(order);
             let w = checker.check_name("Alexanderr Doe").expect("flagged");
             assert_eq!(w.tier, ConfusableTier::NearMiss);
             assert_eq!(w.impersonated.role, ProtectedRole::Owner);
@@ -1049,10 +1089,11 @@ mod tests {
     /// turns most names into most other names.
     #[test]
     fn short_names_require_an_identical_skeleton() {
-        let checker = ImpersonationChecker::new(
-            vec![ProtectedName::new(ProtectedRole::Deputy, "Ada")],
-            HashSet::new(),
-        );
+        let checker = ImpersonationChecker::new(vec![ProtectedName::new(
+            ProtectedRole::Deputy,
+            "Ada",
+            mid(111),
+        )]);
         assert_eq!(checker.check_name("Ida"), None, "one edit, but too short");
         assert_eq!(checker.check_name("Adam"), None);
         // The identical-skeleton path still fires.
@@ -1230,14 +1271,11 @@ mod tests {
     /// people's names is worse than the problem it solves.
     #[test]
     fn real_names_in_other_scripts_are_not_flagged() {
-        let checker = ImpersonationChecker::new(
-            vec![
-                ProtectedName::new(ProtectedRole::Deputy, "Ian Clarke"),
-                ProtectedName::new(ProtectedRole::Owner, "Room Owner"),
-                ProtectedName::new(ProtectedRole::Deputy, "Alice Chen"),
-            ],
-            HashSet::new(),
-        );
+        let checker = ImpersonationChecker::new(vec![
+            ProtectedName::new(ProtectedRole::Deputy, "Ian Clarke", mid(112)),
+            ProtectedName::new(ProtectedRole::Owner, "Room Owner", mid(113)),
+            ProtectedName::new(ProtectedRole::Deputy, "Alice Chen", mid(114)),
+        ]);
         for name in [
             "李小龍",
             "さくら 田中",
@@ -1352,10 +1390,11 @@ mod tests {
             ("Jema", "Jenna"),
             ("Ame", "Anne"),
         ] {
-            let checker = ImpersonationChecker::new(
-                vec![ProtectedName::new(ProtectedRole::Deputy, deputy)],
-                HashSet::new(),
-            );
+            let checker = ImpersonationChecker::new(vec![ProtectedName::new(
+                ProtectedRole::Deputy,
+                deputy,
+                mid(115),
+            )]);
             assert_eq!(
                 checker.check_name(innocent),
                 None,
@@ -1365,10 +1404,11 @@ mod tests {
         }
         // `rn -> m` and `vv -> w` stay — they ARE confusable at UI sizes, and
         // `rn` is what catches `Roorn Owner`.
-        let checker = ImpersonationChecker::new(
-            vec![ProtectedName::new(ProtectedRole::Owner, "Room Owner")],
-            HashSet::new(),
-        );
+        let checker = ImpersonationChecker::new(vec![ProtectedName::new(
+            ProtectedRole::Owner,
+            "Room Owner",
+            mid(116),
+        )]);
         assert!(checker.check_name("Roorn Owner").is_some());
     }
 
@@ -1390,10 +1430,11 @@ mod tests {
             ("Lina", "Iina"), // Arabic / Finnish
         ] {
             for (deputy, innocent) in [(a, b), (b, a)] {
-                let checker = ImpersonationChecker::new(
-                    vec![ProtectedName::new(ProtectedRole::Deputy, deputy)],
-                    HashSet::new(),
-                );
+                let checker = ImpersonationChecker::new(vec![ProtectedName::new(
+                    ProtectedRole::Deputy,
+                    deputy,
+                    mid(117),
+                )]);
                 assert_eq!(
                     checker.check_name(innocent),
                     None,
@@ -1462,10 +1503,11 @@ mod tests {
             ("Boll", "B\u{00F6}ll", "accent stripping"),
             ("Moller", "M\u{00F6}ller", "accent stripping"),
         ] {
-            let checker = ImpersonationChecker::new(
-                vec![ProtectedName::new(ProtectedRole::Deputy, deputy)],
-                HashSet::new(),
-            );
+            let checker = ImpersonationChecker::new(vec![ProtectedName::new(
+                ProtectedRole::Deputy,
+                deputy,
+                mid(118),
+            )]);
             assert!(
                 checker.check_name(other).is_some(),
                 "{other:?} vs {deputy:?} ({why}) is a KNOWN accepted collision; \
@@ -1480,7 +1522,7 @@ mod tests {
     #[test]
     fn tooltip_names_the_remedy() {
         let deputy = ImpersonationWarning {
-            impersonated: ProtectedName::new(ProtectedRole::Deputy, "Ian Clarke"),
+            impersonated: ProtectedName::new(ProtectedRole::Deputy, "Ian Clarke", mid(119)),
             tier: ConfusableTier::Identical,
         }
         .tooltip();
@@ -1491,7 +1533,7 @@ mod tests {
         );
 
         let owner = ImpersonationWarning {
-            impersonated: ProtectedName::new(ProtectedRole::Owner, "Room Owner"),
+            impersonated: ProtectedName::new(ProtectedRole::Owner, "Room Owner", mid(120)),
             tier: ConfusableTier::NearMiss,
         }
         .tooltip();
@@ -1531,14 +1573,14 @@ mod tests {
         ];
         for role in [ProtectedRole::Deputy, ProtectedRole::Owner] {
             let baseline = ImpersonationWarning {
-                impersonated: ProtectedName::new(role, "Anodyne"),
+                impersonated: ProtectedName::new(role, "Anodyne", mid(1)),
                 tier: ConfusableTier::Identical,
             }
             .tooltip();
 
             for payload in payloads {
                 let tip = ImpersonationWarning {
-                    impersonated: ProtectedName::new(role, payload),
+                    impersonated: ProtectedName::new(role, payload, mid(1)),
                     tier: ConfusableTier::Identical,
                 }
                 .tooltip();

--- a/ui/src/util/display_name.rs
+++ b/ui/src/util/display_name.rs
@@ -117,6 +117,17 @@ use std::collections::HashMap;
 /// distinguishable in the UI.
 pub const UNNAMED: &str = "Unnamed";
 
+/// Shown for a member with no `member_info` record at all.
+///
+/// A constant rather than a literal at each fallback because it is a
+/// CLASS-WIDE name: every member whose record has not synced yet renders as
+/// this string simultaneously (see `.claude/rules/private-rooms.md` and the
+/// `build_member_info_heal` path). Anything that treats a display name as
+/// identifying — [`crate::components::members::impersonation_checker_for_viewer`]
+/// above all — has to be able to name it, or it accuses a dozen members at once
+/// during an ordinary sync gap.
+pub const UNKNOWN_MEMBER: &str = "Unknown";
+
 /// Shown next to a nickname `<input>` whose contents would not survive
 /// [`sanitize_display_name`]. One wording, used by every nickname input, so a
 /// user gets the same explanation wherever they hit it.

--- a/ui/src/util/display_name.rs
+++ b/ui/src/util/display_name.rs
@@ -133,6 +133,68 @@ pub const UNKNOWN_MEMBER: &str = "Unknown";
 /// user gets the same explanation wherever they hit it.
 pub const EMOJI_REJECTION_MESSAGE: &str = "Nicknames can't contain emoji";
 
+/// Unicode general category `Cf` (Format): every character whose whole job is
+/// to be invisible and change how neighbouring text is laid out.
+///
+/// **Generated from Unicode 15.0 data, not hand-listed.** The list above grew
+/// one codepoint at a time as each was noticed, and the result had the exact
+/// signature of that process: U+06DE was in it but U+06DD was not; U+0488/U+0489
+/// were covered but U+0890/U+0891 were not. Thirteen `Cf` codepoints survived
+/// BOTH the sanitiser and the confusable fold — U+0600..U+0605, U+06DD, U+070F,
+/// U+0890, U+0891, U+08E2, U+110BD, U+110CD and U+13430..U+1343F — and because
+/// `is_display_hidden` also gates [`sanitize_display_name`], they survived into
+/// the RENDERED nickname. `Ian\u{070F} Clarke` is not merely a fold miss; it is
+/// a pixel-identical clone of another member's displayed name.
+///
+/// Regenerate by sweeping `0..0x110000` for `unicodedata.category(chr(cp)) ==
+/// 'Cf'` and collapsing to ranges; 170 codepoints in 21 ranges as of Unicode
+/// 15.0. `every_format_character_is_hidden` pins a representative of each range.
+///
+/// ## The other invisible categories
+///
+/// * `Cs` (surrogates) cannot exist in a Rust `char`, so there is nothing to do.
+/// * `Co` (private use) is covered by the PUA ranges in [`is_display_hidden`].
+/// * `Cn` (unassigned) is deliberately NOT covered. An unassigned codepoint
+///   renders as a visible replacement box, not as nothing, so it does not clone
+///   anyone's name — and the set SHRINKS with every Unicode release, so a frozen
+///   `Cn` table would start stripping newly-assigned letters out of real names.
+///   That is the one direction of error this module must not have.
+///
+/// ## The two exceptions, which are the same ones as everywhere else
+///
+/// U+200C ZWNJ and U+200D ZWJ are `Cf` and are deliberately NOT reported. They
+/// are orthography in Persian, Sinhala and Malayalam, and stripping them at
+/// RENDER time mangles real names — the reasoning is on the `0x200B` entry
+/// below. `crate::util::confusable::skeleton` drops them anyway, because
+/// comparison is not rendering.
+fn is_format_control(c: char) -> bool {
+    if c == '\u{200C}' || c == '\u{200D}' {
+        return false;
+    }
+    matches!(u32::from(c),
+        0x00AD                  // SOFT HYPHEN
+        | 0x0600..=0x0605       // ARABIC NUMBER SIGN..ARABIC NUMBER MARK ABOVE
+        | 0x061C                // ARABIC LETTER MARK
+        | 0x06DD                // ARABIC END OF AYAH
+        | 0x070F                // SYRIAC ABBREVIATION MARK
+        | 0x0890..=0x0891       // ARABIC POUND/PIASTRE MARK ABOVE
+        | 0x08E2                // ARABIC DISPUTED END OF AYAH
+        | 0x180E                // MONGOLIAN VOWEL SEPARATOR
+        | 0x200B..=0x200F       // ZWSP, ZWNJ, ZWJ, LRM, RLM (joiners excepted above)
+        | 0x202A..=0x202E       // bidi embedding / override
+        | 0x2060..=0x2064       // word joiner, invisible operators
+        | 0x2066..=0x206F       // bidi isolates, deprecated formatting
+        | 0xFEFF                // ZERO WIDTH NO-BREAK SPACE / BOM
+        | 0xFFF9..=0xFFFB       // interlinear annotation anchors
+        | 0x110BD | 0x110CD     // KAITHI NUMBER SIGN, ...ABOVE
+        | 0x13430..=0x1343F     // Egyptian hieroglyph format controls
+        | 0x1BCA0..=0x1BCA3     // shorthand format controls
+        | 0x1D173..=0x1D17A     // musical beam/slur/phrase controls
+        | 0xE0001               // LANGUAGE TAG
+        | 0xE0020..=0xE007F     // TAG SPACE..CANCEL TAG
+    )
+}
+
 /// Whether `c` must never appear in rendered display text.
 ///
 /// Ranges are Unicode *blocks* rather than the `Emoji` character property:
@@ -145,6 +207,11 @@ pub fn is_display_hidden(c: char) -> bool {
     // Control characters (C0/C1). A newline or NUL in a nickname is never
     // legitimate and breaks layout.
     if c.is_control() {
+        return true;
+    }
+    // Every Unicode FORMAT character, by category rather than by whichever ones
+    // someone happened to hit. See [`is_format_control`].
+    if is_format_control(c) {
         return true;
     }
 
@@ -495,6 +562,53 @@ mod tests {
     /// The badge glyphs River itself renders. A nickname able to display any
     /// of these can impersonate a moderator, the room owner, or "you".
     const BADGE_GLYPHS: &[&str] = &["🛡", "👑", "⭐", "🔑", "🎪", "✅", "⚠", "🔰", "⚔"];
+
+    /// Every Unicode `Cf` FORMAT character must be hidden, because
+    /// `is_display_hidden` gates the sanitiser: one that survives is not merely
+    /// a fold miss, it renders as nothing inside the nickname and clones
+    /// another member's displayed name exactly.
+    ///
+    /// One representative from each of the 21 ranges (the whole range where it
+    /// is short), so a range dropped from [`is_format_control`] fails here.
+    /// The specific codepoints called out below are the ones that survived
+    /// BOTH this sanitiser and the confusable fold before the list was
+    /// generated rather than hand-extended.
+    #[test]
+    fn every_format_character_is_hidden() {
+        for cp in [
+            0x00ADu32, 0x0600, 0x0601, 0x0602, 0x0603, 0x0604, 0x0605, 0x061C, 0x06DD, 0x070F,
+            0x0890, 0x0891, 0x08E2, 0x180E, 0x200B, 0x200E, 0x200F, 0x202A, 0x202E, 0x2060, 0x2064,
+            0x2066, 0x206F, 0xFEFF, 0xFFF9, 0xFFFB, 0x110BD, 0x110CD, 0x13430, 0x1343F, 0x1BCA0,
+            0x1BCA3, 0x1D173, 0x1D17A, 0xE0001, 0xE0020, 0xE007F,
+        ] {
+            let c = char::from_u32(cp).expect("a valid codepoint");
+            assert!(
+                is_display_hidden(c),
+                "U+{cp:04X} is a Cf format character and renders as nothing, so \
+                 it must never survive into a displayed nickname"
+            );
+        }
+
+        // The two deliberate exceptions survive, exactly as before: they are
+        // orthography in Persian, Sinhala and Malayalam.
+        assert!(!is_display_hidden('\u{200C}'));
+        assert!(!is_display_hidden('\u{200D}'));
+
+        // The end-to-end property: a name carrying one of these must not
+        // render identically to the plain one. Both of these used to.
+        for hidden in ['\u{070F}', '\u{13437}', '\u{06DD}', '\u{0890}', '\u{110BD}'] {
+            let spoofed = format!("Ian{hidden} Clarke");
+            assert!(
+                contains_hidden_chars(&spoofed),
+                "{spoofed:?} must be reported as containing hidden characters"
+            );
+            assert_eq!(
+                sanitize_display_name(&spoofed),
+                "Ian Clarke",
+                "{spoofed:?} rendered as a pixel-identical clone of `Ian Clarke`"
+            );
+        }
+    }
 
     #[test]
     fn badge_glyphs_cannot_survive_a_nickname() {


### PR DESCRIPTION
## Problem

An impersonation campaign is running against the Freenet Official room: attackers join under nicknames that render identically to Ian Clarke's and to the room's moderators'. Two defenses exist and neither closes it.

- Invisible characters are stripped from nicknames — but a homoglyph is not invisible.
- A cron bans exact visual matches of a protected name — but `Ιan Clarke` with a Greek capital iota (U+0399) is not an exact match. That is how the tenth impersonator got in after the first nine were banned.

**No character-blocking table can fix this.** U+0399 is a letter. So is Cyrillic `а`. Rejecting them breaks real Greek and Russian names — the users least able to argue with a rule that mangles their name. The answer has to be detection and warning, not rejection.

Branch `feat/impersonation-warning-badge` already carried a confusable-detection engine (`ui/src/util/confusable.rs`), but **nothing called it**: `git grep "confusable::"` outside the module returned zero hits, and its doc comments pointed at a function that did not exist. This PR is that missing wiring, plus the work of making the engine actually hold up.

## Approach

### The protected set comes from live room state

`impersonation_checker_for_viewer` builds it from the room **owner** plus the **same deputy-badge map the 🛡 shield already uses** (`deputy_badges_for_viewer`), taken as a parameter rather than recomputed. There is one answer to "who is a deputy", so a deputize or revoke moves the protected set on the next render with nothing to maintain by hand. Reusing the viewer-relative badge map also scopes it correctly: a protected name is one whose authority *this viewer* would be fooled by, which is exactly the set whose shield they can see.

**Every badged deputy contributes a name, whoever appointed them.** An earlier revision of this PR admitted only owner- or viewer-appointed grants, to keep the set unwritable by an attacker. That gate had to go: in the live Freenet Official room *all five* deputy grants are issued by `Invite Bot` (`PMAQEUP5`), not by the owner (`NRKA4WVX`) — verified with `riverctl debug room-state`. The gate protected exactly one name, `Room Owner`, and left `Ian Clarke`, `HostFat`, `Ivvor` and `ofansifkapital-xmpp` unprotected, i.e. it switched the feature off in the only room that has needed it.

The cost is accepted deliberately and is pinned by a test rather than left to be rediscovered: `MemberInfoV1::verify` validates only the *length* of a `deputies` list, never who is in it, so any strict ancestor of the viewer can deputise a sockpuppet, name it after an innocent member, and have that member render a warning across the attacker's invite subtree. `a_sockpuppet_can_inject_a_protected_name` asserts the current behaviour and says in its doc that re-narrowing the set is a policy change, not a bug fix.

### Identity beats name, always

The exemption is keyed on `ProtectedName::source`, a `MemberId` derived from a keypair, so **a member is never accused of impersonating an identity that is genuinely theirs**. It is deliberately *not* the broader "anyone privileged is immune", which an attacker exploited: a deputised sockpuppet earned a genuine 🛡 and suppressed its own ⚠, and on the author line that is worse than shipping nothing, because the real Ian is the *owner*, whose 👑 renders only in the member list.

### Only tier 1 renders

The engine reports `Identical` (same skeleton) and `NearMiss` (small edit distance). The UI renders `Identical` only, on measured evidence: River assigns 10,000 generated handles and `Amber Worm` / `Ember Worm` are one edit apart, so the near-miss tier accuses a pair of members River itself created, before any attacker acts. Both facts are pinned. `Ivvor2` — a real member — is one edit from the moderator `Ivvor`, and has its own named test row so nobody flips this decision without seeing who it lands on.

### The guards are as wide as the matcher

The filters deciding which names *enter* the protected set compared exact strings while the matcher they gate compares folds — a guard weaker than the thing it guards. `amber worm`, `AmberWorm` and `Arnber Worm` all passed `is_generated_handle` and all tier-1 match the member River assigned `Amber Worm`; no attacker is needed, a moderator styling their own name lower-case is enough. `"Unknown"` was not filtered at all, despite being the no-`member_info` fallback both surfaces render, so one deputy named `Unknown` would flag every member waiting on a sync gap. All three placeholders now compare skeletons.

### The tooltip does not assert things that are false

It switched on the *impersonated* role alone, so it said "this member is NOT a moderator" about members who provably hold a grant: two deputies with colliding names each render 🛡 **and** ⚠, and the room owner can render 👑 alongside the same sentence. It now switches on the flagged member's own privilege and says "Name conflict … check the member ID". The badge is **never** suppressed — a deputised sockpuppet carries a genuine shield, and suppressing on it is the immunity this PR exists to deny.

### Fold coverage

Five classes of total bypass were closed:

| Class | What evaded |
|---|---|
| Math Greek blocks | `% 52` ran past U+1D6A3 where the alignment stops, so `𝝞` (sans-bold capital IOTA) folded to `e`. Wrong both ways: bold Alpha folded to `E`. |
| Latin small capitals | `ɪᴀɴ ᴄʟᴀʀᴋᴇ` — all `Ll`, so both folds left it verbatim at edit distance 8. |
| Precomposed Latin past U+017F | 327 letters, all of Vietnamese. `Iạn Clarke` is a speck at member-list size. |
| Unicode `Cf` invisibles | 13 codepoints survived the sanitiser *and* the fold, so they reached the rendered nickname as a pixel-identical clone. |
| Partial block coverage | Lisu 2 of 26 folded, Cherokee 1 of 35, four Coptic lowercase missing while their capitals folded. |

Cherokee went from 1-of-35 folded to the whole block and Lisu from 2-of-26, which is the largest new false-positive surface here — so the sweep in `foldable_scripts_do_not_collide_with_latin_names` gained entries that *contain* the newly folded letters: `ᏣᎳᎩ` (Tsalagi) carries Ꮃ and Ꭹ, `ꓡꓲꓢꓴ` (Li-Su) carries all four of ꓡ ꓲ ꓢ ꓴ. Cherokee is a living script, but its letters are syllables, so what a Cherokee name folds to is not a word in any language and cannot land on a moderator by accident.

Tables are **generated, not curated**: the Latin ones from NFD, the `Cf` set from the Unicode category, and the shape-homoglyph blocks from UTR39 `confusables.txt` 17.0 — which matters because several Lisu letters are rotated or mirrored Latin capitals, and reading them off a chart gets it wrong in both directions.

The costs are enumerated in `documented_accepted_collisions`, which fails if any row silently stops holding. New rows record what the fold genuinely accepts, including two that hit the real moderator list: `Host Fat` collides with `HostFat` (spaces are removed, which is what catches `IanClarke`), and `Iwor` collides with `Ivvor` via `vv -> w`.

## Testing

650 tests, all green. Every fix has a test that fails without it, and the ones most likely to be pinned by a vacuous assertion were verified **mechanically** — revert the fix, confirm the test goes red, restore:

| Fix | Mutation | Result |
|---|---|---|
| Math Greek bound | restore `0x1D7CB` upper bound | RED |
| Small capitals | disable the fold step | RED |
| Wiring argument (member list) | `member_id` → `self_member_id` | RED |
| Wiring argument (author line) | `author_id` → `self_member_id` | RED |
| Clipping pin | reintroduce `truncate` in a different class position | RED |
| Precomposed Latin | remove both table ranges | RED (2 tests) |
| `Cf` invisibles | remove the `is_format_control` call | RED |
| Appointer gate removal | reinstate the gate | RED (5 tests) |
| `ProtectedRole::Owner` | change it to `Deputy` | RED |
| Citation pin | introduce a citation to a test that does not exist | RED |

The highest-value new test is `the_live_freenet_official_topology_protects_every_moderator`. Every existing fixture deputised its moderators from the *owner*, which passes under both the old policy and the new one — that is precisely why the appointer gate survived review. This one builds the real room's shape (owner deputizes nobody, `Invite Bot` deputizes all four moderators, the bot invited the viewer) and requires each moderator's name to be protected against a homoglyph while each genuine moderator stays unbadged.

`every_cited_pin_test_exists` now makes the most repeated defect in this feature's history fail CI: three separate comments claimed a `shield_and_warning_are_mutually_exclusive` pin, the test was never written, and the invariant it named was provably false — reviewers read the citation and believed the property was covered. I then did it three more times in this PR (two renamed tests, one never written); all three are fixed and the class is now caught mechanically.

Pins that were cited in comments but **never existed** are now written (`a_shield_and_a_warning_can_both_render`, `the_protected_set_is_not_gated_on_the_appointer`), and the comments that cited them — three of which asserted a mutual exclusivity that is provably false — are corrected. `check_name`, which bypasses the identity exemption and would flag every real moderator, is `#[cfg(test)]` rather than `pub` with a comment asking callers not to use it.

The wiring pins previously asserted only that `impersonation_warning_for_display(` was *called*, so the worst available mutation — passing `self_member_id` — compiled, passed everything, and branded the genuine owner and every genuine moderator. They now pin the argument list.

## Known gaps, stated rather than implied

- **Rendered on two surfaces**: the member-list row and the message author line. Not the member-info modal, DM thread, DM rail, mention chips, notifications or reaction tooltips. The doc comment used to claim "every render surface must go through this"; it now enumerates. Since `title=` tooltips do not fire on touch, the badge is currently a bare glyph on mobile — the modal wiring that fixes this is a follow-up.
- **No example-data fixture or Playwright spec yet**, so the badge has never been looked at in a browser. Both surfaces are now addressable — `message-author-impersonation-warning` on the author line and `member-list-impersonation-warning` in the member row — so the spec is unblocked; it is a follow-up, in progress separately.

Follow-up to #488 (invisible-character stripping), which closed the other half of this attack.

[AI-assisted - Claude]
