### PR TITLE
chore(cli): bump riverctl to 0.2.5 for the SUBSCRIBE-interleaving release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4766,7 +4766,7 @@ dependencies = [
 
 [[package]]
 name = "riverctl"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riverctl"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 authors = ["Freenet Project"]
 description = "Command-line interface for River decentralized chat on Freenet"


### PR DESCRIPTION
## Problem

`riverctl` on crates.io is at 0.2.4, which predates two fixes already merged to `main`:

- **#516** — the WebSocket API is multiplexed, so an UPDATE notification arriving between the SUBSCRIBE request and its response was consumed as the SUBSCRIBE answer, killing the reader session. Measured **~30 reader reconnects/hour** against the Freenet Official room.
- **#497** — verified reply target IDs in CLI JSON, plus the ban guards the moderator depends on.

Users installing from crates.io get neither. This is a version bump so the release tag can ship them.

## Approach

Bump `cli/Cargo.toml` only. `river-core` is untouched — both PRs changed only `cli/`, so it stays at the workspace version 0.1.18 and the release workflow's skip-if-already-published handles it.

## Testing

Production-verified rather than newly tested: a `riverctl` built from this exact commit's content has been running nova's River moderator since 2026-07-27 08:22, showing **0 reader reconnects and 0 SUBSCRIBE errors** over the soak window against a ~30/hour baseline. Both PRs carried their own tests when they merged (#516 added five classifier tests).

No new code here — the diff is two version strings.

## Release

After merge, tag `riverctl-v0.2.5` from `main` to trigger `release-riverctl.yml` (crates.io + GitHub release binaries).

[AI-assisted - Claude]