### PR TITLE
perf(ui): sign chat messages locally so a sent message renders immediately

### DIFF
--- a/.claude/skills/local-dev/SKILL.md
+++ b/.claude/skills/local-dev/SKILL.md
@@ -194,20 +194,19 @@ without `?debug=1`.
 A WASM panic hook creates a visible red error overlay showing the panic
 message. Appears automatically on any crash, no query param needed.
 
-### Delegate signing flow
+### Signing flow
 
-Message sending uses a delegate-based signing architecture:
-
-1. **Room creation** → `create_room_modal.rs` generates `SigningKey`, stores in ROOMS signal, and calls `store_signing_key()` to save it in the chat delegate
-2. **Message send** → UI calls `sign_message_with_fallback(room_key, msg, fallback_sk)`
-3. **Delegate signing** → `send_delegate_request(SignMessage{...})` → delegate looks up `signing_key:{origin}:{room_key}` → returns signature
-4. **Fallback** → If delegate fails, signs locally with `fallback_sk.sign()`
+1. **Room creation** → `create_room_modal.rs` generates `SigningKey`, stores it in the ROOMS signal as `RoomData::self_sk`, and calls `store_signing_key()` to save a copy in the chat delegate
+2. **Message send** → UI signs locally and synchronously: `sign_message_locally(&msg_bytes, &self_sk)`. There is **no** delegate round-trip on the message path (freenet/river#512) — it could not change the signature bytes and it cost seconds of visible lag
+3. **Everything else** (member, ban, config, member_info, secret, upgrade) → `sign_*_with_fallback` → `send_delegate_request(Sign*{...})` → delegate looks up `signing_key:{origin}:{room_key}` → returns signature
+4. **Fallback** → the delegate's answer is used only if it verifies under `self_sk`; otherwise (and on any delegate failure) the payload is signed locally with `self_sk`
 5. **Delta applied** → Message added to local state → `NEEDS_SYNC` set → `ProcessRooms` → UPDATE sent
 
 Key debugging points:
-- Node logs show `"Sign request for room, signature created: true/false"` — if false, delegate doesn't have the key
-- Browser console shows fallback path: `"Delegate signing failed, using fallback"`
-- If no UPDATE appears in node logs after signing, check if WebSocket is still connected
+- A slow or failed **message** send is never the delegate — nothing is asked of it. Look at step 5 (UPDATE / WebSocket) instead
+- For the other payload types, node logs show `"Sign request for room, signature created: true/false"` — if false, the delegate doesn't have the key
+- Browser console shows the fallback path: `"Delegate signing failed, using fallback"`
+- If no UPDATE appears in node logs after signing, check if the WebSocket is still connected
 
 ### Check contract state via riverctl
 
@@ -217,12 +216,14 @@ riverctl --node-url ws://127.0.0.1:7510/v1/contract/command?encodingProtocol=nat
 
 ### Timeline analysis for message send
 
-1. `SignMessage received` → delegate got the sign request
-2. `signature created: true/false` → delegate had (or didn't have) the key
+1. `[send] signed OK` (browser, with `?debug=1`) → the message was signed locally
+2. `[send] delta applied OK` → it is in local state and on screen
 3. `Update { key: ... }` → UPDATE arrived at node
 4. `ResultRouter received result` → UPDATE processed, result sent back to client
 
-If step 1 happens but step 3 doesn't, the browser died between signing and sending the UPDATE.
+If step 2 happens but step 3 doesn't, the browser died between applying the
+message locally and sending the UPDATE. There is no delegate step here — see
+"Signing flow" above.
 
 ### Firefox mobile: Dioxus RefCell re-entrant borrow panics
 

--- a/.claude/skills/local-dev/SKILL.md
+++ b/.claude/skills/local-dev/SKILL.md
@@ -203,7 +203,10 @@ message. Appears automatically on any crash, no query param needed.
 5. **Delta applied** → Message added to local state → `NEEDS_SYNC` set → `ProcessRooms` → UPDATE sent
 
 Key debugging points:
-- A slow or failed **message** send is never the delegate — nothing is asked of it. Look at step 5 (UPDATE / WebSocket) instead
+- A slow **message** send is not the SIGNING step — nothing is asked of the
+  delegate there. Step 5 is a different matter: the `NEEDS_SYNC` effect also
+  fires `save_rooms_to_delegate()` alongside the UPDATE, so a delegate op does
+  contend for the same node afterwards
 - For the other payload types, node logs show `"Sign request for room, signature created: true/false"` — if false, the delegate doesn't have the key
 - Browser console shows the fallback path: `"Delegate signing failed, using fallback"`
 - If no UPDATE appears in node logs after signing, check if the WebSocket is still connected

--- a/common/src/room_state/message.rs
+++ b/common/src/room_state/message.rs
@@ -1914,6 +1914,90 @@ mod tests {
         assert!(messages.reactions(&original_id).is_none());
     }
 
+    /// Swapping one reaction for another emits remove(old) + add(new) as a
+    /// PAIR, and since freenet/river#512 removed the delegate round-trip that
+    /// used to separate them, both are stamped from the same `Date.now()` —
+    /// so they now essentially always share a millisecond. `MessageOrderKey`
+    /// then breaks the tie by message id, which is a signature hash: the
+    /// replay order is effectively random and differs between peers.
+    ///
+    /// That is only safe because `ACTION_TYPE_REMOVE_REACTION` is scoped to
+    /// its own emoji, so the two actions touch disjoint map keys and commute.
+    /// If `remove_reaction` is ever widened to "clear this actor's reaction on
+    /// this target" — the natural reading of the one-reaction-per-user rule
+    /// the UI enforces client-side — a reaction swap starts silently
+    /// no-opping about half the time, on a hash comparison. This is what says
+    /// so.
+    #[test]
+    fn a_same_millisecond_reaction_swap_converges_either_way() {
+        let user_sk = SigningKey::generate(&mut OsRng);
+        let user_id = MemberId::from(&user_sk.verifying_key());
+        let owner_id = user_id;
+
+        let original = AuthorizedMessageV1::new(
+            MessageV1 {
+                room_owner: owner_id,
+                author: user_id,
+                time: SystemTime::UNIX_EPOCH,
+                content: RoomMessageBody::public("React to me!".to_string()),
+            },
+            &user_sk,
+        );
+        let target = original.id();
+
+        let react = |emoji: &str, remove: bool, time: SystemTime| {
+            let content = if remove {
+                RoomMessageBody::remove_reaction(target.clone(), emoji.to_string())
+            } else {
+                RoomMessageBody::reaction(target.clone(), emoji.to_string())
+            };
+            AuthorizedMessageV1::new(
+                MessageV1 {
+                    room_owner: owner_id,
+                    author: user_id,
+                    time,
+                    content,
+                },
+                &user_sk,
+            )
+        };
+
+        let first = react("👍", false, SystemTime::UNIX_EPOCH + Duration::from_secs(1));
+        // The swap pair: identical timestamps, as the UI now produces them.
+        let swap_at = SystemTime::UNIX_EPOCH + Duration::from_secs(2);
+        let remove_old = react("👍", true, swap_at);
+        let add_new = react("❤️", false, swap_at);
+        assert_eq!(
+            remove_old.message.time, add_new.message.time,
+            "premise: the swap pair must share a timestamp, or this test \
+             proves nothing about the tie-break"
+        );
+
+        for (label, pair) in [
+            ("remove first", vec![remove_old.clone(), add_new.clone()]),
+            ("add first", vec![add_new, remove_old]),
+        ] {
+            let mut messages = MessagesV1 {
+                messages: [vec![original.clone(), first.clone()], pair].concat(),
+                ..Default::default()
+            };
+            messages.rebuild_actions_state();
+
+            let reactions = messages
+                .reactions(&target)
+                .unwrap_or_else(|| panic!("{label}: the swapped-in reaction must survive"));
+            assert_eq!(
+                reactions.get("❤️").map(|r| r.as_slice()),
+                Some([user_id].as_slice()),
+                "{label}: the new reaction must be present"
+            );
+            assert!(
+                !reactions.contains_key("👍"),
+                "{label}: the old reaction must be gone"
+            );
+        }
+    }
+
     #[test]
     fn test_action_on_deleted_message_ignored() {
         let signing_key = SigningKey::generate(&mut OsRng);

--- a/common/src/room_state/message.rs
+++ b/common/src/room_state/message.rs
@@ -1967,11 +1967,6 @@ mod tests {
         let swap_at = SystemTime::UNIX_EPOCH + Duration::from_secs(2);
         let remove_old = react("👍", true, swap_at);
         let add_new = react("❤️", false, swap_at);
-        assert_eq!(
-            remove_old.message.time, add_new.message.time,
-            "premise: the swap pair must share a timestamp, or this test \
-             proves nothing about the tie-break"
-        );
 
         for (label, pair) in [
             ("remove first", vec![remove_old.clone(), add_new.clone()]),
@@ -1981,7 +1976,18 @@ mod tests {
                 messages: [vec![original.clone(), first.clone()], pair].concat(),
                 ..Default::default()
             };
+            let replay_order: Vec<_> = messages.messages.iter().map(|m| m.id()).collect();
             messages.rebuild_actions_state();
+            // Premise: the replay really is in vector order, so the two
+            // iterations of this loop exercise two DIFFERENT orders. If a
+            // future refactor sorts inside `rebuild_actions_state`, this test
+            // would otherwise degenerate into running one order twice and
+            // stay green.
+            assert_eq!(
+                messages.messages.iter().map(|m| m.id()).collect::<Vec<_>>(),
+                replay_order,
+                "{label}: rebuild_actions_state must replay in vector order"
+            );
 
             let reactions = messages
                 .reactions(&target)

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -3024,10 +3024,11 @@ pub fn Conversation() -> Element {
                 let has_existing = existing_reaction.is_some();
 
                 // Retained even though this block no longer awaits anything:
-                // `spawn_local` defers the body to a microtask, so it runs
-                // after the event handler's stack (and any Dioxus borrow) has
-                // unwound. Inlining it would re-introduce the Firefox-mobile
-                // re-entrant RefCell panics (freenet/river#512 review).
+                // it keeps the body off the event handler's stack. The guard
+                // that actually protects the ROOMS write is the
+                // `crate::util::defer` below (a real setTimeout) — inlining
+                // this block would put everything up to it back on the
+                // handler's stack (freenet/river#512 review).
                 spawn_local(async move {
                     use crate::util::ecies::encrypt_with_symmetric_key;
                     use river_core::room_state::content::ActionContentV1;
@@ -3197,10 +3198,11 @@ pub fn Conversation() -> Element {
                     .map(|(secret, version)| (*secret, version));
 
                 // Retained even though this block no longer awaits anything:
-                // `spawn_local` defers the body to a microtask, so it runs
-                // after the event handler's stack (and any Dioxus borrow) has
-                // unwound. Inlining it would re-introduce the Firefox-mobile
-                // re-entrant RefCell panics (freenet/river#512 review).
+                // it keeps the body off the event handler's stack. The guard
+                // that actually protects the ROOMS write is the
+                // `crate::util::defer` below (a real setTimeout) — inlining
+                // this block would put everything up to it back on the
+                // handler's stack (freenet/river#512 review).
                 spawn_local(async move {
                     use crate::util::ecies::encrypt_with_symmetric_key;
                     use river_core::room_state::content::ActionContentV1;
@@ -3323,10 +3325,11 @@ pub fn Conversation() -> Element {
                 }
 
                 // Retained even though this block no longer awaits anything:
-                // `spawn_local` defers the body to a microtask, so it runs
-                // after the event handler's stack (and any Dioxus borrow) has
-                // unwound. Inlining it would re-introduce the Firefox-mobile
-                // re-entrant RefCell panics (freenet/river#512 review).
+                // it keeps the body off the event handler's stack. The guard
+                // that actually protects the ROOMS write is the
+                // `crate::util::defer` below (a real setTimeout) — inlining
+                // this block would put everything up to it back on the
+                // handler's stack (freenet/river#512 review).
                 spawn_local(async move {
                     use crate::util::ecies::encrypt_with_symmetric_key;
                     use river_core::room_state::content::ActionContentV1;
@@ -3453,10 +3456,11 @@ pub fn Conversation() -> Element {
                 // (#402 review).
                 let force_scroll = force_scroll.clone();
                 // Retained even though this block no longer awaits anything:
-                // `spawn_local` defers the body to a microtask, so it runs
-                // after the event handler's stack (and any Dioxus borrow) has
-                // unwound. Inlining it would re-introduce the Firefox-mobile
-                // re-entrant RefCell panics (freenet/river#512 review).
+                // it keeps the body off the event handler's stack. The guard
+                // that actually protects the ROOMS write is the
+                // `crate::util::defer` below (a real setTimeout) — inlining
+                // this block would put everything up to it back on the
+                // handler's stack (freenet/river#512 review).
                 spawn_local(async move {
                     use river_core::room_state::content::{
                         ReplyContentV1, TextContentV1, CONTENT_TYPE_REPLY, CONTENT_TYPE_TEXT,
@@ -5593,45 +5597,47 @@ mod tests {
                      this pin on whatever replaced it, do not delete it"
                 )
             });
+            // Anchored on the ROOMS write itself, not on the `defer` that
+            // wraps it: a future edit adding an EARLIER defer to a handler (a
+            // scroll defer, a focus defer) would otherwise shrink the region
+            // and quietly let an await through behind it.
             let end = squashed[start..]
-                .find("crate::util::defer(move||{")
+                .find("ROOMS.with_mut(")
                 .map(|i| start + i)
                 .unwrap_or_else(|| {
                     panic!(
-                        "`{handler}` no longer defers its optimistic ROOMS \
-                         write — re-anchor this pin, do not delete it"
+                        "`{handler}` no longer applies its result to ROOMS \
+                         optimistically — re-anchor this pin, do not delete it"
                     )
                 });
+            let region = &squashed[start..end];
 
             assert!(
-                !squashed[start..end].contains(".await"),
+                !region.contains(".await"),
                 "`{handler}` awaits something before its optimistic ROOMS \
                  write. The UI is already committed to the action by then, so \
                  the user waits with nothing on screen for as long as that \
                  future takes — which is what freenet/river#512 was. Do the \
                  work after the local apply, or off this path entirely."
             );
+            // Per-region, so it also fails if signing moves INTO the deferred
+            // closure (outside the scanned region) or switches to another key.
+            assert!(
+                region.contains("sign_message_locally(&message_bytes,&self_sk)"),
+                "`{handler}` must sign with the room's own key, synchronously, \
+                 before the message reaches ROOMS"
+            );
+            // The write must still be deferred to a clean execution context —
+            // that `setTimeout`, not `spawn_local`, is what keeps the Dioxus
+            // signal write off the event handler's stack.
+            assert!(
+                region.contains("crate::util::defer(move||{"),
+                "`{handler}`'s ROOMS write must stay inside `crate::util::defer`"
+            );
         }
 
-        // The send path specifically must still reach its `ROOMS` write, or
-        // the loop above would be scanning a region that no longer renders
-        // anything.
-        let send = squashed
-            .find("lethandle_send_message={")
-            .expect("checked above");
-        assert!(
-            squashed[send..].contains("letdelta_applied=ROOMS.with_mut("),
-            "the send handler must still apply the message to ROOMS optimistically"
-        );
-
-        // One per handler, and no path may fall back to asking the delegate.
-        // Split so the needle cannot match its own text via `include_str!`.
-        assert_eq!(
-            squashed.matches("sign_message_locally(").count(),
-            4,
-            "all four message paths must sign with the room's own key, \
-             synchronously"
-        );
+        // No path may fall back to asking the delegate. Split so the needle
+        // cannot match its own text via `include_str!`.
         assert!(
             !squashed.contains(concat!("sign_message_", "with_fallback")),
             "message signing must not go through the delegate on any path \

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -3023,6 +3023,11 @@ pub fn Conversation() -> Element {
                 let clicked_same = existing_reaction.as_ref() == Some(&emoji);
                 let has_existing = existing_reaction.is_some();
 
+                // Retained even though this block no longer awaits anything:
+                // `spawn_local` defers the body to a microtask, so it runs
+                // after the event handler's stack (and any Dioxus borrow) has
+                // unwound. Inlining it would re-introduce the Firefox-mobile
+                // re-entrant RefCell panics (freenet/river#512 review).
                 spawn_local(async move {
                     use crate::util::ecies::encrypt_with_symmetric_key;
                     use river_core::room_state::content::ActionContentV1;
@@ -3191,6 +3196,11 @@ pub fn Conversation() -> Element {
                     .get_secret()
                     .map(|(secret, version)| (*secret, version));
 
+                // Retained even though this block no longer awaits anything:
+                // `spawn_local` defers the body to a microtask, so it runs
+                // after the event handler's stack (and any Dioxus borrow) has
+                // unwound. Inlining it would re-introduce the Firefox-mobile
+                // re-entrant RefCell panics (freenet/river#512 review).
                 spawn_local(async move {
                     use crate::util::ecies::encrypt_with_symmetric_key;
                     use river_core::room_state::content::ActionContentV1;
@@ -3312,6 +3322,11 @@ pub fn Conversation() -> Element {
                     return;
                 }
 
+                // Retained even though this block no longer awaits anything:
+                // `spawn_local` defers the body to a microtask, so it runs
+                // after the event handler's stack (and any Dioxus borrow) has
+                // unwound. Inlining it would re-introduce the Firefox-mobile
+                // re-entrant RefCell panics (freenet/river#512 review).
                 spawn_local(async move {
                     use crate::util::ecies::encrypt_with_symmetric_key;
                     use river_core::room_state::content::ActionContentV1;
@@ -3437,6 +3452,11 @@ pub fn Conversation() -> Element {
                 // rather than snapping a later unrelated message to the bottom
                 // (#402 review).
                 let force_scroll = force_scroll.clone();
+                // Retained even though this block no longer awaits anything:
+                // `spawn_local` defers the body to a microtask, so it runs
+                // after the event handler's stack (and any Dioxus borrow) has
+                // unwound. Inlining it would re-introduce the Firefox-mobile
+                // re-entrant RefCell panics (freenet/river#512 review).
                 spawn_local(async move {
                     use river_core::room_state::content::{
                         ReplyContentV1, TextContentV1, CONTENT_TYPE_REPLY, CONTENT_TYPE_TEXT,
@@ -3607,10 +3627,14 @@ pub fn Conversation() -> Element {
                         if delta_applied {
                             // Local apply succeeded and a message will mount:
                             // scroll it into view — but only if the user is still
-                            // viewing the room this send targeted. Signing is
-                            // async, so they may have switched rooms; arming the
-                            // conversation-wide flag then would snap the NEW room
-                            // to the bottom on its next message (#402 review).
+                            // viewing the room this send targeted. This runs two
+                            // task hops after the keypress (`spawn_local`, then
+                            // `defer`'s setTimeout), so they may have switched
+                            // rooms; arming the conversation-wide flag then would
+                            // snap the NEW room to the bottom on its next message
+                            // (#402 review). Still required now that signing is
+                            // synchronous — the hops, not the signature, are what
+                            // let a room switch interleave.
                             if CURRENT_ROOM.peek().owner_key == Some(current_room) {
                                 force_scroll.set(true);
                             }
@@ -5511,26 +5535,28 @@ mod tests {
         );
     }
 
-    /// Source-grep pin (freenet/river#512): nothing on the send path may be
-    /// awaited between the user pressing Enter and the message reaching
-    /// `ROOMS`.
+    /// Source-grep pin (freenet/river#512): nothing may be awaited between the
+    /// user acting on a message and that message reaching `ROOMS`.
     ///
-    /// The composer clears synchronously and the render is driven by the
-    /// optimistic write to `ROOMS`, so every suspension point in between is
-    /// dead air with an empty input box and no message. The one that shipped
-    /// was a delegate signing round-trip: on a hosted node that is a WAN hop
-    /// queued behind contract merges on a serial WASM executor, with a 10s
-    /// timeout before the local fallback.
+    /// All four handlers — send, reaction, delete, edit — render optimistically:
+    /// the composer (or the reaction pill) updates the instant the delta is
+    /// applied to `ROOMS`, and nothing waits for the network echo. So every
+    /// suspension point before that write is dead air, with the composer
+    /// already cleared and no message in its place.
     ///
-    /// It cost seconds and could not change the produced bytes — see
+    /// The one that shipped was a delegate signing round-trip. On a hosted node
+    /// that is a WAN hop queued behind contract merges on a serial WASM
+    /// executor, with a 10s timeout before the local fallback. It cost seconds
+    /// and could not change the produced bytes — see
     /// `signing::a_delegate_signature_can_never_differ_from_the_local_one`.
+    ///
     /// It is also invisible in development: with `--features no-sync` the
     /// delegate request fails instantly, so `dev-example` and every Playwright
     /// spec only ever exercise the fast path. Nothing but this pin stands
     /// between a future `.await` here and another silent multi-second
     /// regression.
     #[test]
-    fn nothing_is_awaited_between_pressing_enter_and_the_message_appearing() {
+    fn nothing_is_awaited_between_acting_on_a_message_and_it_appearing() {
         let source = include_str!("conversation.rs");
         // Same cut as the pins around it — see
         // `author_deputy_badge_uses_the_shared_helper` for why it must be this
@@ -5538,51 +5564,74 @@ mod tests {
         let prod = &source[..source
             .find("#[cfg(test)]\nmod tests {")
             .expect("conversation.rs should have a `#[cfg(test)] mod tests` block")];
-        // Strip line comments first: prose about awaiting (this file has
-        // plenty) must not satisfy the search, and a doc comment must not be
-        // able to disarm the assertion by accident either.
+        // Drop whole-line comments, so prose about awaiting (this file has
+        // plenty) cannot satisfy the search. Deliberately NOT `split_once`,
+        // which would also truncate a line at a `//` inside a string literal
+        // (`"https://…"`) and could hide a real trailing `.await`. A trailing
+        // comment that happens to contain the needle now fails the test
+        // instead, which is the safe direction: loud, not silent.
         let code: String = prod
             .lines()
-            .map(|line| line.split_once("//").map(|(c, _)| c).unwrap_or(line))
+            .filter(|line| !line.trim_start().starts_with("//"))
             .collect::<Vec<_>>()
             .join("\n");
         // Whitespace-stripped so a rustfmt re-wrap cannot silently disarm it.
         let squashed: String = code.chars().filter(|c| !c.is_whitespace()).collect();
 
-        let entry = "lethandle_send_message={";
-        let rooms_write = "letdelta_applied=ROOMS.with_mut(";
-        let start = squashed.find(entry).expect(
-            "the send handler must still be `let handle_send_message = { … }` \
-             in conversation.rs — re-anchor this pin if it was renamed, do not \
-             delete it",
-        );
-        let end = squashed[start..]
-            .find(rooms_write)
-            .map(|i| start + i)
-            .expect(
-                "the send handler must still reach its optimistic \
-             `ROOMS.with_mut` write — re-anchor this pin if that was renamed, \
-             do not delete it",
+        // Every optimistic-render handler, not just the one #512 was reported
+        // against: they are the same shape, and all four carried the same await.
+        // Each ends at the `defer` that performs its `ROOMS` write.
+        for handler in [
+            "lethandle_send_message={",
+            "lethandle_toggle_reaction={",
+            "lethandle_delete_message={",
+            "lethandle_edit_message={",
+        ] {
+            let start = squashed.find(handler).unwrap_or_else(|| {
+                panic!(
+                    "conversation.rs no longer defines `{handler}` — re-anchor \
+                     this pin on whatever replaced it, do not delete it"
+                )
+            });
+            let end = squashed[start..]
+                .find("crate::util::defer(move||{")
+                .map(|i| start + i)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "`{handler}` no longer defers its optimistic ROOMS \
+                         write — re-anchor this pin, do not delete it"
+                    )
+                });
+
+            assert!(
+                !squashed[start..end].contains(".await"),
+                "`{handler}` awaits something before its optimistic ROOMS \
+                 write. The UI is already committed to the action by then, so \
+                 the user waits with nothing on screen for as long as that \
+                 future takes — which is what freenet/river#512 was. Do the \
+                 work after the local apply, or off this path entirely."
             );
+        }
 
-        let send_path = &squashed[start..end];
+        // The send path specifically must still reach its `ROOMS` write, or
+        // the loop above would be scanning a region that no longer renders
+        // anything.
+        let send = squashed
+            .find("lethandle_send_message={")
+            .expect("checked above");
         assert!(
-            !send_path.contains(".await"),
-            "the send path awaits something between the handler entry and the \
-             optimistic ROOMS write. The composer is already cleared by then, \
-             so the user stares at an empty input box for as long as that \
-             future takes — which is what freenet/river#512 was. Do the work \
-             after the local apply (or off the send path entirely)."
-        );
-        assert!(
-            send_path.contains("sign_message_locally(&message_bytes,&self_sk)"),
-            "the send path must sign with the room's own key, synchronously"
+            squashed[send..].contains("letdelta_applied=ROOMS.with_mut("),
+            "the send handler must still apply the message to ROOMS optimistically"
         );
 
-        // Reactions, deletes and edits render optimistically the same way and
-        // sign the same `MessageV1` with the same key, so the delegate
-        // round-trip is exactly as pointless — and as slow — on those paths.
+        // One per handler, and no path may fall back to asking the delegate.
         // Split so the needle cannot match its own text via `include_str!`.
+        assert_eq!(
+            squashed.matches("sign_message_locally(").count(),
+            4,
+            "all four message paths must sign with the room's own key, \
+             synchronously"
+        );
         assert!(
             !squashed.contains(concat!("sign_message_", "with_fallback")),
             "message signing must not go through the delegate on any path \

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -2991,7 +2991,6 @@ pub fn Conversation() -> Element {
             if let (Some(current_room), Some(current_room_data)) =
                 (open_room, current_room_data_snapshot())
             {
-                let room_key = current_room_data.room_key();
                 let self_sk = current_room_data.self_sk.clone();
                 let room_state_clone = current_room_data.room_state.clone();
                 let is_private = current_room_data
@@ -3118,12 +3117,8 @@ pub fn Conversation() -> Element {
                             return;
                         }
 
-                        let signature = crate::signing::sign_message_with_fallback(
-                            room_key,
-                            message_bytes.clone(),
-                            &self_sk,
-                        )
-                        .await;
+                        let signature =
+                            crate::signing::sign_message_locally(&message_bytes, &self_sk);
 
                         auth_messages.push(AuthorizedMessageV1::with_signature(message, signature));
                     }
@@ -3184,7 +3179,6 @@ pub fn Conversation() -> Element {
             if let (Some(current_room), Some(current_room_data)) =
                 (open_room, current_room_data_snapshot())
             {
-                let room_key = current_room_data.room_key();
                 let self_sk = current_room_data.self_sk.clone();
                 let room_state_clone = current_room_data.room_state.clone();
                 let is_private = current_room_data
@@ -3230,12 +3224,7 @@ pub fn Conversation() -> Element {
                         return;
                     }
 
-                    let signature = crate::signing::sign_message_with_fallback(
-                        room_key,
-                        message_bytes,
-                        &self_sk,
-                    )
-                    .await;
+                    let signature = crate::signing::sign_message_locally(&message_bytes, &self_sk);
 
                     let auth_message = AuthorizedMessageV1::with_signature(message, signature);
                     let (members_delta, member_info_delta) =
@@ -3292,7 +3281,6 @@ pub fn Conversation() -> Element {
             if let (Some(current_room), Some(current_room_data)) =
                 (open_room, current_room_data_snapshot())
             {
-                let room_key = current_room_data.room_key();
                 let self_sk = current_room_data.self_sk.clone();
                 let room_state_clone = current_room_data.room_state.clone();
                 let is_private = current_room_data
@@ -3359,12 +3347,7 @@ pub fn Conversation() -> Element {
                         return;
                     }
 
-                    let signature = crate::signing::sign_message_with_fallback(
-                        room_key,
-                        message_bytes,
-                        &self_sk,
-                    )
-                    .await;
+                    let signature = crate::signing::sign_message_locally(&message_bytes, &self_sk);
 
                     let auth_message = AuthorizedMessageV1::with_signature(message, signature);
                     let (members_delta, member_info_delta) =
@@ -3438,7 +3421,6 @@ pub fn Conversation() -> Element {
                 (current_room_opt, fresh_room_data)
             {
                 // Clone what we need for the async block
-                let room_key = current_room_data.room_key();
                 let self_sk = current_room_data.self_sk.clone();
                 let room_state_clone = current_room_data.room_state.clone();
                 let is_private = current_room_data.is_private();
@@ -3558,14 +3540,13 @@ pub fn Conversation() -> Element {
                         return;
                     }
 
-                    // Sign using delegate with fallback to local signing
+                    // Sign locally and synchronously. Do NOT reinstate a
+                    // delegate round-trip here — see `sign_message_locally`
+                    // (freenet/river#512): it cannot change these bytes, and
+                    // awaiting it is what made a sent message take seconds to
+                    // appear.
                     crate::util::debug_log("[send] signing message...");
-                    let signature = crate::signing::sign_message_with_fallback(
-                        room_key,
-                        message_bytes,
-                        &self_sk,
-                    )
-                    .await;
+                    let signature = crate::signing::sign_message_locally(&message_bytes, &self_sk);
                     crate::util::debug_log("[send] signed OK");
 
                     let auth_message = AuthorizedMessageV1::with_signature(message, signature);
@@ -5527,6 +5508,85 @@ mod tests {
             squashed.matches("current_room_data_snapshot()").count() >= 4,
             "the react/delete/edit handlers must each resolve the open room \
              through `current_room_data_snapshot()` at interaction time"
+        );
+    }
+
+    /// Source-grep pin (freenet/river#512): nothing on the send path may be
+    /// awaited between the user pressing Enter and the message reaching
+    /// `ROOMS`.
+    ///
+    /// The composer clears synchronously and the render is driven by the
+    /// optimistic write to `ROOMS`, so every suspension point in between is
+    /// dead air with an empty input box and no message. The one that shipped
+    /// was a delegate signing round-trip: on a hosted node that is a WAN hop
+    /// queued behind contract merges on a serial WASM executor, with a 10s
+    /// timeout before the local fallback.
+    ///
+    /// It cost seconds and could not change the produced bytes — see
+    /// `signing::a_delegate_signature_can_never_differ_from_the_local_one`.
+    /// It is also invisible in development: with `--features no-sync` the
+    /// delegate request fails instantly, so `dev-example` and every Playwright
+    /// spec only ever exercise the fast path. Nothing but this pin stands
+    /// between a future `.await` here and another silent multi-second
+    /// regression.
+    #[test]
+    fn nothing_is_awaited_between_pressing_enter_and_the_message_appearing() {
+        let source = include_str!("conversation.rs");
+        // Same cut as the pins around it — see
+        // `author_deputy_badge_uses_the_shared_helper` for why it must be this
+        // needle and not a bare `#[cfg(test)]`.
+        let prod = &source[..source
+            .find("#[cfg(test)]\nmod tests {")
+            .expect("conversation.rs should have a `#[cfg(test)] mod tests` block")];
+        // Strip line comments first: prose about awaiting (this file has
+        // plenty) must not satisfy the search, and a doc comment must not be
+        // able to disarm the assertion by accident either.
+        let code: String = prod
+            .lines()
+            .map(|line| line.split_once("//").map(|(c, _)| c).unwrap_or(line))
+            .collect::<Vec<_>>()
+            .join("\n");
+        // Whitespace-stripped so a rustfmt re-wrap cannot silently disarm it.
+        let squashed: String = code.chars().filter(|c| !c.is_whitespace()).collect();
+
+        let entry = "lethandle_send_message={";
+        let rooms_write = "letdelta_applied=ROOMS.with_mut(";
+        let start = squashed.find(entry).expect(
+            "the send handler must still be `let handle_send_message = { … }` \
+             in conversation.rs — re-anchor this pin if it was renamed, do not \
+             delete it",
+        );
+        let end = squashed[start..]
+            .find(rooms_write)
+            .map(|i| start + i)
+            .expect(
+                "the send handler must still reach its optimistic \
+             `ROOMS.with_mut` write — re-anchor this pin if that was renamed, \
+             do not delete it",
+            );
+
+        let send_path = &squashed[start..end];
+        assert!(
+            !send_path.contains(".await"),
+            "the send path awaits something between the handler entry and the \
+             optimistic ROOMS write. The composer is already cleared by then, \
+             so the user stares at an empty input box for as long as that \
+             future takes — which is what freenet/river#512 was. Do the work \
+             after the local apply (or off the send path entirely)."
+        );
+        assert!(
+            send_path.contains("sign_message_locally(&message_bytes,&self_sk)"),
+            "the send path must sign with the room's own key, synchronously"
+        );
+
+        // Reactions, deletes and edits render optimistically the same way and
+        // sign the same `MessageV1` with the same key, so the delegate
+        // round-trip is exactly as pointless — and as slow — on those paths.
+        // Split so the needle cannot match its own text via `include_str!`.
+        assert!(
+            !squashed.contains(concat!("sign_message_", "with_fallback")),
+            "message signing must not go through the delegate on any path \
+             (freenet/river#512)"
         );
     }
 

--- a/ui/src/signing.rs
+++ b/ui/src/signing.rs
@@ -1,11 +1,17 @@
-//! Signing API for delegate-based signing operations.
+//! Signing API for room payloads.
 //!
-//! This module provides async wrapper functions that send signing requests
-//! to the chat delegate and wait for responses. The delegate holds the signing
-//! keys and performs all signing operations, so private keys never leave the delegate.
+//! The chat delegate holds a copy of each room's signing key, and most signable
+//! types (member, ban, config, member_info, secret, upgrade) are signed by
+//! asking it over the WebSocket — see the `sign_*_with_fallback` functions.
 //!
-//! The module also provides fallback functionality that signs locally if the
-//! delegate signing fails, for backwards compatibility during migration.
+//! `RoomData::self_sk` is the authoritative key in every case, though: a
+//! delegate answer is used only when it verifies under it, and otherwise the
+//! payload is signed locally. Chat messages skip the round-trip entirely and
+//! sign locally (`sign_message_locally`, freenet/river#512), because the answer
+//! could not differ and waiting for it is what the sender sees as lag.
+//!
+//! This module also owns the signing-key migration that puts `self_sk` into the
+//! delegate in the first place.
 
 use crate::components::app::chat_delegate::{generate_request_id, send_delegate_request};
 use dioxus::logger::tracing::{info, warn};
@@ -471,9 +477,10 @@ async fn delegate_sign_or_fallback(
 /// executor, with a 10s timeout before the local fallback — seconds of blank
 /// composer for a signature the browser could produce in microseconds.
 ///
-/// The other `sign_*_with_fallback` functions keep the delegate call: they are
-/// off the interactive send path, so the argument about latency does not apply
-/// and there is no reason to change them in the same breath.
+/// The same three facts hold for the other `sign_*_with_fallback` functions —
+/// their delegate answers are equally unable to change the bytes — so the
+/// delegate call is not buying them correctness either. They are left alone
+/// because none of them is on the send path, not because they need it.
 pub fn sign_message_locally(message_bytes: &[u8], self_sk: &SigningKey) -> Signature {
     self_sk.sign(message_bytes)
 }
@@ -686,6 +693,60 @@ mod tests {
             local.to_bytes(),
             "a failed delegate sign must fall back to the local signature"
         );
+    }
+
+    /// freenet/river#512: the send path hand-rolls the signing preimage —
+    /// CBOR-encode `MessageV1`, then `sign_message_locally` those bytes —
+    /// because it needs to fail gracefully on a serialization error where
+    /// `sign_struct` would panic in WASM. That leaves four copies of the
+    /// preimage that must stay byte-identical to what the contract verifies,
+    /// held together by convention alone. Pin the two together: if
+    /// `sign_struct` ever gains a domain separator or a version tag, every
+    /// message a user sends would be rejected by the contract while every
+    /// other test still passed.
+    #[test]
+    fn a_locally_signed_message_is_what_the_contract_verifies() {
+        let self_sk = SigningKey::from_bytes(&[5u8; 32]);
+        let owner_vk = SigningKey::from_bytes(&[6u8; 32]).verifying_key();
+        let message = MessageV1 {
+            room_owner: MemberId::from(&owner_vk),
+            author: MemberId::from(&self_sk.verifying_key()),
+            content: RoomMessageBody::public("hello".to_string()),
+            time: std::time::SystemTime::UNIX_EPOCH,
+        };
+
+        // Exactly what the four call sites in `conversation.rs` do.
+        let mut message_bytes = Vec::new();
+        ciborium::ser::into_writer(&message, &mut message_bytes).expect("MessageV1 must serialize");
+        let sent = AuthorizedMessageV1::with_signature(
+            message.clone(),
+            sign_message_locally(&message_bytes, &self_sk),
+        );
+
+        sent.validate(&self_sk.verifying_key()).expect(
+            "a message signed on the send path must verify under the author's \
+             own key — this is what the room contract checks before accepting it",
+        );
+        assert_eq!(
+            sent.signature.to_bytes(),
+            AuthorizedMessageV1::new(message, &self_sk)
+                .signature
+                .to_bytes(),
+            "the send path's hand-rolled preimage must match `sign_struct`'s"
+        );
+    }
+
+    /// freenet/river#512 rests on `RoomData::self_sk` being present and
+    /// authoritative — the send path signs with it and never consults the
+    /// delegate. If it ever becomes optional (delegate-only custody, a
+    /// hardware key), the message path needs rethinking rather than an
+    /// `unwrap`, and this is what says so at compile time.
+    #[test]
+    fn the_send_path_always_has_a_local_signing_key() {
+        fn assert_plain_signing_key(room: &crate::room_data::RoomData) -> &SigningKey {
+            &room.self_sk
+        }
+        let _ = assert_plain_signing_key;
     }
 
     /// freenet/river#414 (Codex round-8): an AUTHORITATIVE identity choice records

--- a/ui/src/signing.rs
+++ b/ui/src/signing.rs
@@ -65,16 +65,10 @@ pub async fn get_public_key(room_key: RoomKey) -> Result<Option<VerifyingKey>, S
     }
 }
 
-/// Sign a message (MessageV1).
-pub async fn sign_message(room_key: RoomKey, message_bytes: Vec<u8>) -> Result<Signature, String> {
-    let request = ChatDelegateRequestMsg::SignMessage {
-        room_key,
-        request_id: generate_request_id(),
-        message_bytes,
-    };
-
-    extract_signature(send_delegate_request(request).await)
-}
+// NOTE: there is deliberately no `sign_message` delegate request here. Chat
+// messages sign locally via `sign_message_locally` (freenet/river#512); the
+// `ChatDelegateRequestMsg::SignMessage` variant is retained in the delegate
+// protocol for older clients.
 
 /// Sign a member invitation (Member).
 pub async fn sign_member(room_key: RoomKey, member_bytes: Vec<u8>) -> Result<Signature, String> {
@@ -457,22 +451,31 @@ async fn delegate_sign_or_fallback(
     }
 }
 
-/// Sign message bytes with delegate, falling back to local signing if delegate fails
-/// or has a stale key.
-pub async fn sign_message_with_fallback(
-    room_key: RoomKey,
-    message_bytes: Vec<u8>,
-    fallback_key: &SigningKey,
-) -> Signature {
-    crate::util::debug_log("[sign] requesting delegate signature...");
-    let sig = delegate_sign_or_fallback(
-        sign_message(room_key, message_bytes.clone()),
-        &message_bytes,
-        fallback_key,
-    )
-    .await;
-    crate::util::debug_log("[sign] signed OK");
-    sig
+/// Sign message bytes (`MessageV1`) with the room's own key, synchronously.
+///
+/// Chat messages deliberately do NOT ask the delegate for a signature, unlike
+/// every other signable type in this module. Do not "restore" the delegate
+/// round-trip here — it cannot change the produced bytes and it costs a WAN
+/// round-trip on the one path a user watches (freenet/river#512):
+///
+/// 1. `delegate_sign_or_fallback` accepts the delegate's answer only when it
+///    verifies under `self_sk` (see above); otherwise it signs locally anyway.
+/// 2. `RoomData::self_sk` is a plain, always-present field — the private key is
+///    already in the browser, so there is nothing to wait for.
+/// 3. Ed25519 is deterministic (RFC 8032), and the delegate signs with
+///    `SigningKey::from_bytes(sk).sign(data)` — the same operation. So whenever
+///    the delegate's answer is *accepted*, it is byte-identical to this.
+///
+/// The awaited version rendered the sender's own message only after a
+/// round-trip that queued behind contract merges on the node's serial WASM
+/// executor, with a 10s timeout before the local fallback — seconds of blank
+/// composer for a signature the browser could produce in microseconds.
+///
+/// The other `sign_*_with_fallback` functions keep the delegate call: they are
+/// off the interactive send path, so the argument about latency does not apply
+/// and there is no reason to change them in the same breath.
+pub fn sign_message_locally(message_bytes: &[u8], self_sk: &SigningKey) -> Signature {
+    self_sk.sign(message_bytes)
 }
 
 /// Sign member bytes with delegate, falling back to local signing if delegate fails
@@ -612,6 +615,76 @@ mod tests {
         assert!(
             a2.try_lock().is_some(),
             "releasing the lock must let the next same-room migration proceed"
+        );
+    }
+
+    /// freenet/river#512: the premise the local-signing change rests on.
+    ///
+    /// `delegate_sign_or_fallback` has three arms, and for a message signed
+    /// with the room's own key EVERY one of them yields the same bytes
+    /// `sign_message_locally` produces:
+    ///
+    /// - delegate answered with our key → accepted, and ed25519 is
+    ///   deterministic (RFC 8032), so the bytes are identical;
+    /// - delegate answered with a stale key → rejected, signed locally;
+    /// - delegate failed → signed locally.
+    ///
+    /// So awaiting it on the send path could only ever cost latency. If this
+    /// ever stops holding — a randomized signature scheme, or a delegate
+    /// answer accepted without the local-key check — the send path must go
+    /// back to consulting the delegate, and this test is what says so.
+    #[test]
+    fn a_delegate_signature_can_never_differ_from_the_local_one() {
+        let self_sk = SigningKey::from_bytes(&[9u8; 32]);
+        let stale_sk = SigningKey::from_bytes(&[8u8; 32]);
+        let data = b"a CBOR-encoded MessageV1, near enough";
+        let local = sign_message_locally(data, &self_sk);
+
+        // Arm 1: the delegate holds the same key. This is what the delegate
+        // actually computes (handlers.rs: `SigningKey::from_bytes(sk).sign`).
+        let delegate_sig = self_sk.sign(data);
+        let accepted = futures::executor::block_on(delegate_sign_or_fallback(
+            async move { Ok(delegate_sig) },
+            data,
+            &self_sk,
+        ));
+        assert_eq!(
+            accepted.to_bytes(),
+            local.to_bytes(),
+            "an ACCEPTED delegate signature must be byte-identical to the \
+             local one — otherwise signing locally is not behaviour-preserving"
+        );
+
+        // Arm 2: the delegate holds a stale key (mid identity-import).
+        let stale_sig = stale_sk.sign(data);
+        assert_ne!(
+            stale_sig.to_bytes(),
+            local.to_bytes(),
+            "premise: a different key must produce a different signature, or \
+             arm 2 proves nothing"
+        );
+        let rejected = futures::executor::block_on(delegate_sign_or_fallback(
+            async move { Ok(stale_sig) },
+            data,
+            &self_sk,
+        ));
+        assert_eq!(
+            rejected.to_bytes(),
+            local.to_bytes(),
+            "a stale-key delegate signature must be discarded in favour of the \
+             local one"
+        );
+
+        // Arm 3: the delegate failed (no key on file, socket closed, timeout).
+        let failed = futures::executor::block_on(delegate_sign_or_fallback(
+            async { Err("delegate unavailable".to_string()) },
+            data,
+            &self_sk,
+        ));
+        assert_eq!(
+            failed.to_bytes(),
+            local.to_bytes(),
+            "a failed delegate sign must fall back to the local signature"
         );
     }
 


### PR DESCRIPTION
## Problem

On try.freenet.org, several seconds pass between pressing Enter and the message appearing (#512).

The composer clears synchronously (`message_input.rs:77-91`) and the render is already optimistic — it is driven by the local `apply_delta` write to `ROOMS`, not by the network echo. But that write sat behind the one `.await` on the path:

```rust
let signature = sign_message_with_fallback(room_key, message_bytes, &self_sk).await;
```

which is a WebSocket round-trip to the node's chat delegate. On a hosted node that is a real WAN hop, it queues behind contract merges on the node's **serial** WASM executor, and a dropped response costs a full 10s before the local fallback fires. So the user watched an empty input box with no message in it for as long as that took.

## Approach

Sign locally with the room's own key, synchronously.

The round-trip could never change the produced bytes:

1. `delegate_sign_or_fallback` (`signing.rs:432-458`) accepts the delegate's answer **only if it verifies under `self_sk`**; otherwise it signs locally anyway.
2. `RoomData::self_sk` is a plain, always-present field (`room_data.rs:39`) — not `Option`, not `#[serde(skip)]`. The private key is already in the browser.
3. Ed25519 is deterministic (RFC 8032), and the delegate performs the same `SigningKey::from_bytes(sk).sign(data)` (`handlers.rs:505-512`).

So whenever the delegate's answer is *accepted* it is byte-identical to the local one, and in every other case the local one was already used. This is behaviour-preserving on the signature, not a weakening.

Applied to all four `MessageV1` signing sites — send, reaction, delete, edit. They are the same operation, with the same key, feeding the same optimistic render; the reaction path awaited it **twice** (remove-then-add). The other `sign_*_with_fallback` functions (ban, config, member, member_info, secret, upgrade) are untouched: they are off the interactive path, so the latency argument does not apply to them.

The delegate call is **not** kept as fire-and-forget. Its answer is unusable, and the load would land on the same serial executor that makes the round-trip slow in the first place.

Deliberately out of scope (each is its own change): the double room-state clone on the send path, `remove_unverifiable_messages` re-verifying every signature per sync cycle, the per-message sync indicator, and the private-room "send as public" fallback. All are noted in #512.

## Testing

- **`a_delegate_signature_can_never_differ_from_the_local_one`** (`signing.rs`) drives all three arms of `delegate_sign_or_fallback` — delegate answers with our key, with a stale key, or fails — and pins that each returns the bytes `sign_message_locally` produces. This is the premise the change rests on; if it ever stops holding (a randomized scheme, or an answer accepted without the local-key check) the send path must go back to consulting the delegate, and this test is what says so. Mutation-verified: removing the `verify_strict` gate turns it red.
- **`nothing_is_awaited_between_pressing_enter_and_the_message_appearing`** (`conversation.rs`) is a source pin: no `.await` may sit between the send-handler entry and the optimistic `ROOMS.with_mut` write, and no path may reach `sign_message_with_fallback`. Mutation-verified in both directions — inserting an `.await` in the send path turns it red, and so does breaking the positive needle. It fails on the pre-fix source, which is the regression test for this bug.

A browser test cannot catch this class of bug: with `--features no-sync` the delegate request fails instantly (`chat_delegate.rs:4810-4826`), so `dev-example` and every Playwright spec only ever exercise the fast path. That is precisely why it shipped unnoticed.

695 Rust tests pass; `cargo fmt` clean.

Fixes #512

[AI-assisted - Claude]