### PR TITLE
fix(ui): tell a mobile user their rooms are loading, not that they have none

### DIFF
--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -2154,6 +2154,41 @@ fn install_scroll_pin_listeners(
     true
 }
 
+/// The two affordances the no-room screen must offer in EVERY load state
+/// (freenet/river#509).
+///
+/// * The #159 quickstart invite link. A brand-new user has `room_count == 0`,
+///   so they are in an unresolved state for the whole load window; putting the
+///   link only on the resolved screen would hide their one concrete next step
+///   for exactly as long as they need it.
+/// * The connection pill. On mobile the rooms rail is `display:none`, so this
+///   is the only copy of it a phone user can see (Bug #5, Ivvor 2026-05-17).
+///   It matters most in the unresolved states: a node that never connects
+///   leaves `ROOMS_LOAD_STATE` at its `Loading` default forever, because
+///   `begin_load_attempt` — which arms the 60s backstop — runs only after a
+///   successful connect. Without the pill that user watches a spinner with
+///   nothing on screen saying the socket is down. It is also what makes the
+///   failed state's "Check your connection and try again" actionable.
+///
+/// One component so the three unresolved arms and the Welcome arm cannot drift.
+#[component]
+fn NoRoomFooter() -> Element {
+    rsx! {
+        p { class: "text-text-muted mt-3",
+            a {
+                class: "text-accent hover:underline",
+                href: "https://freenet.org/quickstart#invite-form",
+                target: "_blank",
+                rel: "noopener noreferrer",
+                "Click here to get an invitation to channel \"Freenet Official\""
+            }
+        }
+        div { class: "mt-8 md:hidden",
+            crate::components::members::ConnectionStatusIndicator {}
+        }
+    }
+}
+
 #[component]
 pub fn Conversation() -> Element {
     let current_room_data = {
@@ -4415,10 +4450,23 @@ pub fn Conversation() -> Element {
                         // they had no rooms, and hid a FAILED load (and its
                         // Retry button) behind advice to create one.
                         //
-                        // Branch on the same shared state the rail uses, so the
-                        // two surfaces cannot disagree. This is viewport-
-                        // independent on purpose: the desktop centre panel had
-                        // the same false-empty text.
+                        // Branches on the SAME call the rail makes, so the two
+                        // surfaces cannot disagree. Viewport-independent on
+                        // purpose: the desktop centre panel had the same
+                        // false-empty text.
+                        //
+                        // Every arm keeps the two things that are useful in any
+                        // state: the #159 quickstart invite link (a brand-new
+                        // user has `room_count == 0`, so they are in the
+                        // unresolved states for the whole load window and would
+                        // otherwise lose their only onboarding affordance) and
+                        // the connection pill. The pill matters MOST here: a
+                        // node that never connects leaves `ROOMS_LOAD_STATE` at
+                        // its `Loading` default indefinitely — `begin_load_attempt`,
+                        // which arms the 60s backstop, runs only after a
+                        // successful connect — so without the pill that user
+                        // would watch a spinner with nothing telling them the
+                        // socket is down (#509 review).
                         match crate::components::room_list::current_room_list_display() {
                             crate::components::room_list::RoomListDisplay::Loading => rsx! {
                                 div {
@@ -4426,6 +4474,7 @@ pub fn Conversation() -> Element {
                                     "data-testid": "conversation-rooms-loading",
                                     div { class: "animate-spin w-6 h-6 border-2 border-text-muted border-t-transparent rounded-full" }
                                     span { class: "text-sm text-text-muted", "Loading your rooms…" }
+                                    NoRoomFooter {}
                                 }
                             },
                             crate::components::room_list::RoomListDisplay::Migrating => rsx! {
@@ -4435,6 +4484,7 @@ pub fn Conversation() -> Element {
                                     div { class: "animate-spin w-6 h-6 border-2 border-text-muted border-t-transparent rounded-full" }
                                     span { class: "text-sm text-text-muted", "Migrating your rooms…" }
                                     span { class: "text-xs text-text-muted opacity-70", "(one-time step after an update)" }
+                                    NoRoomFooter {}
                                 }
                             },
                             crate::components::room_list::RoomListDisplay::LoadFailed => rsx! {
@@ -4453,54 +4503,31 @@ pub fn Conversation() -> Element {
                                         onclick: move |_| crate::components::app::chat_delegate::retry_rooms_load(),
                                         span { "Retry" }
                                     }
+                                    NoRoomFooter {}
                                 }
                             },
-                            // Empty (the load resolved and there really are no
-                            // rooms) or List (rooms exist, none selected yet):
-                            // today's screen, unchanged.
-                            _ => rsx! {
-                        div { class: "flex-1 flex flex-col items-center justify-center text-center p-8",
-                            img {
-                                class: "w-24 h-24 mb-6 opacity-50",
-                                src: asset!("/assets/river_logo.svg"),
-                                alt: "River Logo"
-                            }
-                            h1 { class: "text-2xl font-semibold text-text mb-2",
-                                "Welcome to River"
-                            }
-                            p { class: "text-text-muted",
-                                "Create a new room, or get invited to an existing one."
-                            }
-                            // Issue #159: new users (especially on mobile) need a
-                            // concrete next step. Link to the Freenet quickstart
-                            // invite form so they can get into the "Freenet
-                            // Official" room.
-                            p { class: "text-text-muted mt-3",
-                                a {
-                                    class: "text-accent hover:underline",
-                                    href: "https://freenet.org/quickstart#invite-form",
-                                    target: "_blank",
-                                    rel: "noopener noreferrer",
-                                    "Click here to get an invitation to channel \"Freenet Official\""
+                            // The load resolved and there really are no rooms,
+                            // or rooms exist and none is selected yet: today's
+                            // screen, unchanged. Spelled out rather than `_` so
+                            // a future variant is a compile error here instead
+                            // of silently falling back to "you have no rooms" —
+                            // which is the #397 -> #509 story exactly.
+                            crate::components::room_list::RoomListDisplay::Empty
+                            | crate::components::room_list::RoomListDisplay::List => rsx! {
+                                div { class: "flex-1 flex flex-col items-center justify-center text-center p-8",
+                                    img {
+                                        class: "w-24 h-24 mb-6 opacity-50",
+                                        src: asset!("/assets/river_logo.svg"),
+                                        alt: "River Logo"
+                                    }
+                                    h1 { class: "text-2xl font-semibold text-text mb-2",
+                                        "Welcome to River"
+                                    }
+                                    p { class: "text-text-muted",
+                                        "Create a new room, or get invited to an existing one."
+                                    }
+                                    NoRoomFooter {}
                                 }
-                            }
-                            // Bug #5 (Ivvor, Matrix 2026-05-17): on mobile,
-                            // the default MOBILE_VIEW is Chat, so a brand-new
-                            // user with no rooms lands here without ever
-                            // seeing the left-rail indicator. Render the
-                            // pill inline so they get the same WebSocket
-                            // signal regardless of viewport.
-                            //
-                            // Deliberately NOT rendered in the loading and
-                            // migrating arms above: the pill reflects only
-                            // WebSocket transport and flips to a green
-                            // "Connected" within about a second, which on a
-                            // still-loading screen reads as "everything is
-                            // done" (freenet/river#509).
-                            div { class: "mt-8 md:hidden",
-                                crate::components::members::ConnectionStatusIndicator {}
-                            }
-                        }
                             },
                         }
                     },
@@ -5794,20 +5821,27 @@ mod tests {
              pixel-identical to an empty account, and the advice on screen is \
              to create a room"
         );
-        // The green "Connected" pill reflects only WebSocket transport and
-        // flips within about a second, so on a still-loading screen it reads
-        // as "nothing is pending". It belongs to the Welcome arm only.
-        let welcome_at = squashed
-            .find("WelcometoRiver")
-            .expect("the Welcome copy must still exist for the resolved states");
-        let pill_at = squashed
-            .find("ConnectionStatusIndicator{}")
-            .expect("the no-room screen must still show the connection pill");
+        // The invite link and the connection pill must reach EVERY arm, which
+        // is what `NoRoomFooter` is for. The pill in particular is the only
+        // thing on screen that can explain an unbounded `Loading`: a node that
+        // never connects never runs `begin_load_attempt`, so the 60s backstop
+        // is never armed either.
+        assert_eq!(
+            squashed.matches("NoRoomFooter{}").count(),
+            4,
+            "every arm of the no-room screen must render `NoRoomFooter` — the \
+             invite link and the connection pill are useful in all of them, and \
+             the pill is what makes 'Check your connection' actionable"
+        );
         assert!(
-            pill_at > welcome_at,
-            "the connection pill must sit inside the Welcome arm, not above \
-             the load-state branch where it would reassure a user whose rooms \
-             are still loading"
+            squashed.contains("fnNoRoomFooter()->Element{"),
+            "the shared footer must exist as one component, so the arms cannot \
+             drift on what it contains"
+        );
+        assert!(
+            !squashed.contains("RoomListDisplay::List=>rsx!{}"),
+            "the conversation panel must not copy the rail's empty `List` arm; \
+             it renders the Welcome screen for List"
         );
     }
 

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -4406,6 +4406,59 @@ pub fn Conversation() -> Element {
                                 }
                             }
                         }
+                        // freenet/river#509: this panel is the ONLY thing a
+                        // phone user can see while rooms load — below 768px the
+                        // rail that carries #397's loading / migrating / failed
+                        // states is `display:none`, not unmounted, and the
+                        // default mobile view is Chat. Rendering the Welcome
+                        // copy unconditionally therefore told a mid-load user
+                        // they had no rooms, and hid a FAILED load (and its
+                        // Retry button) behind advice to create one.
+                        //
+                        // Branch on the same shared state the rail uses, so the
+                        // two surfaces cannot disagree. This is viewport-
+                        // independent on purpose: the desktop centre panel had
+                        // the same false-empty text.
+                        match crate::components::room_list::current_room_list_display() {
+                            crate::components::room_list::RoomListDisplay::Loading => rsx! {
+                                div {
+                                    class: "flex-1 flex flex-col items-center justify-center gap-3 text-center p-8",
+                                    "data-testid": "conversation-rooms-loading",
+                                    div { class: "animate-spin w-6 h-6 border-2 border-text-muted border-t-transparent rounded-full" }
+                                    span { class: "text-sm text-text-muted", "Loading your rooms…" }
+                                }
+                            },
+                            crate::components::room_list::RoomListDisplay::Migrating => rsx! {
+                                div {
+                                    class: "flex-1 flex flex-col items-center justify-center gap-3 text-center p-8",
+                                    "data-testid": "conversation-rooms-migrating",
+                                    div { class: "animate-spin w-6 h-6 border-2 border-text-muted border-t-transparent rounded-full" }
+                                    span { class: "text-sm text-text-muted", "Migrating your rooms…" }
+                                    span { class: "text-xs text-text-muted opacity-70", "(one-time step after an update)" }
+                                }
+                            },
+                            crate::components::room_list::RoomListDisplay::LoadFailed => rsx! {
+                                div {
+                                    class: "flex-1 flex flex-col items-center justify-center gap-3 text-center p-8",
+                                    "data-testid": "conversation-rooms-error",
+                                    span { class: "text-sm text-text-muted", "Couldn't load your rooms" }
+                                    span { class: "text-xs text-text-muted opacity-70", "Check your connection and try again." }
+                                    button {
+                                        "data-testid": "conversation-rooms-retry-button",
+                                        class: "flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm text-text-muted bg-surface hover:bg-surface-hover transition-colors",
+                                        // Same entry point as the rail's Retry.
+                                        // Safe to call directly — `retry_rooms_load`
+                                        // defers its signal write and spawns via
+                                        // setTimeout(0) (Dioxus signal-safety rules).
+                                        onclick: move |_| crate::components::app::chat_delegate::retry_rooms_load(),
+                                        span { "Retry" }
+                                    }
+                                }
+                            },
+                            // Empty (the load resolved and there really are no
+                            // rooms) or List (rooms exist, none selected yet):
+                            // today's screen, unchanged.
+                            _ => rsx! {
                         div { class: "flex-1 flex flex-col items-center justify-center text-center p-8",
                             img {
                                 class: "w-24 h-24 mb-6 opacity-50",
@@ -4437,9 +4490,18 @@ pub fn Conversation() -> Element {
                             // seeing the left-rail indicator. Render the
                             // pill inline so they get the same WebSocket
                             // signal regardless of viewport.
+                            //
+                            // Deliberately NOT rendered in the loading and
+                            // migrating arms above: the pill reflects only
+                            // WebSocket transport and flips to a green
+                            // "Connected" within about a second, which on a
+                            // still-loading screen reads as "everything is
+                            // done" (freenet/river#509).
                             div { class: "mt-8 md:hidden",
                                 crate::components::members::ConnectionStatusIndicator {}
                             }
+                        }
+                            },
                         }
                     },
                 }
@@ -5676,6 +5738,76 @@ mod tests {
             !squashed.contains(concat!("sign_message_", "with_fallback")),
             "message signing must not go through the delegate on any path \
              (freenet/river#512)"
+        );
+    }
+
+    /// Source-grep pin (freenet/river#509): the no-room screen must branch on
+    /// the SHARED room-list display state.
+    ///
+    /// Below 768px the rooms rail is `display:none` rather than unmounted and
+    /// the default mobile view is Chat, so for the whole load window this panel
+    /// is the only thing a phone user can see. Rendering the Welcome copy
+    /// unconditionally told a mid-load user they had no rooms, and hid a FAILED
+    /// load — and its Retry button — behind advice to create one.
+    ///
+    /// The states themselves are covered by `room_list_display_state`'s unit
+    /// tests and by `rooms-loading-state.spec.ts`; what this pins is the
+    /// WIRING, which is what #397 left undone: it added the states to the rail
+    /// and never touched `app.rs` or this file, so `ROOMS_LOAD_STATE` had
+    /// exactly one consumer in the whole UI.
+    #[test]
+    fn the_no_room_screen_branches_on_the_shared_load_state() {
+        let source = include_str!("conversation.rs");
+        let prod = &source[..source
+            .find("#[cfg(test)]\nmod tests {")
+            .expect("conversation.rs should have a `#[cfg(test)] mod tests` block")];
+        let code: String = prod
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let squashed: String = code.chars().filter(|c| !c.is_whitespace()).collect();
+
+        assert!(
+            squashed.contains("current_room_list_display()"),
+            "the no-room screen must read the shared room-list display state, \
+             not render the Welcome copy unconditionally — that is what mobile \
+             showed a user mid-load (freenet/river#509)"
+        );
+        for (arm, testid) in [
+            ("Loading", "conversation-rooms-loading"),
+            ("Migrating", "conversation-rooms-migrating"),
+            ("LoadFailed", "conversation-rooms-error"),
+        ] {
+            assert!(
+                squashed.contains(&format!("RoomListDisplay::{arm}=>")),
+                "the no-room screen must handle `RoomListDisplay::{arm}`"
+            );
+            assert!(
+                squashed.contains(&format!("\"data-testid\":\"{testid}\"")),
+                "the {arm} arm must render its `{testid}` element"
+            );
+        }
+        assert!(
+            squashed.contains("retry_rooms_load()"),
+            "the failed arm must offer Retry — a stalled load is otherwise \
+             pixel-identical to an empty account, and the advice on screen is \
+             to create a room"
+        );
+        // The green "Connected" pill reflects only WebSocket transport and
+        // flips within about a second, so on a still-loading screen it reads
+        // as "nothing is pending". It belongs to the Welcome arm only.
+        let welcome_at = squashed
+            .find("WelcometoRiver")
+            .expect("the Welcome copy must still exist for the resolved states");
+        let pill_at = squashed
+            .find("ConnectionStatusIndicator{}")
+            .expect("the no-room screen must still show the connection pill");
+        assert!(
+            pill_at > welcome_at,
+            "the connection pill must sit inside the Welcome arm, not above \
+             the load-state branch where it would reassure a user whose rooms \
+             are still loading"
         );
     }
 

--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -118,10 +118,17 @@ fn unread_badge_label(unread: usize, is_mentions: bool) -> String {
 /// it shows when the load has FAILED, hiding the Retry button behind advice to
 /// create a room.
 ///
-/// Reads are fallible per the Dioxus signal-safety rules, with the same
-/// `Loading` fallback the rail uses: an unresolved read must never resolve to
-/// `Empty`, because `Empty` is the one state that tells the user there is
-/// nothing to wait for.
+/// Reads are fallible per the Dioxus signal-safety rules. An unresolved
+/// LOAD-STATE read falls back to `Loading`, never `Empty` — `Empty` is the one
+/// state that tells the user there is nothing to wait for, so it must never be
+/// something a failed read can produce.
+///
+/// The room-count read has no such guarantee, and deliberately: an unresolved
+/// `ROOMS` read yields 0, so a successfully-read `Loaded` plus a failed count
+/// does render `Empty`. That matches what the rail has always done (its
+/// `room_items` memo returns an empty `Vec` on the same failure), and the
+/// alternative — inventing a non-zero count — would render a list with nothing
+/// in it. Both reads are one poll from correcting.
 pub(crate) fn current_room_list_display() -> RoomListDisplay {
     let load_state = ROOMS_LOAD_STATE
         .try_read()
@@ -303,17 +310,15 @@ pub fn RoomList() -> Element {
     // room there is nothing to reorder.
     let room_count: usize = room_items.read().len();
 
-    // Rail display state (freenet/river#397). Read the load-state signal
-    // reactively (fallible per the Dioxus signal-safety rules — a concurrent
-    // write returns Err, in which case we treat the load as still `Loading` and
-    // re-render on the next signal settle rather than panicking on Firefox).
-    // Combined with `room_count` this decides whether the rail shows the list,
-    // a loading spinner, a migrating spinner, or the calm empty state.
-    let load_state: RoomsLoadState = ROOMS_LOAD_STATE
-        .try_read()
-        .map(|g| *g)
-        .unwrap_or(RoomsLoadState::Loading);
-    let display = room_list_display_state(load_state, room_count);
+    // Rail display state (freenet/river#397): the list, a loading spinner, a
+    // migrating spinner, the failed block, or the calm empty state.
+    //
+    // Through the SHARED reader, which the conversation panel's no-room screen
+    // also calls (freenet/river#509). Deriving it separately here is what let
+    // the two surfaces disagree in the first place: #397 wired these states
+    // into the rail and nowhere else, and below 768px the rail is
+    // `display:none`, so mobile users saw none of them.
+    let display = current_room_list_display();
 
     rsx! {
         aside {

--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -105,6 +105,32 @@ fn unread_badge_label(unread: usize, is_mentions: bool) -> String {
     }
 }
 
+/// [`room_list_display_state`] read from the live signals.
+///
+/// Shared with the conversation panel's no-room screen (freenet/river#509).
+/// That screen and this rail must never disagree about whether rooms are still
+/// loading: below the 768px breakpoint the rail is `display:none` rather than
+/// unmounted, and the default mobile view is Chat, so for the whole load window
+/// the ONLY thing a phone user can see is the conversation panel. #397 put the
+/// loading / migrating / failed states in the rail and nowhere else, which is
+/// how "Create a new room, or get invited to an existing one" ended up being
+/// what mobile shows a user whose rooms are still arriving — and, worse, what
+/// it shows when the load has FAILED, hiding the Retry button behind advice to
+/// create a room.
+///
+/// Reads are fallible per the Dioxus signal-safety rules, with the same
+/// `Loading` fallback the rail uses: an unresolved read must never resolve to
+/// `Empty`, because `Empty` is the one state that tells the user there is
+/// nothing to wait for.
+pub(crate) fn current_room_list_display() -> RoomListDisplay {
+    let load_state = ROOMS_LOAD_STATE
+        .try_read()
+        .map(|g| *g)
+        .unwrap_or(RoomsLoadState::Loading);
+    let room_count = ROOMS.try_read().map(|rooms| rooms.map.len()).unwrap_or(0);
+    room_list_display_state(load_state, room_count)
+}
+
 /// Convert UTC ISO timestamp to local time string
 fn format_build_time_local() -> String {
     #[cfg(target_arch = "wasm32")]

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -1337,6 +1337,46 @@ pub fn install_test_hooks() {
     );
     append_many.forget();
 
+    // Drive the no-room screen's load states (freenet/river#509). The example
+    // build always seeds rooms and never leaves `ROOMS_LOAD_STATE` anywhere
+    // but its default, so Loading / Migrating / LoadFailed are otherwise
+    // unreachable from a browser test — which is exactly why #397's states
+    // shipped with Rust unit tests only, and why nobody noticed they were
+    // invisible on mobile.
+    //
+    // Clears ROOMS as well as setting the state: `room_list_display_state`
+    // renders the list whenever there is anything to show, so a state change
+    // alone would change nothing.
+    let set_load_state = Closure::wrap(Box::new(move |state: String| {
+        use crate::components::app::chat_delegate::{RoomsLoadState, ROOMS_LOAD_STATE};
+        let parsed = match state.as_str() {
+            "loading" => RoomsLoadState::Loading,
+            "migrating" => RoomsLoadState::Migrating,
+            "failed" => RoomsLoadState::LoadFailed,
+            "loaded" => RoomsLoadState::Loaded,
+            other => {
+                crate::util::debug_log(&format!("[test] unknown rooms load state {other:?}"));
+                return;
+            }
+        };
+        crate::util::defer(move || {
+            crate::components::app::ROOMS.with_mut(|rooms| {
+                rooms.map.clear();
+                rooms.room_order.clear();
+                rooms.current_room_key = None;
+            });
+            *crate::components::app::CURRENT_ROOM.write() =
+                crate::room_data::CurrentRoom { owner_key: None };
+            *ROOMS_LOAD_STATE.write() = parsed;
+        });
+    }) as Box<dyn FnMut(String)>);
+    let _ = js_sys::Reflect::set(
+        &hooks,
+        &JsValue::from_str("setRoomsLoadState"),
+        set_load_state.as_ref(),
+    );
+    set_load_state.forget();
+
     let _ = js_sys::Reflect::set(&window, &JsValue::from_str("__riverTest"), &hooks);
 }
 

--- a/ui/tests/connection-status-indicator.spec.ts
+++ b/ui/tests/connection-status-indicator.spec.ts
@@ -207,9 +207,15 @@ test.describe("Connection status indicator on desktop (Bug #5)", () => {
 
 test.describe("Connection status indicator on mobile (Bug #5)", () => {
   // Mobile-Chat is the default `MOBILE_VIEW`, so a brand-new user with
-  // no rooms lands on the Welcome screen with the left rail hidden
-  // behind `hidden md:flex`. Without the inline Welcome-screen copy of
-  // the indicator, Bug #5 would reappear on mobile.
+  // no rooms lands on the no-room screen with the left rail hidden
+  // behind `hidden md:flex`. Without the inline copy of the indicator,
+  // Bug #5 would reappear on mobile.
+  //
+  // Since freenet/river#509 that screen has four states, and the inline copy
+  // lives in `NoRoomFooter` so it reaches all of them — which matters most in
+  // the states these tests do NOT reach: a node that never connects leaves the
+  // load state at `Loading` indefinitely, and the pill is the only thing on
+  // that screen that says so. `rooms-loading-state.spec.ts` covers those.
   test.use({ viewport: { width: 375, height: 812 } });
 
   test("exactly one indicator is visible on the mobile Welcome screen", async ({

--- a/ui/tests/rooms-loading-state.spec.ts
+++ b/ui/tests/rooms-loading-state.spec.ts
@@ -61,22 +61,36 @@ for (const { label, viewport, isMobile } of [
       await expect(loading).toBeVisible({ timeout: 5_000 });
       await expect(loading.getByText("Loading your rooms…")).toBeVisible();
 
+      // The two surfaces read one shared state, so the rail must agree. This
+      // is also the first browser coverage #397's rail states have ever had —
+      // their absence is why #509 went unnoticed.
+      await expect(page.getByTestId("room-list-loading")).toHaveCount(1);
+
       // The bug: the false-empty invitation to create a room.
       await expect(page.getByText(WELCOME)).toHaveCount(0);
 
-      // …and the green "Connected" pill, which reflects only WebSocket
-      // transport and flips within about a second, must not be sitting on a
-      // still-loading screen telling the user nothing is pending.
+      // The connection pill must SURVIVE this state, not be hidden by it.
+      // A node that never connects leaves the load state at its `Loading`
+      // default indefinitely — `begin_load_attempt`, which arms the 60s
+      // backstop, only runs after a successful connect — so the pill is the
+      // only thing on this screen that can tell the user the socket is down.
       //
-      // Mobile only: on desktop the rooms rail carries its own persistent
-      // pill, which is correct and not what #509 is about. Counting VISIBLE
-      // matches rather than all of them, because below 768px the rail is
-      // `display:none`, so its pill is in the DOM either way.
+      // Mobile only: on desktop the rooms rail carries its own copy, so this
+      // would not be measuring the conversation panel's. Counting VISIBLE
+      // matches, because below 768px the rail is `display:none` and its pill
+      // is in the DOM either way.
       if (isMobile) {
         await expect(
           page.locator('[data-testid="connection-status-indicator"]:visible')
-        ).toHaveCount(0);
+        ).toHaveCount(1);
       }
+
+      // …and so must the #159 quickstart invite link: a brand-new user has no
+      // rooms, so they are in THIS state for the whole load window, and it is
+      // their only concrete next step.
+      await expect(
+        page.locator('a[href="https://freenet.org/quickstart#invite-form"]')
+      ).toBeVisible();
     });
 
     test("a migrating account is told so", async ({ page }) => {
@@ -90,6 +104,7 @@ for (const { label, viewport, isMobile } of [
       const migrating = page.getByTestId("conversation-rooms-migrating");
       await expect(migrating).toBeVisible({ timeout: 5_000 });
       await expect(migrating.getByText("Migrating your rooms…")).toBeVisible();
+      await expect(page.getByTestId("room-list-migrating")).toHaveCount(1);
       await expect(page.getByText(WELCOME)).toHaveCount(0);
     });
 
@@ -106,10 +121,19 @@ for (const { label, viewport, isMobile } of [
       const failed = page.getByTestId("conversation-rooms-error");
       await expect(failed).toBeVisible({ timeout: 5_000 });
       await expect(failed.getByText(/Couldn.t load your rooms/)).toBeVisible();
+      await expect(page.getByTestId("room-list-error")).toHaveCount(1);
       await expect(
         page.getByTestId("conversation-rooms-retry-button")
       ).toBeVisible();
       await expect(page.getByText(WELCOME)).toHaveCount(0);
+
+      // "Check your connection and try again" is only actionable if the
+      // connection status is on the same screen.
+      if (isMobile) {
+        await expect(
+          page.locator('[data-testid="connection-status-indicator"]:visible')
+        ).toHaveCount(1);
+      }
     });
 
     test("a genuinely empty account still gets the Welcome screen", async ({
@@ -117,15 +141,25 @@ for (const { label, viewport, isMobile } of [
     }) => {
       await page.goto("/");
       await waitForApp(page);
-      // Settle on the Welcome screen first, so the hook is not racing
-      // the fixture's own first render.
       await expect(page.getByText(WELCOME)).toBeVisible({ timeout: 10_000 });
+
+      // Drive a REAL transition. Asserting "loaded" straight from the fixture's
+      // own start state would be satisfied by the pre-hook DOM: Welcome is
+      // already visible and neither state element exists, so the assertions
+      // would resolve against the old render and pass even if the hook did
+      // nothing (it logs and returns on an unrecognised string) or if the
+      // Empty arm were broken.
+      await setLoadState(page, "loading");
+      await expect(page.getByText(WELCOME)).toHaveCount(0, { timeout: 5_000 });
+
       await setLoadState(page, "loaded");
 
       // The one state that SHOULD say "create a room": the load resolved and
-      // there really is nothing. Without this the fix could suppress the
-      // Welcome screen entirely and every assertion above would still pass.
+      // there really is nothing. `room-list-empty` proves BOTH halves of the
+      // premise — the state reached Loaded and ROOMS really was cleared —
+      // which `WELCOME` alone cannot, since it also renders for `List`.
       await expect(page.getByText(WELCOME)).toBeVisible({ timeout: 5_000 });
+      await expect(page.getByTestId("room-list-empty")).toHaveCount(1);
       await expect(
         page.getByTestId("conversation-rooms-loading")
       ).toHaveCount(0);

--- a/ui/tests/rooms-loading-state.spec.ts
+++ b/ui/tests/rooms-loading-state.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect, Page } from "@playwright/test";
+
+// Regression coverage for freenet/river#509.
+//
+// #397 added loading / migrating / failed states for the rooms list, but put
+// them entirely inside the rooms rail. Below the 768px breakpoint that panel is
+// `display:none` rather than unmounted, and the default mobile view is Chat, so
+// for the whole load window the only thing a phone user could see was the
+// conversation panel's no-room screen — which rendered "Welcome to River /
+// Create a new room, or get invited to an existing one" regardless of state.
+//
+// So mobile affirmatively told a mid-load user they had no rooms, and a FAILED
+// load was pixel-identical to an empty account, with the Retry button invisible
+// and the advice on screen being to create a room.
+//
+// The example build always seeds rooms, so these states are unreachable without
+// a hook: `__riverTest.setRoomsLoadState(state)` clears ROOMS and sets
+// ROOMS_LOAD_STATE (example_data.rs, gated on example-data + no-sync).
+
+async function waitForApp(page: Page) {
+  await page.waitForSelector(".app-root", { timeout: 30_000 });
+  await expect(page.locator("aside, .app-root button")).not.toHaveCount(0);
+}
+
+async function setLoadState(page: Page, state: string) {
+  await page.evaluate((s) => {
+    (window as any).__riverTest.setRoomsLoadState(s);
+  }, state);
+}
+
+const WELCOME = "Welcome to River";
+
+for (const { label, viewport, isMobile } of [
+  // The mobile case is the reported bug…
+  { label: "mobile", viewport: { width: 390, height: 844 }, isMobile: true },
+  // …and the desktop centre panel showed the same false-empty text, so the
+  // fix is viewport-independent and so is this coverage.
+  { label: "desktop", viewport: { width: 1280, height: 800 }, isMobile: false },
+]) {
+  test.describe(`Rooms load state on the no-room screen (${label})`, () => {
+    test.use({ viewport });
+
+    test("a loading account is told its rooms are loading, not that it has none", async ({
+      page,
+    }) => {
+      await page.goto("/");
+      await waitForApp(page);
+
+      // PREMISE, and the pre-fix state: the fixture seeds rooms but selects
+      // none, so this screen opens on the Welcome copy. If that ever stops
+      // being true, the "Welcome is gone" assertions below would pass without
+      // the fix doing anything.
+      await expect(page.getByText(WELCOME)).toBeVisible({ timeout: 10_000 });
+
+      await setLoadState(page, "loading");
+
+      // Scoped to THIS surface: the rail renders the same copy (deliberately —
+      // both read one shared state), so an unscoped text locator is a strict-
+      // mode violation rather than a signal.
+      const loading = page.getByTestId("conversation-rooms-loading");
+      await expect(loading).toBeVisible({ timeout: 5_000 });
+      await expect(loading.getByText("Loading your rooms…")).toBeVisible();
+
+      // The bug: the false-empty invitation to create a room.
+      await expect(page.getByText(WELCOME)).toHaveCount(0);
+
+      // …and the green "Connected" pill, which reflects only WebSocket
+      // transport and flips within about a second, must not be sitting on a
+      // still-loading screen telling the user nothing is pending.
+      //
+      // Mobile only: on desktop the rooms rail carries its own persistent
+      // pill, which is correct and not what #509 is about. Counting VISIBLE
+      // matches rather than all of them, because below 768px the rail is
+      // `display:none`, so its pill is in the DOM either way.
+      if (isMobile) {
+        await expect(
+          page.locator('[data-testid="connection-status-indicator"]:visible')
+        ).toHaveCount(0);
+      }
+    });
+
+    test("a migrating account is told so", async ({ page }) => {
+      await page.goto("/");
+      await waitForApp(page);
+      // Settle on the Welcome screen first, so the hook is not racing
+      // the fixture's own first render.
+      await expect(page.getByText(WELCOME)).toBeVisible({ timeout: 10_000 });
+      await setLoadState(page, "migrating");
+
+      const migrating = page.getByTestId("conversation-rooms-migrating");
+      await expect(migrating).toBeVisible({ timeout: 5_000 });
+      await expect(migrating.getByText("Migrating your rooms…")).toBeVisible();
+      await expect(page.getByText(WELCOME)).toHaveCount(0);
+    });
+
+    test("a failed load offers Retry instead of advice to create a room", async ({
+      page,
+    }) => {
+      await page.goto("/");
+      await waitForApp(page);
+      // Settle on the Welcome screen first, so the hook is not racing
+      // the fixture's own first render.
+      await expect(page.getByText(WELCOME)).toBeVisible({ timeout: 10_000 });
+      await setLoadState(page, "failed");
+
+      const failed = page.getByTestId("conversation-rooms-error");
+      await expect(failed).toBeVisible({ timeout: 5_000 });
+      await expect(failed.getByText(/Couldn.t load your rooms/)).toBeVisible();
+      await expect(
+        page.getByTestId("conversation-rooms-retry-button")
+      ).toBeVisible();
+      await expect(page.getByText(WELCOME)).toHaveCount(0);
+    });
+
+    test("a genuinely empty account still gets the Welcome screen", async ({
+      page,
+    }) => {
+      await page.goto("/");
+      await waitForApp(page);
+      // Settle on the Welcome screen first, so the hook is not racing
+      // the fixture's own first render.
+      await expect(page.getByText(WELCOME)).toBeVisible({ timeout: 10_000 });
+      await setLoadState(page, "loaded");
+
+      // The one state that SHOULD say "create a room": the load resolved and
+      // there really is nothing. Without this the fix could suppress the
+      // Welcome screen entirely and every assertion above would still pass.
+      await expect(page.getByText(WELCOME)).toBeVisible({ timeout: 5_000 });
+      await expect(
+        page.getByTestId("conversation-rooms-loading")
+      ).toHaveCount(0);
+      await expect(page.getByTestId("conversation-rooms-error")).toHaveCount(0);
+    });
+  });
+}

--- a/ui/tests/welcome-invite-link.spec.ts
+++ b/ui/tests/welcome-invite-link.spec.ts
@@ -18,7 +18,10 @@ async function expectInviteLink(page: Page) {
   await page.goto("/");
   await waitForApp(page);
 
-  // Confirm we're on the Welcome screen (no room selected on first load).
+  // Confirm we're on the Welcome screen (the fixture seeds rooms and selects
+  // none, so the load state resolves to `List`). Since freenet/river#509 the
+  // no-room screen has four states; the link survives all of them via
+  // `NoRoomFooter`, and `rooms-loading-state.spec.ts` covers the other three.
   await expect(page.getByText("Welcome to River")).toBeVisible({
     timeout: 5_000,
   });


### PR DESCRIPTION
## Problem

On Android, loading `https://try.freenet.org/v1/contract/web/raAqMhMG.../` shows no loading indicator — and the impact is worse than a missing spinner: **the app affirmatively tells a mid-load user they have no rooms.**

#397 added the loading / migrating / failed / empty states, but put them entirely inside `RoomList` (`room_list.rs:341-387`). Below the 768px breakpoint that panel is `display:none` rather than unmounted (`app.rs:476-500`), and the default mobile view is Chat (`app.rs:85`). `CURRENT_ROOM` starts `None` and is only set after the load resolves, so for the whole load window the only thing a phone user can see is the conversation panel's no-room screen — which rendered, unconditionally:

> **Welcome to River**
> Create a new room, or get invited to an existing one.

That is the exact false-empty message #397 was written to eliminate, still shipping on mobile. `ROOMS_LOAD_STATE` had exactly one consumer in the whole UI, which is the root cause: #397 never touched `app.rs` or `conversation.rs`.

Two aggravating details, both fixed here:

- **`LoadFailed` was invisible too**, along with its Retry button. A stalled load was pixel-identical to an empty account, so the user was advised to create a room when the correct action was retry.
- **A green "Connected" pill sat on that same screen** (`conversation.rs:4392-4399`), flipping within about a second while rooms were still loading. It reflects only WebSocket transport, so it actively reassured the user that nothing was pending.

The window is roughly 2-4s of false Welcome screen after the WASM loads — connect, `RegisterDelegate`, `ListRequest`, per-room GETs in waves of 16, the legacy-migration probe burst (#425), then a 1500ms quiescence debounce — with a 60s hard backstop.

Closes #509.

## Approach

Branch the no-room screen on the same state the rail uses, through a shared `current_room_list_display()`, so the two surfaces can never disagree about whether rooms are still loading. Purely additive rendering; no state-machine change.

Viewport-independent on purpose — the desktop centre panel showed the same false-empty text.

The connection pill now lives in the Welcome arm only, so it no longer appears on a still-loading screen. `Empty` (the load resolved and there really are no rooms) and `List` (rooms exist, none selected yet) both keep today's screen unchanged.

Alternatives considered and rejected in the issue: auto-opening the room list on mobile while loading (fights the current-room restore path and can steal the panel mid-interaction), and a global first-load overlay (the only option that also addresses the blank-page phase, but needs a custom `index.html` and risks a hard lockout if it fails to dismiss).

## Testing

There was none — grepping for #397's test ids across the repo returned nothing, so those states shipped with Rust unit tests only. Which is how they went unnoticed on the surface that matters.

`rooms-loading-state.spec.ts` covers all four states at a mobile AND a desktop viewport (8 cases). Reaching them needs a hook, since the example build always seeds rooms and never leaves `ROOMS_LOAD_STATE` at anything but its default: `__riverTest.setRoomsLoadState(state)` clears `ROOMS` and sets the state, gated on `example-data` + `no-sync` like its neighbours.

Every state test carries the premise that the screen opens on the Welcome copy, so "Welcome is gone" cannot pass without the fix doing something. The `loaded` case pins that a genuinely empty account still gets the Welcome screen — without it the fix could suppress that screen entirely and every other assertion would still pass.

**Mutation-verified in the browser**, not just asserted: forcing the resolved arm (the pre-fix rendering) and rebuilding turns all six state cases red while the `loaded` case stays green. `the_no_room_screen_branches_on_the_shared_load_state` pins the same wiring in Rust, and goes red under the same mutation.

Note `welcome-invite-link.spec.ts` still passes: with rooms seeded, `room_list_display_state` returns `List`, which keeps today's screen.

701 Rust tests pass; 8/8 Playwright locally against a static example-data build; `cargo fmt` clean.

[AI-assisted - Claude]