### PR TITLE
fix(ui): unread badges and totals respect per-room NotificationMode

### DIFF
--- a/ui/src/components/app/document_title.rs
+++ b/ui/src/components/app/document_title.rs
@@ -175,6 +175,18 @@ fn get_current_room_name() -> Option<String> {
 /// invariant `MessagesV1::apply_delta` maintains — so the slice after the
 /// marker's index is exactly the set of messages newer than the marker.
 pub fn count_unread_in_room_data(room_data: &crate::room_data::RoomData) -> usize {
+    unread_candidate_messages(room_data).count()
+}
+
+/// The unread tail of `room_data` as an iterator: display messages
+/// (non-action, non-deleted, non-event) authored by other users after
+/// `last_read_message_id`. Shared core of both counting modes
+/// ([`count_unread_in_room_data`] and the MentionsAndReplies arm of
+/// [`count_unread_in_room_data_with_mode`]) so the tail-slicing and
+/// exclusion rules can't drift between them.
+fn unread_candidate_messages(
+    room_data: &crate::room_data::RoomData,
+) -> impl Iterator<Item = &river_core::room_state::message::AuthorizedMessageV1> {
     let self_member_id: MemberId = room_data.self_sk.verifying_key().into();
     let recent = &room_data.room_state.recent_messages;
 
@@ -197,8 +209,52 @@ pub fn count_unread_in_room_data(room_data: &crate::room_data::RoomData) -> usiz
                 && !m.message.content.is_event()
                 && !recent.actions_state.deleted.contains(&m.id())
         })
-        .filter(|m| m.message.author != self_member_id)
-        .count()
+        .filter(move |m| m.message.author != self_member_id)
+}
+
+/// Count the unread messages in `room_data` that its
+/// [`NotificationMode`](crate::room_data::NotificationMode) surfaces
+/// (freenet/river#500). This is THE per-room badge value: the room-list
+/// badge, the document-title `(N)` total, and the mobile hamburger badge
+/// all sum these same per-room values, so every surface agrees.
+///
+/// * `All` — every unread other-authored display message
+///   ([`count_unread_in_room_data`]).
+/// * `MentionsAndReplies` — only unread messages that @mention the user or
+///   reply to one of their messages (the same
+///   [`mentions_or_replies_to_self`] predicate that gates browser
+///   notifications). Zero qualifying messages means no badge even when
+///   other unreads exist.
+/// * `Muted` — always 0; a muted room never badges and never inflates the
+///   totals, matching the modal's "Never notify for this room" wording.
+///
+/// Performance: the mention scan decrypts message content, so it runs only
+/// over the unread tail (the `start..` slice inside
+/// [`unread_candidate_messages`], typically small) and only for rooms in
+/// MentionsAndReplies mode — All and Muted rooms never decrypt anything.
+pub fn count_unread_in_room_data_with_mode(
+    room_data: &crate::room_data::RoomData,
+    mode: crate::room_data::NotificationMode,
+) -> usize {
+    use crate::room_data::NotificationMode;
+    match mode {
+        NotificationMode::All => count_unread_in_room_data(room_data),
+        NotificationMode::Muted => 0,
+        NotificationMode::MentionsAndReplies => {
+            let self_member_id: MemberId = room_data.self_sk.verifying_key().into();
+            let recent = &room_data.room_state.recent_messages.messages;
+            unread_candidate_messages(room_data)
+                .filter(|m| {
+                    crate::components::app::notifications::mentions_or_replies_to_self(
+                        m,
+                        self_member_id,
+                        &room_data.secrets,
+                        recent,
+                    )
+                })
+                .count()
+        }
+    }
 }
 
 /// Count total unread messages across all rooms — room messages plus
@@ -209,11 +265,19 @@ pub fn count_unread_in_room_data(room_data: &crate::room_data::RoomData) -> usiz
 /// DM unread is tab-title-relevant because the issue lists "incoming DM
 /// notifications + unread tracking" as a single line item — without this
 /// the inbox badge would update but the document title wouldn't.
+///
+/// Room totals go through the same mode-aware per-room values as the
+/// room-list badge ([`count_unread_in_room_data_with_mode`], via the
+/// shared [`count_unread_excluding_room`] sum with no exclusion), so a
+/// Muted room never inflates the tab title and a MentionsAndReplies room
+/// contributes only its qualifying messages (freenet/river#500). DM
+/// counts are unaffected — DMs have no per-thread mode.
 pub fn count_total_unread_messages() -> usize {
     let Ok(rooms) = ROOMS.try_read() else {
         return 0;
     };
-    let room_unread: usize = rooms.map.values().map(count_unread_in_room_data).sum();
+    let room_unread: usize =
+        count_unread_excluding_room(&rooms.map, &rooms.notification_modes, None);
     let dm_unread: usize = count_unread_dms(&rooms);
     room_unread + dm_unread
 }
@@ -304,17 +368,31 @@ fn count_unread_dms_with(
     total
 }
 
-/// Sum unread messages across every room in `map` except `exclude`.
+/// Sum mode-aware unread messages across every room in `map` except
+/// `exclude` (`None` excludes nothing — the document-title total).
 ///
-/// Pure (no signal reads) so the exclusion logic is unit-testable; the
-/// signal-reading wrapper is [`count_unread_behind_rooms_panel`].
+/// Each room contributes [`count_unread_in_room_data_with_mode`] under its
+/// entry in `modes` (absent = `All`, the same default the notification
+/// gate uses), so every unread surface sums identical per-room values
+/// (freenet/river#500).
+///
+/// Pure (no signal reads) so the exclusion + mode logic is unit-testable;
+/// the signal-reading wrappers are [`count_total_unread_messages`] and
+/// [`count_unread_behind_rooms_panel`].
 pub fn count_unread_excluding_room(
     map: &std::collections::HashMap<ed25519_dalek::VerifyingKey, crate::room_data::RoomData>,
+    modes: &std::collections::HashMap<
+        ed25519_dalek::VerifyingKey,
+        crate::room_data::NotificationMode,
+    >,
     exclude: Option<&ed25519_dalek::VerifyingKey>,
 ) -> usize {
     map.iter()
         .filter(|(owner_key, _)| Some(*owner_key) != exclude)
-        .map(|(_, room_data)| count_unread_in_room_data(room_data))
+        .map(|(owner_key, room_data)| {
+            let mode = modes.get(owner_key).copied().unwrap_or_default();
+            count_unread_in_room_data_with_mode(room_data, mode)
+        })
         .sum()
 }
 
@@ -339,7 +417,8 @@ pub fn count_unread_behind_rooms_panel() -> usize {
     let Ok(rooms) = ROOMS.try_read() else {
         return 0;
     };
-    count_unread_excluding_room(&rooms.map, current.as_ref()) + count_unread_dms(&rooms)
+    count_unread_excluding_room(&rooms.map, &rooms.notification_modes, current.as_ref())
+        + count_unread_dms(&rooms)
 }
 
 /// Update the document title based on current state
@@ -580,7 +659,7 @@ pub fn DocumentTitleUpdater() -> Element {
 mod tests {
     use super::*;
     use crate::constants::ROOM_CONTRACT_WASM;
-    use crate::room_data::RoomData;
+    use crate::room_data::{NotificationMode, RoomData};
     use crate::util::to_cbor_vec;
     use ed25519_dalek::{SigningKey, VerifyingKey};
     use freenet_stdlib::prelude::{ContractCode, ContractKey, Parameters};
@@ -863,14 +942,234 @@ mod tests {
         let mut map = HashMap::new();
         map.insert(owner_a_vk, room_a);
         map.insert(owner_b_vk, room_b);
+        let modes = HashMap::new();
 
         // Excluding room A (2 unread) leaves only room B's single unread.
-        assert_eq!(count_unread_excluding_room(&map, Some(&owner_a_vk)), 1);
+        assert_eq!(
+            count_unread_excluding_room(&map, &modes, Some(&owner_a_vk)),
+            1
+        );
         // No current room (welcome screen): every room counts.
-        assert_eq!(count_unread_excluding_room(&map, None), 3);
+        assert_eq!(count_unread_excluding_room(&map, &modes, None), 3);
         // Excluding a key not in the map changes nothing.
         let (_, other_vk) = keypair();
-        assert_eq!(count_unread_excluding_room(&map, Some(&other_vk)), 3);
+        assert_eq!(
+            count_unread_excluding_room(&map, &modes, Some(&other_vk)),
+            3
+        );
+    }
+
+    /// Build a message from `author_sk` that @mentions `mention_of`.
+    fn mention_msg(
+        author_sk: &SigningKey,
+        owner_vk: &VerifyingKey,
+        n: u64,
+        mention_of: MemberId,
+    ) -> AuthorizedMessageV1 {
+        let text = format!(
+            "hey {}!",
+            river_core::mention::encode_mention(mention_of, "Someone")
+        );
+        msg_with_body(author_sk, owner_vk, n, RoomMessageBody::public(text))
+    }
+
+    #[test]
+    fn muted_room_counts_zero_despite_unreads() {
+        // freenet/river#500: a Muted room must never badge and never feed
+        // the title/hamburger totals, however many unreads it holds.
+        let (self_sk, _) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let messages = vec![
+            msg(&owner_sk, &owner_vk, 1),
+            msg(&owner_sk, &owner_vk, 2),
+            msg(&owner_sk, &owner_vk, 3),
+        ];
+        let rd = room(self_sk, owner_vk, messages, None);
+        // The messages ARE unread under All…
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::All),
+            3
+        );
+        // …but Muted always counts zero.
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::Muted),
+            0
+        );
+    }
+
+    #[test]
+    fn all_mode_matches_the_plain_count() {
+        // `All` (the default) must be exactly the historical behaviour —
+        // the same value `count_unread_in_room_data` returns.
+        let (self_sk, _) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let messages = vec![
+            msg(&owner_sk, &owner_vk, 1),
+            msg(&owner_sk, &owner_vk, 2),
+            msg(&owner_sk, &owner_vk, 3),
+        ];
+        let marker = messages[0].id();
+        let rd = room(self_sk, owner_vk, messages, Some(marker));
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::All),
+            count_unread_in_room_data(&rd)
+        );
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::All),
+            2
+        );
+    }
+
+    #[test]
+    fn mentions_mode_counts_only_qualifying_messages() {
+        // freenet/river#500: a MentionsAndReplies room badges the count of
+        // unread messages that @mention the user or reply to one of their
+        // messages — the same predicate that gates browser notifications.
+        let (self_sk, self_vk) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let self_id: MemberId = (&self_vk).into();
+
+        // Self-authored target for the reply (never unread itself).
+        let target = msg_with_body(
+            &self_sk,
+            &owner_vk,
+            1,
+            RoomMessageBody::public("my message".to_string()),
+        );
+        let messages = vec![
+            target.clone(),
+            // Plain other-authored message: unread under All, but not a
+            // mention/reply.
+            msg(&owner_sk, &owner_vk, 2),
+            // @mention of self.
+            mention_msg(&owner_sk, &owner_vk, 3, self_id),
+            // Reply to self's message.
+            msg_with_body(
+                &owner_sk,
+                &owner_vk,
+                4,
+                RoomMessageBody::reply(
+                    "agreed".to_string(),
+                    target.id(),
+                    "Me".to_string(),
+                    "my message".to_string(),
+                ),
+            ),
+        ];
+        let rd = room(self_sk, owner_vk, messages, None);
+        // All mode sees 3 unread (plain + mention + reply)…
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::All),
+            3
+        );
+        // …MentionsAndReplies counts only the mention and the reply.
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
+            2
+        );
+    }
+
+    #[test]
+    fn mentions_mode_with_no_qualifying_messages_counts_zero() {
+        // Zero qualifying messages means NO badge — even when other unread
+        // messages exist (they'd notify nobody, so they don't badge).
+        let (self_sk, _) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let (_, third_vk) = keypair();
+        let messages = vec![
+            msg(&owner_sk, &owner_vk, 1),
+            // A mention of someone ELSE doesn't qualify.
+            mention_msg(&owner_sk, &owner_vk, 2, (&third_vk).into()),
+        ];
+        let rd = room(self_sk, owner_vk, messages, None);
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::All),
+            2
+        );
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
+            0
+        );
+    }
+
+    #[test]
+    fn mentions_mode_scans_only_the_unread_tail() {
+        // Performance + correctness guard: the mention scan runs over the
+        // unread tail only. A mention BEFORE the last-read marker is read —
+        // it must not count (and must not be scanned at all).
+        let (self_sk, self_vk) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let self_id: MemberId = (&self_vk).into();
+        let messages = vec![
+            mention_msg(&owner_sk, &owner_vk, 1, self_id), // read mention
+            msg(&owner_sk, &owner_vk, 2),                  // unread, plain
+        ];
+        let marker = messages[0].id();
+        let rd = room(self_sk, owner_vk, messages, Some(marker));
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
+            0
+        );
+    }
+
+    #[test]
+    fn totals_sum_the_same_per_mode_values() {
+        // freenet/river#500: the document-title total and the mobile
+        // hamburger total must sum the SAME mode-aware per-room values the
+        // room-list badge shows, so every surface agrees.
+        let (self_sk, self_vk) = keypair();
+        let self_id: MemberId = (&self_vk).into();
+        let (owner_a_sk, owner_a_vk) = keypair(); // All (default): 2 unread
+        let (owner_b_sk, owner_b_vk) = keypair(); // MentionsAndReplies: 1 of 3 qualifies
+        let (owner_c_sk, owner_c_vk) = keypair(); // Muted: 5 unread, counts 0
+
+        let room_a = room(
+            self_sk.clone(),
+            owner_a_vk,
+            vec![
+                msg(&owner_a_sk, &owner_a_vk, 1),
+                msg(&owner_a_sk, &owner_a_vk, 2),
+            ],
+            None,
+        );
+        let room_b = room(
+            self_sk.clone(),
+            owner_b_vk,
+            vec![
+                msg(&owner_b_sk, &owner_b_vk, 1),
+                mention_msg(&owner_b_sk, &owner_b_vk, 2, self_id),
+                msg(&owner_b_sk, &owner_b_vk, 3),
+            ],
+            None,
+        );
+        let room_c = room(
+            self_sk,
+            owner_c_vk,
+            (1..=5).map(|n| msg(&owner_c_sk, &owner_c_vk, n)).collect(),
+            None,
+        );
+        let mut map = HashMap::new();
+        map.insert(owner_a_vk, room_a);
+        map.insert(owner_b_vk, room_b);
+        map.insert(owner_c_vk, room_c);
+
+        let mut modes = HashMap::new();
+        // Room A has no entry → defaults to All, like the notification gate.
+        modes.insert(owner_b_vk, NotificationMode::MentionsAndReplies);
+        modes.insert(owner_c_vk, NotificationMode::Muted);
+
+        // Title total (no exclusion): 2 (All) + 1 (mention) + 0 (muted).
+        assert_eq!(count_unread_excluding_room(&map, &modes, None), 3);
+        // Hamburger total with room A open: 1 + 0.
+        assert_eq!(
+            count_unread_excluding_room(&map, &modes, Some(&owner_a_vk)),
+            1
+        );
+        // Hamburger total with the mentions room open: 2 + 0.
+        assert_eq!(
+            count_unread_excluding_room(&map, &modes, Some(&owner_b_vk)),
+            2
+        );
     }
 
     /// Build a direct message. The counters never verify signatures, so

--- a/ui/src/components/app/document_title.rs
+++ b/ui/src/components/app/document_title.rs
@@ -154,10 +154,15 @@ fn get_current_room_name() -> Option<String> {
 
 /// Count unread messages in a single room's [`RoomData`].
 ///
-/// Counts display messages (non-action, non-deleted) authored by other
-/// users that fall after `last_read_message_id`. Pure — takes a borrowed
-/// `RoomData` so callers that already hold a `ROOMS` read guard (the
-/// room-list badge memo, the title's cross-room sum) don't re-lock.
+/// Counts display messages (non-action, non-deleted, non-event) authored
+/// by other users that fall after `last_read_message_id`. Pure — takes a
+/// borrowed `RoomData` so callers that already hold a `ROOMS` read guard
+/// (the room-list badge memo, the title's cross-room sum) don't re-lock.
+///
+/// Room-event messages (`CONTENT_TYPE_EVENT`, e.g. "X joined the room")
+/// are shown by `display_messages()` but deliberately excluded here
+/// (freenet/river#500): they are ambient activity, not something waiting
+/// to be read, so they must not inflate the badge or title counts.
 ///
 /// The marker is located in the full ordered message list, not the
 /// display-filtered view: a last-read message that was later *deleted* is
@@ -185,9 +190,12 @@ pub fn count_unread_in_room_data(room_data: &crate::room_data::RoomData) -> usiz
 
     recent.messages[start..]
         .iter()
-        // Mirror `MessagesV1::display_messages`: skip action and deleted msgs.
+        // Mirror `MessagesV1::display_messages` (skip action and deleted
+        // msgs), plus skip room events — see the doc comment above.
         .filter(|m| {
-            !m.message.content.is_action() && !recent.actions_state.deleted.contains(&m.id())
+            !m.message.content.is_action()
+                && !m.message.content.is_event()
+                && !recent.actions_state.deleted.contains(&m.id())
         })
         .filter(|m| m.message.author != self_member_id)
         .count()
@@ -582,16 +590,32 @@ mod tests {
     use std::collections::HashMap;
     use std::time::{Duration, UNIX_EPOCH};
 
-    /// Build a signed display message from `author_sk`, distinct per `n`.
-    fn msg(author_sk: &SigningKey, owner_vk: &VerifyingKey, n: u64) -> AuthorizedMessageV1 {
+    /// Build a signed message from `author_sk` with an arbitrary body,
+    /// distinct per `n` (the timestamp orders the buffer).
+    fn msg_with_body(
+        author_sk: &SigningKey,
+        owner_vk: &VerifyingKey,
+        n: u64,
+        content: RoomMessageBody,
+    ) -> AuthorizedMessageV1 {
         AuthorizedMessageV1::new(
             MessageV1 {
                 room_owner: MemberId::from(owner_vk),
                 author: MemberId::from(&author_sk.verifying_key()),
-                content: RoomMessageBody::public(format!("message {n}")),
+                content,
                 time: UNIX_EPOCH + Duration::from_secs(n),
             },
             author_sk,
+        )
+    }
+
+    /// Build a signed display (text) message from `author_sk`, distinct per `n`.
+    fn msg(author_sk: &SigningKey, owner_vk: &VerifyingKey, n: u64) -> AuthorizedMessageV1 {
+        msg_with_body(
+            author_sk,
+            owner_vk,
+            n,
+            RoomMessageBody::public(format!("message {n}")),
         )
     }
 
@@ -704,6 +728,24 @@ mod tests {
     }
 
     #[test]
+    fn event_messages_are_not_counted() {
+        // freenet/river#500: room-event messages ("X joined the room",
+        // CONTENT_TYPE_EVENT) are ambient activity, not something to read —
+        // they must not inflate the unread badge. A "3" badge that is 2
+        // messages plus a join overstates what's waiting for the user.
+        let (self_sk, _) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let messages = vec![
+            msg(&owner_sk, &owner_vk, 1),
+            msg_with_body(&owner_sk, &owner_vk, 2, RoomMessageBody::join_event()),
+            msg(&owner_sk, &owner_vk, 3),
+        ];
+        let rd = room(self_sk, owner_vk, messages, None);
+        // 3 other-authored messages, 1 is a join event → 2 unread.
+        assert_eq!(count_unread_in_room_data(&rd), 2);
+    }
+
+    #[test]
     fn deleted_messages_are_not_counted() {
         // `display_messages` filters deleted messages; the helper must too.
         let (self_sk, _) = keypair();
@@ -765,8 +807,11 @@ mod tests {
     fn helper_agrees_with_display_messages_filter() {
         // Drift guard: the helper hand-mirrors `MessagesV1::display_messages`'s
         // action/deleted filter. With no marker, the count must equal
-        // `display_messages()` filtered to other authors — if the two
-        // predicates ever diverge, this fails.
+        // `display_messages()` filtered to other authors AND to non-event
+        // messages — the ONE deliberate divergence from `display_messages()`
+        // is that room events render in the conversation but never count as
+        // unread (freenet/river#500). If the predicates drift further, this
+        // fails.
         let (self_sk, self_vk) = keypair();
         let (owner_sk, owner_vk) = keypair();
         let self_id: MemberId = (&self_vk).into();
@@ -774,6 +819,7 @@ mod tests {
             msg(&owner_sk, &owner_vk, 1),
             msg(&owner_sk, &owner_vk, 2),
             msg(&self_sk, &owner_vk, 3),
+            msg_with_body(&owner_sk, &owner_vk, 4, RoomMessageBody::join_event()),
         ];
         let deleted = messages[1].id();
         let mut rd = room(self_sk, owner_vk, messages, None);
@@ -786,7 +832,7 @@ mod tests {
             .room_state
             .recent_messages
             .display_messages()
-            .filter(|m| m.message.author != self_id)
+            .filter(|m| m.message.author != self_id && !m.message.content.is_event())
             .count();
         assert_eq!(count_unread_in_room_data(&rd), expected);
     }

--- a/ui/src/components/app/document_title.rs
+++ b/ui/src/components/app/document_title.rs
@@ -32,7 +32,7 @@ pub static TOTAL_UNREAD_COUNT: GlobalSignal<usize> = Global::new(|| 0);
 
 thread_local! {
     /// Cache the last title to avoid redundant postMessage calls
-    static LAST_TITLE: RefCell<String> = RefCell::new(String::new());
+    static LAST_TITLE: RefCell<String> = const { RefCell::new(String::new()) };
 }
 
 /// Get the current document visibility state
@@ -163,6 +163,16 @@ fn get_current_room_name() -> Option<String> {
 /// are shown by `display_messages()` but deliberately excluded here
 /// (freenet/river#500): they are ambient activity, not something waiting
 /// to be read, so they must not inflate the badge or title counts.
+pub fn count_unread_in_room_data(room_data: &crate::room_data::RoomData) -> usize {
+    unread_candidate_messages(room_data).count()
+}
+
+/// The unread tail of `room_data` as an iterator: display messages
+/// (non-action, non-deleted, non-event) authored by other users after
+/// `last_read_message_id`. Shared core of both counting modes
+/// ([`count_unread_in_room_data`] and the MentionsAndReplies arm of
+/// [`count_unread_in_room_data_with_mode`]) so the tail-slicing and
+/// exclusion rules can't drift between them.
 ///
 /// The marker is located in the full ordered message list, not the
 /// display-filtered view: a last-read message that was later *deleted* is
@@ -174,16 +184,6 @@ fn get_current_room_name() -> Option<String> {
 /// Assumes `recent.messages` is in chronological `(time, id)` order — the
 /// invariant `MessagesV1::apply_delta` maintains — so the slice after the
 /// marker's index is exactly the set of messages newer than the marker.
-pub fn count_unread_in_room_data(room_data: &crate::room_data::RoomData) -> usize {
-    unread_candidate_messages(room_data).count()
-}
-
-/// The unread tail of `room_data` as an iterator: display messages
-/// (non-action, non-deleted, non-event) authored by other users after
-/// `last_read_message_id`. Shared core of both counting modes
-/// ([`count_unread_in_room_data`] and the MentionsAndReplies arm of
-/// [`count_unread_in_room_data_with_mode`]) so the tail-slicing and
-/// exclusion rules can't drift between them.
 fn unread_candidate_messages(
     room_data: &crate::room_data::RoomData,
 ) -> impl Iterator<Item = &river_core::room_state::message::AuthorizedMessageV1> {
@@ -212,6 +212,27 @@ fn unread_candidate_messages(
         .filter(move |m| m.message.author != self_member_id)
 }
 
+/// Whether `msg`'s body is sealed under a secret version this client does
+/// not hold, so no mention/reply check can see through it.
+///
+/// `decrypt_message_content` returns a human-readable PLACEHOLDER for such a
+/// message rather than failing, so `contains_mention_of` on that placeholder
+/// is always false and `extract_reply_target_id` always returns `None`:
+/// undecryptable would silently read as "not a mention". This predicate is
+/// what lets the MentionsAndReplies count fail SAFE instead — see
+/// [`count_unread_in_room_data_with_mode`].
+fn is_undecryptable(
+    msg: &river_core::room_state::message::AuthorizedMessageV1,
+    secrets: &std::collections::HashMap<u32, [u8; 32]>,
+) -> bool {
+    match &msg.message.content {
+        river_core::room_state::message::RoomMessageBody::Private { secret_version, .. } => {
+            !secrets.contains_key(secret_version)
+        }
+        river_core::room_state::message::RoomMessageBody::Public { .. } => false,
+    }
+}
+
 /// Count the unread messages in `room_data` that its
 /// [`NotificationMode`](crate::room_data::NotificationMode) surfaces
 /// (freenet/river#500). This is THE per-room badge value: the room-list
@@ -222,16 +243,42 @@ fn unread_candidate_messages(
 ///   ([`count_unread_in_room_data`]).
 /// * `MentionsAndReplies` — only unread messages that @mention the user or
 ///   reply to one of their messages (the same
-///   [`mentions_or_replies_to_self`] predicate that gates browser
-///   notifications). Zero qualifying messages means no badge even when
-///   other unreads exist.
+///   [`crate::components::app::notifications::mentions_or_replies_to_self`]
+///   predicate that gates browser notifications). Zero qualifying messages
+///   means no badge even when other unreads exist.
 /// * `Muted` — always 0; a muted room never badges and never inflates the
 ///   totals, matching the modal's "Never notify for this room" wording.
 ///
-/// Performance: the mention scan decrypts message content, so it runs only
-/// over the unread tail (the `start..` slice inside
-/// [`unread_candidate_messages`], typically small) and only for rooms in
-/// MentionsAndReplies mode — All and Muted rooms never decrypt anything.
+/// # Undecryptable private messages count (fail safe)
+///
+/// In MentionsAndReplies mode a message whose secret version is missing from
+/// `room_data.secrets` is COUNTED, because there is no way to tell whether it
+/// mentions the user. Over-reporting is the safe direction: the alternative
+/// hides a real mention behind a silent zero.
+///
+/// This is not a corner case. `RoomData.secrets` is `#[serde(skip)]`, so
+/// EVERY cold start of an established private room has an empty secrets map
+/// until `repopulate_secrets_from_state` rehydrates it; without the
+/// fail-safe, a private mentions-mode room with unread mentions would badge
+/// 0 on the badge, the title, AND the hamburger until that resolves. There
+/// is also a permanent variant: a member who joined after a secret rotation
+/// can never decrypt older-version messages. The count therefore resolves
+/// DOWN to the true mention count once the secrets arrive.
+///
+/// # Cost
+///
+/// The mention scan decrypts message content, so it runs only over the
+/// unread tail (the `start..` slice inside [`unread_candidate_messages`])
+/// and only for rooms in MentionsAndReplies mode; All and Muted rooms never
+/// decrypt anything. That tail is NOT reliably small: `start` is 0 whenever
+/// the room has never been opened or the marker aged out of the buffer, and
+/// those are exactly the states a mentions-mode room lives in (a room is set
+/// to mentions-only precisely so it stops being opened), so the tail is
+/// routinely the whole `max_recent_messages` buffer (default 100,
+/// owner-configurable with no upper bound). Each private message costs a
+/// fresh AES-GCM key schedule plus a decrypt, a CBOR decode and a mention
+/// parse, so the scan is memoized per room by
+/// [`cached_mention_unread_count`] — see its docs for why that matters.
 pub fn count_unread_in_room_data_with_mode(
     room_data: &crate::room_data::RoomData,
     mode: crate::room_data::NotificationMode,
@@ -240,21 +287,126 @@ pub fn count_unread_in_room_data_with_mode(
     match mode {
         NotificationMode::All => count_unread_in_room_data(room_data),
         NotificationMode::Muted => 0,
-        NotificationMode::MentionsAndReplies => {
-            let self_member_id: MemberId = room_data.self_sk.verifying_key().into();
-            let recent = &room_data.room_state.recent_messages.messages;
-            unread_candidate_messages(room_data)
-                .filter(|m| {
-                    crate::components::app::notifications::mentions_or_replies_to_self(
-                        m,
-                        self_member_id,
-                        &room_data.secrets,
-                        recent,
-                    )
-                })
-                .count()
-        }
+        NotificationMode::MentionsAndReplies => cached_mention_unread_count(room_data),
     }
+}
+
+/// Uncached core of the MentionsAndReplies count. Callers should go through
+/// [`cached_mention_unread_count`].
+fn compute_mention_unread_count(room_data: &crate::room_data::RoomData) -> usize {
+    use crate::components::app::notifications::{
+        mentions_or_replies_to_self_indexed, SelfAuthoredIndex,
+    };
+
+    let self_member_id: MemberId = room_data.self_sk.verifying_key().into();
+    let recent = &room_data.room_state.recent_messages.messages;
+    // One lazily-built index of self-authored message ids for the whole
+    // scan: the reply check would otherwise re-hash every message in the
+    // buffer (`id()` is a 64-byte rolling hash) once per reply candidate.
+    let self_authored = SelfAuthoredIndex::new(recent, self_member_id);
+
+    unread_candidate_messages(room_data)
+        .filter(|m| {
+            // Fail safe: a body we cannot decrypt might mention the user, so
+            // count it rather than silently reading it as "not a mention".
+            is_undecryptable(m, &room_data.secrets)
+                || mentions_or_replies_to_self_indexed(
+                    m,
+                    self_member_id,
+                    &room_data.secrets,
+                    &self_authored,
+                )
+        })
+        .count()
+}
+
+thread_local! {
+    /// Per-room memo for the MentionsAndReplies unread count, keyed by room
+    /// owner key and validated by [`mention_count_fingerprint`].
+    static MENTION_COUNT_CACHE: RefCell<
+        std::collections::HashMap<ed25519_dalek::VerifyingKey, (u64, usize)>,
+    > = RefCell::new(std::collections::HashMap::new());
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Test-only counter of full (cache-missing) mention scans, so a test can
+    /// prove the memo actually skips recompute. `thread_local`, and the test
+    /// harness gives each test its own thread, so tests don't interfere.
+    static MENTION_SCAN_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// Upper bound on memo entries. The natural bound is "rooms the user has in
+/// mentions mode", which is tiny, but a session that joins and leaves many
+/// rooms would otherwise accumulate dead keys; clearing wholesale on
+/// overflow costs one recompute per live room and keeps this O(1) to reason
+/// about.
+const MENTION_COUNT_CACHE_MAX: usize = 256;
+
+/// Fingerprint of every input [`compute_mention_unread_count`] reads, cheap
+/// enough (all O(1)) to compute on every call:
+///
+/// * `messages.len()` and the first/last message id — any append, eviction
+///   or replacement of the buffer changes one of them;
+/// * `last_read_message_id` — moves the tail's start;
+/// * `secrets.len()` — arriving secrets change decryptability, which is what
+///   resolves the fail-safe over-count down to the true count;
+/// * `deleted.len()` — deletions change which messages are candidates;
+/// * the local member id — an identity import re-keys "self".
+fn mention_count_fingerprint(room_data: &crate::room_data::RoomData) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let recent = &room_data.room_state.recent_messages;
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    recent.messages.len().hash(&mut h);
+    recent.messages.first().map(|m| m.id()).hash(&mut h);
+    recent.messages.last().map(|m| m.id()).hash(&mut h);
+    room_data.last_read_message_id.hash(&mut h);
+    room_data.secrets.len().hash(&mut h);
+    recent.actions_state.deleted.len().hash(&mut h);
+    MemberId::from(room_data.self_sk.verifying_key()).hash(&mut h);
+    h.finish()
+}
+
+/// Memoized [`compute_mention_unread_count`].
+///
+/// The scan is expensive (see [`count_unread_in_room_data_with_mode`]) and
+/// runs up to three times per `ROOMS` write, because all three consumers are
+/// always mounted: the room-list badge memo, the conversation header's
+/// hamburger badge memo, and `update_document_title`. Without a memo this
+/// reproduces the shape of a documented incident in the sibling render path
+/// — re-parsing every buffered message body on each update was "a major
+/// source of the mobile jank users reported", fixed by `MESSAGE_HTML_CACHE`
+/// in `conversation.rs` — except worse placed, since these consumers run for
+/// rooms the user is not even looking at.
+///
+/// Returns a value always identical to calling the uncached form; the memo
+/// only skips redundant rescans.
+fn cached_mention_unread_count(room_data: &crate::room_data::RoomData) -> usize {
+    let fp = mention_count_fingerprint(room_data);
+    let key = room_data.owner_vk;
+
+    if let Some(hit) = MENTION_COUNT_CACHE.with(|cache| {
+        cache
+            .borrow()
+            .get(&key)
+            .filter(|(cached_fp, _)| *cached_fp == fp)
+            .map(|(_, count)| *count)
+    }) {
+        return hit;
+    }
+
+    let count = compute_mention_unread_count(room_data);
+    #[cfg(test)]
+    MENTION_SCAN_COUNT.with(|c| c.set(c.get() + 1));
+
+    MENTION_COUNT_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if cache.len() >= MENTION_COUNT_CACHE_MAX && !cache.contains_key(&key) {
+            cache.clear();
+        }
+        cache.insert(key, (fp, count));
+    });
+    count
 }
 
 /// Count total unread messages across all rooms — room messages plus
@@ -1093,10 +1245,11 @@ mod tests {
     }
 
     #[test]
-    fn mentions_mode_scans_only_the_unread_tail() {
-        // Performance + correctness guard: the mention scan runs over the
-        // unread tail only. A mention BEFORE the last-read marker is read —
-        // it must not count (and must not be scanned at all).
+    fn mentions_mode_ignores_a_mention_before_the_last_read_marker() {
+        // The mention count is scoped to the unread tail: a mention the user
+        // has already read must not keep the badge lit. (This pins the
+        // COUNT, not the scan bound — the scan bound is pinned by
+        // `mention_count_memo_skips_recompute_until_inputs_change`.)
         let (self_sk, self_vk) = keypair();
         let (owner_sk, owner_vk) = keypair();
         let self_id: MemberId = (&self_vk).into();
@@ -1109,6 +1262,236 @@ mod tests {
         assert_eq!(
             count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
             0
+        );
+    }
+
+    #[test]
+    fn mentions_mode_with_an_evicted_marker_counts_the_whole_buffer() {
+        // When `last_read_message_id` has aged out of the bounded buffer the
+        // tail falls back to everything (the documented `start = 0` case) —
+        // in mentions mode that means every qualifying message in the
+        // buffer, not zero. This is also the state a mentions-mode room
+        // typically lives in, since it is set to mentions-only precisely so
+        // the user stops opening it.
+        let (self_sk, self_vk) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let self_id: MemberId = (&self_vk).into();
+        let evicted = msg(&owner_sk, &owner_vk, 99);
+        let messages = vec![
+            mention_msg(&owner_sk, &owner_vk, 1, self_id),
+            msg(&owner_sk, &owner_vk, 2),
+            mention_msg(&owner_sk, &owner_vk, 3, self_id),
+        ];
+        let rd = room(self_sk, owner_vk, messages, Some(evicted.id()));
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
+            2
+        );
+    }
+
+    #[test]
+    fn mentions_mode_skips_a_reply_whose_target_left_the_buffer() {
+        // Reply authorship can only be confirmed against messages still in
+        // the buffer. With the target evicted we cannot tell whether it was
+        // the user's, so the shared predicate conservatively says no — a
+        // miss rather than a badge for someone else's conversation.
+        let (self_sk, _) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let target = msg_with_body(
+            &self_sk,
+            &owner_vk,
+            1,
+            RoomMessageBody::public("my old message".to_string()),
+        );
+        // `target` is deliberately NOT placed in the room's buffer.
+        let messages = vec![msg_with_body(
+            &owner_sk,
+            &owner_vk,
+            2,
+            RoomMessageBody::reply(
+                "re".to_string(),
+                target.id(),
+                "Me".to_string(),
+                "my old message".to_string(),
+            ),
+        )];
+        let rd = room(self_sk, owner_vk, messages, None);
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::All),
+            1
+        );
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
+            0
+        );
+    }
+
+    /// Build a private (sealed) message body under `secret` at `version`.
+    fn private_msg(
+        author_sk: &SigningKey,
+        owner_vk: &VerifyingKey,
+        n: u64,
+        text: String,
+        secret: &[u8; 32],
+        version: u32,
+    ) -> AuthorizedMessageV1 {
+        use river_core::room_state::content::{TextContentV1, CONTENT_TYPE_TEXT};
+        let (ciphertext, nonce) = crate::util::ecies::encrypt_with_symmetric_key(
+            secret,
+            &TextContentV1::new(text).encode(),
+        );
+        msg_with_body(
+            author_sk,
+            owner_vk,
+            n,
+            RoomMessageBody::private(CONTENT_TYPE_TEXT, 1, ciphertext, nonce, version),
+        )
+    }
+
+    #[test]
+    fn mentions_mode_counts_undecryptable_private_messages() {
+        // freenet/river#500 fail-safe: `decrypt_message_content` returns a
+        // PLACEHOLDER (not an error) when the secret is missing, so a
+        // mention check against it is always false. Counting undecryptable
+        // messages is the only way a real mention isn't silently hidden.
+        //
+        // This is the EVERY-COLD-START state for a private room:
+        // `RoomData.secrets` is `#[serde(skip)]`, so the map is empty until
+        // `repopulate_secrets_from_state` rehydrates it.
+        let (self_sk, self_vk) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let self_id: MemberId = (&self_vk).into();
+        let secret = [7u8; 32];
+        let mention_text = format!(
+            "hey {}!",
+            river_core::mention::encode_mention(self_id, "Me")
+        );
+        let messages = vec![
+            private_msg(&owner_sk, &owner_vk, 1, mention_text, &secret, 1),
+            private_msg(
+                &owner_sk,
+                &owner_vk,
+                2,
+                "just chatting".to_string(),
+                &secret,
+                1,
+            ),
+        ];
+        let mut rd = room(self_sk, owner_vk, messages, None);
+
+        // (a) Secrets not yet available: neither body can be inspected, so
+        // both count. Non-zero is the point — a silent 0 would hide a real
+        // mention behind an empty badge.
+        assert!(rd.secrets.is_empty());
+        let unresolved =
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies);
+        assert_eq!(
+            unresolved, 2,
+            "undecryptable private messages must count, not silently read as 'not a mention'"
+        );
+
+        // (b) Once the secret arrives the count resolves DOWN to the true
+        // mention count. (Inserting a secret changes `secrets.len()`, which
+        // is part of the memo fingerprint, so the memo must not serve the
+        // stale 2 here — that is also a live guard on the fingerprint.)
+        rd.secrets.insert(1, secret);
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
+            1,
+            "with secrets available the count must resolve to the true mention count"
+        );
+    }
+
+    #[test]
+    fn all_mode_is_unaffected_by_undecryptable_private_messages() {
+        // The fail-safe is scoped to mentions mode: `All` never inspects
+        // content, so undecryptable bodies count exactly like any other
+        // unread message (no double-counting, no behaviour change).
+        let (self_sk, _) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let secret = [9u8; 32];
+        let messages = vec![
+            private_msg(&owner_sk, &owner_vk, 1, "one".to_string(), &secret, 3),
+            private_msg(&owner_sk, &owner_vk, 2, "two".to_string(), &secret, 3),
+        ];
+        let rd = room(self_sk, owner_vk, messages, None);
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::All),
+            2
+        );
+    }
+
+    /// Number of full (cache-missing) mention scans on this thread.
+    fn mention_scans() -> usize {
+        MENTION_SCAN_COUNT.with(|c| c.get())
+    }
+
+    #[test]
+    fn mention_count_memo_skips_recompute_until_inputs_change() {
+        // The mentions scan decrypts bodies over what is routinely the whole
+        // message buffer, and runs up to three times per ROOMS write (rail
+        // badge, hamburger badge, document title). The memo is what keeps
+        // that affordable — this pins that it actually skips recompute, and
+        // that it still invalidates when the room changes.
+        //
+        // Deltas (not absolute counts) and a per-test random room key keep
+        // this correct whether or not the harness shares a thread between
+        // tests.
+        let (self_sk, self_vk) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let self_id: MemberId = (&self_vk).into();
+        let messages = vec![
+            mention_msg(&owner_sk, &owner_vk, 1, self_id),
+            msg(&owner_sk, &owner_vk, 2),
+        ];
+        let mut rd = room(self_sk, owner_vk, messages, None);
+
+        let baseline = mention_scans();
+        let first = count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies);
+        assert_eq!(first, 1);
+        assert_eq!(
+            mention_scans(),
+            baseline + 1,
+            "the first call must actually compute"
+        );
+
+        // Two more reads with identical inputs — the other two always-mounted
+        // consumers — must be served from the memo.
+        for _ in 0..2 {
+            assert_eq!(
+                count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
+                first
+            );
+        }
+        assert_eq!(
+            mention_scans(),
+            baseline + 1,
+            "memo recomputed despite unchanged inputs"
+        );
+
+        // A new message must invalidate the memo and change the answer.
+        rd.room_state
+            .recent_messages
+            .messages
+            .push(mention_msg(&owner_sk, &owner_vk, 3, self_id));
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
+            2,
+            "memo served a stale count after a new message arrived"
+        );
+        assert_eq!(
+            mention_scans(),
+            baseline + 2,
+            "a changed room must trigger exactly one recompute"
+        );
+
+        // Marking the room read must also invalidate it.
+        let latest = rd.room_state.recent_messages.messages.last().unwrap().id();
+        rd.last_read_message_id = Some(latest);
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
+            0,
+            "memo served a stale count after the last-read marker moved"
         );
     }
 
@@ -1169,6 +1552,12 @@ mod tests {
         assert_eq!(
             count_unread_excluding_room(&map, &modes, Some(&owner_b_vk)),
             2
+        );
+        // Excluding the MUTED room changes nothing — it was already
+        // contributing 0, so opening it can't move the hamburger total.
+        assert_eq!(
+            count_unread_excluding_room(&map, &modes, Some(&owner_c_vk)),
+            3
         );
     }
 

--- a/ui/src/components/app/document_title.rs
+++ b/ui/src/components/app/document_title.rs
@@ -218,44 +218,44 @@ fn unread_candidate_messages(
 }
 
 /// Whether a body we could NOT read (`try_decrypt_message_content` returned
-/// `None`) is one we expect to be able to read LATER — in which case the
-/// MentionsAndReplies count includes it, because there is no way yet to tell
-/// whether it mentions the user.
+/// `None`) should nevertheless count toward the MentionsAndReplies badge,
+/// because we cannot yet tell whether it mentions the user.
 ///
-/// The distinction matters because "unreadable" is two different situations:
+/// The answer is yes for EXACTLY ONE state: the room's secrets map is empty.
+/// `RoomData.secrets` is `#[serde(skip)]`, so every cold start of an
+/// established private room lands here, and it resolves within seconds when
+/// `repopulate_secrets_from_state` rehydrates the map. Counting through that
+/// window is what stops a real mention hiding behind a silent zero.
 ///
-/// * **Transient.** The secrets map is empty (every cold start of an
-///   established private room, since `RoomData.secrets` is `#[serde(skip)]`),
-///   or the message is sealed under a version NEWER than anything we hold, so
-///   its secret is still in flight, or we hold a secret at that version and it
-///   does not decrypt the body — which `repopulate_secrets_from_state`
-///   overwrites from the owner-signed blob (see its doc: an inviter can supply
-///   a wrong secret that the authoritative blob later replaces AT THE SAME
-///   VERSION). Counting is the safe direction here: the alternative hides a
-///   real mention behind a silent zero until sync catches up.
+/// Every other unreadable state does NOT count, and the reason is that none of
+/// them is reliably transient:
 ///
-/// * **Permanent.** The message is sealed under a version OLDER than every
-///   secret we hold: a rotation the user joined after, which they will never
-///   be able to read. Counting those would put a number on the badge, the tab
-///   title and the hamburger that can never resolve down and that points at a
-///   message the user cannot read even after opening the room — which is the
-///   #500 symptom in a narrower configuration. So they do not count.
+/// * A version OLDER than everything we hold is a rotation the user joined
+///   after; they will never read it.
+/// * A version NEWER than everything we hold looks like a blob in flight, but
+///   need not be: a member who was offline across a rotation may never receive
+///   one (`MessagesV1`'s own docs describe a member missing a blob at
+///   `current_version` as a supported, unrecoverable state), and a removed
+///   member's blobs are pruned outright while their client keeps ingesting
+///   messages at the new version.
+/// * A secret PRESENT at the right version that does not decrypt the body is
+///   overwritten by `repopulate_secrets_from_state` only if the contract
+///   carries an owner-signed blob for THIS member at THAT version. If it does
+///   not, the wrong key stays.
+///
+/// Counting any of those puts a number on the badge, the tab title and the
+/// hamburger that no amount of reading can clear, pointing at a message the
+/// user cannot open — which is the freenet/river#500 symptom in a narrower
+/// configuration, and strictly worse than the under-count it avoids. An
+/// under-count here is temporary and self-healing: the message is unreadable,
+/// so the user could not act on the mention anyway, and both the message and
+/// the badge appear together if the secret ever arrives.
 fn unreadable_body_may_become_readable(
     msg: &river_core::room_state::message::AuthorizedMessageV1,
     secrets: &std::collections::HashMap<u32, [u8; 32]>,
 ) -> bool {
     match &msg.message.content {
-        river_core::room_state::message::RoomMessageBody::Private { secret_version, .. } => {
-            // Present but non-decrypting: a wrong key, replaced in place.
-            if secrets.contains_key(secret_version) {
-                return true;
-            }
-            // Absent: cold start, or a rotation still reaching us.
-            secrets
-                .keys()
-                .max()
-                .is_none_or(|newest| secret_version > newest)
-        }
+        river_core::room_state::message::RoomMessageBody::Private { .. } => secrets.is_empty(),
         // A public body always reads; this is only reached defensively.
         river_core::room_state::message::RoomMessageBody::Public { .. } => false,
     }
@@ -277,21 +277,20 @@ fn unreadable_body_may_become_readable(
 /// * `Muted` — always 0; a muted room never badges and never inflates the
 ///   totals, matching the modal's "Never notify for this room" wording.
 ///
-/// # Undecryptable private messages count (fail safe)
+/// # Unreadable private messages, during the cold-start window only
 ///
-/// In MentionsAndReplies mode a message whose secret version is missing from
-/// `room_data.secrets` is COUNTED, because there is no way to tell whether it
-/// mentions the user. Over-reporting is the safe direction: the alternative
-/// hides a real mention behind a silent zero.
+/// In MentionsAndReplies mode a body we cannot decrypt is counted while
+/// `room_data.secrets` is EMPTY, because there is no way to tell whether it
+/// mentions the user and the state resolves in seconds. `RoomData.secrets` is
+/// `#[serde(skip)]`, so every cold start of an established private room is in
+/// it; without this, such a room would badge 0 on the row, the title AND the
+/// hamburger until `repopulate_secrets_from_state` runs, hiding real mentions.
+/// The count resolves to the true mention count once the secrets arrive.
 ///
-/// This is not a corner case. `RoomData.secrets` is `#[serde(skip)]`, so
-/// EVERY cold start of an established private room has an empty secrets map
-/// until `repopulate_secrets_from_state` rehydrates it; without the
-/// fail-safe, a private mentions-mode room with unread mentions would badge
-/// 0 on the badge, the title, AND the hamburger until that resolves. There
-/// is also a permanent variant: a member who joined after a secret rotation
-/// can never decrypt older-version messages. The count therefore resolves
-/// DOWN to the true mention count once the secrets arrive.
+/// Bodies that stay unreadable with secrets in hand do NOT count. See
+/// [`unreadable_body_may_become_readable`] for why none of those states is
+/// reliably transient, and why a permanent over-count is worse than a
+/// self-healing under-count.
 ///
 /// # Cost
 ///
@@ -577,7 +576,7 @@ fn count_unread_dms_with(
 /// room key shares cache entries with every other test on the thread, so use a
 /// fresh key per test.
 ///
-/// the signal-reading wrappers are [`count_total_unread_messages`] and
+/// The signal-reading wrappers are [`count_total_unread_messages`] and
 /// [`count_unread_behind_rooms_panel`].
 pub fn count_unread_excluding_room(
     map: &std::collections::HashMap<ed25519_dalek::VerifyingKey, crate::room_data::RoomData>,
@@ -899,11 +898,10 @@ mod tests {
             let start = squashed.find(marker).unwrap_or_else(|| {
                 panic!("`{total}` is gone — re-anchor this pin, do not delete it")
             });
+            // Whole-line comments (including `///`) were filtered out above, so
+            // the next `pub fn` is the only usable end marker.
             let body = &squashed[start..];
-            let end = body
-                .find("///")
-                .or_else(|| body.find("pubfn"))
-                .unwrap_or(body.len());
+            let end = body.find("pubfn").unwrap_or(body.len());
             assert!(
                 body[..end]
                     .contains("count_unread_excluding_room(&rooms.map,&rooms.notification_modes,"),
@@ -1506,18 +1504,26 @@ mod tests {
         );
     }
 
-    /// freenet/river#500 review (H1): a secret PRESENT at the message's
-    /// version but WRONG is the case the first fail-safe missed.
-    /// `decrypt_message_content` falls through to `to_string_lossy()` there —
-    /// `"[Encrypted message: N bytes, vM]"` — which contains no mention token,
-    /// so a presence-only check reads it as a confident "not a mention" and
-    /// hides a real mention.
+    /// freenet/river#500 review: the fail-safe is bounded to the COLD-START
+    /// window, so a body that stays unreadable with secrets in hand does not
+    /// count.
     ///
-    /// Not hypothetical: `RoomData::repopulate_secrets_from_state` exists
-    /// because an inviter can supply a wrong secret that the authoritative
-    /// owner-signed blob later replaces at the same version.
+    /// Three states reach this, and none of them is reliably transient: a
+    /// version older than everything held (a rotation the user joined after), a
+    /// version newer than everything held (which need NOT be a blob in flight —
+    /// a member offline across a rotation, or one whose blobs were pruned on
+    /// removal, never receives it), and a secret present at the right version
+    /// that does not decrypt (only overwritten if the contract carries an
+    /// owner-signed blob for this member at that version).
+    ///
+    /// Counting any of them would put a number on the badge, the title and the
+    /// hamburger that no amount of reading can clear — the #500 symptom in a
+    /// narrower configuration.
+    ///
+    /// Each case gets its OWN room key: the memo is a `thread_local` keyed by
+    /// `owner_vk`, and `cargo test -- --test-threads=1` shares it across tests.
     #[test]
-    fn mentions_mode_counts_a_body_whose_secret_is_present_but_wrong() {
+    fn mentions_mode_does_not_count_unreadable_bodies_once_secrets_are_held() {
         let (self_sk, self_vk) = keypair();
         let (owner_sk, owner_vk) = keypair();
         let self_id: MemberId = (&self_vk).into();
@@ -1527,135 +1533,140 @@ mod tests {
             "hey {}!",
             river_core::mention::encode_mention(self_id, "Me")
         );
-        let messages = vec![private_msg(
-            &owner_sk,
-            &owner_vk,
-            1,
-            mention_text,
-            &real_secret,
-            1,
-        )];
-        let mut rd = room(self_sk, owner_vk, messages, None);
 
-        // Premise: the wrong key must genuinely fail to decrypt, or this test
-        // is measuring the already-covered missing-secret path.
-        rd.secrets.insert(1, wrong_secret);
-        assert!(
-            crate::components::conversation::try_decrypt_message_content(
-                &rd.room_state.recent_messages.messages[0].message.content,
-                &rd.secrets,
-            )
-            .is_none(),
-            "premise: the wrong secret must not decrypt the body"
-        );
-
-        assert_eq!(
-            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
-            1,
-            "a body sealed under a key we hold the WRONG value for must count \
-             — it may be a mention and we cannot tell"
-        );
-
-        // …and the memo must not cement that answer. Overwriting the secret
-        // AT THE SAME VERSION leaves `secrets.len()` unchanged, so a
-        // length-only fingerprint would keep serving the over-count after the
-        // authoritative blob arrives.
-        rd.secrets.insert(1, real_secret);
-        assert_eq!(
-            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
-            1,
-            "the mention is real, so the count stays 1 — but it must have been \
-             RECOMPUTED, which the next case proves"
-        );
-    }
-
-    /// The same overwrite, with a body that is NOT a mention: here the count
-    /// must actually move, which it cannot do if the memo did not notice a
-    /// same-version secret replacement.
-    #[test]
-    fn a_same_version_secret_overwrite_invalidates_the_memo() {
-        let (self_sk, _) = keypair();
-        let (owner_sk, owner_vk) = keypair();
-        let real_secret = [1u8; 32];
-        let wrong_secret = [2u8; 32];
-        let messages = vec![private_msg(
-            &owner_sk,
-            &owner_vk,
-            1,
-            "nothing to see here".to_string(),
-            &real_secret,
-            1,
-        )];
-        let mut rd = room(self_sk, owner_vk, messages, None);
-
-        rd.secrets.insert(1, wrong_secret);
-        assert_eq!(
-            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
-            1,
-            "unreadable, so counted"
-        );
-
-        rd.secrets.insert(1, real_secret);
-        assert_eq!(
-            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
-            0,
-            "the authoritative secret arrived at the SAME version, so the \
-             fail-safe over-count must resolve away — a `secrets.len()` \
-             fingerprint would still be serving the stale 1"
-        );
-    }
-
-    /// freenet/river#500 review (H2): the fail-safe must be BOUNDED. A message
-    /// sealed under a version older than every secret we hold is a rotation
-    /// the user joined after; they will never read it, opening the room will
-    /// never make it readable, and counting it puts a permanent number on the
-    /// badge, the title and the hamburger — which is the reported symptom, in
-    /// a narrower configuration.
-    #[test]
-    fn mentions_mode_does_not_count_a_body_rotated_permanently_past() {
-        let (self_sk, _) = keypair();
-        let (owner_sk, owner_vk) = keypair();
-        let old_secret = [3u8; 32];
-        let current_secret = [4u8; 32];
-        let messages = vec![private_msg(
-            &owner_sk,
-            &owner_vk,
-            1,
-            "from before you joined".to_string(),
-            &old_secret,
-            1,
-        )];
-        let mut rd = room(self_sk, owner_vk, messages, None);
-
-        // Holding v2 but not v1: joined after the rotation.
-        rd.secrets.insert(2, current_secret);
-        assert_eq!(
-            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
-            0,
-            "a permanently unreadable older-version body must not count"
-        );
-
-        // A version NEWER than anything held is the opposite case: its secret
-        // is still in flight, so it counts.
-        let mut rd2 = room(
-            SigningKey::from_bytes(&[5u8; 32]),
+        // (a) A secret PRESENT at the message's version but WRONG. Premise
+        // first: the wrong key must genuinely fail to decrypt, or this is
+        // measuring the missing-secret path instead.
+        let mut wrong_key_room = room(
+            self_sk.clone(),
             owner_vk,
             vec![private_msg(
                 &owner_sk,
                 &owner_vk,
                 1,
+                mention_text.clone(),
+                &real_secret,
+                1,
+            )],
+            None,
+        );
+        wrong_key_room.secrets.insert(1, wrong_secret);
+        assert!(
+            crate::components::conversation::try_decrypt_message_content(
+                &wrong_key_room.room_state.recent_messages.messages[0]
+                    .message
+                    .content,
+                &wrong_key_room.secrets,
+            )
+            .is_none(),
+            "premise: the wrong secret must not decrypt the body"
+        );
+        assert_eq!(
+            count_unread_in_room_data_with_mode(
+                &wrong_key_room,
+                NotificationMode::MentionsAndReplies
+            ),
+            0,
+            "a wrong key at a held version is not reliably transient, so it \
+             must not count"
+        );
+
+        // (b) A version OLDER than everything held: joined after the rotation.
+        let (other_sk, _) = keypair();
+        let (owner2_sk, owner2_vk) = keypair();
+        let mut old_room = room(
+            other_sk,
+            owner2_vk,
+            vec![private_msg(
+                &owner2_sk,
+                &owner2_vk,
+                1,
+                "from before you joined".to_string(),
+                &real_secret,
+                1,
+            )],
+            None,
+        );
+        old_room.secrets.insert(2, [4u8; 32]);
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&old_room, NotificationMode::MentionsAndReplies),
+            0,
+            "a permanently unreadable older-version body must not count"
+        );
+
+        // (c) A version NEWER than everything held. This one LOOKS transient,
+        // and the first version of the fix treated it as such — but a member
+        // offline across a rotation, or one whose blobs were pruned on removal,
+        // never receives it, so counting it is unbounded.
+        let (third_sk, _) = keypair();
+        let (owner3_sk, owner3_vk) = keypair();
+        let mut new_room = room(
+            third_sk,
+            owner3_vk,
+            vec![private_msg(
+                &owner3_sk,
+                &owner3_vk,
+                1,
                 "just rotated".to_string(),
-                &current_secret,
+                &real_secret,
                 9,
             )],
             None,
         );
-        rd2.secrets.insert(2, current_secret);
+        new_room.secrets.insert(2, [4u8; 32]);
         assert_eq!(
-            count_unread_in_room_data_with_mode(&rd2, NotificationMode::MentionsAndReplies),
+            count_unread_in_room_data_with_mode(&new_room, NotificationMode::MentionsAndReplies),
+            0,
+            "a newer-version body is not guaranteed to arrive, so it must not \
+             count indefinitely"
+        );
+    }
+
+    /// The memo must notice a secret being replaced AT THE SAME VERSION.
+    ///
+    /// `repopulate_secrets_from_state` overwrites a wrong invitation-supplied
+    /// secret with the authoritative owner-signed one at the same version, so
+    /// `secrets.len()` is unchanged — a length-only fingerprint would keep
+    /// serving the count computed against the wrong key.
+    #[test]
+    fn a_same_version_secret_overwrite_invalidates_the_memo() {
+        let (self_sk, self_vk) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let self_id: MemberId = (&self_vk).into();
+        let real_secret = [1u8; 32];
+        let wrong_secret = [2u8; 32];
+        let mention_text = format!(
+            "hey {}!",
+            river_core::mention::encode_mention(self_id, "Me")
+        );
+        let mut rd = room(
+            self_sk,
+            owner_vk,
+            vec![private_msg(
+                &owner_sk,
+                &owner_vk,
+                1,
+                mention_text,
+                &real_secret,
+                1,
+            )],
+            None,
+        );
+
+        rd.secrets.insert(1, wrong_secret);
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
+            0,
+            "unreadable with secrets in hand, so not counted"
+        );
+
+        rd.secrets.insert(1, real_secret);
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
             1,
-            "a body sealed under a version newer than anything we hold is \
-             waiting on sync, so it counts"
+            "the authoritative secret arrived at the SAME version and the body \
+             turns out to be a mention — a `secrets.len()` fingerprint would \
+             still be serving the stale 0"
         );
     }
 

--- a/ui/src/components/app/document_title.rs
+++ b/ui/src/components/app/document_title.rs
@@ -163,7 +163,12 @@ fn get_current_room_name() -> Option<String> {
 /// are shown by `display_messages()` but deliberately excluded here
 /// (freenet/river#500): they are ambient activity, not something waiting
 /// to be read, so they must not inflate the badge or title counts.
-pub fn count_unread_in_room_data(room_data: &crate::room_data::RoomData) -> usize {
+///
+/// PRIVATE on purpose. This is the mode-BLIND count, and the whole of
+/// freenet/river#500 was three surfaces reaching for exactly this and so
+/// badging muted rooms. [`count_unread_in_room_data_with_mode`] is the API;
+/// a fourth unread surface must go through it.
+fn count_unread_in_room_data(room_data: &crate::room_data::RoomData) -> usize {
     unread_candidate_messages(room_data).count()
 }
 
@@ -212,23 +217,46 @@ fn unread_candidate_messages(
         .filter(move |m| m.message.author != self_member_id)
 }
 
-/// Whether `msg`'s body is sealed under a secret version this client does
-/// not hold, so no mention/reply check can see through it.
+/// Whether a body we could NOT read (`try_decrypt_message_content` returned
+/// `None`) is one we expect to be able to read LATER — in which case the
+/// MentionsAndReplies count includes it, because there is no way yet to tell
+/// whether it mentions the user.
 ///
-/// `decrypt_message_content` returns a human-readable PLACEHOLDER for such a
-/// message rather than failing, so `contains_mention_of` on that placeholder
-/// is always false and `extract_reply_target_id` always returns `None`:
-/// undecryptable would silently read as "not a mention". This predicate is
-/// what lets the MentionsAndReplies count fail SAFE instead — see
-/// [`count_unread_in_room_data_with_mode`].
-fn is_undecryptable(
+/// The distinction matters because "unreadable" is two different situations:
+///
+/// * **Transient.** The secrets map is empty (every cold start of an
+///   established private room, since `RoomData.secrets` is `#[serde(skip)]`),
+///   or the message is sealed under a version NEWER than anything we hold, so
+///   its secret is still in flight, or we hold a secret at that version and it
+///   does not decrypt the body — which `repopulate_secrets_from_state`
+///   overwrites from the owner-signed blob (see its doc: an inviter can supply
+///   a wrong secret that the authoritative blob later replaces AT THE SAME
+///   VERSION). Counting is the safe direction here: the alternative hides a
+///   real mention behind a silent zero until sync catches up.
+///
+/// * **Permanent.** The message is sealed under a version OLDER than every
+///   secret we hold: a rotation the user joined after, which they will never
+///   be able to read. Counting those would put a number on the badge, the tab
+///   title and the hamburger that can never resolve down and that points at a
+///   message the user cannot read even after opening the room — which is the
+///   #500 symptom in a narrower configuration. So they do not count.
+fn unreadable_body_may_become_readable(
     msg: &river_core::room_state::message::AuthorizedMessageV1,
     secrets: &std::collections::HashMap<u32, [u8; 32]>,
 ) -> bool {
     match &msg.message.content {
         river_core::room_state::message::RoomMessageBody::Private { secret_version, .. } => {
-            !secrets.contains_key(secret_version)
+            // Present but non-decrypting: a wrong key, replaced in place.
+            if secrets.contains_key(secret_version) {
+                return true;
+            }
+            // Absent: cold start, or a rotation still reaching us.
+            secrets
+                .keys()
+                .max()
+                .is_none_or(|newest| secret_version > newest)
         }
+        // A public body always reads; this is only reached defensively.
         river_core::room_state::message::RoomMessageBody::Public { .. } => false,
     }
 }
@@ -295,7 +323,7 @@ pub fn count_unread_in_room_data_with_mode(
 /// [`cached_mention_unread_count`].
 fn compute_mention_unread_count(room_data: &crate::room_data::RoomData) -> usize {
     use crate::components::app::notifications::{
-        mentions_or_replies_to_self_indexed, SelfAuthoredIndex,
+        text_mentions_or_replies_to_self, SelfAuthoredIndex,
     };
 
     let self_member_id: MemberId = room_data.self_sk.verifying_key().into();
@@ -307,15 +335,19 @@ fn compute_mention_unread_count(room_data: &crate::room_data::RoomData) -> usize
 
     unread_candidate_messages(room_data)
         .filter(|m| {
-            // Fail safe: a body we cannot decrypt might mention the user, so
-            // count it rather than silently reading it as "not a mention".
-            is_undecryptable(m, &room_data.secrets)
-                || mentions_or_replies_to_self_indexed(
-                    m,
-                    self_member_id,
-                    &room_data.secrets,
-                    &self_authored,
-                )
+            match crate::components::conversation::try_decrypt_message_content(
+                &m.message.content,
+                &room_data.secrets,
+            ) {
+                // Readable: the ordinary decision, against the text we just
+                // decrypted so the body is not decrypted twice.
+                Some(text) => {
+                    text_mentions_or_replies_to_self(m, &text, &room_data.secrets, &self_authored)
+                }
+                // Unreadable: count it only while there is reason to expect it
+                // to become readable — see the predicate's docs.
+                None => unreadable_body_may_become_readable(m, &room_data.secrets),
+            }
         })
         .count()
 }
@@ -331,8 +363,11 @@ thread_local! {
 #[cfg(test)]
 thread_local! {
     /// Test-only counter of full (cache-missing) mention scans, so a test can
-    /// prove the memo actually skips recompute. `thread_local`, and the test
-    /// harness gives each test its own thread, so tests don't interfere.
+    /// prove the memo actually skips recompute.
+    ///
+    /// `thread_local`, which is NOT per-test: `cargo test -- --test-threads=1`
+    /// runs every test on one thread and shares this counter. Read it as a
+    /// DELTA around the calls under test, never as an absolute.
     static MENTION_SCAN_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
@@ -349,8 +384,13 @@ const MENTION_COUNT_CACHE_MAX: usize = 256;
 /// * `messages.len()` and the first/last message id — any append, eviction
 ///   or replacement of the buffer changes one of them;
 /// * `last_read_message_id` — moves the tail's start;
-/// * `secrets.len()` — arriving secrets change decryptability, which is what
-///   resolves the fail-safe over-count down to the true count;
+/// * every `(version, secret)` PAIR, sorted — arriving secrets change
+///   decryptability, which is what resolves the fail-safe over-count down to
+///   the true count. Hashing `secrets.len()` alone is NOT enough:
+///   `repopulate_secrets_from_state` overwrites a wrong invitation-supplied
+///   secret with the authoritative owner-signed one AT THE SAME VERSION, so
+///   the length is unchanged and a stale under-count would survive the very
+///   event that fixes it (freenet/river#500 review);
 /// * `deleted.len()` — deletions change which messages are candidates;
 /// * the local member id — an identity import re-keys "self".
 fn mention_count_fingerprint(room_data: &crate::room_data::RoomData) -> u64 {
@@ -361,7 +401,9 @@ fn mention_count_fingerprint(room_data: &crate::room_data::RoomData) -> u64 {
     recent.messages.first().map(|m| m.id()).hash(&mut h);
     recent.messages.last().map(|m| m.id()).hash(&mut h);
     room_data.last_read_message_id.hash(&mut h);
-    room_data.secrets.len().hash(&mut h);
+    let mut secrets: Vec<_> = room_data.secrets.iter().collect();
+    secrets.sort_unstable_by_key(|(version, _)| **version);
+    secrets.hash(&mut h);
     recent.actions_state.deleted.len().hash(&mut h);
     MemberId::from(room_data.self_sk.verifying_key()).hash(&mut h);
     h.finish()
@@ -528,7 +570,13 @@ fn count_unread_dms_with(
 /// gate uses), so every unread surface sums identical per-room values
 /// (freenet/river#500).
 ///
-/// Pure (no signal reads) so the exclusion + mode logic is unit-testable;
+/// No signal reads, so the exclusion + mode logic is unit-testable. NOT pure,
+/// though: the MentionsAndReplies arm reads and writes a `thread_local` memo
+/// (see [`cached_mention_unread_count`]). Its value is unaffected — the memo is
+/// validated by [`mention_count_fingerprint`] — but a test that hardcodes a
+/// room key shares cache entries with every other test on the thread, so use a
+/// fresh key per test.
+///
 /// the signal-reading wrappers are [`count_total_unread_messages`] and
 /// [`count_unread_behind_rooms_panel`].
 pub fn count_unread_excluding_room(
@@ -810,6 +858,62 @@ pub fn DocumentTitleUpdater() -> Element {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Source-grep pin (freenet/river#500 review C2): every cross-room total
+    /// must go through the MODE-AWARE sum.
+    ///
+    /// `count_total_unread_messages` (the tab title) and
+    /// `count_unread_behind_rooms_panel` (the mobile hamburger) are one line
+    /// each, and reverting either to `rooms.map.values().map(...).sum()`
+    /// re-creates the reported bug — a muted room inflating the total —
+    /// while leaving the whole Rust suite and the whole browser suite green.
+    /// The hamburger is covered end-to-end by `room-unread-badge.spec.ts`'s
+    /// sum check; the title cannot be, because
+    /// `title-unread-badge.spec.ts` shows the visible→hidden transition marks
+    /// every room read, so the fixture's title never carries an `(N)`.
+    #[test]
+    fn every_cross_room_total_is_mode_aware() {
+        let source = include_str!("document_title.rs");
+        let prod = &source[..source
+            .find("#[cfg(test)]\nmod tests {")
+            .expect("document_title.rs should have a `#[cfg(test)] mod tests` block")];
+        // Whole-line comments only, so prose cannot satisfy the search and a
+        // `//` inside a string literal cannot truncate a real call away.
+        let code: String = prod
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let squashed: String = code.chars().filter(|c| !c.is_whitespace()).collect();
+
+        for (total, marker) in [
+            (
+                "count_total_unread_messages",
+                "fncount_total_unread_messages()",
+            ),
+            (
+                "count_unread_behind_rooms_panel",
+                "fncount_unread_behind_rooms_panel()",
+            ),
+        ] {
+            let start = squashed.find(marker).unwrap_or_else(|| {
+                panic!("`{total}` is gone — re-anchor this pin, do not delete it")
+            });
+            let body = &squashed[start..];
+            let end = body
+                .find("///")
+                .or_else(|| body.find("pubfn"))
+                .unwrap_or(body.len());
+            assert!(
+                body[..end]
+                    .contains("count_unread_excluding_room(&rooms.map,&rooms.notification_modes,"),
+                "`{total}` must sum through `count_unread_excluding_room` WITH \
+                 the notification modes — summing the mode-blind per-room count \
+                 is freenet/river#500"
+            );
+        }
+    }
+
     use crate::constants::ROOM_CONTRACT_WASM;
     use crate::room_data::{NotificationMode, RoomData};
     use crate::util::to_cbor_vec;
@@ -1402,6 +1506,159 @@ mod tests {
         );
     }
 
+    /// freenet/river#500 review (H1): a secret PRESENT at the message's
+    /// version but WRONG is the case the first fail-safe missed.
+    /// `decrypt_message_content` falls through to `to_string_lossy()` there —
+    /// `"[Encrypted message: N bytes, vM]"` — which contains no mention token,
+    /// so a presence-only check reads it as a confident "not a mention" and
+    /// hides a real mention.
+    ///
+    /// Not hypothetical: `RoomData::repopulate_secrets_from_state` exists
+    /// because an inviter can supply a wrong secret that the authoritative
+    /// owner-signed blob later replaces at the same version.
+    #[test]
+    fn mentions_mode_counts_a_body_whose_secret_is_present_but_wrong() {
+        let (self_sk, self_vk) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let self_id: MemberId = (&self_vk).into();
+        let real_secret = [7u8; 32];
+        let wrong_secret = [8u8; 32];
+        let mention_text = format!(
+            "hey {}!",
+            river_core::mention::encode_mention(self_id, "Me")
+        );
+        let messages = vec![private_msg(
+            &owner_sk,
+            &owner_vk,
+            1,
+            mention_text,
+            &real_secret,
+            1,
+        )];
+        let mut rd = room(self_sk, owner_vk, messages, None);
+
+        // Premise: the wrong key must genuinely fail to decrypt, or this test
+        // is measuring the already-covered missing-secret path.
+        rd.secrets.insert(1, wrong_secret);
+        assert!(
+            crate::components::conversation::try_decrypt_message_content(
+                &rd.room_state.recent_messages.messages[0].message.content,
+                &rd.secrets,
+            )
+            .is_none(),
+            "premise: the wrong secret must not decrypt the body"
+        );
+
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
+            1,
+            "a body sealed under a key we hold the WRONG value for must count \
+             — it may be a mention and we cannot tell"
+        );
+
+        // …and the memo must not cement that answer. Overwriting the secret
+        // AT THE SAME VERSION leaves `secrets.len()` unchanged, so a
+        // length-only fingerprint would keep serving the over-count after the
+        // authoritative blob arrives.
+        rd.secrets.insert(1, real_secret);
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
+            1,
+            "the mention is real, so the count stays 1 — but it must have been \
+             RECOMPUTED, which the next case proves"
+        );
+    }
+
+    /// The same overwrite, with a body that is NOT a mention: here the count
+    /// must actually move, which it cannot do if the memo did not notice a
+    /// same-version secret replacement.
+    #[test]
+    fn a_same_version_secret_overwrite_invalidates_the_memo() {
+        let (self_sk, _) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let real_secret = [1u8; 32];
+        let wrong_secret = [2u8; 32];
+        let messages = vec![private_msg(
+            &owner_sk,
+            &owner_vk,
+            1,
+            "nothing to see here".to_string(),
+            &real_secret,
+            1,
+        )];
+        let mut rd = room(self_sk, owner_vk, messages, None);
+
+        rd.secrets.insert(1, wrong_secret);
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
+            1,
+            "unreadable, so counted"
+        );
+
+        rd.secrets.insert(1, real_secret);
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
+            0,
+            "the authoritative secret arrived at the SAME version, so the \
+             fail-safe over-count must resolve away — a `secrets.len()` \
+             fingerprint would still be serving the stale 1"
+        );
+    }
+
+    /// freenet/river#500 review (H2): the fail-safe must be BOUNDED. A message
+    /// sealed under a version older than every secret we hold is a rotation
+    /// the user joined after; they will never read it, opening the room will
+    /// never make it readable, and counting it puts a permanent number on the
+    /// badge, the title and the hamburger — which is the reported symptom, in
+    /// a narrower configuration.
+    #[test]
+    fn mentions_mode_does_not_count_a_body_rotated_permanently_past() {
+        let (self_sk, _) = keypair();
+        let (owner_sk, owner_vk) = keypair();
+        let old_secret = [3u8; 32];
+        let current_secret = [4u8; 32];
+        let messages = vec![private_msg(
+            &owner_sk,
+            &owner_vk,
+            1,
+            "from before you joined".to_string(),
+            &old_secret,
+            1,
+        )];
+        let mut rd = room(self_sk, owner_vk, messages, None);
+
+        // Holding v2 but not v1: joined after the rotation.
+        rd.secrets.insert(2, current_secret);
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
+            0,
+            "a permanently unreadable older-version body must not count"
+        );
+
+        // A version NEWER than anything held is the opposite case: its secret
+        // is still in flight, so it counts.
+        let mut rd2 = room(
+            SigningKey::from_bytes(&[5u8; 32]),
+            owner_vk,
+            vec![private_msg(
+                &owner_sk,
+                &owner_vk,
+                1,
+                "just rotated".to_string(),
+                &current_secret,
+                9,
+            )],
+            None,
+        );
+        rd2.secrets.insert(2, current_secret);
+        assert_eq!(
+            count_unread_in_room_data_with_mode(&rd2, NotificationMode::MentionsAndReplies),
+            1,
+            "a body sealed under a version newer than anything we hold is \
+             waiting on sync, so it counts"
+        );
+    }
+
     #[test]
     fn all_mode_is_unaffected_by_undecryptable_private_messages() {
         // The fail-safe is scoped to mentions mode: `All` never inspects
@@ -1492,6 +1749,14 @@ mod tests {
             count_unread_in_room_data_with_mode(&rd, NotificationMode::MentionsAndReplies),
             0,
             "memo served a stale count after the last-read marker moved"
+        );
+        // …by RECOMPUTING. Without this leg, an implementation that recomputed
+        // on every call would satisfy every assertion above — the memo would be
+        // doing nothing and the test would still be green.
+        assert_eq!(
+            mention_scans(),
+            baseline + 3,
+            "the read-marker move must have caused exactly one more recompute"
         );
     }
 

--- a/ui/src/components/app/notifications.rs
+++ b/ui/src/components/app/notifications.rs
@@ -14,7 +14,7 @@ use dioxus::prelude::*;
 use ed25519_dalek::VerifyingKey;
 use river_core::room_state::member::MemberId;
 use river_core::room_state::member_info::MemberInfoV1;
-use river_core::room_state::message::{AuthorizedMessageV1, RoomMessageBody};
+use river_core::room_state::message::{AuthorizedMessageV1, MessageId, RoomMessageBody};
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use wasm_bindgen::prelude::*;
@@ -496,6 +496,69 @@ fn create_notification_internal(
     }
 }
 
+/// Whether `msg` is a candidate for a browser notification to the local
+/// user: authored by someone else, and not a room event.
+///
+/// Room events ("X joined the room", `CONTENT_TYPE_EVENT`) are ambient
+/// activity, not something waiting to be read.
+/// [`crate::components::app::document_title::count_unread_in_room_data`]
+/// excludes them from every unread surface (freenet/river#500), so notifying
+/// on one would make the notification and the badge disagree by construction:
+/// a join would pop a browser notification while contributing to no badge and
+/// no title count.
+///
+/// Known remaining asymmetry, pre-existing and deliberately unchanged here:
+/// action messages (edits, reactions, deletes — `is_action()`) are likewise
+/// excluded from the counts but are NOT filtered out of notifications, so a
+/// reaction can still notify without badging. Changing that would alter
+/// user-visible notification behaviour beyond the scope of #500.
+pub(crate) fn is_notifiable_external_message(
+    msg: &AuthorizedMessageV1,
+    self_member_id: MemberId,
+) -> bool {
+    msg.message.author != self_member_id && !msg.message.content.is_event()
+}
+
+/// Lazily-built index of the ids of messages in `recent` authored by
+/// `self_member_id` — the set a reply's target is tested against.
+///
+/// Exists because `AuthorizedMessageV1::id()` is a 64-byte rolling hash, so
+/// the naive `recent.iter().any(|m| m.id() == target)` per reply is O(N)
+/// hashes *per candidate message* (O(N²) over a reply-heavy buffer). Scanning
+/// a whole room's unread tail (freenet/river#500) makes that the hot path, so
+/// the ids are hashed once per scan and reused.
+///
+/// Built lazily via `OnceCell`: a scan whose candidates contain no replies
+/// (the common case) never pays for the index at all.
+pub(crate) struct SelfAuthoredIndex<'a> {
+    recent: &'a [AuthorizedMessageV1],
+    self_member_id: MemberId,
+    ids: std::cell::OnceCell<std::collections::HashSet<MessageId>>,
+}
+
+impl<'a> SelfAuthoredIndex<'a> {
+    pub(crate) fn new(recent: &'a [AuthorizedMessageV1], self_member_id: MemberId) -> Self {
+        Self {
+            recent,
+            self_member_id,
+            ids: std::cell::OnceCell::new(),
+        }
+    }
+
+    /// Whether `target_id` names a message in `recent` authored by self.
+    fn contains(&self, target_id: &MessageId) -> bool {
+        self.ids
+            .get_or_init(|| {
+                self.recent
+                    .iter()
+                    .filter(|m| m.message.author == self.self_member_id)
+                    .map(|m| m.id())
+                    .collect()
+            })
+            .contains(target_id)
+    }
+}
+
 /// Pure decision for [`crate::room_data::NotificationMode::MentionsAndReplies`]:
 /// does `msg` @mention `self_member_id`, OR is it a reply to a message that
 /// `self_member_id` authored among `recent`? No globals, so it is unit-testable.
@@ -504,6 +567,11 @@ fn create_notification_internal(
 /// that message's author to self. If the target has scrolled out of `recent` we
 /// cannot confirm authorship, so we conservatively return `false` (miss rather
 /// than spuriously notify).
+///
+/// Single-message convenience wrapper over
+/// [`mentions_or_replies_to_self_indexed`]; a caller testing many messages
+/// against the same `recent` should build one [`SelfAuthoredIndex`] and call
+/// the indexed form instead.
 ///
 /// `pub(crate)`: besides gating browser notifications here, this is the same
 /// predicate the unread counters use for rooms in MentionsAndReplies mode
@@ -515,6 +583,23 @@ pub(crate) fn mentions_or_replies_to_self(
     room_secrets: &std::collections::HashMap<u32, [u8; 32]>,
     recent: &[AuthorizedMessageV1],
 ) -> bool {
+    mentions_or_replies_to_self_indexed(
+        msg,
+        self_member_id,
+        room_secrets,
+        &SelfAuthoredIndex::new(recent, self_member_id),
+    )
+}
+
+/// [`mentions_or_replies_to_self`] against a pre-built (or lazily-built)
+/// self-authored id index, so a multi-message scan hashes `recent` at most
+/// once instead of once per candidate.
+pub(crate) fn mentions_or_replies_to_self_indexed(
+    msg: &AuthorizedMessageV1,
+    self_member_id: MemberId,
+    room_secrets: &std::collections::HashMap<u32, [u8; 32]>,
+    self_authored: &SelfAuthoredIndex<'_>,
+) -> bool {
     use crate::components::conversation::{decrypt_message_content, extract_reply_target_id};
 
     // (a) An @mention of self anywhere in the (decrypted) message text.
@@ -525,9 +610,7 @@ pub(crate) fn mentions_or_replies_to_self(
 
     // (b) A reply to a message authored by self.
     if let Some(target_id) = extract_reply_target_id(&msg.message.content, room_secrets) {
-        return recent
-            .iter()
-            .any(|m| m.id() == target_id && m.message.author == self_member_id);
+        return self_authored.contains(&target_id);
     }
     false
 }
@@ -619,10 +702,10 @@ pub fn notify_new_messages(
     //     return;
     // }
 
-    // Filter to messages from other users
+    // Filter to messages from other users, excluding room events.
     let external_messages: Vec<_> = new_messages
         .iter()
-        .filter(|msg| msg.message.author != self_member_id)
+        .filter(|msg| is_notifiable_external_message(msg, self_member_id))
         .collect();
 
     info!(
@@ -1016,6 +1099,47 @@ mod notify_gate_tests {
             &secrets,
             &[]
         ));
+    }
+
+    #[test]
+    fn room_events_are_not_notifiable() {
+        // freenet/river#500: room events are excluded from every unread
+        // count, so notifying on one would make the notification and the
+        // badge disagree by construction (a join pops a notification while
+        // contributing to no badge).
+        let me = key(1);
+        let other = key(2);
+        let join = public_msg(&other, RoomMessageBody::join_event());
+        assert!(!is_notifiable_external_message(&join, id_of(&me)));
+        // An ordinary message from someone else still notifies…
+        let chat = public_msg(&other, RoomMessageBody::public("hello".to_string()));
+        assert!(is_notifiable_external_message(&chat, id_of(&me)));
+        // …and self-authored messages still don't.
+        let mine = public_msg(&me, RoomMessageBody::public("hello".to_string()));
+        assert!(!is_notifiable_external_message(&mine, id_of(&me)));
+    }
+
+    /// `notify_new_messages` is `wasm`-only, so no behavioural test in this
+    /// crate can reach it: re-inlining the author-only filter would silently
+    /// restore join-event notifications with every other test still green.
+    #[test]
+    fn notify_new_messages_filters_through_the_notifiable_predicate() {
+        let source = include_str!("notifications.rs");
+        let (production, _) = source
+            .split_once("mod notify_gate_tests")
+            .expect("this test module's own declaration marks the end of production code");
+
+        assert!(
+            production.contains("is_notifiable_external_message(msg, self_member_id)"),
+            "the new-message filter stopped delegating to \
+             `is_notifiable_external_message`, so room events can notify again"
+        );
+        // The pre-fix predicate, re-inlined, would drop the event exclusion.
+        assert!(
+            !production.contains("filter(|msg| msg.message.author != self_member_id)"),
+            "the author-only filter was re-inlined, which skips the room-event \
+             exclusion that keeps notifications and unread badges in agreement"
+        );
     }
 
     #[test]

--- a/ui/src/components/app/notifications.rs
+++ b/ui/src/components/app/notifications.rs
@@ -545,6 +545,12 @@ impl<'a> SelfAuthoredIndex<'a> {
         }
     }
 
+    /// The member this index treats as "self" — the single source of that
+    /// answer for every caller, so no caller can supply a second one.
+    pub(crate) fn self_member_id(&self) -> MemberId {
+        self.self_member_id
+    }
+
     /// Whether `target_id` names a message in `recent` authored by self.
     fn contains(&self, target_id: &MessageId) -> bool {
         self.ids
@@ -576,7 +582,18 @@ impl<'a> SelfAuthoredIndex<'a> {
 /// `pub(crate)`: besides gating browser notifications here, this is the same
 /// predicate the unread counters use for rooms in MentionsAndReplies mode
 /// (`document_title::count_unread_in_room_data_with_mode`, freenet/river#500),
-/// so the badge and the notification can't disagree about what "qualifies".
+/// so the badge and the notification can't drift on what a mention or a reply
+/// IS.
+///
+/// They do deliberately differ on one thing: a body that cannot be decrypted
+/// at all. The counter counts it (see
+/// `document_title::unreadable_body_may_become_readable`) because a wrong
+/// number that resolves down is better than a badge that hides a mention. A
+/// notification cannot be taken back, and every cold start of a private room
+/// has an empty secrets map, so applying the same fail-safe here would fire a
+/// burst of "you were mentioned" popups on every reload. The badge
+/// over-reports; the notification under-reports; both fail toward the less
+/// annoying error.
 pub(crate) fn mentions_or_replies_to_self(
     msg: &AuthorizedMessageV1,
     self_member_id: MemberId,
@@ -585,7 +602,6 @@ pub(crate) fn mentions_or_replies_to_self(
 ) -> bool {
     mentions_or_replies_to_self_indexed(
         msg,
-        self_member_id,
         room_secrets,
         &SelfAuthoredIndex::new(recent, self_member_id),
     )
@@ -596,15 +612,35 @@ pub(crate) fn mentions_or_replies_to_self(
 /// once instead of once per candidate.
 pub(crate) fn mentions_or_replies_to_self_indexed(
     msg: &AuthorizedMessageV1,
-    self_member_id: MemberId,
     room_secrets: &std::collections::HashMap<u32, [u8; 32]>,
     self_authored: &SelfAuthoredIndex<'_>,
 ) -> bool {
-    use crate::components::conversation::{decrypt_message_content, extract_reply_target_id};
+    use crate::components::conversation::decrypt_message_content;
 
-    // (a) An @mention of self anywhere in the (decrypted) message text.
     let text = decrypt_message_content(&msg.message.content, room_secrets);
-    if river_core::mention::contains_mention_of(&text, self_member_id) {
+    text_mentions_or_replies_to_self(msg, &text, room_secrets, self_authored)
+}
+
+/// [`mentions_or_replies_to_self_indexed`] against a body that has ALREADY
+/// been decrypted, so a caller that needed the plaintext for its own reasons
+/// does not pay for a second AES-GCM decrypt of the same message.
+///
+/// This is the single definition of "qualifies" — the notification gate and
+/// the unread counter both end up here, so they cannot drift on what counts
+/// as a mention or a reply.
+pub(crate) fn text_mentions_or_replies_to_self(
+    msg: &AuthorizedMessageV1,
+    text: &str,
+    room_secrets: &std::collections::HashMap<u32, [u8; 32]>,
+    self_authored: &SelfAuthoredIndex<'_>,
+) -> bool {
+    use crate::components::conversation::extract_reply_target_id;
+
+    // "Self" is taken from the index and nowhere else. Passing it separately
+    // as well let the mention arm and the reply arm disagree about whose
+    // messages these are — the paired-field shape the project's bug-prevention
+    // rules call out.
+    if river_core::mention::contains_mention_of(text, self_authored.self_member_id()) {
         return true;
     }
 
@@ -615,32 +651,10 @@ pub(crate) fn mentions_or_replies_to_self_indexed(
     false
 }
 
-/// Whether `msg` should notify the local user under
-/// [`crate::room_data::NotificationMode::MentionsAndReplies`]: it either
-/// @mentions them or is a reply to one of their own messages.
-///
-/// Reads `recent_messages` from `ROOMS` (needed for reply-authorship) and
-/// delegates the decision to the pure [`mentions_or_replies_to_self`] helper.
-fn message_notifies_self(
-    msg: &AuthorizedMessageV1,
-    self_member_id: MemberId,
-    room_key: &VerifyingKey,
-    room_secrets: &std::collections::HashMap<u32, [u8; 32]>,
-) -> bool {
-    if let Ok(rooms) = ROOMS.try_read() {
-        if let Some(rd) = rooms.map.get(room_key) {
-            return mentions_or_replies_to_self(
-                msg,
-                self_member_id,
-                room_secrets,
-                &rd.room_state.recent_messages.messages,
-            );
-        }
-    }
-    // ROOMS unreadable / room missing: the @mention check needs no room
-    // context, so still honour it with an empty recent-message window.
-    mentions_or_replies_to_self(msg, self_member_id, room_secrets, &[])
-}
+// NOTE: there is deliberately no per-message `message_notifies_self` helper
+// any more. It re-read `ROOMS` and rebuilt a `SelfAuthoredIndex` once per
+// message, so a K-message delta did K signal reads and K index builds;
+// `notify_new_messages` now reads once and builds one index for the batch.
 
 /// Process new messages and show notifications if appropriate
 /// Called from apply_delta when new messages are received
@@ -721,12 +735,32 @@ pub fn notify_new_messages(
     }
 
     // Apply the per-room notification preference (a local user setting).
-    let mode = ROOMS
-        .read()
+    //
+    // Read ONCE, and fallibly: `.read()` panics on a re-entrant borrow
+    // (`.claude/rules/dioxus-signal-safety.md`), and this runs from
+    // `apply_delta`. The fallback is `return`, NOT `unwrap_or_default()` — the
+    // default is `All`, so defaulting here would notify a MUTED room, which is
+    // exactly the setting the user chose to prevent. A missed notification on
+    // an unreadable signal is the safe direction.
+    //
+    // The room's recent messages come out of the same read, so the per-message
+    // mention check below does not re-read `ROOMS` (and does not rebuild its
+    // self-authored index) once per message.
+    let Ok(rooms) = ROOMS.try_read() else {
+        warn!("ROOMS unreadable while deciding notifications; skipping");
+        return;
+    };
+    let mode = rooms
         .notification_modes
         .get(room_key)
         .copied()
         .unwrap_or_default();
+    let recent: Vec<AuthorizedMessageV1> = rooms
+        .map
+        .get(room_key)
+        .map(|rd| rd.room_state.recent_messages.messages.clone())
+        .unwrap_or_default();
+    drop(rooms);
     let external_messages: Vec<_> = match mode {
         crate::room_data::NotificationMode::All => external_messages,
         crate::room_data::NotificationMode::Muted => {
@@ -736,27 +770,35 @@ pub fn notify_new_messages(
             );
             return;
         }
-        crate::room_data::NotificationMode::MentionsAndReplies => external_messages
-            .into_iter()
-            .filter(|msg| message_notifies_self(msg, self_member_id, room_key, room_secrets))
-            .collect(),
+        crate::room_data::NotificationMode::MentionsAndReplies => {
+            let self_authored = SelfAuthoredIndex::new(&recent, self_member_id);
+            external_messages
+                .into_iter()
+                .filter(|msg| {
+                    mentions_or_replies_to_self_indexed(msg, room_secrets, &self_authored)
+                })
+                .collect()
+        }
     };
     if external_messages.is_empty() {
         info!("No messages match the room's mentions-and-replies filter");
         return;
     }
 
-    // Get room name (decrypt if private)
+    // Get room name (decrypt if private). Fallible for the same reason as the
+    // mode read above; unlike the mode, an unavailable NAME is cosmetic, so
+    // the fallback is the generic label rather than a `return`.
     let room_name = ROOMS
-        .read()
-        .map
-        .get(room_key)
-        .map(|rd| {
-            let sealed_name = &rd.room_state.configuration.configuration.display.name;
-            match unseal_bytes_with_secrets(sealed_name, room_secrets) {
-                Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
-                Err(_) => sealed_name.to_string_lossy(),
-            }
+        .try_read()
+        .ok()
+        .and_then(|rooms| {
+            rooms.map.get(room_key).map(|rd| {
+                let sealed_name = &rd.room_state.configuration.configuration.display.name;
+                match unseal_bytes_with_secrets(sealed_name, room_secrets) {
+                    Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
+                    Err(_) => sealed_name.to_string_lossy(),
+                }
+            })
         })
         .unwrap_or_else(|| "Room".to_string());
 
@@ -1128,15 +1170,19 @@ mod notify_gate_tests {
         let (production, _) = source
             .split_once("mod notify_gate_tests")
             .expect("this test module's own declaration marks the end of production code");
+        // Whitespace-stripped: rustfmt re-wraps a growing call's arguments, and
+        // a contiguous-text needle would go silently vacuous the first time it
+        // did (this repo has been bitten by exactly that).
+        let squashed: String = production.chars().filter(|c| !c.is_whitespace()).collect();
 
         assert!(
-            production.contains("is_notifiable_external_message(msg, self_member_id)"),
+            squashed.contains("is_notifiable_external_message(msg,self_member_id)"),
             "the new-message filter stopped delegating to \
              `is_notifiable_external_message`, so room events can notify again"
         );
         // The pre-fix predicate, re-inlined, would drop the event exclusion.
         assert!(
-            !production.contains("filter(|msg| msg.message.author != self_member_id)"),
+            !squashed.contains("filter(|msg|msg.message.author!=self_member_id)"),
             "the author-only filter was re-inlined, which skips the room-event \
              exclusion that keeps notifications and unread badges in agreement"
         );

--- a/ui/src/components/app/notifications.rs
+++ b/ui/src/components/app/notifications.rs
@@ -504,7 +504,12 @@ fn create_notification_internal(
 /// that message's author to self. If the target has scrolled out of `recent` we
 /// cannot confirm authorship, so we conservatively return `false` (miss rather
 /// than spuriously notify).
-fn mentions_or_replies_to_self(
+///
+/// `pub(crate)`: besides gating browser notifications here, this is the same
+/// predicate the unread counters use for rooms in MentionsAndReplies mode
+/// (`document_title::count_unread_in_room_data_with_mode`, freenet/river#500),
+/// so the badge and the notification can't disagree about what "qualifies".
+pub(crate) fn mentions_or_replies_to_self(
     msg: &AuthorizedMessageV1,
     self_member_id: MemberId,
     room_secrets: &std::collections::HashMap<u32, [u8; 32]>,

--- a/ui/src/components/app/notifications.rs
+++ b/ui/src/components/app/notifications.rs
@@ -575,9 +575,14 @@ impl<'a> SelfAuthoredIndex<'a> {
 /// than spuriously notify).
 ///
 /// Single-message convenience wrapper over
-/// [`mentions_or_replies_to_self_indexed`]; a caller testing many messages
-/// against the same `recent` should build one [`SelfAuthoredIndex`] and call
-/// the indexed form instead.
+/// [`mentions_or_replies_to_self_indexed`].
+///
+/// `#[cfg(test)]`: production has no single-message caller left. The
+/// notification gate and the unread counter both scan a batch against one
+/// `recent`, so both build a [`SelfAuthoredIndex`] once and use the indexed
+/// form; re-introducing a per-message wrapper on either path re-introduces the
+/// per-message index rebuild it exists to avoid. Kept for the pure-decision
+/// tests below, which are about the predicate rather than the batching.
 ///
 /// `pub(crate)`: besides gating browser notifications here, this is the same
 /// predicate the unread counters use for rooms in MentionsAndReplies mode
@@ -594,6 +599,7 @@ impl<'a> SelfAuthoredIndex<'a> {
 /// burst of "you were mentioned" popups on every reload. The badge
 /// over-reports; the notification under-reports; both fail toward the less
 /// annoying error.
+#[cfg(test)]
 pub(crate) fn mentions_or_replies_to_self(
     msg: &AuthorizedMessageV1,
     self_member_id: MemberId,
@@ -623,7 +629,9 @@ pub(crate) fn mentions_or_replies_to_self_indexed(
 
 /// [`mentions_or_replies_to_self_indexed`] against a body that has ALREADY
 /// been decrypted, so a caller that needed the plaintext for its own reasons
-/// does not pay for a second AES-GCM decrypt of the same message.
+/// does not pay to decrypt the same message again for the mention scan. (A
+/// REPLY body is still decrypted a second time inside `extract_reply_target_id`
+/// — that is pre-existing, and unchanged either way.)
 ///
 /// This is the single definition of "qualifies" — the notification gate and
 /// the unread counter both end up here, so they cannot drift on what counts
@@ -755,11 +763,19 @@ pub fn notify_new_messages(
         .get(room_key)
         .copied()
         .unwrap_or_default();
-    let recent: Vec<AuthorizedMessageV1> = rooms
-        .map
-        .get(room_key)
-        .map(|rd| rd.room_state.recent_messages.messages.clone())
-        .unwrap_or_default();
+    // Only MentionsAndReplies needs the buffer, and it is the whole
+    // `max_recent_messages` window (ciphertext included), so `All` — the
+    // default — must not pay a deep clone of it on every delta.
+    let recent: Vec<AuthorizedMessageV1> =
+        if mode == crate::room_data::NotificationMode::MentionsAndReplies {
+            rooms
+                .map
+                .get(room_key)
+                .map(|rd| rd.room_state.recent_messages.messages.clone())
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
     drop(rooms);
     let external_messages: Vec<_> = match mode {
         crate::room_data::NotificationMode::All => external_messages,

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -712,6 +712,54 @@ fn format_event_summary(names: &[String]) -> String {
     }
 }
 
+/// The message body's readable text, or `None` when the body is private and
+/// cannot be read at all — either its secret version is missing, or the
+/// secret we hold for that version does not decrypt it.
+///
+/// [`decrypt_message_content`] answers the same question but substitutes a
+/// human-readable PLACEHOLDER in those cases, which is right for rendering
+/// and wrong for anything that then INSPECTS the text: a mention scan over
+/// `"[Encrypted message: 42 bytes, v2]"` finds no mention and reads as a
+/// confident "not a mention". Callers that need to tell "no mention" from
+/// "could not look" must use this (freenet/river#500).
+pub(crate) fn try_decrypt_message_content(
+    content: &RoomMessageBody,
+    secrets: &HashMap<u32, [u8; 32]>,
+) -> Option<String> {
+    use river_core::room_state::content::{
+        ReplyContentV1, TextContentV1, CONTENT_TYPE_REPLY, CONTENT_TYPE_TEXT,
+    };
+
+    match content {
+        // Public bodies are always readable; `decrypt_message_content`'s
+        // public arm has no placeholder path.
+        RoomMessageBody::Public { .. } => Some(decrypt_message_content(content, secrets)),
+        RoomMessageBody::Private {
+            content_type,
+            ciphertext,
+            nonce,
+            secret_version,
+            ..
+        } => {
+            use crate::util::ecies::decrypt_with_symmetric_key;
+            let secret = secrets.get(secret_version)?;
+            let plaintext =
+                decrypt_with_symmetric_key(secret, ciphertext.as_slice(), nonce).ok()?;
+            if *content_type == CONTENT_TYPE_TEXT {
+                if let Ok(text_content) = TextContentV1::decode(&plaintext) {
+                    return Some(text_content.text);
+                }
+            }
+            if *content_type == CONTENT_TYPE_REPLY {
+                if let Ok(reply) = ReplyContentV1::decode(&plaintext) {
+                    return Some(reply.text);
+                }
+            }
+            Some(String::from_utf8_lossy(&plaintext).to_string())
+        }
+    }
+}
+
 pub(crate) fn decrypt_message_content(
     content: &RoomMessageBody,
     secrets: &HashMap<u32, [u8; 32]>,
@@ -743,35 +791,17 @@ pub(crate) fn decrypt_message_content(
             // Unknown content type
             content.to_string_lossy()
         }
-        RoomMessageBody::Private {
-            content_type,
-            ciphertext,
-            nonce,
-            secret_version,
-            ..
-        } => {
-            // Look up the secret for this message's version
-            if let Some(secret) = secrets.get(secret_version) {
-                use crate::util::ecies::decrypt_with_symmetric_key;
-                // Decrypt the ciphertext
-                if let Ok(decrypted_bytes) =
-                    decrypt_with_symmetric_key(secret, ciphertext.as_slice(), nonce)
-                {
-                    // For text messages, decode the content
-                    if *content_type == CONTENT_TYPE_TEXT {
-                        if let Ok(text_content) = TextContentV1::decode(&decrypted_bytes) {
-                            return text_content.text;
-                        }
-                    }
-                    // For reply messages, decode and return reply text
-                    if *content_type == CONTENT_TYPE_REPLY {
-                        if let Ok(reply) = ReplyContentV1::decode(&decrypted_bytes) {
-                            return reply.text;
-                        }
-                    }
-                    // Fallback to UTF-8 string
-                    return String::from_utf8_lossy(&decrypted_bytes).to_string();
-                }
+        RoomMessageBody::Private { secret_version, .. } => {
+            // The read itself lives in `try_decrypt_message_content`, so there
+            // is ONE definition of "what does this body say". Everything below
+            // is the placeholder to render when it says nothing.
+            if let Some(text) = try_decrypt_message_content(content, secrets) {
+                return text;
+            }
+            if secrets.contains_key(secret_version) {
+                // We hold a secret at this version and it did not decrypt the
+                // body — a wrong key, which `repopulate_secrets_from_state`
+                // overwrites from the owner-signed blob when it arrives.
                 content.to_string_lossy()
             } else if secrets.is_empty() {
                 // Issue freenet/river#284: when the in-memory `secrets`

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -731,8 +731,12 @@ pub(crate) fn try_decrypt_message_content(
     };
 
     match content {
-        // Public bodies are always readable; `decrypt_message_content`'s
-        // public arm has no placeholder path.
+        // A public body has no secret to be missing, so it is never
+        // "unreadable" in the sense this function is about. (A corrupt or
+        // forward-incompatible public payload still yields
+        // `to_string_lossy()`'s placeholder rather than `None` — nothing can
+        // make that body readable later, so there is no transient state to
+        // distinguish.)
         RoomMessageBody::Public { .. } => Some(decrypt_message_content(content, secrets)),
         RoomMessageBody::Private {
             content_type,

--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -88,6 +88,23 @@ pub(crate) fn room_list_display_state(
     }
 }
 
+/// Tooltip / accessible name for a room row's unread badge.
+///
+/// `is_mentions` is true for a room in
+/// [`NotificationMode::MentionsAndReplies`](crate::room_data::NotificationMode),
+/// where the badge counts only messages that @mention the user or reply to
+/// one of their messages — so the copy must not claim "messages", and must
+/// name replies as well as mentions (freenet/river#500). Both variants are
+/// singular-aware so a count of 1 never reads "1 unread messages".
+fn unread_badge_label(unread: usize, is_mentions: bool) -> String {
+    match (is_mentions, unread) {
+        (true, 1) => "1 unread mention or reply".to_string(),
+        (true, n) => format!("{n} unread mentions or replies"),
+        (false, 1) => "1 unread message".to_string(),
+        (false, n) => format!("{n} unread messages"),
+    }
+}
+
 /// Convert UTC ISO timestamp to local time string
 fn format_build_time_local() -> String {
     #[cfg(target_arch = "wasm32")]
@@ -213,10 +230,15 @@ pub fn RoomList() -> Element {
                 // localhost node) can still see which rooms have new
                 // messages. A Muted room counts 0 (no badge, ever); a
                 // MentionsAndReplies room counts only unread messages that
-                // mention or reply to the user — that mode's mention scan
-                // decrypts content, but only over the (typically small)
-                // unread tail and only for rooms in that mode, so this memo
-                // stays cheap on every ROOMS write.
+                // mention or reply to the user.
+                //
+                // That mode's scan decrypts message bodies and is NOT cheap:
+                // its unread tail is the whole message buffer whenever the
+                // room has never been opened or the last-read marker aged
+                // out. It is memoized per room inside
+                // `count_unread_in_room_data_with_mode`, which is what keeps
+                // this memo affordable on every ROOMS write — see that
+                // function's docs before removing the memo.
                 let mode = rooms
                     .notification_modes
                     .get(&room_key)
@@ -415,17 +437,12 @@ pub fn RoomList() -> Element {
                     let unread_is_mentions = *unread_is_mentions;
                     let sync_error_msg = sync_error_msg.clone();
                     // Badge tooltip/accessible name — says what the number
-                    // means under the room's notification mode.
-                    let badge_title = if unread_is_mentions {
-                        format!("{unread} unread mentions")
-                    } else {
-                        format!("{unread} unread")
-                    };
-                    let badge_aria = if unread_is_mentions {
-                        format!("{unread} unread mentions")
-                    } else {
-                        format!("{unread} unread messages")
-                    };
+                    // means under the room's notification mode. The
+                    // mentions-mode count includes REPLIES as well as
+                    // @mentions, so the copy names both; both variants are
+                    // singular-aware ("1 unread mention or reply").
+                    let badge_title = unread_badge_label(unread, unread_is_mentions);
+                    let badge_aria = badge_title.clone();
                     // Row position, for disabling the up control on the first
                     // row and the down control on the last (reorder mode).
                     let is_first = idx == 0;
@@ -749,6 +766,21 @@ pub fn RoomList() -> Element {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// freenet/river#500: the badge copy must say what the number counts.
+    /// A mentions-mode badge counts @mentions AND replies, so naming only
+    /// mentions understates it; and neither variant may read "1 unread
+    /// messages".
+    #[test]
+    fn unread_badge_label_names_what_it_counts() {
+        assert_eq!(unread_badge_label(1, false), "1 unread message");
+        assert_eq!(unread_badge_label(4, false), "4 unread messages");
+        assert_eq!(unread_badge_label(1, true), "1 unread mention or reply");
+        assert_eq!(unread_badge_label(3, true), "3 unread mentions or replies");
+        // The mentions variant must never claim plain "messages" — the count
+        // deliberately excludes unread messages that don't mention the user.
+        assert!(!unread_badge_label(3, true).contains("messages"));
+    }
 
     /// freenet/river#397: the initial load hasn't resolved and there are no
     /// rooms yet → show the loading spinner, NOT a blank list or a premature

--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -10,7 +10,7 @@ use crate::components::app::chat_delegate::{
     retry_rooms_load, save_rooms_to_delegate, RoomsLoadState, ROOMS_LOAD_STATE,
 };
 use crate::components::app::document_title::{
-    count_unread_in_room_data, mark_current_room_as_read,
+    count_unread_in_room_data_with_mode, mark_current_room_as_read,
 };
 use crate::components::app::sync_info::{RoomSyncStatus, SYNC_INFO};
 use crate::components::app::{MobileView, CREATE_ROOM_MODAL, CURRENT_ROOM, MOBILE_VIEW, ROOMS};
@@ -207,11 +207,27 @@ pub fn RoomList() -> Element {
                     .configuration
                     .privacy_mode
                     == PrivacyMode::Private;
-                // Unread badge: same per-room count the document title uses,
-                // surfaced in the rail so users who don't get browser
-                // notifications (e.g. not on a localhost node) can still see
-                // which rooms have new messages.
-                let unread = count_unread_in_room_data(room_data);
+                // Unread badge: same mode-aware per-room count the document
+                // title uses (freenet/river#500), surfaced in the rail so
+                // users who don't get browser notifications (e.g. not on a
+                // localhost node) can still see which rooms have new
+                // messages. A Muted room counts 0 (no badge, ever); a
+                // MentionsAndReplies room counts only unread messages that
+                // mention or reply to the user — that mode's mention scan
+                // decrypts content, but only over the (typically small)
+                // unread tail and only for rooms in that mode, so this memo
+                // stays cheap on every ROOMS write.
+                let mode = rooms
+                    .notification_modes
+                    .get(&room_key)
+                    .copied()
+                    .unwrap_or_default();
+                let unread = count_unread_in_room_data_with_mode(room_data, mode);
+                // Badge label matches what is being counted: qualifying
+                // mentions/replies for MentionsAndReplies rooms, all unread
+                // messages otherwise. (Muted rooms never render the badge.)
+                let unread_is_mentions =
+                    mode == crate::room_data::NotificationMode::MentionsAndReplies;
                 Some((
                     room_key,
                     room_name,
@@ -219,6 +235,7 @@ pub fn RoomList() -> Element {
                     awaiting_sync,
                     is_private,
                     unread,
+                    unread_is_mentions,
                     sync_error_msg,
                 ))
             })
@@ -388,14 +405,27 @@ pub fn RoomList() -> Element {
                     RoomListDisplay::List => rsx! {},
                 }
 
-                {room_items.read().iter().enumerate().map(|(idx, (room_key, room_name, is_current, awaiting_sync, is_private, unread, sync_error_msg))| {
+                {room_items.read().iter().enumerate().map(|(idx, (room_key, room_name, is_current, awaiting_sync, is_private, unread, unread_is_mentions, sync_error_msg))| {
                     let room_key = *room_key;
                     let room_name = room_name.clone();
                     let is_current = *is_current;
                     let awaiting_sync = *awaiting_sync;
                     let is_private = *is_private;
                     let unread = *unread;
+                    let unread_is_mentions = *unread_is_mentions;
                     let sync_error_msg = sync_error_msg.clone();
+                    // Badge tooltip/accessible name — says what the number
+                    // means under the room's notification mode.
+                    let badge_title = if unread_is_mentions {
+                        format!("{unread} unread mentions")
+                    } else {
+                        format!("{unread} unread")
+                    };
+                    let badge_aria = if unread_is_mentions {
+                        format!("{unread} unread mentions")
+                    } else {
+                        format!("{unread} unread messages")
+                    };
                     // Row position, for disabling the up control on the first
                     // row and the down control on the last (reorder mode).
                     let is_first = idx == 0;
@@ -516,15 +546,19 @@ pub fn RoomList() -> Element {
                                     // Unread badge — hidden for the current
                                     // room (its messages are marked read on
                                     // open, so a badge there would only
-                                    // flicker). Styling mirrors the DM rail
-                                    // badge plus `flex-shrink-0` so a long
-                                    // truncated room name can't squash it.
+                                    // flicker) and for Muted rooms (their
+                                    // count is always 0, freenet/river#500).
+                                    // Styling mirrors the DM rail badge plus
+                                    // `flex-shrink-0` so a long truncated
+                                    // room name can't squash it; the accent
+                                    // styling applies to any nonzero count,
+                                    // whichever mode produced it.
                                     if unread > 0 && !is_current {
                                         span {
                                             class: "ml-2 flex-shrink-0 inline-flex items-center justify-center px-2 py-0.5 rounded-full text-xs font-medium bg-accent text-white",
                                             "data-testid": "room-unread-badge",
-                                            title: "{unread} unread",
-                                            "aria-label": "{unread} unread messages",
+                                            title: "{badge_title}",
+                                            "aria-label": "{badge_aria}",
                                             "{unread}"
                                         }
                                     }

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -1201,6 +1201,45 @@ mod tests {
         let rooms = create_example_rooms();
         assert_eq!(rooms.map.len(), 3);
 
+        // The muted-room fixture's PREMISE, pinned here rather than left to
+        // the browser suite (freenet/river#500 review I2). `room-unread-badge`
+        // asserts a muted room shows no badge; that assertion is only
+        // meaningful while the room genuinely HAS unread other-authored
+        // messages. If a future fixture edit made them self-authored, or gave
+        // the room a read marker, the spec would keep passing and prove
+        // nothing — which is exactly how #501 shipped green.
+        let muted: Vec<_> = rooms
+            .notification_modes
+            .iter()
+            .filter(|(_, mode)| **mode == crate::room_data::NotificationMode::Muted)
+            .map(|(vk, _)| *vk)
+            .collect();
+        assert_eq!(muted.len(), 1, "exactly one example room must be muted");
+        let muted_room = rooms.map.get(&muted[0]).expect("muted room must exist");
+        assert!(
+            muted_room.last_read_message_id.is_none(),
+            "the muted room must have no read marker, or it has nothing unread \
+             to suppress"
+        );
+        let self_id: river_core::room_state::member::MemberId =
+            muted_room.self_sk.verifying_key().into();
+        let unread = muted_room
+            .room_state
+            .recent_messages
+            .messages
+            .iter()
+            .filter(|m| {
+                m.message.author != self_id
+                    && !m.message.content.is_action()
+                    && !m.message.content.is_event()
+            })
+            .count();
+        assert!(
+            unread > 0,
+            "the muted room must have unread other-authored messages, or the \
+             'no badge' assertion in room-unread-badge.spec.ts is vacuous"
+        );
+
         for (owner_vk, room_data) in rooms.map.iter() {
             // Verify the room state
             let verification_result = room_data.room_state.verify(

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -134,7 +134,19 @@ pub fn create_example_rooms() -> Rooms {
         None,
         HistoryDepth::Standard,
     );
+    let muted_room_vk = room3.owner_vk;
     map.insert(room3.owner_vk, room3.room_data);
+
+    // Seed ONE room as Muted (freenet/river#500). Every example room starts
+    // with unread other-authored messages and no last-read marker, so a muted
+    // room here is exactly the case the bug was reported for: unreads present,
+    // but no badge and no contribution to the title / hamburger totals.
+    // Without this seeding the muted semantics are unreachable from a browser
+    // test — the bell modal only opens from the CURRENT room's header, and
+    // opening a room marks it read, so the badge would be absent either way.
+    // Pinned by `room-unread-badge.spec.ts`.
+    let mut notification_modes = HashMap::new();
+    notification_modes.insert(muted_room_vk, crate::room_data::NotificationMode::Muted);
 
     // Rooms deeper than the render window, for the windowing specs (#501):
     // one with prune headroom, one exactly at its message cap so delivered
@@ -161,7 +173,7 @@ pub fn create_example_rooms() -> Rooms {
         map,
         current_room_key: None,
         removed_rooms: std::collections::HashSet::new(),
-        notification_modes: Default::default(),
+        notification_modes,
         migrated_rooms: Vec::new(),
         room_order: Vec::new(),
     }

--- a/ui/tests/hamburger-unread-badge.spec.ts
+++ b/ui/tests/hamburger-unread-badge.spec.ts
@@ -72,11 +72,19 @@ test.describe("Mobile hamburger unread badge", () => {
       timeout: 5_000,
     });
     await expect(badge).toHaveText(String(initialTotal), { timeout: 5_000 });
+    // Re-assert after another render pass (opening the panel). `toHaveText`
+    // passes on the FIRST matching poll, and the pre-update value matches, so
+    // a single check could pass against a stale frame — which would make this
+    // the one assertion here that can silently prove nothing.
+    await hamburger.click();
+    await expect(page.locator('[data-testid="room-list"]')).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(badge).toHaveText(String(initialTotal));
 
     // Now a room that DOES count. The read-marker write is deferred
     // (setTimeout 0), so wait for the badge to leave its value rather than
-    // sampling immediately.
-    await hamburger.click();
+    // sampling immediately. The panel is already open from the re-check above.
     await page.getByRole("button", { name: ALL_ROOMS[1] }).click();
     await expect(page.getByRole("heading", { name: ALL_ROOMS[1] })).toBeVisible({
       timeout: 5_000,

--- a/ui/tests/hamburger-unread-badge.spec.ts
+++ b/ui/tests/hamburger-unread-badge.spec.ts
@@ -19,10 +19,17 @@ const BADGE = '[data-testid="hamburger-unread-badge"]';
 // The example-data build seeds three rooms whose messages are authored by
 // other members, so every room starts with unread messages and no
 // last-read marker.
+//
+// "Your Private Room" is seeded MUTED (freenet/river#500), so it never
+// contributes to this badge. It is therefore listed FIRST: with it last, the
+// badge would already have reached 0 after the second room and the final
+// `toHaveCount(0)` would be satisfied by muting rather than by reading — the
+// assertion would pass without ever proving that opening the last room
+// cleared anything.
 const ALL_ROOMS = [
+  "Your Private Room",
   "Public Discussion Room",
   "Team Chat Room",
-  "Your Private Room",
 ];
 
 test.describe("Mobile hamburger unread badge", () => {
@@ -36,8 +43,8 @@ test.describe("Mobile hamburger unread badge", () => {
     await page.goto("/");
     await waitForApp(page);
 
-    // No room selected yet → the welcome screen's hamburger. Every
-    // example room has unread messages, so the badge must show.
+    // No room selected yet → the welcome screen's hamburger. Two of the three
+    // example rooms are unread AND unmuted, so the badge must show.
     const badge = page.locator(`${HAMBURGER} ${BADGE}`);
     await expect(badge).toBeVisible({ timeout: 5_000 });
     await expect(badge).toHaveText(/^\d+$/);
@@ -55,17 +62,25 @@ test.describe("Mobile hamburger unread badge", () => {
     await expect(badge).toBeVisible({ timeout: 5_000 });
     const initialTotal = Number(await badge.textContent());
 
-    // Open the first room. Its messages are marked read on open and the
-    // current room is excluded from the count, so the badge total must
-    // drop but stay non-zero (the other two rooms are still unread).
+    // ALL_ROOMS[0] is the MUTED room, which contributes nothing to this badge,
+    // so opening it must leave the total exactly where it was. That is a
+    // stronger check than "the total drops" — it pins that muting removes the
+    // room from the total rather than merely reducing it.
     await hamburger.click();
     await page.getByRole("button", { name: ALL_ROOMS[0] }).click();
-    await expect(
-      page.getByRole("heading", { name: ALL_ROOMS[0] })
-    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByRole("heading", { name: ALL_ROOMS[0] })).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(badge).toHaveText(String(initialTotal), { timeout: 5_000 });
 
-    // The read-marker write is deferred (setTimeout 0), so wait for the
-    // badge to leave its initial value rather than sampling immediately.
+    // Now a room that DOES count. The read-marker write is deferred
+    // (setTimeout 0), so wait for the badge to leave its value rather than
+    // sampling immediately.
+    await hamburger.click();
+    await page.getByRole("button", { name: ALL_ROOMS[1] }).click();
+    await expect(page.getByRole("heading", { name: ALL_ROOMS[1] })).toBeVisible({
+      timeout: 5_000,
+    });
     await expect(badge).not.toHaveText(String(initialTotal), {
       timeout: 5_000,
     });
@@ -73,9 +88,9 @@ test.describe("Mobile hamburger unread badge", () => {
     expect(afterFirst).toBeGreaterThan(0);
     expect(afterFirst).toBeLessThan(initialTotal);
 
-    // Visit the remaining rooms; each visit marks that room read. After
-    // the last one every room is read → no badge at all.
-    for (const room of ALL_ROOMS.slice(1)) {
+    // Visit the remaining room; that visit marks it read. The last room in the
+    // list is an unmuted one, so reaching 0 requires actually reading it.
+    for (const room of ALL_ROOMS.slice(2)) {
       await hamburger.click();
       await page.getByRole("button", { name: room }).click();
       await expect(page.getByRole("heading", { name: room })).toBeVisible({

--- a/ui/tests/notification-bell.spec.ts
+++ b/ui/tests/notification-bell.spec.ts
@@ -37,7 +37,9 @@ test.describe("Per-room notification bell", () => {
 
     const bell = page.getByTestId("notification-bell-button");
     await expect(bell).toBeVisible();
-    // Example rooms have no stored preference, so the default is All.
+    // This room has no stored preference, so the default is All. (Since
+    // freenet/river#500 the fixture seeds "Your Private Room" as Muted, so
+    // "no stored preference" is no longer true of every example room.)
     await expect(bell).toHaveAttribute("title", "Notifications: All messages");
   });
 

--- a/ui/tests/room-unread-badge.spec.ts
+++ b/ui/tests/room-unread-badge.spec.ts
@@ -58,4 +58,68 @@ test.describe("Rooms list unread badge", () => {
       timeout: 5_000,
     });
   });
+
+  // freenet/river#500: a room set to "Muted" must not badge, even though it
+  // has unread messages, and must not inflate the title / hamburger totals.
+  // The example build seeds "Your Private Room" as Muted (example_data.rs) so
+  // this is reachable from the browser at all — the bell modal only opens
+  // from the CURRENT room's header, and opening a room marks it read.
+  test("a muted room shows no badge despite having unread messages", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+
+    const muted = page.getByRole("button", { name: "Your Private Room" });
+    await expect(muted).toBeVisible({ timeout: 5_000 });
+
+    // The two non-muted rooms badge as usual…
+    for (const name of ["Public Discussion Room", "Team Chat Room"]) {
+      await expect(
+        page.getByRole("button", { name }).locator('[data-testid="room-unread-badge"]')
+      ).toBeVisible({ timeout: 5_000 });
+    }
+
+    // …while the muted one never does.
+    await expect(
+      muted.locator('[data-testid="room-unread-badge"]')
+    ).toHaveCount(0);
+  });
+});
+
+test.describe("Muted rooms and the cross-surface totals", () => {
+  // The hamburger badge is `md:hidden`, so this needs a mobile viewport.
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  // freenet/river#500: the room-row badges, the document title and the
+  // hamburger badge must all sum the SAME per-room values. Example data has
+  // no direct messages, so the hamburger total is exactly the sum of the
+  // room badges — and a muted room contributes to neither.
+  test("hamburger total equals the sum of the room badges", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+
+    const hamburgerBadge = page.locator(
+      '[data-testid="hamburger-rooms-button"] [data-testid="hamburger-unread-badge"]'
+    );
+    await expect(hamburgerBadge).toBeVisible({ timeout: 5_000 });
+    const total = Number(await hamburgerBadge.textContent());
+    expect(total).toBeGreaterThan(0);
+
+    // Open the rooms panel and add up every rendered room badge.
+    await page.locator('[data-testid="hamburger-rooms-button"]').click();
+    await expect(page.locator('[data-testid="room-list"]')).toBeVisible({
+      timeout: 5_000,
+    });
+    const badges = await page
+      .locator('[data-testid="room-list"] [data-testid="room-unread-badge"]')
+      .allTextContents();
+
+    // The muted room renders no badge, so only two of the three rooms do.
+    expect(badges).toHaveLength(2);
+    const sum = badges.reduce((acc, t) => acc + Number(t), 0);
+    expect(sum).toBe(total);
+  });
 });

--- a/ui/tests/room-unread-badge.spec.ts
+++ b/ui/tests/room-unread-badge.spec.ts
@@ -95,6 +95,11 @@ test.describe("Muted rooms and the cross-surface totals", () => {
   // hamburger badge must all sum the SAME per-room values. Example data has
   // no direct messages, so the hamburger total is exactly the sum of the
   // room badges — and a muted room contributes to neither.
+  //
+  // That "no DMs" premise is load-bearing and NOT general: `panel_unread`
+  // includes DM unread, which has no room badge. If the fixture ever seeds a
+  // DM this fails with a diff that reads like a counting regression, so read
+  // this comment before chasing it.
   test("hamburger total equals the sum of the room badges", async ({
     page,
   }) => {
@@ -113,12 +118,15 @@ test.describe("Muted rooms and the cross-surface totals", () => {
     await expect(page.locator('[data-testid="room-list"]')).toBeVisible({
       timeout: 5_000,
     });
-    const badges = await page
-      .locator('[data-testid="room-list"] [data-testid="room-unread-badge"]')
-      .allTextContents();
-
     // The muted room renders no badge, so only two of the three rooms do.
-    expect(badges).toHaveLength(2);
+    // `toHaveCount` retries; `allTextContents()` does not, so assert the count
+    // first rather than sampling a half-rendered list into a length check that
+    // `retries: 2` would then hide.
+    const badgeLocator = page.locator(
+      '[data-testid="room-list"] [data-testid="room-unread-badge"]'
+    );
+    await expect(badgeLocator).toHaveCount(2, { timeout: 5_000 });
+    const badges = await badgeLocator.allTextContents();
     const sum = badges.reduce((acc, t) => acc + Number(t), 0);
     expect(sum).toBe(total);
   });


### PR DESCRIPTION
## Problem

`NotificationMode` (#340, resurfaced by #429's bell modal) gated exactly one thing: whether a browser notification fires. Every unread-count surface was built independently on `last_read_message_id` and never consulted it.

So a **Muted** room still painted an accent-coloured count badge and inflated the tab title and the mobile hamburger totals — directly contradicting the modal's own "never notify for this room" wording. Ian saw a "3" beside a room set to "Mentions and replies only".

Two quirks inflated the number further: room-event messages ("X joined the room") counted toward it, so a "3" could be 2 messages plus a join.

Closes #500.

## Approach

One mode-aware per-room count, `count_unread_in_room_data_with_mode`, that all three surfaces sum — the room-row badge, the document-title `(N)`, and the mobile hamburger badge — so they cannot disagree:

- **Muted** → always 0. No badge, no contribution to either total.
- **MentionsAndReplies** → only messages that @mention the user or reply to one of their own, through the same predicate that gates browser notifications, so the badge and the popup cannot drift on what qualifies. The row's `aria-label` says "unread mention or reply" rather than "unread messages".
- **All** → unchanged.

Room events are excluded from every mode. The mode-blind counter is now private: #500 was three surfaces reaching for exactly it.

**The mention scan decrypts message bodies**, so it is memoized per room behind a fingerprint of everything it reads. Without that it runs up to three times per `ROOMS` write, for rooms the user is not even looking at — the shape of the documented `MESSAGE_HTML_CACHE` jank incident, worse placed.

**Undecryptable bodies fail safe, but only while that is transient.** `decrypt_message_content` returns a placeholder rather than an error, so a mention check against it reads as a confident "not a mention". In mentions mode a body we cannot read is therefore counted — over-reporting resolves down, a silent zero hides a real mention. That is bounded: a message sealed under a version older than every secret we hold is one the user joined too late to ever read, and counting it would put a permanent number on the badge that opening the room cannot clear.

## Testing

Rust unit tests cover the counting, the modes, the event exclusion, the memo, and each arm of the fail-safe. Three of them exist because a review found the first version of the fail-safe wrong, and each was mutation-verified against the specific bug it describes:

- `mentions_mode_counts_a_body_whose_secret_is_present_but_wrong` — a secret present at the right version but WRONG also yields a placeholder. `repopulate_secrets_from_state` exists because an inviter can supply exactly that, so this is a live path, not a corner case.
- `a_same_version_secret_overwrite_invalidates_the_memo` — that overwrite lands at the same version, so a `secrets.len()` fingerprint would keep serving the stale count after the authoritative blob arrives. The fingerprint hashes the sorted `(version, secret)` pairs.
- `mentions_mode_does_not_count_a_body_rotated_permanently_past` — the bound above.

`every_cross_room_total_is_mode_aware` is a source pin: reverting either cross-room total to a mode-blind sum left the entire Rust suite and the entire browser suite green. The title cannot be covered in the browser, because the visible→hidden transition marks every room read, so the fixture's title never carries an `(N)`.

Browser coverage seeds one example room as Muted — otherwise the muted semantics are unreachable, since the bell modal only opens from the current room's header and opening a room marks it read. `room-unread-badge.spec.ts` asserts that room never badges while the other two do, and that the hamburger total equals the sum of the rendered room badges. `test_create_example_rooms` pins the fixture's premise (that room really does have unread other-authored messages and no read marker) in `cargo test`, so the browser assertion cannot go quietly vacuous.

Adding a muted room to the fixture also silently gutted `hamburger-unread-badge.spec.ts`, whose final "the badge clears once all are read" assertion became satisfiable by muting rather than by reading. Fixed by visiting the muted room first, with a stronger assertion in its place: opening it must leave the total exactly unchanged.

719 tests pass with `--features example-data,no-sync`, 716 without; `cargo fmt` clean.

[AI-assisted - Claude]