### PR TITLE
fix(ui): keep the DM rail stable under signal contention (#499)

### DIFF
--- a/ui/src/components/direct_messages.rs
+++ b/ui/src/components/direct_messages.rs
@@ -42,10 +42,43 @@ pub static OPEN_DM_THREAD: GlobalSignal<Option<(VerifyingKey, MemberId)>> = Glob
 pub static DM_LAST_SEEN: GlobalSignal<HashMap<(VerifyingKey, MemberId), u64>> =
     Global::new(HashMap::new);
 
+/// Pure decision for [`mark_thread_read`]: would recording `up_to_ts`
+/// actually advance the stored cutoff? `current` is the existing
+/// `DM_LAST_SEEN` entry for the `(room, peer)` pair (`None` = no entry
+/// yet, which reads as cutoff 0 everywhere else).
+///
+/// Split out because the answer gates whether `mark_thread_read`
+/// touches the signal at all: `DmThreadModalBody` calls
+/// `mark_thread_read` from its render body on every render while a
+/// thread is open, and `with_mut` notifies subscribers even when the
+/// mutation changed nothing — so an unconditional write turned an open
+/// DM thread into a continuous write pulse on `DM_LAST_SEEN`, widening
+/// the contention window that blanked the DM rail (issue #499).
+/// Pinned by the `thread_read_needs_write_*` tests plus the wiring pin
+/// `mark_thread_read_write_is_gated_pinned`.
+pub(crate) fn thread_read_needs_write(current: Option<u64>, up_to_ts: u64) -> bool {
+    up_to_ts > current.unwrap_or(0)
+}
+
 /// Mark every DM from `peer` in `room` as seen up to (and including) the
 /// most recent inbound message timestamp known to the synchronizer.
 pub fn mark_thread_read(room: VerifyingKey, peer: MemberId, up_to_ts: u64) {
     crate::util::defer(move || {
+        // Skip the write when the stored cutoff would not advance —
+        // `with_mut` notifies subscribers even for a no-op mutation and
+        // this runs on every render of an open thread (issue #499
+        // write-pulse). `try_peek` registers no subscription and takes
+        // no write borrow; if it is somehow contended (it shouldn't be
+        // — we're in a `defer`'d clean context) we conservatively
+        // attempt the write rather than risk losing a genuine
+        // mark-read.
+        let needs_write = DM_LAST_SEEN
+            .try_peek()
+            .map(|seen| thread_read_needs_write(seen.get(&(room, peer)).copied(), up_to_ts))
+            .unwrap_or(true);
+        if !needs_write {
+            return;
+        }
         DM_LAST_SEEN.with_mut(|seen| {
             let entry = seen.entry((room, peer)).or_insert(0);
             if up_to_ts > *entry {
@@ -700,6 +733,65 @@ mod tests {
                  the send here makes that fix invisible to UI users."
             );
         }
+    }
+
+    /// Issue #499 write-pulse: `mark_thread_read` is called from
+    /// `DmThreadModalBody`'s render body on every render while a thread
+    /// is open, and `with_mut` notifies subscribers even when the
+    /// mutation is a no-op — so the `with_mut` MUST stay gated on
+    /// `thread_read_needs_write`. Source-scrape (the function needs a
+    /// Dioxus runtime to exercise): match whitespace-stripped source so
+    /// rustfmt reflowing can't fake a failure; cut at `mod tests` (this
+    /// file has exactly one) so these needles can't satisfy their own
+    /// check; bound the segment by the NEXT function head so a gate
+    /// elsewhere in the file can't vacuously pass.
+    #[test]
+    fn mark_thread_read_write_is_gated_pinned() {
+        let src = include_str!("direct_messages.rs");
+        let body = &src[..src.find("mod tests").unwrap_or(src.len())];
+        let stripped: String = body.chars().filter(|c| !c.is_whitespace()).collect();
+
+        let start = stripped
+            .find("pubfnmark_thread_read")
+            .expect("mark_thread_read not found");
+        let end = stripped[start..]
+            .find("pubfnopen_dm_thread")
+            .map(|i| start + i)
+            .expect("open_dm_thread must follow mark_thread_read");
+        let seg = &stripped[start..end];
+
+        let gate = seg
+            .find("if!needs_write{return;}")
+            .expect("mark_thread_read must early-return when the cutoff would not advance");
+        let decide = seg
+            .find("thread_read_needs_write(")
+            .expect("mark_thread_read must decide via thread_read_needs_write");
+        let write = seg
+            .find(".with_mut(")
+            .expect("mark_thread_read must still perform the gated write");
+        assert!(
+            decide < gate && gate < write,
+            "mark_thread_read's with_mut must come AFTER the needs-write gate \
+             (decide at {decide}, gate at {gate}, write at {write}) — an ungated \
+             with_mut notifies DM rail subscribers on every render of an open \
+             thread (issue #499 write-pulse)"
+        );
+    }
+
+    /// Decision table for the issue #499 write-pulse gate.
+    #[test]
+    fn thread_read_needs_write_only_when_cutoff_advances() {
+        // No stored entry: any positive timestamp advances the cutoff…
+        assert!(thread_read_needs_write(None, 1));
+        // …but a zero timestamp does not (absent reads as 0 everywhere).
+        assert!(!thread_read_needs_write(None, 0));
+        // Equal to the stored cutoff: no-op — this is the exact case the
+        // render body hits on every re-render while a thread is open.
+        assert!(!thread_read_needs_write(Some(100), 100));
+        // Older than the stored cutoff: no-op.
+        assert!(!thread_read_needs_write(Some(100), 99));
+        // Strictly newer: write.
+        assert!(thread_read_needs_write(Some(100), 101));
     }
 
     use super::*;

--- a/ui/src/components/direct_messages.rs
+++ b/ui/src/components/direct_messages.rs
@@ -67,15 +67,21 @@ pub fn mark_thread_read(room: VerifyingKey, peer: MemberId, up_to_ts: u64) {
         // Skip the write when the stored cutoff would not advance —
         // `with_mut` notifies subscribers even for a no-op mutation and
         // this runs on every render of an open thread (issue #499
-        // write-pulse). `try_peek` registers no subscription and takes
-        // no write borrow; if it is somehow contended (it shouldn't be
-        // — we're in a `defer`'d clean context) we conservatively
-        // attempt the write rather than risk losing a genuine
-        // mark-read.
+        // write-pulse). `try_peek` registers no subscription; it fails
+        // ONLY while a live WRITE borrow exists on `DM_LAST_SEEN` — and
+        // on that same synchronous stack `with_mut` (which is
+        // `f(&mut *self.write())`, a panicking borrow) would be a
+        // GUARANTEED panic. So a contended peek must SKIP, never fall
+        // through to the write. Skipping is harmless: this function
+        // re-fires on every render of the open thread and again on the
+        // next inbound message, so a skipped advance self-heals on the
+        // next clean pass. The `false` fallback below is load-bearing —
+        // a `true` fallback is the panic path. Pinned by
+        // `mark_thread_read_write_is_gated_pinned`.
         let needs_write = DM_LAST_SEEN
             .try_peek()
             .map(|seen| thread_read_needs_write(seen.get(&(room, peer)).copied(), up_to_ts))
-            .unwrap_or(true);
+            .unwrap_or(false);
         if !needs_write {
             return;
         }
@@ -775,6 +781,31 @@ mod tests {
              (decide at {decide}, gate at {gate}, write at {write}) — an ungated \
              with_mut notifies DM rail subscribers on every render of an open \
              thread (issue #499 write-pulse)"
+        );
+
+        // The contended-peek fallback must be FALSE (skip the write).
+        // `try_peek` fails only while a live WRITE borrow exists on
+        // DM_LAST_SEEN, and on that same synchronous stack `with_mut`
+        // is a panicking borrow — so a `true` fallback converts every
+        // contended peek into a guaranteed RefCell panic. `false` is
+        // safe: mark_thread_read re-fires on every render of the open
+        // thread, so a skipped advance self-heals on the next clean
+        // pass. (Needles built with concat! so this comment and the
+        // assertion literals cannot drift into matching themselves —
+        // they sit inside the cut anyway, belt and braces.)
+        let fallback_false = concat!(".unwrap_or(", "false)");
+        let fallback_true = concat!(".unwrap_or(", "true)");
+        assert!(
+            seg.contains(fallback_false),
+            "mark_thread_read's try_peek fallback must be `false` (skip on \
+             contention) — a contended peek means a live write borrow, and \
+             falling through to with_mut on that stack panics"
+        );
+        assert!(
+            !seg.contains(fallback_true),
+            "mark_thread_read must NOT fall back to `true` on a contended \
+             try_peek — that is the guaranteed-panic path (with_mut on a \
+             signal whose write borrow is live)"
         );
     }
 

--- a/ui/src/components/direct_messages.rs
+++ b/ui/src/components/direct_messages.rs
@@ -968,7 +968,7 @@ mod tests {
         assert_eq!(updates.get(&(owner_vk, bob_id)), Some(&200));
         // Outbound DM: must NOT seed against my own self_id.
         let me_id: MemberId = (&me.verifying_key()).into();
-        assert!(updates.get(&(owner_vk, me_id)).is_none());
+        assert!(!updates.contains_key(&(owner_vk, me_id)));
     }
 
     #[test]

--- a/ui/src/components/room_list/dm_rail_section.rs
+++ b/ui/src/components/room_list/dm_rail_section.rs
@@ -1573,10 +1573,15 @@ mod tests {
     /// with zero subscriptions — permanently frozen (`DmRailSection`
     /// never unmounts). Mirrors the `CURRENT_ROOM.read()` guard in
     /// `room_list.rs`. The anchor is `RAIL_REBUILD_TICK`, which doubles
-    /// as the recovery channel: every degraded pass must ALSO schedule
+    /// as the recovery channel: EVERY degraded pass must ALSO schedule
     /// a rail nudge (a deferred tick bump), so recovery is one
     /// macrotask away rather than parked until unrelated user action —
-    /// each segment is checked for at least one nudge call too.
+    /// each segment is checked for its full PER-DEGRADE-ARM count of
+    /// nudge calls (3 in `build_view`: ROOMS / DM_LAST_SEEN / HIDDEN;
+    /// 2 in each archived builder: ROOMS / HIDDEN). A bare "at least
+    /// one" check would let a refactor drop the nudge from the ROOMS
+    /// arm alone — the most critical arm, since that pass leaves the
+    /// memo subscribed ONLY to the tick — while the pin stayed green.
     ///
     /// Source-scrape because the builders need a Dioxus runtime to run.
     /// Conventions: match WHITESPACE-STRIPPED source so rustfmt
@@ -1595,13 +1600,14 @@ mod tests {
         let body = &src[..src.find("mod tests").unwrap_or(src.len())];
         let stripped: String = body.chars().filter(|c| !c.is_whitespace()).collect();
 
-        // (builder head, next-function head bounding the segment)
+        // (builder head, next-function head bounding the segment,
+        //  expected schedule_rail_nudge() call count = degrade-arm count)
         let cases = [
-            ("fnbuild_archived_view()", "fncurrent_archived_count()"),
-            ("fncurrent_archived_count()", "fnbuild_view()"),
-            ("fnbuild_view()", "fnshort_member_id("),
+            ("fnbuild_archived_view()", "fncurrent_archived_count()", 2),
+            ("fncurrent_archived_count()", "fnbuild_view()", 2),
+            ("fnbuild_view()", "fnshort_member_id(", 3),
         ];
-        for (head, next_head) in cases {
+        for (head, next_head, expected_nudges) in cases {
             let start = stripped
                 .find(head)
                 .unwrap_or_else(|| panic!("{head} not found — function renamed/removed?"));
@@ -1625,11 +1631,17 @@ mod tests {
                  come BEFORE the first fallible try_read (at {fallible}) — otherwise a \
                  contended poll leaves the memo with zero subscriptions (issue #499)"
             );
+            let nudges = seg.matches("schedule_rail_nudge()").count();
             assert!(
-                seg.contains("schedule_rail_nudge()"),
-                "{head} has no schedule_rail_nudge() call — a degraded pass must \
-                 queue a deferred tick bump so the memo re-polls one macrotask \
-                 later instead of serving stale data until unrelated user action"
+                nudges >= expected_nudges,
+                "{head} has {nudges} schedule_rail_nudge() call(s), expected at \
+                 least {expected_nudges} (one per degrade arm) — EVERY contended-read \
+                 arm must queue a deferred tick bump so the memo re-polls one \
+                 macrotask later instead of serving stale data until unrelated \
+                 user action. Dropping the nudge from even one arm (e.g. the \
+                 ROOMS arm, whose pass leaves the memo subscribed only to the \
+                 tick) reopens the parked-stale window. If a degrade arm was \
+                 deliberately removed, update this count alongside it."
             );
         }
     }

--- a/ui/src/components/room_list/dm_rail_section.rs
+++ b/ui/src/components/room_list/dm_rail_section.rs
@@ -31,7 +31,7 @@
 use crate::components::app::chat_delegate::{hide_dm_thread, unhide_dm_thread};
 use crate::components::app::ROOMS;
 use crate::components::direct_messages::{
-    is_thread_hidden_for, open_dm_thread, DM_LAST_SEEN, HIDDEN_DM_THREADS, OPEN_DM_THREAD,
+    is_thread_hidden_for, open_dm_thread, DM_LAST_SEEN, HIDDEN_DM_THREADS,
 };
 use crate::util::ecies::unseal_bytes_with_secrets;
 use dioxus::prelude::*;
@@ -42,7 +42,7 @@ use dioxus_free_icons::{
 use ed25519_dalek::VerifyingKey;
 use river_core::chat_delegate::HiddenDmThreadEntry;
 use river_core::room_state::member::MemberId;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -116,10 +116,11 @@ pub fn DmRailSection() -> Element {
     //
     // `current_archived_count` walks ROOMS to compute the per-pair
     // `last_any_ts` and runs `count_currently_archived`. On contention
-    // (any `try_read` failing) we fall back to 0 so the link disappears
-    // for THIS render — a brief mid-write flicker is preferable to
-    // showing a stale count.
-    let archived_count = use_memo(move || current_archived_count().unwrap_or(0));
+    // (any `try_read` failing) it serves the last clean count and
+    // schedules a self-nudge — a transient 0 here could combine with an
+    // empty thread list to satisfy the empty-state early return below
+    // and unmount the whole DIRECT MESSAGES section for a pass.
+    let archived_count = use_memo(current_archived_count);
     let archived_count = *archived_count.read();
 
     let mut archived_panel_open: Signal<bool> = use_signal(|| false);
@@ -441,12 +442,15 @@ pub(crate) fn filter_rail_entries(
 ///   failed OPEN (skipped the filter), flashing every archived thread
 ///   into the active rail for a render. Failing closed to an EMPTY list
 ///   instead would blink the whole rail (the other #499 symptom), so we
-///   return `last_good`: the most recent successfully-filtered rail. It
-///   is at worst one render stale and by construction contains no
-///   thread that was archived as of the last clean pass (a thread whose
-///   archive click is the very write we're contending with may persist
-///   for that single render — matching what was on screen the instant
-///   before the click, never resurrecting older archived threads).
+///   return `last_good`: the most recent successfully-filtered rail. By
+///   construction it contains no thread that was archived as of the
+///   last clean pass (a thread whose archive click is the very write
+///   we're contending with may persist briefly — matching what was on
+///   screen the instant before the click, never resurrecting older
+///   archived threads). Staleness is bounded: every degraded pass
+///   schedules a rail nudge (`schedule_rail_nudge`), so the memo
+///   re-polls one macrotask later in a clean context rather than
+///   waiting for an unrelated signal write.
 ///
 /// Invariants, in priority order: (1) archived threads never appear in
 /// the active rail; (2) the rail collapses as rarely as possible.
@@ -494,9 +498,12 @@ pub(crate) struct PeerDmActivity {
 /// contended read must degrade to "no unread info for this pass" —
 /// entries are still produced, with `unread = 0` and correct recency —
 /// instead of aborting the whole rail build (which blanked the entire
-/// active list while "Archived (N)" stayed put). A peer merely ABSENT
-/// from a `Some` map still means cutoff 0 (thread never read). Pinned
-/// by the `accumulate_peer_activity_*` tests.
+/// active list while "Archived (N)" stayed put). `build_view` then
+/// backfills the zeroed unread counts from the last good rail (see
+/// [`backfill_unread_from_last_good`]) so the degrade doesn't reorder
+/// the unread-first sort. A peer merely ABSENT from a `Some` map still
+/// means cutoff 0 (thread never read). Pinned by the
+/// `accumulate_peer_activity_*` tests.
 pub(crate) fn accumulate_peer_activity(
     room: &VerifyingKey,
     self_id: MemberId,
@@ -530,6 +537,31 @@ pub(crate) fn accumulate_peer_activity(
     per_peer
 }
 
+/// Pure helper: carry per-pair unread counts forward from the last good
+/// rail when the CURRENT pass had no readable `DM_LAST_SEEN` (issue
+/// #499 review follow-up). Zeroing unread on a contended pass is not
+/// merely cosmetic: unread is the PRIMARY sort key, so a transient 0
+/// reorders the rail (unread rows drop from the top) for that pass and
+/// snaps back a moment later — the same visual flap #499 is about.
+/// Pairs absent from `last_good` keep `unread = 0`: we have no better
+/// information for them. Recency (`last_any_ts`) is deliberately NOT
+/// backfilled — the current pass computed it from live room state.
+/// Pinned by the `backfill_unread_from_last_good_*` tests.
+pub(crate) fn backfill_unread_from_last_good(
+    entries: &mut [DmRailEntry],
+    last_good: &[DmRailEntry],
+) {
+    let prev: HashMap<(VerifyingKey, MemberId), usize> = last_good
+        .iter()
+        .map(|e| ((e.room, e.peer), e.unread))
+        .collect();
+    for e in entries.iter_mut() {
+        if let Some(unread) = prev.get(&(e.room, e.peer)) {
+            e.unread = *unread;
+        }
+    }
+}
+
 /// Project a room's authorized DM list into the `(sender, recipient,
 /// timestamp)` triples [`accumulate_peer_activity`] consumes. Shared by
 /// all three builders so their per-pair `last_any_ts` scans can't
@@ -552,16 +584,34 @@ fn dm_message_triples(
 }
 
 thread_local! {
-    /// Last successfully filtered + sorted rail, kept by `build_view`.
-    /// Serves as the degrade value when a signal read is contended:
-    /// showing the one-render-old rail is strictly better than blanking
-    /// it (issue #499's headline symptom), and — unlike the old skip-
-    /// the-filter fallback — can never flash archived threads into the
-    /// active list, because every cached list already went through
-    /// `filter_rail_entries`. Plain `thread_local` (not a signal): the
-    /// UI is single-threaded WASM and writing a signal from inside a
-    /// memo would re-trigger reactivity.
+    /// Last rail built by a FULLY-clean `build_view` pass (hide-list
+    /// AND unread cutoffs both read cleanly — see the gated write at
+    /// the end of `build_view`; a pass with degraded unread would
+    /// poison the unread backfill that reads from here). Serves as the
+    /// degrade value when a signal read is contended: showing the
+    /// last-good rail is strictly better than blanking it (issue #499's
+    /// headline symptom), and — unlike the old skip-the-filter
+    /// fallback — can never flash archived threads into the active
+    /// list, because every cached list already went through
+    /// `filter_rail_entries`. Staleness is bounded by the rail nudge
+    /// (every degraded pass schedules one, so the memo re-polls a
+    /// macrotask later). Plain `thread_local` (not a signal): the UI is
+    /// single-threaded WASM and writing a signal from inside a memo
+    /// would re-trigger reactivity.
     static LAST_GOOD_RAIL: RefCell<Vec<DmRailEntry>> = const { RefCell::new(Vec::new()) };
+
+    /// Last archived count computed by a clean `current_archived_count`
+    /// pass. Served on contended passes: a transient 0 there could
+    /// combine with an empty thread list to satisfy `DmRailSection`'s
+    /// empty-state early return and unmount the whole DIRECT MESSAGES
+    /// section for a pass. Same clean-pass-only write discipline as
+    /// `LAST_GOOD_RAIL`.
+    static LAST_GOOD_ARCHIVED_COUNT: Cell<usize> = const { Cell::new(0) };
+
+    /// "A rail nudge is already queued" latch, so N degraded builder
+    /// passes in one render schedule exactly ONE deferred tick bump
+    /// (storm-proof). Cleared when the deferred bump runs.
+    static RAIL_NUDGE_PENDING: Cell<bool> = const { Cell::new(false) };
 }
 
 fn last_good_rail() -> Vec<DmRailEntry> {
@@ -570,6 +620,45 @@ fn last_good_rail() -> Vec<DmRailEntry> {
 
 fn set_last_good_rail(entries: &[DmRailEntry]) {
     LAST_GOOD_RAIL.with(|c| *c.borrow_mut() = entries.to_vec());
+}
+
+fn last_good_archived_count() -> usize {
+    LAST_GOOD_ARCHIVED_COUNT.with(|c| c.get())
+}
+
+fn set_last_good_archived_count(count: usize) {
+    LAST_GOOD_ARCHIVED_COUNT.with(|c| c.set(count));
+}
+
+/// Rebuild-nudge channel for the rail's three builder memos (issue #499
+/// review follow-up). Each builder anchors its subscription set with an
+/// infallible read of this tick BEFORE any fallible `try_read`, so a
+/// contended poll can never leave a memo with zero subscriptions — and,
+/// because every degraded pass schedules a deferred bump via
+/// [`schedule_rail_nudge`], the tick is also the RECOVERY channel: the
+/// memo re-polls one macrotask later instead of serving last-good data
+/// until some unrelated user action happens to write a signal it reads.
+static RAIL_REBUILD_TICK: GlobalSignal<u64> = Global::new(|| 0);
+
+/// Schedule a one-shot deferred bump of [`RAIL_REBUILD_TICK`]. Called
+/// from every degraded (contended-read) builder pass.
+///
+/// Self-terminating: the bump runs through `crate::util::defer` (the
+/// clean execution context the dioxus-signal-safety rules require for
+/// signal mutations), and the re-poll it triggers happens in a later,
+/// borrow-free context — so the retried pass reads cleanly and
+/// schedules no further nudge. If contention somehow persists, the
+/// retried pass schedules exactly one more; the loop converges the
+/// moment a pass reads cleanly. Storm-proof via `RAIL_NUDGE_PENDING`:
+/// however many degrade paths fire in one render, only one bump queues.
+fn schedule_rail_nudge() {
+    if RAIL_NUDGE_PENDING.with(|c| c.replace(true)) {
+        return; // a bump is already queued
+    }
+    crate::util::defer(|| {
+        RAIL_NUDGE_PENDING.with(|c| c.set(false));
+        RAIL_REBUILD_TICK.with_mut(|t| *t = t.wrapping_add(1));
+    });
 }
 
 /// Pure helper: project the archived viewer's rows from the in-memory
@@ -653,18 +742,28 @@ struct ArchivedRoomMeta {
 }
 
 fn build_archived_view() -> Option<Vec<ArchivedEntry>> {
-    // OPEN_DM_THREAD is read (infallibly) BEFORE the fallible reads:
+    // RAIL_REBUILD_TICK is read (infallibly) BEFORE the fallible reads:
     // `try_read() -> Err` registers no subscription (dioxus-signal-safety
     // rules) and each memo run clears the previous subscription set, so
-    // without this guard one contended poll would leave the memo with
+    // without this anchor one contended poll would leave the memo with
     // ZERO subscriptions — permanently frozen (issue #499 mechanism 3;
-    // mirrors the CURRENT_ROOM guard in room_list.rs). OPEN_DM_THREAD is
-    // the DM surface's own view-state signal and is only written through
-    // `defer` from clean contexts, so the infallible read cannot hit a
-    // live write borrow.
-    let _ = OPEN_DM_THREAD.read();
-    let rooms = ROOMS.try_read().ok()?;
-    let hidden = HIDDEN_DM_THREADS.try_read().ok()?.clone();
+    // mirrors the CURRENT_ROOM guard in room_list.rs). The tick is only
+    // written through `defer` from clean contexts, so the infallible
+    // read cannot hit a live write borrow — and each degraded pass
+    // below bumps it (via `schedule_rail_nudge`) so the retry is one
+    // macrotask away.
+    let _ = RAIL_REBUILD_TICK.read();
+    let Ok(rooms) = ROOMS.try_read() else {
+        schedule_rail_nudge();
+        return None;
+    };
+    let hidden = match HIDDEN_DM_THREADS.try_read() {
+        Ok(h) => h.clone(),
+        Err(_) => {
+            schedule_rail_nudge();
+            return None;
+        }
+    };
 
     // Materialise per-room display data once and compute the per-pair
     // max DM timestamp at the same time. Both decryption and the
@@ -730,15 +829,27 @@ fn build_archived_view() -> Option<Vec<ArchivedEntry>> {
 /// the same scan as `build_archived_view` but without materialising
 /// the per-pair display metadata — saves a HashMap of decrypted
 /// nicknames per render when the viewer is closed (the common case).
-fn current_archived_count() -> Option<usize> {
-    // Same subscription guard as `build_view` / `build_archived_view`:
+fn current_archived_count() -> usize {
+    // Same subscription anchor as `build_view` / `build_archived_view`:
     // an infallible read must precede the first fallible `try_read`,
     // otherwise one contended poll leaves this memo with zero
     // subscriptions and the count freezes for the session (issue #499
     // mechanism 3; mirrors the CURRENT_ROOM guard in room_list.rs).
-    let _ = OPEN_DM_THREAD.read();
-    let rooms = ROOMS.try_read().ok()?;
-    let hidden = HIDDEN_DM_THREADS.try_read().ok()?;
+    //
+    // Contended passes serve the last CLEAN count instead of 0: a
+    // transient 0 could combine with an empty thread list to satisfy
+    // the component's empty-state early return and unmount the whole
+    // DIRECT MESSAGES section for a pass. The nudge re-polls one
+    // macrotask later.
+    let _ = RAIL_REBUILD_TICK.read();
+    let Ok(rooms) = ROOMS.try_read() else {
+        schedule_rail_nudge();
+        return last_good_archived_count();
+    };
+    let Ok(hidden) = HIDDEN_DM_THREADS.try_read() else {
+        schedule_rail_nudge();
+        return last_good_archived_count();
+    };
     let mut last_any_ts: HashMap<(VerifyingKey, MemberId), u64> = HashMap::new();
     for (owner_vk, room_data) in &rooms.map {
         let self_id: MemberId = room_data.self_sk.verifying_key().into();
@@ -748,27 +859,31 @@ fn current_archived_count() -> Option<usize> {
             last_any_ts.insert((*owner_vk, peer), activity.last_any_ts);
         }
     }
-    Some(count_currently_archived(&hidden, &last_any_ts))
+    let count = count_currently_archived(&hidden, &last_any_ts);
+    set_last_good_archived_count(count);
+    count
 }
 
 fn build_view() -> Vec<DmRailEntry> {
-    // OPEN_DM_THREAD is read (infallibly) BEFORE the fallible reads:
+    // RAIL_REBUILD_TICK is read (infallibly) BEFORE the fallible reads:
     // `try_read() -> Err` registers no subscription (dioxus-signal-safety
     // rules) and each memo run clears the previous subscription set, so
-    // without this guard a single contended `ROOMS` poll would leave the
+    // without this anchor a single contended `ROOMS` poll would leave the
     // memo with ZERO subscriptions — a permanently empty rail, since
     // `DmRailSection` never unmounts (issue #499 mechanism 3; mirrors
-    // the CURRENT_ROOM guard in room_list.rs). OPEN_DM_THREAD is the DM
-    // surface's own view-state signal and is only written through
-    // `defer` from clean contexts, so the infallible read cannot hit a
-    // live write borrow.
-    let _ = OPEN_DM_THREAD.read();
+    // the CURRENT_ROOM guard in room_list.rs). The tick is only written
+    // through `defer` from clean contexts, so the infallible read cannot
+    // hit a live write borrow — and every degraded pass below bumps it
+    // (via `schedule_rail_nudge`) so the retry is one macrotask away,
+    // not parked until some unrelated signal write.
+    let _ = RAIL_REBUILD_TICK.read();
 
     let Ok(rooms) = ROOMS.try_read() else {
         // ROOMS is mid-write: reuse the last successfully-built rail
         // rather than blanking the whole list for this pass (issue #499
-        // mechanism 1's symptom shape). The guard read above keeps the
-        // memo subscribed, so a later signal write re-runs this build.
+        // mechanism 1's symptom shape). The scheduled nudge re-polls
+        // this memo one macrotask later, when the write has finished.
+        schedule_rail_nudge();
         return last_good_rail();
     };
     if rooms.map.is_empty() {
@@ -780,8 +895,15 @@ fn build_view() -> Vec<DmRailEntry> {
     // mechanism 1 — the old `?` blanked the entire active list while
     // "Archived (N)" stayed put): degrade to `None`, which
     // `accumulate_peer_activity` renders as "unread = 0 for this pass";
-    // badges reappear on the next clean pass.
-    let last_seen = DM_LAST_SEEN.try_read().ok().map(|s| s.clone());
+    // the backfill below then restores the last-known unread per pair
+    // so the unread-first sort doesn't transiently reorder.
+    let last_seen = match DM_LAST_SEEN.try_read() {
+        Ok(s) => Some(s.clone()),
+        Err(_) => {
+            schedule_rail_nudge();
+            None
+        }
+    };
 
     // Snapshot the hide-list (#261). `try_read` keeps us cooperative
     // with any in-flight `defer`-scheduled mutation. On contention
@@ -790,7 +912,13 @@ fn build_view() -> Vec<DmRailEntry> {
     // archived thread into the active rail for a render (#499
     // mechanism 2). Successful `try_read` registers the memo's
     // subscription so subsequent hide/unhide writes re-run this build.
-    let hidden = HIDDEN_DM_THREADS.try_read().ok().map(|h| h.clone());
+    let hidden = match HIDDEN_DM_THREADS.try_read() {
+        Ok(h) => Some(h.clone()),
+        Err(_) => {
+            schedule_rail_nudge();
+            None
+        }
+    };
 
     let mut entries: Vec<DmRailEntry> = Vec::new();
     for (owner_vk, room_data) in &rooms.map {
@@ -862,17 +990,26 @@ fn build_view() -> Vec<DmRailEntry> {
     let mut entries = LAST_GOOD_RAIL
         .with(|cache| resolve_active_entries(entries, hidden.as_ref(), &cache.borrow()));
 
+    // Contended DM_LAST_SEEN: the pass computed every entry with
+    // unread = 0, and unread is the PRIMARY sort key — carry each
+    // pair's last-known unread forward from the last good rail so rows
+    // don't transiently drop from the top and snap back. (When `hidden`
+    // was ALSO contended, `entries` IS the last good rail and the
+    // backfill is a no-op.)
+    if last_seen.is_none() {
+        LAST_GOOD_RAIL.with(|cache| backfill_unread_from_last_good(&mut entries, &cache.borrow()));
+    }
+
     // Unread threads first, then most-recent, then a deterministic
     // tiebreak (#499 mechanism 4). Re-sorting the cached list on the
     // contended path is a no-op because the order is total.
     sort_rail_entries(&mut entries);
 
-    // Cache the result for the contended-read degrade paths above —
-    // only from a pass whose hide-list read was clean, so the cache can
-    // never contain an unfiltered list. (A pass with degraded unread
-    // info is still cache-worthy: hidden-safety is the invariant,
-    // badge staleness is cosmetic and heals on the next clean pass.)
-    if hidden.is_some() {
+    // Cache only a FULLY-clean pass — hide-list AND unread cutoffs both
+    // read cleanly. A hidden-contended pass would cache the cache (no
+    // information), and a last_seen-contended pass would poison the
+    // unread counts the backfill above reads from.
+    if hidden.is_some() && last_seen.is_some() {
         set_last_good_rail(&entries);
     }
 
@@ -1435,7 +1572,11 @@ mod tests {
     /// whose FIRST read is fallible can come out of one contended poll
     /// with zero subscriptions — permanently frozen (`DmRailSection`
     /// never unmounts). Mirrors the `CURRENT_ROOM.read()` guard in
-    /// `room_list.rs`.
+    /// `room_list.rs`. The anchor is `RAIL_REBUILD_TICK`, which doubles
+    /// as the recovery channel: every degraded pass must ALSO schedule
+    /// a rail nudge (a deferred tick bump), so recovery is one
+    /// macrotask away rather than parked until unrelated user action —
+    /// each segment is checked for at least one nudge call too.
     ///
     /// Source-scrape because the builders need a Dioxus runtime to run.
     /// Conventions: match WHITESPACE-STRIPPED source so rustfmt
@@ -1444,10 +1585,10 @@ mod tests {
     /// bound each builder's segment by the NEXT function head so a
     /// guard in one builder can't vacuously cover another. The
     /// non-test comments deliberately avoid the literal guard/fallible
-    /// needles (`OPEN_DM_THREAD` + `.read()` adjacent, or a dotted
-    /// `try_read` call) so a comment can't satisfy the pin either.
-    /// Reordering these functions breaks the segment lookups loudly
-    /// (expect-panic), not silently.
+    /// needles (the tick static's name + `.read()` adjacent, or a
+    /// dotted `try_read` call) so a comment can't satisfy the pin
+    /// either. Reordering these functions breaks the segment lookups
+    /// loudly (expect-panic), not silently.
     #[test]
     fn rail_builders_read_infallible_guard_before_first_fallible_read() {
         let src = include_str!("dm_rail_section.rs");
@@ -1472,18 +1613,159 @@ mod tests {
                 });
             let seg = &stripped[start..end];
 
-            let guard = seg.find("OPEN_DM_THREAD.read()").unwrap_or_else(|| {
-                panic!("{head} lost its infallible OPEN_DM_THREAD.read() subscription guard")
+            let guard = seg.find("RAIL_REBUILD_TICK.read()").unwrap_or_else(|| {
+                panic!("{head} lost its infallible RAIL_REBUILD_TICK.read() subscription anchor")
             });
             let fallible = seg.find(".try_read(").unwrap_or_else(|| {
                 panic!("{head} has no fallible read — pin needs updating if that's intended")
             });
             assert!(
                 guard < fallible,
-                "{head}: the infallible OPEN_DM_THREAD.read() guard (at {guard}) must \
+                "{head}: the infallible RAIL_REBUILD_TICK.read() anchor (at {guard}) must \
                  come BEFORE the first fallible try_read (at {fallible}) — otherwise a \
                  contended poll leaves the memo with zero subscriptions (issue #499)"
             );
+            assert!(
+                seg.contains("schedule_rail_nudge()"),
+                "{head} has no schedule_rail_nudge() call — a degraded pass must \
+                 queue a deferred tick bump so the memo re-polls one macrotask \
+                 later instead of serving stale data until unrelated user action"
+            );
         }
+    }
+
+    /// Review follow-up wiring pins for the last-good degrade caches
+    /// (same source-scrape conventions as the pin above):
+    ///
+    /// 1. `build_view` may write `LAST_GOOD_RAIL` only from a FULLY-
+    ///    clean pass (`hidden` AND `last_seen` both read cleanly). An
+    ///    ungated write from a `last_seen`-contended pass would cache
+    ///    unread = 0 for every pair, poisoning the very backfill that
+    ///    reads from the cache.
+    /// 2. `build_view` must backfill unread from the last good rail on
+    ///    a `last_seen`-contended pass — unread is the PRIMARY sort
+    ///    key, so a transient 0 reorders the rail (the reviewers
+    ///    overturned the earlier "cosmetic" claim).
+    /// 3. `current_archived_count` must serve the last clean count on
+    ///    contention (never a transient 0, which can unmount the whole
+    ///    section via the empty-state early return) and record the
+    ///    count on a clean pass.
+    #[test]
+    fn rail_last_good_caches_have_clean_pass_write_discipline() {
+        let src = include_str!("dm_rail_section.rs");
+        let body = &src[..src.find("mod tests").unwrap_or(src.len())];
+        let stripped: String = body.chars().filter(|c| !c.is_whitespace()).collect();
+
+        let view_start = stripped
+            .find("fnbuild_view()")
+            .expect("build_view not found");
+        let view_end = stripped[view_start..]
+            .find("fnshort_member_id(")
+            .map(|i| view_start + i)
+            .expect("short_member_id must follow build_view");
+        let view_seg = &stripped[view_start..view_end];
+        assert!(
+            view_seg
+                .contains("ifhidden.is_some()&&last_seen.is_some(){set_last_good_rail(&entries);}"),
+            "build_view's LAST_GOOD_RAIL write must be gated on BOTH hidden and \
+             last_seen reading cleanly — an ungated (or half-gated) write lets a \
+             degraded pass poison the cache the degrade paths serve from"
+        );
+        assert!(
+            view_seg.contains(
+                "iflast_seen.is_none(){LAST_GOOD_RAIL.with(|cache|backfill_unread_from_last_good("
+            ),
+            "build_view must backfill unread from LAST_GOOD_RAIL when last_seen \
+             was contended — without it the unread-first sort transiently \
+             reorders (unread is the primary sort key, not a cosmetic badge)"
+        );
+
+        let count_start = stripped
+            .find("fncurrent_archived_count()")
+            .expect("current_archived_count not found");
+        let count_end = stripped[count_start..]
+            .find("fnbuild_view()")
+            .map(|i| count_start + i)
+            .expect("build_view must follow current_archived_count");
+        let count_seg = &stripped[count_start..count_end];
+        assert!(
+            count_seg.contains("schedule_rail_nudge();returnlast_good_archived_count();"),
+            "current_archived_count's contended arms must nudge and serve the \
+             last clean count — a transient 0 can combine with an empty thread \
+             list to unmount the whole DIRECT MESSAGES section"
+        );
+        assert!(
+            count_seg.contains("set_last_good_archived_count(count);"),
+            "current_archived_count must record the count from a clean pass — \
+             otherwise the contended arms serve a stale default forever"
+        );
+    }
+
+    /// Review follow-up (issue #499): a `last_seen`-contended pass
+    /// computes unread = 0 for every entry, and unread is the PRIMARY
+    /// sort key — the backfill must restore each pair's last-known
+    /// unread so rows keep their order across the degraded pass.
+    #[test]
+    fn backfill_unread_from_last_good_preserves_unread_and_order() {
+        let room = sk(1).verifying_key();
+        // Last good rail (fully-clean pass): peer 11 has 3 unread and
+        // sorts first; peer 22 read, more recent.
+        let mut last_good = vec![entry(room, 11, 1_000, 3), entry(room, 22, 2_000, 0)];
+        sort_rail_entries(&mut last_good);
+        assert_eq!(
+            last_good[0].peer,
+            MemberId(FastHash(11)),
+            "precondition: unread row sorts first on the clean pass"
+        );
+
+        // Degraded pass: same pairs, unread zeroed by the contended
+        // DM_LAST_SEEN read. Without the backfill, peer 22 (more
+        // recent) would sort first — a visible transient reorder.
+        let mut degraded = vec![entry(room, 11, 1_000, 0), entry(room, 22, 2_000, 0)];
+        backfill_unread_from_last_good(&mut degraded, &last_good);
+        sort_rail_entries(&mut degraded);
+        assert_eq!(
+            degraded[0].peer,
+            MemberId(FastHash(11)),
+            "backfill must restore unread so the degraded pass keeps the \
+             clean pass's order"
+        );
+        assert_eq!(
+            degraded[0].unread, 3,
+            "cached unread must be carried forward"
+        );
+        assert_eq!(degraded[1].unread, 0);
+    }
+
+    /// Pairs absent from the last good rail keep unread = 0 — the
+    /// backfill has no better information for them (e.g. a thread whose
+    /// first message arrived during the contended pass).
+    #[test]
+    fn backfill_unread_from_last_good_leaves_uncached_pairs_at_zero() {
+        let room = sk(1).verifying_key();
+        let last_good = vec![entry(room, 11, 1_000, 3)];
+        let mut degraded = vec![entry(room, 11, 1_000, 0), entry(room, 22, 2_000, 0)];
+        backfill_unread_from_last_good(&mut degraded, &last_good);
+        assert_eq!(degraded[0].unread, 3);
+        assert_eq!(
+            degraded[1].unread, 0,
+            "a pair the cache has never seen must stay at unread = 0"
+        );
+        // Recency is never backfilled — the current pass computed it
+        // from live room state.
+        assert_eq!(degraded[1].last_any_ts, 2_000);
+    }
+
+    /// The archived-count last-good cell round-trips (thread_local, so
+    /// each test thread starts at the default 0). Wiring — clean-pass
+    /// writes, contended-pass serves — is pinned by
+    /// `rail_last_good_caches_have_clean_pass_write_discipline`.
+    #[test]
+    fn last_good_archived_count_round_trip() {
+        assert_eq!(last_good_archived_count(), 0, "default is 0");
+        set_last_good_archived_count(7);
+        assert_eq!(last_good_archived_count(), 7);
+        set_last_good_archived_count(0);
+        assert_eq!(last_good_archived_count(), 0);
     }
 }

--- a/ui/src/components/room_list/dm_rail_section.rs
+++ b/ui/src/components/room_list/dm_rail_section.rs
@@ -31,7 +31,7 @@
 use crate::components::app::chat_delegate::{hide_dm_thread, unhide_dm_thread};
 use crate::components::app::ROOMS;
 use crate::components::direct_messages::{
-    is_thread_hidden_for, open_dm_thread, DM_LAST_SEEN, HIDDEN_DM_THREADS,
+    is_thread_hidden_for, open_dm_thread, DM_LAST_SEEN, HIDDEN_DM_THREADS, OPEN_DM_THREAD,
 };
 use crate::util::ecies::unseal_bytes_with_secrets;
 use dioxus::prelude::*;
@@ -42,6 +42,7 @@ use dioxus_free_icons::{
 use ed25519_dalek::VerifyingKey;
 use river_core::chat_delegate::HiddenDmThreadEntry;
 use river_core::room_state::member::MemberId;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -85,7 +86,7 @@ const ARCHIVE_TOAST_DURATION_MS: u64 = 5_000;
 
 #[component]
 pub fn DmRailSection() -> Element {
-    let threads = use_memo(move || build_view().unwrap_or_default());
+    let threads = use_memo(build_view);
     let threads_value = threads.read().clone();
 
     // Reading the toast signal here subscribes the rail to its writes so
@@ -432,6 +433,145 @@ pub(crate) fn filter_rail_entries(
         .collect()
 }
 
+/// Pure helper deciding what the ACTIVE rail may show given the outcome
+/// of the `HIDDEN_DM_THREADS` read (issue #499 mechanism 2).
+///
+/// * `hidden = Some(map)` — clean read: apply the #261 archive filter.
+/// * `hidden = None` — the signal was contended. The old behaviour
+///   failed OPEN (skipped the filter), flashing every archived thread
+///   into the active rail for a render. Failing closed to an EMPTY list
+///   instead would blink the whole rail (the other #499 symptom), so we
+///   return `last_good`: the most recent successfully-filtered rail. It
+///   is at worst one render stale and by construction contains no
+///   thread that was archived as of the last clean pass (a thread whose
+///   archive click is the very write we're contending with may persist
+///   for that single render — matching what was on screen the instant
+///   before the click, never resurrecting older archived threads).
+///
+/// Invariants, in priority order: (1) archived threads never appear in
+/// the active rail; (2) the rail collapses as rarely as possible.
+/// Pinned by the `resolve_active_entries_*` tests.
+pub(crate) fn resolve_active_entries(
+    entries: Vec<DmRailEntry>,
+    hidden: Option<&HashMap<(VerifyingKey, MemberId), HiddenDmThreadEntry>>,
+    last_good: &[DmRailEntry],
+) -> Vec<DmRailEntry> {
+    match hidden {
+        Some(h) => filter_rail_entries(entries, h),
+        None => last_good.to_vec(),
+    }
+}
+
+/// Total-order sort for the rail: unread desc, most-recent activity
+/// desc, then `(room key bytes, peer id)` as a deterministic tiebreak.
+/// Entries accumulate through a fresh `HashMap` each pass, so without
+/// the tiebreak threads tied on `(unread, last_any_ts)` shuffled
+/// position between renders (issue #499 mechanism 4). Pinned by the
+/// `sort_rail_entries_*` tests.
+pub(crate) fn sort_rail_entries(entries: &mut [DmRailEntry]) {
+    entries.sort_by(|a, b| {
+        b.unread
+            .cmp(&a.unread)
+            .then_with(|| b.last_any_ts.cmp(&a.last_any_ts))
+            .then_with(|| a.room.as_bytes().cmp(b.room.as_bytes()))
+            .then_with(|| a.peer.cmp(&b.peer))
+    });
+}
+
+/// Per-peer DM activity accumulated from one room's message list.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub(crate) struct PeerDmActivity {
+    pub(crate) last_any_ts: u64,
+    pub(crate) unread: usize,
+}
+
+/// Pure helper: fold one room's DM stream into per-peer activity.
+/// `messages` yields `(sender, recipient, timestamp)` triples; anything
+/// not involving `self_id` is skipped.
+///
+/// `last_seen` is `Some(map)` when `DM_LAST_SEEN` read cleanly and
+/// `None` when the signal was contended. Issue #499 mechanism 1: a
+/// contended read must degrade to "no unread info for this pass" —
+/// entries are still produced, with `unread = 0` and correct recency —
+/// instead of aborting the whole rail build (which blanked the entire
+/// active list while "Archived (N)" stayed put). A peer merely ABSENT
+/// from a `Some` map still means cutoff 0 (thread never read). Pinned
+/// by the `accumulate_peer_activity_*` tests.
+pub(crate) fn accumulate_peer_activity(
+    room: &VerifyingKey,
+    self_id: MemberId,
+    messages: impl IntoIterator<Item = (MemberId, MemberId, u64)>,
+    last_seen: Option<&HashMap<(VerifyingKey, MemberId), u64>>,
+) -> HashMap<MemberId, PeerDmActivity> {
+    let mut per_peer: HashMap<MemberId, PeerDmActivity> = HashMap::new();
+    for (sender, recipient, timestamp) in messages {
+        let is_self_sender = sender == self_id;
+        let is_self_recipient = recipient == self_id;
+        if !is_self_sender && !is_self_recipient {
+            continue;
+        }
+        let peer = if is_self_sender { recipient } else { sender };
+        let acc = per_peer.entry(peer).or_insert(PeerDmActivity {
+            last_any_ts: 0,
+            unread: 0,
+        });
+        if timestamp > acc.last_any_ts {
+            acc.last_any_ts = timestamp;
+        }
+        if is_self_recipient {
+            if let Some(seen) = last_seen {
+                let cutoff = seen.get(&(*room, peer)).copied().unwrap_or(0);
+                if timestamp > cutoff {
+                    acc.unread += 1;
+                }
+            }
+        }
+    }
+    per_peer
+}
+
+/// Project a room's authorized DM list into the `(sender, recipient,
+/// timestamp)` triples [`accumulate_peer_activity`] consumes. Shared by
+/// all three builders so their per-pair `last_any_ts` scans can't
+/// drift apart.
+fn dm_message_triples(
+    room_data: &crate::room_data::RoomData,
+) -> impl Iterator<Item = (MemberId, MemberId, u64)> + '_ {
+    room_data
+        .room_state
+        .direct_messages
+        .messages
+        .iter()
+        .map(|msg| {
+            (
+                msg.message.sender,
+                msg.message.recipient,
+                msg.message.timestamp,
+            )
+        })
+}
+
+thread_local! {
+    /// Last successfully filtered + sorted rail, kept by `build_view`.
+    /// Serves as the degrade value when a signal read is contended:
+    /// showing the one-render-old rail is strictly better than blanking
+    /// it (issue #499's headline symptom), and — unlike the old skip-
+    /// the-filter fallback — can never flash archived threads into the
+    /// active list, because every cached list already went through
+    /// `filter_rail_entries`. Plain `thread_local` (not a signal): the
+    /// UI is single-threaded WASM and writing a signal from inside a
+    /// memo would re-trigger reactivity.
+    static LAST_GOOD_RAIL: RefCell<Vec<DmRailEntry>> = const { RefCell::new(Vec::new()) };
+}
+
+fn last_good_rail() -> Vec<DmRailEntry> {
+    LAST_GOOD_RAIL.with(|c| c.borrow().clone())
+}
+
+fn set_last_good_rail(entries: &[DmRailEntry]) {
+    LAST_GOOD_RAIL.with(|c| *c.borrow_mut() = entries.to_vec());
+}
+
 /// Pure helper: project the archived viewer's rows from the in-memory
 /// hide map plus the per-room display data and a per-pair
 /// `last_any_ts` map (the max DM timestamp for each `(room, peer)` in
@@ -513,6 +653,16 @@ struct ArchivedRoomMeta {
 }
 
 fn build_archived_view() -> Option<Vec<ArchivedEntry>> {
+    // OPEN_DM_THREAD is read (infallibly) BEFORE the fallible reads:
+    // `try_read() -> Err` registers no subscription (dioxus-signal-safety
+    // rules) and each memo run clears the previous subscription set, so
+    // without this guard one contended poll would leave the memo with
+    // ZERO subscriptions — permanently frozen (issue #499 mechanism 3;
+    // mirrors the CURRENT_ROOM guard in room_list.rs). OPEN_DM_THREAD is
+    // the DM surface's own view-state signal and is only written through
+    // `defer` from clean contexts, so the infallible read cannot hit a
+    // live write borrow.
+    let _ = OPEN_DM_THREAD.read();
     let rooms = ROOMS.try_read().ok()?;
     let hidden = HIDDEN_DM_THREADS.try_read().ok()?.clone();
 
@@ -561,24 +711,14 @@ fn build_archived_view() -> Option<Vec<ArchivedEntry>> {
         );
 
         // Max DM timestamp per (this room, peer) across both inbound and
-        // outbound DMs — same accumulator shape as `build_view`. We do
-        // NOT pre-filter by `hidden` here; the strict-`<=` revival rule
-        // is applied inside `build_archived_rows`.
-        for msg in &room_data.room_state.direct_messages.messages {
-            let is_self_sender = msg.message.sender == self_id;
-            let is_self_recipient = msg.message.recipient == self_id;
-            if !is_self_sender && !is_self_recipient {
-                continue;
-            }
-            let peer = if is_self_sender {
-                msg.message.recipient
-            } else {
-                msg.message.sender
-            };
-            let entry = last_any_ts.entry((*owner_vk, peer)).or_insert(0);
-            if msg.message.timestamp > *entry {
-                *entry = msg.message.timestamp;
-            }
+        // outbound DMs — the same accumulator `build_view` uses (unread
+        // info irrelevant here, so `last_seen = None`). We do NOT
+        // pre-filter by `hidden`; the strict-`<=` revival rule is
+        // applied inside `build_archived_rows`.
+        for (peer, activity) in
+            accumulate_peer_activity(owner_vk, self_id, dm_message_triples(room_data), None)
+        {
+            last_any_ts.insert((*owner_vk, peer), activity.last_any_ts);
         }
     }
 
@@ -591,44 +731,65 @@ fn build_archived_view() -> Option<Vec<ArchivedEntry>> {
 /// the per-pair display metadata — saves a HashMap of decrypted
 /// nicknames per render when the viewer is closed (the common case).
 fn current_archived_count() -> Option<usize> {
+    // Same subscription guard as `build_view` / `build_archived_view`:
+    // an infallible read must precede the first fallible `try_read`,
+    // otherwise one contended poll leaves this memo with zero
+    // subscriptions and the count freezes for the session (issue #499
+    // mechanism 3; mirrors the CURRENT_ROOM guard in room_list.rs).
+    let _ = OPEN_DM_THREAD.read();
     let rooms = ROOMS.try_read().ok()?;
     let hidden = HIDDEN_DM_THREADS.try_read().ok()?;
     let mut last_any_ts: HashMap<(VerifyingKey, MemberId), u64> = HashMap::new();
     for (owner_vk, room_data) in &rooms.map {
         let self_id: MemberId = room_data.self_sk.verifying_key().into();
-        for msg in &room_data.room_state.direct_messages.messages {
-            let is_self_sender = msg.message.sender == self_id;
-            let is_self_recipient = msg.message.recipient == self_id;
-            if !is_self_sender && !is_self_recipient {
-                continue;
-            }
-            let peer = if is_self_sender {
-                msg.message.recipient
-            } else {
-                msg.message.sender
-            };
-            let entry = last_any_ts.entry((*owner_vk, peer)).or_insert(0);
-            if msg.message.timestamp > *entry {
-                *entry = msg.message.timestamp;
-            }
+        for (peer, activity) in
+            accumulate_peer_activity(owner_vk, self_id, dm_message_triples(room_data), None)
+        {
+            last_any_ts.insert((*owner_vk, peer), activity.last_any_ts);
         }
     }
     Some(count_currently_archived(&hidden, &last_any_ts))
 }
 
-fn build_view() -> Option<Vec<DmRailEntry>> {
-    let rooms = ROOMS.try_read().ok()?;
+fn build_view() -> Vec<DmRailEntry> {
+    // OPEN_DM_THREAD is read (infallibly) BEFORE the fallible reads:
+    // `try_read() -> Err` registers no subscription (dioxus-signal-safety
+    // rules) and each memo run clears the previous subscription set, so
+    // without this guard a single contended `ROOMS` poll would leave the
+    // memo with ZERO subscriptions — a permanently empty rail, since
+    // `DmRailSection` never unmounts (issue #499 mechanism 3; mirrors
+    // the CURRENT_ROOM guard in room_list.rs). OPEN_DM_THREAD is the DM
+    // surface's own view-state signal and is only written through
+    // `defer` from clean contexts, so the infallible read cannot hit a
+    // live write borrow.
+    let _ = OPEN_DM_THREAD.read();
+
+    let Ok(rooms) = ROOMS.try_read() else {
+        // ROOMS is mid-write: reuse the last successfully-built rail
+        // rather than blanking the whole list for this pass (issue #499
+        // mechanism 1's symptom shape). The guard read above keeps the
+        // memo subscribed, so a later signal write re-runs this build.
+        return last_good_rail();
+    };
     if rooms.map.is_empty() {
-        return Some(Vec::new());
+        set_last_good_rail(&[]);
+        return Vec::new();
     }
-    let last_seen = DM_LAST_SEEN.try_read().ok()?.clone();
+
+    // Unread cutoffs. Contention here must NOT abort the rail (#499
+    // mechanism 1 — the old `?` blanked the entire active list while
+    // "Archived (N)" stayed put): degrade to `None`, which
+    // `accumulate_peer_activity` renders as "unread = 0 for this pass";
+    // badges reappear on the next clean pass.
+    let last_seen = DM_LAST_SEEN.try_read().ok().map(|s| s.clone());
+
     // Snapshot the hide-list (#261). `try_read` keeps us cooperative
-    // with any in-flight `defer`-scheduled mutation. On contention we
-    // silently treat the list as empty for THIS render — a hidden
-    // thread briefly re-appearing during a write storm is preferable
-    // to dropping the entire rail. Successful `try_read` registers
-    // the memo's subscription so subsequent hide/unhide writes
-    // re-run this build (Dioxus signal-safety semantics).
+    // with any in-flight `defer`-scheduled mutation. On contention
+    // (`None`) the archive filter must fail CLOSED — see
+    // `resolve_active_entries`: the old fail-open path flashed every
+    // archived thread into the active rail for a render (#499
+    // mechanism 2). Successful `try_read` registers the memo's
+    // subscription so subsequent hide/unhide writes re-run this build.
     let hidden = HIDDEN_DM_THREADS.try_read().ok().map(|h| h.clone());
 
     let mut entries: Vec<DmRailEntry> = Vec::new();
@@ -664,37 +825,15 @@ fn build_view() -> Option<Vec<DmRailEntry>> {
             })
             .collect();
 
-        // Per-peer accumulator.
-        struct Acc {
-            last_any_ts: u64,
-            unread: usize,
-        }
-        let mut per_peer: HashMap<MemberId, Acc> = HashMap::new();
-        for msg in &room_data.room_state.direct_messages.messages {
-            let is_self_sender = msg.message.sender == self_id;
-            let is_self_recipient = msg.message.recipient == self_id;
-            if !is_self_sender && !is_self_recipient {
-                continue;
-            }
-            let peer = if is_self_sender {
-                msg.message.recipient
-            } else {
-                msg.message.sender
-            };
-            let acc = per_peer.entry(peer).or_insert(Acc {
-                last_any_ts: 0,
-                unread: 0,
-            });
-            if msg.message.timestamp > acc.last_any_ts {
-                acc.last_any_ts = msg.message.timestamp;
-            }
-            if is_self_recipient {
-                let cutoff = last_seen.get(&(*owner_vk, peer)).copied().unwrap_or(0);
-                if msg.message.timestamp > cutoff {
-                    acc.unread += 1;
-                }
-            }
-        }
+        // Per-peer accumulator — shared with the archived builders via
+        // `accumulate_peer_activity` (a contended `last_seen` degrades
+        // unread to 0 there, issue #499 mechanism 1).
+        let per_peer = accumulate_peer_activity(
+            owner_vk,
+            self_id,
+            dm_message_triples(room_data),
+            last_seen.as_ref(),
+        );
 
         // Build the candidate entries for this room. The hide-filter
         // step runs once at the end (over all rooms' candidates) so it
@@ -702,7 +841,7 @@ fn build_view() -> Option<Vec<DmRailEntry>> {
         // that helper's doc-comment for the #261 strict-`<=` semantics
         // and the `filter_rail_entries_newer_outbound_revives_hidden`
         // test for the "outbound revives" invariant.
-        for (peer, acc) in per_peer {
+        for (peer, activity) in per_peer {
             entries.push(DmRailEntry {
                 room: *owner_vk,
                 peer,
@@ -711,30 +850,33 @@ fn build_view() -> Option<Vec<DmRailEntry>> {
                     .cloned()
                     .unwrap_or_else(|| short_member_id(&peer)),
                 room_name: room_name.clone(),
-                last_any_ts: acc.last_any_ts,
-                unread: acc.unread,
+                last_any_ts: activity.last_any_ts,
+                unread: activity.unread,
             });
         }
     }
 
-    // Issue freenet/river#261: drop hidden entries. When the signal
-    // read was contended we silently treat the list as empty for THIS
-    // render — a hidden thread briefly re-appearing during a write
-    // storm is preferable to dropping the entire rail.
-    let filtered = match hidden {
-        Some(ref h) => filter_rail_entries(entries, h),
-        None => entries,
-    };
-    let mut entries = filtered;
+    // Issue freenet/river#261: drop hidden entries — failing CLOSED to
+    // the last good rail when the hide-list read was contended (#499
+    // mechanism 2; see `resolve_active_entries` for the full decision).
+    let mut entries = LAST_GOOD_RAIL
+        .with(|cache| resolve_active_entries(entries, hidden.as_ref(), &cache.borrow()));
 
-    // Unread threads first, then most-recent.
-    entries.sort_by(|a, b| {
-        b.unread
-            .cmp(&a.unread)
-            .then_with(|| b.last_any_ts.cmp(&a.last_any_ts))
-    });
+    // Unread threads first, then most-recent, then a deterministic
+    // tiebreak (#499 mechanism 4). Re-sorting the cached list on the
+    // contended path is a no-op because the order is total.
+    sort_rail_entries(&mut entries);
 
-    Some(entries)
+    // Cache the result for the contended-read degrade paths above —
+    // only from a pass whose hide-list read was clean, so the cache can
+    // never contain an unfiltered list. (A pass with degraded unread
+    // info is still cache-worthy: hidden-safety is the invariant,
+    // badge staleness is cosmetic and heals on the next clean pass.)
+    if hidden.is_some() {
+        set_last_good_rail(&entries);
+    }
+
+    entries
 }
 
 fn short_member_id(id: &MemberId) -> String {
@@ -1115,5 +1257,233 @@ mod tests {
              distinct identity tokens — the auto-dismiss timeout's \
              'is it still mine?' check compares tokens, not expiries"
         );
+    }
+
+    /// Issue #499 mechanism 1: a contended `DM_LAST_SEEN` read
+    /// (`last_seen = None`) must degrade to "unread = 0 for this pass"
+    /// — the entries are still produced with correct recency — instead
+    /// of aborting the whole rail build (the old `?` blanked the entire
+    /// active list while "Archived (N)" stayed put).
+    #[test]
+    fn accumulate_peer_activity_contended_last_seen_degrades_unread_to_zero() {
+        let room = sk(1).verifying_key();
+        let self_id = MemberId(FastHash(1));
+        let peer = MemberId(FastHash(2));
+        // Two inbound DMs, never read (no cutoff recorded anywhere).
+        let msgs = vec![(peer, self_id, 100u64), (peer, self_id, 200u64)];
+
+        // Clean pass: both count as unread.
+        let clean = accumulate_peer_activity(&room, self_id, msgs.clone(), Some(&HashMap::new()));
+        assert_eq!(
+            clean[&peer].unread, 2,
+            "precondition: clean pass counts unread"
+        );
+        assert_eq!(clean[&peer].last_any_ts, 200);
+
+        // Contended pass: entry still produced, unread degraded to 0.
+        let degraded = accumulate_peer_activity(&room, self_id, msgs, None);
+        assert_eq!(
+            degraded[&peer].unread, 0,
+            "contended DM_LAST_SEEN must degrade unread to 0, not drop the entry"
+        );
+        assert_eq!(
+            degraded[&peer].last_any_ts, 200,
+            "recency must be unaffected by the unread degrade"
+        );
+    }
+
+    /// Baseline semantics of the shared accumulator: outbound messages
+    /// bump recency but never unread; inbound messages at or below the
+    /// per-pair cutoff are read; third-party traffic is skipped
+    /// entirely. (Behaviour lifted verbatim from the old inline loop in
+    /// `build_view` — this pins the extraction.)
+    #[test]
+    fn accumulate_peer_activity_applies_cutoffs_and_direction() {
+        let room = sk(1).verifying_key();
+        let self_id = MemberId(FastHash(1));
+        let peer = MemberId(FastHash(2));
+        let third_a = MemberId(FastHash(3));
+        let third_b = MemberId(FastHash(4));
+        let msgs = vec![
+            (self_id, peer, 100u64),    // outbound: recency only
+            (peer, self_id, 150u64),    // inbound, <= cutoff: read
+            (peer, self_id, 250u64),    // inbound, > cutoff: unread
+            (third_a, third_b, 999u64), // not ours: skipped
+        ];
+        let mut last_seen = HashMap::new();
+        last_seen.insert((room, peer), 200u64);
+
+        let result = accumulate_peer_activity(&room, self_id, msgs, Some(&last_seen));
+        assert_eq!(
+            result.len(),
+            1,
+            "third-party traffic must not create entries"
+        );
+        assert_eq!(result[&peer].unread, 1);
+        assert_eq!(result[&peer].last_any_ts, 250);
+    }
+
+    /// Clean hide-list read: `resolve_active_entries` applies the #261
+    /// archive filter exactly like `filter_rail_entries`.
+    #[test]
+    fn resolve_active_entries_clean_read_applies_archive_filter() {
+        let room = sk(1).verifying_key();
+        let live = entry(room, 11, 2_000, 1);
+        let archived = entry(room, 22, 1_000, 0);
+        let hidden = HashMap::from([hidden_at(room, 22, 1_000)]);
+
+        let out = resolve_active_entries(vec![live.clone(), archived], Some(&hidden), &[]);
+        assert_eq!(out, vec![live]);
+    }
+
+    /// Issue #499 mechanism 2: a contended `HIDDEN_DM_THREADS` read
+    /// must fail CLOSED. The old behaviour skipped the filter and
+    /// flashed every archived thread into the active rail for a
+    /// render; the fix returns the last successfully-filtered rail —
+    /// so the archived thread never appears AND the rail doesn't
+    /// collapse to empty.
+    #[test]
+    fn resolve_active_entries_contended_hidden_never_yields_archived() {
+        let room = sk(1).verifying_key();
+        let live = entry(room, 11, 2_000, 1);
+        let archived = entry(room, 22, 1_000, 0);
+        let hidden = HashMap::from([hidden_at(room, 22, 1_000)]);
+
+        // A previous CLEAN pass produced the last-good rail.
+        let last_good =
+            resolve_active_entries(vec![live.clone(), archived.clone()], Some(&hidden), &[]);
+        assert_eq!(
+            last_good,
+            vec![live.clone()],
+            "precondition: clean pass filters"
+        );
+
+        // Contended pass over the same candidates.
+        let out = resolve_active_entries(vec![live.clone(), archived.clone()], None, &last_good);
+        assert!(
+            !out.contains(&archived),
+            "an archived thread must NEVER appear in the active rail, \
+             even while the hide-list signal is contended"
+        );
+        assert_eq!(
+            out,
+            vec![live],
+            "the rail must keep the last good list rather than collapse to empty"
+        );
+    }
+
+    /// Cold-start corner of the same degrade: contended hide-list with
+    /// no previous clean pass shows nothing — briefly showing an empty
+    /// rail is preferable to flashing archived threads into it.
+    #[test]
+    fn resolve_active_entries_contended_hidden_with_no_history_shows_nothing() {
+        let room = sk(1).verifying_key();
+        let archived = entry(room, 22, 1_000, 0);
+        let out = resolve_active_entries(vec![archived], None, &[]);
+        assert!(
+            out.is_empty(),
+            "with no last-good rail, the contended-hidden pass must show \
+             nothing rather than unfiltered (possibly archived) entries"
+        );
+    }
+
+    /// Primary sort keys are unchanged: unread desc, then recency desc.
+    #[test]
+    fn sort_rail_entries_orders_unread_then_recency() {
+        let room = sk(1).verifying_key();
+        let mut entries = vec![
+            entry(room, 11, 3_000, 0), // read, most recent
+            entry(room, 22, 1_000, 2), // unread, older
+            entry(room, 33, 2_000, 0), // read, mid
+        ];
+        sort_rail_entries(&mut entries);
+        assert_eq!(entries[0].peer, MemberId(FastHash(22)), "unread first");
+        assert_eq!(entries[1].peer, MemberId(FastHash(11)), "then recency desc");
+        assert_eq!(entries[2].peer, MemberId(FastHash(33)));
+    }
+
+    /// Issue #499 mechanism 4: entries tied on `(unread, last_any_ts)`
+    /// must sort identically regardless of input order. They accumulate
+    /// through a fresh `HashMap` each pass, so without the total-order
+    /// tiebreak tied threads shuffled position between renders.
+    #[test]
+    fn sort_rail_entries_ties_are_deterministic_across_input_orders() {
+        let room_a = sk(1).verifying_key();
+        let room_b = sk(2).verifying_key();
+        // Four entries fully tied on both primary sort keys.
+        let e1 = entry(room_a, 11, 1_000, 0);
+        let e2 = entry(room_a, 22, 1_000, 0);
+        let e3 = entry(room_b, 11, 1_000, 0);
+        let e4 = entry(room_b, 22, 1_000, 0);
+
+        let mut fwd = vec![e1.clone(), e2.clone(), e3.clone(), e4.clone()];
+        let mut rev = vec![e4, e3, e2, e1];
+        sort_rail_entries(&mut fwd);
+        sort_rail_entries(&mut rev);
+        assert_eq!(
+            fwd, rev,
+            "ties must sort identically regardless of the (HashMap-derived) \
+             input order — `sort_by` is stable, so without a total order the \
+             output inherits the per-pass-random input order"
+        );
+    }
+
+    /// Issue #499 mechanism 3: each fallible builder must register an
+    /// INFALLIBLE signal read before its first fallible `try_read`. In
+    /// Dioxus 0.7 an Err `try_read` registers no subscription and each
+    /// memo run clears the previous subscription set, so a builder
+    /// whose FIRST read is fallible can come out of one contended poll
+    /// with zero subscriptions — permanently frozen (`DmRailSection`
+    /// never unmounts). Mirrors the `CURRENT_ROOM.read()` guard in
+    /// `room_list.rs`.
+    ///
+    /// Source-scrape because the builders need a Dioxus runtime to run.
+    /// Conventions: match WHITESPACE-STRIPPED source so rustfmt
+    /// reflowing can't fake a result; cut at `mod tests` (this file has
+    /// exactly one) so these needles can't satisfy their own check;
+    /// bound each builder's segment by the NEXT function head so a
+    /// guard in one builder can't vacuously cover another. The
+    /// non-test comments deliberately avoid the literal guard/fallible
+    /// needles (`OPEN_DM_THREAD` + `.read()` adjacent, or a dotted
+    /// `try_read` call) so a comment can't satisfy the pin either.
+    /// Reordering these functions breaks the segment lookups loudly
+    /// (expect-panic), not silently.
+    #[test]
+    fn rail_builders_read_infallible_guard_before_first_fallible_read() {
+        let src = include_str!("dm_rail_section.rs");
+        let body = &src[..src.find("mod tests").unwrap_or(src.len())];
+        let stripped: String = body.chars().filter(|c| !c.is_whitespace()).collect();
+
+        // (builder head, next-function head bounding the segment)
+        let cases = [
+            ("fnbuild_archived_view()", "fncurrent_archived_count()"),
+            ("fncurrent_archived_count()", "fnbuild_view()"),
+            ("fnbuild_view()", "fnshort_member_id("),
+        ];
+        for (head, next_head) in cases {
+            let start = stripped
+                .find(head)
+                .unwrap_or_else(|| panic!("{head} not found — function renamed/removed?"));
+            let end = stripped[start..]
+                .find(next_head)
+                .map(|i| start + i)
+                .unwrap_or_else(|| {
+                    panic!("{next_head} not found after {head} — functions reordered?")
+                });
+            let seg = &stripped[start..end];
+
+            let guard = seg.find("OPEN_DM_THREAD.read()").unwrap_or_else(|| {
+                panic!("{head} lost its infallible OPEN_DM_THREAD.read() subscription guard")
+            });
+            let fallible = seg.find(".try_read(").unwrap_or_else(|| {
+                panic!("{head} has no fallible read — pin needs updating if that's intended")
+            });
+            assert!(
+                guard < fallible,
+                "{head}: the infallible OPEN_DM_THREAD.read() guard (at {guard}) must \
+                 come BEFORE the first fallible try_read (at {fallible}) — otherwise a \
+                 contended poll leaves the memo with zero subscriptions (issue #499)"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Problem

Entries in the DIRECT MESSAGES rail appear and disappear intermittently while "Archived (7)" stays fixed (reported on Ian's Framework laptop, 2026-07-26). Issue #499's trace found four UI-side mechanisms in the rail's builders, plus an aggravator:

1. **Whole-list collapse**: `build_view()` bailed with `?` when `DM_LAST_SEEN.try_read()` was contended, so the memo rendered the entire active list empty for that pass — while the separately-memoized archived count (which never reads `DM_LAST_SEEN`) stayed put. Exactly the reported asymmetry.
2. **Archive filter failed open**: a contended `HIDDEN_DM_THREADS.try_read()` skipped the filter entirely, flashing every archived thread INTO the active rail for a render.
3. **Permanent-freeze variant**: all three fallible builders took their FIRST signal read fallibly. In Dioxus 0.7 an Err `try_read` registers no subscription and each memo run clears the previous subscription set, so one contended poll left the memo with zero subscriptions — frozen for the session, since `DmRailSection` never unmounts.
4. **Non-total sort order**: entries tied on `(unread, last_any_ts)` accumulate through a fresh `HashMap` per pass and shuffled position between renders.
5. **Aggravator**: `mark_thread_read` ran `DM_LAST_SEEN.with_mut` unconditionally from `DmThreadModalBody`'s render body; `with_mut` notifies subscribers even when nothing changed, so an open DM thread produced a continuous write pulse that widened every contention window above.

## Approach

All changes are `ui/`-only (no WASM key impact).

- **`ui/src/components/room_list/dm_rail_section.rs`**
  - Each builder (`build_view`, `current_archived_count`, `build_archived_view`) now registers an infallible `OPEN_DM_THREAD.read()` BEFORE its first fallible `try_read`, mirroring the `CURRENT_ROOM.read()` guard in `room_list.rs`. `OPEN_DM_THREAD` is the DM surface's own view-state signal and is only written through `defer` from clean contexts, so the infallible read cannot hit a live write borrow.
  - `build_view` degrades a contended `DM_LAST_SEEN` to "unread = 0 for this pass" (recency and row set unaffected) instead of aborting; the per-peer scan is extracted into the pure `accumulate_peer_activity` helper, now shared by all three builders so their `last_any_ts` scans can't drift.
  - The hidden-filter degrade now fails **closed** via the pure `resolve_active_entries` helper: on contention the pass returns the last successfully-filtered rail (a module `thread_local` cache updated only on clean-hidden passes) rather than either the unfiltered candidates (old behaviour — archived threads flashing in) or an empty list (whole-rail blink). Deliberate choice, documented in the helper's doc-comment: (1) archived threads never appear in the active rail; (2) the rail collapses as rarely as possible. A contended `ROOMS` read reuses the same cache instead of blanking.
  - `sort_rail_entries` adds a `(room key bytes, peer id)` tiebreak after `(unread desc, last_any_ts desc)`, making the order total and render-stable.
- **`ui/src/components/direct_messages.rs`**: `mark_thread_read` now `try_peek`s first and only runs `with_mut` when the stored cutoff would actually advance (pure decision helper `thread_read_needs_write`), killing the render-body write pulse.

## Testing

10 new unit tests (all verified to FAIL against the pre-fix logic by temporarily reverting each specific hunk — mutation-checked):

- `accumulate_peer_activity_contended_last_seen_degrades_unread_to_zero` / `_applies_cutoffs_and_direction` — contended `DM_LAST_SEEN` produces entries with unread = 0 and intact recency; extraction preserves the old loop's cutoff/direction semantics.
- `resolve_active_entries_contended_hidden_never_yields_archived` / `_with_no_history_shows_nothing` / `_clean_read_applies_archive_filter` — contended hidden-read never yields archived threads in the active list and never falls open (both fail when reverted to the old `None => entries`).
- `sort_rail_entries_ties_are_deterministic_across_input_orders` / `_orders_unread_then_recency` — ties sort identically regardless of HashMap-derived input order (fails without the tiebreak).
- `rail_builders_read_infallible_guard_before_first_fallible_read` — source-pin (whitespace-stripped, cut at `mod tests`, per-function segments bounded by the next function head) asserting the infallible-read-before-fallible ordering in all three builders (fails when a guard is removed).
- `thread_read_needs_write_only_when_cutoff_advances` + `mark_thread_read_write_is_gated_pinned` — decision table plus a wiring pin that the `with_mut` stays gated (fails when the gate is removed).

```
cargo test -p river-ui --bins   → 675 passed; 0 failed
cargo fmt --check               → clean
cargo clippy -p river-ui --tests → no findings in touched files
cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync → clean
```

Related, deliberately out of scope: individual rows genuinely leaving/re-entering contract state via the `post_apply_cleanup` membership sweep is #490 (different mechanism, `common/` change).

## Review findings addressed (c5840769)

Three independent review lenses (reactivity, code-first, behavioral) converged on four should-fix findings; all applied:

1. **Peek-panic fixed**: `mark_thread_read`'s contended-`try_peek` fallback flipped `true` -> `false`. `try_peek` fails only while a live write borrow exists, so falling through to `with_mut` (a panicking borrow) on that same stack was a guaranteed RefCell panic; skipping self-heals on the next render. Pin extended to reject a `true` fallback.
2. **Self-nudge recovery**: `RAIL_REBUILD_TICK` (a `GlobalSignal` bumped via a storm-proofed, self-terminating one-shot `defer`) replaces `OPEN_DM_THREAD` as the builders' infallible subscription anchor; every degraded pass schedules a bump, so recovery is one macrotask away instead of parked until unrelated user action. Overclaiming comments corrected.
3. **No reorder / no cache poisoning on contended `DM_LAST_SEEN`**: unread is the primary sort key, so the unread=0 degrade was an order change, not cosmetic — `build_view` now backfills per-pair unread from `LAST_GOOD_RAIL`, and the cache write is gated on a fully-clean pass (`hidden` AND `last_seen`).
4. **Archived-count last-good**: `current_archived_count` serves the last clean count on contention instead of 0, which could combine with an empty thread list to unmount the whole DIRECT MESSAGES section via the empty-state early return.

All four are covered by new unit tests + wiring pins, each mutation-verified (revert hunk -> red -> restore -> green).

Two pre-existing nits found during review are deliberately deferred and filed: #503 (chrome-less dead-end modal when a DM thread's room disappears) and #504 (`count_unread_dms_with` duplicates the rail's unread accumulation).

Closes #499

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCUNSVinAJ5fQxTbEtQxXK
