### PR TITLE
feat(ui): explain the impersonation warning where a phone user can read it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,9 @@ the wrong thing, all hit in one session (2026-07-25):
 - **A stale `dx` earlier on PATH.** `/opt/rust/bin/dx` was 0.7.3 against the
   crate's dioxus 0.7.9. It refuses to build and serves a 404 "dx is not serving
   a web app" page that reads exactly like a broken change; `~/.cargo/bin/dx`
-  was correct. Check `dx --version` against `ui/Cargo.toml` before debugging.
+  was correct. Check `dx --version` against the RESOLVED dioxus version —
+  `cargo tree -p dioxus` or `Cargo.lock`, NOT `ui/Cargo.toml`, which declares
+  `0.7.3` and would have confirmed the stale binary as correct.
 - **Port 8082 is shared.** It is the suite's default `baseURL`, so if another
   worktree already has a server on it, `npx playwright test` silently tests
   THAT build. Use a free port and set `PLAYWRIGHT_BASE_URL`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,24 @@ npx playwright test --project=webkit --grep "iframe"
 npx playwright test --project=mobile-safari --grep "Mobile"
 ```
 
+**Verify what you are actually testing.** Three ways a run silently measures
+the wrong thing, all hit in one session (2026-07-25):
+
+- **`dx serve` can serve a stale build.** The warning above is not theoretical.
+  A mutation check — reintroduce a bug and expect the test to go red — "passed"
+  only because the watcher never rebuilt and the browser was still running the
+  previous binary. That inverts the result of the one technique that proves a
+  test is not vacuous. Prefer the static-server flow above; if you must use
+  `dx serve`, read a marker out of the DOM (a row's `class` attribute is
+  enough) to confirm which build is loaded before believing a pass OR a fail.
+- **A stale `dx` earlier on PATH.** `/opt/rust/bin/dx` was 0.7.3 against the
+  crate's dioxus 0.7.9. It refuses to build and serves a 404 "dx is not serving
+  a web app" page that reads exactly like a broken change; `~/.cargo/bin/dx`
+  was correct. Check `dx --version` against `ui/Cargo.toml` before debugging.
+- **Port 8082 is shared.** It is the suite's default `baseURL`, so if another
+  worktree already has a server on it, `npx playwright test` silently tests
+  THAT build. Use a free port and set `PLAYWRIGHT_BASE_URL`.
+
 **Test coverage:**
 - Desktop 1280px: 3-column layout, no overflow
 - Tablet 768px: narrower sidebars via CSS clamp

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -675,7 +675,7 @@ fn group_messages(
             // Passing `self_member_id` compiles and passes every behavioural
             // test while putting ⚠ on the genuine owner and every genuine
             // moderator; the argument is pinned by
-            // `impersonation_warning_is_wired_into_both_render_surfaces`.
+            // `impersonation_warning_is_wired_into_every_render_surface`.
             let author_impersonation = impersonation_warning_for_display(
                 impersonation,
                 author_id,

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1177,16 +1177,21 @@ pub(crate) fn impersonation_checker_for_viewer(
 ///
 /// This used to claim "every render surface must go through this", which was
 /// false and is the class of stale comment this file's credibility depends on
-/// not having. The warning is rendered on **two** surfaces today:
+/// not having. The warning is rendered on **three** surfaces today:
 ///
-/// * the member-list row ([`MemberList`]), and
-/// * the conversation's message author line.
+/// * the member-list row ([`MemberList`]),
+/// * the conversation's message author line, and
+/// * the member-info modal, which is the only one that renders the warning's
+///   sentence as VISIBLE TEXT rather than a `title=` tooltip. That matters
+///   because `title=` never fires on touch: on a phone the other two can show
+///   the glyph and nothing else, so the modal is where a reader who taps the
+///   name finds out what it means (freenet/river#494).
 ///
-/// It is NOT rendered on the member-info modal, the DM thread and DM rail,
-/// @mention chips and autocomplete, notifications, or reaction tooltips. Those
-/// show a nickname with no warning beside it. The DM thread is the most
-/// consequential of the gaps: it is a 1:1 surface, which is where a victim is
-/// most likely to act on perceived authority.
+/// It is NOT rendered on the DM thread and DM rail, @mention chips and
+/// autocomplete, notifications, or reaction tooltips. Those show a nickname
+/// with no warning beside it. The DM thread is the most consequential of the
+/// gaps: it is a 1:1 surface, which is where a victim is most likely to act on
+/// perceived authority.
 ///
 /// Adding a surface is a one-line call to this function plus the glyph; the
 /// reason not to do it blindly is that each surface needs its own
@@ -1423,7 +1428,7 @@ pub fn MemberList() -> Element {
             // `self_member_id` here compiles, passes every behavioural test, and
             // puts ⚠ on the genuine owner and every genuine moderator — the
             // argument is pinned by
-            // `impersonation_warning_is_wired_into_both_render_surfaces`.
+            // `impersonation_warning_is_wired_into_every_render_surface`.
             let impersonation_warning = impersonation_warning_for_display(
                 &impersonation,
                 member_id,
@@ -6894,7 +6899,7 @@ mod tests {
     /// `display_name::nickname_render_paths_go_through_display_nickname`
     /// documents).
     #[test]
-    fn impersonation_warning_is_wired_into_both_render_surfaces() {
+    fn impersonation_warning_is_wired_into_every_render_surface() {
         let members_src = include_str!("members.rs");
         let conversation = include_str!("conversation.rs");
 
@@ -7055,6 +7060,27 @@ mod tests {
             )
             .contains("WARNING_GLYPH"),
             "the author-line warning element no longer renders the warning glyph"
+        );
+
+        // --- Member-info modal -------------------------------------------
+        //
+        // The THIRD surface (freenet/river#494), and the only one that renders
+        // the sentence as visible text — which is the whole reason it exists,
+        // since `title=` does not fire on touch. Its own file pins the
+        // ARGUMENTS and the visible-text shape; what belongs here is the
+        // cross-surface claim this test is named for, so that dropping the
+        // modal fails the same test that would catch dropping either of the
+        // other two.
+        let modal = include_str!("members/member_info_modal.rs");
+        assert!(
+            modal.contains("impersonation_warning_for_display("),
+            "the member-info modal no longer computes an impersonation \
+             warning, so a phone user has no surface that explains the ⚠"
+        );
+        assert!(
+            modal.contains("\"data-testid\": \"member-info-impersonation-explanation\""),
+            "the member-info modal no longer renders the warning's explanation \
+             element"
         );
     }
 }

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1274,13 +1274,24 @@ pub(crate) fn privilege_in_view(
     }
 }
 
-/// [`deputy_badges_for_viewer`] for a SINGLE member.
+/// [`deputy_badges_for_viewer`] for a SINGLE member. Same predicate, same
+/// tooltip; only the sweep is narrowed.
 ///
-/// The member-info modal wants one member's badge and is not memoised, so
-/// building the whole map there would decrypt every deputy's appointer
-/// nicknames on every render — in a private room that is an ECIES unseal per
-/// appointer per keystroke elsewhere in the app. Same predicate, same tooltip;
-/// only the sweep is narrowed.
+/// It exists because a caller wanting one member's badge should not decrypt
+/// every deputy's appointer nicknames — in a private room that is an ECIES
+/// unseal per appointer.
+///
+/// Its only caller today, the member-info modal, no longer collects that
+/// saving in full: since freenet/river#494 that modal ALSO builds the whole
+/// map, because `impersonation_checker_for_viewer` needs it to explain the ⚠
+/// in visible text (`title=` never fires on touch). The shield stays on this
+/// path deliberately — it is pinned by `modal_renders_deputy_shield_via_
+/// shared_helper` and by two Playwright specs — so the duplicate sweep is
+/// known and accepted on a click-opened, single-member surface. Reading the
+/// shield out of that map instead would be equivalent
+/// (`deputy_badges_for_viewer` keys are exactly the targets `badge_for_target`
+/// answers `Some` for), and is the obvious cleanup if this ever shows up in a
+/// profile.
 pub(crate) fn deputy_badge_for_viewer(
     members: &MembersV1,
     member_info: &river_core::room_state::member_info::MemberInfoV1,
@@ -7071,7 +7082,15 @@ mod tests {
         // cross-surface claim this test is named for, so that dropping the
         // modal fails the same test that would catch dropping either of the
         // other two.
-        let modal = include_str!("members/member_info_modal.rs");
+        // Cut at the modal's own test module: the needle below also appears
+        // inside `modal_passes_the_target_id_and_the_targets_own_privilege`'s
+        // argument pin, so scanning the whole file would make this assertion
+        // unfailable. (`member_info_modal.rs` has exactly one `#[cfg(test)]`,
+        // unlike `conversation.rs` above.)
+        let modal_src = include_str!("members/member_info_modal.rs");
+        let modal = &modal_src[..modal_src
+            .find("#[cfg(test)]")
+            .expect("member_info_modal.rs should have a `#[cfg(test)]` block")];
         assert!(
             modal.contains("impersonation_warning_for_display("),
             "the member-info modal no longer computes an impersonation \

--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -257,6 +257,71 @@ pub fn MemberInfoModal() -> Element {
             &room_state.secrets,
         );
 
+        // The ⚠ impersonation warning (freenet/river#489), through the SAME
+        // entry point the member-list row and the conversation's author line
+        // use, so this surface cannot show a badge the others do not — the
+        // cross-surface drift #451 fixed for the shield.
+        //
+        // Fed `target_nickname`, which is the text this modal actually renders.
+        // Checking the raw sealed nickname would compare a string nobody sees.
+        //
+        // ## Why this pays for the whole badge map
+        //
+        // `impersonation_checker_for_viewer` takes the badge map, so this builds
+        // the map `deputy_badge_for_viewer` above deliberately avoids: in a
+        // private room that is an ECIES unseal per appointer. It is worth it
+        // here, because the alternative is not "a cheaper warning" but "no
+        // explanation at all on a phone". A `title=` tooltip NEVER FIRES ON
+        // TOUCH, so on mobile the ⚠ beside a name is a bare glyph, and the
+        // reader's natural next move — tapping the name, which opens THIS modal
+        // — used to explain nothing. This modal is opened by a deliberate click
+        // and renders one member; it is not a per-keystroke path.
+        //
+        // The shield above still uses the single-target helper: it is pinned by
+        // `modal_renders_deputy_shield_via_shared_helper` and by two Playwright
+        // specs, and re-deriving it from this map would put that behaviour on a
+        // different code path for no gain.
+        let impersonation = owner_key_signal.as_ref().and_then(|owner| {
+            let owner_id = MemberId::from(&*owner);
+            let deputy_badges = super::deputy_badges_for_viewer(
+                &room_state.room_state.members,
+                &room_state.room_state.member_info,
+                &room_state.secrets,
+                owner_id,
+                self_member_id,
+            );
+            let checker = super::impersonation_checker_for_viewer(
+                &room_state.room_state.member_info,
+                &room_state.secrets,
+                owner_id,
+                &deputy_badges,
+            );
+            super::impersonation_warning_for_display(
+                &checker,
+                member_id,
+                &target_nickname,
+                // Never suppresses the badge — it only picks which of the two
+                // true sentences the tooltip states. See `ImpersonationWarning`.
+                super::privilege_in_view(member_id, owner_id, &deputy_badges),
+            )
+        });
+        let impersonation_tooltip = impersonation
+            .as_ref()
+            .map(crate::util::confusable::ImpersonationWarning::tooltip)
+            .unwrap_or_default();
+        // The chip's label is the tooltip's OWN leading clause (everything
+        // before the first colon: "Impersonation warning" or "Name conflict").
+        // Deriving it means this surface cannot invent wording that drifts from
+        // the single definition in `ImpersonationWarning::tooltip`, and it
+        // follows the tooltip's privileged/unprivileged branch for free. Safe to
+        // split on: `tooltip_contains_no_nickname_content` pins that no nickname
+        // reaches this string, so the colon is always ours.
+        let impersonation_label = impersonation_tooltip
+            .split(':')
+            .next()
+            .unwrap_or_default()
+            .to_string();
+
         // Get the member ID string to display
         let member_id_str = member_id.to_string();
 
@@ -336,6 +401,54 @@ pub fn MemberInfoModal() -> Element {
                                     title: "{deputy_tooltip}",
                                     "aria-label": "{deputy_tooltip}",
                                     "🛡 Deputy"
+                                }
+                            }
+                            // The ⚠ impersonation warning (#489). Deliberately
+                            // NOT mutually exclusive with the 🛡 above: two
+                            // deputies whose names collide each carry a real
+                            // shield AND a real warning, and suppressing the
+                            // warning for a badged member would hand a
+                            // deputised sockpuppet exactly the immunity the
+                            // per-name exemption exists to deny. The tooltip,
+                            // not the badge, is what changes in that case.
+                            if impersonation.is_some() {
+                                span {
+                                    "data-testid": "member-info-impersonation-tag",
+                                    class: "inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium bg-amber-500/20 text-amber-400",
+                                    title: "{impersonation_tooltip}",
+                                    "aria-label": "{impersonation_tooltip}",
+                                    "{crate::util::confusable::WARNING_GLYPH} {impersonation_label}"
+                                }
+                            }
+                        }
+
+                        // The warning, SPELLED OUT. This is the reason the modal
+                        // was wired up at all: `title=` never fires on touch, so
+                        // on a phone every other surface can only show the bare
+                        // ⚠ glyph. Rendering the same sentence as visible text
+                        // makes this the one place a phone user can find out
+                        // what the badge means.
+                        //
+                        // The imitated NAME is shown here and nowhere else, as
+                        // its own element. That is safe for the same reason
+                        // `appointer_names` is: a nickname is attacker-chosen
+                        // and a comma inside it (`Bob, the room owner, Carol`)
+                        // forges structure in a flat string, but cannot span two
+                        // DOM nodes. Do NOT join it into the sentence above, and
+                        // do NOT move it into the tooltip — see
+                        // `ImpersonationWarning::tooltip`.
+                        if let Some(warning) = impersonation.as_ref() {
+                            div {
+                                "data-testid": "member-info-impersonation-explanation",
+                                class: "mb-4 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20 text-sm text-amber-200",
+                                p { class: "mb-1", "{impersonation_tooltip}" }
+                                div {
+                                    span { class: "mr-1 text-text-muted", "Resembles:" }
+                                    span {
+                                        "data-testid": "member-info-impersonated-name",
+                                        class: "inline-block px-2 py-0.5 rounded bg-surface border border-border text-text",
+                                        "{warning.impersonated.display_name}"
+                                    }
                                 }
                             }
                         }
@@ -673,6 +786,68 @@ mod ban_gate_tests {
                 !prod.contains(joiner),
                 "`{joiner}` flattens attacker-controlled nicknames into one \
                  string, which is the forgery this shape exists to prevent"
+            );
+        }
+    }
+
+    /// freenet/river#489: this modal must render the ⚠ warning, and must render
+    /// its sentence as VISIBLE TEXT.
+    ///
+    /// The visible-text half is the entire reason the modal was wired up, and a
+    /// future refactor that "tidied" the explanation into the `title=` alone
+    /// would silently undo it while still looking correct on a desktop. A
+    /// `title=` tooltip NEVER FIRES ON TOUCH, so on a phone every other surface
+    /// can show only a bare glyph, and the reader's natural next move — tapping
+    /// the name, which opens this modal — has to be what explains it.
+    #[test]
+    fn modal_renders_the_impersonation_warning_as_visible_text() {
+        let source = include_str!("member_info_modal.rs");
+        let prod = &source[..source
+            .find("#[cfg(test)]")
+            .expect("member_info_modal.rs should have a #[cfg(test)] block")];
+
+        assert!(
+            prod.contains("impersonation_warning_for_display"),
+            "the ⚠ must come from the shared `impersonation_warning_for_display` \
+             entry point, which carries the tier decision — a surface that \
+             called the checker directly would render a badge the member list \
+             and the conversation do not (#451's cross-surface drift)"
+        );
+        for bypass in ["check_identical(", "ImpersonationChecker::check"] {
+            assert!(
+                !prod.contains(bypass),
+                "`{bypass}` skips the tier decision in \
+                 `impersonation_warning_for_display`"
+            );
+        }
+
+        let explanation = prod
+            .find("member-info-impersonation-explanation")
+            .map(|i| &prod[i..(i + 900).min(prod.len())])
+            .expect("the modal must render an explanation block for the ⚠");
+        assert!(
+            explanation.contains("{impersonation_tooltip}"),
+            "the warning's SENTENCE must be rendered as visible text, not only \
+             as a `title=` attribute: `title=` does not fire on touch, so a \
+             phone user would get a bare glyph and no way to find out what it \
+             means"
+        );
+        assert!(
+            explanation.contains("member-info-impersonated-name"),
+            "the imitated name must be its own element, so a comma inside an \
+             attacker-chosen nickname cannot forge structure the way it did in \
+             #488's tooltip"
+        );
+
+        // The name must never be folded INTO the sentence — the same rule
+        // `ImpersonationWarning::tooltip` states and `appointer_names` follows.
+        for joiner in [
+            "impersonated.display_name.join",
+            "{impersonation_tooltip} {warning.impersonated.display_name}",
+        ] {
+            assert!(
+                !prod.contains(joiner),
+                "`{joiner}` joins an attacker-chosen nickname into our sentence"
             );
         }
     }

--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -296,12 +296,20 @@ pub fn MemberInfoModal() -> Element {
                 owner_id,
                 &deputy_badges,
             );
+            // BOTH ids below are `member_id`, the member whose modal this is —
+            // never `self_member_id`. The 4th argument never suppresses the
+            // badge; it picks which of the two true sentences the tooltip
+            // states (see `ImpersonationWarning`), so passing the VIEWER's
+            // privilege there would tell a moderator looking at an impostor
+            // "Name conflict … Both are real", exonerating the impostor to
+            // exactly the people who would act on it. The argument list is
+            // kept contiguous, with no comment inside it, so the pin in
+            // `modal_passes_the_target_id_and_the_targets_own_privilege` can
+            // match it whitespace-insensitively.
             super::impersonation_warning_for_display(
                 &checker,
                 member_id,
                 &target_nickname,
-                // Never suppresses the badge — it only picks which of the two
-                // true sentences the tooltip states. See `ImpersonationWarning`.
                 super::privilege_in_view(member_id, owner_id, &deputy_badges),
             )
         });
@@ -444,9 +452,15 @@ pub fn MemberInfoModal() -> Element {
                                 p { class: "mb-1", "{impersonation_tooltip}" }
                                 div {
                                     span { class: "mr-1 text-text-muted", "Resembles:" }
+                                    // `max-w-full break-words`: this is an
+                                    // attacker-chosen nickname, so it can be
+                                    // long and contain no spaces at all.
+                                    // Without them it overflows the modal's
+                                    // `max-w-md` at 320px and pushes the panel
+                                    // wider than the viewport.
                                     span {
                                         "data-testid": "member-info-impersonated-name",
-                                        class: "inline-block px-2 py-0.5 rounded bg-surface border border-border text-text",
+                                        class: "inline-block max-w-full break-words px-2 py-0.5 rounded bg-surface border border-border text-text",
                                         "{warning.impersonated.display_name}"
                                     }
                                 }
@@ -821,10 +835,20 @@ mod ban_gate_tests {
             );
         }
 
-        let explanation = prod
-            .find("member-info-impersonation-explanation")
-            .map(|i| &prod[i..(i + 900).min(prod.len())])
-            .expect("the modal must render an explanation block for the ⚠");
+        // Scoped between anchors rather than by a byte count: the first version
+        // took a fixed 900-character window, and adding a comment inside the
+        // block silently pushed the element it checks out of range. A pin whose
+        // reach depends on how much prose sits above it is not a pin.
+        let explanation = {
+            let start = prod
+                .find("member-info-impersonation-explanation")
+                .expect("the modal must render an explanation block for the ⚠");
+            let end = prod[start..]
+                .find("NicknameField")
+                .expect("the explanation block is followed by the nickname field")
+                + start;
+            &prod[start..end]
+        };
         assert!(
             explanation.contains("{impersonation_tooltip}"),
             "the warning's SENTENCE must be rendered as visible text, not only \
@@ -850,5 +874,61 @@ mod ban_gate_tests {
                 "`{joiner}` joins an attacker-chosen nickname into our sentence"
             );
         }
+    }
+
+    /// **The ARGUMENTS, not just the call.** The member list and the
+    /// conversation author line each pin theirs; this is the third surface and
+    /// was pinned by nothing.
+    ///
+    /// Two swaps compile, pass every other test in this file, and are invisible
+    /// in the example-data fixture — where the impostor and the viewer both
+    /// have `privilege_in_view` of `None`, so nothing observable changes:
+    ///
+    /// * `member_id` -> `self_member_id` at the 2nd argument puts the ⚠ on the
+    ///   genuine owner and every genuine moderator.
+    /// * `member_id` -> `self_member_id` INSIDE `privilege_in_view` at the 4th
+    ///   is the subtler one and matters most in the room this feature exists
+    ///   for. A viewer who is themselves badged — every moderator in Freenet
+    ///   Official — would open an impostor's modal and be shown the
+    ///   PRIVILEGED-clash sentence: "Name conflict … Both are real; check the
+    ///   member ID". That is the wording for a legitimate collision, displayed
+    ///   for a genuine impersonation, exonerating the impostor to precisely the
+    ///   people who would otherwise ban them.
+    ///
+    /// Whitespace-insensitive so `cargo fmt` may rewrap the call, but still
+    /// failing if an ARGUMENT changes.
+    #[test]
+    fn modal_passes_the_target_id_and_the_targets_own_privilege() {
+        let source = include_str!("member_info_modal.rs");
+        let prod = &source[..source
+            .find("#[cfg(test)]")
+            .expect("member_info_modal.rs should have a #[cfg(test)] block")];
+
+        // Scope to the one computation, not the whole file: this file also
+        // contains the comment describing the call, and a whole-file scrape
+        // would match that instead.
+        let start = prod
+            .find("let impersonation = owner_key_signal")
+            .expect("the modal must compute an impersonation warning");
+        let end = prod[start..]
+            .find("let impersonation_tooltip")
+            .expect("the warning computation is followed by its tooltip")
+            + start;
+        let call = &prod[start..end];
+
+        let squashed = call.split_whitespace().collect::<Vec<_>>().join(" ");
+        assert!(
+            squashed.contains(
+                "impersonation_warning_for_display( &checker, member_id, &target_nickname, \
+                 super::privilege_in_view(member_id, owner_id, &deputy_badges), )"
+            ),
+            "the member-info modal no longer passes `member_id` — the member \
+             whose modal this is — as BOTH the flagged id and the subject of \
+             `privilege_in_view`. Passing `self_member_id` at the 2nd argument \
+             brands the genuine owner and every genuine moderator; passing it \
+             at the 4th shows a badged viewer the \"Name conflict … Both are \
+             real\" sentence for a real impostor. Neither is visible in the \
+             example-data fixture, which is why this pin exists.\ngot: {squashed}"
+        );
     }
 }

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -48,7 +48,7 @@ const DEEP_HISTORY_FILLER_MESSAGES: usize = 188;
 /// has its own dedicated fixture room below).
 const DEEP_ROOM_MAX_RECENT_MESSAGES: usize = 300;
 
-/// Fillers for the AT-CAP fixture room: 148 + the 12 standard messages lands
+/// Fillers for the AT-CAP fixture room: 148 + the 13 standard messages lands
 /// exactly on that room's `max_recent_messages`
 /// ([`AT_CAP_MAX_RECENT_MESSAGES`]), so every delivered arrival drains the
 /// oldest message — the steady state of every busy production room, and the
@@ -67,7 +67,13 @@ const AT_CAP_FILLER_MESSAGES: usize = 148;
 /// `max_recent_messages` for the at-cap room. Raised from the default 100 so
 /// the room can hold enough PAIRED fillers to exceed the render window in
 /// display items (pairs halve the item count) while sitting exactly at cap.
-const AT_CAP_MAX_RECENT_MESSAGES: usize = 160;
+///
+/// Tracks the seeded total exactly: [`AT_CAP_FILLER_MESSAGES`] plus the
+/// standard block. It went 160 -> 161 when #489's guaranteed impostor message
+/// was added to that block — `at_cap_room_is_exactly_at_its_message_cap` is
+/// what catches the drift, so bump this rather than shrinking the fillers
+/// (they must stay an EVEN count to keep the same-author pairing).
+const AT_CAP_MAX_RECENT_MESSAGES: usize = 161;
 
 /// How deep a fixture room's message history is seeded.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -309,18 +315,55 @@ fn create_room(
         inviter_sk,
     ));
 
+    // The deputy's nickname, captured rather than inlined: the impostor added
+    // below is DERIVED from it (see `confusable_variant`), because these names
+    // are re-rolled on every run.
+    let deputy_nickname = random_full_name() + " (Member)";
+
     member_info
         .member_info
         .push(AuthorizedMemberInfo::new_with_member_key(
             MemberInfo {
                 member_id: other_member_id,
                 version: 0,
-                preferred_nickname: SealedBytes::public(
-                    (random_full_name() + " (Member)").into_bytes(),
-                ),
+                preferred_nickname: SealedBytes::public(deputy_nickname.clone().into_bytes()),
                 deputies: Vec::new(),
             },
             &other_member_sk,
+        ));
+
+    // The IMPOSTOR (freenet/river#489), so the ⚠ impersonation warning is
+    // visible in `cargo make dev-example` and reachable from Playwright. Before
+    // this, the badge had never been seen in a browser: nothing in example data
+    // produced two members whose names fold together.
+    //
+    // They are a plain member, NOT a deputy. Adding a second deputy would break
+    // `member-info-deputy-tag.spec.ts`, which asserts exactly ONE member row
+    // carries a 🛡 — and it would be the wrong shape anyway, since the point is
+    // a member with no authority wearing a moderator's name.
+    let impostor_sk = SigningKey::generate(&mut csprng);
+    let impostor_vk = impostor_sk.verifying_key();
+    let impostor_id = MemberId::from(&impostor_vk);
+    members.members.push(AuthorizedMember::new(
+        Member {
+            owner_member_id: owner_id,
+            invited_by: inviter_id,
+            member_vk: impostor_vk,
+        },
+        inviter_sk,
+    ));
+    member_info
+        .member_info
+        .push(AuthorizedMemberInfo::new_with_member_key(
+            MemberInfo {
+                member_id: impostor_id,
+                version: 0,
+                preferred_nickname: SealedBytes::public(
+                    confusable_variant(&deputy_nickname).into_bytes(),
+                ),
+                deputies: Vec::new(),
+            },
+            &impostor_sk,
         ));
 
     // Add members to the room
@@ -333,6 +376,7 @@ fn create_room(
         member_keys.insert(self_id, self_sk.clone());
     }
     member_keys.insert(other_member_id, other_member_sk);
+    member_keys.insert(impostor_id, impostor_sk);
 
     // Add example messages
     add_example_messages(
@@ -341,6 +385,7 @@ fn create_room(
         owner_sk,
         &member_keys,
         other_member_id,
+        impostor_id,
         history_depth,
     );
 
@@ -396,6 +441,10 @@ fn add_example_messages(
     // conversation's 🛡 badge is deterministically present for Playwright —
     // the random author picks alone leave it to chance.
     deputy_id: MemberId,
+    // The member whose nickname is confusable with the deputy's (#489). Given a
+    // guaranteed message for the same reason: the ⚠ on an author line must not
+    // depend on the random author picks above.
+    impostor_id: MemberId,
     history_depth: HistoryDepth,
 ) {
     // Use a timestamp 24 hours ago as base time for messages
@@ -529,6 +578,26 @@ fn add_example_messages(
                 ),
             },
             deputy_key,
+        );
+        messages.messages.push(msg);
+        current_time_ms += 60_000;
+    }
+
+    // One guaranteed message from the IMPOSTOR, so the conversation always has
+    // an author line carrying the ⚠ warning (#489) just below the deputy's 🛡
+    // line above — which is exactly the comparison the badge exists to let a
+    // reader make.
+    if let Some(impostor_key) = member_keys.get(&impostor_id) {
+        let msg = AuthorizedMessageV1::new(
+            MessageV1 {
+                room_owner: *owner_id,
+                author: impostor_id,
+                time: get_time_from_millis(current_time_ms),
+                content: RoomMessageBody::public(
+                    "Hi all, DM me your invite code and I'll sort it out.".to_string(),
+                ),
+            },
+            impostor_key,
         );
         messages.messages.push(msg);
         current_time_ms += 60_000;
@@ -736,6 +805,38 @@ fn add_example_messages(
     room_state.recent_messages = messages;
 }
 
+/// A nickname visually confusable with `real` — the impostor half of the #489
+/// ⚠ fixture.
+///
+/// **Derived, not hardcoded, and that is the whole point.** Example nicknames
+/// come from [`random_full_name`] and are re-rolled on every run, so a literal
+/// `"lan Clarke"` would collide with the deputy only on the runs where the
+/// generator happened to pick `Ian Clarke` — a fixture that reaches its own
+/// premise about 1 time in 1,000.
+///
+/// Every branch is a TIER-1 collision by construction, for ANY input:
+///
+/// * `I` -> `l` and `l` -> `I` swap one member of the fold's *bar class*
+///   (`I`, `l`, `1`, `|`, `!` all fold to the same sentinel), so the VISUAL
+///   skeleton is unchanged. This is the live 2026-07-25 attack, and the branch
+///   the demo wants: the two names are near-indistinguishable on screen.
+/// * Uppercasing changes only case, so the CASE-INSENSITIVE skeleton is
+///   unchanged.
+///
+/// `the_example_impostor_always_collides_with_the_deputy` pins the property
+/// against the real generator rather than against one hand-picked name.
+fn confusable_variant(real: &str) -> String {
+    // `I` and `l` are ASCII, so a `find` hit is always a char boundary and
+    // `i + 1` is the next one.
+    if let Some(i) = real.find('I') {
+        format!("{}l{}", &real[..i], &real[i + 1..])
+    } else if let Some(i) = real.find('l') {
+        format!("{}I{}", &real[..i], &real[i + 1..])
+    } else {
+        real.to_uppercase()
+    }
+}
+
 fn get_time_from_millis(ms: u64) -> SystemTime {
     // Use WASM-compatible time function
     crate::util::get_current_system_time()
@@ -867,6 +968,126 @@ mod tests {
              items or the windowing specs quietly degrade to the small-room \
              path; got {display_items}"
         );
+    }
+
+    /// The impostor's name must ACTUALLY collide with the deputy's, for every
+    /// name the generator can produce — not just for the one a developer had in
+    /// mind when they wrote the fixture.
+    ///
+    /// This is the fixture-reaches-its-premise check. A fixture that silently
+    /// fails to set up the state it claims is this repo's signature failure
+    /// mode: the Playwright spec would still pass its "no ⚠ on the deputy" half
+    /// while the ⚠ it is supposed to find never rendered at all.
+    #[test]
+    fn the_example_impostor_always_collides_with_the_deputy() {
+        use crate::util::confusable::folds_together;
+
+        // One name per branch of `confusable_variant`, so a future edit that
+        // breaks a branch fails here rather than in a browser.
+        for (real, why) in [
+            ("Ian Clarke (Member)", "capital I -> lowercase l"),
+            ("Alice Golden (Member)", "no capital I; lowercase l -> I"),
+            ("Bob Smith (Member)", "neither I nor l; uppercased"),
+        ] {
+            let variant = confusable_variant(real);
+            assert_ne!(
+                variant, real,
+                "{why}: the impostor must differ from {real:?}"
+            );
+            assert!(
+                folds_together(&variant, real),
+                "{why}: {variant:?} must fold onto {real:?} or the ⚠ never fires"
+            );
+        }
+
+        // And against the REAL generator, which is what the fixture uses.
+        for _ in 0..500 {
+            let real = random_full_name() + " (Member)";
+            let variant = confusable_variant(&real);
+            assert_ne!(variant, real);
+            assert!(
+                folds_together(&variant, &real),
+                "{variant:?} does not fold onto {real:?}"
+            );
+        }
+    }
+
+    /// The end-to-end fixture precondition: in EVERY example room the viewer's
+    /// own checker is non-empty, the deputy is badged, and the impostor is the
+    /// member it flags.
+    ///
+    /// Asserted through the same entry points the UI renders from, so it cannot
+    /// pass while the browser shows nothing.
+    #[test]
+    fn every_example_room_shows_the_impersonation_warning() {
+        use crate::components::members::{
+            deputy_badges_for_viewer, impersonation_checker_for_viewer,
+            impersonation_warning_for_display, privilege_in_view,
+        };
+        use crate::util::display_name::display_nickname;
+
+        for (owner_vk, room_data) in create_example_rooms().map.iter() {
+            let owner_id = MemberId::from(owner_vk);
+            let self_member_id = MemberId::from(&room_data.self_sk.verifying_key());
+            let state = &room_data.room_state;
+
+            let deputy_badges = deputy_badges_for_viewer(
+                &state.members,
+                &state.member_info,
+                &room_data.secrets,
+                owner_id,
+                self_member_id,
+            );
+            assert!(
+                !deputy_badges.is_empty(),
+                "the owner-appointed deputy must be badged, or there is no \
+                 protected name for the impostor to collide with"
+            );
+
+            let checker = impersonation_checker_for_viewer(
+                &state.member_info,
+                &room_data.secrets,
+                owner_id,
+                &deputy_badges,
+            );
+            assert!(
+                !checker.is_empty(),
+                "the protected set is empty, so no ⚠ can ever render in this room"
+            );
+
+            let flagged: Vec<MemberId> = state
+                .members
+                .members
+                .iter()
+                .map(|m| m.member.id())
+                .filter(|&id| {
+                    let Some(mi) = state.member_info.canonical(id) else {
+                        return false;
+                    };
+                    let name =
+                        display_nickname(&mi.member_info.preferred_nickname, &room_data.secrets);
+                    impersonation_warning_for_display(
+                        &checker,
+                        id,
+                        &name,
+                        privilege_in_view(id, owner_id, &deputy_badges),
+                    )
+                    .is_some()
+                })
+                .collect();
+
+            assert_eq!(
+                flagged.len(),
+                1,
+                "exactly one member (the impostor) must be flagged; the deputy \
+                 is exempt from their OWN name and nobody else should collide"
+            );
+            assert!(
+                !deputy_badges.contains_key(&flagged[0]),
+                "the flagged member must be the plain-member impostor, not a \
+                 badged deputy"
+            );
+        }
     }
 
     #[test]

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -35,7 +35,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 /// item: alternation makes messages == items, so the count is a guarantee
 /// rather than a hope.
 ///
-/// Sized to more than THREE windows (188 + the 12 standard messages = 200), so
+/// Sized to more than THREE windows (188 + the 13 standard messages = 201), so
 /// the backfill-paging spec takes several growth steps to exhaust the room and
 /// the #505 blocker-2 scenario (arrivals widening the rendered window past one
 /// whole growth step) is reachable with a single batched delivery. The room's
@@ -78,7 +78,7 @@ const AT_CAP_MAX_RECENT_MESSAGES: usize = 161;
 /// How deep a fixture room's message history is seeded.
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum HistoryDepth {
-    /// The standard ~12-message fixture. Fits inside the render window, so
+    /// The standard ~13-message fixture. Fits inside the render window, so
     /// these rooms exercise the pre-window code path exactly as before.
     Standard,
     /// [`DEEP_HISTORY_FILLER_MESSAGES`] alternating-author fillers ahead of the
@@ -814,7 +814,8 @@ fn add_example_messages(
 /// generator happened to pick `Ian Clarke` — a fixture that reaches its own
 /// premise about 1 time in 1,000.
 ///
-/// Every branch is a TIER-1 collision by construction, for ANY input:
+/// The first three branches are a TIER-1 collision by construction for any
+/// ASCII input:
 ///
 /// * `I` -> `l` and `l` -> `I` swap one member of the fold's *bar class*
 ///   (`I`, `l`, `1`, `|`, `!` all fold to the same sentinel), so the VISUAL
@@ -823,8 +824,12 @@ fn add_example_messages(
 /// * A letter-for-digit swap from [`crate::util::confusable`]'s ASCII table
 ///   (`o`->`0`, `e`->`3`, `s`->`5`, `a`->`4`, `t`->`7`), which that table folds
 ///   straight back, so the skeleton is unchanged.
-/// * Uppercasing changes only case, so the CASE-INSENSITIVE skeleton is
-///   unchanged.
+/// * Uppercasing, for ASCII, changes only case, so the CASE-INSENSITIVE
+///   skeleton is unchanged. This one is NOT universal — `str::to_uppercase`
+///   is not case-only for every input (`ß` -> `SS`, `ﬁ` -> `FI` change
+///   length) — which is fine, because it is the fallback for inputs outside
+///   the generator's ASCII pools and the tests pin that it never fires for
+///   inputs inside them.
 ///
 /// **The branch ORDER is a demo decision, not an arbitrary one.** Measured
 /// exhaustively over the real pools (46 x 23 = 1,058 handles): `I`->`l` covers
@@ -835,9 +840,18 @@ fn add_example_messages(
 /// a developer reasonably reads as a FALSE POSITIVE. A fixture that teaches the
 /// reader to distrust the badge inverts its own purpose, and is the same
 /// "trains people to ignore the warning" harm the tier-1-only decision exists
-/// to avoid. The digit swap is checked first for that reason: all 544 of those
-/// handles contain at least one of `o/e/s/a/t`, so it covers the remainder
-/// completely and `B0b Smith (Member)` is what the demo shows.
+/// to avoid. The digit swap is tried BEFORE the uppercase fallback for that
+/// reason: all 544 of those handles contain at least one of `o/e/s/a/t`, so it
+/// covers the remainder completely and `B0b Smith (Member)` is what the demo
+/// shows.
+///
+/// The digit swap searches only the NAME, never the `" (Member)"` / `" (Owner)"`
+/// role suffix. The suffix contains an `e`, so an unconstrained search would
+/// always find a target there and quietly hide a name the pools cannot spoof —
+/// producing `Quinn Zhu (M3mber)`, which reads as a broken label rather than a
+/// spoofed name. `the_example_impostor_always_collides_with_the_deputy` pins
+/// that the swap lands inside the name for every handle the generator can
+/// produce.
 ///
 /// Uppercasing stays as a last resort for inputs outside the generator's pools.
 ///
@@ -860,7 +874,12 @@ fn confusable_variant(real: &str) -> String {
     }
     // Both cases: the visual fold lowercases, so `O` and `o` both end up at
     // `o`, which is where the table sends `0`.
-    for (i, c) in real.char_indices() {
+    //
+    // Searched over the NAME only — everything before the role suffix — so a
+    // name with none of `o/e/s/a/t` falls through to the fallback instead of
+    // silently mangling `" (Member)"` into `" (M3mber)"`.
+    let name_len = real.find(" (").unwrap_or(real.len());
+    for (i, c) in real[..name_len].char_indices() {
         if let Some((_, digit)) = DIGIT_FOR
             .iter()
             .find(|(letter, _)| c.eq_ignore_ascii_case(letter))
@@ -1035,32 +1054,52 @@ mod tests {
             );
         }
 
-        // The demo-QUALITY property, pinned rather than left to a comment: the
-        // uppercase fallback must be unreachable for every handle the generator
-        // can actually produce. It used to catch 51.4% of them, and
-        // `BOB SMITH (MEMBER)` beside `Bob Smith (Member)` reads as a false
-        // positive to anyone looking at the dev build — which teaches exactly
-        // the distrust of the badge this feature cannot afford.
-        for _ in 0..500 {
-            let real = random_full_name() + " (Member)";
-            assert_ne!(
-                confusable_variant(&real),
-                real.to_uppercase(),
-                "{real:?} fell through to the uppercase fallback; the demo now \
-                 shows a shouted name, which reads as a false positive"
-            );
-        }
-
-        // And against the REAL generator, which is what the fixture uses.
-        for _ in 0..500 {
-            let real = random_full_name() + " (Member)";
+        // Now against the real generator, EXHAUSTIVELY — all 1,058 handles, not
+        // a sample. Sampling ~40% of the product per run would turn a pool
+        // regression into an intermittent failure, and the doc above claims
+        // these numbers were measured over the whole pool, so the test should
+        // measure the whole pool too.
+        let mut checked = 0usize;
+        for name in crate::util::all_full_names() {
+            let real = name + " (Member)";
             let variant = confusable_variant(&real);
-            assert_ne!(variant, real);
+
+            assert_ne!(variant, real, "{real:?} produced no variant at all");
             assert!(
                 folds_together(&variant, &real),
                 "{variant:?} does not fold onto {real:?}"
             );
+
+            // The demo-QUALITY property, pinned rather than left to a comment:
+            // the uppercase fallback must be unreachable for every handle the
+            // generator can actually produce. It used to catch 51.4% of them,
+            // and `BOB SMITH (MEMBER)` beside `Bob Smith (Member)` reads as a
+            // false positive to anyone looking at the dev build — which teaches
+            // exactly the distrust of the badge this feature cannot afford.
+            assert_ne!(
+                variant,
+                real.to_uppercase(),
+                "{real:?} fell through to the uppercase fallback; the demo now \
+                 shows a shouted name, which reads as a false positive"
+            );
+
+            // …and the substitution must land in the NAME, never in the
+            // `" (Member)"` role suffix. `Quinn Zhu (M3mber)` would satisfy
+            // every assertion above while showing the reader a broken label
+            // rather than a spoofed name.
+            let suffix_at = real.find(" (").expect("the fixture appends a role");
+            assert_eq!(
+                &variant[suffix_at..],
+                &real[suffix_at..],
+                "{variant:?} mangled the role suffix instead of the name"
+            );
+            checked += 1;
         }
+        assert!(
+            checked > 1_000,
+            "premise: the enumeration must cover the whole pool product; only \
+             {checked} names were checked"
+        );
     }
 
     /// The end-to-end fixture precondition: in EVERY example room the viewer's
@@ -1130,8 +1169,12 @@ mod tests {
             assert_eq!(
                 flagged.len(),
                 1,
-                "exactly one member (the impostor) must be flagged; the deputy \
-                 is exempt from their OWN name and nobody else should collide"
+                "exactly one MEMBER (the impostor) must be flagged; the deputy \
+                 is exempt from their OWN name and nobody else should collide. \
+                 Note this sweeps `members.members`, which deliberately \
+                 excludes the owner — a warning wrongly painted on the OWNER is \
+                 caught by impersonation-warning.spec.ts, which renders the \
+                 owner as a row, not here"
             );
             assert!(
                 !deputy_badges.contains_key(&flagged[0]),

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -820,21 +820,55 @@ fn add_example_messages(
 ///   (`I`, `l`, `1`, `|`, `!` all fold to the same sentinel), so the VISUAL
 ///   skeleton is unchanged. This is the live 2026-07-25 attack, and the branch
 ///   the demo wants: the two names are near-indistinguishable on screen.
+/// * A letter-for-digit swap from [`crate::util::confusable`]'s ASCII table
+///   (`o`->`0`, `e`->`3`, `s`->`5`, `a`->`4`, `t`->`7`), which that table folds
+///   straight back, so the skeleton is unchanged.
 /// * Uppercasing changes only case, so the CASE-INSENSITIVE skeleton is
 ///   unchanged.
+///
+/// **The branch ORDER is a demo decision, not an arbitrary one.** Measured
+/// exhaustively over the real pools (46 x 23 = 1,058 handles): `I`->`l` covers
+/// 6.5%, `l`->`I` covers 42.1%, and the remaining 51.4% used to fall through to
+/// uppercasing. That meant more than half of `cargo make dev-example` runs
+/// showed `BOB SMITH (MEMBER)` flagged as impersonating `Bob Smith (Member)` —
+/// a correct tier-1 match (the case-insensitive fold is exactly that), but one
+/// a developer reasonably reads as a FALSE POSITIVE. A fixture that teaches the
+/// reader to distrust the badge inverts its own purpose, and is the same
+/// "trains people to ignore the warning" harm the tier-1-only decision exists
+/// to avoid. The digit swap is checked first for that reason: all 544 of those
+/// handles contain at least one of `o/e/s/a/t`, so it covers the remainder
+/// completely and `B0b Smith (Member)` is what the demo shows.
+///
+/// Uppercasing stays as a last resort for inputs outside the generator's pools.
 ///
 /// `the_example_impostor_always_collides_with_the_deputy` pins the property
 /// against the real generator rather than against one hand-picked name.
 fn confusable_variant(real: &str) -> String {
+    // Letters the ASCII confusable table folds a digit back onto. Kept in the
+    // fold's own order so the correspondence is checkable by eye against
+    // `fold_ascii_confusable`.
+    const DIGIT_FOR: [(char, char); 5] =
+        [('o', '0'), ('e', '3'), ('s', '5'), ('a', '4'), ('t', '7')];
+
     // `I` and `l` are ASCII, so a `find` hit is always a char boundary and
     // `i + 1` is the next one.
     if let Some(i) = real.find('I') {
-        format!("{}l{}", &real[..i], &real[i + 1..])
-    } else if let Some(i) = real.find('l') {
-        format!("{}I{}", &real[..i], &real[i + 1..])
-    } else {
-        real.to_uppercase()
+        return format!("{}l{}", &real[..i], &real[i + 1..]);
     }
+    if let Some(i) = real.find('l') {
+        return format!("{}I{}", &real[..i], &real[i + 1..]);
+    }
+    // Both cases: the visual fold lowercases, so `O` and `o` both end up at
+    // `o`, which is where the table sends `0`.
+    for (i, c) in real.char_indices() {
+        if let Some((_, digit)) = DIGIT_FOR
+            .iter()
+            .find(|(letter, _)| c.eq_ignore_ascii_case(letter))
+        {
+            return format!("{}{}{}", &real[..i], digit, &real[i + c.len_utf8()..]);
+        }
+    }
+    real.to_uppercase()
 }
 
 fn get_time_from_millis(ms: u64) -> SystemTime {
@@ -987,7 +1021,8 @@ mod tests {
         for (real, why) in [
             ("Ian Clarke (Member)", "capital I -> lowercase l"),
             ("Alice Golden (Member)", "no capital I; lowercase l -> I"),
-            ("Bob Smith (Member)", "neither I nor l; uppercased"),
+            ("Bob Smith (Member)", "neither I nor l; letter -> digit"),
+            ("Zyx Wvu", "no I, no l, no o/e/s/a/t; uppercased"),
         ] {
             let variant = confusable_variant(real);
             assert_ne!(
@@ -997,6 +1032,22 @@ mod tests {
             assert!(
                 folds_together(&variant, real),
                 "{why}: {variant:?} must fold onto {real:?} or the ⚠ never fires"
+            );
+        }
+
+        // The demo-QUALITY property, pinned rather than left to a comment: the
+        // uppercase fallback must be unreachable for every handle the generator
+        // can actually produce. It used to catch 51.4% of them, and
+        // `BOB SMITH (MEMBER)` beside `Bob Smith (Member)` reads as a false
+        // positive to anyone looking at the dev build — which teaches exactly
+        // the distrust of the badge this feature cannot afford.
+        for _ in 0..500 {
+            let real = random_full_name() + " (Member)";
+            assert_ne!(
+                confusable_variant(&real),
+                real.to_uppercase(),
+                "{real:?} fell through to the uppercase fallback; the demo now \
+                 shows a shouted name, which reads as a false positive"
             );
         }
 

--- a/ui/src/util.rs
+++ b/ui/src/util.rs
@@ -334,6 +334,8 @@ pub async fn sleep(duration: Duration) {
 
 #[cfg(feature = "example-data")]
 mod name_gen;
+#[cfg(all(test, feature = "example-data"))]
+pub(crate) use name_gen::all_full_names;
 #[cfg(feature = "example-data")]
 pub use name_gen::random_full_name;
 

--- a/ui/src/util/confusable.rs
+++ b/ui/src/util/confusable.rs
@@ -367,8 +367,18 @@ impl ImpersonationWarning {
     ///   `flagged_privilege`, so a collision can appear in only one of them and
     ///   look intermittent.
     ///
-    /// If you reword this, grep the Playwright specs for `getByRole` name
-    /// locators and check each against the NEW text.
+    /// Since freenet/river#494 the member-info modal also renders this sentence
+    /// as VISIBLE TEXT, so the collision surface is wider than accessible
+    /// names: `getByText`, `filter({ hasText })` and `toContainText` can now
+    /// match it too, which they could not when it lived only in `title` and
+    /// `aria-label`. The deputy wording contains 🛡, and
+    /// `member-info-deputy-tag.spec.ts` filters rows on `hasText: "🛡"` — safe
+    /// today only because that locator is scoped to `button[title^="Member
+    /// ID"]`, not because the glyph is unique on the page.
+    ///
+    /// If you reword this, grep the Playwright specs for `getByRole`,
+    /// `getByText`, `hasText` and `toContainText` and check each against the
+    /// NEW text.
     ///
     /// Pinned by `tooltip_contains_no_nickname_content`.
     pub fn tooltip(&self) -> String {

--- a/ui/src/util/confusable.rs
+++ b/ui/src/util/confusable.rs
@@ -380,7 +380,17 @@ impl ImpersonationWarning {
     /// `getByText`, `hasText` and `toContainText` and check each against the
     /// NEW text.
     ///
-    /// Pinned by `tooltip_contains_no_nickname_content`.
+    /// ## The leading clause is a UI label
+    ///
+    /// Everything before the FIRST colon is used verbatim as the member-info
+    /// modal's chip label, so this string must always start with a short label
+    /// followed by `:`. Drop the colon and the chip silently becomes the whole
+    /// sentence. Deriving it that way is deliberate — it is what stops that
+    /// surface inventing wording that drifts from this one definition — but it
+    /// makes the colon load-bearing rather than cosmetic.
+    ///
+    /// Pinned by `tooltip_contains_no_nickname_content` and
+    /// `tooltip_leads_with_a_short_label_before_a_colon`.
     pub fn tooltip(&self) -> String {
         if self.flagged_privilege.is_some() {
             return "Name conflict: this member's name is visually the same as \
@@ -3153,6 +3163,47 @@ mod tests {
             // ROLE is being imitated, and the badge to look for.
             assert!(baseline.contains("Impersonation warning"), "{baseline}");
             assert!(baseline.contains("is NOT"), "{baseline}");
+        }
+    }
+
+    /// The member-info modal takes everything before the FIRST colon as its
+    /// chip label (freenet/river#494), so the colon is load-bearing, not
+    /// punctuation. A reword that drops it — or that buries it a sentence in —
+    /// turns the chip into a paragraph, and nothing about the modal would say
+    /// so, because the label is derived rather than written.
+    #[test]
+    fn tooltip_leads_with_a_short_label_before_a_colon() {
+        for warning in [
+            ImpersonationWarning {
+                impersonated: ProtectedName::new(ProtectedRole::Deputy, "Anodyne", mid(1)),
+                tier: ConfusableTier::Identical,
+                flagged_privilege: None,
+            },
+            ImpersonationWarning {
+                impersonated: ProtectedName::new(ProtectedRole::Owner, "Anodyne", mid(1)),
+                tier: ConfusableTier::Identical,
+                flagged_privilege: None,
+            },
+            // The privileged branch, which has its own wording.
+            ImpersonationWarning {
+                impersonated: ProtectedName::new(ProtectedRole::Deputy, "Anodyne", mid(1)),
+                tier: ConfusableTier::Identical,
+                flagged_privilege: Some(ProtectedRole::Deputy),
+            },
+        ] {
+            let tip = warning.tooltip();
+            let label = tip
+                .split(':')
+                .next()
+                .expect("split always yields at least one part");
+            assert_ne!(
+                label, tip,
+                "the tooltip must contain a colon — the modal's chip label is                  the clause before it: {tip:?}"
+            );
+            assert!(
+                ["Impersonation warning", "Name conflict"].contains(&label),
+                "the chip label derived from this tooltip is {label:?}, which                  is not one of the two labels the modal is designed around.                  Either keep the leading clause short, or stop deriving the                  label in `member_info_modal.rs`."
+            );
         }
     }
 

--- a/ui/src/util/confusable.rs
+++ b/ui/src/util/confusable.rs
@@ -345,6 +345,31 @@ impl ImpersonationWarning {
     /// ID River shows on hover). Pinned by
     /// `crate::components::members::a_shield_and_a_warning_can_both_render`.
     ///
+    /// ## Rewording this text can break browser tests in unrelated files
+    ///
+    /// Read this before changing a word of it. Every surface puts this string
+    /// in an `aria-label`, and an element's accessible name is composed from
+    /// its descendants — so this text becomes part of the accessible name of
+    /// the whole member ROW, message header, or chip that contains the badge.
+    ///
+    /// Playwright's `getByRole(role, { name })` matches that accessible name by
+    /// case-insensitive SUBSTRING unless the caller passes `exact: true`. The
+    /// two consequences are not obvious and have already cost one debugging
+    /// session:
+    ///
+    /// * A word in here can capture a locator in a spec that has nothing to do
+    ///   with impersonation. "…but their name **close**ly resembles one" made
+    ///   every flagged row answer to `getByRole("button", { name: "Close" })`,
+    ///   and the Export Identity spec failed on a strict-mode violation
+    ///   pointing at a member row (freenet/river#494). The mitigation is
+    ///   `exact: true` at the locator, not softer wording here.
+    /// * There is more than one wording, because the sentence branches on
+    ///   `flagged_privilege`, so a collision can appear in only one of them and
+    ///   look intermittent.
+    ///
+    /// If you reword this, grep the Playwright specs for `getByRole` name
+    /// locators and check each against the NEW text.
+    ///
     /// Pinned by `tooltip_contains_no_nickname_content`.
     pub fn tooltip(&self) -> String {
         if self.flagged_privilege.is_some() {

--- a/ui/src/util/name_gen.rs
+++ b/ui/src/util/name_gen.rs
@@ -34,6 +34,19 @@ static LAST_NAMES: &[&str] = &[
     "Meier",
 ];
 
+/// Every name [`random_full_name`] can produce, in pool order.
+///
+/// Test-only. A property that must hold for EVERY generated handle should be
+/// enumerated, not sampled: the product is only 46 x 23 = 1,058 names, and
+/// sampling turns a pool regression into an intermittent CI failure — which
+/// this repo treats as a broken test, not a flaky one.
+#[cfg(test)]
+pub(crate) fn all_full_names() -> impl Iterator<Item = String> {
+    FIRST_NAMES
+        .iter()
+        .flat_map(|first| LAST_NAMES.iter().map(move |last| format!("{first} {last}")))
+}
+
 pub fn random_full_name() -> String {
     let mut rng = rand::thread_rng();
     let first = FIRST_NAMES.choose(&mut rng).unwrap();

--- a/ui/tests/conversation-autoscroll.spec.ts
+++ b/ui/tests/conversation-autoscroll.spec.ts
@@ -453,7 +453,7 @@ test.describe("Conversation follows layout-only growth (#486)", () => {
 //
 // The fixture: `?deep-history-room=1` adds a room of 80 alternating-author
 // messages (alternation makes messages == display items, so >60 items is a
-// guarantee) plus the ~12 standard fixture messages. The default fixture is
+// guarantee) plus the ~13 standard fixture messages. The default fixture is
 // untouched; the describes above still exercise the small-room path.
 test.describe("Windowed history follows arrivals (#501)", () => {
   test.use({ viewport: { width: 1280, height: 900 } });

--- a/ui/tests/copy-clipboard-feedback.spec.ts
+++ b/ui/tests/copy-clipboard-feedback.spec.ts
@@ -22,17 +22,13 @@ async function selectRoom(page: Page) {
   const roomBtn = page.getByRole("button", { name: ROOM_NAME });
   await expect(roomBtn).toBeVisible({ timeout: 5_000 });
   await roomBtn.click();
-  await expect(
-    page.getByRole("heading", { name: ROOM_NAME })
-  ).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByRole("heading", { name: ROOM_NAME })).toBeVisible({ timeout: 5_000 });
 }
 
 test.describe("Export Identity copy feedback", () => {
   test.use({ viewport: { width: 1280, height: 800 } });
 
-  test("clicking Copy to Clipboard updates the button to 'Copied!'", async ({
-    page,
-  }) => {
+  test("clicking Copy to Clipboard updates the button to 'Copied!'", async ({ page }) => {
     await page.goto("/");
     await waitForApp(page);
     await selectRoom(page);
@@ -46,14 +42,10 @@ test.describe("Export Identity copy feedback", () => {
 
     await copyButton.click();
 
-    await expect(
-      page.getByRole("button", { name: "Copied!" })
-    ).toBeVisible({ timeout: 2_000 });
+    await expect(page.getByRole("button", { name: "Copied!" })).toBeVisible({ timeout: 2_000 });
   });
 
-  test("dismissing via the backdrop also resets the button text", async ({
-    page,
-  }) => {
+  test("dismissing via the backdrop also resets the button text", async ({ page }) => {
     await page.goto("/");
     await waitForApp(page);
     await selectRoom(page);
@@ -64,24 +56,18 @@ test.describe("Export Identity copy feedback", () => {
     const copyButton = page.getByRole("button", { name: "Copy to Clipboard" });
     await expect(copyButton).toBeVisible({ timeout: 5_000 });
     await copyButton.click();
-    await expect(
-      page.getByRole("button", { name: "Copied!" })
-    ).toBeVisible({ timeout: 2_000 });
+    await expect(page.getByRole("button", { name: "Copied!" })).toBeVisible({ timeout: 2_000 });
 
     // Click the backdrop (anywhere outside the inner panel). The modal panel
     // calls stop_propagation, so a click in the corner reaches the backdrop.
     await page.mouse.click(5, 5);
-    await expect(
-      page.getByRole("button", { name: "Copied!" })
-    ).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Copied!" })).toHaveCount(0);
 
     await exportButton.click();
-    await expect(
-      page.getByRole("button", { name: "Copy to Clipboard" })
-    ).toBeVisible({ timeout: 5_000 });
-    await expect(
-      page.getByRole("button", { name: "Copied!" })
-    ).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Copy to Clipboard" })).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByRole("button", { name: "Copied!" })).toHaveCount(0);
   });
 
   test("reopening the modal resets the button text", async ({ page }) => {
@@ -95,23 +81,24 @@ test.describe("Export Identity copy feedback", () => {
     const copyButton = page.getByRole("button", { name: "Copy to Clipboard" });
     await expect(copyButton).toBeVisible({ timeout: 5_000 });
     await copyButton.click();
-    await expect(
-      page.getByRole("button", { name: "Copied!" })
-    ).toBeVisible({ timeout: 2_000 });
+    await expect(page.getByRole("button", { name: "Copied!" })).toBeVisible({ timeout: 2_000 });
 
     // Close via the explicit Close button.
-    await page.getByRole("button", { name: "Close" }).click();
-    await expect(
-      page.getByRole("button", { name: "Copied!" })
-    ).toHaveCount(0);
+    //
+    // `exact: true` is load-bearing. `getByRole` matches the accessible name by
+    // case-insensitive SUBSTRING, and a member row's accessible name includes
+    // its badges' `aria-label`s — the ⚠ impersonation warning's begins
+    // "…their name CLOSEly resembles…" (freenet/river#489). So a room
+    // containing a flagged member gives this locator a second match and the
+    // click fails on strict mode, with no obvious connection to the cause.
+    await page.getByRole("button", { name: "Close", exact: true }).click();
+    await expect(page.getByRole("button", { name: "Copied!" })).toHaveCount(0);
 
     // Reopen — the button must say "Copy to Clipboard" again, not stay stuck on "Copied!".
     await exportButton.click();
-    await expect(
-      page.getByRole("button", { name: "Copy to Clipboard" })
-    ).toBeVisible({ timeout: 5_000 });
-    await expect(
-      page.getByRole("button", { name: "Copied!" })
-    ).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Copy to Clipboard" })).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByRole("button", { name: "Copied!" })).toHaveCount(0);
   });
 });

--- a/ui/tests/impersonation-warning.spec.ts
+++ b/ui/tests/impersonation-warning.spec.ts
@@ -115,9 +115,18 @@ test.describe("Impersonation warning (#489)", () => {
     // FLAGGED member's own name there would pass a non-empty check, and under
     // the two bar-class branches of `confusable_variant` the two names differ
     // by a single character — so it would also survive inspection by eye.
-    const deputyName = ((await rowsWithShield(page).first().textContent()) || "")
-      .replace(/[\u{1F6E1}\u{FE0F}\u{26A0}]/gu, "")
-      .trim();
+    // Read the NAME span rather than stripping glyphs out of the whole row:
+    // a row's text is "<nickname> <badges>", and the badge set is fixture-
+    // dependent (🌐 / 🔑 / 🎪 / 🔭 all render there under other conditions).
+    // Stripping a fixed glyph list would silently poison this string the first
+    // time the fixture grew another badge.
+    const deputyName = (
+      (await rowsWithShield(page)
+        .first()
+        .locator("span:not(.member-icon)")
+        .first()
+        .textContent()) || ""
+    ).trim();
     expect(deputyName, "could not read the deputy's name").not.toBe("");
 
     await rowsWithWarning(page).first().click();

--- a/ui/tests/impersonation-warning.spec.ts
+++ b/ui/tests/impersonation-warning.spec.ts
@@ -1,0 +1,245 @@
+import { test, expect, Page } from "@playwright/test";
+
+// Render coverage for freenet/river#489: the ⚠ impersonation warning.
+//
+// Example data (ui/src/example_data.rs) seeds an IMPOSTOR — a plain member
+// whose nickname is derived from the owner-appointed deputy's so the two fold
+// to the same skeleton. `every_example_room_shows_the_impersonation_warning`
+// pins in Rust that the fixture actually reaches that state; this spec pins
+// that the badge reaches the DOM, which a source-grep cannot catch.
+//
+// Two things here are structurally beyond a unit test:
+//
+//  * **Visible explanatory text in the modal.** `title=` never fires on touch,
+//    so on a phone the glyph alone conveys nothing. A unit test can assert the
+//    string exists in the source; only a browser can assert a reader can get
+//    at it.
+//  * **The 320px case.** The warning used to be clipped away entirely by a
+//    `truncate` on the row BUTTON (see the comment on the member row in
+//    members.rs, and the repro `"Ian Clarke" + "\u{3000}".repeat(13) + "."`).
+//    That class of bug is invisible to every assertion that is not a real
+//    layout at a real width.
+
+const WARNING = "\u{26a0}";
+const MODAL = '[data-testid="member-info-modal"]';
+const MODAL_WARNING_TAG = '[data-testid="member-info-impersonation-tag"]';
+const MODAL_WARNING_TEXT = '[data-testid="member-info-impersonation-explanation"]';
+const MODAL_IMITATED_NAME = '[data-testid="member-info-impersonated-name"]';
+const MODAL_DEPUTY_TAG = '[data-testid="member-info-deputy-tag"]';
+const CONVERSATION_WARNING = '[data-testid="message-author-impersonation-warning"]';
+
+// Every member-list badge carries its own `data-testid` (`MemberTag.test_id`),
+// so these address the badge directly rather than filtering rows by glyph. A
+// glyph filter would also match a nickname that merely CONTAINS the character,
+// which is the kind of thing this feature exists to be careful about.
+const MEMBER_ROW = 'button[title^="Member ID"]';
+const LIST_WARNING = '[data-testid="member-list-impersonation-warning"]';
+const LIST_DEPUTY = '[data-testid="member-list-deputy"]';
+const rowsWithWarning = (page: Page) =>
+  page.locator(MEMBER_ROW).filter({ has: page.locator(LIST_WARNING) });
+const rowsWithShield = (page: Page) =>
+  page.locator(MEMBER_ROW).filter({ has: page.locator(LIST_DEPUTY) });
+
+async function waitForApp(page: Page) {
+  await page.waitForSelector(".app-root", { timeout: 30_000 });
+}
+
+async function openTeamChat(page: Page) {
+  await page.goto("/");
+  await waitForApp(page);
+  await page.getByText("Team Chat Room").first().click();
+  await page.locator(MEMBER_ROW).first().waitFor({ state: "visible", timeout: 15_000 });
+  // Wait for the badge itself, not merely for the list to have rows.
+  //
+  // The member list paints before the impersonation sweep has produced a
+  // result, so a count assertion made on "first row visible" can run against a
+  // half-populated list and see zero warnings. That is a real ordering in the
+  // app, not a slow machine, so the fix is to synchronise on the thing under
+  // test rather than to raise a timeout.
+  await page.locator(LIST_WARNING).first().waitFor({ state: "visible", timeout: 15_000 });
+}
+
+test.describe("Impersonation warning (#489)", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("the impostor's row carries ⚠ and the deputy's does not", async ({ page }) => {
+    await openTeamChat(page);
+
+    // Exactly one member is flagged. More than one would mean the warning is
+    // firing on someone the fixture did not make an impostor — the
+    // false-positive failure the tier-1-only decision exists to prevent.
+    await expect(rowsWithWarning(page)).toHaveCount(1);
+
+    // And it is NOT the deputy — in THIS fixture.
+    //
+    // Read the scope carefully, because the general rule is the opposite of
+    // what this line looks like. 🛡 and ⚠ are NOT mutually exclusive: with the
+    // appointer gate gone, a sockpuppet deputised under a real moderator's name
+    // injects that name into the protected set, and then the genuine moderator
+    // is flagged too (with the tooltip reworded for a member who does hold
+    // privilege). Suppressing the badge for badged members was considered and
+    // deliberately rejected, because it would hand exactly that sockpuppet
+    // immunity.
+    //
+    // What holds here is narrower and is a property of the fixture: there is
+    // ONE deputy, the impostor is a plain member contributing no protected
+    // name, and a member is never accused of impersonating their own identity
+    // (the exemption is keyed on the unforgeable `MemberId`). So a ⚠ on this
+    // shielded row would mean that per-name exemption broke — which would be
+    // worse than shipping nothing. Do not generalise this assertion to "a
+    // deputy is never warned".
+    await expect(rowsWithShield(page)).toHaveCount(1);
+    await expect(
+      page
+        .locator(MEMBER_ROW)
+        .filter({ has: page.locator(LIST_DEPUTY) })
+        .filter({ has: page.locator(LIST_WARNING) }),
+    ).toHaveCount(0);
+  });
+
+  test("the impostor's message author line carries ⚠", async ({ page }) => {
+    await openTeamChat(page);
+
+    const badge = page.locator(CONVERSATION_WARNING).first();
+    await expect(badge).toBeVisible({ timeout: 15_000 });
+    // The tooltip must name the remedy, not merely alarm — and must never
+    // contain a nickname (see `tooltip_contains_no_nickname_content`).
+    await expect(badge).toHaveAttribute("title", /is NOT a moderator/i);
+  });
+
+  test("the impostor's modal EXPLAINS the warning in visible text", async ({ page }) => {
+    await openTeamChat(page);
+    await rowsWithWarning(page).first().click();
+    await expect(page.locator(MODAL)).toBeVisible({ timeout: 5_000 });
+
+    await expect(page.locator(MODAL_WARNING_TAG)).toBeVisible();
+
+    // The point of the whole surface: the sentence is READABLE, with no hover.
+    const explanation = page.locator(MODAL_WARNING_TEXT);
+    await expect(explanation).toBeVisible();
+    await expect(explanation).toContainText(/is NOT a moderator/i);
+
+    // The imitated name is shown as its own element, never folded into the
+    // sentence above it.
+    await expect(page.locator(MODAL_IMITATED_NAME)).toBeVisible();
+    await expect(page.locator(MODAL_IMITATED_NAME)).not.toHaveText("");
+  });
+
+  // Again: fixture-scoped, not a general rule. See the note in the row test —
+  // a genuine deputy CAN carry both badges once someone deputises a sockpuppet
+  // under their name. This fixture has one deputy and a plain-member impostor,
+  // so the only ⚠ belongs to the impostor.
+  test("the deputy's modal shows 🛡 and no ⚠", async ({ page }) => {
+    await openTeamChat(page);
+    await rowsWithShield(page).first().click();
+    await expect(page.locator(MODAL)).toBeVisible({ timeout: 5_000 });
+
+    await expect(page.locator(MODAL_DEPUTY_TAG)).toBeVisible();
+    await expect(page.locator(MODAL_WARNING_TAG)).toHaveCount(0);
+    await expect(page.locator(MODAL_WARNING_TEXT)).toHaveCount(0);
+  });
+});
+
+test.describe("Impersonation warning survives a narrow viewport (#489)", () => {
+  // 320px — the narrowest width the responsive layout targets
+  // (responsive-layout.spec.ts uses the same). The warning was previously
+  // clipped off the row entirely by a `truncate` on the button; only the NAME
+  // may truncate, and every badge is `flex-shrink-0`.
+  test.use({ viewport: { width: 320, height: 568 } });
+
+  test("the ⚠ is still visible at 320px", async ({ page }) => {
+    await page.goto("/");
+    await waitForApp(page);
+
+    // At 320px no room is selected yet and the room-list panel is hidden, so
+    // the room cannot be clicked at all. `responsive-layout.spec.ts` hit the
+    // same wall and solved it by selecting at desktop width and resizing back;
+    // the LAYOUT under test is still the 320px one, which is what matters here.
+    const roomBtn = page.getByRole("button", { name: "Team Chat Room" });
+    const vp = page.viewportSize();
+    await page.setViewportSize({ width: 1280, height: vp?.height ?? 568 });
+    await expect(roomBtn).toBeVisible({ timeout: 15_000 });
+    await roomBtn.click();
+    await expect(page.getByRole("heading", { name: "Team Chat Room" })).toBeVisible({
+      timeout: 15_000,
+    });
+    await page.setViewportSize({ width: 320, height: vp?.height ?? 568 });
+
+    // Now switch to the members panel, which is a separate view at this width.
+    const header = page.locator(".border-b.border-border.bg-panel");
+    await header.locator("button").last().click();
+    await expect(page.locator("aside").filter({ hasText: "Active Members" })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const memberList = page.locator('[data-testid="member-list"]');
+    await memberList.waitFor({ state: "visible", timeout: 15_000 });
+
+    // FORCE the row to overflow before measuring anything.
+    //
+    // Without this the test is vacuous, and quietly so: the example data's
+    // nicknames are short generated names, so at 320px the row does not
+    // overflow, nothing is clipped, and the assertions below would pass
+    // whether or not the clipping bug were present. The bug only bites when
+    // the name is longer than the row — the original repro was
+    // `"Ian Clarke" + "\u{3000}".repeat(13) + "."`.
+    //
+    // Squeezing the panel reproduces exactly that condition without putting an
+    // absurd nickname into the demo data every developer sees. What is under
+    // test is the layout rule, not the specific name: however long the name,
+    // only the NAME may truncate and the badges must survive.
+    await page.addStyleTag({
+      content:
+        'aside:has([data-testid="member-list"]) { width: 150px !important;' +
+        " max-width: 150px !important; min-width: 0 !important; }",
+    });
+
+    const flagged = rowsWithWarning(page).first();
+    await expect(flagged).toBeVisible();
+
+    // Measure the row, the name and the badge in ONE evaluate, so every number
+    // comes from the same layout pass.
+    const m = await flagged.evaluate((el) => {
+      const btn = el as HTMLElement;
+      const name = btn.querySelector("span:not(.member-icon)") as HTMLElement;
+      const icon = btn.querySelector(
+        '[data-testid="member-list-impersonation-warning"]',
+      ) as HTMLElement | null;
+      return {
+        buttonRight: btn.getBoundingClientRect().right,
+        badgeRight: icon ? icon.getBoundingClientRect().right : null,
+        badgeWidth: icon ? icon.getBoundingClientRect().width : 0,
+        nameScrollW: name ? name.scrollWidth : 0,
+        nameClientW: name ? name.clientWidth : 0,
+      };
+    });
+
+    // THE PROPERTY, asserted FIRST so a broken layout fails with the message
+    // that describes the bug. `toBeVisible` alone is not enough — a badge
+    // pushed outside an `overflow:hidden` row still reports a box, which is
+    // exactly how the original bug presented.
+    expect(m.badgeRight, "the ⚠ is not in the row at all").not.toBeNull();
+    expect(m.badgeWidth, "the ⚠ has zero width").toBeGreaterThan(0);
+    expect(
+      m.badgeRight as number,
+      "the ⚠ is clipped past the right edge of its row",
+    ).toBeLessThanOrEqual(m.buttonRight + 1);
+
+    // PREMISE, not decoration: the squeeze must actually be clamping the name.
+    // If it is not, the row has room for everything and the assertion above
+    // would pass with or without the bug.
+    //
+    // Checked SECOND and deliberately so. `scrollWidth`/`clientWidth` are 0 for
+    // an INLINE element, and putting `truncate` back on the row button (the
+    // regression this test exists for) stops the button being a flex container,
+    // which makes both spans inline and both numbers 0. Run first, this would
+    // have failed the mutation check with "the name is not being clamped",
+    // which is true but describes a symptom rather than the clipping.
+    expect(
+      m.nameScrollW,
+      "the name is not being clamped (or the row stopped being a flex " +
+        "container, which makes these numbers 0), so this test cannot " +
+        "detect clipping",
+    ).toBeGreaterThan(m.nameClientW);
+  });
+});

--- a/ui/tests/impersonation-warning.spec.ts
+++ b/ui/tests/impersonation-warning.spec.ts
@@ -168,14 +168,16 @@ test.describe("Impersonation warning survives a narrow viewport (#489)", () => {
   // may truncate, and every badge is `flex-shrink-0`.
   test.use({ viewport: { width: 320, height: 568 } });
 
-  test("the ⚠ is still visible at 320px", async ({ page }) => {
+  /// Open Team Chat's member list at 320px.
+  ///
+  /// At 320px no room is selected yet and the room-list panel is hidden, so
+  /// the room cannot be clicked at all. `responsive-layout.spec.ts` hit the
+  /// same wall and solved it by selecting at desktop width and resizing back;
+  /// the LAYOUT under test is still the 320px one, which is what matters here.
+  async function openTeamChatAtNarrowWidth(page: Page) {
     await page.goto("/");
     await waitForApp(page);
 
-    // At 320px no room is selected yet and the room-list panel is hidden, so
-    // the room cannot be clicked at all. `responsive-layout.spec.ts` hit the
-    // same wall and solved it by selecting at desktop width and resizing back;
-    // the LAYOUT under test is still the 320px one, which is what matters here.
     const roomBtn = page.getByRole("button", { name: "Team Chat Room" });
     const vp = page.viewportSize();
     await page.setViewportSize({ width: 1280, height: vp?.height ?? 568 });
@@ -195,6 +197,10 @@ test.describe("Impersonation warning survives a narrow viewport (#489)", () => {
 
     const memberList = page.locator('[data-testid="member-list"]');
     await memberList.waitFor({ state: "visible", timeout: 15_000 });
+  }
+
+  test("the ⚠ is still visible at 320px", async ({ page }) => {
+    await openTeamChatAtNarrowWidth(page);
 
     // FORCE the row to overflow before measuring anything.
     //
@@ -262,5 +268,69 @@ test.describe("Impersonation warning survives a narrow viewport (#489)", () => {
         "container, which makes these numbers 0), so this test cannot " +
         "detect clipping",
     ).toBeGreaterThan(m.nameClientW);
+  });
+
+  // The reason this whole PR exists: `title=` never fires on touch, so the
+  // modal is the only place a phone user can READ the warning. A test that
+  // only ever opens it at 1280px would not have noticed if it were unreadable
+  // on the device the feature is for.
+  test("the modal's explanation is readable at 320px, and cannot widen the page", async ({
+    page,
+  }) => {
+    await openTeamChatAtNarrowWidth(page);
+
+    await rowsWithWarning(page).first().click();
+    await expect(page.locator(MODAL)).toBeVisible({ timeout: 15_000 });
+
+    const explanation = page.locator(MODAL_WARNING_TEXT);
+    await expect(explanation).toBeVisible();
+    await expect(explanation).toContainText(/is NOT a moderator/i);
+    await expect(page.locator(MODAL_IMITATED_NAME)).toBeVisible();
+
+    // The nickname in that chip is ATTACKER-CHOSEN, so it can be long and
+    // contain no break opportunity at all — which is the case
+    // `member_info_modal.rs`'s `max-w-full break-words` exists for. The
+    // fixture's generated names are short, so as with the row test above this
+    // has to force the condition or it measures nothing.
+    const forced = await page.locator(MODAL_IMITATED_NAME).evaluate((el) => {
+      const span = el as HTMLElement;
+      span.textContent = "W".repeat(160);
+
+      // PREMISE: the injected text must actually be wider than the panel that
+      // has to contain it. Measured on an off-screen clone with wrapping
+      // disabled, so this is the text's NATURAL width, not the wrapped one.
+      const probe = span.cloneNode(true) as HTMLElement;
+      probe.style.position = "absolute";
+      probe.style.left = "-9999px";
+      probe.style.whiteSpace = "nowrap";
+      probe.style.width = "max-content";
+      probe.style.maxWidth = "none";
+      document.body.appendChild(probe);
+      const naturalWidth = probe.getBoundingClientRect().width;
+      probe.remove();
+
+      const panel = span.closest('[data-testid="member-info-modal"]') as HTMLElement;
+      return { naturalWidth, panelWidth: panel.getBoundingClientRect().width };
+    });
+    expect(
+      forced.naturalWidth,
+      "the forced nickname is not wider than the modal panel, so nothing " +
+        "here could overflow and this test proves nothing",
+    ).toBeGreaterThan(forced.panelWidth);
+
+    // THE PROPERTY: a nickname nobody can break must not make the whole page
+    // scroll sideways. `scrollWidth` is read off the document element, so it
+    // catches the panel pushing the layout wide even when the chip itself
+    // reports a box that fits.
+    const overflow = await page.evaluate(() => ({
+      pageScrollWidth: document.documentElement.scrollWidth,
+      viewport: window.innerWidth,
+    }));
+    expect(
+      overflow.pageScrollWidth,
+      "an unbreakable nickname in the impersonation chip pushed the page " +
+        "wider than the viewport — the modal's `max-w-full break-words` is " +
+        "what prevents that",
+    ).toBeLessThanOrEqual(overflow.viewport + 1);
   });
 });

--- a/ui/tests/impersonation-warning.spec.ts
+++ b/ui/tests/impersonation-warning.spec.ts
@@ -274,7 +274,7 @@ test.describe("Impersonation warning survives a narrow viewport (#489)", () => {
   // modal is the only place a phone user can READ the warning. A test that
   // only ever opens it at 1280px would not have noticed if it were unreadable
   // on the device the feature is for.
-  test("the modal's explanation is readable at 320px, and cannot widen the page", async ({
+  test("the modal's explanation is readable at 320px", async ({
     page,
   }) => {
     await openTeamChatAtNarrowWidth(page);
@@ -296,9 +296,9 @@ test.describe("Impersonation warning survives a narrow viewport (#489)", () => {
       const span = el as HTMLElement;
       span.textContent = "W".repeat(160);
 
-      // PREMISE: the injected text must actually be wider than the panel that
-      // has to contain it. Measured on an off-screen clone with wrapping
-      // disabled, so this is the text's NATURAL width, not the wrapped one.
+      // The text's NATURAL width, measured on an off-screen clone with
+      // wrapping disabled — that is what the premise below needs, not the
+      // wrapped width.
       const probe = span.cloneNode(true) as HTMLElement;
       probe.style.position = "absolute";
       probe.style.left = "-9999px";
@@ -310,27 +310,34 @@ test.describe("Impersonation warning survives a narrow viewport (#489)", () => {
       probe.remove();
 
       const panel = span.closest('[data-testid="member-info-modal"]') as HTMLElement;
-      return { naturalWidth, panelWidth: panel.getBoundingClientRect().width };
+      return {
+        naturalWidth,
+        nameRight: span.getBoundingClientRect().right,
+        panelRight: panel.getBoundingClientRect().right,
+        panelWidth: panel.getBoundingClientRect().width,
+      };
     });
+
+    // THE PROPERTY, asserted before the premise for the same reason the row
+    // test does it: a broken layout should fail with the message that
+    // describes the bug. The page does NOT scroll sideways either way — an
+    // ancestor clips it — so measuring `document.scrollWidth` here would be
+    // vacuous. What actually breaks is the chip running out past the panel
+    // that is supposed to contain it: with `max-w-full break-words` removed,
+    // the measured right edge is ~2375px against a 320px panel.
+    expect(
+      forced.nameRight,
+      "an unbreakable nickname ran past the right edge of the modal panel, " +
+        "so a phone reader cannot see the name being imitated — the chip's " +
+        "`max-w-full break-words` is what prevents that",
+    ).toBeLessThanOrEqual(forced.panelRight + 1);
+
+    // PREMISE: without a name wider than the panel, nothing above could
+    // overflow and the assertion would hold with or without the fix.
     expect(
       forced.naturalWidth,
       "the forced nickname is not wider than the modal panel, so nothing " +
         "here could overflow and this test proves nothing",
     ).toBeGreaterThan(forced.panelWidth);
-
-    // THE PROPERTY: a nickname nobody can break must not make the whole page
-    // scroll sideways. `scrollWidth` is read off the document element, so it
-    // catches the panel pushing the layout wide even when the chip itself
-    // reports a box that fits.
-    const overflow = await page.evaluate(() => ({
-      pageScrollWidth: document.documentElement.scrollWidth,
-      viewport: window.innerWidth,
-    }));
-    expect(
-      overflow.pageScrollWidth,
-      "an unbreakable nickname in the impersonation chip pushed the page " +
-        "wider than the viewport — the modal's `max-w-full break-words` is " +
-        "what prevents that",
-    ).toBeLessThanOrEqual(overflow.viewport + 1);
   });
 });

--- a/ui/tests/impersonation-warning.spec.ts
+++ b/ui/tests/impersonation-warning.spec.ts
@@ -109,6 +109,17 @@ test.describe("Impersonation warning (#489)", () => {
 
   test("the impostor's modal EXPLAINS the warning in visible text", async ({ page }) => {
     await openTeamChat(page);
+
+    // Read the DEPUTY's name first, so the imitated-name chip can be compared
+    // to it rather than merely checked for being non-empty. Rendering the
+    // FLAGGED member's own name there would pass a non-empty check, and under
+    // the two bar-class branches of `confusable_variant` the two names differ
+    // by a single character — so it would also survive inspection by eye.
+    const deputyName = ((await rowsWithShield(page).first().textContent()) || "")
+      .replace(/[\u{1F6E1}\u{FE0F}\u{26A0}]/gu, "")
+      .trim();
+    expect(deputyName, "could not read the deputy's name").not.toBe("");
+
     await rowsWithWarning(page).first().click();
     await expect(page.locator(MODAL)).toBeVisible({ timeout: 5_000 });
 
@@ -120,9 +131,10 @@ test.describe("Impersonation warning (#489)", () => {
     await expect(explanation).toContainText(/is NOT a moderator/i);
 
     // The imitated name is shown as its own element, never folded into the
-    // sentence above it.
+    // sentence above it — and it is the DEPUTY's name, not the flagged
+    // member's own.
     await expect(page.locator(MODAL_IMITATED_NAME)).toBeVisible();
-    await expect(page.locator(MODAL_IMITATED_NAME)).not.toHaveText("");
+    await expect(page.locator(MODAL_IMITATED_NAME)).toHaveText(deputyName);
   });
 
   // Again: fixture-scoped, not a general rule. See the note in the row test —

--- a/ui/tests/invite-via-dm-picker.spec.ts
+++ b/ui/tests/invite-via-dm-picker.spec.ts
@@ -302,9 +302,11 @@ test.describe("Invite-via-DM picker (structured-Invite variant)", () => {
     // member's own title. These assertions pin each title to the member
     // it was opened for — with the bug, titleB held member A's name and
     // `memberB.text.startsWith(titleB)` was false. (A row text can't
-    // start with a *different* member's nickname unless the two members
-    // share a nickname, which example data's owner/member suffixes rule
-    // out — so this also implicitly proves titleA ≠ titleB.)
+    // start with a *different* member's nickname unless one nickname is a
+    // PREFIX of another. Since #494 the fixture deliberately contains two
+    // confusable names, but `confusable_variant` substitutes a character
+    // rather than appending, so they are the same length and neither is a
+    // prefix of the other — this still implicitly proves titleA ≠ titleB.)
     expect(titleA.length).toBeGreaterThan(0);
     expect(memberA.text.startsWith(titleA)).toBeTruthy();
     expect(memberB.text.startsWith(titleB!)).toBeTruthy();


### PR DESCRIPTION
## Problem

#489 shipped the ⚠ impersonation warning on two surfaces, and on both of them the explanation lived only in a `title=` attribute. **`title=` never fires on touch.** So on a phone the feature conveyed "there is a ⚠ here" and stopped, and the reader's natural next move — tapping the name — opened a member-info modal that said nothing about it at all.

Separately, nobody had ever seen the badge in a browser. `example_data.rs` seeds a spoof nickname so the 🛡 shield is visible in dev builds, but nothing in it produced two members whose names fold together, so `cargo make dev-example` could not render a ⚠ under any circumstances.

## Approach

**The modal now explains the warning in visible text.** It goes through `impersonation_warning_for_display` with `privilege_in_view` — the same entry point the member list and the conversation author line use — so this surface cannot show a badge the others do not, and it inherits the privileged/unprivileged tooltip branch rather than restating it. The chip's label is *derived* from the tooltip's own leading clause ("Impersonation warning" / "Name conflict") instead of being written by hand, so this surface cannot invent wording that drifts from the single definition in `ImpersonationWarning::tooltip`. The imitated name is shown here and nowhere else, as its own DOM node — safe for the same reason `appointer_names` is, since a comma inside an attacker-chosen nickname forges structure in a flat string but cannot span two elements.

This does pay for the whole badge map, which `deputy_badge_for_viewer` deliberately avoids. That cost is documented at the call site: the modal opens on a deliberate click and renders one member, and the alternative is not a cheaper warning but no explanation at all on a phone. The shield still uses the single-target helper so its Playwright-pinned behaviour stays on its own path.

**Example data gains an impostor** so the badge is visible in dev builds and reachable from a browser test. It is a plain member, not a second deputy — a second deputy would break `member-info-deputy-tag.spec.ts`, which asserts exactly one shield, and it would be the wrong shape anyway since the point is a member with *no* authority wearing a moderator's name. Its nickname is derived from the deputy's at fixture-build time rather than hardcoded, because those names are re-rolled every run and a literal `lan Clarke` would collide only on the runs where the generator happened to pick `Ian Clarke`.

## Testing

Five Playwright tests (member-list row, conversation author line, the modal's visible explanation, the deputy's modal, and a 320px layout case) plus three Rust tests. Every new behaviour was checked by mutation rather than by trusting a green.

**The 320px test was vacuous as first written, and passed against the clipping bug.** This is the most useful thing in this PR for whoever reads it next. Reintroducing the regression that `7c2511e8` fixed (`truncate` back on the row button) and measuring the real DOM:

| build | condition | badge right | row right | verdict |
|---|---|---|---|---|
| buggy | plain 320px | 165 | 312 | **passed against the bug** |
| buggy | row squeezed | 230 | 143 | RED |
| clean | row squeezed | 130 | 142 | GREEN |

The fixture's generated nicknames are short, so at 320px the row never overflows, nothing can be clipped, and the assertion was measuring a condition that never occurs. The test now forces the overflow itself and carries a premise assertion that the name is actually being clamped, so it fails loudly rather than silently going vacuous again.

Two further corrections came out of the same exercise, both worth knowing:

- My first premise check measured overflow on the *button*, which is wrong — on a correct layout the button never overflows, because the name clamps instead. That version failed on the clean build.
- The premise originally ran *before* the property assertion. Putting `truncate` back on the button stops it being a flex container, which makes both child spans inline, and `scrollWidth`/`clientWidth` are 0 for inline elements — so the mutation check failed with "the name is not being clamped", which is true but describes a symptom rather than the clipping. The property is now asserted first and the mutation fails with "the ⚠ is clipped past the right edge of its row".

**Adding a flagged member to example data broke an unrelated spec**, and the mechanism is worth recording. `getByRole` matches the accessible name by case-insensitive *substring*, and a member row's accessible name includes the `aria-label` of every badge inside it. The warning's label reads "…but their name **close**ly resembles one", so every row carrying a ⚠ now also answers to `getByRole("button", { name: "Close" })`. The Export Identity spec failed on a strict-mode violation at its Close button, pointing at a member row, with nothing to suggest this feature was involved. Fixed with `exact: true`, which is also simply correct for a button whose entire label is "Close". Found only by running the whole suite — the new spec passed throughout.

Also verified: breaking `confusable_variant` so the names stop folding turns both example-data tests red, and deleting the modal's visible sentence turns the modal pin red. `every_example_room_shows_the_impersonation_warning` asserts the fixture reaches its own premise in all three rooms — deputy badged, checker non-empty, exactly one member flagged, and that member not a badged deputy — which was re-run after the guard changes in #489 landed rather than assumed to still hold.

`AGENTS.md` gains a short note on telling whether a UI test measured the build you think it did: `dx serve` served a stale build during this work and reported a mutation check as passing, which inverts the one technique that proves a browser test is not vacuous.

Full suite green: 649 Rust tests, 5/5 Playwright, `cargo fmt` and prettier clean.

[AI-assisted - Claude]
