### PR TITLE
fix(ui): stop the conversation view latching away from the newest message

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -35,10 +35,12 @@ dioxus-free-icons = { version = "0.10.0", features = ["font-awesome-solid"] }
 
 # Web-related
 web-sys = { workspace = true, features = [
+    "AddEventListenerOptions",
     "Clipboard",
     "Document",
     "DomTokenList",
     "Element",
+    "Event",
     "EventTarget",
     "CssStyleDeclaration",
     "HtmlAnchorElement",
@@ -53,6 +55,9 @@ web-sys = { workspace = true, features = [
     "Notification",
     "NotificationOptions",
     "NotificationPermission",
+    "ResizeObserver",
+    "ScrollBehavior",
+    "ScrollToOptions",
     "Storage",
     "VisibilityState",
     "Window",

--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -99,6 +99,13 @@ pub fn App() -> Element {
     // Must be called from within a Dioxus component where the runtime is active.
     crate::util::capture_runtime();
 
+    // Playwright's inbound-message hooks. `example-data` builds that also have
+    // sync switched off, and nothing else — the hooks mint messages signed by a
+    // non-member key, so they must never reach a real node. See
+    // `example_data::install_test_hooks`.
+    #[cfg(all(feature = "example-data", feature = "no-sync"))]
+    crate::example_data::install_test_hooks();
+
     // In the gateway iframe, notifications are shown by the shell page; listen
     // for its `notification_click` replies to route to the clicked room
     // (freenet/river#408). No-op when served as a top-level page. Installs once.

--- a/ui/src/components/app/receive_times.rs
+++ b/ui/src/components/app/receive_times.rs
@@ -38,11 +38,32 @@ fn parse_map(s: &str) -> HashMap<i64, f64> {
         let mut parts = pair.splitn(2, ':');
         if let (Some(k), Some(v)) = (parts.next(), parts.next()) {
             if let (Ok(key), Ok(val)) = (k.parse::<i64>(), v.parse::<f64>()) {
-                map.insert(key, val);
+                if is_plausible_arrival_ms(val) {
+                    map.insert(key, val);
+                }
             }
         }
     }
     map
+}
+
+/// Is `ms` a time this client could plausibly have received a message at?
+///
+/// These values come back out of `localStorage`, which anything running in the
+/// origin can write, and they are no longer only a diagnostic: `group_messages`
+/// clamps a future-dated sender timestamp to the arrival time, so a garbage
+/// entry would move that message's rendered time, its 5-minute grouping and its
+/// day separator. A NaN, a negative, or a value from before this project
+/// existed is not an arrival time; neither is one in the future, since we
+/// record arrivals as they happen. Rejecting them here means every reader gets
+/// a sane map rather than each one re-checking.
+#[cfg(target_arch = "wasm32")]
+fn is_plausible_arrival_ms(ms: f64) -> bool {
+    /// 2020-01-01, comfortably before any River build existed.
+    const EARLIEST_PLAUSIBLE_MS: f64 = 1_577_836_800_000.0;
+    // A little slack for a clock that ticks between the write and the read.
+    const FUTURE_SLACK_MS: f64 = 60.0 * 1000.0;
+    ms.is_finite() && ms >= EARLIEST_PLAUSIBLE_MS && ms <= now_ms() + FUTURE_SLACK_MS
 }
 
 /// Serialize to "key:value,key:value,..." format
@@ -121,10 +142,30 @@ pub fn record_receive_times(message_ids: &[MessageId]) {
     });
 }
 
+/// A snapshot of the first-seen times, taken once per grouping pass.
+///
+/// `group_messages` needs the same map for every message it walks, and reading
+/// the `RECEIVE_TIMES` `GlobalSignal` per message both costs a borrow each time
+/// and makes the function unusable outside a Dioxus runtime (so untestable).
+/// Taking the reference once and threading it through fixes both.
+pub type ReceiveTimes = HashMap<i64, f64>;
+
+/// When this client FIRST saw a message, in ms since the epoch.
+///
+/// This is local wall-clock at arrival, so unlike the sender-supplied
+/// timestamp it cannot be in the future and cannot be moved by a remote clock.
+pub fn first_seen_ms(times: &ReceiveTimes, message_id: &MessageId) -> Option<f64> {
+    times.get(&message_id.0 .0).copied()
+}
+
 /// Get the propagation delay for a message, if known.
 /// Returns delay in seconds, or None if unknown or negative (clock skew).
-pub fn get_delay_secs(message_id: &MessageId, send_time_ms: i64) -> Option<i64> {
-    let recv_ms = *RECEIVE_TIMES.read().get(&message_id.0 .0)?;
+pub fn get_delay_secs_from(
+    times: &ReceiveTimes,
+    message_id: &MessageId,
+    send_time_ms: i64,
+) -> Option<i64> {
+    let recv_ms = first_seen_ms(times, message_id)?;
     let delay_ms = recv_ms as i64 - send_time_ms;
     let delay_secs = delay_ms / 1000;
     if delay_secs >= 0 {

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1,7 +1,9 @@
 use crate::components::app::document_title::count_unread_behind_rooms_panel;
 #[cfg(target_arch = "wasm32")]
 use crate::components::app::notifications::request_permission_on_first_message;
-use crate::components::app::receive_times::{format_delay, get_delay_secs};
+use crate::components::app::receive_times::{
+    first_seen_ms, format_delay, get_delay_secs_from, ReceiveTimes,
+};
 use crate::components::app::sync_info::{RoomSyncStatus, SYNC_INFO};
 use crate::components::app::{
     MobileView, CURRENT_ROOM, EDIT_ROOM_MODAL, MEMBER_INFO_MODAL, MOBILE_VIEW, NOTIFICATION_MODAL,
@@ -104,7 +106,9 @@ struct MessageGroup {
     author_impersonation: Option<ImpersonationWarning>,
     is_self: bool,
     first_time: DateTime<Utc>,
-    /// True if any message in this group had a future timestamp that was clamped
+    /// True if any message in this group carried a sender timestamp later than
+    /// when we received it, by more than [`CLOCK_SKEW_TOLERANCE_SECS`], and was
+    /// therefore clamped back to its arrival time.
     time_clamped: bool,
     /// Propagation delay for the first message in the group (shown in header)
     first_delay_secs: Option<i64>,
@@ -117,7 +121,10 @@ struct GroupedMessage {
     content_html: String,
     #[allow(dead_code)]
     time: DateTime<Utc>,
-    /// True if the original timestamp was in the future and was clamped to now
+    /// True if the sender's timestamp ran ahead of when we received this
+    /// message and was clamped back to that arrival time. (It is clamped to
+    /// ARRIVAL, not to "now": see [`MessageClock`] for why the render's wall
+    /// clock cannot be the target.)
     #[allow(dead_code)]
     time_clamped: bool,
     id: String,
@@ -440,8 +447,55 @@ fn resolve_member_nickname(
         .unwrap_or_else(|| crate::util::display_name::UNKNOWN_MEMBER.to_string())
 }
 
+/// How far a sender's timestamp may run ahead of when we received the message
+/// before we stop believing it.
+///
+/// Not zero. The clamp target used to be `Utc::now()` at render time, which
+/// carried the whole propagation delay as implicit slack; the target is now
+/// arrival time, which has none, so a bare `>` would flag EVERY message from
+/// any peer whose clock is a few seconds fast — and a few seconds of skew
+/// between two ordinary machines is normal. A minute is roughly where the
+/// rendered `HH:MM` would start disagreeing with reality, which is the point at
+/// which telling the reader the timestamp is untrustworthy earns its keep.
+const CLOCK_SKEW_TOLERANCE_SECS: i64 = 60;
+
+/// What a grouping pass knows about time.
+///
+/// Both fields are read once for the whole pass. That is the point: reading
+/// the clock per message made the grouping of a clock-skewed message depend on
+/// exactly when the render happened, so it changed under the reader.
+#[derive(Clone, Copy)]
+struct MessageClock<'a> {
+    /// When this client first saw each message — see [`ReceiveTimes`].
+    receive_times: &'a ReceiveTimes,
+    /// Clamp target for a message with no recorded arrival time.
+    fallback_now: DateTime<Utc>,
+}
+
+impl MessageClock<'_> {
+    /// The latest time `message_id` is allowed to claim.
+    fn clamp_target(&self, message_id: &MessageId) -> DateTime<Utc> {
+        first_seen_ms(self.receive_times, message_id)
+            .and_then(|ms| DateTime::<Utc>::from_timestamp_millis(ms as i64))
+            .unwrap_or(self.fallback_now)
+    }
+}
+
 /// Group consecutive messages from the same sender within 5 minutes,
 /// and summarize consecutive event messages (e.g. joins).
+///
+/// A message whose sender-supplied timestamp runs ahead of when we received it
+/// (a skewed remote clock) is clamped, because an hour-ahead timestamp would
+/// otherwise group and date-separate as if it were an hour in the future — and
+/// would then move again on every single render, since the old clamp target was
+/// `Utc::now()` read fresh inside this loop. (Nothing here sorts: the display
+/// order is the stored order, via `display_messages`.) Clamping to when THIS
+/// client first saw the message
+/// (`RECEIVE_TIMES`, first-seen-wins and persisted in localStorage) makes the
+/// result idempotent: the same input produces the same grouping on every
+/// render, which is what `2cb49ec11` set out to do. `fallback_now` covers a
+/// message with no recorded arrival — the same behaviour as before, but read
+/// once for the whole pass rather than once per message.
 fn group_messages(
     messages_state: &MessagesV1,
     member_info: &MemberInfoV1,
@@ -458,6 +512,7 @@ fn group_messages(
     // The room owner, so an author line can tell whether the member it is
     // flagging holds privilege themselves — see `privilege_in_view`.
     owner_id: MemberId,
+    clock: MessageClock<'_>,
 ) -> Vec<DisplayItem> {
     let mut items: Vec<DisplayItem> = Vec::new();
     let group_threshold = Duration::from_secs(5 * 60); // 5 minutes
@@ -471,11 +526,16 @@ fn group_messages(
     // Only iterate over displayable messages (non-deleted, non-action)
     for message in messages_state.display_messages() {
         let author_id = message.message.author;
-        let now = Utc::now();
-        let raw_time = DateTime::<Utc>::from(message.message.time);
-        let time_clamped = raw_time > now;
-        let message_time = if time_clamped { now } else { raw_time };
         let message_id = message.id();
+        let raw_time = DateTime::<Utc>::from(message.message.time);
+        // Clamp target: when we first saw it, else the pass-wide "now".
+        let clamp_to = clock.clamp_target(&message_id);
+        // `checked_add_signed` rather than `+`: `clamp_to` can come from
+        // persisted storage, and chrono's `Add` panics at the end of its range.
+        let time_clamped = clamp_to
+            .checked_add_signed(chrono::Duration::seconds(CLOCK_SKEW_TOLERANCE_SECS))
+            .is_some_and(|limit| raw_time > limit);
+        let message_time = if time_clamped { clamp_to } else { raw_time };
 
         let author_name = resolve_member_nickname(member_info, author_id, secrets);
 
@@ -534,7 +594,8 @@ fn group_messages(
 
         // Look up propagation delay (send time → receive time)
         let send_time_ms = raw_time.timestamp_millis();
-        let receive_delay_secs = get_delay_secs(&message_id, send_time_ms);
+        let receive_delay_secs =
+            get_delay_secs_from(clock.receive_times, &message_id, send_time_ms);
 
         let grouped_message = GroupedMessage {
             content_text: content_text.clone(),
@@ -1300,6 +1361,234 @@ fn beautify_freenet_label(url: &str) -> Option<String> {
     Some(format!("freenet:{id_prefix}{suffix}"))
 }
 
+/// How close to the end of the history (in px) still counts as "at the bottom".
+///
+/// Shared by the scroll-to-latest button's IntersectionObserver `rootMargin`
+/// and by the pin flag, so the two agree about where the bottom is.
+#[cfg(target_arch = "wasm32")]
+const BOTTOM_THRESHOLD_PX: f64 = 100.0;
+
+/// Trailing delay used to spot a scroll settling on browsers with no
+/// `scrollend` event (Safari before 17.4).
+#[cfg(target_arch = "wasm32")]
+const SCROLL_SETTLE_DEBOUNCE_MS: i32 = 120;
+
+/// Read the chat history's scroll container, if it is currently in the DOM.
+#[cfg(target_arch = "wasm32")]
+fn chat_scroll_container() -> Option<web_sys::Element> {
+    web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.get_element_by_id("chat-scroll-container"))
+}
+
+/// Read the wrapper the history's rows are laid out in.
+#[cfg(target_arch = "wasm32")]
+fn chat_content_wrapper() -> Option<web_sys::Element> {
+    web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.get_element_by_id("chat-content"))
+}
+
+/// The furthest down `container` can be scrolled, in px.
+#[cfg(target_arch = "wasm32")]
+fn max_scroll_top(container: &web_sys::Element) -> i32 {
+    (container.scroll_height() - container.client_height()).max(0)
+}
+
+/// Slack for comparing one scroll offset against another.
+///
+/// `scrollTop` is fractional in every engine while `Element::scroll_top`
+/// rounds, so an exact comparison would report a 1px difference on a view that
+/// never moved. `conversation-autoscroll.spec.ts` is what catches this being
+/// too tight.
+#[cfg(target_arch = "wasm32")]
+const SCROLL_TOP_SLACK_PX: i32 = 2;
+
+/// Has the view moved ABOVE the offset `last_top` records?
+///
+/// `pinned_to_bottom` is only re-measured when a scroll SETTLES, so between the
+/// reader moving the view and their `scrollend` arriving it is stale by design.
+/// Everything that scrolls on the strength of that flag has to consult this
+/// too, or it drags the reader back down inside that window. The interleaving
+/// is ordinary rather than contrived — a message arriving, or a layout settling,
+/// while the reader is scrolling up — and it reproduced on Firefox, WebKit and
+/// mobile Safari, where the reader reached the top of the history and the view
+/// snapped back within a few milliseconds.
+///
+/// This is deliberately NOT a re-measurement of "is the end on screen": that
+/// question is what latched in the first place (#486). It only ever answers
+/// "has the position moved since we last knew what it was", which cannot latch,
+/// because every settle refreshes `last_top`.
+///
+/// Known limit: `last_top` records the offset a scroll ASKED for, so while the
+/// scroll-to-latest button's smooth scroll is animating this reports true and
+/// stands both follow paths down. A message arriving inside that ~300ms window
+/// therefore lands short until the next content change, which corrects it. Only
+/// the button animates; every automatic scroll is instant and lands within the
+/// same task.
+#[cfg(target_arch = "wasm32")]
+fn reader_moved_up_since(last_top: &Rc<std::cell::Cell<i32>>) -> bool {
+    let Some(container) = chat_scroll_container() else {
+        return false;
+    };
+    // Never judge against an offset the container can no longer reach: if the
+    // history shrank, the browser clamped the position down on its own and that
+    // is not the reader moving.
+    let reference = last_top.get().min(max_scroll_top(&container));
+    container.scroll_top() + SCROLL_TOP_SLACK_PX < reference
+}
+
+/// Snap the history to its newest message.
+///
+/// Every programmatic scroll goes through here so two things always happen
+/// together: the pin is re-armed (we are taking the reader to the bottom, so
+/// that is where they now are), and the offset we asked for is recorded. That
+/// offset is what the settle handler compares against to tell OUR scroll's
+/// settle from the reader's, and what a later resize compares against to tell
+/// "content grew underneath us" from "the reader has moved since".
+/// See [`install_scroll_pin_listeners`].
+#[cfg(target_arch = "wasm32")]
+fn scroll_history_to_bottom(
+    pinned: &Rc<std::cell::Cell<bool>>,
+    last_top: &Rc<std::cell::Cell<i32>>,
+    behavior: web_sys::ScrollBehavior,
+) {
+    let Some(container) = chat_scroll_container() else {
+        warn!("chat-scroll-container missing; skipping scroll-to-bottom");
+        return;
+    };
+    pinned.set(true);
+    last_top.set(max_scroll_top(&container));
+    let opts = web_sys::ScrollToOptions::new();
+    opts.set_top(container.scroll_height() as f64);
+    opts.set_behavior(behavior);
+    container.scroll_to_with_scroll_to_options(&opts);
+}
+
+/// Wire up the "the reader is pinned to the newest message" flag.
+///
+/// This flag exists because the scroll-to-latest button's IntersectionObserver
+/// answers a different question: *is the end of the history on screen right
+/// now?* Gating auto-scroll on that answer is freenet/river#486 — anything that
+/// grew the gap past the observer's margin (a burst of arrivals, or merely
+/// growing the composer, which shrinks the container by more than the margin)
+/// switched auto-scroll off, and nothing turned it back on short of a manual
+/// scroll to the bottom or a room switch. The recorded failure ran 54 arrivals
+/// with the view frozen while the gap ratcheted out to roughly three screens.
+///
+/// `pinned` therefore tracks *intent*, and only a settle the reader caused can
+/// clear it. A settle WE caused must not: a smooth auto-scroll that lands short
+/// because more content arrived mid-flight would otherwise read as "the reader
+/// moved away".
+///
+/// Whose settle it is, is decided by POSITION, not by a flag. `last_top` holds
+/// the offset our last scroll asked for; a settle that lands there is ours, and
+/// a settle that lands anywhere else is the reader's. An earlier version raised
+/// a boolean instead, and it could not survive two settles being in flight at
+/// once: clearing a long draft grows the container, the browser clamps
+/// `scrollTop` down on its own, and that clamp's settle was consumed by the
+/// flag our previous scroll had raised. `last_top` then kept pointing at an
+/// offset the view had already left, `reader_moved_up_since` read that as the
+/// reader having scrolled up, and BOTH follow paths stood down — the view sat
+/// 62px short of the newest message and stayed there (observed on mobile
+/// Safari, 12s and counting). A position cannot go stale the way a flag can,
+/// because every settle rewrites it, and it needs no `wheel`/`pointerdown`
+/// listeners to guess at reader intent — which also removes the hole where
+/// Firefox dispatches no pointer event for a native scrollbar drag.
+///
+/// Returns whether the listener was installed; `false` means the container was
+/// not in the DOM yet and the caller should try again.
+#[cfg(target_arch = "wasm32")]
+#[must_use]
+fn install_scroll_pin_listeners(
+    pinned: Rc<std::cell::Cell<bool>>,
+    last_top: Rc<std::cell::Cell<i32>>,
+) -> bool {
+    use wasm_bindgen::prelude::*;
+
+    let Some(container) = chat_scroll_container() else {
+        return false;
+    };
+
+    // Passive throughout: none of these handlers call `preventDefault`, and the
+    // jank this replaces (#151) came from doing work on the scroll path.
+    let passive = web_sys::AddEventListenerOptions::new();
+    passive.set_passive(true);
+
+    // One DOM measurement per settle, not per scroll event.
+    let settle = {
+        let pinned = pinned.clone();
+        let last_top = last_top.clone();
+        Closure::wrap(Box::new(move || {
+            let Some(container) = chat_scroll_container() else {
+                return;
+            };
+            let settled_at = container.scroll_top();
+            let ours = (settled_at - last_top.get()).abs() <= SCROLL_TOP_SLACK_PX;
+            // Where the view ended up is a fact whoever caused it, and it is
+            // what everything else compares against. Recorded before the
+            // `ours` early-out on purpose: the version that only recorded it
+            // for reader settles is what let a stale offset suppress the
+            // follow indefinitely.
+            last_top.set(settled_at);
+            if ours {
+                return;
+            }
+            let distance = container.scroll_height() as f64
+                - settled_at as f64
+                - container.client_height() as f64;
+            pinned.set(distance <= BOTTOM_THRESHOLD_PX);
+        }) as Box<dyn FnMut()>)
+    };
+    let settle_fn: js_sys::Function = settle.as_ref().unchecked_ref::<js_sys::Function>().clone();
+    // Leaked deliberately, on the same reasoning as the IntersectionObserver
+    // below: `Conversation` mounts once for the app's lifetime (rooms are
+    // swapped by CSS, not by unmount) and `use_effect` has no cleanup hook, so
+    // there is nothing to disconnect these from.
+    settle.forget();
+
+    // `scrollend` fires once, when the position has settled. Where it is
+    // missing, a trailing debounce on `scroll` stands in; that listener still
+    // measures nothing per event, it only resets a timer.
+    let has_scrollend =
+        js_sys::Reflect::has(&container, &JsValue::from_str("onscrollend")).unwrap_or(false);
+    if has_scrollend {
+        let cb = Closure::wrap(Box::new(move |_: web_sys::Event| {
+            let _ = settle_fn.call0(&JsValue::NULL);
+        }) as Box<dyn FnMut(web_sys::Event)>);
+        let _ = container.add_event_listener_with_callback_and_add_event_listener_options(
+            "scrollend",
+            cb.as_ref().unchecked_ref(),
+            &passive,
+        );
+        cb.forget();
+    } else {
+        let pending: Rc<std::cell::Cell<Option<i32>>> = Rc::new(std::cell::Cell::new(None));
+        let cb = Closure::wrap(Box::new(move |_: web_sys::Event| {
+            let Some(window) = web_sys::window() else {
+                return;
+            };
+            if let Some(handle) = pending.take() {
+                window.clear_timeout_with_handle(handle);
+            }
+            if let Ok(handle) = window.set_timeout_with_callback_and_timeout_and_arguments_0(
+                &settle_fn,
+                SCROLL_SETTLE_DEBOUNCE_MS,
+            ) {
+                pending.set(Some(handle));
+            }
+        }) as Box<dyn FnMut(web_sys::Event)>);
+        let _ = container.add_event_listener_with_callback_and_add_event_listener_options(
+            "scroll",
+            cb.as_ref().unchecked_ref(),
+            &passive,
+        );
+        cb.forget();
+    }
+
+    true
+}
+
 #[component]
 pub fn Conversation() -> Element {
     let current_room_data = {
@@ -1316,8 +1605,26 @@ pub fn Conversation() -> Element {
             None
         }
     };
-    let last_chat_element = use_signal(|| None as Option<Rc<MountedData>>);
+    // Drives the scroll-to-latest button only: "is the end of the history on
+    // screen right now?". Auto-scroll is gated on `pinned_to_bottom` below,
+    // which answers the different question this one cannot (#486).
     let mut is_at_bottom = use_signal(|| true);
+    // "The reader wants to stay with the newest message." Plain `Cell`s, not
+    // signals: they are written from raw JS event callbacks that run with no
+    // Dioxus scope on the stack, and nothing renders from them, so there is no
+    // subscriber to notify and no reason to risk the Firefox-mobile panic that
+    // forced the IntersectionObserver's write through `defer` (#402).
+    let pinned_to_bottom = use_hook(|| Rc::new(std::cell::Cell::new(true)));
+    // Where the scroll position was last accounted for: our own scrolls write
+    // the offset they asked for, and every settle overwrites it with where the
+    // view actually came to rest. Two readers depend on it — the settle handler
+    // uses it to tell our own scroll's settle from the reader's, and the
+    // ResizeObserver uses it to tell "content grew underneath us" from "the
+    // reader has moved since", which `pinned_to_bottom` alone cannot answer
+    // until the settle lands. Only the browser has scroll positions, hence the
+    // gate. See `install_scroll_pin_listeners`.
+    #[cfg(target_arch = "wasm32")]
+    let last_scroll_top = use_hook(|| Rc::new(std::cell::Cell::new(0i32)));
     // Which message's touch action menu (kebab) is open, by message ID string.
     // Owned by Conversation (not per message group) so only ONE menu is open at
     // a time across the whole history — opening one closes any other (#402).
@@ -1460,6 +1767,14 @@ pub fn Conversation() -> Element {
                         MemberId::from(&key),
                         &deputy_badges,
                     );
+                    // Borrowed once per pass, not once per message. The old
+                    // per-message `get_delay_secs` read the same global from
+                    // inside the loop, so for any room with messages this is
+                    // the same subscription taken once instead of N times. (A
+                    // room with no displayable messages never reached that read
+                    // and so did not subscribe; now it does. Harmless, and
+                    // noted so the claim is not overstated.)
+                    let receive_times = crate::components::app::receive_times::RECEIVE_TIMES.read();
                     let groups = group_messages(
                         &room_state.recent_messages,
                         &room_state.member_info,
@@ -1469,6 +1784,12 @@ pub fn Conversation() -> Element {
                         &deputy_badges,
                         &impersonation,
                         MemberId::from(&key),
+                        MessageClock {
+                            receive_times: &receive_times,
+                            // One "now" for the whole pass. Only reached by
+                            // messages with no recorded arrival time.
+                            fallback_now: Utc::now(),
+                        },
                     );
                     return Some((groups, self_member_id, member_names));
                 }
@@ -1522,9 +1843,12 @@ pub fn Conversation() -> Element {
 
         let options = web_sys::IntersectionObserverInit::new();
         options.set_root(Some(&root));
-        // Expand detection zone 100px below the viewport edge so the user is
-        // considered "at bottom" when within 100px of the sentinel.
-        options.set_root_margin("0px 0px 100px 0px");
+        // Expand the detection zone below the viewport edge so the user counts
+        // as "at bottom" when within `BOTTOM_THRESHOLD_PX` of the sentinel.
+        // Built from the constant rather than written out, so the button and
+        // the pin cannot drift apart: the doc on `BOTTOM_THRESHOLD_PX` claims
+        // they agree, and this is what makes that true.
+        options.set_root_margin(&format!("0px 0px {BOTTOM_THRESHOLD_PX}px 0px"));
         options.set_threshold(&JsValue::from_f64(0.0));
 
         if let Ok(observer) =
@@ -1539,65 +1863,179 @@ pub fn Conversation() -> Element {
         }
     });
 
-    // Trigger scroll to bottom when recent messages change (only if user is near bottom).
-    // Scroll the chat-scroll-container itself, not the last bubble: scrollIntoView aligns
-    // the bubble's top to the container's top, which can leave the actual bottom (reactions,
-    // sentinel, padding) off-screen. On page refresh this surfaced as scrolling only ~70%
-    // of the way down.
+    // The pin that actually gates auto-scroll. Installed once, in its own
+    // effect, because the listeners must outlive every re-render of the
+    // history. Reading `message_groups` only makes the effect re-runnable, so
+    // a first attempt that found no container yet (nothing rendered) gets
+    // another chance; `installed` is set only on success, so a successful
+    // install is never repeated.
+    #[cfg(target_arch = "wasm32")]
+    {
+        let pinned_to_bottom = pinned_to_bottom.clone();
+        let last_scroll_top = last_scroll_top.clone();
+        let installed = use_hook(|| Rc::new(std::cell::Cell::new(false)));
+        use_effect(move || {
+            let _retry_on_content_change = message_groups.read().is_some();
+            if installed.get() {
+                return;
+            }
+            if install_scroll_pin_listeners(pinned_to_bottom.clone(), last_scroll_top.clone()) {
+                installed.set(true);
+            }
+        });
+    }
+
+    // Keep the newest message in view when the history grows.
     //
-    // First scroll uses Instant so a page refresh snaps to the bottom rather than animating
-    // a ~500ms scroll from top. Subsequent scrolls (new messages while at bottom) use Smooth.
-    let first_scroll = use_hook(|| Rc::new(std::cell::Cell::new(true)));
-    // Set by the room-change effect below to force the next mount-triggered
-    // scroll regardless of `is_at_bottom` (#402). This decouples the room-switch
-    // snap from `is_at_bottom`, so the IntersectionObserver flipping the signal
-    // to `false` (new room's persisted scroll position) between the room-change
-    // effect and this one can't suppress the snap. A plain `Cell`, not a signal,
+    // Scroll the chat-scroll-container itself, not the last bubble:
+    // scrollIntoView aligns the bubble's top to the container's top, which can
+    // leave the actual bottom (reactions, sentinel, padding) off-screen. On
+    // page refresh this surfaced as scrolling only ~70% of the way down.
+    //
+    // Set by the room-change effect and the send path to force the next scroll
+    // regardless of the pin (#402), so a room switch or your own outgoing
+    // message always lands at the newest message. A plain `Cell`, not a signal,
     // so reading it here does not subscribe.
     let force_scroll = use_hook(|| Rc::new(std::cell::Cell::new(false)));
     use_effect({
-        let first_scroll = first_scroll.clone();
         let force_scroll = force_scroll.clone();
+        let pinned_to_bottom = pinned_to_bottom.clone();
+        // Only the wasm arm below scrolls anything, so on native this clone is
+        // genuinely unused rather than accidentally so.
+        #[cfg(target_arch = "wasm32")]
+        let last_scroll_top = last_scroll_top.clone();
         move || {
-            // Re-run when the last bubble mounts (new messages or initial load).
-            let trigger = last_chat_element();
+            // Re-run on ANY change to the rendered history, not just a remount
+            // of the last bubble. The old trigger was an `onmounted` on the
+            // last message group, which is silent for every content change
+            // that leaves that row in place: a mid-list insert, a reaction, an
+            // edit, or another join folding into an existing "N people joined"
+            // summary (that summary is keyed on its FIRST event, so absorbing
+            // a new one grows it without remounting anything). Subscribing to
+            // the memo is what makes those cases reach this effect at all.
+            let has_content = message_groups.read().is_some();
             let forced = force_scroll.get();
-            let should_scroll = forced || *is_at_bottom.peek();
-            if should_scroll && trigger.is_some() {
-                force_scroll.set(false);
-                let is_first = first_scroll.replace(false);
-                // `behavior` is only used inside the wasm32 block below; on
-                // native it would warn as unused. Gate the binding too so
-                // clippy stays clean across both targets.
-                #[cfg(target_arch = "wasm32")]
-                let behavior = if is_first {
-                    web_sys::ScrollBehavior::Instant
-                } else {
-                    web_sys::ScrollBehavior::Smooth
-                };
-                #[cfg(not(target_arch = "wasm32"))]
-                let _ = is_first;
-                #[cfg(target_arch = "wasm32")]
+            if !has_content || !(forced || pinned_to_bottom.get()) {
+                return;
+            }
+            force_scroll.set(false);
+            #[cfg(target_arch = "wasm32")]
+            {
+                let pinned_to_bottom = pinned_to_bottom.clone();
+                let last_scroll_top = last_scroll_top.clone();
+                // Deferred so the scroll measures a container Dioxus has
+                // finished patching, and (per `safe_spawn_local`) so no signal
+                // borrow is live when it runs.
                 crate::util::safe_spawn_local(async move {
-                    let Some(window) = web_sys::window() else {
+                    // A forced scroll — a room switch, or your own outgoing
+                    // message — is an explicit instruction, and nothing below
+                    // may cancel it. Everything else has to survive two
+                    // separate ways of being out of date by the time this
+                    // deferred task actually runs:
+                    //
+                    // 1. the gate above ran BEFORE this task was queued, and a
+                    //    reader `scrollend` can resolve the pin to false in
+                    //    between (measured on Firefox: the gate saw
+                    //    `pinned = true` at 4791ms, the reader's settle cleared
+                    //    it at 4854ms, and this task ran at 4974ms), so the pin
+                    //    is re-read here rather than trusted from then;
+                    // 2. the reader may have moved with their `scrollend` still
+                    //    in flight, so the pin has not caught up at all yet —
+                    //    which is what `reader_moved_up_since` answers.
+                    //
+                    // Neither check subsumes the other, and dropping either one
+                    // reproduces the yank-back on Firefox, WebKit or mobile
+                    // Safari while Chromium stays green.
+                    if !forced
+                        && (!pinned_to_bottom.get() || reader_moved_up_since(&last_scroll_top))
+                    {
                         return;
-                    };
-                    let Some(document) = window.document() else {
-                        return;
-                    };
-                    let Some(container) = document.get_element_by_id("chat-scroll-container")
-                    else {
-                        warn!("chat-scroll-container missing; skipping scroll-to-bottom");
-                        return;
-                    };
-                    let opts = web_sys::ScrollToOptions::new();
-                    opts.set_top(container.scroll_height() as f64);
-                    opts.set_behavior(behavior);
-                    container.scroll_to_with_scroll_to_options(&opts);
+                    }
+                    scroll_history_to_bottom(
+                        &pinned_to_bottom,
+                        &last_scroll_top,
+                        // Instant, not Smooth. The ResizeObserver below reaches
+                        // the same target as soon as layout settles, so an
+                        // animation here would only ever be overtaken by it —
+                        // and a smooth scroll that lands short because more
+                        // content arrived mid-flight is exactly the race the
+                        // pin has to be defended against. Deliberate scrolls
+                        // the reader asks for (the scroll-to-latest button)
+                        // still animate.
+                        web_sys::ScrollBehavior::Instant,
+                    );
                 });
             }
         }
     });
+
+    // Size changes that no re-render can see still have to keep the newest
+    // message in view. `message_groups` covers state changes; this covers
+    // layout ones, and there are two independent kinds:
+    //
+    // * the CONTENT grows or reflows under a fixed window — a late-loading
+    //   image, a web font swapping in, a markdown block rewrapping on a
+    //   narrower screen;
+    // * the WINDOW shrinks over fixed content — which is what growing the
+    //   composer does. That is freenet/river#486's third cause: the composer
+    //   reaching its 168px maximum takes more than the observer's 100px margin
+    //   off the history in one step, with no network activity at all.
+    //   De-latching the gate stops that freezing auto-scroll for good, but on
+    //   its own it still leaves the newest message below the fold until
+    //   something else happens, so the container has to be watched too.
+    //
+    // Watching only the content wrapper misses the second kind entirely: the
+    // container's `clientHeight` changes while the wrapper's box does not.
+    #[cfg(target_arch = "wasm32")]
+    {
+        let pinned_to_bottom = pinned_to_bottom.clone();
+        let last_scroll_top = last_scroll_top.clone();
+        let observed = use_hook(|| Rc::new(std::cell::Cell::new(false)));
+        use_effect(move || {
+            use wasm_bindgen::prelude::*;
+
+            let _retry_on_content_change = message_groups.read().is_some();
+            if observed.get() {
+                return;
+            }
+            let (Some(content), Some(container)) =
+                (chat_content_wrapper(), chat_scroll_container())
+            else {
+                return;
+            };
+
+            let pinned_to_bottom = pinned_to_bottom.clone();
+            let last_scroll_top = last_scroll_top.clone();
+            let cb = Closure::wrap(Box::new(move |_: js_sys::Array| {
+                if !pinned_to_bottom.get() {
+                    return;
+                }
+                // Stand down if the reader has moved since we last knew where
+                // the view was; the settle on its way is what decides. Without
+                // this, a resize landing in that window undoes their scroll —
+                // measured on Firefox: reader reaches scrollTop 0, a resize
+                // fires 2ms later, the view snaps back.
+                if reader_moved_up_since(&last_scroll_top) {
+                    return;
+                }
+                // Instant: this fires DURING layout settling, so animating
+                // would chase a target that is still moving.
+                scroll_history_to_bottom(
+                    &pinned_to_bottom,
+                    &last_scroll_top,
+                    web_sys::ScrollBehavior::Instant,
+                );
+            }) as Box<dyn FnMut(js_sys::Array)>);
+
+            if let Ok(observer) = web_sys::ResizeObserver::new(cb.as_ref().unchecked_ref()) {
+                observer.observe(&content);
+                observer.observe(&container);
+                // Leaked for the same reason as the observers above.
+                cb.forget();
+                observed.set(true);
+            }
+        });
+    }
 
     // Snap to the newest message whenever the selected room changes (#402). The
     // Conversation component is mounted once and reused across rooms (hidden or
@@ -1607,23 +2045,24 @@ pub fn Conversation() -> Element {
     // makes this effect re-run on every room change and nothing else.
     //
     // This effect only raises `force_scroll`; the actual scroll runs in the
-    // mount-triggered effect above once the new room's last bubble mounts (its
-    // trigger, `last_chat_element`, necessarily changes AFTER this room change,
-    // so the ordering is causal — not dependent on effect scheduling). Using a
-    // persistent `force_scroll` flag instead of `is_at_bottom` means the
-    // observer can't cancel the snap in the gap between the two effects.
-    // `first_scroll` = true makes that snap instant rather than animated from an
-    // arbitrary position. `is_at_bottom` = true hides the scroll-to-latest
-    // button immediately on switch (the observer reconfirms after the snap).
+    // content-triggered effect above once the new room's groups are rendered
+    // (its trigger, `message_groups`, necessarily changes AFTER this room
+    // change, so the ordering is causal — not dependent on effect scheduling).
+    // Using a persistent `force_scroll` flag means nothing can cancel the snap
+    // in the gap between the two effects.
+    // `is_at_bottom` = true hides the scroll-to-latest button immediately on
+    // switch (the observer reconfirms after the snap).
     //
     // Guarded on an ACTUAL key change: Dioxus re-runs the effect on any write
     // to `CURRENT_ROOM`, and re-selecting the already-open room in the sidebar
     // rewrites it with the same key. Without the guard that would arm
-    // `force_scroll` with no new bubble to consume it, so a later message would
-    // snap the reader to the bottom (#402 review).
+    // `force_scroll` with no new content to consume it, so a later message
+    // would snap the reader to the bottom (#402 review).
     {
-        let first_scroll = first_scroll.clone();
         let force_scroll = force_scroll.clone();
+        let pinned_to_bottom = pinned_to_bottom.clone();
+        #[cfg(target_arch = "wasm32")]
+        let last_scroll_top = last_scroll_top.clone();
         let prev_room =
             use_hook(|| Rc::new(std::cell::Cell::new(None::<ed25519_dalek::VerifyingKey>)));
         use_effect(move || {
@@ -1631,8 +2070,18 @@ pub fn Conversation() -> Element {
             if prev_room.get() != room {
                 prev_room.set(room);
                 force_scroll.set(true);
-                first_scroll.set(true);
                 is_at_bottom.set(true);
+                // Opening a room starts you at its newest message, so the pin
+                // starts armed. Set here rather than left to the snap below,
+                // because a room with no messages produces no scroll at all
+                // and would otherwise inherit the previous room's pin state.
+                pinned_to_bottom.set(true);
+                // Same reason: an offset measured in the room we just left says
+                // nothing about this one, and `reader_moved_up_since` would
+                // read it as "the reader has scrolled up" and stand the follow
+                // down. Zero is the "no constraint yet" value it starts at.
+                #[cfg(target_arch = "wasm32")]
+                last_scroll_top.set(0);
             }
         });
     }
@@ -2432,7 +2881,7 @@ pub fn Conversation() -> Element {
                     // than show a horizontal scrollbar in the history. #402.
                     class: "h-full overflow-y-auto overflow-x-hidden",
                     id: "chat-scroll-container",
-                    div { class: "max-w-4xl mx-auto px-4 py-4",
+                    div { class: "max-w-4xl mx-auto px-4 py-4", id: "chat-content",
                     {
                         // Use memoized message groups to avoid expensive re-computation on keystrokes
                         if current_room_data.is_some() {
@@ -2485,14 +2934,12 @@ pub fn Conversation() -> Element {
                                         }
                                         rows
                                     };
-                                    let rows_len = rows.len();
                                     Some(rsx! {
                                         div { class: "space-y-4",
-                                            {rows.into_iter().enumerate().map({
+                                            {rows.into_iter().map({
                                                 let handle_toggle_reaction = handle_toggle_reaction.clone();
                                                 let member_names = member_names.clone();
-                                                move |(row_idx, row)| {
-                                                let is_last_group = row_idx == rows_len - 1;
+                                                move |row| {
                                                 let handle_toggle_reaction = handle_toggle_reaction.clone();
                                                 let handle_edit_message = handle_edit_message.clone();
                                                 let member_names = member_names.clone();
@@ -2510,7 +2957,6 @@ pub fn Conversation() -> Element {
                                                     DisplayRow::Item(DisplayItem::Event(summary)) => {
                                                         let text = format_event_summary(&summary.names);
                                                         let key = summary.id.clone();
-                                                        let mut last_el = last_chat_element;
                                                         rsx! {
                                                             div {
                                                                 key: "{key}",
@@ -2518,13 +2964,6 @@ pub fn Conversation() -> Element {
                                                                 span {
                                                                     class: "text-xs text-text-muted italic",
                                                                     "{text}"
-                                                                }
-                                                                if is_last_group {
-                                                                    div {
-                                                                        onmounted: move |data| {
-                                                                            last_el.set(Some(data.data()));
-                                                                        }
-                                                                    }
                                                                 }
                                                             }
                                                         }
@@ -2539,7 +2978,6 @@ pub fn Conversation() -> Element {
                                                                 member_names: member_names,
                                                                 max_message_size: edit_max_size,
                                                                 is_private: edit_is_private,
-                                                                last_chat_element: if is_last_group { Some(last_chat_element) } else { None },
                                                                 edit_trigger: edit_trigger,
                                                                 on_react: move |(msg_id, emoji)| {
                                                                     handle_toggle_reaction(msg_id, emoji);
@@ -2610,19 +3048,23 @@ pub fn Conversation() -> Element {
                         // the smooth scroll before reaching the bottom (the
                         // observer emits no new change and stays quiet). #402.
                         onclick: move |_| {
+                            // Asking for the newest message is the clearest
+                            // possible statement of intent, so this re-arms the
+                            // pin (inside `scroll_history_to_bottom`) even
+                            // though the button itself renders off the
+                            // IntersectionObserver.
                             #[cfg(target_arch = "wasm32")]
-                            crate::util::safe_spawn_local(async move {
-                                let Some(container) = web_sys::window()
-                                    .and_then(|w| w.document())
-                                    .and_then(|d| d.get_element_by_id("chat-scroll-container"))
-                                else {
-                                    return;
-                                };
-                                let opts = web_sys::ScrollToOptions::new();
-                                opts.set_top(container.scroll_height() as f64);
-                                opts.set_behavior(web_sys::ScrollBehavior::Smooth);
-                                container.scroll_to_with_scroll_to_options(&opts);
-                            });
+                            {
+                                let pinned_to_bottom = pinned_to_bottom.clone();
+                                let last_scroll_top = last_scroll_top.clone();
+                                crate::util::safe_spawn_local(async move {
+                                    scroll_history_to_bottom(
+                                        &pinned_to_bottom,
+                                        &last_scroll_top,
+                                        web_sys::ScrollBehavior::Smooth,
+                                    );
+                                });
+                            }
                         },
                         Icon { icon: FaChevronDown, width: 18, height: 18 }
                     }
@@ -2870,7 +3312,6 @@ fn MessageGroupComponent(
     max_message_size: usize,
     /// Whether the room is private (encrypted edits carry the AES-GCM tag).
     is_private: bool,
-    last_chat_element: Option<Signal<Option<Rc<MountedData>>>>,
     edit_trigger: Signal<Option<(String, String)>>,
     on_react: EventHandler<(MessageId, String)>,
     on_request_delete: EventHandler<MessageId>,
@@ -2893,7 +3334,9 @@ fn MessageGroupComponent(
         .map(|s| format!(" (received after {} delay)", format_delay(s)));
     let full_time_str = if group.time_clamped {
         format!(
-            "{} (sender's clock may be incorrect — original timestamp was in the future)",
+            "{} (sender's clock may be ahead of yours — their timestamp was later \
+             than when this message reached you, so the time shown is when it \
+             arrived)",
             format_utc_as_full_datetime(timestamp_ms)
         )
     } else if let Some(ref suffix) = delay_suffix {
@@ -3326,13 +3769,6 @@ fn MessageGroupComponent(
                                                         // the nowrap strip from widening the bubble.
                                                         "max-w-prose"
                                                     ),
-                                                    onmounted: move |cx| {
-                                                        if is_last {
-                                                            if let Some(mut last_el) = last_chat_element {
-                                                                last_el.set(Some(cx.data()));
-                                                            }
-                                                        }
-                                                    },
                                                     // Reply-quote strip (inside bubble, first child).
                                                     // Exactly one arm renders, enforced by the type: an
                                                     // unverifiable quote is `Unavailable`, which carries no
@@ -4983,10 +5419,11 @@ mod tests {
 /// Tests for [`resolve_reply_strip`] — the rule that a reply's quoted
 /// snapshot is rendered only when it can be re-read from live room state.
 ///
-/// These target the helper rather than `group_messages` because the latter
-/// reads the `RECEIVE_TIMES` `GlobalSignal`, which panics outside a Dioxus
-/// runtime. The render side (which arm of [`ReplyStrip`] produces what markup)
-/// is covered by `ui/tests/message-layout.spec.ts`.
+/// These target the helper rather than `group_messages` because it is the unit
+/// under test; `group_messages` itself is now callable outside a Dioxus runtime
+/// and is covered by `group_messages_clock_tests`. The render side (which arm
+/// of [`ReplyStrip`] produces what markup) is covered by
+/// `ui/tests/message-layout.spec.ts`.
 #[cfg(test)]
 mod resolve_reply_strip_tests {
     use super::*;
@@ -5832,5 +6269,485 @@ mod resolve_reply_strip_tests {
 
         let ctx = resolve(&plain, &state(vec![plain.clone()]), &info(vec![]));
         assert_eq!(ctx, ReplyStrip::NotAReply);
+    }
+}
+
+/// Tests for [`group_messages`]' clock handling.
+///
+/// These are possible at all because the receive-time snapshot is now a
+/// parameter: the function used to read the `RECEIVE_TIMES` `GlobalSignal`
+/// per message, which panics outside a Dioxus runtime.
+#[cfg(test)]
+mod group_messages_clock_tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use river_core::room_state::member_info::{AuthorizedMemberInfo, MemberInfo};
+    use std::time::{Duration as StdDuration, UNIX_EPOCH};
+
+    fn signing_key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    fn member_id_of(sk: &SigningKey) -> MemberId {
+        MemberId::from(&sk.verifying_key())
+    }
+
+    /// A public text message from `sk`, stamped with the sender's clock.
+    fn message_at(owner: MemberId, sk: &SigningKey, sent: DateTime<Utc>) -> AuthorizedMessageV1 {
+        AuthorizedMessageV1::new(
+            MessageV1 {
+                room_owner: owner,
+                author: member_id_of(sk),
+                time: UNIX_EPOCH + StdDuration::from_millis(sent.timestamp_millis().max(0) as u64),
+                content: RoomMessageBody::public("hello".to_string()),
+            },
+            sk,
+        )
+    }
+
+    fn state(messages: Vec<AuthorizedMessageV1>) -> MessagesV1 {
+        MessagesV1 {
+            messages,
+            actions_state: Default::default(),
+        }
+    }
+
+    fn info(sk: &SigningKey, nickname: &str) -> MemberInfoV1 {
+        MemberInfoV1 {
+            member_info: vec![AuthorizedMemberInfo::new(
+                MemberInfo::new_public(member_id_of(sk), 1, nickname.to_string()),
+                sk,
+            )],
+        }
+    }
+
+    fn group(
+        messages: &MessagesV1,
+        member_info: &MemberInfoV1,
+        me: MemberId,
+        receive_times: &ReceiveTimes,
+        fallback_now: DateTime<Utc>,
+    ) -> Vec<DisplayItem> {
+        group_messages(
+            messages,
+            member_info,
+            me,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            // No protected names, so no ⚠ warning can fire — these tests are
+            // about the clock, and an empty checker keeps them about only that.
+            &ImpersonationChecker::default(),
+            me,
+            MessageClock {
+                receive_times,
+                fallback_now,
+            },
+        )
+    }
+
+    fn only_group(items: &[DisplayItem]) -> &MessageGroup {
+        match items {
+            [DisplayItem::Messages(g)] => g,
+            other => panic!(
+                "expected exactly one message group, got {} items",
+                other.len()
+            ),
+        }
+    }
+
+    fn at(ms: i64) -> DateTime<Utc> {
+        DateTime::<Utc>::from_timestamp_millis(ms).expect("valid timestamp")
+    }
+
+    /// A message from a clock that runs an hour fast is pinned to when THIS
+    /// client first saw it — not to "now", which moves on every render.
+    ///
+    /// This is the assertion that fails if the clamp target goes back to
+    /// `Utc::now()`: `now` and `first_seen` are deliberately far apart.
+    #[test]
+    fn future_timestamp_is_clamped_to_first_seen_not_to_now() {
+        let owner = signing_key(1);
+        let alice = signing_key(2);
+        let owner_id = member_id_of(&owner);
+
+        let now = at(1_700_000_000_000);
+        let first_seen = now - chrono::Duration::minutes(10);
+        let sent = now + chrono::Duration::hours(1);
+
+        let msg = message_at(owner_id, &alice, sent);
+        let mut receive_times = ReceiveTimes::new();
+        receive_times.insert(msg.id().0 .0, first_seen.timestamp_millis() as f64);
+
+        let items = group(
+            &state(vec![msg]),
+            &info(&alice, "Alice"),
+            owner_id,
+            &receive_times,
+            now,
+        );
+        let g = only_group(&items);
+
+        assert!(g.time_clamped, "a future timestamp must be flagged clamped");
+        assert_eq!(
+            g.messages[0].time, first_seen,
+            "the clamp target must be when we first saw the message, not the \
+             render's wall clock"
+        );
+    }
+
+    /// Same input, two renders a minute apart: identical grouping, and both
+    /// pinned to the arrival time. The old code read `Utc::now()` inside the
+    /// loop, so a clock-skewed message re-timed itself on every render.
+    ///
+    /// The send time is deliberately far in the future in ABSOLUTE terms, not
+    /// merely relative to the fixture's `now`: a fixture-relative future is
+    /// already in the past by the time the suite runs, so the clamp branch
+    /// would never be taken and the test could not fail. The explicit
+    /// `first_seen` assertions are what make it fail rather than a
+    /// `first == later` comparison, which would otherwise pass on two
+    /// `Utc::now()` reads that happen to land in the same instant.
+    #[test]
+    fn grouping_is_idempotent_across_renders() {
+        let owner = signing_key(1);
+        let alice = signing_key(2);
+        let owner_id = member_id_of(&owner);
+
+        let now = at(1_700_000_000_000);
+        let first_seen = now - chrono::Duration::minutes(10);
+        // Year 4000-ish: later than any clock this test could run against.
+        let msg = message_at(owner_id, &alice, at(64_060_588_800_000));
+        let mut receive_times = ReceiveTimes::new();
+        receive_times.insert(msg.id().0 .0, first_seen.timestamp_millis() as f64);
+
+        let messages = state(vec![msg]);
+        let member_info = info(&alice, "Alice");
+
+        let first = group(&messages, &member_info, owner_id, &receive_times, now);
+        let later = group(
+            &messages,
+            &member_info,
+            owner_id,
+            &receive_times,
+            now + chrono::Duration::minutes(1),
+        );
+
+        assert_eq!(only_group(&first).messages[0].time, first_seen);
+        assert_eq!(only_group(&later).messages[0].time, first_seen);
+        assert!(
+            first == later,
+            "a clock-skewed message must group identically on a later render"
+        );
+    }
+
+    /// No recorded arrival (an older message restored from contract state, or
+    /// one whose entry aged out of the 24h window): fall back to the pass-wide
+    /// "now", which is the pre-existing behaviour.
+    #[test]
+    fn unknown_first_seen_falls_back_to_the_pass_wide_now() {
+        let owner = signing_key(1);
+        let alice = signing_key(2);
+        let owner_id = member_id_of(&owner);
+
+        let now = at(1_700_000_000_000);
+        let msg = message_at(owner_id, &alice, now + chrono::Duration::hours(1));
+
+        let items = group(
+            &state(vec![msg]),
+            &info(&alice, "Alice"),
+            owner_id,
+            &ReceiveTimes::new(),
+            now,
+        );
+        let g = only_group(&items);
+
+        assert!(g.time_clamped);
+        assert_eq!(g.messages[0].time, now);
+    }
+
+    /// The case the clamp-target change actually creates: a timestamp in the
+    /// PAST relative to the render, but later than when we received the
+    /// message. The old code compared against `Utc::now()`, so it left this
+    /// alone; the new code clamps it, because a send time after the arrival
+    /// time is not something an accurate clock produces.
+    ///
+    /// This is the assertion that would have caught the change slipping in
+    /// unnoticed — `past_timestamps_are_never_rewritten` below passes either
+    /// way, so on its own it pins nothing about this fix.
+    #[test]
+    fn a_timestamp_later_than_arrival_is_clamped_even_though_it_is_in_the_past() {
+        let owner = signing_key(1);
+        let alice = signing_key(2);
+        let owner_id = member_id_of(&owner);
+
+        let now = at(1_700_000_000_000);
+        let first_seen = now - chrono::Duration::hours(2);
+        let sent = now - chrono::Duration::hours(1);
+
+        let msg = message_at(owner_id, &alice, sent);
+        let mut receive_times = ReceiveTimes::new();
+        receive_times.insert(msg.id().0 .0, first_seen.timestamp_millis() as f64);
+
+        let items = group(
+            &state(vec![msg]),
+            &info(&alice, "Alice"),
+            owner_id,
+            &receive_times,
+            now,
+        );
+        let g = only_group(&items);
+
+        assert!(
+            g.time_clamped,
+            "a send time an hour after arrival is skew, even though it is in \
+             the past relative to this render"
+        );
+        assert_eq!(g.messages[0].time, first_seen);
+    }
+
+    /// Skew inside the tolerance is left alone and NOT flagged.
+    ///
+    /// Without the tolerance the clamp target's move from "now at render" to
+    /// "arrival" would silently widen the flag: the old comparison carried the
+    /// whole propagation delay as slack, the new one carries none, so every
+    /// message from any peer whose clock is a few seconds fast would render
+    /// with the "clock may be wrong" marker.
+    #[test]
+    fn skew_within_the_tolerance_is_left_alone() {
+        let owner = signing_key(1);
+        let alice = signing_key(2);
+        let owner_id = member_id_of(&owner);
+
+        let now = at(1_700_000_000_000);
+        let first_seen = now - chrono::Duration::minutes(10);
+        // Ahead of arrival, but by less than CLOCK_SKEW_TOLERANCE_SECS.
+        let sent = first_seen + chrono::Duration::seconds(CLOCK_SKEW_TOLERANCE_SECS - 1);
+
+        let msg = message_at(owner_id, &alice, sent);
+        let mut receive_times = ReceiveTimes::new();
+        receive_times.insert(msg.id().0 .0, first_seen.timestamp_millis() as f64);
+
+        let items = group(
+            &state(vec![msg]),
+            &info(&alice, "Alice"),
+            owner_id,
+            &receive_times,
+            now,
+        );
+        let g = only_group(&items);
+
+        assert!(
+            !g.time_clamped,
+            "a few seconds of clock skew is normal and must not put a \
+             \"sender's clock may be wrong\" marker on the message"
+        );
+        assert_eq!(
+            g.messages[0].time, sent,
+            "and the time must be left as sent"
+        );
+    }
+
+    /// A timestamp that is merely in the past is left exactly as the sender
+    /// wrote it, whether or not we have an arrival time for it.
+    ///
+    /// Passes against the pre-fix code too — it is here to pin the unchanged
+    /// half, not the change. See
+    /// `a_timestamp_later_than_arrival_is_clamped_even_though_it_is_in_the_past`
+    /// for the assertion that depends on the fix.
+    #[test]
+    fn past_timestamps_are_never_rewritten() {
+        let owner = signing_key(1);
+        let alice = signing_key(2);
+        let owner_id = member_id_of(&owner);
+
+        let now = at(1_700_000_000_000);
+        let sent = now - chrono::Duration::hours(2);
+        let msg = message_at(owner_id, &alice, sent);
+        let mut receive_times = ReceiveTimes::new();
+        receive_times.insert(
+            msg.id().0 .0,
+            (now - chrono::Duration::hours(1)).timestamp_millis() as f64,
+        );
+
+        let items = group(
+            &state(vec![msg]),
+            &info(&alice, "Alice"),
+            owner_id,
+            &receive_times,
+            now,
+        );
+        let g = only_group(&items);
+
+        assert!(!g.time_clamped);
+        assert_eq!(g.messages[0].time, sent);
+    }
+}
+
+/// Source-grep pins for the auto-scroll wiring in [`Conversation`].
+///
+/// The behaviour these guard is only observable in a browser (it is measured
+/// by `ui/tests/conversation-autoscroll.spec.ts`), so these exist to make a
+/// silent revert in a refactor fail at `cargo test` rather than in the field.
+/// freenet/river#486 is what a silent revert costs: the view stopped following
+/// the conversation for 54 consecutive arrivals.
+#[cfg(test)]
+mod autoscroll_wiring_pins {
+    /// The production half of this file, cut at the first test module.
+    ///
+    /// Cut by a needle that cannot match itself — it contains an escaped
+    /// newline in the source, not a literal one. `rfind` would land on
+    /// whichever test module was appended most recently and quietly put these
+    /// needles inside the scanned text, making every assertion below
+    /// self-satisfying (freenet/river#471).
+    fn production_source() -> &'static str {
+        let source = include_str!("conversation.rs");
+        &source[..source
+            .find("#[cfg(test)]\nmod tests {")
+            .expect("conversation.rs should have a `#[cfg(test)] mod tests` block")]
+    }
+
+    /// `is_at_bottom` answers "is the end of the history on screen right now?".
+    /// Gating auto-scroll on it is the #486 latch: once the gap exceeded the
+    /// observer's margin the gate read false and nothing re-armed it. The
+    /// signal may still drive the scroll-to-latest button, so this pins the
+    /// narrow thing — it must not appear in the auto-scroll effect's condition.
+    #[test]
+    fn autoscroll_is_not_gated_on_the_intersection_observer() {
+        let prod = production_source();
+        for forbidden in [
+            "forced || *is_at_bottom.peek()",
+            "*is_at_bottom.peek() || forced",
+            "forced || is_at_bottom()",
+        ] {
+            assert!(
+                !prod.contains(forbidden),
+                "auto-scroll must be gated on the user-intent pin, not on the \
+                 scroll-to-latest button's IntersectionObserver: found `{forbidden}`"
+            );
+        }
+        assert!(
+            prod.contains("forced || pinned_to_bottom.get()"),
+            "the auto-scroll gate must read the user-intent pin"
+        );
+    }
+
+    /// The pin is only meaningful if something maintains it. Removing the
+    /// listener install would freeze it at its initial `true`, which looks
+    /// fine until the reader scrolls up to read history and gets yanked back.
+    #[test]
+    fn the_pin_is_maintained_by_scroll_listeners() {
+        let prod = production_source();
+        assert!(
+            prod.contains("fn install_scroll_pin_listeners"),
+            "the user-intent pin needs a listener that maintains it"
+        );
+        assert!(
+            prod.contains("if install_scroll_pin_listeners("),
+            "`install_scroll_pin_listeners` must actually be called from `Conversation`"
+        );
+        assert!(
+            prod.contains("\"scrollend\""),
+            "the pin is re-evaluated once per settle, via `scrollend`"
+        );
+        // Safari before 17.4 has no `scrollend`, so the settle is spotted by a
+        // trailing debounce on `scroll` instead. Every engine Playwright drives
+        // exposes `scrollend`, so that branch NEVER executes in CI and could be
+        // deleted or broken without a single test going red.
+        assert!(
+            prod.contains("SCROLL_SETTLE_DEBOUNCE_MS") && prod.contains("\"scroll\""),
+            "browsers without `scrollend` need the debounced `scroll` fallback; \
+             nothing in the browser suite covers it, so it is pinned here"
+        );
+        // Whose settle it is, is decided by comparing where it landed against
+        // the offset our last scroll asked for — and `last_top` is refreshed
+        // for EVERY settle, including our own, BEFORE the early-out. Recording
+        // it only for the reader's settles is what let a stale offset suppress
+        // the follow indefinitely, so the ORDER of these three is the thing
+        // being pinned, not merely their presence.
+        let dense: String = prod.chars().filter(|c| !c.is_whitespace()).collect();
+        let at = |needle: &str| {
+            dense
+                .find(needle)
+                .unwrap_or_else(|| panic!("the settle handler must contain `{needle}`"))
+        };
+        let decide = at("letours=(settled_at-last_top.get()).abs()<=SCROLL_TOP_SLACK_PX;");
+        let record = at("last_top.set(settled_at);");
+        let early_out = at("ifours{return;}");
+        assert!(
+            decide < record && record < early_out,
+            "the settle handler must decide whose settle it is by POSITION, then \
+             record that position, and only THEN skip the pin update for our own \
+             scroll"
+        );
+    }
+
+    /// The pin is resolved by a `scrollend`, which arrives milliseconds after
+    /// the reader actually moves. Both things that scroll on the strength of
+    /// the pin must therefore also check that the reader has not moved since —
+    /// otherwise a message (or a resize) landing inside that window drags them
+    /// back down. Dropping either call site is silent: the suite still passes
+    /// on Chromium, where the `scrollend` happens to win the race, and fails
+    /// only on Firefox, WebKit and mobile Safari.
+    #[test]
+    fn both_scroll_paths_defer_to_a_reader_scroll_the_pin_has_not_seen_yet() {
+        let prod = production_source();
+        assert!(
+            prod.contains("fn reader_moved_up_since"),
+            "the stale-pin window needs an explicit guard"
+        );
+        assert_eq!(
+            prod.matches("reader_moved_up_since(&last_scroll_top)")
+                .count(),
+            2,
+            "BOTH the content-change effect and the ResizeObserver must consult \
+             the guard; found a different number of call sites"
+        );
+        // Whitespace-insensitive: `cargo fmt` decides how this condition wraps,
+        // and a pin that a reformat can break is a pin that gets deleted.
+        let dense: String = prod.chars().filter(|c| !c.is_whitespace()).collect();
+        assert!(
+            dense.contains(
+                "if!forced&&(!pinned_to_bottom.get()||reader_moved_up_since(&last_scroll_top))"
+            ),
+            "the deferred scroll must RE-READ the pin (a reader settle can clear \
+             it between the gate and the scroll) as well as consult the guard, \
+             and a forced scroll must override both"
+        );
+    }
+
+    /// The trigger, not just the gate. An `onmounted` on the last bubble is
+    /// silent for every content change that leaves that row in place, so the
+    /// effect has to subscribe to the grouped-message memo instead.
+    #[test]
+    fn autoscroll_is_triggered_by_content_change_not_by_a_remount() {
+        let prod = production_source();
+        assert!(
+            !prod.contains("last_chat_element"),
+            "the last-bubble mount handle is not a content-change trigger; it \
+             misses mid-list inserts, merged join summaries, reactions and edits"
+        );
+        // Whitespace-insensitive, like the sibling pin below: `cargo fmt`
+        // decides how this wraps, and a pin a reformat can break gets deleted.
+        let dense: String = prod.chars().filter(|c| !c.is_whitespace()).collect();
+        assert!(
+            dense.contains("lethas_content=message_groups.read().is_some();"),
+            "the auto-scroll effect must subscribe to `message_groups` so any \
+             content change re-runs it"
+        );
+        assert!(
+            prod.contains("ResizeObserver::new"),
+            "content-height changes with no re-render (late-loading images, \
+             font swaps) must also reach the scroll"
+        );
+        // Two observations, not one. The content wrapper sees the history
+        // growing or reflowing; only the container sees the WINDOW shrinking,
+        // which is what growing the composer does — #486's third cause.
+        let dense: String = prod.chars().filter(|c| !c.is_whitespace()).collect();
+        assert!(
+            dense.contains("observer.observe(&content);observer.observe(&container);"),
+            "the resize follow must watch BOTH the content wrapper and the \
+             scroll container; watching only the wrapper misses the composer \
+             taking height away from the history"
+        );
     }
 }

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -631,3 +631,141 @@ mod tests {
         }
     }
 }
+
+/// Browser hooks the Playwright specs use to deliver INBOUND messages.
+///
+/// The composer is not a substitute: `handle_send_message` raises
+/// `force_scroll`, which deliberately bypasses the pin that the scroll specs
+/// exist to test, so a message sent through the UI proves nothing about how an
+/// arriving one behaves. These write straight into `ROOMS`, as an arriving
+/// network update does.
+///
+/// They skip `apply_delta`'s verification on purpose, so they must never be
+/// reachable anywhere the result could be pushed to the network. Two gates,
+/// both required:
+///
+/// * `example-data`, which is off for the published webapp (`UI_FEATURES` is
+///   empty for `build-webapp`) and for every non-example build;
+/// * `no-sync`, because `cargo make dev-example` turns `example-data` on
+///   WITHOUT it. A message minted here is signed by a key that is not a room
+///   member, so a developer pointing that build at a live node would otherwise
+///   have the synchronizer try to push contract-invalid state.
+#[cfg(all(target_arch = "wasm32", feature = "no-sync"))]
+pub fn install_test_hooks() {
+    use wasm_bindgen::prelude::*;
+
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    // Idempotent: `App` may re-render, and re-installing would leak closures.
+    if js_sys::Reflect::has(&window, &JsValue::from_str("__riverTest")).unwrap_or(false) {
+        return;
+    }
+
+    let hooks = js_sys::Object::new();
+
+    let append = Closure::wrap(Box::new(move |text: String| {
+        crate::util::defer(move || deliver_message(text, Delivery::Append));
+    }) as Box<dyn FnMut(String)>);
+    let _ = js_sys::Reflect::set(&hooks, &JsValue::from_str("appendMessage"), append.as_ref());
+    append.forget();
+
+    let insert = Closure::wrap(Box::new(move |text: String| {
+        crate::util::defer(move || deliver_message(text, Delivery::BeforeLast));
+    }) as Box<dyn FnMut(String)>);
+    let _ = js_sys::Reflect::set(
+        &hooks,
+        &JsValue::from_str("insertMessageBeforeLast"),
+        insert.as_ref(),
+    );
+    insert.forget();
+
+    let _ = js_sys::Reflect::set(&window, &JsValue::from_str("__riverTest"), &hooks);
+}
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "no-sync"))]
+pub fn install_test_hooks() {}
+
+/// Where a delivered message lands in the room's message list.
+#[cfg(all(target_arch = "wasm32", feature = "no-sync"))]
+#[derive(Clone, Copy, PartialEq)]
+enum Delivery {
+    /// At the end, as an ordinary arrival does.
+    Append,
+    /// One position from the end — the mid-list insert that grows the history
+    /// WITHOUT remounting its last row, which is the case the old
+    /// `onmounted`-on-the-last-bubble scroll trigger could not see.
+    BeforeLast,
+}
+
+/// Two fixed identities, so a delivered message never merges into the group
+/// above it by accident: grouping needs the same author within 5 minutes, and
+/// `BeforeLast` in particular has to leave the last group's key (its first
+/// message's id) untouched or the row remounts and the test proves nothing.
+#[cfg(all(target_arch = "wasm32", feature = "no-sync"))]
+fn test_author(delivery: Delivery) -> SigningKey {
+    match delivery {
+        Delivery::Append => SigningKey::from_bytes(&[0x5A; 32]),
+        Delivery::BeforeLast => SigningKey::from_bytes(&[0x7B; 32]),
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "no-sync"))]
+fn deliver_message(text: String, delivery: Delivery) {
+    use crate::components::app::{CURRENT_ROOM, ROOMS};
+    use dioxus::prelude::*;
+
+    let Some(room_key) = CURRENT_ROOM.peek().owner_key else {
+        return;
+    };
+    let sk = test_author(delivery);
+    let author = MemberId::from(&sk.verifying_key());
+
+    ROOMS.with_mut(|rooms| {
+        let Some(room) = rooms.map.get_mut(&room_key) else {
+            return;
+        };
+
+        // Give the sender a name the first time it speaks, so the bubble
+        // renders like any other member's rather than as "Unknown".
+        if !room
+            .room_state
+            .member_info
+            .member_info
+            .iter()
+            .any(|entry| entry.member_info.member_id == author)
+        {
+            room.room_state.member_info.member_info.push(
+                AuthorizedMemberInfo::new_with_member_key(
+                    MemberInfo {
+                        member_id: author,
+                        version: 0,
+                        preferred_nickname: SealedBytes::public(
+                            format!("Test Sender {}", u8::from(delivery == Delivery::BeforeLast))
+                                .into_bytes(),
+                        ),
+                        deputies: Vec::new(),
+                    },
+                    &sk,
+                ),
+            );
+        }
+
+        let message = AuthorizedMessageV1::new(
+            MessageV1 {
+                room_owner: MemberId::from(&room_key),
+                author,
+                content: RoomMessageBody::public(text),
+                time: crate::util::get_current_system_time(),
+            },
+            &sk,
+        );
+
+        let messages = &mut room.room_state.recent_messages.messages;
+        let at = match delivery {
+            Delivery::Append => messages.len(),
+            Delivery::BeforeLast => messages.len().saturating_sub(1),
+        };
+        messages.insert(at, message);
+    });
+}

--- a/ui/tests/conversation-autoscroll.spec.ts
+++ b/ui/tests/conversation-autoscroll.spec.ts
@@ -1,0 +1,434 @@
+import { test, expect, Page } from "@playwright/test";
+
+// Regression tests for freenet/river#486: new messages arrived and the view
+// did not follow them.
+//
+// It looked intermittent. It is a permanent latch. Auto-scroll was gated on an
+// IntersectionObserver watching a 1px sentinel with a 100px `rootMargin`, which
+// answers "is the end of the history on screen right now?" — not "was the
+// reader following the conversation". Once the gap passed 100px the gate read
+// false and nothing re-armed it short of a manual scroll back down or a room
+// switch. On the live Freenet room that meant 54 arrivals with the view frozen
+// while the gap ratcheted from 147px to 2725px.
+//
+// Two things have to hold, and a suite that only checked the first would pass a
+// "pin is always true" implementation that yanks the reader back down every
+// time they try to read history:
+//
+//   1. anything that pushes the view off the bottom WITHOUT the reader asking
+//      must not stop the view following new messages;
+//   2. the reader scrolling away MUST stop it, and their coming back MUST start
+//      it again.
+//
+// Which test carries which is worth stating, because the two groups fail for
+// different reasons and only the first group fails against the unfixed code:
+//
+//   * `keeps following...`, `follows a mid-list insert...` and `keeps the
+//     newest message in view when a resize reflows...` are the #486 tests. Each
+//     fails against the pre-fix code at its own assertion.
+//   * `respects the reader...`, `respects a reader scroll that produces no
+//     gesture event` and `does not drag a parked reader down...` are the
+//     opposite guard. They constrain the FIX, not the bug: the pre-fix code
+//     also refuses to scroll a parked reader (for the wrong reason — its gate
+//     has latched), so a revert makes them fail at their setup rather than at
+//     the assertion that matters. Their teeth are against a wrong fix, and that
+//     is established by mutating the fix, not by reverting it.
+//
+// Assumes the example-data build, which exposes `window.__riverTest` for
+// delivering INBOUND messages. Sending through the composer would prove
+// nothing: that path raises `force_scroll`, deliberately bypassing the pin.
+
+/// Matches BOTTOM_THRESHOLD_PX in ui/src/components/conversation.rs.
+const BOTTOM_THRESHOLD_PX = 100;
+/// Slack for fractional layout after a scroll that did land at the bottom.
+const AT_BOTTOM_EPSILON_PX = 4;
+
+async function waitForApp(page: Page) {
+  await page.waitForSelector(".app-root", { timeout: 30_000 });
+  await expect(page.locator("aside, .app-root button")).not.toHaveCount(0);
+  await page.waitForFunction(() => (window as any).__riverTest !== undefined, {
+    timeout: 30_000,
+  });
+}
+
+async function selectRoom(page: Page, roomName: string) {
+  await page.getByRole("button", { name: roomName }).click();
+  await expect(page.getByRole("heading", { name: roomName })).toBeVisible({
+    timeout: 5_000,
+  });
+  // The mobile projects keep their touch/UA emulation but run at the desktop
+  // viewport these describes set, so the chat panel is always the visible one.
+  // Asserted rather than assumed: if it were hidden, every geometry read below
+  // would return 0 and the failures would point at scrolling rather than at
+  // layout.
+  await expect(page.locator("#chat-scroll-container")).toBeVisible({
+    timeout: 5_000,
+  });
+}
+
+/// scrollHeight - scrollTop - clientHeight: how far the end of the history is
+/// below the visible area. 0 means the newest message is fully in view.
+function distanceFromBottom(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const el = document.getElementById("chat-scroll-container");
+    if (!el) return Number.NaN;
+    return el.scrollHeight - el.scrollTop - el.clientHeight;
+  });
+}
+
+/// Total height of the rendered history, independent of where it is scrolled.
+function historyHeight(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const el = document.getElementById("chat-scroll-container");
+    return el ? el.scrollHeight : Number.NaN;
+  });
+}
+
+/// Height of the WINDOW onto the history. Shrinks when the composer grows.
+function viewportHeight(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const el = document.getElementById("chat-scroll-container");
+    return el ? el.clientHeight : Number.NaN;
+  });
+}
+
+function scrollTop(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const el = document.getElementById("chat-scroll-container");
+    return el ? el.scrollTop : Number.NaN;
+  });
+}
+
+async function expectSettledAtBottom(page: Page, why: string) {
+  await expect
+    .poll(() => distanceFromBottom(page), {
+      timeout: 5_000,
+      message: why,
+    })
+    .toBeLessThanOrEqual(AT_BOTTOM_EPSILON_PX);
+}
+
+/// Deliver an inbound message, exactly as an arriving network update does, and
+/// wait until it is actually on the page.
+///
+/// Waiting on the text rather than on a fixed delay matters for the tests that
+/// assert the view did NOT move: a timeout that expires before the render lands
+/// passes whether or not the bug is present, and `retries: 2` would keep that
+/// invisible.
+async function deliver(page: Page, text: string) {
+  await page.evaluate((t) => (window as any).__riverTest.appendMessage(t), text);
+  await expect(page.getByText(text, { exact: false }).last()).toBeVisible({
+    timeout: 5_000,
+  });
+}
+
+/// Deliver an inbound message one position from the end of the history: it
+/// grows the content WITHOUT remounting the last row.
+async function insertBeforeLast(page: Page, text: string) {
+  await page.evaluate(
+    (t) => (window as any).__riverTest.insertMessageBeforeLast(t),
+    text
+  );
+}
+
+/// Open a room and wait until the history has settled at its newest message.
+async function openRoomAtBottom(page: Page, roomName: string) {
+  await page.goto("/");
+  await waitForApp(page);
+  await selectRoom(page, roomName);
+  await expectSettledAtBottom(page, "opening a room should land on its newest message");
+}
+
+/// Simulate the reader dragging the history with a pointing device.
+///
+/// A synthetic `wheel` followed by a `scrollTop` assignment rather than
+/// `page.mouse.wheel`, which is unsupported on mobile WebKit. Both halves
+/// matter: the `wheel` is what tells the pin that the settle about to arrive is
+/// the reader's, and the `scrollTop` write is what produces that settle.
+async function readerScrollsTo(page: Page, top: number) {
+  await page.evaluate((t) => {
+    const el = document.getElementById("chat-scroll-container")!;
+    el.dispatchEvent(new WheelEvent("wheel", { bubbles: true, deltaY: -1 }));
+    el.scrollTop = t;
+  }, top);
+}
+
+/// The same, with NO gesture event at all.
+///
+/// Not a contrivance: a native scrollbar drag dispatches no pointer event to
+/// the content on Firefox, and find-in-page, focus-driven scrolling and browser
+/// scroll restoration produce none either. Nothing in the implementation
+/// listens for gestures — whose settle it is, is decided by where the view came
+/// to rest — so this is the ordinary path rather than a fallback, and these two
+/// helpers should behave identically.
+async function readerScrollsWithoutGesture(page: Page, top: number) {
+  await page.evaluate((t) => {
+    document.getElementById("chat-scroll-container")!.scrollTop = t;
+  }, top);
+}
+
+/// Hold for a moment and assert the view did not move.
+///
+/// Compares `scrollTop` rather than distance-from-bottom: distance also moves
+/// when content grows, so it would tolerate a partial yank of up to the new
+/// message's height.
+async function expectStaysPut(page: Page, why: string) {
+  const before = await scrollTop(page);
+  await page.waitForTimeout(600);
+  expect(await scrollTop(page), why).toBeCloseTo(before, 0);
+}
+
+/// Add enough history to have somewhere to scroll back through.
+async function fillHistory(page: Page) {
+  for (let i = 0; i < 8; i++) {
+    await deliver(page, `filler ${i}: ${"y".repeat(200)}`);
+  }
+  await expectSettledAtBottom(page, "filler messages should have been followed");
+}
+
+test.describe("Conversation follows new messages (#486)", () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test("keeps following a burst of arrivals after the composer takes the bottom off screen", async ({
+    page,
+  }) => {
+    await openRoomAtBottom(page, "Team Chat Room");
+    const roomyViewport = await viewportHeight(page);
+
+    // Typing a long message grows the composer to its 168px maximum, which
+    // takes more than the observer's 100px margin off the history in one step
+    // — so the old gate latched with no network activity at all. This is why
+    // #468 (the composer auto-resize) is a CAUSE of #486 rather than only a
+    // performance cost.
+    await page
+      .getByTestId("message-input")
+      .fill(Array.from({ length: 12 }, (_, i) => `draft line ${i}`).join("\n"));
+
+    // The premise, asserted rather than assumed: the window over the history
+    // has to shrink by more than the margin, or the latch would never have
+    // armed and everything below would pass against the unfixed code too.
+    //
+    // It is the WINDOW that is measured, not the gap. Under the fix the gap
+    // closes again immediately (the container is watched for resizes, so the
+    // view follows the newest message down), which makes "the view is off the
+    // bottom" unusable as a precondition — a complete fix erases it. What the
+    // old gate keyed on, and what stays true either way, is that the container
+    // lost more than 100px.
+    await expect
+      .poll(() => viewportHeight(page), {
+        timeout: 5_000,
+        message:
+          "the composer did not grow enough to clear the observer's margin, so " +
+          "this test is not exercising the latch",
+      })
+      .toBeLessThan(roomyViewport - BOTTOM_THRESHOLD_PX);
+
+    await expectSettledAtBottom(
+      page,
+      "the composer grew over the newest message and the view did not follow it"
+    );
+
+    // The recorded failure: 54 arrivals, none of which scrolled, with the gap
+    // ratcheting out to about three screens. Every one of these must land, and
+    // the loop is what catches a fix that survives one arrival and then
+    // re-latches.
+    for (let i = 1; i <= 6; i++) {
+      await deliver(page, `arrival ${i}`);
+      await expectSettledAtBottom(
+        page,
+        `message ${i} arrived while a draft was open and the view did not follow it`
+      );
+    }
+
+    // Clearing the draft gives the height back, so the container GROWS and the
+    // browser clamps `scrollTop` down on its own. The follow has to survive
+    // that too, in both directions.
+    //
+    // It does NOT pin `reader_moved_up_since`'s `.min(max_scroll_top(...))`:
+    // deleting that clamp was tried and this still passed, because the browser
+    // fires a settle for its own clamping and the settle repairs the reference
+    // before the next arrival. The `.min` narrows a race window rather than
+    // deciding an outcome, and nothing here is strong enough to claim otherwise.
+    await page.getByTestId("message-input").fill("");
+    await expect
+      .poll(() => viewportHeight(page), { timeout: 5_000 })
+      .toBeGreaterThan(roomyViewport - BOTTOM_THRESHOLD_PX);
+    await deliver(page, "arrived after the draft was cleared");
+    await expectSettledAtBottom(
+      page,
+      "the draft was cleared and the next arrival was not followed"
+    );
+  });
+
+  test("follows a mid-list insert that does not remount the last row", async ({
+    page,
+  }) => {
+    await openRoomAtBottom(page, "Team Chat Room");
+
+    // Tag the last row so we can prove afterwards that it was diffed, not
+    // remounted. Without this the test would pass for the wrong reason: a
+    // remount would fire the old `onmounted` trigger, which is exactly the
+    // path that already worked.
+    //
+    // It holds because of how the fixture ends, not by luck: "Team Chat Room"
+    // finishes with messages from different authors, so its last group is a
+    // single message whose key (its first message's id) cannot change when
+    // something is inserted before it. `insertMessageBeforeLast` also signs
+    // with its own key, so it can never merge into that group.
+    await page.evaluate(() => {
+      const rows = document.querySelectorAll("#chat-scroll-container .space-y-4 > *");
+      (rows[rows.length - 1] as any).__riverProbe = "last-row";
+    });
+
+    await insertBeforeLast(
+      page,
+      "inserted above the last row: " + "x".repeat(400)
+    );
+
+    await expectSettledAtBottom(
+      page,
+      "content grew above the last row and the view did not follow it"
+    );
+
+    const lastRowSurvived = await page.evaluate(() => {
+      const rows = document.querySelectorAll("#chat-scroll-container .space-y-4 > *");
+      return (rows[rows.length - 1] as any).__riverProbe === "last-row";
+    });
+    expect(
+      lastRowSurvived,
+      "the last row remounted, so this exercised the old trigger rather than " +
+        "the content-change trigger it is meant to pin"
+    ).toBe(true);
+  });
+
+  test("respects the reader scrolling away, and re-arms when they come back", async ({
+    page,
+  }) => {
+    await openRoomAtBottom(page, "Team Chat Room");
+    await fillHistory(page);
+
+    await readerScrollsTo(page, 0);
+    await expect
+      .poll(() => distanceFromBottom(page), { timeout: 5_000 })
+      .toBeGreaterThan(BOTTOM_THRESHOLD_PX);
+
+    await deliver(page, "arrived while reading history");
+    await expectStaysPut(
+      page,
+      "a message arrived while the reader was scrolled up and yanked the view"
+    );
+
+    // The reader scrolls back to the bottom THEMSELVES. This is the settle
+    // handler's re-arm branch, and it is the only place in the suite that
+    // reaches it: the scroll-to-latest button re-arms the pin directly, so a
+    // suite that only used the button would still pass if the re-arm branch
+    // were narrowed to, say, `distance <= 0`, and a reader who stopped a few
+    // fractional pixels short would never be followed again.
+    await readerScrollsWithoutGesture(page, await historyHeight(page));
+    await expectSettledAtBottom(page, "the reader's own scroll should reach the bottom");
+    await deliver(page, "arrived after the reader scrolled back down");
+    await expectSettledAtBottom(
+      page,
+      "the reader returned to the bottom and the follow did not re-arm"
+    );
+
+    // The button is a second, independent way back, and it re-arms the pin
+    // itself rather than through a settle.
+    await readerScrollsTo(page, 0);
+    await expect(page.getByTestId("scroll-to-bottom")).toBeVisible({
+      timeout: 5_000,
+    });
+    await page.getByTestId("scroll-to-bottom").click();
+    await expectSettledAtBottom(page, "the scroll-to-latest button should reach the bottom");
+    await deliver(page, "arrived after the button was used");
+    await expectSettledAtBottom(
+      page,
+      "the scroll-to-latest button must re-arm the follow"
+    );
+  });
+
+  test("respects a reader scroll that produces no gesture event", async ({
+    page,
+  }) => {
+    await openRoomAtBottom(page, "Team Chat Room");
+    await fillHistory(page);
+
+    // No `wheel`, no `pointerdown`, no `touchstart`: only the settle handler
+    // can notice this. Kept as its own test because an earlier implementation
+    // DID lean on gesture events to decide whose settle a settle was, and this
+    // is the shape that broke it — a native scrollbar drag on Firefox,
+    // find-in-page, or focus-driven scrolling, none of which produce one.
+    await readerScrollsWithoutGesture(page, 0);
+    await expect
+      .poll(() => distanceFromBottom(page), { timeout: 5_000 })
+      .toBeGreaterThan(BOTTOM_THRESHOLD_PX);
+
+    await deliver(page, "arrived after a gesture-less scroll");
+    await expectStaysPut(
+      page,
+      "the reader scrolled up without a gesture event and the view was yanked back"
+    );
+  });
+});
+
+test.describe("Conversation follows layout-only growth (#486)", () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test("keeps the newest message in view when a resize reflows the history", async ({
+    page,
+  }) => {
+    await openRoomAtBottom(page, "Team Chat Room");
+
+    const before = await historyHeight(page);
+
+    // Narrowing the window makes every message wrap onto more lines, so the
+    // history gets taller and its end drops below the fold. No state changed,
+    // so the grouped-message memo does not re-run and the content-change
+    // trigger never fires — only the ResizeObserver sees this. It is the same
+    // class as a late-loading image or a font swapping in, which are the cases
+    // a state-only trigger cannot cover.
+    await page.setViewportSize({ width: 380, height: 900 });
+
+    // The premise, asserted rather than assumed. How much a reflow grows the
+    // history depends entirely on where the text happens to wrap: measured on
+    // this fixture, 1280 -> 700 grows it by *zero* pixels, so a test written at
+    // that width passes without the view ever having been pushed off the
+    // bottom — it pins nothing. 1280 -> 380 grows it by ~340px. If a fixture or
+    // layout change ever flattens that again, this fails loudly instead of
+    // going quietly vacuous.
+    await expect
+      .poll(() => historyHeight(page), {
+        timeout: 5_000,
+        message:
+          "narrowing the window did not make the history taller, so this test " +
+          "is not exercising a reflow at all",
+      })
+      .toBeGreaterThan(before + BOTTOM_THRESHOLD_PX);
+
+    await expectSettledAtBottom(
+      page,
+      "the history reflowed taller and the view did not follow it"
+    );
+  });
+
+  test("does not drag a parked reader down when a resize reflows the history", async ({
+    page,
+  }) => {
+    await openRoomAtBottom(page, "Team Chat Room");
+    await fillHistory(page);
+
+    await readerScrollsTo(page, 0);
+    await expect
+      .poll(() => distanceFromBottom(page), { timeout: 5_000 })
+      .toBeGreaterThan(BOTTOM_THRESHOLD_PX);
+
+    // Same reflow as above, with the reader parked. The follow and the refusal
+    // to follow run through the same ResizeObserver, so this is the half that
+    // stops "keep the newest message in view" from becoming "never let the
+    // reader look away".
+    await page.setViewportSize({ width: 380, height: 900 });
+    await expect
+      .poll(() => distanceFromBottom(page), { timeout: 5_000 })
+      .toBeGreaterThan(BOTTOM_THRESHOLD_PX);
+  });
+});


### PR DESCRIPTION
## Problem

New messages arrive in a room and the view does not follow them. It reads as
intermittent, but it is a **permanent latch**: once it triggers, the view never
follows again until the reader manually scrolls back to the bottom or switches
rooms. Recorded live on the Freenet room with CDP + rAF sampling: after the gate
latched at t=60s there were **54 further arrivals, 35 of which fired the scroll
trigger, and zero scrolled**, while the distance from the bottom ratcheted
147px → 285 → 387 → … → **2725px**, about 3.2 viewport heights.

Two independent defects, both in the same direction, so fixing either alone
leaves the bug standing.

**The gate.** `should_scroll = forced || *is_at_bottom.peek()`. `is_at_bottom` is
written by an IntersectionObserver on a 1px sentinel with a 100px `rootMargin`.
That signal answers *"is the end of the history on screen right now?"*, not *"was
the reader following the conversation before this update"*. Once the gap exceeds
100px it reads false and nothing re-arms it. Growing the composer to its 168px
maximum shrinks the history by more than the margin on its own, so typing a long
message latched it with no network activity at all — which is why #468 is a
**cause** of this bug rather than only a performance cost.

**The trigger.** `last_chat_element` was written only by an `onmounted` on the
last bubble, and that was the effect's only reactive dependency. Every content
change that leaves the last row in place was invisible to it: a mid-list insert,
a reaction, an edit, or another join folding into an existing "N people joined"
summary (keyed on its FIRST event, so absorbing a new one grows it without
remounting anything).

## Approach

**Gate → a pin that tracks intent.** A `scrollend` listener (a debounced `scroll`
where `scrollend` is missing) re-measures the distance once per settle. Whose
settle it is, is decided by **position**: `last_scroll_top` holds the offset our
last scroll asked for, a settle that lands there is ours and leaves the pin
alone, a settle anywhere else is the reader's.

Deciding it with a "this settle is ours" flag was tried first and does not
survive two settles being in flight at once. Clearing a long draft grows the
container, the browser clamps `scrollTop` on its own, and that clamp's settle was
consumed by the flag the previous scroll had raised — the recorded offset then
pointed somewhere the view had already left, and both follow paths stood down.
Caught by the new suite on mobile Safari (62px short of the newest message, still
short 12s later), not by reading the code. Position also needs no
`wheel`/`pointerdown` listeners to guess at intent, so reader scrolls that
produce no gesture event (native scrollbar drag on Firefox, find-in-page,
focus-driven scrolling) stop being a hole.

The IntersectionObserver stays exactly where its semantics are correct — the
scroll-to-latest button — and its `rootMargin` is now built from the same
constant, so the doc claim that the two agree about where the bottom is became
true.

**Trigger → any content change.** The effect subscribes to the grouped-message
memo, and a ResizeObserver covers the size changes no re-render can see. It
watches **both** the content wrapper and the scroll container, because they see
different halves: the wrapper sees the history reflowing (late-loading image,
font swap, rewrap on a narrower screen), and only the container sees the *window*
shrinking, which is what the composer does. De-latching the gate alone would
have left the newest message below the fold after a long draft until something
else happened.

**Resolving the pin takes a `scrollend`**, which arrives milliseconds after the
reader actually moves, so both scroll paths also refuse to act over a reader
scroll the pin has not seen yet, and the deferred one re-reads the pin when it
runs rather than trusting what its gate saw. Both reproduced on Firefox, WebKit
and mobile Safari while Chromium stayed green.

**Also here, because the new trigger depends on it:** `Utc::now()` was read per
message, per render, inside the grouping loop as the clamp target for
future-dated timestamps, so a clock-skewed message re-timed itself on every
render. The memo is now the auto-scroll trigger, so it has to be a pure function
of the content rather than of when the render happened. It clamps against when
this client first saw the message instead. Two consequences are handled rather
than left to surprise someone: the old comparison carried the whole propagation
delay as implicit slack and the new one carries none, so a minute of tolerance
keeps a peer with a slightly fast clock from having every message marked "clock
may be wrong"; and the clamp target is now persisted data, so `receive_times`
rejects values that are not plausible arrival times.

## Testing

Six Playwright tests across all five browser projects (30 cases), plus Rust unit
tests for the clock change and source-grep pins for the wiring.

**Verified two ways.** Against the pre-fix code, all 30 fail — but only the three
#486 tests fail at their own assertions:

| assertion | cases |
|---|---|
| the composer grew over the newest message and the view did not follow it | 5 |
| content grew above the last row and the view did not follow it | 5 |
| the history reflowed taller and the view did not follow it | 5 |
| filler messages should have been followed (**setup** of the 3 guard tests) | 15 |

The guard tests constrain the *fix*, not the bug — the pre-fix code also refuses
to scroll a parked reader, for the wrong reason — so a revert says nothing about
their teeth. Those were established by **mutating the fix** instead: making the
pin always true fails all three; making the settle handler able to clear the pin
but never re-arm it fails the reader-returns leg specifically.

Every test asserts its own premise rather than assuming it. That is not
decoration: at 1280 → 700 this fixture reflows by exactly **zero** pixels, so the
reflow test as first written passed without the view ever having been pushed off
the bottom. It narrows to 380 now and fails loudly if the history does not get
taller. The composer test measures the *window* rather than the gap for the same
reason in reverse — under the fix the gap closes again immediately, so "the view
is off the bottom" is a precondition a complete fix erases.

Delivery goes through `window.__riverTest`, installed only in builds with example
data **and** sync switched off (it writes messages signed by a non-member key
straight into `ROOMS`). The composer is not a substitute: that path raises
`force_scroll` and deliberately bypasses the pin.

Full local runs on the branch: `cargo test -p river-ui --bins` 660 passed; full
Playwright suite 485 passed / 0 failed / 0 flaky; the autoscroll spec 4x30 clean,
and the previously flaky composer case 8x clean (it was failing ~1 in 3 before
the position-based redesign). No new clippy warnings against `main`.

## Review

Codex is out of credit, so this had three independent Claude adversarial reviews
with distinct lenses (skeptical bug-hunt, code-first, test-quality) instead. All
findings are addressed in the diff; the ones that changed behaviour were the
composer-resize gap, the `time_clamped` widening and its now-inaccurate tooltip,
the persisted-clamp-target validation, and the `rootMargin` constant. One review
claim was checked and found false — the composer-clear leg does not pin
`reader_moved_up_since`'s `.min(max_scroll_top(..))` (deleting it, the test still
passes) — and the comment now says so rather than claiming coverage it lacks.

Not folded in: #487 (the DM thread modal has the same class of bug, filed
separately and deliberately kept out of this PR).

Closes #486

[AI-assisted - Claude]
