### PR TITLE
fix(ui): don't slide the history window under a pinned reader (#501)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,6 +188,17 @@ jobs:
       # `cargo test -p river-ui`. This step gates them on every push.
       run: cargo test -p river-ui --bins
 
+    - name: Test river-ui (example-data fixture tests)
+      env:
+        RUST_MIN_STACK: 8388608
+        CARGO_TARGET_DIR: ${{ github.workspace }}/target
+      # The example_data module (and its tests — the deep/at-cap windowing
+      # fixture pins for freenet/river#501/#505) only compiles behind the
+      # example-data feature, so the featureless run above never executes
+      # them. Without this step a fixture regression that vacuates the
+      # windowing Playwright specs would pass CI silently.
+      run: cargo test -p river-ui --bins --features example-data,no-sync
+
   ui-playwright-tests:
     runs-on: freenet-default-runner
 

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1476,6 +1476,65 @@ struct HistoryWindow {
     has_older: bool,
 }
 
+/// The identity of the window's head: which display item the last render
+/// started at, remembered by KEY, with the index it held as a relocation hint.
+///
+/// The anchor is by IDENTITY, not position, because positions are not stable:
+/// `MessagesV1::apply_delta` drains the oldest message once a room exceeds
+/// `max_recent_messages` (the steady state of every busy room), so an arrival
+/// shifts every index down by one. A positional anchor then renders a head one
+/// item LATER in identity — the top rendered row is removed in the same patch
+/// that appends the arrival, which is the #501 slide reproduced in content
+/// space, and with scroll anchoring disabled it crawls a parked reader upward
+/// one row per arrival. Anchoring on the head item's key holds the rendered
+/// set fixed in identity no matter how the indices shift underneath it.
+#[derive(Clone, PartialEq, Debug)]
+struct WindowAnchor {
+    /// `display_item_key` of the item the window started at.
+    key: String,
+    /// The index that item held last render — a hint so relocation is O(shift),
+    /// not O(total), in the common case, and the positional fallback when the
+    /// item is gone entirely.
+    index: usize,
+}
+
+/// Re-locate the anchored head item after the item list changed.
+///
+/// Front prunes shift every surviving index DOWN, so the hint is checked
+/// first, then the indices below it, then (for completeness — a merge can
+/// insert older history above the head) the indices above. `None` means the
+/// key is gone entirely — the head itself was drained, or its whole group was
+/// deleted. The caller then falls back to the POSITION: for a front prune
+/// that consumed the head, the hint (having marched to ~0 with the shifts) is
+/// the nearest surviving item — everything between the new index 0 and the
+/// old head was pruned with it — and for a mid-window deletion it is off by
+/// at most the deleted item. Either way the `head_reposition` effect
+/// compensates the parked reader's offset for whatever content the swap
+/// removed.
+fn relocate_anchor(total: usize, hint: usize, is_anchor: impl Fn(usize) -> bool) -> Option<usize> {
+    if hint < total && is_anchor(hint) {
+        return Some(hint);
+    }
+    if let Some(i) = (0..hint.min(total)).rev().find(|&i| is_anchor(i)) {
+        return Some(i);
+    }
+    (hint.saturating_add(1)..total).find(|&i| is_anchor(i))
+}
+
+/// The requested window size after one backfill growth step.
+///
+/// Grows from the RENDERED size, not the requested size. Arrivals grow an
+/// anchored window past what was requested (`rendered = total - start` exceeds
+/// `requested` by the number of arrivals), and a growth step computed from the
+/// stale requested size can resolve to a start the anchor already renders —
+/// zero new rows, no DOM change, so the sentinel's IntersectionObserver never
+/// re-fires and paging dead-ends (#505 review, blocker 2). Growing from the
+/// rendered size guarantees every step reveals `WINDOW_GROWTH_ITEMS` more
+/// items than are currently on screen.
+fn grown_window(requested: usize, rendered: usize) -> usize {
+    rendered.max(requested) + WINDOW_GROWTH_ITEMS
+}
+
 impl HistoryWindow {
     /// Resolve where the rendered tail starts.
     ///
@@ -1517,7 +1576,13 @@ impl HistoryWindow {
             Some(prev) => prev.min(base),
         };
         // The ceiling on arrival growth; never on reader-requested backfill.
-        let cap = window.max(WINDOW_ITEMS_CEILING).max(1);
+        // One growth step of grace above the requested size, so a reader who
+        // parked right after backfilling to the ceiling is not hit with a
+        // ceiling slide on the first arrival — belt-and-braces on top of the
+        // `head_reposition` compensation (#505 review).
+        let cap = (window + WINDOW_GROWTH_ITEMS)
+            .max(WINDOW_ITEMS_CEILING)
+            .max(1);
         if total_items - start > cap {
             start = total_items - cap;
         }
@@ -1553,6 +1618,29 @@ fn chat_content_wrapper() -> Option<web_sys::Element> {
 #[cfg(target_arch = "wasm32")]
 fn max_scroll_top(container: &web_sys::Element) -> i32 {
     (container.scroll_height() - container.client_height()).max(0)
+}
+
+/// The `offsetTop` of the history row carrying `data-item-key == key`, if it
+/// is currently in the DOM.
+///
+/// Matched by comparing attributes rather than an attribute SELECTOR, so a key
+/// never needs CSS escaping. The scan is bounded by the rendered window (≤ a
+/// few hundred rows) and only runs on the rare head-swap paths.
+#[cfg(target_arch = "wasm32")]
+fn history_row_offset_top(key: &str) -> Option<i32> {
+    use wasm_bindgen::JsCast;
+    let container = chat_scroll_container()?;
+    let rows = container.query_selector_all("[data-item-key]").ok()?;
+    for i in 0..rows.length() {
+        let Some(node) = rows.item(i) else { continue };
+        let Some(el) = node.dyn_ref::<web_sys::HtmlElement>() else {
+            continue;
+        };
+        if el.get_attribute("data-item-key").as_deref() == Some(key) {
+            return Some(el.offset_top());
+        }
+    }
+    None
 }
 
 /// Slack for comparing one scroll offset against another.
@@ -1664,7 +1752,7 @@ fn install_scroll_pin_listeners(
     pinned: Rc<std::cell::Cell<bool>>,
     last_top: Rc<std::cell::Cell<i32>>,
     window_items: Signal<usize>,
-    window_anchor: Rc<std::cell::Cell<Option<usize>>>,
+    window_anchor: Rc<std::cell::RefCell<Option<WindowAnchor>>>,
     window_overgrown: Rc<std::cell::Cell<bool>>,
 ) -> bool {
     use wasm_bindgen::prelude::*;
@@ -1696,35 +1784,44 @@ fn install_scroll_pin_listeners(
             // for reader settles is what let a stale offset suppress the
             // follow indefinitely.
             last_top.set(settled_at);
-            if ours {
-                return;
-            }
             let distance = container.scroll_height() as f64
                 - settled_at as f64
                 - container.client_height() as f64;
-            pinned.set(distance <= BOTTOM_THRESHOLD_PX);
-            // The reader's own settle landing at the bottom is the ONE moment
-            // a window trim is provably invisible: at the bottom, removing
-            // rows above the viewport shrinks `scrollHeight` and the browser
-            // clamps `scrollTop` down with it, so the same tail stays glued to
-            // the bottom edge (`reader_moved_up_since`'s
-            // `.min(max_scroll_top(..))` already treats that clamp as not the
-            // reader). Trimming anywhere else shifts content under the reader
-            // now that scroll anchoring is off, so growth accumulated while
-            // parked is bounded by `WINDOW_ITEMS_CEILING` instead of trimmed.
+            // A settle landing AT the bottom is the ONE moment a window trim
+            // is provably invisible: removing rows above the viewport shrinks
+            // `scrollHeight` and the browser clamps `scrollTop` down with it,
+            // so the same tail stays glued to the bottom edge
+            // (`reader_moved_up_since`'s `.min(max_scroll_top(..))` already
+            // treats that clamp as not the reader). Trimming anywhere else
+            // shifts content under the reader now that scroll anchoring is
+            // off, so growth accumulated while parked is bounded by
+            // `WINDOW_ITEMS_CEILING` instead of trimmed.
+            //
+            // Checked BEFORE the `ours` early-out, deliberately: every
+            // followed arrival's snap settles as ours, and so does the
+            // scroll-to-latest button — a touch reader who only ever returns
+            // to the bottom through the button would otherwise never trim
+            // (#505 review). Gated at SCROLL_TOP_SLACK_PX, not
+            // BOTTOM_THRESHOLD_PX: a reader parked up to 100px above the
+            // bottom still counts as pinned, and a trim from there would
+            // clamp their offset to the exact bottom — a visible yank.
             //
             // Deferred: this runs from a raw JS callback with no Dioxus scope,
             // and `window_items` is a signal the render subscribes to. See
             // .claude/rules/dioxus-signal-safety.md.
-            if distance <= BOTTOM_THRESHOLD_PX && window_overgrown.get() {
+            if distance <= SCROLL_TOP_SLACK_PX as f64 && window_overgrown.get() {
                 window_overgrown.set(false);
                 let window_anchor = window_anchor.clone();
                 let mut window_items = window_items;
                 crate::util::defer(move || {
-                    window_anchor.set(None);
+                    *window_anchor.borrow_mut() = None;
                     window_items.set(INITIAL_WINDOW_ITEMS);
                 });
             }
+            if ours {
+                return;
+            }
+            pinned.set(distance <= BOTTOM_THRESHOLD_PX);
         }) as Box<dyn FnMut()>)
     };
     let settle_fn: js_sys::Function = settle.as_ref().unchecked_ref::<js_sys::Function>().clone();
@@ -1799,16 +1896,31 @@ pub fn Conversation() -> Element {
     // How many trailing display items the history renders. Grows only when the
     // reader reaches the top of what is rendered — see `INITIAL_WINDOW_ITEMS`.
     let mut window_items = use_signal(|| INITIAL_WINDOW_ITEMS);
-    // The start index the last render used, so arrivals GROW the window
-    // instead of sliding it (#501) — see `HistoryWindow::resolve`. A plain
-    // `Cell` written back during render: it is memory between renders, not
-    // state anything renders FROM, so there is no subscriber to notify.
-    let window_anchor = use_hook(|| Rc::new(std::cell::Cell::new(None::<usize>)));
+    // The IDENTITY of the item the last render's window started at, so
+    // arrivals GROW the window instead of sliding it (#501), and so index
+    // shifts from at-cap message pruning cannot move the head in content
+    // space (#505 review, blocker 1) — see `WindowAnchor`. Inter-render
+    // memory written back during render; nothing renders FROM it, so there is
+    // no subscriber to notify.
+    let window_anchor = use_hook(|| Rc::new(std::cell::RefCell::new(None::<WindowAnchor>)));
+    // How many display items the last render actually put on screen. The
+    // backfill growth step reads this instead of the requested size: after
+    // arrivals grow an anchored window, growing from the stale requested size
+    // can reveal zero new rows and dead-end paging (#505 review, blocker 2).
+    let window_rendered = use_hook(|| Rc::new(std::cell::Cell::new(0usize)));
     // Whether the rendered window currently holds more than a fresh room-open
     // would render — i.e. whether the bottom-settle trim in
     // `install_scroll_pin_listeners` has anything to do. Maintained by render,
     // read from the raw settle callback (which cannot touch signals).
     let window_overgrown = use_hook(|| Rc::new(std::cell::Cell::new(false)));
+    // A pending "keep the parked reader's view still" adjustment: when a
+    // render swaps the window head for a LATER item (the head was pruned out
+    // from under the anchor, or a ceiling trim dropped it), the rows above
+    // the viewport shrink, and with scroll anchoring disabled nothing
+    // compensates. The render captures the NEW head's pre-patch `offsetTop`
+    // here; the `head_reposition` effect below re-measures it after the patch
+    // and shifts `scrollTop` by the difference. `(key, pre_patch_offset_top)`.
+    let reposition_pending = use_hook(|| Rc::new(std::cell::RefCell::new(None::<(String, i32)>)));
     // Whether the opening snap for the CURRENT room has landed. The backfill
     // sentinel only mounts once this is true: a freshly-opened >window room
     // renders at `scrollTop = 0` for a beat before the snap runs, and a
@@ -1823,6 +1935,34 @@ pub fn Conversation() -> Element {
     // scroll effect that consumes it) because the backfill-restore effect
     // below also has to stand down while a forced snap is in flight.
     let force_scroll = use_hook(|| Rc::new(std::cell::Cell::new(false)));
+
+    // Reset the windowing Cells the moment THIS render is for a different
+    // room — not only in the effect below, which runs AFTER the first render
+    // of the new room has already resolved against the OLD room's anchor and
+    // requested size (cloning and patching up to a fully-backfilled room's
+    // depth for one wasted frame; #505 review). Cells are safe to write
+    // during render; the signals (`window_items`, `opening_snap_done`) still
+    // reset in the effect, so this render substitutes `INITIAL_WINDOW_ITEMS`
+    // below and keeps the sentinel unmounted until they catch up.
+    let room_changed_this_render = {
+        // `Option<Option<..>>` so the very first render (no room recorded yet)
+        // also counts as a change and starts from a clean window.
+        let prev_render_room = use_hook(|| {
+            Rc::new(std::cell::Cell::new(
+                None::<Option<ed25519_dalek::VerifyingKey>>,
+            ))
+        });
+        let room = CURRENT_ROOM.read().owner_key;
+        let changed = prev_render_room.get() != Some(room);
+        if changed {
+            prev_render_room.set(Some(room));
+            *window_anchor.borrow_mut() = None;
+            window_rendered.set(0);
+            window_overgrown.set(false);
+            *reposition_pending.borrow_mut() = None;
+        }
+        changed
+    };
     // Scroll geometry captured just before a backfill, so the view can be put
     // back on the message the reader was looking at once the older items land
     // above it. `(scroll_height, scroll_top)` at capture time; `None` when no
@@ -1862,17 +2002,14 @@ pub fn Conversation() -> Element {
     {
         let prev_windowed_room =
             use_hook(|| Rc::new(std::cell::Cell::new(None::<ed25519_dalek::VerifyingKey>)));
-        let window_anchor = window_anchor.clone();
-        let window_overgrown = window_overgrown.clone();
         use_effect(move || {
             let room = CURRENT_ROOM.read().owner_key;
+            // The Cells (anchor, rendered, overgrown) were already reset by
+            // the render-side check above; only the SIGNALS reset here,
+            // because writing them from render would re-enter the render.
             if prev_windowed_room.get() != room {
                 prev_windowed_room.set(room);
                 window_items.set(INITIAL_WINDOW_ITEMS);
-                // The anchor is an index into the PREVIOUS room's items; the
-                // new room resolves a fresh tail.
-                window_anchor.set(None);
-                window_overgrown.set(false);
                 // Re-gate the backfill sentinel until the new room's opening
                 // snap has landed (#501 H2).
                 opening_snap_done.set(false);
@@ -1897,41 +2034,45 @@ pub fn Conversation() -> Element {
             let Some((prev_height, prev_top)) = backfill_anchor.get() else {
                 return;
             };
-            let backfill_anchor = backfill_anchor.clone();
-            let last_scroll_top = last_scroll_top.clone();
-            let pinned_to_bottom = pinned_to_bottom.clone();
-            let force_scroll = force_scroll.clone();
-            // Deferred so the browser has laid the new rows out and
-            // `scroll_height` reflects them.
-            crate::util::defer(move || {
-                backfill_anchor.set(None);
-                // The restore serves a reader who is up in the history holding
-                // their place. It must never fight the bottom pin or a forced
-                // snap (#501 H3): unconditionally it could park the view at
-                // the anchor over a concurrent arrival — and because it writes
-                // `last_scroll_top`, the settle would read as OURS and the pin
-                // would quietly survive pointing somewhere the reader never
-                // asked to be.
-                if pinned_to_bottom.get() || force_scroll.get() {
-                    return;
-                }
-                let Some(container) = chat_scroll_container() else {
-                    return;
-                };
-                let grew_by = container.scroll_height() - prev_height;
-                if grew_by > 0 {
-                    let target = prev_top + grew_by;
-                    // Record the offset we asked for BEFORE asking for it, the
-                    // same contract `scroll_history_to_bottom` keeps: the
-                    // settle handler decides whose scroll a settle was by
-                    // POSITION, so a programmatic scroll that does not write
-                    // `last_scroll_top` is later mistaken for the reader
-                    // moving, and the ResizeObserver stands down on the
-                    // strength of it. See `install_scroll_pin_listeners`.
-                    last_scroll_top.set(target);
-                    container.set_scroll_top(target);
-                }
-            });
+            backfill_anchor.set(None);
+            // The restore serves a reader who is up in the history holding
+            // their place. It must never fight the bottom pin or a forced
+            // snap (#501 H3): unconditionally it could park the view at
+            // the anchor over a concurrent arrival — and because it writes
+            // `last_scroll_top`, the settle would read as OURS and the pin
+            // would quietly survive pointing somewhere the reader never
+            // asked to be. The pin alone is not enough, though: a continuous
+            // fling from the bottom into the sentinel band produces no settle
+            // mid-gesture, so `pinned_to_bottom` can still read a stale true —
+            // a reader AT the sentinel has definitionally moved up, which is
+            // exactly what `reader_moved_up_since` detects (#505 review).
+            if (pinned_to_bottom.get() && !reader_moved_up_since(&last_scroll_top))
+                || force_scroll.get()
+            {
+                return;
+            }
+            let Some(container) = chat_scroll_container() else {
+                return;
+            };
+            // Synchronous, not deferred: Dioxus has already patched the DOM
+            // when effects run, and reading `scroll_height` forces the layout
+            // the restore needs. A macrotask hop here let the browser paint
+            // one frame of the prepended rows at the wrong offset before the
+            // reposition landed — a flicker native scroll anchoring used to
+            // mask (#505 review).
+            let grew_by = container.scroll_height() - prev_height;
+            if grew_by > 0 {
+                let target = prev_top + grew_by;
+                // Record the offset we asked for BEFORE asking for it, the
+                // same contract `scroll_history_to_bottom` keeps: the
+                // settle handler decides whose scroll a settle was by
+                // POSITION, so a programmatic scroll that does not write
+                // `last_scroll_top` is later mistaken for the reader
+                // moving, and the ResizeObserver stands down on the
+                // strength of it. See `install_scroll_pin_listeners`.
+                last_scroll_top.set(target);
+                container.set_scroll_top(target);
+            }
         });
     }
     // Which message's touch action menu (kebab) is open, by message ID string.
@@ -2202,6 +2343,63 @@ pub fn Conversation() -> Element {
         });
     }
 
+    // Keep a PARKED reader's view still when the window head is swapped for a
+    // later item — the head was pruned out from under the anchor (an at-cap
+    // room drains its oldest message on every arrival), or a ceiling trim
+    // dropped it (#505 review, blocker 1). Rows above the viewport shrink,
+    // and with `overflow-anchor: none` the browser no longer compensates, so
+    // this effect is the one piece of scroll anchoring reimplemented under
+    // our own control: the render captured the NEW head row's `offsetTop`
+    // BEFORE the patch (into `reposition_pending`); re-measuring it after the
+    // patch gives exactly how far the content above the viewport shifted,
+    // date-separator churn included. Synchronous — post-patch, pre-paint —
+    // for the same no-flicker reason as the backfill restore above.
+    //
+    // Known limitation, deliberately accepted: a mid-window removal (a
+    // deletion, a ban purge) or late-loading media above the viewport still
+    // shifts a parked reader — rare events, versus the every-arrival churn
+    // this compensates. Full generality is what browser scroll anchoring
+    // does, and fighting the pin machinery is why it is switched off.
+    #[cfg(target_arch = "wasm32")]
+    {
+        let reposition_pending = reposition_pending.clone();
+        let last_scroll_top = last_scroll_top.clone();
+        let pinned_to_bottom = pinned_to_bottom.clone();
+        let force_scroll = force_scroll.clone();
+        use_effect(move || {
+            // Subscribe: head swaps only happen on content changes.
+            let _ = message_groups.read().is_some();
+            let Some((key, pre_top)) = reposition_pending.borrow_mut().take() else {
+                return;
+            };
+            // A pinned reader needs no compensation — the arrival effect
+            // snaps to the bottom — and a forced snap owns the view outright.
+            // The pin is distrusted mid-gesture exactly as in the restore
+            // above: a reader flinging upward has moved even if their settle
+            // has not landed yet.
+            if force_scroll.get()
+                || (pinned_to_bottom.get() && !reader_moved_up_since(&last_scroll_top))
+            {
+                return;
+            }
+            let Some(container) = chat_scroll_container() else {
+                return;
+            };
+            let Some(post_top) = history_row_offset_top(&key) else {
+                return;
+            };
+            let shift = post_top - pre_top;
+            if shift != 0 {
+                let target = (container.scroll_top() + shift).max(0);
+                // Same contract as every programmatic scroll: record the
+                // offset so the settle reads as ours. See
+                // `install_scroll_pin_listeners`.
+                last_scroll_top.set(target);
+                container.set_scroll_top(target);
+            }
+        });
+    }
+
     // Keep the newest message in view when the history grows.
     //
     // Scroll the chat-scroll-container itself, not the last bubble:
@@ -2237,6 +2435,10 @@ pub fn Conversation() -> Element {
             {
                 let pinned_to_bottom = pinned_to_bottom.clone();
                 let last_scroll_top = last_scroll_top.clone();
+                // Which room this snap belongs to. A rapid room switch can
+                // leave the previous room's snap task queued; it must not
+                // un-gate the NEW room's backfill sentinel (#505 review).
+                let room_at_snap = CURRENT_ROOM.peek().owner_key;
                 // Deferred so the scroll measures a container Dioxus has
                 // finished patching, and (per `safe_spawn_local`) so no signal
                 // borrow is live when it runs.
@@ -2281,9 +2483,14 @@ pub fn Conversation() -> Element {
                     // The opening snap for this room has landed, so the
                     // backfill sentinel may mount (#501 H2). Deferred, and the
                     // signal is only written on the transition, so steady-state
-                    // arrivals do not re-notify the render for nothing.
+                    // arrivals do not re-notify the render for nothing. The
+                    // room is re-checked because this task can outlive a rapid
+                    // room switch, and a stale set here would un-gate the new
+                    // room's sentinel before ITS snap (#505 review).
                     crate::util::defer(move || {
-                        if !*opening_snap_done.peek() {
+                        if CURRENT_ROOM.peek().owner_key == room_at_snap
+                            && !*opening_snap_done.peek()
+                        {
                             opening_snap_done.set(true);
                         }
                     });
@@ -3235,19 +3442,76 @@ pub fn Conversation() -> Element {
                                     // so cloning the whole history here — on
                                     // every re-render — would pay most of the
                                     // cost the window exists to avoid.
-                                    let requested_window = window_items();
+                                    // Subscribe every render; the value is
+                                    // substituted on a room switch because the
+                                    // signal's own reset only lands in the
+                                    // NEXT render's effect pass.
+                                    let subscribed_window = window_items();
+                                    let requested_window = if room_changed_this_render {
+                                        INITIAL_WINDOW_ITEMS
+                                    } else {
+                                        subscribed_window
+                                    };
+                                    // Re-locate the anchored head by IDENTITY:
+                                    // at-cap pruning shifts every index, so the
+                                    // stored index is only a hint (#505
+                                    // blocker 1; see `WindowAnchor`).
+                                    let prev_anchor = window_anchor.borrow().clone();
+                                    let located_head = prev_anchor.as_ref().and_then(|a| {
+                                        relocate_anchor(groups.len(), a.index, |i| {
+                                            display_item_key(&groups[i]) == a.key
+                                        })
+                                    });
+                                    let anchor_index = prev_anchor.as_ref().map(|a| {
+                                        located_head.unwrap_or_else(|| {
+                                            a.index.min(groups.len().saturating_sub(1))
+                                        })
+                                    });
                                     let history_window = HistoryWindow::resolve(
                                         groups.len(),
                                         requested_window,
-                                        window_anchor.get(),
+                                        anchor_index,
                                     );
                                     // Remember where this render started so the
                                     // NEXT one grows instead of sliding (#501).
-                                    // A `Cell` write during render is fine: it
-                                    // is inter-render memory, nothing renders
-                                    // from it, and re-resolving with the value
-                                    // just written is a fixed point.
-                                    window_anchor.set(Some(history_window.start));
+                                    // Cell/RefCell writes during render are
+                                    // fine: inter-render memory, nothing
+                                    // renders from them, and re-resolving with
+                                    // the values just written is a fixed point.
+                                    let new_head_key =
+                                        display_item_key(&groups[history_window.start]);
+                                    // Was rendered content above the new head
+                                    // removed in this very patch? True when
+                                    // the old head is gone (pruned or deleted)
+                                    // or now sits BEFORE the window (ceiling
+                                    // trim). A parked reader needs their
+                                    // offset compensated for it — the
+                                    // `head_reposition` effect's job.
+                                    let head_removed = match (&prev_anchor, located_head) {
+                                        (Some(_), None) => true,
+                                        (Some(_), Some(i)) => i < history_window.start,
+                                        (None, _) => false,
+                                    };
+                                    if head_removed {
+                                        // Capture the new head row's PRE-patch
+                                        // offset; the DOM still shows the
+                                        // previous render here.
+                                        #[cfg(target_arch = "wasm32")]
+                                        if let Some(pre_top) =
+                                            history_row_offset_top(&new_head_key)
+                                        {
+                                            *reposition_pending.borrow_mut() =
+                                                Some((new_head_key.clone(), pre_top));
+                                        }
+                                    }
+                                    *window_anchor.borrow_mut() = Some(WindowAnchor {
+                                        key: new_head_key,
+                                        index: history_window.start,
+                                    });
+                                    // What the backfill growth step grows FROM
+                                    // (#505 blocker 2; see `grown_window`).
+                                    window_rendered
+                                        .set(groups.len() - history_window.start);
                                     // Tell the settle handler whether a
                                     // bottom-settle trim would shrink anything.
                                     window_overgrown.set(
@@ -3326,8 +3590,16 @@ pub fn Conversation() -> Element {
                                         // the backfill (#501 H2). Mounting it
                                         // after the snap means its first
                                         // observation sees the view at the
-                                        // bottom, far below the strip.
-                                        if history_window.has_older && opening_snap_done() {
+                                        // bottom, far below the strip. The
+                                        // room-change check covers the one
+                                        // render where `opening_snap_done` is
+                                        // still the PREVIOUS room's true —
+                                        // its reset only lands in the effect
+                                        // pass after this render.
+                                        if history_window.has_older
+                                            && opening_snap_done()
+                                            && !room_changed_this_render
+                                        {
                                             // Zero-height anchor; the sentinel
                                             // inside it is absolutely
                                             // positioned, so it contributes no
@@ -3366,14 +3638,27 @@ pub fn Conversation() -> Element {
                                                                     container.scroll_top(),
                                                                 )));
                                                             }
-                                                            window_items
-                                                                .with_mut(|n| *n += WINDOW_GROWTH_ITEMS);
+                                                            // Grow from the RENDERED size, not the
+                                                            // requested one: arrivals grow an anchored
+                                                            // window past the request, and growing from
+                                                            // the stale request can reveal zero new rows
+                                                            // — the sentinel then never re-fires and
+                                                            // paging dead-ends (#505 blocker 2; see
+                                                            // `grown_window`).
+                                                            window_items.with_mut(|n| {
+                                                                *n = grown_window(*n, window_rendered.get())
+                                                            });
                                                         }
                                                     },
                                                 }
                                             }
                                         }
-                                        div { class: "space-y-4",
+                                        div {
+                                            class: "space-y-4",
+                                            // Stable automation hook for the
+                                            // history rows (AGENTS.md test-id
+                                            // rule); additive markup only.
+                                            "data-testid": "conversation-history",
                                             {rows.into_iter().map({
                                                 let handle_toggle_reaction = handle_toggle_reaction.clone();
                                                 let member_names = member_names.clone();
@@ -3398,6 +3683,10 @@ pub fn Conversation() -> Element {
                                                         rsx! {
                                                             div {
                                                                 key: "{key}",
+                                                                // Identity tag for the
+                                                                // head-reposition machinery
+                                                                // (`history_row_offset_top`).
+                                                                "data-item-key": "{key}",
                                                                 class: "flex justify-center py-1",
                                                                 span {
                                                                     class: "text-xs text-text-muted italic",
@@ -3409,8 +3698,19 @@ pub fn Conversation() -> Element {
                                                     DisplayRow::Item(DisplayItem::Messages(group)) => {
                                                         let key = group.messages[0].id.clone();
                                                         rsx! {
-                                                            MessageGroupComponent {
+                                                            // The wrapper exists to carry
+                                                            // `data-item-key` — the identity
+                                                            // the head-reposition machinery
+                                                            // locates rows by — since a
+                                                            // component cannot carry a DOM
+                                                            // attribute directly. It is the
+                                                            // keyed list child, so diffing
+                                                            // and `space-y-4` spacing are
+                                                            // unchanged.
+                                                            div {
                                                                 key: "{key}",
+                                                                "data-item-key": "{key}",
+                                                                MessageGroupComponent {
                                                                 group: group,
                                                                 self_member_id: self_member_id,
                                                                 member_names: member_names,
@@ -3439,6 +3739,7 @@ pub fn Conversation() -> Element {
                                                                     }
                                                                 },
                                                                 open_action_menu: open_action_menu,
+                                                                }
                                                             }
                                                         }
                                                     }
@@ -4938,6 +5239,125 @@ mod tests {
         let requested = WINDOW_ITEMS_CEILING + WINDOW_GROWTH_ITEMS;
         let w = HistoryWindow::resolve(1000, requested, Some(1000 - requested));
         assert_eq!(w.start, 1000 - requested);
+
+        // Arrival-grace headroom: a reader who backfilled TO the ceiling and
+        // parked is not hit with a ceiling slide by the next few arrivals —
+        // the cap sits one growth step above the request (#505 review).
+        let at_ceiling = WINDOW_ITEMS_CEILING;
+        let anchor = 1000 - at_ceiling;
+        let w = HistoryWindow::resolve(1010, at_ceiling, Some(anchor));
+        assert_eq!(
+            w.start, anchor,
+            "10 arrivals within the grace must not slide a ceiling-deep window"
+        );
+    }
+
+    /// #505 blocker 1: the anchor is re-located by IDENTITY. An at-cap room
+    /// prunes its oldest message per arrival, shifting every index down — the
+    /// walk below is that steady state, and the head must stay the same ITEM
+    /// (its index marching toward 0), not the same index.
+    #[test]
+    fn the_anchor_follows_the_item_through_at_cap_pruning() {
+        // A 100-item room at cap: items are identified by these keys.
+        let mut keys: Vec<usize> = (0..100).collect();
+        let opened = HistoryWindow::resolve(keys.len(), INITIAL_WINDOW_ITEMS, None);
+        assert_eq!(opened.start, 40);
+        let mut anchor_key = keys[opened.start];
+        let mut anchor_hint = opened.start;
+
+        for arrival in 0..40usize {
+            // apply_delta at cap: drain the oldest, append the new.
+            keys.remove(0);
+            keys.push(1000 + arrival);
+            let located = relocate_anchor(keys.len(), anchor_hint, |i| keys[i] == anchor_key);
+            let start =
+                HistoryWindow::resolve(keys.len(), INITIAL_WINDOW_ITEMS, Some(located.unwrap()))
+                    .start;
+            assert_eq!(
+                keys[start], anchor_key,
+                "arrival {arrival}: the window head changed identity — the \
+                 #501 slide reproduced in content space"
+            );
+            assert_eq!(start, opened.start - (arrival + 1), "start marches down");
+            anchor_hint = start;
+            anchor_key = keys[start];
+        }
+
+        // One more prune consumes the head itself: relocation fails, and the
+        // positional fallback (the hint, at 0) is the nearest surviving item.
+        keys.remove(0);
+        keys.push(2000);
+        assert_eq!(anchor_hint, 0);
+        let located = relocate_anchor(keys.len(), anchor_hint, |i| keys[i] == anchor_key);
+        assert_eq!(located, None, "the head itself was pruned");
+        let fallback = anchor_hint.min(keys.len() - 1);
+        assert_eq!(
+            fallback, 0,
+            "the fallback is the nearest surviving item — everything before \
+             the old head was pruned with it"
+        );
+    }
+
+    /// `relocate_anchor` search order and fallbacks.
+    #[test]
+    fn relocate_anchor_finds_shifted_heads_and_reports_lost_ones() {
+        let keys = ["a", "b", "c", "d", "e"];
+        let find =
+            |key: &'static str, hint: usize| relocate_anchor(keys.len(), hint, |i| keys[i] == key);
+        // Unshifted: found at the hint.
+        assert_eq!(find("c", 2), Some(2));
+        // Front prune shifted it down: found below the hint.
+        assert_eq!(find("c", 3), Some(2));
+        // Older history merged in above: found above the hint.
+        assert_eq!(find("c", 0), Some(2));
+        // Hint out of range entirely: still found.
+        assert_eq!(find("e", 400), Some(4));
+        // Gone: None, and the caller falls back to the position.
+        assert_eq!(find("zz", 2), None);
+        assert_eq!(relocate_anchor(0, 0, |_| true), None, "empty list");
+    }
+
+    /// #505 blocker 2: one backfill growth step must always reveal more than
+    /// what is RENDERED — growing from the stale requested size can resolve to
+    /// a start the anchor already renders (zero new rows, sentinel never
+    /// re-fires, paging dead-ends). The trace is the review's: open at 1000
+    /// items, 61 arrivals, page up.
+    #[test]
+    fn a_growth_step_reveals_rows_even_after_arrivals_grew_the_window() {
+        let opened = HistoryWindow::resolve(1000, INITIAL_WINDOW_ITEMS, None);
+        assert_eq!(opened.start, 940);
+        // 61 arrivals: the anchored start holds, rendered = 121.
+        let grown = HistoryWindow::resolve(1061, INITIAL_WINDOW_ITEMS, Some(opened.start));
+        assert_eq!(grown.start, opened.start);
+        let rendered = 1061 - grown.start;
+        assert_eq!(rendered, 121);
+
+        // The regression this pins: growing from the REQUESTED size reveals
+        // nothing (min(anchor, 1061-120) = anchor).
+        let dead = HistoryWindow::resolve(
+            1061,
+            INITIAL_WINDOW_ITEMS + WINDOW_GROWTH_ITEMS,
+            Some(grown.start),
+        );
+        assert_eq!(
+            dead.start, grown.start,
+            "premise: the naive growth really does dead-end — if this stops \
+             holding, the whole scenario needs rebuilding"
+        );
+
+        // The fix: grow from the rendered size.
+        let requested = grown_window(INITIAL_WINDOW_ITEMS, rendered);
+        assert_eq!(requested, rendered + WINDOW_GROWTH_ITEMS);
+        let paged = HistoryWindow::resolve(1061, requested, Some(grown.start));
+        assert!(
+            paged.start < grown.start,
+            "a growth step must strictly decrease start"
+        );
+        assert_eq!(
+            grown.start - paged.start,
+            WINDOW_GROWTH_ITEMS,
+            "and by exactly one growth step"
+        );
     }
 
     /// Source-grep pin: the history must render through the window. Rendering
@@ -4957,14 +5377,26 @@ mod tests {
             "the history must slice its display items through `HistoryWindow`"
         );
         assert!(
-            squashed.contains("window_anchor.get(),)"),
-            "the resolve must carry the previous render's start (the anchor) — \
-             without it every arrival slides the window, which is #501"
+            squashed.contains("relocate_anchor(groups.len(),a.index,"),
+            "the anchor must be re-located by IDENTITY before resolving — a \
+             positional anchor slides the head in content space whenever an \
+             at-cap room prunes a message (#505 blocker 1)"
         );
         assert!(
-            squashed.contains("window_anchor.set(Some(history_window.start));"),
-            "the render must write the resolved start back so the NEXT render \
-             grows instead of sliding (#501)"
+            squashed.contains("*window_anchor.borrow_mut()=Some(WindowAnchor{"),
+            "the render must write the resolved head's identity back so the \
+             NEXT render grows instead of sliding (#501)"
+        );
+        assert!(
+            squashed.contains("window_rendered.set(groups.len()-history_window.start);"),
+            "the render must record the RENDERED size — the backfill growth \
+             step grows from it, or paging dead-ends after arrivals (#505 \
+             blocker 2)"
+        );
+        assert!(
+            squashed.contains("*n=grown_window(*n,window_rendered.get())"),
+            "the backfill sentinel must grow through `grown_window`, from the \
+             rendered size (#505 blocker 2)"
         );
         assert!(
             squashed.contains("groups[history_window.start..].to_vec()"),
@@ -4976,9 +5408,21 @@ mod tests {
             "the backfill sentinel must be rendered, or a reader can never see \
              messages older than the initial window"
         );
+        // Anchored on needles unique to the ROOM-SWITCH reset. The obvious
+        // needle — `window_items.set(INITIAL_WINDOW_ITEMS)` — also matches
+        // the bottom-settle trim, so deleting the room reset would have
+        // false-passed against it (#505 review).
         assert!(
-            squashed.contains("window_items.set(INITIAL_WINDOW_ITEMS)"),
-            "the window must reset when the reader opens another room"
+            squashed.contains("prev_render_room.set(Some(room));*window_anchor.borrow_mut()=None;"),
+            "the windowing Cells must reset inline in the render on a room \
+             switch — the effect-based reset runs one render too late, so \
+             the new room's first frame would render at the old room's depth"
+        );
+        assert!(
+            squashed
+                .contains("prev_windowed_room.set(room);window_items.set(INITIAL_WINDOW_ITEMS);"),
+            "the requested window signal must reset when the reader opens \
+             another room"
         );
     }
 
@@ -7332,9 +7776,12 @@ mod autoscroll_wiring_pins {
         assert_eq!(
             prod.matches("reader_moved_up_since(&last_scroll_top)")
                 .count(),
-            2,
-            "BOTH the content-change effect and the ResizeObserver must consult \
-             the guard; found a different number of call sites"
+            4,
+            "the guard has exactly four consumers: the content-change effect \
+             and the ResizeObserver (which scroll on the strength of the pin), \
+             plus the backfill restore and the head reposition (which distrust \
+             a stale-true pin mid-fling, #505 review); found a different \
+             number of call sites"
         );
         // Whitespace-insensitive: `cargo fmt` decides how this condition wraps,
         // and a pin that a reformat can break is a pin that gets deleted.
@@ -7404,30 +7851,84 @@ mod autoscroll_wiring_pins {
         );
     }
 
-    /// The #501 windowing contract: trims happen at the reader's own
-    /// bottom-settle (the one place they are invisible), the backfill restore
-    /// stands down while the view is pinned or a forced snap is in flight
-    /// (H3), and the backfill sentinel waits for the opening snap (H2).
-    /// Each of these is a one-line edit away from silently reverting, and none
-    /// of them is visible to `cargo test` except through these pins.
+    /// The #501/#505 windowing contract: trims happen at a settle landing AT
+    /// the bottom — ours included, so the scroll-to-latest button trims too —
+    /// gated at the slack, not the threshold, so a reader parked inside the
+    /// 100px band is never clamped to the exact bottom; the backfill restore
+    /// stands down while the view is pinned (unless the reader has visibly
+    /// moved — the fling case) or a forced snap is in flight (H3); the
+    /// backfill sentinel waits for the opening snap (H2) and for the
+    /// room-switch reset to catch up. Each of these is a one-line edit away
+    /// from silently reverting, and none is visible to `cargo test` except
+    /// through these pins.
     #[test]
     fn the_window_trims_at_the_bottom_and_backfill_defers_to_the_pin() {
         let prod = production_source();
         let dense: String = prod.chars().filter(|c| !c.is_whitespace()).collect();
         assert!(
-            dense.contains("ifdistance<=BOTTOM_THRESHOLD_PX&&window_overgrown.get()"),
-            "the settle handler must trim the grown window when the reader's \
-             own settle lands at the bottom"
+            dense.contains("ifdistance<=SCROLL_TOP_SLACK_PXasf64&&window_overgrown.get()"),
+            "the settle handler must trim the grown window when a settle — \
+             the reader's or ours — lands at the exact bottom"
+        );
+        let trim_at = dense
+            .find("ifdistance<=SCROLL_TOP_SLACK_PXasf64&&window_overgrown.get()")
+            .expect("asserted above");
+        let ours_early_out = dense
+            .find("ifours{return;}")
+            .expect("the settle handler early-outs for our own settles");
+        assert!(
+            trim_at < ours_early_out,
+            "the trim check must run BEFORE the `ours` early-out, or a touch \
+             reader who only returns to the bottom via the scroll-to-latest \
+             button (whose settle is ours) never trims (#505 review)"
         );
         assert!(
-            dense.contains("ifpinned_to_bottom.get()||force_scroll.get(){return;}"),
-            "the backfill restore must stand down while the view is pinned to \
-             the bottom or a forced snap is in flight (#501 H3)"
+            dense.contains(
+                "if(pinned_to_bottom.get()&&!reader_moved_up_since(&last_scroll_top))||force_scroll.get(){return;}"
+            ),
+            "the backfill restore must stand down while the view is pinned — \
+             unless the reader has visibly moved up (a fling into the sentinel \
+             band settles no pin) — or a forced snap is in flight (#501 H3, \
+             #505 review)"
         );
         assert!(
-            dense.contains("ifhistory_window.has_older&&opening_snap_done()"),
+            dense.contains(
+                "ifhistory_window.has_older&&opening_snap_done()&&!room_changed_this_render"
+            ),
             "the backfill sentinel must not mount until the room-open snap has \
-             landed (#501 H2)"
+             landed (#501 H2), including the one render where the previous \
+             room's `opening_snap_done` is still true"
+        );
+    }
+
+    /// The #505 blocker-1 compensation wiring: rows carry their item identity,
+    /// the render captures the new head's pre-patch offset when rendered
+    /// content above it is removed, and the reposition effect shifts a parked
+    /// reader's offset by the measured difference. Removing any leg silently
+    /// reverts to "parked readers crawl upward one row per arrival in every
+    /// at-cap room".
+    #[test]
+    fn head_swaps_reposition_a_parked_reader() {
+        let prod = production_source();
+        let dense: String = prod.chars().filter(|c| !c.is_whitespace()).collect();
+        assert!(
+            dense.contains("\"data-item-key\":\"{key}\""),
+            "history rows must carry `data-item-key` — the reposition \
+             machinery locates rows by item identity"
+        );
+        assert!(
+            dense.contains("fnhistory_row_offset_top"),
+            "the reposition machinery needs the row-offset lookup"
+        );
+        assert!(
+            dense.contains("reposition_pending.borrow_mut().take()"),
+            "the head-reposition effect must consume the render's pre-patch \
+             capture and shift the parked reader's offset"
+        );
+        assert!(
+            dense.contains("letshift=post_top-pre_top;"),
+            "the reposition must be BY MEASUREMENT (post-patch minus pre-patch \
+             offset of the surviving head row), not a guess"
         );
     }
 }

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1426,6 +1426,23 @@ const INITIAL_WINDOW_ITEMS: usize = 60;
 /// back through history grows the window at the rate they consume it.
 const WINDOW_GROWTH_ITEMS: usize = 60;
 
+/// Hard ceiling on how many display items arrival-growth can accumulate.
+///
+/// While the reader is pinned to the bottom (or parked mid-history), arrivals
+/// GROW the rendered window instead of sliding it — see
+/// [`HistoryWindow::resolve`] — so a long session in a busy room would
+/// otherwise re-accumulate exactly the unbounded render the window exists to
+/// prevent (freenet/river#498). Four initial windows is the chosen bound:
+/// deep enough that trims are rare (240 items is hours of a busy room, and the
+/// bottom-settle trim usually fires long before), shallow enough that the
+/// worst-case DOM stays ~4x the room-open cost rather than unbounded.
+///
+/// The ceiling caps ARRIVAL growth only. A reader paging back through history
+/// raises `window_items` explicitly, and that requested size always wins over
+/// the ceiling — capping it would make the backfill sentinel a no-op past 240
+/// items and dead-end the history (see the cap in [`HistoryWindow::resolve`]).
+const WINDOW_ITEMS_CEILING: usize = INITIAL_WINDOW_ITEMS * 4;
+
 /// How far into the rendered history the backfill trigger REACHES, in px.
 ///
 /// The sentinel is a strip spanning `[0, BACKFILL_LEAD_PX]` from the top of the
@@ -1460,10 +1477,50 @@ struct HistoryWindow {
 }
 
 impl HistoryWindow {
-    fn resolve(total_items: usize, window: usize) -> Self {
+    /// Resolve where the rendered tail starts.
+    ///
+    /// `anchor` is the start index the PREVIOUS render used (`None` when the
+    /// room was just opened, or after a trim). It is what keeps the window
+    /// from SLIDING on arrival: without it, every new message advanced `start`
+    /// by one, dropping the oldest rendered row in the same patch that
+    /// appended the new one at the bottom. Removing content above the viewport
+    /// while adding below it is what broke arrival auto-scroll in
+    /// freenet/river#501 — browser scroll anchoring rewrote `scrollTop`, and
+    /// `reader_moved_up_since` attributed the shift to the reader — and it
+    /// visibly shifts a reader parked mid-history now that scroll anchoring is
+    /// disabled on the container. So:
+    ///
+    /// * `start` NEVER moves forward from the anchor on an ordinary render:
+    ///   arrivals grow the rendered count instead (start fixed, new items
+    ///   appended below).
+    /// * `start` moves BACK (upward, revealing older items) when the reader
+    ///   backfills — `window` grew, so the plain tail start is earlier than
+    ///   the anchor.
+    /// * The one exception is [`WINDOW_ITEMS_CEILING`]: past it, `start` is
+    ///   dragged forward to cap arrival growth. `max(window, ...)` keeps the
+    ///   ceiling from ever capping a reader-requested backfill.
+    ///
+    /// Trimming back toward [`INITIAL_WINDOW_ITEMS`] is NOT done here — it is
+    /// an explicit event (the reader's own settle landing at the bottom, or a
+    /// room switch) that clears the anchor and resets `window`, because a trim
+    /// is only invisible when the view is at the bottom, where the browser's
+    /// scrollTop clamp keeps the tail glued in place.
+    fn resolve(total_items: usize, window: usize, anchor: Option<usize>) -> Self {
         // `max(1)` so the newest item is always on screen: a zero window would
         // render an empty history that the reader has no way to scroll into.
-        let start = total_items.saturating_sub(window.max(1));
+        let base = total_items.saturating_sub(window.max(1));
+        // Grow, never slide: keep the anchored start unless a backfill asked
+        // for an even earlier one. `min` also repairs an anchor past the end
+        // (messages pruned out from under it).
+        let mut start = match anchor {
+            None => base,
+            Some(prev) => prev.min(base),
+        };
+        // The ceiling on arrival growth; never on reader-requested backfill.
+        let cap = window.max(WINDOW_ITEMS_CEILING).max(1);
+        if total_items - start > cap {
+            start = total_items - cap;
+        }
         Self {
             start,
             has_older: start > 0,
@@ -1606,6 +1663,9 @@ fn scroll_history_to_bottom(
 fn install_scroll_pin_listeners(
     pinned: Rc<std::cell::Cell<bool>>,
     last_top: Rc<std::cell::Cell<i32>>,
+    window_items: Signal<usize>,
+    window_anchor: Rc<std::cell::Cell<Option<usize>>>,
+    window_overgrown: Rc<std::cell::Cell<bool>>,
 ) -> bool {
     use wasm_bindgen::prelude::*;
 
@@ -1622,6 +1682,8 @@ fn install_scroll_pin_listeners(
     let settle = {
         let pinned = pinned.clone();
         let last_top = last_top.clone();
+        let window_anchor = window_anchor.clone();
+        let window_overgrown = window_overgrown.clone();
         Closure::wrap(Box::new(move || {
             let Some(container) = chat_scroll_container() else {
                 return;
@@ -1641,6 +1703,28 @@ fn install_scroll_pin_listeners(
                 - settled_at as f64
                 - container.client_height() as f64;
             pinned.set(distance <= BOTTOM_THRESHOLD_PX);
+            // The reader's own settle landing at the bottom is the ONE moment
+            // a window trim is provably invisible: at the bottom, removing
+            // rows above the viewport shrinks `scrollHeight` and the browser
+            // clamps `scrollTop` down with it, so the same tail stays glued to
+            // the bottom edge (`reader_moved_up_since`'s
+            // `.min(max_scroll_top(..))` already treats that clamp as not the
+            // reader). Trimming anywhere else shifts content under the reader
+            // now that scroll anchoring is off, so growth accumulated while
+            // parked is bounded by `WINDOW_ITEMS_CEILING` instead of trimmed.
+            //
+            // Deferred: this runs from a raw JS callback with no Dioxus scope,
+            // and `window_items` is a signal the render subscribes to. See
+            // .claude/rules/dioxus-signal-safety.md.
+            if distance <= BOTTOM_THRESHOLD_PX && window_overgrown.get() {
+                window_overgrown.set(false);
+                let window_anchor = window_anchor.clone();
+                let mut window_items = window_items;
+                crate::util::defer(move || {
+                    window_anchor.set(None);
+                    window_items.set(INITIAL_WINDOW_ITEMS);
+                });
+            }
         }) as Box<dyn FnMut()>)
     };
     let settle_fn: js_sys::Function = settle.as_ref().unchecked_ref::<js_sys::Function>().clone();
@@ -1715,6 +1799,30 @@ pub fn Conversation() -> Element {
     // How many trailing display items the history renders. Grows only when the
     // reader reaches the top of what is rendered — see `INITIAL_WINDOW_ITEMS`.
     let mut window_items = use_signal(|| INITIAL_WINDOW_ITEMS);
+    // The start index the last render used, so arrivals GROW the window
+    // instead of sliding it (#501) — see `HistoryWindow::resolve`. A plain
+    // `Cell` written back during render: it is memory between renders, not
+    // state anything renders FROM, so there is no subscriber to notify.
+    let window_anchor = use_hook(|| Rc::new(std::cell::Cell::new(None::<usize>)));
+    // Whether the rendered window currently holds more than a fresh room-open
+    // would render — i.e. whether the bottom-settle trim in
+    // `install_scroll_pin_listeners` has anything to do. Maintained by render,
+    // read from the raw settle callback (which cannot touch signals).
+    let window_overgrown = use_hook(|| Rc::new(std::cell::Cell::new(false)));
+    // Whether the opening snap for the CURRENT room has landed. The backfill
+    // sentinel only mounts once this is true: a freshly-opened >window room
+    // renders at `scrollTop = 0` for a beat before the snap runs, and a
+    // sentinel mounted during that beat is intersecting, fires, and cascades
+    // the backfill until the whole room is rendered (#501 H2). A signal, not a
+    // `Cell`, because the sentinel's `if` in rsx renders from it.
+    let mut opening_snap_done = use_signal(|| false);
+    // Set by the room-change effect and the send path to force the next scroll
+    // regardless of the pin (#402), so a room switch or your own outgoing
+    // message always lands at the newest message. A plain `Cell`, not a
+    // signal, so reading it does not subscribe. Declared here (not next to the
+    // scroll effect that consumes it) because the backfill-restore effect
+    // below also has to stand down while a forced snap is in flight.
+    let force_scroll = use_hook(|| Rc::new(std::cell::Cell::new(false)));
     // Scroll geometry captured just before a backfill, so the view can be put
     // back on the message the reader was looking at once the older items land
     // above it. `(scroll_height, scroll_top)` at capture time; `None` when no
@@ -1754,11 +1862,20 @@ pub fn Conversation() -> Element {
     {
         let prev_windowed_room =
             use_hook(|| Rc::new(std::cell::Cell::new(None::<ed25519_dalek::VerifyingKey>)));
+        let window_anchor = window_anchor.clone();
+        let window_overgrown = window_overgrown.clone();
         use_effect(move || {
             let room = CURRENT_ROOM.read().owner_key;
             if prev_windowed_room.get() != room {
                 prev_windowed_room.set(room);
                 window_items.set(INITIAL_WINDOW_ITEMS);
+                // The anchor is an index into the PREVIOUS room's items; the
+                // new room resolves a fresh tail.
+                window_anchor.set(None);
+                window_overgrown.set(false);
+                // Re-gate the backfill sentinel until the new room's opening
+                // snap has landed (#501 H2).
+                opening_snap_done.set(false);
             }
         });
     }
@@ -1772,6 +1889,8 @@ pub fn Conversation() -> Element {
     {
         let backfill_anchor = backfill_anchor.clone();
         let last_scroll_top = last_scroll_top.clone();
+        let pinned_to_bottom = pinned_to_bottom.clone();
+        let force_scroll = force_scroll.clone();
         use_effect(move || {
             // Subscribe, so this runs after the render that added the items.
             let _ = window_items();
@@ -1780,10 +1899,22 @@ pub fn Conversation() -> Element {
             };
             let backfill_anchor = backfill_anchor.clone();
             let last_scroll_top = last_scroll_top.clone();
+            let pinned_to_bottom = pinned_to_bottom.clone();
+            let force_scroll = force_scroll.clone();
             // Deferred so the browser has laid the new rows out and
             // `scroll_height` reflects them.
             crate::util::defer(move || {
                 backfill_anchor.set(None);
+                // The restore serves a reader who is up in the history holding
+                // their place. It must never fight the bottom pin or a forced
+                // snap (#501 H3): unconditionally it could park the view at
+                // the anchor over a concurrent arrival — and because it writes
+                // `last_scroll_top`, the settle would read as OURS and the pin
+                // would quietly survive pointing somewhere the reader never
+                // asked to be.
+                if pinned_to_bottom.get() || force_scroll.get() {
+                    return;
+                }
                 let Some(container) = chat_scroll_container() else {
                     return;
                 };
@@ -2051,13 +2182,21 @@ pub fn Conversation() -> Element {
     {
         let pinned_to_bottom = pinned_to_bottom.clone();
         let last_scroll_top = last_scroll_top.clone();
+        let window_anchor = window_anchor.clone();
+        let window_overgrown = window_overgrown.clone();
         let installed = use_hook(|| Rc::new(std::cell::Cell::new(false)));
         use_effect(move || {
             let _retry_on_content_change = message_groups.read().is_some();
             if installed.get() {
                 return;
             }
-            if install_scroll_pin_listeners(pinned_to_bottom.clone(), last_scroll_top.clone()) {
+            if install_scroll_pin_listeners(
+                pinned_to_bottom.clone(),
+                last_scroll_top.clone(),
+                window_items,
+                window_anchor.clone(),
+                window_overgrown.clone(),
+            ) {
                 installed.set(true);
             }
         });
@@ -2070,11 +2209,8 @@ pub fn Conversation() -> Element {
     // leave the actual bottom (reactions, sentinel, padding) off-screen. On
     // page refresh this surfaced as scrolling only ~70% of the way down.
     //
-    // Set by the room-change effect and the send path to force the next scroll
-    // regardless of the pin (#402), so a room switch or your own outgoing
-    // message always lands at the newest message. A plain `Cell`, not a signal,
-    // so reading it here does not subscribe.
-    let force_scroll = use_hook(|| Rc::new(std::cell::Cell::new(false)));
+    // `force_scroll` (declared with the pin cells above) is what makes a room
+    // switch or your own outgoing message snap regardless of the pin (#402).
     use_effect({
         let force_scroll = force_scroll.clone();
         let pinned_to_bottom = pinned_to_bottom.clone();
@@ -2142,6 +2278,15 @@ pub fn Conversation() -> Element {
                         // still animate.
                         web_sys::ScrollBehavior::Instant,
                     );
+                    // The opening snap for this room has landed, so the
+                    // backfill sentinel may mount (#501 H2). Deferred, and the
+                    // signal is only written on the transition, so steady-state
+                    // arrivals do not re-notify the render for nothing.
+                    crate::util::defer(move || {
+                        if !*opening_snap_done.peek() {
+                            opening_snap_done.set(true);
+                        }
+                    });
                 });
             }
         }
@@ -3063,6 +3208,19 @@ pub fn Conversation() -> Element {
                     // menu content is left-aligned and stays visible) rather
                     // than show a horizontal scrollbar in the history. #402.
                     class: "h-full overflow-y-auto overflow-x-hidden",
+                    // `overflow-anchor: none`: the pin machinery owns this
+                    // container's `scrollTop`. Browser scroll anchoring rewrites
+                    // it whenever rendered rows change above the viewport (a
+                    // window trim, date-separator churn at the window head), and
+                    // `reader_moved_up_since` then attributes the browser's
+                    // adjustment to the reader and stands the follow down —
+                    // freenet/river#501. With anchoring off, `scrollTop` only
+                    // changes through our own scrolls, the reader's, or the
+                    // browser's shrink clamp, which the guard's
+                    // `.min(max_scroll_top(..))` already accounts for. Inline
+                    // style, not a Tailwind arbitrary class, so it cannot depend
+                    // on the class scanner seeing it.
+                    style: "overflow-anchor:none;",
                     id: "chat-scroll-container",
                     div { class: "max-w-4xl mx-auto px-4 py-4", id: "chat-content",
                     {
@@ -3077,8 +3235,26 @@ pub fn Conversation() -> Element {
                                     // so cloning the whole history here — on
                                     // every re-render — would pay most of the
                                     // cost the window exists to avoid.
-                                    let history_window =
-                                        HistoryWindow::resolve(groups.len(), window_items());
+                                    let requested_window = window_items();
+                                    let history_window = HistoryWindow::resolve(
+                                        groups.len(),
+                                        requested_window,
+                                        window_anchor.get(),
+                                    );
+                                    // Remember where this render started so the
+                                    // NEXT one grows instead of sliding (#501).
+                                    // A `Cell` write during render is fine: it
+                                    // is inter-render memory, nothing renders
+                                    // from it, and re-resolving with the value
+                                    // just written is a fixed point.
+                                    window_anchor.set(Some(history_window.start));
+                                    // Tell the settle handler whether a
+                                    // bottom-settle trim would shrink anything.
+                                    window_overgrown.set(
+                                        requested_window > INITIAL_WINDOW_ITEMS
+                                            || groups.len() - history_window.start
+                                                > INITIAL_WINDOW_ITEMS,
+                                    );
                                     let groups = groups[history_window.start..].to_vec();
                                     let self_member_id = *self_member_id;
                                     let member_names = member_names.clone();
@@ -3141,7 +3317,17 @@ pub fn Conversation() -> Element {
                                         // history by that much every time the
                                         // sentinel appeared or (on the last
                                         // backfill) disappeared.
-                                        if history_window.has_older {
+                                        // Gated on the opening snap having
+                                        // landed as well: a >window room's
+                                        // first render sits at `scrollTop = 0`
+                                        // until the snap runs, and a sentinel
+                                        // mounted during that beat fires from
+                                        // the top of the history and cascades
+                                        // the backfill (#501 H2). Mounting it
+                                        // after the snap means its first
+                                        // observation sees the view at the
+                                        // bottom, far below the strip.
+                                        if history_window.has_older && opening_snap_done() {
                                             // Zero-height anchor; the sentinel
                                             // inside it is absolutely
                                             // positioned, so it contributes no
@@ -4650,12 +4836,15 @@ mod tests {
     fn the_window_always_renders_the_newest_item() {
         for total in 1..200usize {
             for window in [0, 1, 2, 59, 60, 61, 199, 200, 5000] {
-                let w = HistoryWindow::resolve(total, window);
-                assert!(
-                    w.start < total,
-                    "total {total}, window {window}: start {} skips every item",
-                    w.start
-                );
+                for anchor in [None, Some(0), Some(30), Some(total)] {
+                    let w = HistoryWindow::resolve(total, window, anchor);
+                    assert!(
+                        w.start < total,
+                        "total {total}, window {window}, anchor {anchor:?}: \
+                         start {} skips every item",
+                        w.start
+                    );
+                }
             }
         }
     }
@@ -4665,7 +4854,7 @@ mod tests {
     #[test]
     fn a_room_inside_the_window_is_rendered_whole() {
         for total in 0..=INITIAL_WINDOW_ITEMS {
-            let w = HistoryWindow::resolve(total, INITIAL_WINDOW_ITEMS);
+            let w = HistoryWindow::resolve(total, INITIAL_WINDOW_ITEMS, None);
             assert_eq!(
                 w.start, 0,
                 "total {total} should render from the first item"
@@ -4678,18 +4867,77 @@ mod tests {
     /// counts here are the live "Off Topic" room's shape.
     #[test]
     fn a_room_past_the_window_renders_only_its_tail() {
-        let w = HistoryWindow::resolve(1133, INITIAL_WINDOW_ITEMS);
+        let w = HistoryWindow::resolve(1133, INITIAL_WINDOW_ITEMS, None);
         assert_eq!(w.start, 1133 - INITIAL_WINDOW_ITEMS);
         assert!(w.has_older, "1133 items must offer a backfill");
 
-        // Each backfill reveals exactly one growth step more...
-        let grown = HistoryWindow::resolve(1133, INITIAL_WINDOW_ITEMS + WINDOW_GROWTH_ITEMS);
+        // Each backfill reveals exactly one growth step more... (the anchor is
+        // carried the way the render carries it, and moving it BACK for a
+        // backfill is allowed — only forward movement is the #501 slide)
+        let grown = HistoryWindow::resolve(
+            1133,
+            INITIAL_WINDOW_ITEMS + WINDOW_GROWTH_ITEMS,
+            Some(w.start),
+        );
         assert_eq!(w.start - grown.start, WINDOW_GROWTH_ITEMS);
 
         // ...until the window covers the room, at which point the sentinel goes.
-        let all = HistoryWindow::resolve(1133, 1133);
+        let all = HistoryWindow::resolve(1133, 1133, Some(grown.start));
         assert_eq!(all.start, 0);
         assert!(!all.has_older);
+    }
+
+    /// Arrivals GROW an anchored window instead of sliding it (#501): with the
+    /// reader pinned to the bottom, the start index stays put as the total
+    /// climbs, so nothing is removed above the viewport in the same patch that
+    /// appends below it.
+    #[test]
+    fn arrivals_grow_an_anchored_window_instead_of_sliding_it() {
+        let opened = HistoryWindow::resolve(100, INITIAL_WINDOW_ITEMS, None);
+        assert_eq!(opened.start, 40);
+
+        let mut anchor = Some(opened.start);
+        for arrivals in 1..=50usize {
+            let w = HistoryWindow::resolve(100 + arrivals, INITIAL_WINDOW_ITEMS, anchor);
+            assert_eq!(
+                w.start, opened.start,
+                "arrival {arrivals} slid the window instead of growing it"
+            );
+            anchor = Some(w.start);
+        }
+    }
+
+    /// The trim — the settle handler clearing the anchor and resetting the
+    /// requested window once the reader's own settle lands at the bottom —
+    /// resolves back to the plain tail.
+    #[test]
+    fn a_trim_resolves_back_to_the_plain_tail() {
+        // 40 arrivals grew the anchored window to 100 rendered items...
+        let grown = HistoryWindow::resolve(140, INITIAL_WINDOW_ITEMS, Some(40));
+        assert_eq!(grown.start, 40);
+        // ...and the trim (anchor cleared, window back to INITIAL) collapses
+        // it to the newest INITIAL_WINDOW_ITEMS.
+        let trimmed = HistoryWindow::resolve(140, INITIAL_WINDOW_ITEMS, None);
+        assert_eq!(trimmed.start, 140 - INITIAL_WINDOW_ITEMS);
+        assert!(trimmed.has_older);
+    }
+
+    /// The ceiling bounds what arrival growth can accumulate — a reader pinned
+    /// through a very long burst must not re-accumulate the unbounded render
+    /// the window exists to prevent — but it NEVER caps a reader-requested
+    /// backfill, which would dead-end paging through history.
+    #[test]
+    fn the_ceiling_caps_arrival_growth_but_never_reader_backfill() {
+        // Anchored at 100 while the room ran away to 1000 items: capped.
+        let w = HistoryWindow::resolve(1000, INITIAL_WINDOW_ITEMS, Some(100));
+        assert_eq!(w.start, 1000 - WINDOW_ITEMS_CEILING);
+        assert!(w.has_older);
+
+        // A reader who backfilled PAST the ceiling keeps everything they asked
+        // for: the requested window wins over the ceiling.
+        let requested = WINDOW_ITEMS_CEILING + WINDOW_GROWTH_ITEMS;
+        let w = HistoryWindow::resolve(1000, requested, Some(1000 - requested));
+        assert_eq!(w.start, 1000 - requested);
     }
 
     /// Source-grep pin: the history must render through the window. Rendering
@@ -4705,8 +4953,18 @@ mod tests {
         let squashed: String = prod.chars().filter(|c| !c.is_whitespace()).collect();
 
         assert!(
-            squashed.contains("HistoryWindow::resolve(groups.len(),window_items())"),
+            squashed.contains("HistoryWindow::resolve(groups.len(),requested_window,"),
             "the history must slice its display items through `HistoryWindow`"
+        );
+        assert!(
+            squashed.contains("window_anchor.get(),)"),
+            "the resolve must carry the previous render's start (the anchor) — \
+             without it every arrival slides the window, which is #501"
+        );
+        assert!(
+            squashed.contains("window_anchor.set(Some(history_window.start));"),
+            "the render must write the resolved start back so the NEXT render \
+             grows instead of sliding (#501)"
         );
         assert!(
             squashed.contains("groups[history_window.start..].to_vec()"),
@@ -7124,6 +7382,52 @@ mod autoscroll_wiring_pins {
             "the resize follow must watch BOTH the content wrapper and the \
              scroll container; watching only the wrapper misses the composer \
              taking height away from the history"
+        );
+    }
+
+    /// The scroll container must opt out of browser scroll anchoring (#501).
+    /// With anchoring on, any change to rendered rows above the viewport (a
+    /// window trim, date-separator churn) makes the browser rewrite
+    /// `scrollTop` behind the pin machinery's back, and
+    /// `reader_moved_up_since` attributes the browser's adjustment to the
+    /// reader — which is exactly how the windowed tail latched the follow.
+    #[test]
+    fn the_scroll_container_disables_scroll_anchoring() {
+        let dense: String = production_source()
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+        assert!(
+            dense.contains(concat!("style:\"overflow-", "anchor:none;\"")),
+            "#chat-scroll-container must set `overflow-anchor: none` — browser \
+             scroll anchoring rewriting scrollTop is #501's H1"
+        );
+    }
+
+    /// The #501 windowing contract: trims happen at the reader's own
+    /// bottom-settle (the one place they are invisible), the backfill restore
+    /// stands down while the view is pinned or a forced snap is in flight
+    /// (H3), and the backfill sentinel waits for the opening snap (H2).
+    /// Each of these is a one-line edit away from silently reverting, and none
+    /// of them is visible to `cargo test` except through these pins.
+    #[test]
+    fn the_window_trims_at_the_bottom_and_backfill_defers_to_the_pin() {
+        let prod = production_source();
+        let dense: String = prod.chars().filter(|c| !c.is_whitespace()).collect();
+        assert!(
+            dense.contains("ifdistance<=BOTTOM_THRESHOLD_PX&&window_overgrown.get()"),
+            "the settle handler must trim the grown window when the reader's \
+             own settle lands at the bottom"
+        );
+        assert!(
+            dense.contains("ifpinned_to_bottom.get()||force_scroll.get(){return;}"),
+            "the backfill restore must stand down while the view is pinned to \
+             the bottom or a forced snap is in flight (#501 H3)"
+        );
+        assert!(
+            dense.contains("ifhistory_window.has_older&&opening_snap_done()"),
+            "the backfill sentinel must not mount until the room-open snap has \
+             landed (#501 H2)"
         );
     }
 }

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1972,6 +1972,7 @@ fn install_scroll_pin_listeners(
     window_anchor: Rc<std::cell::RefCell<Option<WindowAnchor>>>,
     window_overgrown: Rc<std::cell::Cell<bool>>,
     window_rendered: Rc<std::cell::Cell<usize>>,
+    trim_landed: Rc<std::cell::Cell<bool>>,
 ) -> bool {
     use wasm_bindgen::prelude::*;
 
@@ -1990,6 +1991,7 @@ fn install_scroll_pin_listeners(
         let last_top = last_top.clone();
         let window_anchor = window_anchor.clone();
         let window_overgrown = window_overgrown.clone();
+        let trim_landed = trim_landed.clone();
         Closure::wrap(Box::new(move || {
             let Some(container) = chat_scroll_container() else {
                 return;
@@ -2043,6 +2045,16 @@ fn install_scroll_pin_listeners(
                 window_overgrown.set(false);
                 let window_anchor = window_anchor.clone();
                 let mut window_items = window_items;
+                // The trim removes rows ABOVE a view that is at the bottom, so
+                // the browser clamps `scrollTop` down by their height. That
+                // clamp is OURS, but `last_scroll_top` still holds the
+                // pre-trim bottom, so an arrival that grows the content back
+                // before the clamp's settle lands makes
+                // `reader_moved_up_since` read the clamp as the reader
+                // scrolling up — and the follow stands down, leaving them a
+                // row short of the newest message. Flagged here and repaired
+                // by the effect that watches `window_items`.
+                trim_landed.set(true);
                 crate::util::defer(move || {
                     *window_anchor.borrow_mut() = None;
                     window_items.set(INITIAL_WINDOW_ITEMS);
@@ -2143,6 +2155,10 @@ pub fn Conversation() -> Element {
     // `install_scroll_pin_listeners` has anything to do. Maintained by render,
     // read from the raw settle callback (which cannot touch signals).
     let window_overgrown = use_hook(|| Rc::new(std::cell::Cell::new(false)));
+    // Set when the settle handler schedules a trim, cleared once the view has
+    // been re-anchored to the bottom afterwards. See the trim site in
+    // `install_scroll_pin_listeners` for why the re-anchor is required.
+    let trim_landed = use_hook(|| Rc::new(std::cell::Cell::new(false)));
     // A pending "keep the parked reader's view still" adjustment: when a
     // render swaps the window head for a LATER item (the head was pruned out
     // from under the anchor, or a ceiling trim dropped it), the rows above
@@ -2202,6 +2218,7 @@ pub fn Conversation() -> Element {
             *window_anchor.borrow_mut() = None;
             window_rendered.set(0);
             window_overgrown.set(false);
+            trim_landed.set(false);
             *reposition_pending.borrow_mut() = None;
             // A capture from the OLD room's geometry must not restore into
             // the new room (#505 re-review).
@@ -2252,6 +2269,37 @@ pub fn Conversation() -> Element {
                 // snap has landed (#501 H2).
                 opening_snap_done.set(false);
             }
+        });
+    }
+
+    // Re-anchor to the bottom after a TRIM. The trim only ever runs from a
+    // settle that landed at the bottom, so "at the bottom" is where the view
+    // belongs afterwards — but the rows it removes are ABOVE the viewport, so
+    // the browser clamps `scrollTop` down by their height while
+    // `last_scroll_top` still holds the pre-trim bottom. Left alone, that gap
+    // reads as the reader having scrolled up (`reader_moved_up_since`), and
+    // an arrival landing before the clamp's settle is NOT followed — the
+    // reader sits a row short of the newest message, and a taller row would
+    // push them past `BOTTOM_THRESHOLD_PX` and clear the pin for good.
+    // Routing through `scroll_history_to_bottom` fixes both halves: it puts
+    // the view on the bottom and records that offset as ours.
+    #[cfg(target_arch = "wasm32")]
+    {
+        let trim_landed = trim_landed.clone();
+        let pinned_to_bottom = pinned_to_bottom.clone();
+        let last_scroll_top = last_scroll_top.clone();
+        use_effect(move || {
+            // Subscribe, so this runs after the render the trim caused.
+            let _ = window_items();
+            if !trim_landed.get() {
+                return;
+            }
+            trim_landed.set(false);
+            scroll_history_to_bottom(
+                &pinned_to_bottom,
+                &last_scroll_top,
+                web_sys::ScrollBehavior::Instant,
+            );
         });
     }
 
@@ -2575,6 +2623,7 @@ pub fn Conversation() -> Element {
         let window_anchor = window_anchor.clone();
         let window_overgrown = window_overgrown.clone();
         let window_rendered = window_rendered.clone();
+        let trim_landed = trim_landed.clone();
         let installed = use_hook(|| Rc::new(std::cell::Cell::new(false)));
         use_effect(move || {
             let _retry_on_content_change = message_groups.read().is_some();
@@ -2588,6 +2637,7 @@ pub fn Conversation() -> Element {
                 window_anchor.clone(),
                 window_overgrown.clone(),
                 window_rendered.clone(),
+                trim_landed.clone(),
             ) {
                 installed.set(true);
             }
@@ -8398,6 +8448,17 @@ mod autoscroll_wiring_pins {
             dense.contains("ifdistance<=SCROLL_TOP_SLACK_PXasf64&&window_overgrown.get()"),
             "the settle handler must trim the grown window when a settle — \
              the reader's or ours — lands at the exact bottom"
+        );
+        assert!(
+            dense.contains("trim_landed.set(true);"),
+            "a trim must flag itself so the view is re-anchored to the bottom \
+             afterwards: the rows it removes are above the viewport, and the \
+             browser's clamp otherwise reads as the reader scrolling up, so \
+             the next arrival is not followed"
+        );
+        assert!(
+            dense.contains("if!trim_landed.get(){return;}"),
+            "the re-anchor effect must consume the trim flag"
         );
         assert!(
             dense.contains("&&!trim_would_rearm_backfill("),

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1825,9 +1825,10 @@ fn first_history_row_offset(keys: &[String]) -> Option<(String, i32)> {
     let container = chat_scroll_container()?;
     let rows = container.query_selector_all("[data-item-key]").ok()?;
     // Candidate key -> offsetTop. Bounded by `keys.len()`, not by the rendered
-    // window: measuring every row would cost an `offsetTop` and a `String`
-    // allocation per row (up to the ceiling, 240) on a path that runs per
-    // arrival in an at-cap room.
+    // window: measuring every row cost an `offsetTop` and a map insert per row
+    // (up to the ceiling, 240) on a path that runs per arrival in an at-cap
+    // room. The `String` per row is NOT saved — `get_attribute` allocates one
+    // either way; what this avoids is the layout read and the insert.
     let mut present: std::collections::HashMap<String, i32> = std::collections::HashMap::new();
     for i in 0..rows.length() {
         if present.len() == keys.len() {
@@ -2054,9 +2055,13 @@ fn install_scroll_pin_listeners(
                 // scrolling up — and the follow stands down, leaving them a
                 // row short of the newest message. Flagged here and repaired
                 // by the effect that watches `window_items`.
-                trim_landed.set(true);
+                let trim_landed = trim_landed.clone();
                 crate::util::defer(move || {
                     *window_anchor.borrow_mut() = None;
+                    // Raised in the SAME task as the write it describes, so
+                    // no other `window_items` writer can run between the two
+                    // and consume a flag meant for this trim.
+                    trim_landed.set(true);
                     window_items.set(INITIAL_WINDOW_ITEMS);
                 });
             }
@@ -2172,8 +2177,12 @@ pub fn Conversation() -> Element {
     // clamps `scrollTop` down on its own when a patch shortens the content,
     // and it does so BEFORE the effect runs: computing the target from the
     // post-clamp offset would apply the shift on top of the clamp and
-    // over-shift the reader (#505 delta review). Capture and effect run in
-    // the same task, so the captured offset cannot go stale.
+    // over-shift the reader (#505 delta review). This is a TRADE, not a
+    // strict improvement — a live read is immune to the reader scrolling
+    // between render and effect, a captured one is immune to the browser's
+    // clamp. The clamp is the far more frequent hazard here (every
+    // head-removing patch that shortens the content), and `BackfillAnchor`
+    // already captures its offset even earlier for the same reason.
     let reposition_pending =
         use_hook(|| Rc::new(std::cell::RefCell::new(None::<(String, i32, i32)>)));
     // The backfill sentinel's capture, consumed by the restore effect. See
@@ -2295,6 +2304,24 @@ pub fn Conversation() -> Element {
                 return;
             }
             trim_landed.set(false);
+            let Some(container) = chat_scroll_container() else {
+                return;
+            };
+            // The trim fired from a settle AT the bottom, but this effect runs
+            // a task later — long enough on a mid-range phone for the reader
+            // to have started swiping up. Re-anchoring then yanks them back,
+            // re-arms the pin, and records their position as ours, so their
+            // own `scrollend` is discarded and nothing self-corrects inside
+            // the gesture. Both halves are needed and neither subsumes the
+            // other: the pin catches a reader whose settle beat this effect,
+            // the distance catches one still inside the pre-settle window.
+            // Same shape as the arrival snap's gate.
+            if !pinned_to_bottom.get()
+                || (max_scroll_top(&container) - container.scroll_top()) as f64
+                    > BOTTOM_THRESHOLD_PX
+            {
+                return;
+            }
             scroll_history_to_bottom(
                 &pinned_to_bottom,
                 &last_scroll_top,
@@ -8459,6 +8486,42 @@ mod autoscroll_wiring_pins {
         assert!(
             dense.contains("if!trim_landed.get(){return;}"),
             "the re-anchor effect must consume the trim flag"
+        );
+        // Consuming the flag is not the repair — SCROLLING is. Deleting the
+        // scroll call leaves the assertions above passing with the fix gone,
+        // so the repair itself is pinned here.
+        assert!(
+            dense.contains("trim_landed.set(false);letSome(container)=chat_scroll_container()"),
+            "the re-anchor effect must go on to measure the container after \
+             consuming the flag"
+        );
+        assert!(
+            dense.contains(
+                "if!pinned_to_bottom.get()||(max_scroll_top(&container)-container.scroll_top())asf64>BOTTOM_THRESHOLD_PX"
+            ),
+            "the re-anchor must stand down for a reader who has started \
+             moving inside the flag-to-effect window — it is otherwise the \
+             one unguarded programmatic scroll in the file"
+        );
+        assert_eq!(
+            dense
+                .matches(
+                    "scroll_history_to_bottom(&pinned_to_bottom,&last_scroll_top,web_sys::ScrollBehavior::Instant,);"
+                )
+                .count(),
+            2,
+            "both the arrival snap and the trim re-anchor must scroll through \
+             `scroll_history_to_bottom`, which is what records the offset as \
+             ours; consuming the trim flag without scrolling silently reverts \
+             the fix"
+        );
+        // Without the read the effect never re-runs — it would fire once at
+        // mount and then go silent, which no other assertion can see.
+        assert_eq!(
+            dense.matches("let_=window_items();").count(),
+            2,
+            "the trim re-anchor and the backfill restore must each subscribe \
+             to `window_items`"
         );
         assert!(
             dense.contains("&&!trim_would_rearm_backfill("),

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1490,27 +1490,48 @@ struct HistoryWindow {
 /// set fixed in identity no matter how the indices shift underneath it.
 #[derive(Clone, PartialEq, Debug)]
 struct WindowAnchor {
-    /// `display_item_key` of the item the window started at.
-    key: String,
-    /// The index that item held last render — a hint so relocation is O(shift),
-    /// not O(total), in the common case, and the positional fallback when the
-    /// item is gone entirely.
+    /// `display_item_key` of the first [`WINDOW_ANCHOR_KEYS`] rendered items,
+    /// head first. The spares exist because the head key alone can vanish
+    /// while its NEIGHBORS survive: an at-cap drain that consumes the head
+    /// (or only its first message — a multi-message head group RE-KEYS, since
+    /// a group's key is its first message's id), or a batched delta draining
+    /// many items at once. The first spare still present tells us exactly
+    /// where the surviving remainder of the old window now sits.
+    keys: Vec<String>,
+    /// The index the head held last render — a hint so relocation is
+    /// O(shift), not O(total), in the common case.
     index: usize,
 }
 
-/// Re-locate the anchored head item after the item list changed.
+/// How many leading item keys the anchor remembers (head + spares).
+///
+/// Bounds how large a head-consuming removal can be precisely relocated: a
+/// front drain that consumes the head and ALL spares falls back to index 0,
+/// which for a front-contiguous drain — the only mechanism that can remove
+/// this many contiguous leading items — is exactly the nearest surviving
+/// item anyway.
+const WINDOW_ANCHOR_KEYS: usize = 8;
+
+/// Where the anchored window starts after the item list changed.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+struct RelocatedWindow {
+    /// Start index for the resolve: the head's new position when it survived,
+    /// otherwise derived from the first surviving spare (its position minus
+    /// its offset in the anchor), otherwise 0.
+    start: usize,
+    /// Whether the HEAD itself survived under its own key. False means the
+    /// pre-patch head row is gone or re-keyed, so rendered content above (or
+    /// at) the new head changed and a parked reader needs the measured
+    /// reposition.
+    head_survived: bool,
+}
+
+/// Search for one anchored key after the item list changed.
 ///
 /// Front prunes shift every surviving index DOWN, so the hint is checked
 /// first, then the indices below it, then (for completeness — a merge can
-/// insert older history above the head) the indices above. `None` means the
-/// key is gone entirely — the head itself was drained, or its whole group was
-/// deleted. The caller then falls back to the POSITION: for a front prune
-/// that consumed the head, the hint (having marched to ~0 with the shifts) is
-/// the nearest surviving item — everything between the new index 0 and the
-/// old head was pruned with it — and for a mid-window deletion it is off by
-/// at most the deleted item. Either way the `head_reposition` effect
-/// compensates the parked reader's offset for whatever content the swap
-/// removed.
+/// insert older history above the head) the indices above. `None` means this
+/// key is gone entirely.
 fn relocate_anchor(total: usize, hint: usize, is_anchor: impl Fn(usize) -> bool) -> Option<usize> {
     if hint < total && is_anchor(hint) {
         return Some(hint);
@@ -1519,6 +1540,134 @@ fn relocate_anchor(total: usize, hint: usize, is_anchor: impl Fn(usize) -> bool)
         return Some(i);
     }
     (hint.saturating_add(1)..total).find(|&i| is_anchor(i))
+}
+
+/// Re-locate the anchored window: the head by its own key, else by the first
+/// surviving spare, else index 0 (a front-contiguous drain consumed the head
+/// and every spare, so the oldest remaining item IS the nearest survivor).
+///
+/// The `head_reposition` effect measures and compensates a parked reader for
+/// the FRONT-CONTIGUOUS removals this relocation deals in (at-cap drains,
+/// batched or not, including a re-keyed multi-message head group). It does
+/// NOT make every removal invisible: a bulk MID-window removal (a ban purge)
+/// or late-loading media above the viewport still shifts a parked reader —
+/// tracked as follow-up work, not covered here.
+fn relocate_window(
+    total: usize,
+    anchor: &WindowAnchor,
+    key_at: impl Fn(usize, &str) -> bool,
+) -> RelocatedWindow {
+    for (spare, key) in anchor.keys.iter().enumerate() {
+        let located = relocate_anchor(total, anchor.index + spare, |i| key_at(i, key));
+        if let Some(i) = located {
+            return RelocatedWindow {
+                start: i.saturating_sub(spare),
+                head_survived: spare == 0,
+            };
+        }
+    }
+    RelocatedWindow {
+        start: 0,
+        head_survived: false,
+    }
+}
+
+/// How many rows past the window head the reposition capture will probe for a
+/// row that exists in the PRE-patch DOM.
+///
+/// The new head itself may have no pre-patch row to measure: a multi-message
+/// head group whose first message was drained RE-KEYS (a group's key is its
+/// first message's id), so its new key is in no pre-patch row and a
+/// head-only probe dead-fires — the parked reader then crawls one intra-group
+/// line per arrival (#505 re-review blocker). For a front-contiguous removal
+/// every surviving row at or below the head shifts by the same amount, so ANY
+/// nearby surviving row measures the shift exactly; a handful of candidates
+/// is plenty (one re-keyed head plus a couple of simultaneously-drained
+/// neighbors).
+#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+const REPOSITION_PROBE_ROWS: usize = 4;
+
+/// Pick the row the reposition will measure: the first of the leading
+/// `REPOSITION_PROBE_ROWS` post-patch keys that has a PRE-patch row (i.e.
+/// `pre_patch_offset_of` returns its current `offsetTop`).
+///
+/// Only the wasm render path calls this at runtime; natively it is exercised
+/// by the unit tests, hence the targeted allow rather than a cfg that would
+/// hide it from them.
+#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+fn select_reposition_probe(
+    keys_from_head: impl Iterator<Item = String>,
+    pre_patch_offset_of: impl Fn(&str) -> Option<i32>,
+) -> Option<(String, i32)> {
+    keys_from_head
+        .take(REPOSITION_PROBE_ROWS)
+        .find_map(|key| pre_patch_offset_of(&key).map(|top| (key, top)))
+}
+
+/// Does `key` identify `item`, without allocating a key `String`?
+///
+/// The relocation walk compares keys against up to every item on a miss;
+/// building a `String` per probe made that O(total) allocations per render at
+/// the at-cap steady state (#505 re-review).
+fn display_item_key_matches(item: &DisplayItem, key: &str) -> bool {
+    match item {
+        DisplayItem::Messages(group) => group.messages[0].id == key,
+        DisplayItem::Event(summary) => summary.id == key,
+    }
+}
+
+/// What the backfill sentinel captures just before growing the window, so the
+/// restore can put the reader back on the row they were looking at.
+#[derive(Clone, PartialEq, Debug)]
+struct BackfillAnchor {
+    /// `data-item-key` of the head row at capture time. It survives the
+    /// backfill (revealed rows land ABOVE it), and its `offsetTop` shift
+    /// measures EXACTLY the height prepended above the viewport — unlike the
+    /// raw `scrollHeight` delta, which also counts content appended BELOW the
+    /// viewport when an arrival batches into the same patch, over-shifting
+    /// the reader by that content's height (#505 re-review).
+    probe_key: String,
+    /// The probe row's `offsetTop` at capture time.
+    probe_top: i32,
+    /// `scrollTop` at capture time.
+    scroll_top: i32,
+    /// `scrollHeight` at capture time — the fallback delta if the probe row
+    /// vanishes in the same patch (an at-cap drain re-keying it; rare).
+    scroll_height: i32,
+}
+
+/// Extra estimated px the retained tail must clear beyond "sentinel exactly
+/// out of range" before a bottom-settle trim is allowed. Absorbs the error in
+/// estimating the trimmed height from the average row height.
+#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+const TRIM_HEADROOM_PX: f64 = 200.0;
+
+/// Would trimming the rendered window down to `target` items leave the
+/// backfill sentinel strip inside the bottom viewport?
+///
+/// At the bottom, the sentinel strip `[0, BACKFILL_LEAD_PX]` intersects the
+/// viewport iff `content_height < client_height + BACKFILL_LEAD_PX`. A tail
+/// short enough for that (browser zoom-out, a tall portrait monitor over a
+/// modest window) would re-fire the backfill the moment the trim lands:
+/// grow → snap → settle → trim → grow, a silent render loop at full speed
+/// (#505 re-review). The settle handler skips the trim when the retained
+/// tail's ESTIMATED height (current height scaled by the retained fraction)
+/// would sit within the strip's reach; the window then simply stays grown,
+/// bounded by the ceiling as ever.
+/// Only the wasm settle handler calls this at runtime; natively it is
+/// exercised by the unit tests, hence the targeted allow.
+#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+fn trim_would_rearm_backfill(
+    scroll_height: i32,
+    client_height: i32,
+    rendered: usize,
+    target: usize,
+) -> bool {
+    if rendered == 0 || target >= rendered {
+        return false;
+    }
+    let estimated_tail = scroll_height as f64 * target as f64 / rendered as f64;
+    estimated_tail < client_height as f64 + BACKFILL_LEAD_PX as f64 + TRIM_HEADROOM_PX
 }
 
 /// The requested window size after one backfill growth step.
@@ -1643,6 +1792,18 @@ fn history_row_offset_top(key: &str) -> Option<i32> {
     None
 }
 
+/// The first history row carrying a `data-item-key` — the current window head
+/// item's row — as `(key, offsetTop)`. The backfill capture probes it.
+#[cfg(target_arch = "wasm32")]
+fn first_history_row_identity() -> Option<(String, i32)> {
+    use wasm_bindgen::JsCast;
+    let container = chat_scroll_container()?;
+    let el = container.query_selector("[data-item-key]").ok()??;
+    let key = el.get_attribute("data-item-key")?;
+    let html = el.dyn_ref::<web_sys::HtmlElement>()?;
+    Some((key, html.offset_top()))
+}
+
 /// Slack for comparing one scroll offset against another.
 ///
 /// `scrollTop` is fractional in every engine while `Element::scroll_top`
@@ -1754,6 +1915,7 @@ fn install_scroll_pin_listeners(
     window_items: Signal<usize>,
     window_anchor: Rc<std::cell::RefCell<Option<WindowAnchor>>>,
     window_overgrown: Rc<std::cell::Cell<bool>>,
+    window_rendered: Rc<std::cell::Cell<usize>>,
 ) -> bool {
     use wasm_bindgen::prelude::*;
 
@@ -1804,12 +1966,24 @@ fn install_scroll_pin_listeners(
             // (#505 review). Gated at SCROLL_TOP_SLACK_PX, not
             // BOTTOM_THRESHOLD_PX: a reader parked up to 100px above the
             // bottom still counts as pinned, and a trim from there would
-            // clamp their offset to the exact bottom — a visible yank.
+            // clamp their offset to the exact bottom — a visible yank. And
+            // skipped entirely when the trimmed tail would leave the backfill
+            // sentinel in range of the bottom viewport — trimming then
+            // re-fires the backfill and the two oscillate at render speed
+            // (#505 re-review; see `trim_would_rearm_backfill`).
             //
             // Deferred: this runs from a raw JS callback with no Dioxus scope,
             // and `window_items` is a signal the render subscribes to. See
             // .claude/rules/dioxus-signal-safety.md.
-            if distance <= SCROLL_TOP_SLACK_PX as f64 && window_overgrown.get() {
+            if distance <= SCROLL_TOP_SLACK_PX as f64
+                && window_overgrown.get()
+                && !trim_would_rearm_backfill(
+                    container.scroll_height(),
+                    container.client_height(),
+                    window_rendered.get(),
+                    INITIAL_WINDOW_ITEMS,
+                )
+            {
                 window_overgrown.set(false);
                 let window_anchor = window_anchor.clone();
                 let mut window_items = window_items;
@@ -1917,10 +2091,15 @@ pub fn Conversation() -> Element {
     // render swaps the window head for a LATER item (the head was pruned out
     // from under the anchor, or a ceiling trim dropped it), the rows above
     // the viewport shrink, and with scroll anchoring disabled nothing
-    // compensates. The render captures the NEW head's pre-patch `offsetTop`
-    // here; the `head_reposition` effect below re-measures it after the patch
-    // and shifts `scrollTop` by the difference. `(key, pre_patch_offset_top)`.
+    // compensates. The render captures a surviving row's pre-patch
+    // `offsetTop` here (see `select_reposition_probe`); the `head_reposition`
+    // effect below re-measures it after the patch and shifts `scrollTop` by
+    // the difference. `(key, pre_patch_offset_top)`.
     let reposition_pending = use_hook(|| Rc::new(std::cell::RefCell::new(None::<(String, i32)>)));
+    // The backfill sentinel's capture, consumed by the restore effect. See
+    // `BackfillAnchor`. Not `cfg`-gated — the sentinel's handler is compiled
+    // on every target, only the DOM reads inside it are wasm-only.
+    let backfill_anchor = use_hook(|| Rc::new(std::cell::RefCell::new(None::<BackfillAnchor>)));
     // Whether the opening snap for the CURRENT room has landed. The backfill
     // sentinel only mounts once this is true: a freshly-opened >window room
     // renders at `scrollTop = 0` for a beat before the snap runs, and a
@@ -1960,17 +2139,12 @@ pub fn Conversation() -> Element {
             window_rendered.set(0);
             window_overgrown.set(false);
             *reposition_pending.borrow_mut() = None;
+            // A capture from the OLD room's geometry must not restore into
+            // the new room (#505 re-review).
+            *backfill_anchor.borrow_mut() = None;
         }
         changed
     };
-    // Scroll geometry captured just before a backfill, so the view can be put
-    // back on the message the reader was looking at once the older items land
-    // above it. `(scroll_height, scroll_top)` at capture time; `None` when no
-    // backfill is in flight. A plain `Cell` for the same reason
-    // `pinned_to_bottom` is one: nothing renders from it. Not `cfg`-gated —
-    // the sentinel's handler is compiled on every target, only the DOM reads
-    // inside it are wasm-only.
-    let backfill_anchor = use_hook(|| Rc::new(std::cell::Cell::new(None::<(i32, i32)>)));
 
     // "The reader wants to stay with the newest message." Plain `Cell`s, not
     // signals: they are written from raw JS event callbacks that run with no
@@ -2031,10 +2205,9 @@ pub fn Conversation() -> Element {
         use_effect(move || {
             // Subscribe, so this runs after the render that added the items.
             let _ = window_items();
-            let Some((prev_height, prev_top)) = backfill_anchor.get() else {
+            let Some(anchor) = backfill_anchor.borrow_mut().take() else {
                 return;
             };
-            backfill_anchor.set(None);
             // The restore serves a reader who is up in the history holding
             // their place. It must never fight the bottom pin or a forced
             // snap (#501 H3): unconditionally it could park the view at
@@ -2055,14 +2228,24 @@ pub fn Conversation() -> Element {
                 return;
             };
             // Synchronous, not deferred: Dioxus has already patched the DOM
-            // when effects run, and reading `scroll_height` forces the layout
-            // the restore needs. A macrotask hop here let the browser paint
-            // one frame of the prepended rows at the wrong offset before the
+            // when effects run, and reading layout here forces the reflow the
+            // restore needs. A macrotask hop let the browser paint one frame
+            // of the prepended rows at the wrong offset before the
             // reposition landed — a flicker native scroll anchoring used to
             // mask (#505 review).
-            let grew_by = container.scroll_height() - prev_height;
-            if grew_by > 0 {
-                let target = prev_top + grew_by;
+            //
+            // MEASURED, not height-delta'd: the probed head row's `offsetTop`
+            // shift is exactly the height prepended ABOVE the viewport. The
+            // raw `scrollHeight` delta also counts an arrival batched into
+            // the same patch BELOW the viewport, and over-shifts the reader
+            // by its height (#505 re-review). The delta method survives only
+            // as the fallback for a probe row pruned in the same patch.
+            let shift = match history_row_offset_top(&anchor.probe_key) {
+                Some(post_top) => post_top - anchor.probe_top,
+                None => container.scroll_height() - anchor.scroll_height,
+            };
+            if shift > 0 {
+                let target = anchor.scroll_top + shift;
                 // Record the offset we asked for BEFORE asking for it, the
                 // same contract `scroll_history_to_bottom` keeps: the
                 // settle handler decides whose scroll a settle was by
@@ -2325,6 +2508,7 @@ pub fn Conversation() -> Element {
         let last_scroll_top = last_scroll_top.clone();
         let window_anchor = window_anchor.clone();
         let window_overgrown = window_overgrown.clone();
+        let window_rendered = window_rendered.clone();
         let installed = use_hook(|| Rc::new(std::cell::Cell::new(false)));
         use_effect(move || {
             let _retry_on_content_change = message_groups.read().is_some();
@@ -2337,6 +2521,7 @@ pub fn Conversation() -> Element {
                 window_items,
                 window_anchor.clone(),
                 window_overgrown.clone(),
+                window_rendered.clone(),
             ) {
                 installed.set(true);
             }
@@ -2349,11 +2534,15 @@ pub fn Conversation() -> Element {
     // dropped it (#505 review, blocker 1). Rows above the viewport shrink,
     // and with `overflow-anchor: none` the browser no longer compensates, so
     // this effect is the one piece of scroll anchoring reimplemented under
-    // our own control: the render captured the NEW head row's `offsetTop`
-    // BEFORE the patch (into `reposition_pending`); re-measuring it after the
-    // patch gives exactly how far the content above the viewport shifted,
-    // date-separator churn included. Synchronous — post-patch, pre-paint —
-    // for the same no-flicker reason as the backfill restore above.
+    // our own control: the render captured a SURVIVING row's `offsetTop`
+    // BEFORE the patch (into `reposition_pending` — the new head row when it
+    // already existed, else the first row after it that did, since a
+    // re-keyed multi-message head group has no pre-patch row under its new
+    // key; see `select_reposition_probe`). Re-measuring it after the patch
+    // gives exactly how far the content above the viewport shifted,
+    // date-separator churn included — top-contiguous removals shift every
+    // surviving row identically. Synchronous — post-patch, pre-paint — for
+    // the same no-flicker reason as the backfill restore above.
     //
     // Known limitation, deliberately accepted: a mid-window removal (a
     // deletion, a ban purge) or late-loading media above the viewport still
@@ -2385,6 +2574,19 @@ pub fn Conversation() -> Element {
             let Some(container) = chat_scroll_container() else {
                 return;
             };
+            // The scroll-to-latest button's SMOOTH scroll is the one animated
+            // scroll in the app, and while it is in flight the state reads
+            // exactly like a parked reader (pinned, position above the
+            // recorded target). Its recorded target is the bottom — so when
+            // `last_scroll_top` already points at the maximum, a scrollTop
+            // write here would cancel that animation mid-flight for a reader
+            // who is headed to the bottom anyway (#505 re-review). Trade-off,
+            // documented: a parked reader whose content SHRANK enough to pull
+            // `max_scroll_top` under their recorded offset skips one
+            // compensation; the next settle re-records and re-arms.
+            if last_scroll_top.get() >= max_scroll_top(&container) {
+                return;
+            }
             let Some(post_top) = history_row_offset_top(&key) else {
                 return;
             };
@@ -3452,60 +3654,70 @@ pub fn Conversation() -> Element {
                                     } else {
                                         subscribed_window
                                     };
-                                    // Re-locate the anchored head by IDENTITY:
-                                    // at-cap pruning shifts every index, so the
-                                    // stored index is only a hint (#505
-                                    // blocker 1; see `WindowAnchor`).
+                                    // Re-locate the anchored window by
+                                    // IDENTITY: at-cap pruning shifts every
+                                    // index, so the stored index is only a
+                                    // hint, and the head key alone can vanish
+                                    // while its neighbors survive (#505
+                                    // blockers; see `WindowAnchor` and
+                                    // `relocate_window`).
                                     let prev_anchor = window_anchor.borrow().clone();
-                                    let located_head = prev_anchor.as_ref().and_then(|a| {
-                                        relocate_anchor(groups.len(), a.index, |i| {
-                                            display_item_key(&groups[i]) == a.key
-                                        })
-                                    });
-                                    let anchor_index = prev_anchor.as_ref().map(|a| {
-                                        located_head.unwrap_or_else(|| {
-                                            a.index.min(groups.len().saturating_sub(1))
+                                    let relocated = prev_anchor.as_ref().map(|a| {
+                                        relocate_window(groups.len(), a, |i, key| {
+                                            display_item_key_matches(&groups[i], key)
                                         })
                                     });
                                     let history_window = HistoryWindow::resolve(
                                         groups.len(),
                                         requested_window,
-                                        anchor_index,
+                                        relocated.as_ref().map(|r| r.start),
                                     );
+                                    // Was rendered content at or above the new
+                                    // head removed in this very patch? True
+                                    // when the old head is gone (pruned,
+                                    // deleted, or re-keyed by a drained first
+                                    // message) or now sits BEFORE the window
+                                    // (ceiling trim). A parked reader needs
+                                    // their offset compensated for it — the
+                                    // `head_reposition` effect's job.
+                                    let head_removed = match &relocated {
+                                        None => false,
+                                        Some(r) => {
+                                            !r.head_survived
+                                                || history_window.start > r.start
+                                        }
+                                    };
+                                    if head_removed {
+                                        // Capture a surviving row's PRE-patch
+                                        // offset; the DOM still shows the
+                                        // previous render here. Not
+                                        // necessarily the head itself: a
+                                        // re-keyed head group has no
+                                        // pre-patch row under its new key
+                                        // (#505 re-review blocker; see
+                                        // `select_reposition_probe`).
+                                        #[cfg(target_arch = "wasm32")]
+                                        if let Some(probe) = select_reposition_probe(
+                                            groups[history_window.start..]
+                                                .iter()
+                                                .map(display_item_key),
+                                            history_row_offset_top,
+                                        ) {
+                                            *reposition_pending.borrow_mut() = Some(probe);
+                                        }
+                                    }
                                     // Remember where this render started so the
                                     // NEXT one grows instead of sliding (#501).
                                     // Cell/RefCell writes during render are
                                     // fine: inter-render memory, nothing
                                     // renders from them, and re-resolving with
                                     // the values just written is a fixed point.
-                                    let new_head_key =
-                                        display_item_key(&groups[history_window.start]);
-                                    // Was rendered content above the new head
-                                    // removed in this very patch? True when
-                                    // the old head is gone (pruned or deleted)
-                                    // or now sits BEFORE the window (ceiling
-                                    // trim). A parked reader needs their
-                                    // offset compensated for it — the
-                                    // `head_reposition` effect's job.
-                                    let head_removed = match (&prev_anchor, located_head) {
-                                        (Some(_), None) => true,
-                                        (Some(_), Some(i)) => i < history_window.start,
-                                        (None, _) => false,
-                                    };
-                                    if head_removed {
-                                        // Capture the new head row's PRE-patch
-                                        // offset; the DOM still shows the
-                                        // previous render here.
-                                        #[cfg(target_arch = "wasm32")]
-                                        if let Some(pre_top) =
-                                            history_row_offset_top(&new_head_key)
-                                        {
-                                            *reposition_pending.borrow_mut() =
-                                                Some((new_head_key.clone(), pre_top));
-                                        }
-                                    }
                                     *window_anchor.borrow_mut() = Some(WindowAnchor {
-                                        key: new_head_key,
+                                        keys: groups[history_window.start..]
+                                            .iter()
+                                            .take(WINDOW_ANCHOR_KEYS)
+                                            .map(display_item_key)
+                                            .collect(),
                                         index: history_window.start,
                                     });
                                     // What the backfill growth step grows FROM
@@ -3627,16 +3839,31 @@ pub fn Conversation() -> Element {
                                                     style: "position:absolute;top:0;height:{BACKFILL_LEAD_PX}px;width:1px;",
                                                     onvisible: move |evt| {
                                                         if evt.data().is_intersecting().unwrap_or(false) {
-                                                            // Capture the geometry BEFORE the
-                                                            // re-render so the restore effect can
-                                                            // put the reader back on the message
-                                                            // they were looking at.
+                                                            // Capture BEFORE the re-render so the
+                                                            // restore effect can put the reader back
+                                                            // on the row they were looking at: the
+                                                            // current head row's identity + offset
+                                                            // (the measured probe), plus scroll
+                                                            // geometry (offset to restore from, and
+                                                            // the height-delta fallback). See
+                                                            // `BackfillAnchor`.
                                                             #[cfg(target_arch = "wasm32")]
-                                                            if let Some(container) = chat_scroll_container() {
-                                                                backfill_anchor.set(Some((
-                                                                    container.scroll_height(),
-                                                                    container.scroll_top(),
-                                                                )));
+                                                            if let (
+                                                                Some(container),
+                                                                Some((probe_key, probe_top)),
+                                                            ) = (
+                                                                chat_scroll_container(),
+                                                                first_history_row_identity(),
+                                                            ) {
+                                                                *backfill_anchor.borrow_mut() =
+                                                                    Some(BackfillAnchor {
+                                                                        probe_key,
+                                                                        probe_top,
+                                                                        scroll_top: container
+                                                                            .scroll_top(),
+                                                                        scroll_height: container
+                                                                            .scroll_height(),
+                                                                    });
                                                             }
                                                             // Grow from the RENDERED size, not the
                                                             // requested one: arrivals grow an anchored
@@ -5256,46 +5483,160 @@ mod tests {
     /// prunes its oldest message per arrival, shifting every index down — the
     /// walk below is that steady state, and the head must stay the same ITEM
     /// (its index marching toward 0), not the same index.
+    /// Anchor carrying the head + spare keys the way the render does.
+    fn anchor_of(keys: &[String], start: usize) -> WindowAnchor {
+        WindowAnchor {
+            keys: keys[start..]
+                .iter()
+                .take(WINDOW_ANCHOR_KEYS)
+                .cloned()
+                .collect(),
+            index: start,
+        }
+    }
+
     #[test]
     fn the_anchor_follows_the_item_through_at_cap_pruning() {
         // A 100-item room at cap: items are identified by these keys.
-        let mut keys: Vec<usize> = (0..100).collect();
+        let mut keys: Vec<String> = (0..100).map(|i| format!("m{i}")).collect();
         let opened = HistoryWindow::resolve(keys.len(), INITIAL_WINDOW_ITEMS, None);
         assert_eq!(opened.start, 40);
-        let mut anchor_key = keys[opened.start];
-        let mut anchor_hint = opened.start;
+        let head_key = keys[opened.start].clone();
+        let mut anchor = anchor_of(&keys, opened.start);
 
         for arrival in 0..40usize {
             // apply_delta at cap: drain the oldest, append the new.
             keys.remove(0);
-            keys.push(1000 + arrival);
-            let located = relocate_anchor(keys.len(), anchor_hint, |i| keys[i] == anchor_key);
+            keys.push(format!("new{arrival}"));
+            let relocated = relocate_window(keys.len(), &anchor, |i, key| keys[i] == key);
+            assert!(relocated.head_survived, "arrival {arrival}: head survives");
             let start =
-                HistoryWindow::resolve(keys.len(), INITIAL_WINDOW_ITEMS, Some(located.unwrap()))
+                HistoryWindow::resolve(keys.len(), INITIAL_WINDOW_ITEMS, Some(relocated.start))
                     .start;
             assert_eq!(
-                keys[start], anchor_key,
+                keys[start], head_key,
                 "arrival {arrival}: the window head changed identity — the \
                  #501 slide reproduced in content space"
             );
             assert_eq!(start, opened.start - (arrival + 1), "start marches down");
-            anchor_hint = start;
-            anchor_key = keys[start];
+            anchor = anchor_of(&keys, start);
         }
 
-        // One more prune consumes the head itself: relocation fails, and the
-        // positional fallback (the hint, at 0) is the nearest surviving item.
+        // One more prune consumes the head itself: the head key is gone, but
+        // the FIRST SPARE (the item right after the old head) survives at
+        // index 0, so the relocation lands on the nearest surviving item and
+        // reports the head as removed — which is what arms the measured
+        // reposition for a parked reader.
         keys.remove(0);
-        keys.push(2000);
-        assert_eq!(anchor_hint, 0);
-        let located = relocate_anchor(keys.len(), anchor_hint, |i| keys[i] == anchor_key);
-        assert_eq!(located, None, "the head itself was pruned");
-        let fallback = anchor_hint.min(keys.len() - 1);
+        keys.push("new40".into());
+        let relocated = relocate_window(keys.len(), &anchor, |i, key| keys[i] == key);
+        assert!(!relocated.head_survived, "the head itself was pruned");
         assert_eq!(
-            fallback, 0,
-            "the fallback is the nearest surviving item — everything before \
-             the old head was pruned with it"
+            relocated.start, 0,
+            "the first surviving spare pins the window to the nearest \
+             surviving item"
         );
+    }
+
+    /// #505 re-review blocker: a MULTI-message head group RE-KEYS when an
+    /// at-cap drain consumes its first message (a group's key is its first
+    /// message's id). The old key is gone while the group itself survives —
+    /// the spares must still pin the window to the survivors, and the
+    /// reposition probe must skip the un-measurable new head key and land on
+    /// a row that existed pre-patch.
+    #[test]
+    fn a_rekeyed_multi_message_head_group_is_still_anchored_and_measurable() {
+        // Window head at index 0: a group keyed by its first message "m0",
+        // followed by neighbors. The at-cap drain consumes "m0"; the group
+        // survives RE-KEYED as "m1". (Modelled at the key level — exactly
+        // what `display_item_key` exposes to this machinery.)
+        let anchor = WindowAnchor {
+            keys: vec!["m0".into(), "b".into(), "c".into(), "d".into()],
+            index: 0,
+        };
+        let post_keys = ["m1", "b", "c", "d", "e"];
+        let relocated = relocate_window(post_keys.len(), &anchor, |i, key| post_keys[i] == key);
+        assert!(
+            !relocated.head_survived,
+            "the re-keyed head must count as removed — its row is replaced \
+             and its height changed"
+        );
+        assert_eq!(
+            relocated.start, 0,
+            "the first spare (\"b\", found at index 1, offset 1 in the \
+             anchor) pins the window back to the re-keyed group"
+        );
+
+        // The measured probe: the new head key "m1" has NO pre-patch row —
+        // a head-only probe dead-fires and the parked reader crawls one
+        // intra-group line per arrival. The walk lands on "b", which does.
+        let pre_patch_dom = |key: &str| match key {
+            "m0" => Some(100),
+            "b" => Some(160),
+            "c" => Some(220),
+            _ => None,
+        };
+        let probe = select_reposition_probe(post_keys.iter().map(|k| k.to_string()), pre_patch_dom);
+        assert_eq!(
+            probe,
+            Some(("b".to_string(), 160)),
+            "the probe must walk past the un-measurable re-keyed head to the \
+             first row that existed pre-patch"
+        );
+    }
+
+    /// A batched drain that consumes the head AND several spares (the
+    /// `appendMessages` burst crossing the anchor) still lands on the first
+    /// surviving spare, offset back to where the head would have been.
+    #[test]
+    fn a_batched_drain_past_the_head_lands_on_the_first_surviving_spare() {
+        // 100 items, window head at 25 with spares 25..33.
+        let keys: Vec<String> = (0..100).map(|i| format!("m{i}")).collect();
+        let anchor = anchor_of(&keys, 25);
+        // A 30-item drain + 30 arrivals: items 0..30 gone, head (25) and
+        // spares 25..29 with it; spare "m30" (offset 5) survives at index 0.
+        let post_keys: Vec<String> = (30..100)
+            .map(|i| format!("m{i}"))
+            .chain((0..30).map(|i| format!("new{i}")))
+            .collect();
+        let relocated = relocate_window(post_keys.len(), &anchor, |i, key| post_keys[i] == key);
+        assert!(!relocated.head_survived);
+        assert_eq!(
+            relocated.start, 0,
+            "spare m30 found at index 0, offset 5 in the anchor → start 0: \
+             the whole surviving remainder of the old window stays rendered"
+        );
+
+        // And when the drain consumes every spare too, the only safe answer
+        // for a front-contiguous drain is index 0 — the oldest survivor.
+        let post_keys: Vec<String> = (40..100)
+            .map(|i| format!("m{i}"))
+            .chain((0..40).map(|i| format!("new{i}")))
+            .collect();
+        let relocated = relocate_window(post_keys.len(), &anchor, |i, key| post_keys[i] == key);
+        assert!(!relocated.head_survived);
+        assert_eq!(relocated.start, 0);
+    }
+
+    /// The trim guard: skip the bottom-settle trim when the retained tail
+    /// would leave the backfill sentinel strip inside the bottom viewport —
+    /// trimming then re-fires the backfill and the two oscillate at render
+    /// speed (#505 re-review).
+    #[test]
+    fn the_trim_skips_when_the_tail_would_rearm_the_sentinel() {
+        // Ordinary desktop shape: 120 rendered items ~8000px tall, 900px
+        // viewport. Trimming to 60 retains ~4000px >> 900 + 800 + slack.
+        assert!(!trim_would_rearm_backfill(8000, 900, 120, 60));
+
+        // Tall portrait monitor / zoomed out: the same 120 items are only
+        // ~2600px tall over a 2000px viewport. The retained ~1300px tail sits
+        // entirely within client + BACKFILL_LEAD reach — trimming would
+        // re-fire the sentinel immediately.
+        assert!(trim_would_rearm_backfill(2600, 2000, 120, 60));
+
+        // Degenerate inputs never divide by zero or "trim" upward.
+        assert!(!trim_would_rearm_backfill(8000, 900, 0, 60));
+        assert!(!trim_would_rearm_backfill(8000, 900, 50, 60));
     }
 
     /// `relocate_anchor` search order and fallbacks.
@@ -5377,10 +5718,11 @@ mod tests {
             "the history must slice its display items through `HistoryWindow`"
         );
         assert!(
-            squashed.contains("relocate_anchor(groups.len(),a.index,"),
-            "the anchor must be re-located by IDENTITY before resolving — a \
-             positional anchor slides the head in content space whenever an \
-             at-cap room prunes a message (#505 blocker 1)"
+            squashed.contains("relocate_window(groups.len(),a,"),
+            "the anchor must be re-located by IDENTITY (head key, then spare \
+             keys) before resolving — a positional anchor slides the head in \
+             content space whenever an at-cap room prunes a message (#505 \
+             blocker 1)"
         );
         assert!(
             squashed.contains("*window_anchor.borrow_mut()=Some(WindowAnchor{"),
@@ -7870,6 +8212,12 @@ mod autoscroll_wiring_pins {
             "the settle handler must trim the grown window when a settle — \
              the reader's or ours — lands at the exact bottom"
         );
+        assert!(
+            dense.contains("&&!trim_would_rearm_backfill("),
+            "the trim must be geometry-gated: on a viewport tall enough that \
+             the trimmed tail leaves the sentinel strip in range, trim and \
+             backfill oscillate at render speed (#505 re-review)"
+        );
         let trim_at = dense
             .find("ifdistance<=SCROLL_TOP_SLACK_PXasf64&&window_overgrown.get()")
             .expect("asserted above");
@@ -7928,7 +8276,21 @@ mod autoscroll_wiring_pins {
         assert!(
             dense.contains("letshift=post_top-pre_top;"),
             "the reposition must be BY MEASUREMENT (post-patch minus pre-patch \
-             offset of the surviving head row), not a guess"
+             offset of a surviving row), not a guess"
+        );
+        assert!(
+            dense.contains("select_reposition_probe("),
+            "the capture must pick its probe through the forward walk — a \
+             head-only probe dead-fires when an at-cap drain re-keys a \
+             multi-message head group, and the parked reader crawls one \
+             intra-group line per arrival (#505 re-review blocker)"
+        );
+        assert!(
+            dense.contains("matchhistory_row_offset_top(&anchor.probe_key)"),
+            "the backfill restore must reposition by the measured probe row, \
+             not the raw scrollHeight delta — the delta counts arrivals \
+             appended BELOW the viewport in the same patch and over-shifts \
+             the reader (#505 re-review)"
         );
     }
 }

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1594,11 +1594,15 @@ fn relocate_window(
 ///   the first `k` candidates cannot have pre-patch rows either.
 ///
 /// A head-only — or too-short — probe dead-fires, and the parked reader is
-/// left uncompensated. Sized to [`WINDOW_ANCHOR_KEYS`] so the walk always
-/// outlasts the deepest spare the anchor can relocate through (`k <=
-/// WINDOW_ANCHOR_KEYS - 1`, needing `k + 1` candidates). For a
-/// top-contiguous removal every surviving row at or below the head shifts by
-/// the same amount, so whichever candidate lands measures the shift exactly.
+/// left uncompensated. Sized to [`WINDOW_ANCHOR_KEYS`] so the walk covers the
+/// SPARE term exactly (`k <= WINDOW_ANCHOR_KEYS - 1`, needing `k + 1`
+/// candidates). The full count of leading candidates without pre-patch rows is
+/// `k + (relocated.start - history_window.start)`, and that second term is
+/// non-zero only when `resolve` pulls the start back below the relocated head
+/// — the bulk mid-window removal `relocate_window` already declares
+/// out of scope. For a top-contiguous removal every surviving row at or below
+/// the head shifts by the same amount, so whichever candidate lands measures
+/// the shift exactly.
 #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
 const REPOSITION_PROBE_ROWS: usize = WINDOW_ANCHOR_KEYS;
 
@@ -1805,26 +1809,41 @@ fn history_row_offset_top(key: &str) -> Option<i32> {
 /// The first of `keys` (in order) that has a row in the CURRENT DOM, as
 /// `(key, offsetTop)`.
 ///
-/// One DOM pass for the whole candidate list rather than one per candidate:
-/// the reposition capture runs inside the render body, where each
-/// `query_selector_all` + `offsetTop` pair forces a reflow, and the walk can
-/// legitimately need to try [`REPOSITION_PROBE_ROWS`] of them.
+/// One DOM pass for the whole candidate list rather than one pass per
+/// candidate: the walk can legitimately need to try [`REPOSITION_PROBE_ROWS`]
+/// of them, and the old shape re-ran `querySelectorAll` plus an attribute read
+/// per row for each — `candidates x rows` FFI calls. (Not repeated reflows:
+/// the DOM does not change between scans, so layout stayed cached after the
+/// first `offsetTop`.) Only CANDIDATE rows are measured, so a match on the
+/// first row costs a handful of string compares and a single `offsetTop`.
 #[cfg(target_arch = "wasm32")]
 fn first_history_row_offset(keys: &[String]) -> Option<(String, i32)> {
     use wasm_bindgen::JsCast;
+    if keys.is_empty() {
+        return None;
+    }
     let container = chat_scroll_container()?;
     let rows = container.query_selector_all("[data-item-key]").ok()?;
-    // Rendered key -> offsetTop, built in one pass.
+    // Candidate key -> offsetTop. Bounded by `keys.len()`, not by the rendered
+    // window: measuring every row would cost an `offsetTop` and a `String`
+    // allocation per row (up to the ceiling, 240) on a path that runs per
+    // arrival in an at-cap room.
     let mut present: std::collections::HashMap<String, i32> = std::collections::HashMap::new();
     for i in 0..rows.length() {
+        if present.len() == keys.len() {
+            break;
+        }
         let Some(node) = rows.item(i) else { continue };
         let Some(el) = node.dyn_ref::<web_sys::HtmlElement>() else {
             continue;
         };
         if let Some(k) = el.get_attribute("data-item-key") {
-            present.entry(k).or_insert_with(|| el.offset_top());
+            if keys.iter().any(|c| c == &k) {
+                present.entry(k).or_insert_with(|| el.offset_top());
+            }
         }
     }
+    // Priority is the CANDIDATE order (nearest the head first), not DOM order.
     keys.iter()
         .find_map(|k| present.get(k).map(|top| (k.clone(), *top)))
 }
@@ -2132,7 +2151,15 @@ pub fn Conversation() -> Element {
     // `offsetTop` here (see `select_reposition_probe`); the `head_reposition`
     // effect below re-measures it after the patch and shifts `scrollTop` by
     // the difference. `(key, pre_patch_offset_top)`.
-    let reposition_pending = use_hook(|| Rc::new(std::cell::RefCell::new(None::<(String, i32)>)));
+    // `(probe key, its pre-patch offsetTop, the container's pre-patch
+    // scrollTop)`. The scroll offset is captured too because the browser
+    // clamps `scrollTop` down on its own when a patch shortens the content,
+    // and it does so BEFORE the effect runs: computing the target from the
+    // post-clamp offset would apply the shift on top of the clamp and
+    // over-shift the reader (#505 delta review). Capture and effect run in
+    // the same task, so the captured offset cannot go stale.
+    let reposition_pending =
+        use_hook(|| Rc::new(std::cell::RefCell::new(None::<(String, i32, i32)>)));
     // The backfill sentinel's capture, consumed by the restore effect. See
     // `BackfillAnchor`. Not `cfg`-gated — the sentinel's handler is compiled
     // on every target, only the DOM reads inside it are wasm-only.
@@ -2597,7 +2624,8 @@ pub fn Conversation() -> Element {
         use_effect(move || {
             // Subscribe: head swaps only happen on content changes.
             let _ = message_groups.read().is_some();
-            let Some((key, pre_top)) = reposition_pending.borrow_mut().take() else {
+            let Some((key, pre_top, pre_scroll_top)) = reposition_pending.borrow_mut().take()
+            else {
                 return;
             };
             // A pinned reader needs no compensation — the arrival effect
@@ -2632,7 +2660,12 @@ pub fn Conversation() -> Element {
             };
             let shift = post_top - pre_top;
             if shift != 0 {
-                let target = (container.scroll_top() + shift).max(0);
+                // From the PRE-patch offset, not the live one: when the patch
+                // shortens the content the browser has already clamped
+                // `scrollTop` down by the time this runs, and shifting from
+                // the clamped value applies the clamp twice (#505 delta
+                // review). Clamping the result is left to the browser.
+                let target = (pre_scroll_top + shift).max(0);
                 // Move the reference BY THE SHIFT, not to the new absolute
                 // offset. `last_scroll_top` is what `reader_moved_up_since`
                 // measures against, and it is only meaningful in the window
@@ -2642,10 +2675,13 @@ pub fn Conversation() -> Element {
                 // still stale-true BOTH follow paths then yank them to the
                 // bottom (#505 delta review). A relative update preserves
                 // their gap to the reference in both directions, so the guard
-                // keeps answering truthfully. It also resolves the pin
-                // correctly: this settle now reads as the READER's, so the
-                // handler re-measures and clears the stale pin — right, since
-                // this effect only runs for a genuinely parked reader.
+                // keeps answering truthfully. The pin resolves correctly
+                // either way: in the pre-settle window the reference and the
+                // view differ, so this settle reads as the READER's and the
+                // handler re-measures and clears the stale pin; for a reader
+                // whose settle already landed the two move together, so it
+                // reads as ours and leaves their (already correct) pin
+                // alone.
                 last_scroll_top.set(last_scroll_top.get() + shift);
                 container.set_scroll_top(target);
             }
@@ -3739,21 +3775,31 @@ pub fn Conversation() -> Element {
                                     };
                                     if head_removed {
                                         // Capture a surviving row's PRE-patch
-                                        // offset; the DOM still shows the
-                                        // previous render here. Not
-                                        // necessarily the head itself: a
-                                        // re-keyed head group has no
-                                        // pre-patch row under its new key
-                                        // (#505 re-review blocker; see
-                                        // `select_reposition_probe`).
+                                        // offset, AND the container's
+                                        // pre-patch scrollTop; the DOM still
+                                        // shows the previous render here. The
+                                        // probe row is not necessarily the
+                                        // head itself: a re-keyed head group
+                                        // has no pre-patch row under its new
+                                        // key (#505 re-review blocker; see
+                                        // `select_reposition_probe`). The
+                                        // scroll offset is captured because
+                                        // the browser clamps it down before
+                                        // the effect can read it when the
+                                        // patch shortens the content (#505
+                                        // delta review).
                                         #[cfg(target_arch = "wasm32")]
-                                        if let Some(probe) = select_reposition_probe(
-                                            groups[history_window.start..]
-                                                .iter()
-                                                .map(display_item_key),
-                                            first_history_row_offset,
+                                        if let (Some((key, pre_top)), Some(container)) = (
+                                            select_reposition_probe(
+                                                groups[history_window.start..]
+                                                    .iter()
+                                                    .map(display_item_key),
+                                                first_history_row_offset,
+                                            ),
+                                            chat_scroll_container(),
                                         ) {
-                                            *reposition_pending.borrow_mut() = Some(probe);
+                                            *reposition_pending.borrow_mut() =
+                                                Some((key, pre_top, container.scroll_top()));
                                         }
                                     }
                                     // Remember where this render started so the
@@ -8432,6 +8478,13 @@ mod autoscroll_wiring_pins {
             "both the head reposition and the backfill restore must update \
              `last_scroll_top` RELATIVELY — an absolute write erases the \
              reader's movement and the follow paths drag them to the bottom"
+        );
+        assert!(
+            dense.contains("lettarget=(pre_scroll_top+shift).max(0);"),
+            "the reposition target must be computed from the PRE-patch scroll \
+             offset — the browser clamps `scrollTop` down before the effect \
+             runs when a patch shortens the content, and shifting from the \
+             clamped value applies the clamp twice (#505 delta review)"
         );
         assert!(
             dense.contains("select_reposition_probe("),

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -5618,6 +5618,32 @@ mod tests {
         assert_eq!(relocated.start, 0);
     }
 
+    /// The case where the spares are load-bearing and no fallback can stand
+    /// in for them: the head alone vanishes MID-window (its whole group
+    /// deleted), the neighbors survive in place. The first spare pins the
+    /// window one slot back from where it sits — a head-only relocation
+    /// would fall back to index 0 and blow the window open across the whole
+    /// room (ceiling-bounded, but a ~180-item over-render and a torn view).
+    #[test]
+    fn a_mid_window_head_deletion_reanchors_on_the_next_survivor() {
+        let keys: Vec<String> = (0..100).map(|i| format!("m{i}")).collect();
+        let anchor = anchor_of(&keys, 40);
+        // The head item "m40" is deleted outright; everything else survives,
+        // shifted down by one from index 41 on.
+        let post_keys: Vec<String> = keys
+            .iter()
+            .filter(|k| k.as_str() != "m40")
+            .cloned()
+            .collect();
+        let relocated = relocate_window(post_keys.len(), &anchor, |i, key| post_keys[i] == key);
+        assert!(!relocated.head_survived);
+        assert_eq!(
+            relocated.start, 39,
+            "spare m41 (offset 1) found at index 40 → start 39: the window \
+             re-anchors one slot back, not at the front of the room"
+        );
+    }
+
     /// The trim guard: skip the bottom-settle trim when the retained tail
     /// would leave the backfill sentinel strip inside the bottom viewport —
     /// trimming then re-fires the backfill and the two oscillate at render

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -1543,15 +1543,24 @@ fn relocate_anchor(total: usize, hint: usize, is_anchor: impl Fn(usize) -> bool)
 }
 
 /// Re-locate the anchored window: the head by its own key, else by the first
-/// surviving spare, else index 0 (a front-contiguous drain consumed the head
-/// and every spare, so the oldest remaining item IS the nearest survivor).
+/// surviving spare, else index 0.
+///
+/// The index-0 fallback is exact for a front-contiguous drain that consumed
+/// the head and every spare — the oldest remaining item IS then the nearest
+/// survivor. It is a DEGRADED answer for the other way to lose that many
+/// contiguous leading items (a ban purge or bulk delete of >=
+/// [`WINDOW_ANCHOR_KEYS`] display items above the reader): the window jumps
+/// to the front of the room, bounded only by the ceiling, and the reposition
+/// probe finds nothing to measure against. Rare, and it fails toward
+/// rendering MORE history rather than losing the reader's place entirely.
 ///
 /// The `head_reposition` effect measures and compensates a parked reader for
-/// the FRONT-CONTIGUOUS removals this relocation deals in (at-cap drains,
-/// batched or not, including a re-keyed multi-message head group). It does
-/// NOT make every removal invisible: a bulk MID-window removal (a ban purge)
-/// or late-loading media above the viewport still shifts a parked reader —
-/// tracked as follow-up work, not covered here.
+/// the TOP-CONTIGUOUS removals this relocation deals in (at-cap drains,
+/// batched or not, including a re-keyed multi-message head group, and small
+/// leading deletes the spares still cover). It does NOT make every removal
+/// invisible: a bulk MID-window removal (a ban purge) or late-loading media
+/// above the viewport still shifts a parked reader — tracked as follow-up
+/// work, not covered here.
 fn relocate_window(
     total: usize,
     anchor: &WindowAnchor,
@@ -1575,21 +1584,30 @@ fn relocate_window(
 /// How many rows past the window head the reposition capture will probe for a
 /// row that exists in the PRE-patch DOM.
 ///
-/// The new head itself may have no pre-patch row to measure: a multi-message
-/// head group whose first message was drained RE-KEYS (a group's key is its
-/// first message's id), so its new key is in no pre-patch row and a
-/// head-only probe dead-fires — the parked reader then crawls one intra-group
-/// line per arrival (#505 re-review blocker). For a front-contiguous removal
-/// every surviving row at or below the head shifts by the same amount, so ANY
-/// nearby surviving row measures the shift exactly; a handful of candidates
-/// is plenty (one re-keyed head plus a couple of simultaneously-drained
-/// neighbors).
+/// The new head itself may have no pre-patch row to measure, for two reasons:
+///
+/// * a multi-message head group whose first message was drained RE-KEYS (a
+///   group's key is its first message's id), so its new key is in no
+///   pre-patch row (#505 re-review blocker);
+/// * relocation landing via SPARE `k` sets `start = i - k`, widening the
+///   window backward by `k` items that were not rendered pre-patch at all, so
+///   the first `k` candidates cannot have pre-patch rows either.
+///
+/// A head-only — or too-short — probe dead-fires, and the parked reader is
+/// left uncompensated. Sized to [`WINDOW_ANCHOR_KEYS`] so the walk always
+/// outlasts the deepest spare the anchor can relocate through (`k <=
+/// WINDOW_ANCHOR_KEYS - 1`, needing `k + 1` candidates). For a
+/// top-contiguous removal every surviving row at or below the head shifts by
+/// the same amount, so whichever candidate lands measures the shift exactly.
 #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
-const REPOSITION_PROBE_ROWS: usize = 4;
+const REPOSITION_PROBE_ROWS: usize = WINDOW_ANCHOR_KEYS;
 
 /// Pick the row the reposition will measure: the first of the leading
-/// `REPOSITION_PROBE_ROWS` post-patch keys that has a PRE-patch row (i.e.
-/// `pre_patch_offset_of` returns its current `offsetTop`).
+/// `REPOSITION_PROBE_ROWS` post-patch keys that has a PRE-patch row.
+///
+/// `pre_patch_offsets` is handed the whole candidate list at once so the DOM
+/// is scanned a single time (see `first_history_row_offset`) rather than once
+/// per candidate inside the render body.
 ///
 /// Only the wasm render path calls this at runtime; natively it is exercised
 /// by the unit tests, hence the targeted allow rather than a cfg that would
@@ -1597,11 +1615,10 @@ const REPOSITION_PROBE_ROWS: usize = 4;
 #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
 fn select_reposition_probe(
     keys_from_head: impl Iterator<Item = String>,
-    pre_patch_offset_of: impl Fn(&str) -> Option<i32>,
+    pre_patch_offsets: impl Fn(&[String]) -> Option<(String, i32)>,
 ) -> Option<(String, i32)> {
-    keys_from_head
-        .take(REPOSITION_PROBE_ROWS)
-        .find_map(|key| pre_patch_offset_of(&key).map(|top| (key, top)))
+    let candidates: Vec<String> = keys_from_head.take(REPOSITION_PROBE_ROWS).collect();
+    pre_patch_offsets(&candidates)
 }
 
 /// Does `key` identify `item`, without allocating a key `String`?
@@ -1618,6 +1635,11 @@ fn display_item_key_matches(item: &DisplayItem, key: &str) -> bool {
 
 /// What the backfill sentinel captures just before growing the window, so the
 /// restore can put the reader back on the row they were looking at.
+///
+/// Only ever constructed on wasm (the capture reads the DOM), hence the
+/// native allow rather than a cfg that would also hide the type from the
+/// component's non-wasm compile.
+#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
 #[derive(Clone, PartialEq, Debug)]
 struct BackfillAnchor {
     /// `data-item-key` of the head row at capture time. It survives the
@@ -1777,19 +1799,34 @@ fn max_scroll_top(container: &web_sys::Element) -> i32 {
 /// few hundred rows) and only runs on the rare head-swap paths.
 #[cfg(target_arch = "wasm32")]
 fn history_row_offset_top(key: &str) -> Option<i32> {
+    first_history_row_offset(&[key.to_string()]).map(|(_, top)| top)
+}
+
+/// The first of `keys` (in order) that has a row in the CURRENT DOM, as
+/// `(key, offsetTop)`.
+///
+/// One DOM pass for the whole candidate list rather than one per candidate:
+/// the reposition capture runs inside the render body, where each
+/// `query_selector_all` + `offsetTop` pair forces a reflow, and the walk can
+/// legitimately need to try [`REPOSITION_PROBE_ROWS`] of them.
+#[cfg(target_arch = "wasm32")]
+fn first_history_row_offset(keys: &[String]) -> Option<(String, i32)> {
     use wasm_bindgen::JsCast;
     let container = chat_scroll_container()?;
     let rows = container.query_selector_all("[data-item-key]").ok()?;
+    // Rendered key -> offsetTop, built in one pass.
+    let mut present: std::collections::HashMap<String, i32> = std::collections::HashMap::new();
     for i in 0..rows.length() {
         let Some(node) = rows.item(i) else { continue };
         let Some(el) = node.dyn_ref::<web_sys::HtmlElement>() else {
             continue;
         };
-        if el.get_attribute("data-item-key").as_deref() == Some(key) {
-            return Some(el.offset_top());
+        if let Some(k) = el.get_attribute("data-item-key") {
+            present.entry(k).or_insert_with(|| el.offset_top());
         }
     }
-    None
+    keys.iter()
+        .find_map(|k| present.get(k).map(|top| (k.clone(), *top)))
 }
 
 /// The first history row carrying a `data-item-key` — the current window head
@@ -2246,14 +2283,16 @@ pub fn Conversation() -> Element {
             };
             if shift > 0 {
                 let target = anchor.scroll_top + shift;
-                // Record the offset we asked for BEFORE asking for it, the
-                // same contract `scroll_history_to_bottom` keeps: the
-                // settle handler decides whose scroll a settle was by
-                // POSITION, so a programmatic scroll that does not write
-                // `last_scroll_top` is later mistaken for the reader
-                // moving, and the ResizeObserver stands down on the
-                // strength of it. See `install_scroll_pin_listeners`.
-                last_scroll_top.set(target);
+                // Move the reference BY THE SHIFT, for the same reason the
+                // head reposition below does: `last_scroll_top` is what
+                // `reader_moved_up_since` measures against, and writing the
+                // reader's new absolute offset into it erases the fact that
+                // they are up in the history whenever their `scrollend` has
+                // not landed yet — after which the stale-true pin lets both
+                // follow paths drag them to the bottom (#505 delta review).
+                // Relative keeps the gap, and keeps this settle readable as
+                // the reader's so the pin resolves honestly.
+                last_scroll_top.set(last_scroll_top.get() + shift);
                 container.set_scroll_top(target);
             }
         });
@@ -2578,13 +2617,14 @@ pub fn Conversation() -> Element {
             // scroll in the app, and while it is in flight the state reads
             // exactly like a parked reader (pinned, position above the
             // recorded target). Its recorded target is the bottom — so when
-            // `last_scroll_top` already points at the maximum, a scrollTop
-            // write here would cancel that animation mid-flight for a reader
-            // who is headed to the bottom anyway (#505 re-review). Trade-off,
-            // documented: a parked reader whose content SHRANK enough to pull
-            // `max_scroll_top` under their recorded offset skips one
-            // compensation; the next settle re-records and re-arms.
-            if last_scroll_top.get() >= max_scroll_top(&container) {
+            // the view is PINNED and `last_scroll_top` already points at the
+            // maximum, a scrollTop write here would cancel that animation
+            // mid-flight for a reader who is headed to the bottom anyway
+            // (#505 re-review). Gated on the pin as well as the offset: with
+            // `pinned == false` no animation can be in flight, so an unpinned
+            // reader whose patch pulled `max_scroll_top` under their recorded
+            // offset still gets compensated.
+            if pinned_to_bottom.get() && last_scroll_top.get() >= max_scroll_top(&container) {
                 return;
             }
             let Some(post_top) = history_row_offset_top(&key) else {
@@ -2593,10 +2633,20 @@ pub fn Conversation() -> Element {
             let shift = post_top - pre_top;
             if shift != 0 {
                 let target = (container.scroll_top() + shift).max(0);
-                // Same contract as every programmatic scroll: record the
-                // offset so the settle reads as ours. See
-                // `install_scroll_pin_listeners`.
-                last_scroll_top.set(target);
+                // Move the reference BY THE SHIFT, not to the new absolute
+                // offset. `last_scroll_top` is what `reader_moved_up_since`
+                // measures against, and it is only meaningful in the window
+                // between the reader moving and their `scrollend` landing —
+                // writing their freshly-compensated position into it collapses
+                // that signal to "has not moved", and with `pinned_to_bottom`
+                // still stale-true BOTH follow paths then yank them to the
+                // bottom (#505 delta review). A relative update preserves
+                // their gap to the reference in both directions, so the guard
+                // keeps answering truthfully. It also resolves the pin
+                // correctly: this settle now reads as the READER's, so the
+                // handler re-measures and clears the stale pin — right, since
+                // this effect only runs for a genuinely parked reader.
+                last_scroll_top.set(last_scroll_top.get() + shift);
                 container.set_scroll_top(target);
             }
         });
@@ -3701,7 +3751,7 @@ pub fn Conversation() -> Element {
                                             groups[history_window.start..]
                                                 .iter()
                                                 .map(display_item_key),
-                                            history_row_offset_top,
+                                            first_history_row_offset,
                                         ) {
                                             *reposition_pending.borrow_mut() = Some(probe);
                                         }
@@ -5479,10 +5529,6 @@ mod tests {
         );
     }
 
-    /// #505 blocker 1: the anchor is re-located by IDENTITY. An at-cap room
-    /// prunes its oldest message per arrival, shifting every index down — the
-    /// walk below is that steady state, and the head must stay the same ITEM
-    /// (its index marching toward 0), not the same index.
     /// Anchor carrying the head + spare keys the way the render does.
     fn anchor_of(keys: &[String], start: usize) -> WindowAnchor {
         WindowAnchor {
@@ -5495,6 +5541,10 @@ mod tests {
         }
     }
 
+    /// #505 blocker 1: the anchor is re-located by IDENTITY. An at-cap room
+    /// prunes its oldest message per arrival, shifting every index down — the
+    /// walk below is that steady state, and the head must stay the same ITEM
+    /// (its index marching toward 0), not the same index.
     #[test]
     fn the_anchor_follows_the_item_through_at_cap_pruning() {
         // A 100-item room at cap: items are identified by these keys.
@@ -5570,18 +5620,83 @@ mod tests {
         // The measured probe: the new head key "m1" has NO pre-patch row —
         // a head-only probe dead-fires and the parked reader crawls one
         // intra-group line per arrival. The walk lands on "b", which does.
-        let pre_patch_dom = |key: &str| match key {
-            "m0" => Some(100),
-            "b" => Some(160),
-            "c" => Some(220),
-            _ => None,
-        };
-        let probe = select_reposition_probe(post_keys.iter().map(|k| k.to_string()), pre_patch_dom);
+        let probe = select_reposition_probe(
+            post_keys.iter().map(|k| k.to_string()),
+            pre_patch_dom(&[("m0", 100), ("b", 160), ("c", 220)]),
+        );
         assert_eq!(
             probe,
             Some(("b".to_string(), 160)),
             "the probe must walk past the un-measurable re-keyed head to the \
              first row that existed pre-patch"
+        );
+    }
+
+    /// A pre-patch DOM as a `first_history_row_offset`-shaped lookup: the
+    /// first candidate key that has a row, with its offset.
+    fn pre_patch_dom(rows: &[(&'static str, i32)]) -> impl Fn(&[String]) -> Option<(String, i32)> {
+        let rows = rows.to_vec();
+        move |keys: &[String]| {
+            keys.iter().find_map(|k| {
+                rows.iter()
+                    .find(|(rk, _)| rk == k)
+                    .map(|(_, top)| (k.clone(), *top))
+            })
+        }
+    }
+
+    /// The probe walk must outlast the DEEPEST spare the anchor can relocate
+    /// through. Landing via spare `k` sets `start = i - k`, widening the
+    /// window backward by `k` items that were never rendered pre-patch, so
+    /// the first `k` candidates cannot have pre-patch rows. A walk shorter
+    /// than `WINDOW_ANCHOR_KEYS` dead-fires exactly when the removal is
+    /// biggest — a bulk delete of several contiguous leading items above a
+    /// parked reader (#505 delta review).
+    #[test]
+    fn the_probe_walk_outlasts_the_deepest_spare() {
+        assert!(
+            REPOSITION_PROBE_ROWS >= WINDOW_ANCHOR_KEYS,
+            "the probe walk must cover every spare the anchor can land on"
+        );
+
+        // Anchor: head + 7 spares. A bulk delete removes the head and the
+        // first 6 spares; relocation lands on spare 7 ("s7"), so the window
+        // widens back by 7 items that have no pre-patch rows.
+        let anchor = WindowAnchor {
+            keys: (0..WINDOW_ANCHOR_KEYS)
+                .map(|i| {
+                    if i == 0 {
+                        "head".to_string()
+                    } else {
+                        format!("s{i}")
+                    }
+                })
+                .collect(),
+            index: 20,
+        };
+        let post_keys: Vec<String> = (0..7)
+            .map(|i| format!("older{i}"))
+            .chain(std::iter::once("s7".to_string()))
+            .chain((0..10).map(|i| format!("rest{i}")))
+            .collect();
+        let relocated = relocate_window(post_keys.len(), &anchor, |i, key| post_keys[i] == key);
+        assert!(!relocated.head_survived);
+        assert_eq!(
+            relocated.start, 0,
+            "spare 7 found at index 7, offset 7 in the anchor → start 0"
+        );
+
+        // Only the 8th candidate ("s7") has a pre-patch row; the seven
+        // widened-in rows above it do not. A 4-row walk finds nothing.
+        let probe = select_reposition_probe(
+            post_keys.iter().map(|k| k.to_string()),
+            pre_patch_dom(&[("s7", 480), ("rest0", 540)]),
+        );
+        assert_eq!(
+            probe,
+            Some(("s7".to_string(), 480)),
+            "the walk must reach the deepest spare's row, or the compensation \
+             silently dead-fires on the largest removals"
         );
     }
 
@@ -5679,7 +5794,7 @@ mod tests {
         assert_eq!(find("c", 0), Some(2));
         // Hint out of range entirely: still found.
         assert_eq!(find("e", 400), Some(4));
-        // Gone: None, and the caller falls back to the position.
+        // Gone: None, and `relocate_window` moves on to the next spare.
         assert_eq!(find("zz", 2), None);
         assert_eq!(relocate_anchor(0, 0, |_| true), None, "empty list");
     }
@@ -8303,6 +8418,20 @@ mod autoscroll_wiring_pins {
             dense.contains("letshift=post_top-pre_top;"),
             "the reposition must be BY MEASUREMENT (post-patch minus pre-patch \
              offset of a surviving row), not a guess"
+        );
+        // The reference moves BY THE SHIFT. Writing the reader's new absolute
+        // offset instead collapses `reader_moved_up_since` to false while the
+        // pin is still stale-true, and both follow paths then yank a parked
+        // reader to the bottom (#505 delta review). Two call sites: the head
+        // reposition and the backfill restore.
+        assert_eq!(
+            dense
+                .matches("last_scroll_top.set(last_scroll_top.get()+shift);")
+                .count(),
+            2,
+            "both the head reposition and the backfill restore must update \
+             `last_scroll_top` RELATIVELY — an absolute write erases the \
+             reader's movement and the follow paths drag them to the bottom"
         );
         assert!(
             dense.contains("select_reposition_probe("),

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -33,9 +33,27 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 /// shipped with a green suite. Strictly ALTERNATING authors, because
 /// consecutive same-author messages within five minutes fold into one display
 /// item: alternation makes messages == items, so the count is a guarantee
-/// rather than a hope. 80 fillers + the ~12 standard fixture messages stays
-/// under the default `max_recent_messages` (100).
-const DEEP_HISTORY_FILLER_MESSAGES: usize = 80;
+/// rather than a hope.
+///
+/// Sized to more than THREE windows (188 + the 12 standard messages = 200), so
+/// the backfill-paging spec takes several growth steps to exhaust the room and
+/// the #505 blocker-2 scenario (arrivals widening the rendered window past one
+/// whole growth step) is reachable with a single batched delivery. The room's
+/// `max_recent_messages` is raised to [`DEEP_ROOM_MAX_RECENT_MESSAGES`] so
+/// those deliveries do not prune the fillers out from under the test.
+const DEEP_HISTORY_FILLER_MESSAGES: usize = 188;
+
+/// `max_recent_messages` for the deep fixture room: 200 seeded + headroom for
+/// the specs' delivered arrivals without hitting the at-cap prune path (which
+/// has its own dedicated fixture room below).
+const DEEP_ROOM_MAX_RECENT_MESSAGES: usize = 300;
+
+/// Fillers for the AT-CAP fixture room: 88 + the 12 standard messages lands
+/// exactly on the default `max_recent_messages` (100), so every delivered
+/// arrival drains the oldest message — the steady state of every busy
+/// production room, and the index-shift regression surface of #505 blocker 1.
+/// `at_cap_room_is_exactly_at_its_message_cap` pins the arithmetic.
+const AT_CAP_FILLER_MESSAGES: usize = 88;
 
 /// How deep a fixture room's message history is seeded.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -45,8 +63,11 @@ enum HistoryDepth {
     Standard,
     /// [`DEEP_HISTORY_FILLER_MESSAGES`] alternating-author fillers ahead of the
     /// standard fixture, so the room renders a windowed tail with a live
-    /// backfill sentinel.
+    /// backfill sentinel, with prune headroom for delivered arrivals.
     Deep,
+    /// [`AT_CAP_FILLER_MESSAGES`] fillers, landing the room EXACTLY on its
+    /// `max_recent_messages` cap so arrivals prune.
+    AtCap,
 }
 
 /// Whether the page was loaded with `?deep-history-room=1`, asking for the
@@ -95,7 +116,9 @@ pub fn create_example_rooms() -> Rooms {
     );
     map.insert(room3.owner_vk, room3.room_data);
 
-    // A room deeper than the render window, for the windowing specs (#501).
+    // Rooms deeper than the render window, for the windowing specs (#501):
+    // one with prune headroom, one exactly at its message cap so delivered
+    // arrivals exercise the at-cap index-shift path (#505 blocker 1).
     if deep_history_room_requested() {
         let room4 = create_room(
             &"Deep History Room".to_string(),
@@ -104,6 +127,14 @@ pub fn create_example_rooms() -> Rooms {
             HistoryDepth::Deep,
         );
         map.insert(room4.owner_vk, room4.room_data);
+
+        let room5 = create_room(
+            &"Capped History Room".to_string(),
+            SelfIs::Member,
+            None,
+            HistoryDepth::AtCap,
+        );
+        map.insert(room5.owner_vk, room5.room_data);
     }
 
     Rooms {
@@ -161,6 +192,13 @@ fn create_room(
         description: description.map(|d| SealedBytes::public(d.as_bytes().to_vec())),
     };
     config.owner_member_id = owner_id;
+    if history_depth == HistoryDepth::Deep {
+        // Headroom over the 200 seeded messages so the specs can deliver
+        // arrival batches without the at-cap prune shifting the fixture out
+        // from under them. The AT-CAP room keeps the default (100) — landing
+        // exactly on it is its entire purpose.
+        config.max_recent_messages = DEEP_ROOM_MAX_RECENT_MESSAGES;
+    }
     room_state.configuration = AuthorizedConfigurationV1::new(config, owner_sk);
 
     // Initialize member lists
@@ -398,29 +436,32 @@ fn add_example_messages(
         .chain(std::iter::once((*owner_id, owner_key)))
         .collect();
 
-    // Deep-history fixture: filler messages AHEAD of the standard fixture so
+    // Deep-history fixtures: filler messages AHEAD of the standard fixture so
     // the room's display-item count comfortably exceeds the render window.
     // Authors strictly alternate — consecutive same-author messages within
     // five minutes fold into one display item, so alternation is what makes
     // "N messages" mean "N display items". Deterministic content and fixed
     // 60s gaps: nothing here should vary run to run.
-    if history_depth == HistoryDepth::Deep {
-        for i in 0..DEEP_HISTORY_FILLER_MESSAGES {
-            let (author_id, signing_key) = authors[i % 2.min(authors.len())];
-            let msg = AuthorizedMessageV1::new(
-                MessageV1 {
-                    room_owner: *owner_id,
-                    author: author_id,
-                    time: get_time_from_millis(current_time_ms),
-                    content: RoomMessageBody::public(format!(
-                        "history filler {i:02}: the window only renders a tail"
-                    )),
-                },
-                signing_key,
-            );
-            messages.messages.push(msg);
-            current_time_ms += 60_000;
-        }
+    let filler_count = match history_depth {
+        HistoryDepth::Standard => 0,
+        HistoryDepth::Deep => DEEP_HISTORY_FILLER_MESSAGES,
+        HistoryDepth::AtCap => AT_CAP_FILLER_MESSAGES,
+    };
+    for i in 0..filler_count {
+        let (author_id, signing_key) = authors[i % 2.min(authors.len())];
+        let msg = AuthorizedMessageV1::new(
+            MessageV1 {
+                room_owner: *owner_id,
+                author: author_id,
+                time: get_time_from_millis(current_time_ms),
+                content: RoomMessageBody::public(format!(
+                    "history filler {i:02}: the window only renders a tail"
+                )),
+            },
+            signing_key,
+        );
+        messages.messages.push(msg);
+        current_time_ms += 60_000;
     }
 
     let message_count = 6;
@@ -721,8 +762,55 @@ mod tests {
             "the fixture must exceed INITIAL_WINDOW_ITEMS or the windowing \
              specs test nothing"
         );
+        // Prune headroom: the specs deliver arrival batches into this room;
+        // if the total creeps up to the cap, those deliveries silently start
+        // pruning fillers and every count-based premise drifts.
+        let max = room
+            .room_data
+            .room_state
+            .configuration
+            .configuration
+            .max_recent_messages;
+        assert_eq!(max, DEEP_ROOM_MAX_RECENT_MESSAGES);
+        assert!(
+            msgs.len() + 80 <= max,
+            "the deep room needs at least ~80 messages of prune headroom for \
+             delivered arrivals; seeded {} of max {max}",
+            msgs.len()
+        );
         // create_room verifies the state internally (it panics on failure),
         // so reaching this point means the deep room is contract-valid.
+    }
+
+    /// The at-cap fixture must land EXACTLY on its message cap: one message
+    /// under and arrivals do not prune (blocker-1's index shift never
+    /// happens); one over and `create_room`'s verify sees a state
+    /// `apply_delta` would never produce.
+    #[test]
+    fn at_cap_room_is_exactly_at_its_message_cap() {
+        let room = create_room(
+            &"Capped History Room".to_string(),
+            SelfIs::Member,
+            None,
+            HistoryDepth::AtCap,
+        );
+        let state = &room.room_data.room_state;
+        assert_eq!(
+            state.recent_messages.messages.len(),
+            state.configuration.configuration.max_recent_messages,
+            "the capped room must sit exactly at max_recent_messages so every \
+             delivered arrival drains the oldest message (#505 blocker 1)"
+        );
+        // And it is still deeper than the render window, so the windowed
+        // premise assertions hold for this room too.
+        assert!(state.recent_messages.messages.len() > 60);
+        for pair in state.recent_messages.messages[..AT_CAP_FILLER_MESSAGES].windows(2) {
+            assert_ne!(
+                pair[0].message.author, pair[1].message.author,
+                "adjacent fillers share an author and would merge into one \
+                 display item"
+            );
+        }
     }
 
     #[test]
@@ -813,6 +901,20 @@ pub fn install_test_hooks() {
     );
     insert.forget();
 
+    // A burst in ONE state mutation — one delta application, one re-render —
+    // as a network delta carrying many messages produces. The windowing specs
+    // use it to grow an anchored window well past one backfill step without
+    // paying per-delivery render round-trips (#505 blocker 2).
+    let append_many = Closure::wrap(Box::new(move |count: u32| {
+        crate::util::defer(move || deliver_batch(count as usize));
+    }) as Box<dyn FnMut(u32)>);
+    let _ = js_sys::Reflect::set(
+        &hooks,
+        &JsValue::from_str("appendMessages"),
+        append_many.as_ref(),
+    );
+    append_many.forget();
+
     let _ = js_sys::Reflect::set(&window, &JsValue::from_str("__riverTest"), &hooks);
 }
 
@@ -831,15 +933,101 @@ enum Delivery {
     BeforeLast,
 }
 
-/// Two fixed identities, so a delivered message never merges into the group
-/// above it by accident: grouping needs the same author within 5 minutes, and
+/// Fixed identities, so a delivered message never merges into the group above
+/// it by accident: grouping needs the same author within 5 minutes, and
 /// `BeforeLast` in particular has to leave the last group's key (its first
 /// message's id) untouched or the row remounts and the test proves nothing.
+///
+/// APPENDED arrivals ALTERNATE between two identities per message, so a burst
+/// of N arrivals is N display items rather than folding into one group — a
+/// six-arrival follow loop that renders as a single item exercises the
+/// windowing's grow/trim interleave zero times (#505 review).
 #[cfg(all(target_arch = "wasm32", feature = "no-sync"))]
-fn test_author(delivery: Delivery) -> SigningKey {
+fn test_author(delivery: Delivery, seq: u64) -> (SigningKey, &'static str) {
     match delivery {
-        Delivery::Append => SigningKey::from_bytes(&[0x5A; 32]),
-        Delivery::BeforeLast => SigningKey::from_bytes(&[0x7B; 32]),
+        Delivery::Append if seq % 2 == 0 => (SigningKey::from_bytes(&[0x5A; 32]), "Test Sender A"),
+        Delivery::Append => (SigningKey::from_bytes(&[0x6A; 32]), "Test Sender B"),
+        Delivery::BeforeLast => (SigningKey::from_bytes(&[0x7B; 32]), "Test Sender Insert"),
+    }
+}
+
+// Monotone counter driving the append-author alternation. Shared by single
+// and batched deliveries so alternation continues across calls. WASM is
+// single-threaded; the thread_local is just the idiomatic mutable static.
+#[cfg(all(target_arch = "wasm32", feature = "no-sync"))]
+thread_local! {
+    static APPEND_SEQ: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+/// Append `message` to `room` as the given test identity, registering the
+/// identity's nickname the first time it speaks so the bubble renders like
+/// any other member's rather than as "Unknown".
+#[cfg(all(target_arch = "wasm32", feature = "no-sync"))]
+fn push_test_message(
+    room: &mut RoomData,
+    room_key: &VerifyingKey,
+    text: String,
+    sk: &SigningKey,
+    nickname: &str,
+    at_end: bool,
+) {
+    let author = MemberId::from(&sk.verifying_key());
+    if !room
+        .room_state
+        .member_info
+        .member_info
+        .iter()
+        .any(|entry| entry.member_info.member_id == author)
+    {
+        room.room_state
+            .member_info
+            .member_info
+            .push(AuthorizedMemberInfo::new_with_member_key(
+                MemberInfo {
+                    member_id: author,
+                    version: 0,
+                    preferred_nickname: SealedBytes::public(nickname.as_bytes().to_vec()),
+                    deputies: Vec::new(),
+                },
+                sk,
+            ));
+    }
+
+    let message = AuthorizedMessageV1::new(
+        MessageV1 {
+            room_owner: MemberId::from(room_key),
+            author,
+            content: RoomMessageBody::public(text),
+            time: crate::util::get_current_system_time(),
+        },
+        sk,
+    );
+
+    let messages = &mut room.room_state.recent_messages.messages;
+    let at = if at_end {
+        messages.len()
+    } else {
+        messages.len().saturating_sub(1)
+    };
+    messages.insert(at, message);
+}
+
+/// What a real arrival does once the room is at `max_recent_messages`: drain
+/// the oldest. Mirrors `MessagesV1::apply_delta`
+/// (common/src/room_state/message.rs) — without this, the hooks grow the
+/// message list unboundedly and the at-cap index-shift path (#505 blocker 1)
+/// is unreachable from the browser suite.
+#[cfg(all(target_arch = "wasm32", feature = "no-sync"))]
+fn prune_to_cap(room: &mut RoomData) {
+    let max = room
+        .room_state
+        .configuration
+        .configuration
+        .max_recent_messages;
+    let messages = &mut room.room_state.recent_messages.messages;
+    if messages.len() > max {
+        let excess = messages.len() - max;
+        messages.drain(0..excess);
     }
 }
 
@@ -851,54 +1039,62 @@ fn deliver_message(text: String, delivery: Delivery) {
     let Some(room_key) = CURRENT_ROOM.peek().owner_key else {
         return;
     };
-    let sk = test_author(delivery);
-    let author = MemberId::from(&sk.verifying_key());
+    let seq = match delivery {
+        Delivery::Append => APPEND_SEQ.with(|s| {
+            let v = s.get();
+            s.set(v + 1);
+            v
+        }),
+        Delivery::BeforeLast => 0,
+    };
+    let (sk, nickname) = test_author(delivery, seq);
 
     ROOMS.with_mut(|rooms| {
         let Some(room) = rooms.map.get_mut(&room_key) else {
             return;
         };
+        push_test_message(
+            room,
+            &room_key,
+            text,
+            &sk,
+            nickname,
+            delivery == Delivery::Append,
+        );
+        prune_to_cap(room);
+    });
+}
 
-        // Give the sender a name the first time it speaks, so the bubble
-        // renders like any other member's rather than as "Unknown".
-        if !room
-            .room_state
-            .member_info
-            .member_info
-            .iter()
-            .any(|entry| entry.member_info.member_id == author)
-        {
-            room.room_state.member_info.member_info.push(
-                AuthorizedMemberInfo::new_with_member_key(
-                    MemberInfo {
-                        member_id: author,
-                        version: 0,
-                        preferred_nickname: SealedBytes::public(
-                            format!("Test Sender {}", u8::from(delivery == Delivery::BeforeLast))
-                                .into_bytes(),
-                        ),
-                        deputies: Vec::new(),
-                    },
-                    &sk,
-                ),
+/// Deliver `count` appended arrivals in ONE `ROOMS` mutation (one re-render),
+/// alternating authors like single deliveries do.
+#[cfg(all(target_arch = "wasm32", feature = "no-sync"))]
+fn deliver_batch(count: usize) {
+    use crate::components::app::{CURRENT_ROOM, ROOMS};
+    use dioxus::prelude::*;
+
+    let Some(room_key) = CURRENT_ROOM.peek().owner_key else {
+        return;
+    };
+    ROOMS.with_mut(|rooms| {
+        let Some(room) = rooms.map.get_mut(&room_key) else {
+            return;
+        };
+        for i in 0..count {
+            let seq = APPEND_SEQ.with(|s| {
+                let v = s.get();
+                s.set(v + 1);
+                v
+            });
+            let (sk, nickname) = test_author(Delivery::Append, seq);
+            push_test_message(
+                room,
+                &room_key,
+                format!("batched arrival {i:02}"),
+                &sk,
+                nickname,
+                true,
             );
         }
-
-        let message = AuthorizedMessageV1::new(
-            MessageV1 {
-                room_owner: MemberId::from(&room_key),
-                author,
-                content: RoomMessageBody::public(text),
-                time: crate::util::get_current_system_time(),
-            },
-            &sk,
-        );
-
-        let messages = &mut room.room_state.recent_messages.messages;
-        let at = match delivery {
-            Delivery::Append => messages.len(),
-            Delivery::BeforeLast => messages.len().saturating_sub(1),
-        };
-        messages.insert(at, message);
+        prune_to_cap(room);
     });
 }

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -24,6 +24,46 @@ use river_core::{
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+/// How many alternating-author filler messages the deep-history fixture seeds.
+///
+/// The point is to comfortably exceed `INITIAL_WINDOW_ITEMS` (60) in DISPLAY
+/// ITEMS so the windowed-tail rendering (freenet/river#498) is actually active
+/// under Playwright — the standard fixture's ~15-20 items leave the window, the
+/// backfill sentinel and the restore path all unreachable, which is how #501
+/// shipped with a green suite. Strictly ALTERNATING authors, because
+/// consecutive same-author messages within five minutes fold into one display
+/// item: alternation makes messages == items, so the count is a guarantee
+/// rather than a hope. 80 fillers + the ~12 standard fixture messages stays
+/// under the default `max_recent_messages` (100).
+const DEEP_HISTORY_FILLER_MESSAGES: usize = 80;
+
+/// How deep a fixture room's message history is seeded.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum HistoryDepth {
+    /// The standard ~12-message fixture. Fits inside the render window, so
+    /// these rooms exercise the pre-window code path exactly as before.
+    Standard,
+    /// [`DEEP_HISTORY_FILLER_MESSAGES`] alternating-author fillers ahead of the
+    /// standard fixture, so the room renders a windowed tail with a live
+    /// backfill sentinel.
+    Deep,
+}
+
+/// Whether the page was loaded with `?deep-history-room=1`, asking for the
+/// extra >window fixture room. Query-gated so the default fixture (and every
+/// existing spec's timing) is untouched; only the windowing specs opt in.
+#[cfg(target_arch = "wasm32")]
+fn deep_history_room_requested() -> bool {
+    web_sys::window()
+        .and_then(|w| w.location().search().ok())
+        .is_some_and(|search| search.contains("deep-history-room"))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn deep_history_room_requested() -> bool {
+    false
+}
+
 pub fn create_example_rooms() -> Rooms {
     let mut map = HashMap::new();
 
@@ -33,16 +73,38 @@ pub fn create_example_rooms() -> Rooms {
         &"Public Discussion Room".to_string(),
         SelfIs::Observer,
         Some("Welcome | [Website](https://freenet.org/) · [Docs](https://docs.freenet.org/)"),
+        HistoryDepth::Standard,
     );
     map.insert(room1.owner_vk, room1.room_data);
 
     // Room where you're a member
-    let room2 = create_room(&"Team Chat Room".to_string(), SelfIs::Member, None);
+    let room2 = create_room(
+        &"Team Chat Room".to_string(),
+        SelfIs::Member,
+        None,
+        HistoryDepth::Standard,
+    );
     map.insert(room2.owner_vk, room2.room_data);
 
     // Room where you're the owner
-    let room3 = create_room(&"Your Private Room".to_string(), SelfIs::Owner, None);
+    let room3 = create_room(
+        &"Your Private Room".to_string(),
+        SelfIs::Owner,
+        None,
+        HistoryDepth::Standard,
+    );
     map.insert(room3.owner_vk, room3.room_data);
+
+    // A room deeper than the render window, for the windowing specs (#501).
+    if deep_history_room_requested() {
+        let room4 = create_room(
+            &"Deep History Room".to_string(),
+            SelfIs::Member,
+            None,
+            HistoryDepth::Deep,
+        );
+        map.insert(room4.owner_vk, room4.room_data);
+    }
 
     Rooms {
         map,
@@ -68,7 +130,12 @@ enum SelfIs {
 
 // Function to create a room with an owner and members, self_is determines whether
 // the user of the UI is the owner, a member, or an observer (not an owner or member)
-fn create_room(room_name: &String, self_is: SelfIs, description: Option<&str>) -> CreatedRoom {
+fn create_room(
+    room_name: &String,
+    self_is: SelfIs,
+    description: Option<&str>,
+    history_depth: HistoryDepth,
+) -> CreatedRoom {
     let mut csprng = OsRng;
 
     // Create self - the user actually using the app
@@ -218,6 +285,7 @@ fn create_room(room_name: &String, self_is: SelfIs, description: Option<&str>) -
         owner_sk,
         &member_keys,
         other_member_id,
+        history_depth,
     );
 
     let verification_result = room_state.verify(
@@ -272,6 +340,7 @@ fn add_example_messages(
     // conversation's 🛡 badge is deterministically present for Playwright —
     // the random author picks alone leave it to chance.
     deputy_id: MemberId,
+    history_depth: HistoryDepth,
 ) {
     // Use a timestamp 24 hours ago as base time for messages
     let now = crate::util::get_current_system_time()
@@ -328,6 +397,31 @@ fn add_example_messages(
         .map(|(id, key)| (*id, key))
         .chain(std::iter::once((*owner_id, owner_key)))
         .collect();
+
+    // Deep-history fixture: filler messages AHEAD of the standard fixture so
+    // the room's display-item count comfortably exceeds the render window.
+    // Authors strictly alternate — consecutive same-author messages within
+    // five minutes fold into one display item, so alternation is what makes
+    // "N messages" mean "N display items". Deterministic content and fixed
+    // 60s gaps: nothing here should vary run to run.
+    if history_depth == HistoryDepth::Deep {
+        for i in 0..DEEP_HISTORY_FILLER_MESSAGES {
+            let (author_id, signing_key) = authors[i % 2.min(authors.len())];
+            let msg = AuthorizedMessageV1::new(
+                MessageV1 {
+                    room_owner: *owner_id,
+                    author: author_id,
+                    time: get_time_from_millis(current_time_ms),
+                    content: RoomMessageBody::public(format!(
+                        "history filler {i:02}: the window only renders a tail"
+                    )),
+                },
+                signing_key,
+            );
+            messages.messages.push(msg);
+            current_time_ms += 60_000;
+        }
+    }
 
     let message_count = 6;
 
@@ -591,6 +685,45 @@ fn get_time_from_millis(ms: u64) -> SystemTime {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The deep-history fixture must actually put the windowed render path in
+    /// play: more display items than `INITIAL_WINDOW_ITEMS` (60), guaranteed
+    /// by strict author alternation (messages == display items), and a state
+    /// that still verifies. If this shrinks below the window, every #501
+    /// Playwright test silently degrades to the small-room path — the exact
+    /// coverage gap that let #501 ship.
+    #[test]
+    fn deep_history_room_exceeds_the_render_window() {
+        let room = create_room(
+            &"Deep History Room".to_string(),
+            SelfIs::Member,
+            None,
+            HistoryDepth::Deep,
+        );
+
+        let msgs = &room.room_data.room_state.recent_messages.messages;
+        assert!(
+            msgs.len() >= DEEP_HISTORY_FILLER_MESSAGES,
+            "expected at least the filler messages, got {}",
+            msgs.len()
+        );
+        // The fillers are the oldest messages; adjacent authors must differ so
+        // no two fold into one display item.
+        for pair in msgs[..DEEP_HISTORY_FILLER_MESSAGES].windows(2) {
+            assert_ne!(
+                pair[0].message.author, pair[1].message.author,
+                "adjacent fillers share an author and would merge into one \
+                 display item"
+            );
+        }
+        assert!(
+            DEEP_HISTORY_FILLER_MESSAGES > 60,
+            "the fixture must exceed INITIAL_WINDOW_ITEMS or the windowing \
+             specs test nothing"
+        );
+        // create_room verifies the state internally (it panics on failure),
+        // so reaching this point means the deep room is contract-valid.
+    }
 
     #[test]
     fn test_create_example_rooms() {

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -852,7 +852,8 @@ mod tests {
         // Still deeper than the render window in display ITEMS, so the
         // windowed premise assertions hold for this room too. Counted from
         // the seeded DATA (runs of same-author adjacent messages collapse,
-        // exactly as `group_messages` groups them) rather than from the
+        // as `group_messages` does — modulo its 5-minute threshold, which
+        // these fixed 60s-apart fillers never cross) rather than from the
         // constant, so a fixture change that alters the authoring pattern —
         // not just the count — fails here.
         let display_items = fillers

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -850,12 +850,21 @@ mod tests {
             );
         }
         // Still deeper than the render window in display ITEMS, so the
-        // windowed premise assertions hold for this room too.
+        // windowed premise assertions hold for this room too. Counted from
+        // the seeded DATA (runs of same-author adjacent messages collapse,
+        // exactly as `group_messages` groups them) rather than from the
+        // constant, so a fixture change that alters the authoring pattern —
+        // not just the count — fails here.
+        let display_items = fillers
+            .windows(2)
+            .filter(|w| w[0].message.author != w[1].message.author)
+            .count()
+            + 1;
         assert!(
-            AT_CAP_FILLER_MESSAGES / 2 > 60,
+            display_items > 60,
             "paired fillers must still exceed INITIAL_WINDOW_ITEMS display \
              items or the windowing specs quietly degrade to the small-room \
-             path"
+             path; got {display_items}"
         );
     }
 

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -48,12 +48,26 @@ const DEEP_HISTORY_FILLER_MESSAGES: usize = 188;
 /// has its own dedicated fixture room below).
 const DEEP_ROOM_MAX_RECENT_MESSAGES: usize = 300;
 
-/// Fillers for the AT-CAP fixture room: 88 + the 12 standard messages lands
-/// exactly on the default `max_recent_messages` (100), so every delivered
-/// arrival drains the oldest message — the steady state of every busy
-/// production room, and the index-shift regression surface of #505 blocker 1.
-/// `at_cap_room_is_exactly_at_its_message_cap` pins the arithmetic.
-const AT_CAP_FILLER_MESSAGES: usize = 88;
+/// Fillers for the AT-CAP fixture room: 148 + the 12 standard messages lands
+/// exactly on that room's `max_recent_messages`
+/// ([`AT_CAP_MAX_RECENT_MESSAGES`]), so every delivered arrival drains the
+/// oldest message — the steady state of every busy production room, and the
+/// index-shift regression surface of #505 blocker 1.
+///
+/// These fillers come in same-author PAIRS (AABB…), NOT alternating: paired
+/// consecutive messages fold into MULTI-message display groups, which is the
+/// dominant production message shape and the one the #505 re-review blocker
+/// lives in — draining the first message of a multi-message head group
+/// RE-KEYS the group (a group's key is its first message's id). A strictly
+/// alternating fixture is blind to that by construction. 148 paired fillers =
+/// 74 display items, still comfortably past the 60-item window;
+/// `at_cap_room_is_exactly_at_its_message_cap` pins all of it.
+const AT_CAP_FILLER_MESSAGES: usize = 148;
+
+/// `max_recent_messages` for the at-cap room. Raised from the default 100 so
+/// the room can hold enough PAIRED fillers to exceed the render window in
+/// display items (pairs halve the item count) while sitting exactly at cap.
+const AT_CAP_MAX_RECENT_MESSAGES: usize = 160;
 
 /// How deep a fixture room's message history is seeded.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -192,12 +206,16 @@ fn create_room(
         description: description.map(|d| SealedBytes::public(d.as_bytes().to_vec())),
     };
     config.owner_member_id = owner_id;
-    if history_depth == HistoryDepth::Deep {
+    match history_depth {
+        HistoryDepth::Standard => {}
         // Headroom over the 200 seeded messages so the specs can deliver
         // arrival batches without the at-cap prune shifting the fixture out
-        // from under them. The AT-CAP room keeps the default (100) — landing
-        // exactly on it is its entire purpose.
-        config.max_recent_messages = DEEP_ROOM_MAX_RECENT_MESSAGES;
+        // from under them.
+        HistoryDepth::Deep => config.max_recent_messages = DEEP_ROOM_MAX_RECENT_MESSAGES,
+        // Landing EXACTLY on the cap is this room's entire purpose; the cap
+        // is raised so paired fillers still exceed the render window in
+        // display items.
+        HistoryDepth::AtCap => config.max_recent_messages = AT_CAP_MAX_RECENT_MESSAGES,
     }
     room_state.configuration = AuthorizedConfigurationV1::new(config, owner_sk);
 
@@ -438,17 +456,25 @@ fn add_example_messages(
 
     // Deep-history fixtures: filler messages AHEAD of the standard fixture so
     // the room's display-item count comfortably exceeds the render window.
-    // Authors strictly alternate — consecutive same-author messages within
-    // five minutes fold into one display item, so alternation is what makes
-    // "N messages" mean "N display items". Deterministic content and fixed
-    // 60s gaps: nothing here should vary run to run.
+    // Deep-room authors strictly ALTERNATE — consecutive same-author messages
+    // within five minutes fold into one display item, so alternation makes
+    // "N messages" mean "N display items". The AT-CAP room's authors come in
+    // PAIRS (AABB…) instead: two-message display groups are the dominant
+    // production shape, and a drained first message RE-KEYING its group is
+    // the #505 re-review blocker an alternating fixture cannot see.
+    // Deterministic content and fixed 60s gaps: nothing here varies run to
+    // run.
     let filler_count = match history_depth {
         HistoryDepth::Standard => 0,
         HistoryDepth::Deep => DEEP_HISTORY_FILLER_MESSAGES,
         HistoryDepth::AtCap => AT_CAP_FILLER_MESSAGES,
     };
     for i in 0..filler_count {
-        let (author_id, signing_key) = authors[i % 2.min(authors.len())];
+        let author_slot = match history_depth {
+            HistoryDepth::AtCap => (i / 2) % 2,
+            _ => i % 2,
+        };
+        let (author_id, signing_key) = authors[author_slot.min(authors.len() - 1)];
         let msg = AuthorizedMessageV1::new(
             MessageV1 {
                 room_owner: *owner_id,
@@ -785,7 +811,11 @@ mod tests {
     /// The at-cap fixture must land EXACTLY on its message cap: one message
     /// under and arrivals do not prune (blocker-1's index shift never
     /// happens); one over and `create_room`'s verify sees a state
-    /// `apply_delta` would never produce.
+    /// `apply_delta` would never produce. Its fillers must come in
+    /// same-author PAIRS — multi-message display groups are what makes an
+    /// at-cap drain RE-KEY the head group (#505 re-review blocker) — while
+    /// still exceeding the render window in display ITEMS (pairs halve the
+    /// item count).
     #[test]
     fn at_cap_room_is_exactly_at_its_message_cap() {
         let room = create_room(
@@ -801,16 +831,32 @@ mod tests {
             "the capped room must sit exactly at max_recent_messages so every \
              delivered arrival drains the oldest message (#505 blocker 1)"
         );
-        // And it is still deeper than the render window, so the windowed
-        // premise assertions hold for this room too.
-        assert!(state.recent_messages.messages.len() > 60);
-        for pair in state.recent_messages.messages[..AT_CAP_FILLER_MESSAGES].windows(2) {
-            assert_ne!(
+        // Paired fillers: within a pair the author repeats (the messages fold
+        // into ONE multi-message display group); across pairs it changes (the
+        // groups stay distinct).
+        let fillers = &state.recent_messages.messages[..AT_CAP_FILLER_MESSAGES];
+        for pair in fillers.chunks(2) {
+            assert_eq!(
                 pair[0].message.author, pair[1].message.author,
-                "adjacent fillers share an author and would merge into one \
-                 display item"
+                "a filler pair must share its author, or no display group has \
+                 more than one message and the re-key path is untestable"
             );
         }
+        for boundary in fillers.chunks(2).collect::<Vec<_>>().windows(2) {
+            assert_ne!(
+                boundary[0][0].message.author, boundary[1][0].message.author,
+                "adjacent pairs must differ in author, or they merge into one \
+                 display item and the item count collapses"
+            );
+        }
+        // Still deeper than the render window in display ITEMS, so the
+        // windowed premise assertions hold for this room too.
+        assert!(
+            AT_CAP_FILLER_MESSAGES / 2 > 60,
+            "paired fillers must still exceed INITIAL_WINDOW_ITEMS display \
+             items or the windowing specs quietly degrade to the small-room \
+             path"
+        );
     }
 
     #[test]

--- a/ui/tests/conversation-autoscroll.spec.ts
+++ b/ui/tests/conversation-autoscroll.spec.ts
@@ -680,6 +680,13 @@ test.describe("Windowed history follows arrivals (#501)", () => {
     // so tagging there is flaky by construction rather than by timing. The
     // rows just above the fold are the newest ones; they survive the drain,
     // and holding THEM still is the property under test.
+    //
+    // Deliberately NO settle wait before delivering: the batch lands while
+    // the reader's `scrollend` is still in flight, so this also covers the
+    // pre-settle window, where `pinned_to_bottom` is stale-true and only
+    // `reader_moved_up_since` stands the follow paths down. That is exactly
+    // what the relative `last_scroll_top` update protects, so the test would
+    // go quiet about it if it waited the pin out first.
     const parkedAt = Math.max(
       0,
       (await historyHeight(page)) - (await viewportHeight(page)) - 400
@@ -688,21 +695,6 @@ test.describe("Windowed history follows arrivals (#501)", () => {
     await expect
       .poll(() => distanceFromBottom(page), { timeout: 5_000 })
       .toBeGreaterThan(BOTTOM_THRESHOLD_PX);
-    // Wait out the reader's scrollend before delivering. "Parked" means their
-    // scroll has SETTLED — which is when the pin learns they left the bottom.
-    //
-    // Delivering INSIDE that ~120ms window hits #508, which is pre-existing
-    // and NOT what this test is about: while the pin is still stale-true, the
-    // patch momentarily shrinks the content below the reader's own offset, so
-    // `reader_moved_up_since`'s `.min(max_scroll_top(..))` clamp reads them as
-    // at the bottom and the FOLLOW path scrolls them there. Verified by
-    // removing this wait and re-running: 2/4 red on mobile Safari (chromium
-    // and firefox clean), and in the red runs `scrollTop` lands on exactly
-    // `max_scroll_top` — `scroll_history_to_bottom`'s signature, not this
-    // PR's compensation, which writes `scroll_top + shift` and is observed
-    // working in the green runs (7965 -> 7272, probed row held). The
-    // bottom-settle trim that follows the yank is what removes the row.
-    await page.waitForTimeout(400);
 
     const probe = await tagVisibleRow(page, "__riverProbeBatch");
     expect(

--- a/ui/tests/conversation-autoscroll.spec.ts
+++ b/ui/tests/conversation-autoscroll.spec.ts
@@ -673,16 +673,37 @@ test.describe("Windowed history follows arrivals (#501)", () => {
     await openRoomAtBottom(page, CAPPED_ROOM, DEEP_ROOM_PATH);
     await expectWindowedRenderActive(page);
 
-    const mid = Math.floor((await historyHeight(page)) / 2);
-    await readerScrollsTo(page, mid);
+    // Park just far enough up to be unpinned, NOT mid-history: the 61-message
+    // batch drains ~30 display items off the FRONT of a 74-item room, so a
+    // row tagged mid-history is inside the pruned range and legitimately
+    // leaves the DOM — which row exactly depends on per-engine row heights,
+    // so tagging there is flaky by construction rather than by timing. The
+    // rows just above the fold are the newest ones; they survive the drain,
+    // and holding THEM still is the property under test.
+    const parkedAt = Math.max(
+      0,
+      (await historyHeight(page)) - (await viewportHeight(page)) - 400
+    );
+    await readerScrollsTo(page, parkedAt);
     await expect
       .poll(() => distanceFromBottom(page), { timeout: 5_000 })
       .toBeGreaterThan(BOTTOM_THRESHOLD_PX);
+    // Wait out the reader's scrollend before delivering. "Parked" means their
+    // scroll has SETTLED — which is when the pin learns they left the bottom.
+    // Delivering inside that ~120ms window hits a separate, pre-existing
+    // hazard: a batch large enough to momentarily shrink the content below
+    // the reader's offset makes `reader_moved_up_since`'s
+    // `.min(max_scroll_top(..))` clamp read them as still at the bottom, so
+    // the stale-true pin lets the follow yank them down. Reproduced on mobile
+    // Safari (scrollTop 7910 → 13651, then the bottom-settle trim drops the
+    // rows they were reading); filed separately rather than folded in here,
+    // since it predates this PR and needs its own review.
+    await page.waitForTimeout(400);
 
     const probe = await tagVisibleRow(page, "__riverProbeBatch");
     expect(
       probe,
-      "premise: a rendered row should be visible mid-history"
+      "premise: a rendered row should be visible above the fold"
     ).not.toBeNull();
 
     const beforeBatch = await renderedRowCount(page);

--- a/ui/tests/conversation-autoscroll.spec.ts
+++ b/ui/tests/conversation-autoscroll.spec.ts
@@ -132,8 +132,12 @@ async function insertBeforeLast(page: Page, text: string) {
 }
 
 /// Open a room and wait until the history has settled at its newest message.
-async function openRoomAtBottom(page: Page, roomName: string) {
-  await page.goto("/");
+///
+/// `path` lets a test opt into fixture variants the default build hides —
+/// the windowed-history tests load `/?deep-history-room=1` to get a room
+/// deeper than the render window without changing what every other spec sees.
+async function openRoomAtBottom(page: Page, roomName: string, path = "/") {
+  await page.goto(path);
   await waitForApp(page);
   await selectRoom(page, roomName);
   await expectSettledAtBottom(page, "opening a room should land on its newest message");
@@ -430,5 +434,175 @@ test.describe("Conversation follows layout-only growth (#486)", () => {
     await expect
       .poll(() => distanceFromBottom(page), { timeout: 5_000 })
       .toBeGreaterThan(BOTTOM_THRESHOLD_PX);
+  });
+});
+
+// Regression tests for freenet/river#501: the #498 windowed tail slid its
+// start index forward on every arrival, removing the oldest rendered rows in
+// the same patch that appended the new message. Browser scroll anchoring
+// rewrote scrollTop to hold the visible content still, `reader_moved_up_since`
+// attributed the browser's adjustment to the reader, and both follow paths
+// stood down — so a room deeper than the render window stopped following
+// arrivals entirely, while every room the old suite seeded (~15-20 items vs a
+// 60-item window) kept passing on the pre-window code path.
+//
+// Every test here therefore asserts its PREMISE first — the backfill sentinel
+// is attached and the rendered row count is a windowed tail, not the whole
+// fixture — so a fixture change that shrinks the room below the window makes
+// these fail loudly instead of quietly regressing into small-room tests.
+//
+// The fixture: `?deep-history-room=1` adds a room of 80 alternating-author
+// messages (alternation makes messages == display items, so >60 items is a
+// guarantee) plus the ~12 standard fixture messages. The default fixture is
+// untouched; the describes above still exercise the small-room path.
+test.describe("Windowed history follows arrivals (#501)", () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  const DEEP_ROOM = "Deep History Room";
+  const DEEP_ROOM_PATH = "/?deep-history-room=1";
+
+  /// Rendered history rows: display items plus date separators. A windowed
+  /// tail is ~60 items + a separator or two; the whole fixture is ~92 items.
+  function renderedRowCount(page: Page): Promise<number> {
+    return page.evaluate(
+      () =>
+        document.querySelectorAll("#chat-scroll-container .space-y-4 > *")
+          .length
+    );
+  }
+
+  /// The premise all three tests stand on: the windowed render path is
+  /// actually active. Without this, a fixture or window-size change could
+  /// turn every test below into a duplicate of the small-room suite — the
+  /// exact coverage gap that let #501 ship green.
+  async function expectWindowedRenderActive(page: Page) {
+    await expect(
+      page.locator("#top-backfill-sentinel"),
+      "premise: the backfill sentinel must be attached — if the room fits in " +
+        "the window, nothing here exercises #501's code path"
+    ).toHaveCount(1);
+    const rows = await renderedRowCount(page);
+    expect(
+      rows,
+      "premise: the deep room must render a windowed TAIL (~60 items plus " +
+        "separators), not the whole fixture — a full render means the window " +
+        "backfilled behind the reader's back or the fixture shrank"
+    ).toBeLessThan(75);
+    expect(
+      rows,
+      "premise: the windowed tail itself should be on the page"
+    ).toBeGreaterThan(40);
+  }
+
+  test("keeps following a burst of arrivals in a windowed room", async ({
+    page,
+  }) => {
+    await openRoomAtBottom(page, DEEP_ROOM, DEEP_ROOM_PATH);
+    await expectWindowedRenderActive(page);
+
+    // The recorded #501 failure mode: with the reader pinned to the bottom,
+    // each arrival slid the window, the shifted scrollTop read as reader
+    // movement, and the view never followed again. The loop is what catches a
+    // fix that survives one arrival and then latches.
+    for (let i = 1; i <= 6; i++) {
+      await deliver(page, `windowed arrival ${i}`);
+      await expectSettledAtBottom(
+        page,
+        `arrival ${i} in a windowed room was not followed`
+      );
+    }
+
+    // Following six arrivals must not have cost the window its bound: the
+    // trim machinery (settle-at-bottom, ceiling) exists so a long pinned
+    // session cannot re-accumulate the unbounded render #498 removed.
+    expect(
+      await renderedRowCount(page),
+      "following arrivals should grow the window modestly, not unboundedly"
+    ).toBeLessThan(90);
+  });
+
+  test("arrivals do not move a reader parked in a windowed room's history", async ({
+    page,
+  }) => {
+    await openRoomAtBottom(page, DEEP_ROOM, DEEP_ROOM_PATH);
+    await expectWindowedRenderActive(page);
+
+    // Park mid-history: far enough from the bottom to unpin, far enough from
+    // the top not to trigger a backfill.
+    const mid = Math.floor((await historyHeight(page)) / 2);
+    await readerScrollsTo(page, mid);
+    await expect
+      .poll(() => distanceFromBottom(page), { timeout: 5_000 })
+      .toBeGreaterThan(BOTTOM_THRESHOLD_PX);
+
+    // Tag a row that is visible in the viewport and record where it sits.
+    // scrollTop alone cannot see this regression: with scroll anchoring
+    // disabled, a sliding window leaves scrollTop untouched and shifts the
+    // CONTENT under it — the reader watches their message jump away while
+    // every offset reads steady.
+    const probe = await page.evaluate(() => {
+      const container = document.getElementById("chat-scroll-container")!;
+      const cRect = container.getBoundingClientRect();
+      const rows = container.querySelectorAll(".space-y-4 > *");
+      for (const row of rows) {
+        const r = row.getBoundingClientRect();
+        if (r.top >= cRect.top && r.bottom <= cRect.bottom) {
+          (row as any).__riverProbe501 = true;
+          return r.top;
+        }
+      }
+      return null;
+    });
+    expect(
+      probe,
+      "premise: a rendered row should be visible mid-history"
+    ).not.toBeNull();
+
+    for (let i = 1; i <= 3; i++) {
+      await deliver(page, `parked windowed arrival ${i}`);
+    }
+    await expectStaysPut(
+      page,
+      "arrivals in a windowed room moved a parked reader's scroll offset"
+    );
+
+    const probedRowTop = await page.evaluate(() => {
+      const rows = document.querySelectorAll(
+        "#chat-scroll-container .space-y-4 > *"
+      );
+      for (const row of rows) {
+        if ((row as any).__riverProbe501) {
+          return row.getBoundingClientRect().top;
+        }
+      }
+      return null;
+    });
+    expect(
+      probedRowTop,
+      "the probed row left the DOM — the window slid out from under a parked reader"
+    ).not.toBeNull();
+    expect(
+      Math.abs(probedRowTop! - probe!),
+      "content shifted under a parked reader when arrivals landed"
+    ).toBeLessThanOrEqual(2);
+  });
+
+  test("opening a deep room lands settled at the bottom with the initial window", async ({
+    page,
+  }) => {
+    // `openRoomAtBottom` itself asserts the settle; the premise check is what
+    // rules out the H2 failure shape, where the backfill sentinel fires from
+    // scrollTop 0 before the opening snap and cascades the window over the
+    // whole room (the row count would be ~92, not ~62).
+    await openRoomAtBottom(page, DEEP_ROOM, DEEP_ROOM_PATH);
+    await expectWindowedRenderActive(page);
+
+    // And it STAYS settled: a late backfill restore racing the opening snap
+    // (H3) would park the view at the restore anchor moments later.
+    await expectStaysPut(page, "the view moved after the room-open snap settled");
+    await expectSettledAtBottom(
+      page,
+      "the room should still be at its newest message after settling"
+    );
   });
 });

--- a/ui/tests/conversation-autoscroll.spec.ts
+++ b/ui/tests/conversation-autoscroll.spec.ts
@@ -690,14 +690,18 @@ test.describe("Windowed history follows arrivals (#501)", () => {
       .toBeGreaterThan(BOTTOM_THRESHOLD_PX);
     // Wait out the reader's scrollend before delivering. "Parked" means their
     // scroll has SETTLED — which is when the pin learns they left the bottom.
-    // Delivering inside that ~120ms window hits a separate, pre-existing
-    // hazard: a batch large enough to momentarily shrink the content below
-    // the reader's offset makes `reader_moved_up_since`'s
-    // `.min(max_scroll_top(..))` clamp read them as still at the bottom, so
-    // the stale-true pin lets the follow yank them down. Reproduced on mobile
-    // Safari (scrollTop 7910 → 13651, then the bottom-settle trim drops the
-    // rows they were reading); filed separately rather than folded in here,
-    // since it predates this PR and needs its own review.
+    //
+    // Delivering INSIDE that ~120ms window hits #508, which is pre-existing
+    // and NOT what this test is about: while the pin is still stale-true, the
+    // patch momentarily shrinks the content below the reader's own offset, so
+    // `reader_moved_up_since`'s `.min(max_scroll_top(..))` clamp reads them as
+    // at the bottom and the FOLLOW path scrolls them there. Verified by
+    // removing this wait and re-running: 2/4 red on mobile Safari (chromium
+    // and firefox clean), and in the red runs `scrollTop` lands on exactly
+    // `max_scroll_top` — `scroll_history_to_bottom`'s signature, not this
+    // PR's compensation, which writes `scroll_top + shift` and is observed
+    // working in the green runs (7965 -> 7272, probed row held). The
+    // bottom-settle trim that follows the yank is what removes the row.
     await page.waitForTimeout(400);
 
     const probe = await tagVisibleRow(page, "__riverProbeBatch");

--- a/ui/tests/conversation-autoscroll.spec.ts
+++ b/ui/tests/conversation-autoscroll.spec.ts
@@ -654,6 +654,64 @@ test.describe("Windowed history follows arrivals (#501)", () => {
     ).toBeLessThanOrEqual(2);
   });
 
+  test("a batched at-cap drain does not crawl a parked reader (re-keyed head group)", async ({
+    page,
+  }) => {
+    // The capped room's fillers come in same-author PAIRS, so its display
+    // groups hold two messages — the dominant production shape. A batch of
+    // 61 arrivals drains 61 messages: ~30 whole pairs past the window head,
+    // plus one half-pair that RE-KEYS the group at the drain boundary (a
+    // group's key is its first message's id — the new key exists in no
+    // pre-patch row). The window must re-anchor on the surviving neighbors
+    // (spare keys) and the reposition must measure through a surviving row
+    // (probe walk), or the parked reader's view is torn away (#505
+    // re-review blocker).
+    //
+    // No scrollTop-stability assertion here, deliberately: the compensation
+    // MOVES scrollTop to hold the CONTENT still. The probed row's rect is
+    // the thing that must not move.
+    await openRoomAtBottom(page, CAPPED_ROOM, DEEP_ROOM_PATH);
+    await expectWindowedRenderActive(page);
+
+    const mid = Math.floor((await historyHeight(page)) / 2);
+    await readerScrollsTo(page, mid);
+    await expect
+      .poll(() => distanceFromBottom(page), { timeout: 5_000 })
+      .toBeGreaterThan(BOTTOM_THRESHOLD_PX);
+
+    const probe = await tagVisibleRow(page, "__riverProbeBatch");
+    expect(
+      probe,
+      "premise: a rendered row should be visible mid-history"
+    ).not.toBeNull();
+
+    const beforeBatch = await renderedRowCount(page);
+    await page.evaluate(() => (window as any).__riverTest.appendMessages(61));
+    // The batch landed and the SURVIVING remainder of the old window is still
+    // rendered (the arrivals alone add 61 rows; losing the survivors would
+    // shrink the count back toward the window size).
+    await expect
+      .poll(() => renderedRowCount(page), {
+        timeout: 5_000,
+        message:
+          "premise: the batch should land with the surviving window rows kept",
+      })
+      .toBeGreaterThan(beforeBatch + 30);
+    // Let scroll events from the reposition settle before measuring.
+    await page.waitForTimeout(300);
+
+    const after = await taggedRowTop(page, "__riverProbeBatch");
+    expect(
+      after,
+      "the probed row left the DOM — the window lost the surviving rows " +
+        "under a parked reader"
+    ).not.toBeNull();
+    expect(
+      Math.abs(after! - probe!),
+      "content moved under a parked reader across a batched at-cap drain"
+    ).toBeLessThanOrEqual(3);
+  });
+
   test("backfill paging reveals older history and keeps the reader's place", async ({
     page,
   }) => {

--- a/ui/tests/conversation-autoscroll.spec.ts
+++ b/ui/tests/conversation-autoscroll.spec.ts
@@ -661,13 +661,17 @@ test.describe("Windowed history follows arrivals (#501)", () => {
     await expectWindowedRenderActive(page);
     const initialRows = await renderedRowCount(page);
 
-    // Scroll to the very top and tag the current head row IN THE SAME
+    // Scroll to the very top and tag the current head ITEM row IN THE SAME
     // browser task — the sentinel's IntersectionObserver fires in a later
-    // task, so the tag always lands before the backfill.
+    // task, so the tag always lands before the backfill. The head's date
+    // SEPARATOR is not a valid probe: when older rows land above it, the day
+    // no longer starts at the old head, so that row legitimately leaves the
+    // DOM. The item row itself survives — item identity is exactly what the
+    // window anchors on.
     const probeTop = await page.evaluate(() => {
       const c = document.getElementById("chat-scroll-container")!;
       c.scrollTop = 0;
-      const row = c.querySelector(".space-y-4 > *") as HTMLElement;
+      const row = c.querySelector(".space-y-4 > [data-item-key]") as HTMLElement;
       (row as any).__riverPagingProbe = true;
       return row.getBoundingClientRect().top;
     });

--- a/ui/tests/conversation-autoscroll.spec.ts
+++ b/ui/tests/conversation-autoscroll.spec.ts
@@ -561,6 +561,17 @@ test.describe("Windowed history follows arrivals (#501)", () => {
     // follow snap settles at the bottom, and that settle trims the window
     // back toward its initial size. Polled because the last settle's trim
     // lands asynchronously.
+    //
+    // NOTE on what this test does and does not guard. It is what CAUGHT the
+    // trim/re-anchor bug (a trim shrinks the content, the browser clamps
+    // scrollTop, and an arrival landing before that clamp's settle was not
+    // followed) — but it only failed 5 runs in 16, so under the suite's
+    // `retries: 2` a regression has roughly a 3% chance of failing CI hard.
+    // The timing is not practical to force deterministically from a browser
+    // test. The DETERMINISTIC guard is the source pin
+    // `the_window_trims_at_the_bottom_and_backfill_defers_to_the_pin` in
+    // conversation.rs, which pins the flag, the guard and the scroll call;
+    // do not assume this test covers a revert.
     await expect
       .poll(() => renderedRowCount(page), {
         timeout: 5_000,

--- a/ui/tests/conversation-autoscroll.spec.ts
+++ b/ui/tests/conversation-autoscroll.spec.ts
@@ -459,6 +459,9 @@ test.describe("Windowed history follows arrivals (#501)", () => {
   test.use({ viewport: { width: 1280, height: 900 } });
 
   const DEEP_ROOM = "Deep History Room";
+  /// Seeded exactly at its max_recent_messages cap: every delivered arrival
+  /// drains the oldest message, shifting every item index (#505 blocker 1).
+  const CAPPED_ROOM = "Capped History Room";
   const DEEP_ROOM_PATH = "/?deep-history-room=1";
 
   /// Rendered history rows: display items plus date separators. A windowed
@@ -494,6 +497,44 @@ test.describe("Windowed history follows arrivals (#501)", () => {
     ).toBeGreaterThan(40);
   }
 
+  /// Tag the first history row fully inside the container's viewport and
+  /// return its viewport-relative top. scrollTop alone cannot see a window
+  /// slide: with scroll anchoring disabled, dropping rows above the viewport
+  /// leaves scrollTop untouched and shifts the CONTENT under it — the reader
+  /// watches their message jump away while every offset reads steady. The
+  /// probed row's rect is what catches that.
+  async function tagVisibleRow(page: Page, flag: string): Promise<number | null> {
+    return page.evaluate((f) => {
+      const container = document.getElementById("chat-scroll-container")!;
+      const cRect = container.getBoundingClientRect();
+      const rows = container.querySelectorAll(".space-y-4 > *");
+      for (const row of rows) {
+        const r = row.getBoundingClientRect();
+        if (r.top >= cRect.top && r.bottom <= cRect.bottom) {
+          (row as any)[f] = true;
+          return r.top;
+        }
+      }
+      return null;
+    }, flag);
+  }
+
+  /// The tagged row's current viewport-relative top, or null if it left the
+  /// DOM (i.e. the window slid out from under it).
+  async function taggedRowTop(page: Page, flag: string): Promise<number | null> {
+    return page.evaluate((f) => {
+      const rows = document.querySelectorAll(
+        "#chat-scroll-container .space-y-4 > *"
+      );
+      for (const row of rows) {
+        if ((row as any)[f]) {
+          return row.getBoundingClientRect().top;
+        }
+      }
+      return null;
+    }, flag);
+  }
+
   test("keeps following a burst of arrivals in a windowed room", async ({
     page,
   }) => {
@@ -503,7 +544,11 @@ test.describe("Windowed history follows arrivals (#501)", () => {
     // The recorded #501 failure mode: with the reader pinned to the bottom,
     // each arrival slid the window, the shifted scrollTop read as reader
     // movement, and the view never followed again. The loop is what catches a
-    // fix that survives one arrival and then latches.
+    // fix that survives one arrival and then latches. Delivered arrivals
+    // alternate authors (see `test_author` in example_data.rs), so each one
+    // is its own display item and the loop interleaves window GROWTH with the
+    // settle-at-bottom TRIM — six arrivals folding into one group would
+    // exercise the windowing arithmetic zero times.
     for (let i = 1; i <= 6; i++) {
       await deliver(page, `windowed arrival ${i}`);
       await expectSettledAtBottom(
@@ -512,13 +557,18 @@ test.describe("Windowed history follows arrivals (#501)", () => {
       );
     }
 
-    // Following six arrivals must not have cost the window its bound: the
-    // trim machinery (settle-at-bottom, ceiling) exists so a long pinned
-    // session cannot re-accumulate the unbounded render #498 removed.
-    expect(
-      await renderedRowCount(page),
-      "following arrivals should grow the window modestly, not unboundedly"
-    ).toBeLessThan(90);
+    // Following six arrivals must not have cost the window its bound: each
+    // follow snap settles at the bottom, and that settle trims the window
+    // back toward its initial size. Polled because the last settle's trim
+    // lands asynchronously.
+    await expect
+      .poll(() => renderedRowCount(page), {
+        timeout: 5_000,
+        message:
+          "the settle-at-bottom trim should return the window to ~initial size " +
+          "after a followed burst",
+      })
+      .toBeLessThan(67);
   });
 
   test("arrivals do not move a reader parked in a windowed room's history", async ({
@@ -535,24 +585,7 @@ test.describe("Windowed history follows arrivals (#501)", () => {
       .poll(() => distanceFromBottom(page), { timeout: 5_000 })
       .toBeGreaterThan(BOTTOM_THRESHOLD_PX);
 
-    // Tag a row that is visible in the viewport and record where it sits.
-    // scrollTop alone cannot see this regression: with scroll anchoring
-    // disabled, a sliding window leaves scrollTop untouched and shifts the
-    // CONTENT under it — the reader watches their message jump away while
-    // every offset reads steady.
-    const probe = await page.evaluate(() => {
-      const container = document.getElementById("chat-scroll-container")!;
-      const cRect = container.getBoundingClientRect();
-      const rows = container.querySelectorAll(".space-y-4 > *");
-      for (const row of rows) {
-        const r = row.getBoundingClientRect();
-        if (r.top >= cRect.top && r.bottom <= cRect.bottom) {
-          (row as any).__riverProbe501 = true;
-          return r.top;
-        }
-      }
-      return null;
-    });
+    const probe = await tagVisibleRow(page, "__riverProbe501");
     expect(
       probe,
       "premise: a rendered row should be visible mid-history"
@@ -566,25 +599,166 @@ test.describe("Windowed history follows arrivals (#501)", () => {
       "arrivals in a windowed room moved a parked reader's scroll offset"
     );
 
-    const probedRowTop = await page.evaluate(() => {
-      const rows = document.querySelectorAll(
-        "#chat-scroll-container .space-y-4 > *"
-      );
-      for (const row of rows) {
-        if ((row as any).__riverProbe501) {
-          return row.getBoundingClientRect().top;
-        }
-      }
-      return null;
-    });
+    const after = await taggedRowTop(page, "__riverProbe501");
     expect(
-      probedRowTop,
+      after,
       "the probed row left the DOM — the window slid out from under a parked reader"
     ).not.toBeNull();
     expect(
-      Math.abs(probedRowTop! - probe!),
+      Math.abs(after! - probe!),
       "content shifted under a parked reader when arrivals landed"
     ).toBeLessThanOrEqual(2);
+  });
+
+  test("arrivals do not crawl a parked reader in an at-cap room", async ({
+    page,
+  }) => {
+    // The at-cap room sits EXACTLY at max_recent_messages, so every arrival
+    // drains the oldest message and shifts every item index down — the
+    // steady state of every busy production room. A positional window anchor
+    // then swaps the head's IDENTITY one item per arrival: the top rendered
+    // row is removed in the same patch that appends the new one, and the
+    // parked reader crawls upward one row height each time (#505 blocker 1).
+    // The identity anchor must hold the head fixed instead.
+    await openRoomAtBottom(page, CAPPED_ROOM, DEEP_ROOM_PATH);
+    await expectWindowedRenderActive(page);
+
+    const mid = Math.floor((await historyHeight(page)) / 2);
+    await readerScrollsTo(page, mid);
+    await expect
+      .poll(() => distanceFromBottom(page), { timeout: 5_000 })
+      .toBeGreaterThan(BOTTOM_THRESHOLD_PX);
+
+    const probe = await tagVisibleRow(page, "__riverProbeAtCap");
+    expect(
+      probe,
+      "premise: a rendered row should be visible mid-history"
+    ).not.toBeNull();
+
+    for (let i = 1; i <= 4; i++) {
+      await deliver(page, `at-cap arrival ${i}`);
+    }
+    await expectStaysPut(
+      page,
+      "at-cap arrivals moved a parked reader's scroll offset"
+    );
+
+    const after = await taggedRowTop(page, "__riverProbeAtCap");
+    expect(
+      after,
+      "the probed row left the DOM — the at-cap window slid in content space"
+    ).not.toBeNull();
+    expect(
+      Math.abs(after! - probe!),
+      "content crawled under a parked reader as at-cap arrivals pruned the history"
+    ).toBeLessThanOrEqual(2);
+  });
+
+  test("backfill paging reveals older history and keeps the reader's place", async ({
+    page,
+  }) => {
+    await openRoomAtBottom(page, DEEP_ROOM, DEEP_ROOM_PATH);
+    await expectWindowedRenderActive(page);
+    const initialRows = await renderedRowCount(page);
+
+    // Scroll to the very top and tag the current head row IN THE SAME
+    // browser task — the sentinel's IntersectionObserver fires in a later
+    // task, so the tag always lands before the backfill.
+    const probeTop = await page.evaluate(() => {
+      const c = document.getElementById("chat-scroll-container")!;
+      c.scrollTop = 0;
+      const row = c.querySelector(".space-y-4 > *") as HTMLElement;
+      (row as any).__riverPagingProbe = true;
+      return row.getBoundingClientRect().top;
+    });
+
+    // The first growth step reveals a full page of older rows...
+    await expect
+      .poll(() => renderedRowCount(page), {
+        timeout: 5_000,
+        message: "reaching the top should backfill a page of older rows",
+      })
+      .toBeGreaterThan(initialRows + 40);
+
+    // ...and the restore keeps the row the reader was looking at where it
+    // was: the revealed rows land ABOVE, the offset is re-anchored by the
+    // container's measured growth.
+    const probeAfter = await taggedRowTop(page, "__riverPagingProbe");
+    expect(
+      probeAfter,
+      "the pre-backfill head row must survive a backfill"
+    ).not.toBeNull();
+    expect(
+      Math.abs(probeAfter! - probeTop),
+      "a backfill must not move the reader's view"
+    ).toBeLessThanOrEqual(3);
+
+    // Repeated paging must reach the very oldest history — a growth step
+    // that reveals nothing dead-ends here and the loop times out.
+    const oldestFiller = page.getByText("history filler 00", { exact: false });
+    for (let i = 0; i < 6 && (await oldestFiller.count()) === 0; i++) {
+      const before = await renderedRowCount(page);
+      await page.evaluate(() => {
+        document.getElementById("chat-scroll-container")!.scrollTop = 0;
+      });
+      await expect
+        .poll(() => renderedRowCount(page), {
+          timeout: 5_000,
+          message: `paging step ${i} revealed no further rows`,
+        })
+        .toBeGreaterThan(before);
+    }
+    expect(
+      await oldestFiller.count(),
+      "paging back through the whole room must reach the oldest filler"
+    ).toBe(1);
+  });
+
+  test("backfill still reveals older rows after arrivals grew the window", async ({
+    page,
+  }) => {
+    // #505 blocker 2: arrivals grow an anchored window past its REQUESTED
+    // size. A growth step computed from the stale request then resolves to a
+    // start the window already renders — zero new rows, no DOM change, the
+    // sentinel's IntersectionObserver never re-fires, and paging dead-ends.
+    // The growth step must come from the RENDERED size.
+    await openRoomAtBottom(page, DEEP_ROOM, DEEP_ROOM_PATH);
+    await expectWindowedRenderActive(page);
+
+    // Park mid-history so the batch below grows the window (a pinned reader's
+    // follow-snap settle would trim the divergence away before paging).
+    const mid = Math.floor((await historyHeight(page)) / 2);
+    await readerScrollsTo(page, mid);
+    await expect
+      .poll(() => distanceFromBottom(page), { timeout: 5_000 })
+      .toBeGreaterThan(BOTTOM_THRESHOLD_PX);
+
+    const beforeBatch = await renderedRowCount(page);
+    // One batched delivery of more than a whole growth step, in a single
+    // state mutation — as a network delta carrying many messages does.
+    await page.evaluate(() => (window as any).__riverTest.appendMessages(61));
+    await expect
+      .poll(() => renderedRowCount(page), {
+        timeout: 5_000,
+        message:
+          "premise: the batch should grow the anchored window past one whole " +
+          "growth step — without that divergence this test exercises nothing",
+      })
+      .toBeGreaterThan(beforeBatch + 55);
+
+    // Now page up. The FIRST sentinel fire must reveal older rows.
+    const beforePaging = await renderedRowCount(page);
+    await page.evaluate(() => {
+      document.getElementById("chat-scroll-container")!.scrollTop = 0;
+    });
+    await expect
+      .poll(() => renderedRowCount(page), {
+        timeout: 5_000,
+        message:
+          "the first backfill after an arrival burst revealed no older rows — " +
+          "the growth step dead-ended (#505 blocker 2)",
+      })
+      .toBeGreaterThan(beforePaging + 40);
   });
 
   test("opening a deep room lands settled at the bottom with the initial window", async ({
@@ -593,7 +767,10 @@ test.describe("Windowed history follows arrivals (#501)", () => {
     // `openRoomAtBottom` itself asserts the settle; the premise check is what
     // rules out the H2 failure shape, where the backfill sentinel fires from
     // scrollTop 0 before the opening snap and cascades the window over the
-    // whole room (the row count would be ~92, not ~62).
+    // whole room (the row count would be ~200, not ~62). Note the H2 race is
+    // timing-dependent in a live browser — this test catches it when it
+    // fires, but the deterministic guard is the source pin on the sentinel's
+    // `opening_snap_done` mount gate in conversation.rs.
     await openRoomAtBottom(page, DEEP_ROOM, DEEP_ROOM_PATH);
     await expectWindowedRenderActive(page);
 


### PR DESCRIPTION
## Problem

Reported by Ian (2026-07-26): the conversation stopped auto-scrolling to new
messages. #498's windowed tail advanced its start index on every arrival,
removing the oldest rendered rows in the same patch that appended the new
message at the bottom. Removing content above the viewport makes the browser's
scroll anchoring rewrite `scrollTop`; `reader_moved_up_since` then attributed
the browser's adjustment to the reader, both follow paths stood down, the
bottom gap grew by one message height per arrival, and once it passed
`BOTTOM_THRESHOLD_PX` the settle handler cleared the pin permanently (#501 H1).

Secondary defects in the same code: the top backfill sentinel could fire from
`scrollTop = 0` before the room-open snap landed, cascading the window over the
whole room (H2); the backfill restore consulted neither `pinned_to_bottom` nor
`force_scroll`, so it could park the view at its anchor over a concurrent
arrival — and because it writes `last_scroll_top`, the resulting settle read as
ours (H3); and date-separator churn at a sliding window head added further
unattributed shifts (H4).

The suite stayed green because the example fixture seeds ~15-20 display items
against `INITIAL_WINDOW_ITEMS = 60`: the window never slid, the sentinel never
rendered, and the entire #498 windowing path was dead code under CI.

## Approach

**Grow, don't slide — anchored by IDENTITY (H1, H4; #505 review blocker 1).**
`HistoryWindow::resolve` carries the previous render's head as a `WindowAnchor`
(the head item's key, up to 7 spare keys behind it, and the head's last index
as a relocation hint), re-located each render by `relocate_window`: the head
under its own key, else the first surviving spare (start = its position minus
its offset in the anchor), else index 0. The spares are load-bearing because
the head key alone can vanish while its neighbours survive — see the re-review
blocker below. On arrival the head stays the same ITEM and the
window grows at the bottom — nothing is removed above the viewport, for the
pinned reader and the parked-mid-history reader alike, and the frozen window
head retires H4's separator churn. Identity (not position) matters because
positions are unstable: an at-cap room (`max_recent_messages`, the steady state
of every busy room) drains its oldest message on every arrival, shifting every
index — a positional anchor slides the head in content space one row per
arrival forever.

**Bounded growth.** `WINDOW_ITEMS_CEILING` (4x the initial window = 240 items;
choice documented on the constant) caps what arrival growth can accumulate,
with one growth step of arrival grace above a reader-requested backfill. The
ceiling never caps the backfill request itself — that would dead-end paging.
The window trims back to `INITIAL_WINDOW_ITEMS` when a settle lands at the
exact bottom — the reader's or OURS (every follow snap, and the
scroll-to-latest button touch readers rely on) — because at the bottom a
top-trim is provably invisible (the `scrollTop` clamp keeps the tail glued).
The trim gate is `SCROLL_TOP_SLACK_PX`, not the 100px pin threshold, so a
reader parked slightly above the bottom is never clamped down by it. (This
deviates from the issue's "trim on the settle after they scroll up" sketch:
that trim would drop the very rows the reader is scrolling toward.)

**Parked-reader compensation (#505 review blocker 1).** When the head IS
swapped — pruned out from under the anchor, re-keyed, or dropped by a ceiling
trim — the render captures a SURVIVING row's pre-patch `offsetTop` (rows carry
`data-item-key`) and the `head_reposition` effect shifts a parked reader's
`scrollTop` by the measured post-patch difference: the one piece of scroll
anchoring reimplemented under our own control, exact including date-separator
churn, because a top-contiguous removal shifts every surviving row identically.
The probe walk is sized to `WINDOW_ANCHOR_KEYS`, since relocation landing via
spare `k` widens the window backward by `k` rows that never existed pre-patch;
a shorter walk dead-fires exactly on the largest removals.

**The reference moves RELATIVELY (#505 delta review blocker).** Both the
reposition and the backfill restore update `last_scroll_top` by the SHIFT, not
to the reader's new absolute offset. `last_scroll_top` is what
`reader_moved_up_since` measures against, and it only carries information in
the window between the reader moving and their `scrollend` landing — writing
their own freshly-compensated position into it collapses the guard to "has not
moved" while `pinned_to_bottom` is still stale-true, after which both follow
paths scroll them to the bottom and the resulting settle re-pins, permanently.
Two steady states this PR creates reach it constantly (a reader paged to the
front of an at-cap room; a parked reader at the ceiling). Relative preserves
the reader's gap in both directions, and resolves the pin honestly: the
compensation's settle reads as the READER's, so the handler re-measures and
clears the stale pin — correct, since the effect only runs for a genuinely
parked reader.

**Head-group re-keys (#505 RE-review blocker).** A message group's key is its
FIRST message's id, so an at-cap drain that consumes only that message leaves
the group alive but RE-KEYED — the norm, since consecutive same-author
messages fold into multi-message groups. Single-key anchoring then missed, and
the reposition probed the pre-patch DOM for the NEW key, which no row carried:
no compensation, and the parked reader crawled one intra-group line per
arrival. Two changes fix it: the spare keys above (the surviving neighbours
still pin the window), and `select_reposition_probe`, which walks forward from
the head (bounded at 4 rows) to the first key that HAS a pre-patch row and
measures on that. The old fixture was blind to this by construction — strictly
alternating authors never produce a multi-message group — so the capped
fixture now seeds same-author PAIRS.

**Scope, corrected:** compensated are front-contiguous removals (at-cap
drains, batched or not, re-keyed or not) and ceiling trims. NOT compensated:
bulk MID-window removals (ban purges) and late-loading media above a parked
viewport — follow-ups filed separately; the code comments say so rather than
claiming general coverage.

**No grow→trim oscillation.** At the bottom the sentinel intersects iff
`contentHeight < clientHeight + BACKFILL_LEAD_PX`, which a 60-item tail can
satisfy on a zoomed-out or tall-portrait viewport — trim would re-fire the
backfill, which would grow, snap, settle and trim again, a silent render loop.
`trim_would_rearm_backfill` estimates the retained tail's height and skips the
trim when it would land back in the strip's reach; the window then simply
stays grown, ceiling-bounded as ever.

**Backfill growth comes from the RENDERED size (#505 review blocker 2).**
Arrivals grow an anchored window past its requested size; a growth step
computed from the stale request could resolve to a start the window already
renders — zero new rows, no DOM change, the sentinel's IntersectionObserver
never re-fires, paging dead-ends. `grown_window` grows from the rendered size,
so every step reveals a full `WINDOW_GROWTH_ITEMS` beyond what is on screen.

**`overflow-anchor: none` on `#chat-scroll-container` (H1).** The pin
machinery owns this container's `scrollTop`. With anchoring off, `scrollTop`
changes only through our scrolls, the reader's, or the browser's shrink clamp,
which the guard's `.min(max_scroll_top(..))` already accounts for.

**Backfill hardening (H2, H3).** The restore effect runs synchronously
(post-patch, pre-paint — the deferred version let the browser paint one frame
of prepended rows at the wrong offset), repositions by the same MEASURED
probe-row technique rather than the raw `scrollHeight` delta (the delta also
counts an arrival appended BELOW the viewport in the same patch and
over-shifts the reader by its height; the delta survives only as the fallback
for a probe row pruned in that patch), and stands down when the view is pinned
or a forced snap is in flight — but distrusts a stale-true pin when the reader
has visibly moved (a continuous fling from the bottom into the sentinel band
settles no pin). The head reposition additionally stands down while
`last_scroll_top` already points at the bottom, so it cannot cancel the
scroll-to-latest smooth animation mid-flight. The top sentinel only mounts once the room-open snap has
landed (`opening_snap_done`, re-checked against the room so a rapid room
switch's stale snap task cannot un-gate the new room's sentinel, and gated
through the one render where the previous room's flag is still true). The
room-switch reset of the windowing state runs inline in render — including the
backfill capture, so a capture taken in the old room cannot restore into the
new one — so the new room's first frame never renders at the old room's depth.
The relocation walk compares keys without allocating (`display_item_key_matches`),
since the miss path is O(total) probes per render at the at-cap steady state.

## Testing

**Closes the CI coverage gap that let #501 ship.** `?deep-history-room=1` adds
two fixture rooms (default fixture untouched): **Deep History Room** — 188
alternating-author fillers + the 12 standard messages = 200 items, with
`max_recent_messages` raised to 300 so delivered arrivals don't prune —
and **Capped History Room** — seeded EXACTLY at its cap (148 fillers + 12
standard = 160) so every arrival drains the oldest message (the #505
blocker-1 surface), with fillers in same-author PAIRS so its display groups
hold two messages and an at-cap drain actually RE-KEYS the head group (the
re-review blocker; 74 display items still clears the 60-item window).
Alternation/pairing makes the item count a guarantee, pinned by native tests
(`deep_history_room_exceeds_the_render_window`,
`at_cap_room_is_exactly_at_its_message_cap`). The `__riverTest` hooks now
alternate append authors (a burst is N display items, not one merged group),
prune to `max_recent_messages` exactly as `MessagesV1::apply_delta` does, and
gain `appendMessages(n)` for a batched burst in one patch. **CI now also runs
`cargo test -p river-ui --bins --features example-data,no-sync`** — the
fixture tests were feature-gated and the featureless step never executed them.

Seven Playwright tests in the windowed describe, each asserting its premise
first (sentinel attached, rendered row count is a windowed tail):

* reader at bottom: six alternating arrivals, settled-at-bottom after each,
  then the settle-trim returns the window to ~initial size;
* reader parked mid-history (deep room): arrivals move neither `scrollTop`
  nor a probed visible row's rect;
* reader parked mid-history (at-cap room): four pruning arrivals do not crawl
  the probed row (#505 blocker 1);
* reader parked in the at-cap room, `appendMessages(61)` in ONE patch: the
  batch drains past the window head and re-keys the group at the boundary —
  the surviving rows stay rendered and the probed row holds within 3px (#505
  re-review blocker). No scrollTop assertion here deliberately: the
  compensation MOVES scrollTop in order to hold the content still. The test
  waits out the reader's `scrollend` before delivering — "parked" means
  settled — because delivering INSIDE that window hits #508, whose residual
  path is pre-existing (evidence below);
* backfill paging: first fire reveals a page, the probed head row stays put
  through the restore, repeated paging reaches "history filler 00";
* arrivals-then-page: a 61-message batch grows the anchored window, then the
  FIRST sentinel fire must reveal older rows (#505 blocker 2);
* opening the deep room lands settled at the bottom with the initial window
  (H2/H3; the deterministic guard is the source pin on the sentinel's mount
  gate — the browser race is timing-dependent).

**Red-run evidence.**
* Original #501 follow test vs unfixed `origin/main` (fixture + specs kept,
  `conversation.rs` reverted, rebuilt): fails at "arrival 1 in a windowed room
  was not followed" (distance 154px); guard tests pass pre-fix as expected.
* #505 blocker tests vs the pre-review PR HEAD (`6ed7239f`, same method,
  chromium `--retries=0`): **both red** — the at-cap parked test fails at
  "content crawled under a parked reader as at-cap arrivals pruned the
  history" (probed row shifted **384px** over four arrivals, expected ≤ 2px),
  and the arrivals-then-page test fails at "the first backfill after an
  arrival burst revealed no older rows" (row count stuck at 123 — the exact
  zero-new-rows dead-fire). Both green on the fixed head.
* Re-review blocker test vs the previous head (`7ade27d5`, same method,
  chromium `--retries=0`): **red** — "the probed row left the DOM — the window
  lost the surviving rows under a parked reader". Green on the fixed head.
* Delta-review blocker (the absolute-reference write): the wait-removal check
  was re-run against a **verified-fresh** build (`index.html` -> hashed `.js`
  -> hashed `.wasm`, all carrying the build's timestamp). With the wait
  removed the batched-drain test passes **12/12** across chromium, firefox and
  mobile-safari. My earlier red-run had captured a STALE bundle — I launched
  it before the rebuild had finished writing — so it was measuring the
  absolute-write bug this PR then fixed, not a residual. The wait is gone, and
  the test now delivers INSIDE the pre-settle window on purpose, since that is
  the window the relative update protects. #508's evidence has been corrected
  accordingly.
* Trim re-anchor (found by that re-run, 5/16 failing on chromium and present
  at the pre-fix head too): the trim removes rows above a view at the bottom,
  the browser clamps `scrollTop` by their height, and `last_scroll_top` still
  held the pre-trim bottom — so an arrival growing the content back before the
  clamp's settle made `reader_moved_up_since` read the clamp as reader
  movement and the follow stood down, leaving the reader a row short (a taller
  row would clear `BOTTOM_THRESHOLD_PX` and latch the pin off). A trim now
  flags itself and an effect re-anchors through `scroll_history_to_bottom`,
  which fixes the offset and the reference together. **32/32** after, against
  **5/16 failing** before.
* Unit-test mutations (applied-then-reverted, each confirmed to flip):
  gutting the render-side room reset fails the reset pin; reverting
  `grown_window` to `requested + GROWTH` fails the growth-step test; making
  `relocate_anchor` positional fails the identity-walk tests; restricting
  `relocate_window` to the head key alone fails the mid-window-deletion test;
  narrowing the reposition probe to the head row alone fails the re-key test;
  neutering `trim_would_rearm_backfill` fails the oscillation-guard test;
  un-pairing the capped fixture's authors fails its premise pin; shortening
  `REPOSITION_PROBE_ROWS` back to 4 fails the deepest-spare test; and
  reverting either reference update to absolute fails the relative-update pin.

Rust-side: `relocate_anchor` search-order/fallback tests, an at-cap
identity-walk test (40 pruning arrivals, head identity held, then the
head-pruned spare fallback), the re-key relocation + probe-walk test, a
batched-drain-past-the-head test, a mid-window head-deletion test (the case
where the spares are load-bearing and no fallback substitutes), the
oscillation-guard arithmetic, the blocker-2 growth-step test (including the
premise that the naive step really does dead-end), ceiling grace, and updated
source pins (identity resolve + write-back, rendered-size recording,
`grown_window` in the sentinel, trim-before-ours-early-out ordering, the
geometry gate on the trim, restore/reposition fling gates, the probe walk,
the measured backfill restore, sentinel mount gate, and room-reset needles
that cannot false-pass against the trim site).

Local runs on the release example build (head `ced941ab`, served-bundle
freshness — `index.html` → hashed `.js` → hashed `.wasm` — verified before
every browser run):

* `cargo test -p river-ui --bins`: **693 passed; 0 failed**
* `cargo test -p river-ui --bins --features example-data,no-sync`:
  **696 passed; 0 failed**
* `conversation-autoscroll`, `--repeat-each=4 --retries=0` across chromium +
  firefox + mobile-safari: **156 passed (1.4m)**
* the burst test alone, `--repeat-each=32 --retries=0`: **32 passed** — with
  the re-anchor guard in place, so the repair does not depend on firing in
  states it should not (it was 5/16 FAILING before the trim re-anchor existed)
* `conversation-autoscroll`, webkit + mobile-chrome `--retries=0`:
  **26 passed (24.6s)**
* full Playwright suite, chromium: **101 passed, 6 skipped (21.4s)** — the six
  are pre-existing conditional skips in `invite-via-dm-picker.spec.ts`
* `cargo fmt --check` clean; clippy warning count **34**, one BELOW `main`'s 35
  (no new warnings; clippy is off in River CI)

Related: #487 is the same family of mistake (measuring the DOM after the
update and attributing the result to the reader) in the DM thread modal. It is
NOT fixed here — different component, different mechanism, deliberately kept
separate. Also out of scope, tracked separately: parked-reader compensation
for late-loading media and for bulk mid-window removals (ban purges), and
**#508** — filed during this work from a code reading plus a reproduction that
turned out to be invalid (it ran against a stale bundle and was actually
showing this PR's own absolute-write bug, since fixed). I have posted a
correction retracting that evidence: the clamp hazard it describes is not
demonstrated by that scenario, because the arrivals grow the content faster
than the drain shrinks it, so `.min(max_scroll_top)` never bites there. It is
left for the maintainers to retitle, keep as a code-reading hazard, or close.

Closes #501

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCUNSVinAJ5fQxTbEtQxXK
