### PR TITLE
fix(ui): resolve delegate identity conflicts by generation, not arrival order (#527)

### DIFF
--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -951,48 +951,88 @@ mod tests {
     /// exactly ONE writer. This pin fails any future fifth door.
     #[test]
     fn the_seal_has_exactly_one_writer() {
-        // SCOPE NOTE: this file's `mod tests` is MID-FILE, so there is no clean
-        // "production only" slice to count over — the seal machinery lives
-        // AFTER the test module. So this pins the two things it can verify
-        // exactly, which is where all four original doors actually were:
-        //   (1) no OTHER module seals inline (three of the four doors), and
-        //   (2) the region of THIS file before the test module has no door.
-        // The remaining possibility — a new inline seal added after the test
-        // module in this same file — is covered by the companion test
-        // `the_legacy_seal_is_written_only_behind_the_quiescence_debounce`,
-        // which pins that the write sits behind the gate in schedule_legacy_seal.
+        // This file's `mod tests` is MID-FILE, so a plain `split(...).next()`
+        // would cover only the ~700 lines ahead of it and miss the region where
+        // the seal machinery actually lives. Excise the test module instead —
+        // inside it every item's closing brace is indented, so the first
+        // column-0 `}` after the module header is the module's own.
         let src = include_str!("chat_delegate.rs");
-        let before_tests = src
-            .split("#[cfg(test)]\nmod tests {")
-            .next()
-            .expect("code before the test module");
+        let tests_start = src
+            .find("#[cfg(test)]\nmod tests {")
+            .expect("test module must exist");
+        let tests_end = tests_start
+            + src[tests_start..]
+                .find("\n}\n")
+                .expect("test module must terminate")
+            + 3;
+        let production = format!("{}{}", &src[..tests_start], &src[tests_end..]);
+
+        // The CALL form carries a semicolon; the definition ends in `{` and the
+        // doc-comment mentions have neither, so this counts real writers only.
         assert_eq!(
-            before_tests.matches("mark_legacy_migration_done()").count(),
-            0,
-            "no inline seal may be added ahead of the test module — every seal \
-             must route through request_legacy_seal_on_quiescence (freenet/river#527)"
+            production.matches("mark_legacy_migration_done();").count(),
+            1,
+            "exactly ONE writer of the seal — the quiescence-gated write in \
+             schedule_legacy_seal. A second is a new door onto the third cause \
+             of freenet/river#527."
+        );
+        // Guard the excision itself: if the module bounds are ever computed
+        // wrongly, the count above could pass by looking at the wrong text.
+        assert!(
+            production.contains("fn schedule_legacy_seal(")
+                && !production.contains("fn the_seal_has_exactly_one_writer("),
+            "the excision must keep production and drop the test module"
         );
 
-        // No OTHER module may call it directly.
-        for (name, other) in [
-            (
-                "response_handler.rs",
-                include_str!("freenet_api/response_handler.rs"),
-            ),
-            (
-                "freenet_synchronizer.rs",
-                include_str!("freenet_api/freenet_synchronizer.rs"),
-            ),
-        ] {
-            let other_production = other
-                .split("mod tests {")
-                .next()
-                .expect("production code before `mod tests`");
-            assert!(
-                !other_production.contains("mark_legacy_migration_done()"),
-                "{name} must seal via request_legacy_seal_on_quiescence(), not inline"
-            );
-        }
+        // freenet_synchronizer.rs must NEVER seal inline. This is the door that
+        // caused the harm: it seals on any "delegate not found" API error, which
+        // the fan-out itself provokes within milliseconds on any node missing an
+        // old delegate WASM — so it could fire before any generation holding
+        // data had answered.
+        let sync_src = include_str!("freenet_api/freenet_synchronizer.rs");
+        let sync_production = sync_src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+        assert!(
+            !sync_production.contains("mark_legacy_migration_done()"),
+            "freenet_synchronizer.rs must seal via request_legacy_seal_on_quiescence() — \
+             it fires on errors the fan-out itself provokes (freenet/river#527)"
+        );
+
+        // response_handler.rs MAY seal inline, but ONLY at the doors where the
+        // current delegate is authoritative and no fan-out is in flight, and
+        // only with the rationale recorded. Every inline seal must be paired
+        // with a "SYNCHRONOUS, deliberately" marker, so a new undocumented one
+        // fails here rather than silently re-opening the third cause.
+        let rh_src = include_str!("freenet_api/response_handler.rs");
+        let rh_production = rh_src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+        let inline_seals = rh_production
+            .matches("mark_legacy_migration_done()")
+            .count();
+        let documented = rh_production.matches("SYNCHRONOUS, deliberately").count();
+        assert_eq!(
+            inline_seals, documented,
+            "every inline seal in response_handler.rs must carry the \
+             'SYNCHRONOUS, deliberately' rationale explaining why no fan-out is \
+             in flight at that door (freenet/river#527)"
+        );
+        assert_eq!(
+            inline_seals, 2,
+            "expected exactly the two current-delegate-authoritative doors to seal \
+             inline; a change here needs a deliberate decision about fan-out overlap"
+        );
+        assert!(
+            rh_production
+                .matches("request_legacy_seal_on_quiescence()")
+                .count()
+                >= 2,
+            "the legacy re-save and the blob-explosion save must both request a \
+             quiescence-gated seal"
+        );
     }
 
     /// A deliberate identity choice must outrank every delegate generation, so
@@ -5959,6 +5999,17 @@ fn schedule_legacy_seal(armed_gen: u32, armed_attempt: u32) {
             let pending = PENDING_LOADS.load(Ordering::Relaxed);
             if !idle_should_apply(armed_gen, cur_gen, armed_attempt, cur_attempt, pending) {
                 return; // a later generation is still answering — re-armed on its settle
+            }
+            // Never seal over a migration that is mid-flight or has FAILED.
+            // The legacy re-save holds no load-worker guard, so quiescence can
+            // be reached while it is still running; and the not-found door sets
+            // the pending flag unconditionally, saying nothing about success.
+            // Sealing either case would kill the freenet/river#345 recovery
+            // across sessions, since `fire_legacy_migration_request` checks the
+            // seal BEFORE the in-progress flag. Leaving it unsealed just means a
+            // harmless re-probe next session — the safe direction.
+            if is_legacy_migration_in_progress() {
+                return;
             }
             if LEGACY_SEAL_PENDING.swap(false, Ordering::Relaxed) {
                 mark_legacy_migration_done();

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -255,6 +255,70 @@ pub fn is_legacy_delegate_key(key_bytes: &[u8]) -> bool {
         .any(|(dk, _)| dk.as_slice() == key_bytes)
 }
 
+// =============================================================================
+// DELEGATE-GENERATION AUTHORITY (freenet/river#527)
+// =============================================================================
+//
+// `fire_legacy_migration_request` probes EVERY legacy delegate generation at
+// once, and each one that still holds data hydrates independently. Their
+// responses race, so something has to decide which copy of a room is
+// authoritative when two generations disagree about the user's identity for it.
+//
+// Before #527 nothing did: `Rooms::merge` kept whichever copy landed FIRST and
+// silently skipped the rest. Probes are dispatched oldest-generation-first (the
+// `LEGACY_DELEGATES` order), so the oldest surviving copy usually answered
+// first — rolling a long-time user back to an identity from months earlier.
+//
+// The rank below is that missing order. `LEGACY_DELEGATES` is generated from
+// `legacy_delegates.toml` in age order (V1 oldest first), so an entry's INDEX
+// is its generation: higher index = newer delegate = more authoritative, and
+// the current delegate outranks every legacy generation.
+
+/// Rank of the CURRENT delegate — above every legacy generation.
+pub(crate) fn current_delegate_source_rank() -> u32 {
+    LEGACY_DELEGATES.len() as u32
+}
+
+/// Rank of the delegate generation `key_bytes` identifies. An unrecognised key
+/// is the current delegate (the only non-legacy delegate River talks to).
+pub(crate) fn source_rank_for_delegate_key(key_bytes: &[u8]) -> u32 {
+    LEGACY_DELEGATES
+        .iter()
+        .position(|(dk, _)| dk.as_slice() == key_bytes)
+        .map(|i| i as u32)
+        .unwrap_or_else(current_delegate_source_rank)
+}
+
+/// Which source supplied the identity each room in `ROOMS` currently carries,
+/// so a later-arriving copy can be ranked against it. Runtime-only (never
+/// persisted): it describes where the in-memory copy came from this session.
+///
+/// A plain `Mutex`, not a signal — it is read from `Rooms::merge` inside a
+/// `with_mut`, and from spawned tasks with no Dioxus runtime, where reading a
+/// `GlobalSignal` would panic (the same reasoning as `CURRENT_ROOM_IDENTITY` in
+/// `signing.rs`). Single-threaded WASM, so it never contends.
+static ROOM_IDENTITY_SOURCE_RANKS: LazyLock<Mutex<HashMap<RoomKey, u32>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Run `f` against the identity-source-rank registry.
+pub(crate) fn with_identity_source_ranks<R>(f: impl FnOnce(&mut HashMap<RoomKey, u32>) -> R) -> R {
+    let mut guard = ROOM_IDENTITY_SOURCE_RANKS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    f(&mut guard)
+}
+
+/// Record that this room's identity was chosen DELIBERATELY by the user (an
+/// identity import, or accepting an invitation) rather than loaded from a
+/// delegate. Nothing outranks an explicit choice, so no delegate copy — however
+/// new its generation — can overwrite it (this is what preserves the
+/// freenet/river#414 guarantee now that merge can adopt an incoming identity).
+pub(crate) fn mark_identity_source_authoritative(room_key: RoomKey) {
+    with_identity_source_ranks(|ranks| {
+        ranks.insert(room_key, crate::room_data::SOURCE_RANK_AUTHORITATIVE);
+    });
+}
+
 // Prefixes for different pending request types
 const SIGNING_KEY_PREFIX: &[u8] = b"__signing_key:";
 const PUBLIC_KEY_PREFIX: &[u8] = b"__public_key:";
@@ -649,6 +713,75 @@ mod tests {
     /// On the native target there is no `localStorage` cfg block, so this
     /// exercises exactly that fallback: repeated calls must return identical
     /// bytes via the in-memory cache.
+    /// freenet/river#527: the whole generation-ranked identity fix rests on
+    /// `LEGACY_DELEGATES` being in AGE order (oldest first), because an entry's
+    /// INDEX is used as its authority. `legacy_delegates.toml` is append-only
+    /// and `freenet-migrate-build` emits it in file order, but nothing else
+    /// enforces that — if a future generator ever sorted or reversed the list,
+    /// the fix would silently INVERT and start preferring the oldest copy,
+    /// which is the exact bug it exists to prevent.
+    #[test]
+    fn legacy_delegate_ranks_run_oldest_to_newest_and_below_the_current_delegate() {
+        assert!(
+            LEGACY_DELEGATES.len() >= 2,
+            "need at least two generations to have an order to check"
+        );
+
+        // Each entry's rank is its index, so ranks strictly increase with age.
+        for (i, (key_bytes, _)) in LEGACY_DELEGATES.iter().enumerate() {
+            assert_eq!(
+                source_rank_for_delegate_key(key_bytes.as_slice()),
+                i as u32,
+                "legacy entry {i} must rank at its index"
+            );
+        }
+
+        let oldest = source_rank_for_delegate_key(LEGACY_DELEGATES[0].0.as_slice());
+        let newest =
+            source_rank_for_delegate_key(LEGACY_DELEGATES[LEGACY_DELEGATES.len() - 1].0.as_slice());
+        assert!(
+            oldest < newest,
+            "the FIRST registry entry must be the OLDEST generation (lowest authority) — \
+             if this fails, legacy_delegates.toml or its codegen changed order and the \
+             #527 identity ordering is now inverted"
+        );
+        assert!(
+            newest < current_delegate_source_rank(),
+            "the current delegate must outrank every legacy generation"
+        );
+    }
+
+    /// An unrecognised key is the current delegate — the only non-legacy
+    /// delegate River talks to — so it must get the top delegate rank rather
+    /// than accidentally ranking as the oldest generation (index 0).
+    #[test]
+    fn an_unknown_delegate_key_ranks_as_the_current_delegate() {
+        let unknown = [0xABu8; 32];
+        assert!(
+            !is_legacy_delegate_key(&unknown),
+            "fixture must not collide with a real legacy key"
+        );
+        assert_eq!(
+            source_rank_for_delegate_key(&unknown),
+            current_delegate_source_rank()
+        );
+    }
+
+    /// A deliberate identity choice must outrank every delegate generation, so
+    /// no load — however new — can undo an import (freenet/river#414 + #527).
+    #[test]
+    fn an_authoritative_identity_source_outranks_every_delegate() {
+        // A room key no other test uses: the registry is a process-global.
+        let room_key = [0x5Au8; 32];
+        mark_identity_source_authoritative(room_key);
+        let rank = with_identity_source_ranks(|ranks| ranks.get(&room_key).copied());
+        assert_eq!(rank, Some(crate::room_data::SOURCE_RANK_AUTHORITATIVE));
+        assert!(
+            rank.unwrap() > current_delegate_source_rank(),
+            "an explicit choice must outrank the current delegate too"
+        );
+    }
+
     #[test]
     fn cipher_material_is_stable_within_process() {
         let a = chat_delegate_cipher_material();
@@ -5550,6 +5683,51 @@ pub(crate) fn on_load_worker_settled() {
             None if room_count_zero => schedule_idle_resolution(armed_gen, armed_attempt),
             None => {} // rooms present → List renders, leave the state
         }
+        // A legacy migration that completed this session seals only after the
+        // fan-out is quiescent (freenet/river#527), so every generation that
+        // was going to answer has been merged first. Armed here rather than at
+        // the re-save because this is the point where "no load work is
+        // outstanding" is known. Runs for the rooms-present case too, which
+        // `settle_terminal` deliberately leaves alone.
+        if LEGACY_SEAL_PENDING.load(Ordering::Relaxed) {
+            schedule_legacy_seal(armed_gen, armed_attempt);
+        }
+    });
+}
+
+/// A legacy migration re-saved successfully; seal it once the load goes quiet.
+/// See [`schedule_legacy_seal`].
+pub(crate) fn request_legacy_seal_on_quiescence() {
+    LEGACY_SEAL_PENDING.store(true, Ordering::Relaxed);
+    // The re-save runs in its own spawned task, so the load may ALREADY be
+    // quiescent (every worker dropped while the save was in flight) and no
+    // further settle would fire. Drive one now; it no-ops if work is pending.
+    on_load_worker_settled();
+}
+
+/// Set when a legacy migration's re-save succeeds, cleared when the seal is
+/// written. See [`request_legacy_seal_on_quiescence`].
+static LEGACY_SEAL_PENDING: AtomicBool = AtomicBool::new(false);
+
+/// Write the legacy-migration seal after [`LOAD_IDLE_MS`] of quiescence, using
+/// the same debounce as the idle load resolution: any new worker (a later
+/// generation answering) bumps the activity gen and cancels this, and the seal
+/// is re-armed when THAT worker settles. So the seal lands only after the last
+/// responding delegate generation has been merged (freenet/river#527).
+fn schedule_legacy_seal(armed_gen: u32, armed_attempt: u32) {
+    crate::util::safe_spawn_local(async move {
+        crate::util::sleep(std::time::Duration::from_millis(LOAD_IDLE_MS)).await;
+        crate::util::defer(move || {
+            let cur_gen = LOAD_ACTIVITY_GEN.load(Ordering::Relaxed);
+            let cur_attempt = LOAD_ATTEMPT_GEN.load(Ordering::Relaxed);
+            let pending = PENDING_LOADS.load(Ordering::Relaxed);
+            if !idle_should_apply(armed_gen, cur_gen, armed_attempt, cur_attempt, pending) {
+                return; // a later generation is still answering — re-armed on its settle
+            }
+            if LEGACY_SEAL_PENDING.swap(false, Ordering::Relaxed) {
+                mark_legacy_migration_done();
+            }
+        });
     });
 }
 

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -736,14 +736,49 @@ mod tests {
             );
         }
 
-        let oldest = source_rank_for_delegate_key(LEGACY_DELEGATES[0].0.as_slice());
-        let newest =
-            source_rank_for_delegate_key(LEGACY_DELEGATES[LEGACY_DELEGATES.len() - 1].0.as_slice());
+        // Anchor to two SPECIFIC keys of known age, taken from
+        // legacy_delegates.toml: V1 (2026-01-15, the first entry ever recorded)
+        // and V29 (2026-07-27, the generation immediately before this fix).
+        //
+        // This anchoring is the whole point of the test. Asserting "rank ==
+        // index" above only checks `position()` against itself: if the codegen
+        // ever emitted the registry in a different order, every index-based
+        // assertion would still pass while the authority order silently
+        // inverted and the fix started preferring the OLDEST copy — the exact
+        // bug it exists to prevent. Only comparing keys whose real-world age we
+        // know independently can catch that.
+        //
+        // This does not rot as entries are appended: V1 stays older than V29
+        // no matter how many generations follow.
+        fn hex32(s: &str) -> [u8; 32] {
+            let mut out = [0u8; 32];
+            for (i, b) in out.iter_mut().enumerate() {
+                *b = u8::from_str_radix(&s[i * 2..i * 2 + 2], 16).expect("valid hex byte");
+            }
+            out
+        }
+        let v1_oldest = hex32("1a9330820e806cda54eca7dab22b84f20cfa793ebe61a2615312cc6e6ebcfff6");
+        let v29_newest = hex32("d46b5363858c82ed91f0709d179c620c74c1ab84483b114181594c08a3d4b915");
+
+        // Both must still BE legacy entries — otherwise `source_rank_for_delegate_key`
+        // falls through to the current-delegate rank and the comparison below
+        // would pass for the wrong reason.
+        assert!(
+            is_legacy_delegate_key(&v1_oldest),
+            "V1 must still be in the registry for this test to mean anything"
+        );
+        assert!(
+            is_legacy_delegate_key(&v29_newest),
+            "V29 must still be in the registry for this test to mean anything"
+        );
+
+        let oldest = source_rank_for_delegate_key(&v1_oldest);
+        let newest = source_rank_for_delegate_key(&v29_newest);
         assert!(
             oldest < newest,
-            "the FIRST registry entry must be the OLDEST generation (lowest authority) — \
-             if this fails, legacy_delegates.toml or its codegen changed order and the \
-             #527 identity ordering is now inverted"
+            "V1 (2026-01-15) must rank BELOW V29 (2026-07-27) — if this fails, \
+             legacy_delegates.toml or its codegen changed order and the #527 \
+             identity ordering is now inverted, so the oldest copy would win"
         );
         assert!(
             newest < current_delegate_source_rank(),

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -705,14 +705,6 @@ mod tests {
     use super::*;
     use ed25519_dalek::SigningKey;
 
-    /// Blocker-1 pin (freenet/river#394): the chat-delegate cipher/nonce must be
-    /// STABLE within a process. In the production gateway iframe `localStorage`
-    /// throws (opaque origin), so both persistence sides no-op; the pre-fix code
-    /// therefore re-generated fresh material on every `set_up_chat_delegate()`
-    /// (fired on each reconnect / sleep-wake), rotating the cipher within a page.
-    /// On the native target there is no `localStorage` cfg block, so this
-    /// exercises exactly that fallback: repeated calls must return identical
-    /// bytes via the in-memory cache.
     /// freenet/river#527: the whole generation-ranked identity fix rests on
     /// `LEGACY_DELEGATES` being in AGE order (oldest first), because an entry's
     /// INDEX is used as its authority. `legacy_delegates.toml` is append-only
@@ -720,6 +712,15 @@ mod tests {
     /// enforces that — if a future generator ever sorted or reversed the list,
     /// the fix would silently INVERT and start preferring the oldest copy,
     /// which is the exact bug it exists to prevent.
+    ///
+    /// The load-bearing check is the DATE MONOTONICITY assertion below. Every
+    /// index-based assertion here is an identity — `source_rank_for_delegate_key`
+    /// IS `position()` over this array, so "rank == index" holds for ANY
+    /// ordering — and anchoring on two specific keys is not enough either: a
+    /// lexicographic sort by version string ("V10" < "V2") leaves V1 first and
+    /// V29 late, so `rank(V1) < rank(V29)` would still pass while V3 outranked
+    /// V29. Only reading the emitted DATES, which the array position cannot
+    /// influence, actually detects a reordering.
     #[test]
     fn legacy_delegate_ranks_run_oldest_to_newest_and_below_the_current_delegate() {
         assert!(
@@ -727,7 +728,50 @@ mod tests {
             "need at least two generations to have an order to check"
         );
 
-        // Each entry's rank is its index, so ranks strictly increase with age.
+        // THE REAL CHECK: the generated registry carries each entry's date as a
+        // trailing `(YYYY-MM-DD)` comment, emitted in array order. Those dates
+        // must be non-decreasing, or the array is no longer in age order and
+        // every rank derived from it is wrong.
+        let generated = include_str!(concat!(env!("OUT_DIR"), "/legacy_delegates.rs"));
+        let dates: Vec<&str> = generated
+            .lines()
+            .map(str::trim)
+            .filter(|l| l.starts_with("// V"))
+            .filter_map(|l| {
+                // The description itself may contain parentheses, so take the
+                // LAST parenthesised group on the line.
+                let open = l.rfind('(')?;
+                let close = l.rfind(')')?;
+                (close > open).then(|| &l[open + 1..close])
+            })
+            .filter(|d| d.len() == 10 && d.as_bytes()[4] == b'-')
+            .collect();
+
+        // Vacuity guard: if the comment format ever changes, the parse above
+        // would silently yield nothing and the monotonicity check would pass
+        // over an empty list.
+        assert_eq!(
+            dates.len(),
+            LEGACY_DELEGATES.len(),
+            "must parse one date per legacy entry — got {dates:?}; if the codegen's \
+             comment format changed, this pin has gone blind and must be updated"
+        );
+
+        // ISO-8601 dates compare chronologically as strings.
+        for pair in dates.windows(2) {
+            assert!(
+                pair[0] <= pair[1],
+                "legacy delegate registry is NOT in age order ({} comes before {}) — \
+                 an entry's index is its authority rank, so the #527 identity \
+                 ordering is now inverted and the OLDEST copy would win conflicts",
+                pair[0],
+                pair[1]
+            );
+        }
+
+        // Each entry's rank is its index (identity given the implementation, but
+        // it also catches duplicate keys, which would collapse two generations
+        // onto one rank).
         for (i, (key_bytes, _)) in LEGACY_DELEGATES.iter().enumerate() {
             assert_eq!(
                 source_rank_for_delegate_key(key_bytes.as_slice()),
@@ -802,6 +846,79 @@ mod tests {
         );
     }
 
+    /// freenet/river#527 (third cause): the seal must be DEBOUNCED, not merely
+    /// requested.
+    ///
+    /// The response-handler pin only asserts that the legacy re-save CALLS
+    /// `request_legacy_seal_on_quiescence()` instead of sealing inline. That
+    /// says nothing about when the seal actually lands: make this function
+    /// write the seal immediately and that pin stays green while the third
+    /// cause of #527 returns in full — the migration ends while newer delegate
+    /// generations are still answering, and a tab closed in that window leaves
+    /// the rollback permanent.
+    ///
+    /// So pin the property here: the seal is only ever written from inside the
+    /// idle-gated closure, after a `LOAD_IDLE_MS` wait.
+    #[test]
+    fn the_legacy_seal_is_written_only_behind_the_quiescence_debounce() {
+        // NOTE: this file's `mod tests` is MID-FILE, so the usual
+        // `split("mod tests {").next()` trick would slice away everything after
+        // it — including both functions under test — and every assertion below
+        // would fail (or, with `contains`, pass vacuously). Search the whole
+        // source with `rfind` instead, as the other pins in this file do: both
+        // definitions live AFTER this test module, so the last occurrence is
+        // the real definition rather than a needle in this test's own source.
+        let src = include_str!("chat_delegate.rs");
+
+        // The request path must NOT seal — it only sets the flag and pokes the
+        // settle check.
+        let req = src
+            .rfind("pub(crate) fn request_legacy_seal_on_quiescence() {")
+            .expect("request_legacy_seal_on_quiescence must exist");
+        let req_end = src[req..].find("\n}\n").expect("function must terminate");
+        let req_body = &src[req..req + req_end];
+        assert!(
+            !req_body.contains("mark_legacy_migration_done("),
+            "requesting the seal must NOT write it — that is sealing inline by \
+             another name and re-opens the third cause of #527"
+        );
+        assert!(
+            req_body.contains("LEGACY_SEAL_PENDING.store(true"),
+            "the request must record that a seal is owed"
+        );
+
+        // The scheduler must wait, re-check quiescence, and only then seal.
+        let sched = src
+            .rfind("fn schedule_legacy_seal(")
+            .expect("schedule_legacy_seal must exist");
+        let sched_body = &src[sched..];
+        let sched_body = &sched_body[..sched_body.find("\n}\n").expect("function must terminate")];
+        assert!(
+            sched_body.contains("LOAD_IDLE_MS"),
+            "the seal must wait out the quiescence window"
+        );
+        assert!(
+            sched_body.contains("idle_should_apply("),
+            "the seal must re-check that no newer generation started answering — \
+             a later worker cancels it and re-arms on its own settle"
+        );
+        assert!(
+            sched_body.contains("mark_legacy_migration_done()"),
+            "the seal is written here, or nowhere"
+        );
+        // Ordering: the gate precedes the write.
+        let gate = sched_body
+            .find("idle_should_apply(")
+            .expect("gate must be present");
+        let write = sched_body
+            .find("mark_legacy_migration_done()")
+            .expect("write must be present");
+        assert!(
+            gate < write,
+            "the quiescence gate must run BEFORE the seal is written"
+        );
+    }
+
     /// A deliberate identity choice must outrank every delegate generation, so
     /// no load — however new — can undo an import (freenet/river#414 + #527).
     #[test]
@@ -817,6 +934,14 @@ mod tests {
         );
     }
 
+    /// Blocker-1 pin (freenet/river#394): the chat-delegate cipher/nonce must be
+    /// STABLE within a process. In the production gateway iframe `localStorage`
+    /// throws (opaque origin), so both persistence sides no-op; the pre-fix code
+    /// therefore re-generated fresh material on every `set_up_chat_delegate()`
+    /// (fired on each reconnect / sleep-wake), rotating the cipher within a page.
+    /// On the native target there is no `localStorage` cfg block, so this
+    /// exercises exactly that fallback: repeated calls must return identical
+    /// bytes via the in-memory cache.
     #[test]
     fn cipher_material_is_stable_within_process() {
         let a = chat_delegate_cipher_material();

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -917,6 +917,82 @@ mod tests {
             gate < write,
             "the quiescence gate must run BEFORE the seal is written"
         );
+
+        // The arming block must exist, or the seal simply never lands: every
+        // assertion above would still pass while nothing ever writes it.
+        let settled = src
+            .rfind("pub(crate) fn on_load_worker_settled() {")
+            .expect("on_load_worker_settled must exist");
+        let settled_body = &src[settled..];
+        let settled_body =
+            &settled_body[..settled_body.find("\n}\n").expect("function must terminate")];
+        assert!(
+            settled_body.contains("LEGACY_SEAL_PENDING.load(Ordering::Relaxed)")
+                && settled_body.contains("schedule_legacy_seal(armed_gen, armed_attempt)"),
+            "load settlement must ARM the debounced seal, or a requested seal is never written"
+        );
+    }
+
+    /// freenet/river#527 — SINGLE WRITER for the legacy-migration seal.
+    ///
+    /// The seal is what ends legacy migration for good: once set, a later
+    /// session whose current delegate is still empty takes the FireMigration
+    /// branch, finds the seal, and probes nothing. Any code path that sets it
+    /// while the ~26-generation fan-out is still answering can permanently
+    /// strand rooms that live in a generation which had not replied yet.
+    ///
+    /// There were FOUR such doors, all sealing inline. The loudest was in
+    /// `freenet_synchronizer.rs`: it seals on any "delegate not found" API
+    /// error, which the fan-out itself provokes within milliseconds on every
+    /// node where some legacy delegate WASM was never installed — so one absent
+    /// generation spoke for all the others.
+    ///
+    /// They now all route through `request_legacy_seal_on_quiescence`, leaving
+    /// exactly ONE writer. This pin fails any future fifth door.
+    #[test]
+    fn the_seal_has_exactly_one_writer() {
+        // SCOPE NOTE: this file's `mod tests` is MID-FILE, so there is no clean
+        // "production only" slice to count over — the seal machinery lives
+        // AFTER the test module. So this pins the two things it can verify
+        // exactly, which is where all four original doors actually were:
+        //   (1) no OTHER module seals inline (three of the four doors), and
+        //   (2) the region of THIS file before the test module has no door.
+        // The remaining possibility — a new inline seal added after the test
+        // module in this same file — is covered by the companion test
+        // `the_legacy_seal_is_written_only_behind_the_quiescence_debounce`,
+        // which pins that the write sits behind the gate in schedule_legacy_seal.
+        let src = include_str!("chat_delegate.rs");
+        let before_tests = src
+            .split("#[cfg(test)]\nmod tests {")
+            .next()
+            .expect("code before the test module");
+        assert_eq!(
+            before_tests.matches("mark_legacy_migration_done()").count(),
+            0,
+            "no inline seal may be added ahead of the test module — every seal \
+             must route through request_legacy_seal_on_quiescence (freenet/river#527)"
+        );
+
+        // No OTHER module may call it directly.
+        for (name, other) in [
+            (
+                "response_handler.rs",
+                include_str!("freenet_api/response_handler.rs"),
+            ),
+            (
+                "freenet_synchronizer.rs",
+                include_str!("freenet_api/freenet_synchronizer.rs"),
+            ),
+        ] {
+            let other_production = other
+                .split("mod tests {")
+                .next()
+                .expect("production code before `mod tests`");
+            assert!(
+                !other_production.contains("mark_legacy_migration_done()"),
+                "{name} must seal via request_legacy_seal_on_quiescence(), not inline"
+            );
+        }
     }
 
     /// A deliberate identity choice must outrank every delegate generation, so

--- a/ui/src/components/app/freenet_api/freenet_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/freenet_synchronizer.rs
@@ -5,7 +5,7 @@ use super::error::SynchronizerError;
 use super::response_handler::ResponseHandler;
 use super::room_synchronizer::RoomSynchronizer;
 use crate::components::app::chat_delegate::{
-    mark_legacy_migration_done, reset_ensure_subscription_dedup, set_up_chat_delegate,
+    request_legacy_seal_on_quiescence, reset_ensure_subscription_dedup, set_up_chat_delegate,
 };
 use crate::components::app::sync_info::SYNC_INFO;
 use crate::components::app::{ROOMS, SYNC_STATUS, WEB_API};
@@ -701,8 +701,21 @@ impl FreenetSynchronizer {
                                 if e.to_string().contains("delegate")
                                     && e.to_string().contains("not found")
                                 {
-                                    info!("Delegate not found error (likely legacy migration) - marking migration complete");
-                                    mark_legacy_migration_done();
+                                    info!("Delegate not found error (likely legacy migration) - requesting migration seal on quiescence");
+                                    // Quiescence-gated, NOT immediate
+                                    // (freenet/river#527). The fan-out probes ~26
+                                    // generations at once and most are not
+                                    // installed on any given node, so this error
+                                    // arrives within milliseconds of the probes
+                                    // going out — long before any generation that
+                                    // DOES hold data has answered. Sealing here
+                                    // ends the migration for good: a later session
+                                    // whose current delegate is still empty takes
+                                    // the FireMigration branch, finds the seal
+                                    // already set, and probes nothing. One absent
+                                    // legacy delegate must not speak for the other
+                                    // twenty-five.
+                                    request_legacy_seal_on_quiescence();
                                 }
 
                                 // Special handling for "not supported" errors

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -14,15 +14,16 @@ use crate::components::app::chat_delegate::{
     arm_legacy_migration_recovery, await_delegate_response, cas_store_correlation_key,
     clear_legacy_migration_in_progress, complete_pending_public_key_request,
     complete_pending_request, complete_pending_sign_request, complete_pending_signing_key_request,
-    decide_legacy_migration_action, decide_per_room_load_action, enqueue_delegate_request,
-    fire_legacy_migration_request, get_versioned_correlation_key, hydrate_hidden_dm_threads,
-    hydrate_outbound_dms_cache, is_legacy_delegate_key, is_legacy_migration_in_progress,
-    legacy_scoped_correlation, load_state_after_probe_legacy, mark_legacy_migration_done,
-    mark_legacy_migration_in_progress, parse_room_storage_key, per_room_terminal,
-    prune_outbound_dms_for_purges, room_storage_key, save_outbound_dms_to_delegate,
-    save_rooms_to_delegate, send_delegate_request, send_delegate_request_to,
-    set_load_state_if_current, LegacyMigrationAction, LoadWorkerGuard, PendingDelegateRequest,
-    RoomsLoadState, OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY, ROOMS_STORAGE_KEY,
+    current_delegate_source_rank, decide_legacy_migration_action, decide_per_room_load_action,
+    enqueue_delegate_request, fire_legacy_migration_request, get_versioned_correlation_key,
+    hydrate_hidden_dm_threads, hydrate_outbound_dms_cache, is_legacy_delegate_key,
+    is_legacy_migration_in_progress, legacy_scoped_correlation, load_state_after_probe_legacy,
+    mark_legacy_migration_done, mark_legacy_migration_in_progress, parse_room_storage_key,
+    per_room_terminal, prune_outbound_dms_for_purges, request_legacy_seal_on_quiescence,
+    room_storage_key, save_outbound_dms_to_delegate, save_rooms_to_delegate, send_delegate_request,
+    send_delegate_request_to, set_load_state_if_current, source_rank_for_delegate_key,
+    LegacyMigrationAction, LoadWorkerGuard, PendingDelegateRequest, RoomsLoadState,
+    OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY, ROOMS_STORAGE_KEY,
 };
 use crate::components::app::document_title::{mark_current_room_as_read, update_document_title};
 use crate::components::app::notifications::mark_initial_sync_complete;
@@ -135,6 +136,10 @@ impl ResponseHandler {
             HostResponse::DelegateResponse { key, values } => {
                 // Check if this is a response from any known legacy delegate
                 let is_legacy_delegate = is_legacy_delegate_key(key.bytes());
+                // Which delegate GENERATION answered (freenet/river#527).
+                // Captured here, at the DelegateResponse scope, because the
+                // per-value match below shadows `key` with the storage key.
+                let delegate_source_rank = source_rank_for_delegate_key(key.bytes());
                 if is_legacy_delegate {
                     info!("Received response from LEGACY delegate - checking for migration data");
                 }
@@ -361,6 +366,7 @@ impl ResponseHandler {
                                                         if hydrate_loaded_rooms(
                                                             loaded_rooms,
                                                             is_legacy_delegate,
+                                                            delegate_source_rank,
                                                             worker.attempt(),
                                                         ) {
                                                             flags.subscriptions_initiated = true;
@@ -866,7 +872,12 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
             // Capture emptiness BEFORE `loaded` is moved into hydrate, for the
             // authoritative terminal decision below.
             let loaded_map_empty = loaded.map.is_empty();
-            if hydrate_loaded_rooms(loaded, false, worker.attempt()) {
+            if hydrate_loaded_rooms(
+                loaded,
+                false,
+                current_delegate_source_rank(),
+                worker.attempt(),
+            ) {
                 schedule_subscription_timeout_check();
             }
 
@@ -1039,7 +1050,12 @@ async fn migrate_current_blob_to_per_room(recovery: bool) {
                 // live rooms writes `Loaded` — a zero-live-room completion writes
                 // NOTHING so it can't stomp a concurrent legacy probe's `Migrating`
                 // into a false Empty; the universal backstop owns that terminal.
-                let had_rooms = hydrate_loaded_rooms(loaded, false, worker.attempt());
+                let had_rooms = hydrate_loaded_rooms(
+                    loaded,
+                    false,
+                    current_delegate_source_rank(),
+                    worker.attempt(),
+                );
                 if had_rooms {
                     schedule_subscription_timeout_check();
                 }
@@ -1252,7 +1268,12 @@ async fn migrate_legacy_per_room(legacy_key: DelegateKey, keys: Vec<ChatDelegate
     // re-save to the CURRENT delegate (which also marks legacy migration done and
     // resolves the load state to `Loaded` on the re-save's success/`Err` arms).
     let loaded = reconstruct_rooms(slots, meta);
-    if hydrate_loaded_rooms(loaded, true, worker.attempt()) {
+    if hydrate_loaded_rooms(
+        loaded,
+        true,
+        source_rank_for_delegate_key(legacy_key.bytes()),
+        worker.attempt(),
+    ) {
         schedule_subscription_timeout_check();
     }
 }
@@ -1305,7 +1326,12 @@ fn schedule_subscription_timeout_check() {
 /// schedule the subscription-timeout backstop (the old
 /// `flags.subscriptions_initiated`). Holds no `self`/`flags`, so it is callable
 /// from a spawned task as well as the synchronous message-loop arm.
-fn hydrate_loaded_rooms(loaded_rooms: Rooms, is_legacy_delegate: bool, attempt: u32) -> bool {
+fn hydrate_loaded_rooms(
+    loaded_rooms: Rooms,
+    is_legacy_delegate: bool,
+    source_rank: u32,
+    attempt: u32,
+) -> bool {
     // freenet/river#397: a legacy-delegate response means we found the user's
     // rooms under an OLD delegate key and are about to migrate them (Ivvor's
     // case). Announce `Migrating` BEFORE the ROOMS merge below (which is
@@ -1391,64 +1417,20 @@ fn hydrate_loaded_rooms(loaded_rooms: Rooms, is_legacy_delegate: bool, attempt: 
         .copied()
         .filter(|k| !tombstoned.contains(k))
         .collect();
-    // Per-room signing-key migration inputs. For
-    // owner-mode rooms we also need to know the
-    // contract id so we can chain
-    // EnsureRoomSubscription onto the migration
-    // task — chained so the delegate is guaranteed
-    // to have the signing key on file before it
-    // sees the subscribe request (Bug #6). The
-    // previous design fired both requests as
-    // independent `safe_spawn_local` tasks and the
-    // race ordering was non-deterministic, so the
-    // delegate's "no signing key on file" reject
-    // path silently aborted the subscription on
-    // every cold load.
-    let signing_keys: Vec<_> = loaded_rooms
-        .map
-        .iter()
-        .filter(|(key, _)| !tombstoned.contains(*key))
-        .map(|(key, room_data)| {
-            let owns_room = room_data.owner_vk == room_data.self_sk.verifying_key();
-            // Derive the contract id from the
-            // CURRENT bundled room-contract WASM,
-            // NOT from `room_data.contract_key`.
-            // `room_data.contract_key` is the
-            // contract id captured at the time
-            // the room was last saved to the
-            // delegate's `rooms_data` blob — if
-            // the bundled WASM has changed since
-            // then, `Rooms::merge()` (called from
-            // the deferred closure below) will
-            // call `regenerate_contract_key()`
-            // and migrate the key to the new
-            // WASM's hash. Using the stale
-            // pre-merge key here would subscribe
-            // the delegate to the OLD contract,
-            // which no longer exists on the
-            // network — defeating the entire
-            // Bug #6 fix on any cold-load that
-            // happens to coincide with a
-            // room-contract WASM rebuild. Codex
-            // P1 finding on PR #276 round 2.
-            let contract_id_for_owner: Option<[u8; 32]> = if owns_room {
-                Some(**crate::util::owner_vk_to_contract_key(&room_data.owner_vk).id())
-            } else {
-                None
-            };
-            (
-                *key,
-                room_data.room_key(),
-                room_data.self_sk.clone(),
-                contract_id_for_owner,
-            )
-        })
-        .collect();
-
     // Merge the loaded rooms with the current rooms
+    let loaded_keys = room_keys.clone();
     crate::util::defer(move || {
         ROOMS.with_mut(|current_rooms| {
-            if let Err(e) = current_rooms.merge(loaded_rooms) {
+            // Ranked by SOURCE, not arrival order (freenet/river#527): the
+            // legacy fan-out hydrates from every delegate generation at once,
+            // so an identity conflict is decided by which generation the copy
+            // came from.
+            let merged = crate::components::app::chat_delegate::with_identity_source_ranks(
+                |identity_ranks| {
+                    current_rooms.merge_from_source(loaded_rooms, source_rank, identity_ranks)
+                },
+            );
+            if let Err(e) = merged {
                 error!("Failed to merge rooms: {}", e);
             } else {
                 info!("Successfully merged rooms from delegate");
@@ -1524,119 +1506,161 @@ fn hydrate_loaded_rooms(loaded_rooms: Rooms, is_legacy_delegate: bool, attempt: 
         update_document_title();
     });
 
-    // Migrate signing keys to delegate for each loaded room
-    // (uses pre-extracted signing_keys since ROOMS merge is deferred)
-    info!(
-        "Migrating signing keys to delegate for {} rooms",
-        signing_keys.len()
-    );
-    for (room_key, delegate_room_key, signing_key, owner_contract_id) in &signing_keys {
-        {
-            // Spawn async migration task via
-            // `safe_spawn_local`: per AGENTS.md
-            // "Dioxus WASM Signal Safety", direct
-            // `spawn_local` from inside a polled
-            // future causes RefCell re-entrancy
-            // panics on Firefox mobile.
-            let room_key_copy = *room_key;
-            let delegate_room_key = *delegate_room_key;
-            let signing_key = signing_key.clone();
-            let owner_contract_id = *owner_contract_id;
-            crate::util::safe_spawn_local(async move {
-                let result =
+    // Migrate signing keys to delegate for each loaded room.
+    //
+    // DEFERRED so it runs AFTER the merge above — both go through
+    // `crate::util::defer` (setTimeout(0), FIFO), the same ordering
+    // `mark_needs_sync` below already relies on — and reads the identity that
+    // actually WON that merge rather than the one this particular response
+    // happened to carry (freenet/river#527).
+    //
+    // Reading it BEFORE the merge was the second half of the rollback: when the
+    // merge KEPT a different identity for a room, this loop still pushed the
+    // incoming (losing) key to the delegate, and `migrate_signing_key`
+    // overwrites on mismatch ("Delegate has stale key for room") — so the
+    // delegate was left signing with an identity the UI had already rejected,
+    // and every signature it produced was invalid for the room.
+    let loaded_keys_for_signing = loaded_keys;
+    crate::util::defer(move || {
+        let signing_keys: Vec<_> = {
+            let rooms = ROOMS.peek();
+            loaded_keys_for_signing
+                .iter()
+                .filter_map(|vk| {
+                    // Absent => the merge dropped this room (tombstoned, or an
+                    // identity conflict it resolved against this copy). Nothing
+                    // to migrate; pushing a key for it is exactly the bug above.
+                    let room_data = rooms.map.get(vk)?;
+                    let owns_room = room_data.owner_vk == room_data.self_sk.verifying_key();
+                    // Derive the contract id from the CURRENT bundled
+                    // room-contract WASM so an owner-mode subscription can't
+                    // target a contract generation that no longer exists
+                    // (Codex P1 on PR #276 round 2).
+                    let contract_id_for_owner: Option<[u8; 32]> = if owns_room {
+                        Some(**crate::util::owner_vk_to_contract_key(&room_data.owner_vk).id())
+                    } else {
+                        None
+                    };
+                    Some((
+                        *vk,
+                        room_data.room_key(),
+                        room_data.self_sk.clone(),
+                        contract_id_for_owner,
+                    ))
+                })
+                .collect()
+        };
+        info!(
+            "Migrating signing keys to delegate for {} rooms",
+            signing_keys.len()
+        );
+        for (room_key, delegate_room_key, signing_key, owner_contract_id) in &signing_keys {
+            {
+                // Spawn async migration task via
+                // `safe_spawn_local`: per AGENTS.md
+                // "Dioxus WASM Signal Safety", direct
+                // `spawn_local` from inside a polled
+                // future causes RefCell re-entrancy
+                // panics on Firefox mobile.
+                let room_key_copy = *room_key;
+                let delegate_room_key = *delegate_room_key;
+                let signing_key = signing_key.clone();
+                let owner_contract_id = *owner_contract_id;
+                crate::util::safe_spawn_local(async move {
+                    let result =
                     // HYDRATION: startup LoadRooms re-migrating an already-stored
                     // key — NOT a new identity choice, so it must not override the
                     // registry and is discarded if superseded (freenet/river#414 P1).
                     crate::signing::migrate_signing_key(delegate_room_key, &signing_key, false)
                         .await;
 
-                if result != crate::signing::MigrationResult::Failed {
-                    // Must defer signal mutations from spawn_local to
-                    // avoid RefCell already borrowed panics in Dioxus runtime
-                    let migrated_key = signing_key.clone();
-                    crate::util::defer(move || {
-                        let mut sanitized = false;
-                        ROOMS.with_mut(|rooms| {
-                            if let Some(room_data) = rooms.map.get_mut(&room_key_copy) {
-                                // Only mark migrated for the identity that actually
-                                // completed: an overwrite may have replaced `self_sk`
-                                // while this migration ran, and marking the room
-                                // migrated for a superseded key would strand the new
-                                // identity (freenet/river#414).
-                                if room_data.self_sk != migrated_key {
-                                    return;
+                    if result != crate::signing::MigrationResult::Failed {
+                        // Must defer signal mutations from spawn_local to
+                        // avoid RefCell already borrowed panics in Dioxus runtime
+                        let migrated_key = signing_key.clone();
+                        crate::util::defer(move || {
+                            let mut sanitized = false;
+                            ROOMS.with_mut(|rooms| {
+                                if let Some(room_data) = rooms.map.get_mut(&room_key_copy) {
+                                    // Only mark migrated for the identity that actually
+                                    // completed: an overwrite may have replaced `self_sk`
+                                    // while this migration ran, and marking the room
+                                    // migrated for a superseded key would strand the new
+                                    // identity (freenet/river#414).
+                                    if room_data.self_sk != migrated_key {
+                                        return;
+                                    }
+                                    room_data.key_migrated_to_delegate = true;
+                                    let params = river_core::room_state::ChatRoomParametersV1 {
+                                        owner: room_key_copy,
+                                    };
+                                    let removed = crate::signing::remove_unverifiable_messages(
+                                        &mut room_data.room_state,
+                                        &params,
+                                    );
+                                    sanitized = removed > 0;
                                 }
-                                room_data.key_migrated_to_delegate = true;
-                                let params = river_core::room_state::ChatRoomParametersV1 {
-                                    owner: room_key_copy,
-                                };
-                                let removed = crate::signing::remove_unverifiable_messages(
-                                    &mut room_data.room_state,
-                                    &params,
-                                );
-                                sanitized = removed > 0;
+                            });
+                            if sanitized {
+                                crate::components::app::mark_needs_sync(room_key_copy);
                             }
                         });
-                        if sanitized {
-                            crate::components::app::mark_needs_sync(room_key_copy);
-                        }
-                    });
-                }
+                    }
 
-                // For owner-mode rooms, chain
-                // EnsureRoomSubscription onto
-                // the (just-completed) signing
-                // key migration. Sequencing
-                // ensures the delegate's
-                // "no signing key on file"
-                // reject path can't trip on a
-                // race with `StoreSigningKey`
-                // (Bug #6). The
-                // `migrate_signing_key` call
-                // above either confirmed an
-                // existing key or stored a
-                // fresh one, so the delegate's
-                // signing-key probe will
-                // succeed by the time
-                // EnsureRoomSubscription lands.
-                //
-                // Skip on `MigrationResult::Failed`:
-                // a Failed migration means
-                // the delegate refused to
-                // confirm/store the signing
-                // key (transport down,
-                // delegate not registered,
-                // or signature mismatch), so
-                // `EnsureRoomSubscription`
-                // would either be rejected
-                // with the same "no signing
-                // key on file" error or
-                // simply time out. Firing
-                // anyway produced log spam
-                // per cold-load × per
-                // owned-room when the delegate
-                // was persistently
-                // unreachable (PR #276
-                // review feedback). The
-                // trade-off: we lose the
-                // theoretical "stale key
-                // still on file even though
-                // verify failed" recovery
-                // path, but in practice
-                // that's vanishingly rare,
-                // and the next cold-load
-                // after the user reconnects
-                // will retry from scratch
-                // (the per-session dedup
-                // resets across reloads).
-                if let Some(contract_id) = owner_contract_id {
-                    if result == crate::signing::MigrationResult::Failed {
-                        warn!(
+                    // For owner-mode rooms, chain
+                    // EnsureRoomSubscription onto
+                    // the (just-completed) signing
+                    // key migration. Sequencing
+                    // ensures the delegate's
+                    // "no signing key on file"
+                    // reject path can't trip on a
+                    // race with `StoreSigningKey`
+                    // (Bug #6). The
+                    // `migrate_signing_key` call
+                    // above either confirmed an
+                    // existing key or stored a
+                    // fresh one, so the delegate's
+                    // signing-key probe will
+                    // succeed by the time
+                    // EnsureRoomSubscription lands.
+                    //
+                    // Skip on `MigrationResult::Failed`:
+                    // a Failed migration means
+                    // the delegate refused to
+                    // confirm/store the signing
+                    // key (transport down,
+                    // delegate not registered,
+                    // or signature mismatch), so
+                    // `EnsureRoomSubscription`
+                    // would either be rejected
+                    // with the same "no signing
+                    // key on file" error or
+                    // simply time out. Firing
+                    // anyway produced log spam
+                    // per cold-load × per
+                    // owned-room when the delegate
+                    // was persistently
+                    // unreachable (PR #276
+                    // review feedback). The
+                    // trade-off: we lose the
+                    // theoretical "stale key
+                    // still on file even though
+                    // verify failed" recovery
+                    // path, but in practice
+                    // that's vanishingly rare,
+                    // and the next cold-load
+                    // after the user reconnects
+                    // will retry from scratch
+                    // (the per-session dedup
+                    // resets across reloads).
+                    if let Some(contract_id) = owner_contract_id {
+                        if result == crate::signing::MigrationResult::Failed {
+                            warn!(
                                 "Skipping EnsureRoomSubscription for {:?} — signing-key migration failed (delegate likely unreachable). Will retry on next cold load.",
                                 delegate_room_key
                             );
-                    } else {
-                        match crate::components::app::chat_delegate::ensure_room_subscription_once(
+                        } else {
+                            match crate::components::app::chat_delegate::ensure_room_subscription_once(
                                 delegate_room_key,
                                 contract_id,
                             )
@@ -1655,11 +1679,12 @@ fn hydrate_loaded_rooms(loaded_rooms: Rooms, is_legacy_delegate: bool, attempt: 
                                     e
                                 ),
                             }
+                        }
                     }
-                }
-            });
+                });
+            }
         }
-    }
+    });
 
     // Mark all loaded rooms as having completed initial sync
     // and subscribe to receive updates
@@ -1753,7 +1778,16 @@ fn hydrate_loaded_rooms(loaded_rooms: Rooms, is_legacy_delegate: bool, attempt: 
                 Ok(_) => {
                     info!("Successfully migrated room data to new delegate");
                     clear_legacy_migration_in_progress();
-                    mark_legacy_migration_done();
+                    // Seal only once the whole legacy fan-out has gone quiet —
+                    // NOT here (freenet/river#527). Every generation is probed
+                    // at once; sealing on the FIRST one to finish its re-save
+                    // ends the migration for good while newer generations may
+                    // still be answering. If the tab closed in that window, the
+                    // current delegate was left holding the older copy, it is
+                    // now non-empty, and no later session ever re-probes — which
+                    // is what turned a transient identity rollback into a
+                    // permanent one.
+                    request_legacy_seal_on_quiescence();
                     // Review 11: this runs after the save await, so gate on the
                     // captured attempt (a reconnect/retry may have superseded us).
                     if had_loaded_rooms {
@@ -2265,11 +2299,24 @@ mod tests {
             "no bare mark_fetch_failure — all attempt-scoped via worker.mark_fetch_failure"
         );
         // hydrate threads the attempt through, and its legacy writes are gated.
+        // Whitespace-stripped: the signature is long enough that rustfmt splits
+        // it across lines, and a contiguous needle would go vacuously false the
+        // next time a parameter is added.
+        let strip_ws = |s: &str| -> String { s.chars().filter(|c| !c.is_whitespace()).collect() };
+        let squeezed = strip_ws(production);
+        let signature = strip_ws(concat!(
+            "fn hydrate_loaded_rooms(",
+            " loaded_rooms: Rooms,",
+            " is_legacy_delegate: bool,",
+            " source_rank: u32,",
+            " attempt: u32,",
+            ")"
+        ));
         assert!(
-            production.contains(
-                "fn hydrate_loaded_rooms(loaded_rooms: Rooms, is_legacy_delegate: bool, attempt: u32)"
-            ),
-            "hydrate_loaded_rooms must take an attempt to gate its legacy load-state writes"
+            squeezed.contains(&signature),
+            "hydrate_loaded_rooms must take an attempt to gate its legacy load-state writes, \
+             and a source_rank so identity conflicts are resolved by delegate generation \
+             rather than response arrival order (freenet/river#527)"
         );
         assert!(
             production.contains("set_load_state_if_current(attempt, RoomsLoadState::Migrating)"),
@@ -2937,5 +2984,86 @@ mod tests {
         assert!(recovered.removed_rooms.contains(&left));
         assert_eq!(recovered.current_room_key, Some(present_b));
         assert_eq!(recovered.room_order, vec![present_b, present_a]);
+    }
+
+    /// freenet/river#527 (second cause): the signing key pushed to the delegate
+    /// must be the identity that WON the merge, not the one this particular
+    /// delegate response happened to carry.
+    ///
+    /// The extraction used to run BEFORE the (deferred) merge, straight off
+    /// `loaded_rooms`. So when the merge kept a different identity for a room —
+    /// or dropped it — this still pushed the losing key, and
+    /// `migrate_signing_key` overwrites on mismatch. The delegate was left
+    /// signing with an identity the UI had already rejected, which invalidates
+    /// every signature it produces for that room.
+    #[test]
+    fn signing_key_migration_reads_the_merged_rooms_not_the_loaded_copy() {
+        let src = include_str!("response_handler.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+
+        let start = production
+            .find("let loaded_keys_for_signing = loaded_keys;")
+            .expect("the signing-key migration block must exist");
+        let end = production[start..]
+            .find("// Mark all loaded rooms as having completed initial sync")
+            .expect("the block's end marker must exist");
+        let block = &production[start..start + end];
+
+        assert!(
+            block.contains("crate::util::defer("),
+            "the signing-key migration must be DEFERRED so it runs after the merge"
+        );
+        assert!(
+            block.contains("ROOMS.peek()"),
+            "it must read the MERGED rooms to learn which identity won"
+        );
+        assert!(
+            !block.contains("loaded_rooms"),
+            "it must NOT read the pre-merge loaded copy — that is the #527 bug: \
+             pushing an identity the merge rejected over the good one"
+        );
+        assert!(
+            block.contains("migrate_signing_key"),
+            "guard against this pin going vacuous if the block is renamed away"
+        );
+    }
+
+    /// freenet/river#527 (third cause): a legacy migration seals only once the
+    /// whole fan-out is quiescent.
+    ///
+    /// Sealing inside the re-save ended the migration as soon as the FIRST
+    /// generation finished, while newer generations could still be answering.
+    /// Close the tab in that window and the current delegate is left holding
+    /// the older copy — non-empty, so no later session re-probes legacy — which
+    /// is what made an identity rollback permanent rather than transient.
+    #[test]
+    fn legacy_resave_defers_the_seal_to_quiescence() {
+        let src = include_str!("response_handler.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+
+        let ok_arm = production
+            .find("Successfully migrated room data to new delegate")
+            .expect("legacy re-save success marker must exist");
+        // Bounded to the Ok arm itself, before the Err arm's marker.
+        let arm_end = production[ok_arm..]
+            .find("Failed to migrate room data to new delegate")
+            .expect("the Err arm marker must follow the Ok arm");
+        let arm = &production[ok_arm..ok_arm + arm_end];
+
+        assert!(
+            arm.contains("request_legacy_seal_on_quiescence()"),
+            "the legacy re-save must request a quiescence-gated seal"
+        );
+        assert!(
+            !arm.contains("mark_legacy_migration_done("),
+            "it must NOT seal inline — that ends the migration while newer \
+             delegate generations may still be answering (freenet/river#527)"
+        );
     }
 }

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -18,9 +18,9 @@ use crate::components::app::chat_delegate::{
     enqueue_delegate_request, fire_legacy_migration_request, get_versioned_correlation_key,
     hydrate_hidden_dm_threads, hydrate_outbound_dms_cache, is_legacy_delegate_key,
     is_legacy_migration_in_progress, legacy_scoped_correlation, load_state_after_probe_legacy,
-    mark_legacy_migration_done, mark_legacy_migration_in_progress, parse_room_storage_key,
-    per_room_terminal, prune_outbound_dms_for_purges, request_legacy_seal_on_quiescence,
-    room_storage_key, save_outbound_dms_to_delegate, save_rooms_to_delegate, send_delegate_request,
+    mark_legacy_migration_in_progress, parse_room_storage_key, per_room_terminal,
+    prune_outbound_dms_for_purges, request_legacy_seal_on_quiescence, room_storage_key,
+    save_outbound_dms_to_delegate, save_rooms_to_delegate, send_delegate_request,
     send_delegate_request_to, set_load_state_if_current, source_rank_for_delegate_key,
     LegacyMigrationAction, LoadWorkerGuard, PendingDelegateRequest, RoomsLoadState,
     OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY, ROOMS_STORAGE_KEY,
@@ -349,7 +349,7 @@ impl ResponseHandler {
                                                                     info!(
                                                                         "Current delegate has rooms_data — marking legacy migration done"
                                                                     );
-                                                                    mark_legacy_migration_done();
+                                                                    request_legacy_seal_on_quiescence();
                                                                     info!("Successfully loaded rooms from delegate");
                                                                 }
                                                                 LegacyMigrationAction::FireMigration => {
@@ -714,7 +714,7 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
             let migration_interrupted = is_legacy_migration_in_progress();
             let action = decide_per_room_load_action(migration_interrupted);
             if action.mark_done {
-                mark_legacy_migration_done();
+                request_legacy_seal_on_quiescence();
             }
 
             // Defensive dedup (PR #419 review): the concurrent fan-out registers
@@ -1075,7 +1075,7 @@ async fn migrate_current_blob_to_per_room(recovery: bool) {
                     match save_rooms_to_delegate().await {
                         Ok(_) => {
                             clear_legacy_migration_in_progress();
-                            mark_legacy_migration_done();
+                            request_legacy_seal_on_quiescence();
                             // Resolve to `Loaded` only if we merged live rooms;
                             // otherwise let the backstop own the terminal.
                             if had_rooms {

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -1406,8 +1406,10 @@ fn hydrate_loaded_rooms(
         }
     }
 
-    // Collect room keys and signing keys before merge
-    // (must extract before loaded_rooms is moved into defer)
+    // Collect the room keys before the merge, since `loaded_rooms` is moved
+    // into the deferred merge below. These are the rooms THIS response brought;
+    // the identity each one ends up with is whatever the merge settles on, read
+    // back afterwards (freenet/river#527).
     // Filter out tombstoned rooms so we don't
     // re-subscribe / re-sync rooms the user
     // explicitly left (skeptical-review H1).

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -18,9 +18,9 @@ use crate::components::app::chat_delegate::{
     enqueue_delegate_request, fire_legacy_migration_request, get_versioned_correlation_key,
     hydrate_hidden_dm_threads, hydrate_outbound_dms_cache, is_legacy_delegate_key,
     is_legacy_migration_in_progress, legacy_scoped_correlation, load_state_after_probe_legacy,
-    mark_legacy_migration_in_progress, parse_room_storage_key, per_room_terminal,
-    prune_outbound_dms_for_purges, request_legacy_seal_on_quiescence, room_storage_key,
-    save_outbound_dms_to_delegate, save_rooms_to_delegate, send_delegate_request,
+    mark_legacy_migration_done, mark_legacy_migration_in_progress, parse_room_storage_key,
+    per_room_terminal, prune_outbound_dms_for_purges, request_legacy_seal_on_quiescence,
+    room_storage_key, save_outbound_dms_to_delegate, save_rooms_to_delegate, send_delegate_request,
     send_delegate_request_to, set_load_state_if_current, source_rank_for_delegate_key,
     LegacyMigrationAction, LoadWorkerGuard, PendingDelegateRequest, RoomsLoadState,
     OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY, ROOMS_STORAGE_KEY,
@@ -349,7 +349,16 @@ impl ResponseHandler {
                                                                     info!(
                                                                         "Current delegate has rooms_data — marking legacy migration done"
                                                                     );
-                                                                    request_legacy_seal_on_quiescence();
+                                                                    // SYNCHRONOUS, deliberately. This door is not a
+                                                                    // migration completion — the current delegate is
+                                                                    // authoritative and its sibling arm is the one that
+                                                                    // fires the fan-out, so there are no probes in
+                                                                    // flight to wait for. Deferring it behind the
+                                                                    // debounce would buy nothing and would weaken the
+                                                                    // freenet/river#253 guard, since a reconnect inside
+                                                                    // the window cancels the pending seal and could let
+                                                                    // the fan-out fire for a user who HAS data.
+                                                                    mark_legacy_migration_done();
                                                                     info!("Successfully loaded rooms from delegate");
                                                                 }
                                                                 LegacyMigrationAction::FireMigration => {
@@ -714,7 +723,13 @@ async fn load_rooms_per_room(keys: Vec<ChatDelegateKey>) {
             let migration_interrupted = is_legacy_migration_in_progress();
             let action = decide_per_room_load_action(migration_interrupted);
             if action.mark_done {
-                request_legacy_seal_on_quiescence();
+                // SYNCHRONOUS, deliberately — see the rooms_data door above.
+                // The per-room set being authoritative is precisely the
+                // freenet/river#253 condition under which legacy must never be
+                // probed; a deferred seal here is cancellable by a reconnect and
+                // would re-open that. When this fires, `migration_interrupted`
+                // is false, so no recovery re-probe is pending either.
+                mark_legacy_migration_done();
             }
 
             // Defensive dedup (PR #419 review): the concurrent fan-out registers

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -2306,16 +2306,16 @@ mod tests {
         // next time a parameter is added.
         let strip_ws = |s: &str| -> String { s.chars().filter(|c| !c.is_whitespace()).collect() };
         let squeezed = strip_ws(production);
-        let signature = strip_ws(concat!(
-            "fn hydrate_loaded_rooms(",
-            " loaded_rooms: Rooms,",
-            " is_legacy_delegate: bool,",
-            " source_rank: u32,",
-            " attempt: u32,",
-            ")"
-        ));
+        // Matched piecewise, WITHOUT the closing paren: rustfmt drops the
+        // trailing comma if the signature ever fits on one line, which would
+        // fail a whole-signature needle spuriously.
+        let has_param = |p: &str| squeezed.contains(&strip_ws(p));
         assert!(
-            squeezed.contains(&signature),
+            has_param("fn hydrate_loaded_rooms(")
+                && has_param("loaded_rooms: Rooms,")
+                && has_param("is_legacy_delegate: bool,")
+                && has_param("source_rank: u32,")
+                && has_param("attempt: u32"),
             "hydrate_loaded_rooms must take an attempt to gate its legacy load-state writes, \
              and a source_rank so identity conflicts are resolved by delegate generation \
              rather than response arrival order (freenet/river#527)"
@@ -3027,9 +3027,87 @@ mod tests {
             "it must NOT read the pre-merge loaded copy — that is the #527 bug: \
              pushing an identity the merge rejected over the good one"
         );
+        // Anti-vacuity: match the actual CALL, not the words. The previous
+        // needle ("migrate_signing_key") also matched a comment further down,
+        // so deleting the real call left this pin green.
+        let squeeze = |s: &str| -> String { s.chars().filter(|c| !c.is_whitespace()).collect() };
         assert!(
-            block.contains("migrate_signing_key"),
-            "guard against this pin going vacuous if the block is renamed away"
+            squeeze(block).contains(&squeeze(
+                "crate::signing::migrate_signing_key(delegate_room_key, &signing_key, false)"
+            )),
+            "the block must still make the real migrate_signing_key call — otherwise              this pin is guarding nothing"
+        );
+        // The skip-on-absent is the actual mechanism: a room the merge DROPPED
+        // (tombstoned, or an identity conflict resolved against this copy) must
+        // yield no signing key at all. Turn this `?` into a fallback and the
+        // second cause of #527 returns while every other assertion here holds.
+        assert!(
+            squeeze(block).contains(&squeeze("let room_data = rooms.map.get(vk)?;")),
+            "a room absent from the merged map must be SKIPPED, not defaulted —              pushing a key for it is exactly the identity the merge rejected"
+        );
+    }
+
+    /// freenet/river#527 — THE WIRING PIN.
+    ///
+    /// Every behavioural test for the fix lives at the `Rooms::merge_from_source`
+    /// layer and supplies its own ranks map, so they all keep passing if the
+    /// production CALL SITE stops feeding that layer real inputs. Two one-line
+    /// edits revert the entire fix with green CI:
+    ///
+    ///   1. `with_identity_source_ranks(...)` -> `&mut HashMap::new()`. Every
+    ///      conflict then reads `unwrap_or(SOURCE_RANK_AUTHORITATIVE)` for the
+    ///      local rank, so nothing ever outranks it and merge keeps local
+    ///      always — exactly the pre-fix behaviour.
+    ///   2. the threaded `source_rank` -> a constant. Every generation then
+    ///      ranks equal, equal ranks keep local, and first-responder-wins (the
+    ///      original bug) is back.
+    ///
+    /// So pin the wiring itself: the shared registry, the threaded rank, and
+    /// the per-generation rank at the legacy call site.
+    #[test]
+    fn hydrate_wires_the_shared_registry_and_a_per_generation_rank() {
+        let src = include_str!("response_handler.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+        let strip_ws = |s: &str| -> String { s.chars().filter(|c| !c.is_whitespace()).collect() };
+        let squeezed = strip_ws(production);
+
+        // (1) The merge reads the SHARED, process-global rank registry — not a
+        // throwaway map — so ranks recorded by one delegate generation's
+        // hydration are visible to the next one's.
+        assert!(
+            squeezed.contains(&strip_ws(
+                "chat_delegate::with_identity_source_ranks( |identity_ranks| {"
+            )),
+            "the merge must read the SHARED identity-source registry; a fresh map \
+             per hydration makes every conflict keep local and silently reverts #527"
+        );
+
+        // (2) The rank passed to the merge is the THREADED parameter.
+        assert!(
+            squeezed.contains(&strip_ws(
+                "current_rooms.merge_from_source(loaded_rooms, source_rank, identity_ranks)"
+            )),
+            "the merge must be given the threaded per-response source_rank"
+        );
+
+        // (3) The legacy per-room call site derives the rank from THAT
+        // delegate's key, so different generations actually get different
+        // ranks. A constant here collapses them and restores first-wins.
+        assert!(
+            squeezed.contains(&strip_ws(
+                "source_rank_for_delegate_key(legacy_key.bytes())"
+            )),
+            "the legacy per-room hydrate must rank by the responding delegate's own key"
+        );
+        // And the single-blob path ranks by the responding delegate too.
+        assert!(
+            squeezed.contains(&strip_ws(
+                "let delegate_source_rank = source_rank_for_delegate_key(key.bytes());"
+            )),
+            "the delegate-response path must capture the responding generation's rank"
         );
     }
 

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -417,6 +417,23 @@ pub async fn handle_get_response(
                 }
             };
 
+            // Rank this identity above every delegate generation IMMEDIATELY,
+            // synchronously, before the deferred insert below (freenet/river#527).
+            //
+            // Accepting an invitation is a deliberate identity choice, so no
+            // delegate copy may outrank it. The spawned `migrate_signing_key(..,
+            // true)` further down also marks it, but only from inside a task:
+            // that leaves a window where ROOMS carries the new identity while
+            // the registry still holds a stale rank from an earlier load of the
+            // same room (a same-session leave-then-rejoin), and a legacy
+            // generation ranked above that stale value would adopt its identity
+            // over the one just accepted. `complete_identity_import` marks
+            // synchronously for exactly this reason; the two rejoin paths must
+            // agree.
+            crate::components::app::chat_delegate::mark_identity_source_authoritative(
+                owner_vk.to_bytes(),
+            );
+
             // Update the room data
             crate::util::defer(move || {
                 ROOMS.with_mut(|rooms| {

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -2108,6 +2108,14 @@ fn complete_identity_import(
     let new_sk = export.signing_key.clone();
     let room_key_bytes = owner_key.to_bytes();
 
+    // Rank this identity above every delegate generation IMMEDIATELY —
+    // synchronously, before the deferred swap below and before the spawned
+    // `migrate_signing_key` (which marks it too). Merge resolves identity
+    // conflicts by source rank (freenet/river#527), and a legacy response can
+    // land in the window between this call and the swap; marking here means
+    // such a response loses the conflict instead of undoing the import.
+    crate::components::app::chat_delegate::mark_identity_source_authoritative(room_key_bytes);
+
     // Defer signal mutations to a clean execution context to prevent RefCell
     // re-entrant borrow panics.
     //

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -32,6 +32,69 @@ pub enum SendMessageError {
     UserBanned,
 }
 
+/// Rank of an identity the user chose DELIBERATELY (identity import,
+/// invitation-accept) rather than one loaded from a delegate. Outranks every
+/// delegate generation, so no load can overwrite an explicit choice
+/// (freenet/river#414).
+pub const SOURCE_RANK_AUTHORITATIVE: u32 = u32::MAX;
+
+/// What to do with an incoming room copy whose `self_sk` differs from the copy
+/// already in memory.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum IdentityChoice {
+    /// Keep the identity already in memory.
+    KeepLocal,
+    /// The incoming copy comes from a strictly more authoritative source —
+    /// adopt its identity (merging the local state into it, so no messages are
+    /// lost).
+    AdoptIncoming,
+}
+
+/// Decide an identity conflict by SOURCE AUTHORITY rather than arrival order
+/// (freenet/river#527).
+///
+/// Ranks are delegate generations (see
+/// `chat_delegate::source_rank_for_delegate_key`): higher is newer. A strictly
+/// newer source wins; anything else keeps what is already in memory.
+///
+/// Equal ranks deliberately keep local. Two copies from the SAME source that
+/// disagree can't be ordered, and that case is the freenet/river#414 race — a
+/// delegate load issued before an identity overwrite still carrying the old
+/// `self_sk` — where local is the newer one.
+pub fn resolve_identity_conflict(local_rank: u32, incoming_rank: u32) -> IdentityChoice {
+    if incoming_rank > local_rank {
+        IdentityChoice::AdoptIncoming
+    } else {
+        IdentityChoice::KeepLocal
+    }
+}
+
+/// Record which source supplied a room's in-memory identity, so a later copy
+/// can be ranked against it.
+///
+/// Never DOWNGRADES: a room already in memory with no recorded rank was created
+/// or imported in-session (authoritative, see [`SOURCE_RANK_AUTHORITATIVE`]),
+/// and stamping it with a loading source's rank would make an explicit user
+/// choice overwritable by the next delegate response.
+pub fn record_identity_source(
+    identity_ranks: &mut HashMap<RoomKey, u32>,
+    vk: &VerifyingKey,
+    source_rank: u32,
+    was_vacant: bool,
+) {
+    let key = vk.to_bytes();
+    match identity_ranks.get(&key).copied() {
+        Some(existing) if source_rank > existing => {
+            identity_ranks.insert(key, source_rank);
+        }
+        Some(_) => {}
+        None if was_vacant => {
+            identity_ranks.insert(key, source_rank);
+        }
+        None => {}
+    }
+}
+
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct RoomData {
     pub owner_vk: VerifyingKey,
@@ -1756,6 +1819,29 @@ impl Rooms {
     /// rooms that DID merge in that pass, so a private room can render
     /// "[Encrypted message - secret vN not available]" until a clean reload.
     pub fn merge(&mut self, other: Rooms) -> Result<(), String> {
+        // Single-source merge: rank the incoming copy equal to whatever is
+        // already in memory, so an identity conflict always keeps local — the
+        // pre-freenet/river#527 behaviour. Multi-source loads (the legacy
+        // delegate fan-out) must call `merge_from_source` so generations can be
+        // ordered.
+        let mut ranks = HashMap::new();
+        self.merge_from_source(other, SOURCE_RANK_AUTHORITATIVE, &mut ranks)
+    }
+
+    /// Merge a copy of the user's rooms that came from a specific source,
+    /// ranked by [`resolve_identity_conflict`] (freenet/river#527).
+    ///
+    /// `identity_ranks` records which source supplied the identity each room in
+    /// `self` currently carries, so a copy arriving later from a NEWER delegate
+    /// generation can correct one that merely arrived FIRST. A room already in
+    /// memory with no recorded rank is treated as authoritative (it was created
+    /// or imported in-session, not loaded), so it is never downgraded.
+    pub fn merge_from_source(
+        &mut self,
+        other: Rooms,
+        source_rank: u32,
+        identity_ranks: &mut HashMap<RoomKey, u32>,
+    ) -> Result<(), String> {
         // Tombstones first: take the union before anything else, so the
         // filter below sees the combined set.
         for vk in other.removed_rooms {
@@ -1798,15 +1884,38 @@ impl Rooms {
             // still abort the whole merge and drop unrelated rooms. This is a
             // genuine robustness guard, NOT scaffolding for the deleted empty
             // room.
+            // Identity conflict: decide by SOURCE AUTHORITY, not arrival order
+            // (freenet/river#527). A strictly newer delegate generation wins;
+            // anything else keeps the local identity.
+            let mut adopt_incoming_identity = false;
             if let Some(existing) = self.map.get(&vk) {
                 if existing.self_sk != room_data.self_sk {
                     use dioxus::logger::tracing::warn;
-                    warn!(
-                        "merge: skipping room with conflicting self_sk (kept local \
-                         identity) — likely a stale in-flight load during an \
-                         identity overwrite (freenet/river#414)"
-                    );
-                    continue;
+                    let local_rank = identity_ranks
+                        .get(&vk.to_bytes())
+                        .copied()
+                        .unwrap_or(SOURCE_RANK_AUTHORITATIVE);
+                    match resolve_identity_conflict(local_rank, source_rank) {
+                        IdentityChoice::KeepLocal => {
+                            warn!(
+                                "merge: keeping local identity for room with conflicting \
+                                 self_sk — incoming source rank {} does not outrank {} \
+                                 (freenet/river#414, #527)",
+                                source_rank, local_rank
+                            );
+                            continue;
+                        }
+                        IdentityChoice::AdoptIncoming => {
+                            warn!(
+                                "merge: adopting identity from a newer source for room \
+                                 with conflicting self_sk — incoming rank {} outranks {}. \
+                                 The local copy came from an older delegate generation \
+                                 that merely answered first (freenet/river#527)",
+                                source_rank, local_rank
+                            );
+                            adopt_incoming_identity = true;
+                        }
+                    }
                 }
             }
 
@@ -1822,19 +1931,46 @@ impl Rooms {
                 self.migrated_rooms.push((vk, old_contract_key));
             }
 
-            // If not already in the map, add the room
-            if let std::collections::hash_map::Entry::Vacant(e) = self.map.entry(vk) {
-                e.insert(room_data);
-            } else {
-                // Already present with a matching `self_sk` (the conflict case
-                // was skipped above) — merge in the new state.
-                let self_room_data = self.map.get_mut(&vk).unwrap();
-                self_room_data.room_state.merge(
-                    &self_room_data.room_state.clone(),
+            if adopt_incoming_identity {
+                // Fold the local (older-identity) state INTO the incoming copy
+                // before it replaces it, so adopting the newer identity never
+                // costs messages the older copy had.
+                let existing = self
+                    .map
+                    .remove(&vk)
+                    .expect("AdoptIncoming implies the room is present");
+                room_data.room_state.merge(
+                    &room_data.room_state.clone(),
                     &ChatRoomParametersV1 { owner: vk },
-                    &room_data.room_state,
+                    &existing.room_state,
                 )?;
+                self.map.insert(vk, room_data);
+                record_identity_source(
+                    identity_ranks,
+                    &vk,
+                    source_rank,
+                    /* was_vacant */ true,
+                );
+                continue;
             }
+
+            // If not already in the map, add the room
+            let was_vacant =
+                if let std::collections::hash_map::Entry::Vacant(e) = self.map.entry(vk) {
+                    e.insert(room_data);
+                    true
+                } else {
+                    // Already present with a matching `self_sk` (the conflict
+                    // case was resolved above) — merge in the new state.
+                    let self_room_data = self.map.get_mut(&vk).unwrap();
+                    self_room_data.room_state.merge(
+                        &self_room_data.room_state.clone(),
+                        &ChatRoomParametersV1 { owner: vk },
+                        &room_data.room_state,
+                    )?;
+                    false
+                };
+            record_identity_source(identity_ranks, &vk, source_rank, was_vacant);
         }
 
         // Room display order: this device's order is authoritative (a local
@@ -2414,6 +2550,311 @@ mod tests {
             local.map.get(&vk_c).unwrap().self_sk.to_bytes(),
             new_sk_c.to_bytes(),
             "the conflicting room must keep the local (current) identity"
+        );
+    }
+
+    // =====================================================================
+    // freenet/river#527 — identity conflicts resolve by DELEGATE GENERATION,
+    // not by which probe answered first.
+    //
+    // `fire_legacy_migration_request` probes every legacy generation at once
+    // and each hydrates independently, so for a long-time user whose rooms
+    // exist under many generations these merges arrive in a racy order —
+    // dispatched oldest-first, so the oldest copy usually lands first.
+    // =====================================================================
+
+    fn empty_rooms_for_merge() -> Rooms {
+        Rooms {
+            map: HashMap::new(),
+            current_room_key: None,
+            removed_rooms: std::collections::HashSet::new(),
+            notification_modes: Default::default(),
+            room_order: Vec::new(),
+            migrated_rooms: Vec::new(),
+        }
+    }
+
+    fn rooms_holding(vk: VerifyingKey, room: RoomData) -> Rooms {
+        let mut rooms = empty_rooms_for_merge();
+        rooms.map.insert(vk, room);
+        rooms
+    }
+
+    #[test]
+    fn resolve_identity_conflict_prefers_a_strictly_newer_source() {
+        assert_eq!(
+            resolve_identity_conflict(5, 20),
+            IdentityChoice::AdoptIncoming,
+            "a newer delegate generation must win"
+        );
+        assert_eq!(
+            resolve_identity_conflict(20, 5),
+            IdentityChoice::KeepLocal,
+            "an older delegate generation must lose"
+        );
+        assert_eq!(
+            resolve_identity_conflict(7, 7),
+            IdentityChoice::KeepLocal,
+            "same source can't be ordered — keep local (the #414 stale-load race)"
+        );
+        assert_eq!(
+            resolve_identity_conflict(SOURCE_RANK_AUTHORITATIVE, 999),
+            IdentityChoice::KeepLocal,
+            "a deliberate identity choice outranks every delegate generation (#414)"
+        );
+    }
+
+    /// THE #527 REGRESSION. Ivvor's case: an old delegate generation answers
+    /// first and seeds the room with a years-old identity; the current
+    /// generation's copy arrives second carrying the identity the user
+    /// actually uses. Before the fix the second was dropped as "conflicting"
+    /// and the user was rolled back.
+    #[test]
+    fn a_later_arriving_newer_generation_corrects_an_older_one_that_answered_first() {
+        let mut rng = rand::thread_rng();
+        let owner = SigningKey::generate(&mut rng);
+        let vk = owner.verifying_key();
+        let old_identity = SigningKey::generate(&mut rng);
+        let current_identity = SigningKey::generate(&mut rng);
+        assert_ne!(old_identity.to_bytes(), current_identity.to_bytes());
+
+        let mut local = empty_rooms_for_merge();
+        let mut ranks = HashMap::new();
+
+        // The oldest generation (rank 3) answers first.
+        local
+            .merge_from_source(
+                rooms_holding(vk, make_rejoin_test_room(&owner, &old_identity, true)),
+                3,
+                &mut ranks,
+            )
+            .expect("first merge");
+        assert_eq!(
+            local.map.get(&vk).unwrap().self_sk.to_bytes(),
+            old_identity.to_bytes(),
+            "precondition: the first responder seeds the room"
+        );
+
+        // The current delegate (rank 30) answers second.
+        local
+            .merge_from_source(
+                rooms_holding(vk, make_rejoin_test_room(&owner, &current_identity, true)),
+                30,
+                &mut ranks,
+            )
+            .expect("second merge");
+
+        assert_eq!(
+            local.map.get(&vk).unwrap().self_sk.to_bytes(),
+            current_identity.to_bytes(),
+            "the newer delegate generation must correct the identity the older one \
+             seeded — arrival order must not decide (freenet/river#527)"
+        );
+    }
+
+    /// The same two copies in the opposite arrival order must reach the SAME
+    /// result. Without this, the fix would merely move the race rather than
+    /// remove it.
+    #[test]
+    fn identity_resolution_is_independent_of_arrival_order() {
+        let mut rng = rand::thread_rng();
+        let owner = SigningKey::generate(&mut rng);
+        let vk = owner.verifying_key();
+        let old_identity = SigningKey::generate(&mut rng);
+        let current_identity = SigningKey::generate(&mut rng);
+
+        let mut local = empty_rooms_for_merge();
+        let mut ranks = HashMap::new();
+
+        // Newest first this time.
+        local
+            .merge_from_source(
+                rooms_holding(vk, make_rejoin_test_room(&owner, &current_identity, true)),
+                30,
+                &mut ranks,
+            )
+            .expect("first merge");
+        local
+            .merge_from_source(
+                rooms_holding(vk, make_rejoin_test_room(&owner, &old_identity, true)),
+                3,
+                &mut ranks,
+            )
+            .expect("second merge");
+
+        assert_eq!(
+            local.map.get(&vk).unwrap().self_sk.to_bytes(),
+            current_identity.to_bytes(),
+            "an older generation arriving later must not overwrite a newer one"
+        );
+    }
+
+    /// A deliberate identity choice (import / invitation-accept) is recorded as
+    /// authoritative and must survive a load from ANY delegate generation —
+    /// this is the freenet/river#414 guarantee, which the #527 fix must not
+    /// weaken now that merge is able to adopt an incoming identity.
+    #[test]
+    fn an_authoritative_identity_is_not_overwritten_by_any_generation() {
+        let mut rng = rand::thread_rng();
+        let owner = SigningKey::generate(&mut rng);
+        let vk = owner.verifying_key();
+        let imported = SigningKey::generate(&mut rng);
+        let from_delegate = SigningKey::generate(&mut rng);
+
+        let mut local = rooms_holding(vk, make_rejoin_test_room(&owner, &imported, true));
+        let mut ranks = HashMap::new();
+        ranks.insert(vk.to_bytes(), SOURCE_RANK_AUTHORITATIVE);
+
+        local
+            .merge_from_source(
+                rooms_holding(vk, make_rejoin_test_room(&owner, &from_delegate, true)),
+                u32::MAX - 1,
+                &mut ranks,
+            )
+            .expect("merge");
+
+        assert_eq!(
+            local.map.get(&vk).unwrap().self_sk.to_bytes(),
+            imported.to_bytes(),
+            "an explicitly-chosen identity must outrank every delegate generation (#414)"
+        );
+    }
+
+    /// A room already in memory with NO recorded provenance was created or
+    /// imported in-session. It must be treated as authoritative, never
+    /// downgraded to a loading source's rank — otherwise the next delegate
+    /// response could overwrite a room the user just made.
+    #[test]
+    fn unknown_provenance_is_treated_as_authoritative_and_never_downgraded() {
+        let mut rng = rand::thread_rng();
+        let owner = SigningKey::generate(&mut rng);
+        let vk = owner.verifying_key();
+        let in_session = SigningKey::generate(&mut rng);
+        let from_delegate = SigningKey::generate(&mut rng);
+
+        let mut local = rooms_holding(vk, make_rejoin_test_room(&owner, &in_session, true));
+        // Deliberately EMPTY: nothing recorded this room's source.
+        let mut ranks = HashMap::new();
+
+        local
+            .merge_from_source(
+                rooms_holding(vk, make_rejoin_test_room(&owner, &from_delegate, true)),
+                30,
+                &mut ranks,
+            )
+            .expect("merge");
+
+        assert_eq!(
+            local.map.get(&vk).unwrap().self_sk.to_bytes(),
+            in_session.to_bytes(),
+            "a room with no recorded source must not be overwritten by a load"
+        );
+        assert!(
+            !ranks.contains_key(&vk.to_bytes()),
+            "and it must not be stamped with the loading source's rank, which would \
+             make it overwritable by the next response"
+        );
+    }
+
+    /// Adopting a newer identity must not cost messages the older copy had:
+    /// the local state is folded into the incoming copy before it replaces it.
+    #[test]
+    fn adopting_a_newer_identity_keeps_the_older_copys_messages() {
+        let mut rng = rand::thread_rng();
+        let owner = SigningKey::generate(&mut rng);
+        let vk = owner.verifying_key();
+        let old_identity = SigningKey::generate(&mut rng);
+        let current_identity = SigningKey::generate(&mut rng);
+
+        // The old-generation copy carries a message the newer copy lacks.
+        let mut old_room = make_rejoin_test_room(&owner, &old_identity, true);
+        use river_core::room_state::message::{AuthorizedMessageV1, MessageV1, RoomMessageBody};
+        let msg = AuthorizedMessageV1::new(
+            MessageV1 {
+                room_owner: vk.into(),
+                author: vk.into(),
+                time: get_current_system_time(),
+                content: RoomMessageBody::public("only in the old copy".to_string()),
+            },
+            &owner,
+        );
+        old_room.room_state.recent_messages.messages.push(msg);
+        let expected_messages = old_room.room_state.recent_messages.messages.len();
+        assert_eq!(
+            expected_messages, 1,
+            "precondition: old copy has the message"
+        );
+
+        let mut local = empty_rooms_for_merge();
+        let mut ranks = HashMap::new();
+        local
+            .merge_from_source(rooms_holding(vk, old_room), 3, &mut ranks)
+            .expect("old generation merge");
+        local
+            .merge_from_source(
+                rooms_holding(vk, make_rejoin_test_room(&owner, &current_identity, true)),
+                30,
+                &mut ranks,
+            )
+            .expect("newer generation merge");
+
+        let merged = local.map.get(&vk).unwrap();
+        assert_eq!(
+            merged.self_sk.to_bytes(),
+            current_identity.to_bytes(),
+            "identity comes from the newer generation"
+        );
+        assert_eq!(
+            merged.room_state.recent_messages.messages.len(),
+            expected_messages,
+            "…but the older copy's messages are folded in, not discarded"
+        );
+    }
+
+    /// `merge` (the single-source wrapper) must keep its historical
+    /// keep-local-on-conflict behaviour — several callers rely on it.
+    #[test]
+    fn single_source_merge_still_keeps_local_on_conflict() {
+        let mut rng = rand::thread_rng();
+        let owner = SigningKey::generate(&mut rng);
+        let vk = owner.verifying_key();
+        let local_sk = SigningKey::generate(&mut rng);
+        let incoming_sk = SigningKey::generate(&mut rng);
+
+        let mut local = rooms_holding(vk, make_rejoin_test_room(&owner, &local_sk, true));
+        local
+            .merge(rooms_holding(
+                vk,
+                make_rejoin_test_room(&owner, &incoming_sk, true),
+            ))
+            .expect("merge");
+
+        assert_eq!(
+            local.map.get(&vk).unwrap().self_sk.to_bytes(),
+            local_sk.to_bytes(),
+            "plain merge must be unchanged: local identity wins"
+        );
+    }
+
+    #[test]
+    fn record_identity_source_takes_the_highest_rank_seen() {
+        let vk = vk_from_seed(1);
+        let mut ranks = HashMap::new();
+
+        record_identity_source(&mut ranks, &vk, 5, true);
+        assert_eq!(ranks.get(&vk.to_bytes()), Some(&5));
+
+        // A newer source upgrades it.
+        record_identity_source(&mut ranks, &vk, 12, false);
+        assert_eq!(ranks.get(&vk.to_bytes()), Some(&12));
+
+        // An older source must NOT downgrade it — otherwise a late old-generation
+        // response would re-open the room to being overwritten.
+        record_identity_source(&mut ranks, &vk, 2, false);
+        assert_eq!(
+            ranks.get(&vk.to_bytes()),
+            Some(&12),
+            "an older source must never lower a room's recorded provenance"
         );
     }
 

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -1944,6 +1944,19 @@ impl Rooms {
                     &ChatRoomParametersV1 { owner: vk },
                     &existing.room_state,
                 )?;
+                // Union the invitation-carried secrets, same rule as the save-side
+                // reconcile (`chat_delegate::reconcile_room_present`): these are
+                // DECRYPTED per-version room secrets, so they are identity-
+                // INDEPENDENT recovery state, and the older copy may hold a
+                // version the newer one lacks. Dropping them wholesale would
+                // leave a private-room member unable to decrypt messages sealed
+                // under that version. The adopted (newer) copy wins on collision.
+                for (version, secret) in existing.invitation_secrets {
+                    room_data
+                        .invitation_secrets
+                        .entry(version)
+                        .or_insert(secret);
+                }
                 self.map.insert(vk, room_data);
                 record_identity_source(
                     identity_ranks,
@@ -2808,6 +2821,55 @@ mod tests {
             merged.room_state.recent_messages.messages.len(),
             expected_messages,
             "…but the older copy's messages are folded in, not discarded"
+        );
+    }
+
+    /// Adopting a newer identity must not drop invitation-carried room secrets
+    /// the older copy held: they are DECRYPTED per-version secrets, so they are
+    /// identity-independent, and losing one leaves a private-room member unable
+    /// to decrypt messages sealed under that version. Mirrors the save-side rule
+    /// pinned by `chat_delegate::reconcile_room_present_unions_invitation_secrets`.
+    #[test]
+    fn adopting_a_newer_identity_unions_invitation_secrets() {
+        let mut rng = rand::thread_rng();
+        let owner = SigningKey::generate(&mut rng);
+        let vk = owner.verifying_key();
+        let old_identity = SigningKey::generate(&mut rng);
+        let current_identity = SigningKey::generate(&mut rng);
+
+        // The OLD generation holds v0 and v1; the newer holds v1 (different
+        // bytes) and v2.
+        let mut old_room = make_rejoin_test_room(&owner, &old_identity, true);
+        old_room.invitation_secrets.insert(0, [10u8; 32]);
+        old_room.invitation_secrets.insert(1, [11u8; 32]);
+        let mut new_room = make_rejoin_test_room(&owner, &current_identity, true);
+        new_room.invitation_secrets.insert(1, [99u8; 32]);
+        new_room.invitation_secrets.insert(2, [22u8; 32]);
+
+        let mut local = empty_rooms_for_merge();
+        let mut ranks = HashMap::new();
+        local
+            .merge_from_source(rooms_holding(vk, old_room), 3, &mut ranks)
+            .expect("old generation merge");
+        local
+            .merge_from_source(rooms_holding(vk, new_room), 30, &mut ranks)
+            .expect("newer generation merge");
+
+        let merged = local.map.get(&vk).unwrap();
+        assert_eq!(
+            merged.invitation_secrets.get(&0),
+            Some(&[10u8; 32]),
+            "a version only the older copy had must survive the adopt"
+        );
+        assert_eq!(
+            merged.invitation_secrets.get(&1),
+            Some(&[99u8; 32]),
+            "on collision the adopted (newer) copy wins"
+        );
+        assert_eq!(
+            merged.invitation_secrets.get(&2),
+            Some(&[22u8; 32]),
+            "the adopted copy's own versions are kept"
         );
     }
 

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -2001,6 +2001,16 @@ impl Rooms {
                 continue;
             }
 
+            // Record provenance BEFORE the fallible merge below. If the state
+            // merge errors, the identity in the map is still the one THIS
+            // source corroborated, so the rank must reflect that: leaving it
+            // under-stated lets a later, OLDER generation out-rank it and adopt
+            // its identity — the very rollback this ordering exists to stop.
+            let already_present = self.map.contains_key(&vk);
+            if already_present {
+                record_identity_source(identity_ranks, &vk, source_rank, false);
+            }
+
             // If not already in the map, add the room
             let was_vacant =
                 if let std::collections::hash_map::Entry::Vacant(e) = self.map.entry(vk) {
@@ -3088,6 +3098,64 @@ mod tests {
             Some(&30),
             "and the recorded provenance must be the highest rank seen, so a \
              later older response still loses"
+        );
+    }
+
+    /// The chosen nickname must survive an adopt when the newer copy has none,
+    /// and must NOT override one the newer copy does carry.
+    ///
+    /// `self_nickname` is `None` for imported rooms and for rooms joined before
+    /// the field existed — i.e. exactly the long-lived rooms a legacy fan-out
+    /// turns up — so adopting such a copy would silently drop the user's chosen
+    /// name and leave the member-info heal to invent a generated handle. Same
+    /// class as the `invitation_secrets` loss, which got a fix AND a test; this
+    /// one had only a fix, so the three lines could be deleted with CI green.
+    #[test]
+    fn adopting_a_newer_identity_keeps_a_nickname_the_newer_copy_lacks() {
+        let mut rng = rand::thread_rng();
+        let owner = SigningKey::generate(&mut rng);
+        let vk = owner.verifying_key();
+        let old_identity = SigningKey::generate(&mut rng);
+        let current_identity = SigningKey::generate(&mut rng);
+
+        // Case 1: newer copy has no nickname — the local one must survive.
+        let mut old_room = make_rejoin_test_room(&owner, &old_identity, true);
+        old_room.self_nickname = Some("UserPicked".to_string());
+        let mut newer = make_rejoin_test_room(&owner, &current_identity, true);
+        newer.self_nickname = None;
+
+        let mut local = empty_rooms_for_merge();
+        let mut ranks = HashMap::new();
+        local
+            .merge_from_source(rooms_holding(vk, old_room), 3, &mut ranks)
+            .expect("seed");
+        local
+            .merge_from_source(rooms_holding(vk, newer), 30, &mut ranks)
+            .expect("adopt");
+        assert_eq!(
+            local.map.get(&vk).unwrap().self_nickname.as_deref(),
+            Some("UserPicked"),
+            "a nickname the adopted copy lacks must be carried forward"
+        );
+
+        // Case 2: the newer copy's own choice wins.
+        let mut old_room2 = make_rejoin_test_room(&owner, &old_identity, true);
+        old_room2.self_nickname = Some("Stale".to_string());
+        let mut newer2 = make_rejoin_test_room(&owner, &current_identity, true);
+        newer2.self_nickname = Some("Current".to_string());
+
+        let mut local2 = empty_rooms_for_merge();
+        let mut ranks2 = HashMap::new();
+        local2
+            .merge_from_source(rooms_holding(vk, old_room2), 3, &mut ranks2)
+            .expect("seed");
+        local2
+            .merge_from_source(rooms_holding(vk, newer2), 30, &mut ranks2)
+            .expect("adopt");
+        assert_eq!(
+            local2.map.get(&vk).unwrap().self_nickname.as_deref(),
+            Some("Current"),
+            "the adopted copy's own nickname must not be overwritten by the older one"
         );
     }
 

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -2991,7 +2991,7 @@ mod tests {
         let old_identity = SigningKey::generate(&mut rng);
         let current_identity = SigningKey::generate(&mut rng);
 
-        // Local copy: carries a private message sealed at secret version 7.
+        // Local copy: an ordinary PUBLIC room with a public message.
         let mut old_room = make_rejoin_test_room(&owner, &old_identity, true);
         use river_core::room_state::message::{AuthorizedMessageV1, MessageV1, RoomMessageBody};
         let msg = AuthorizedMessageV1::new(
@@ -2999,13 +2999,7 @@ mod tests {
                 room_owner: vk.into(),
                 author: vk.into(),
                 time: get_current_system_time(),
-                content: RoomMessageBody::Private {
-                    content_type: 0,
-                    content_version: 0,
-                    ciphertext: vec![1, 2, 3],
-                    nonce: [0u8; 12],
-                    secret_version: 7,
-                },
+                content: RoomMessageBody::public("public message".to_string()),
             },
             &owner,
         );
@@ -3018,23 +3012,43 @@ mod tests {
             .expect("seeding the local copy must succeed");
         assert!(local.map.contains_key(&vk), "precondition: room is present");
 
-        // A newer generation whose state has no secret version 7.
-        let newer = make_rejoin_test_room(&owner, &current_identity, true);
+        // The newer generation has flipped the room to PRIVATE. Folding the
+        // older copy's PUBLIC message into it hits
+        // "Cannot send public messages in private room"
+        // (common/src/room_state/message.rs), so the fold genuinely fails.
+        // An earlier version of this test used an ordinary public room, where
+        // the fold SUCCEEDS — and it therefore passed even with the map mutated
+        // before the merge, i.e. it was vacuous for the bug it exists to catch.
+        let mut newer = make_rejoin_test_room(&owner, &current_identity, true);
+        newer.room_state.configuration = AuthorizedConfigurationV1::new(
+            Configuration {
+                owner_member_id: vk.into(),
+                configuration_version: 2,
+                privacy_mode: PrivacyMode::Private,
+                ..Configuration::default()
+            },
+            &owner,
+        );
         let result = local.merge_from_source(rooms_holding(vk, newer), 30, &mut ranks);
 
-        // Whether the fold succeeds or fails is a property of the contract's
-        // delta validation and may change; what must NEVER happen is the room
-        // disappearing. Assert the invariant, not the outcome.
+        // PREMISE CHECK: if this ever stops erroring the assertions below go
+        // vacuous, so fail loudly rather than silently guarding nothing.
+        assert!(
+            result.is_err(),
+            "fixture must actually make the fold FAIL, or this test cannot \
+             detect a map mutated before the merge"
+        );
+
+        // THE INVARIANT: a failed fold must leave the room exactly as it was.
         assert!(
             local.map.contains_key(&vk),
-            "the room must still be present regardless of whether the fold \
-             succeeded (result: {result:?}) — a failed adopt must not delete it"
+            "a failed adopt must NOT delete the room — it vanishes from the UI \
+             and, if this pass is the one that re-saves, is stranded for good"
         );
-        let survivor = local.map.get(&vk).unwrap();
-        assert!(
-            survivor.self_sk.to_bytes() == current_identity.to_bytes()
-                || survivor.self_sk.to_bytes() == old_identity.to_bytes(),
-            "and it must hold one of the two real identities, not a blank"
+        assert_eq!(
+            local.map.get(&vk).unwrap().self_sk.to_bytes(),
+            old_identity.to_bytes(),
+            "and it must still hold the identity it had before the failed adopt"
         );
     }
 

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -1804,9 +1804,10 @@ impl Rooms {
     /// removed (see freenet/river#247).
     ///
     /// Known limitation (skeptical review, freenet/river#345): the per-room loop
-    /// below `return`s `Err` on the FIRST room whose `self_sk` diverges or whose
-    /// `room_state.merge` fails, so rooms not yet iterated are dropped from THIS
-    /// merge (they survive only if already present). The per-room SAVE path got
+    /// below `return`s `Err` on the first room whose `room_state.merge` fails,
+    /// so rooms not yet iterated are dropped from THIS merge (they survive only
+    /// if already present). A DIVERGING `self_sk` is not such a case — it is
+    /// resolved per-room by source authority and never returns `Err`. The per-room SAVE path got
     /// the M1 scoping fix (`reconcile_room_present` keeps local for the one
     /// diverged room without wedging the others); the load-side merge did not.
     /// The trigger is rare (it requires the SAME room to already be in memory
@@ -1824,6 +1825,12 @@ impl Rooms {
         // pre-freenet/river#527 behaviour. Multi-source loads (the legacy
         // delegate fan-out) must call `merge_from_source` so generations can be
         // ordered.
+        //
+        // The throwaway map is deliberate: this passes SOURCE_RANK_AUTHORITATIVE,
+        // so handing it the SHARED registry instead would stamp every room
+        // u32::MAX and permanently disable generation ranking for that session.
+        // If you need a caller that records provenance, call `merge_from_source`
+        // directly rather than widening this one.
         let mut ranks = HashMap::new();
         self.merge_from_source(other, SOURCE_RANK_AUTHORITATIVE, &mut ranks)
     }
@@ -1866,15 +1873,17 @@ impl Rooms {
             }
 
             // Identity-conflict guard, BEFORE any contract-key bookkeeping: if
-            // the room is already present with a DIFFERENT `self_sk`, this
-            // incoming copy is a stale/foreign identity for the SAME room. This
-            // happens legitimately during an identity overwrite
-            // (freenet/river#414): a delegate `LoadRooms` response issued before
-            // the replacement can still carry the OLD `self_sk` while `map`
-            // already holds the NEW one. SKIP just this room (keeping the
-            // current local identity) rather than ABORTING the whole merge —
-            // otherwise one stale in-flight copy would drop every other room and
-            // its secret rehydration until reload. The local copy always wins.
+            // the room is already present with a DIFFERENT `self_sk`, the two
+            // copies disagree about who the user is in this room. Resolve it by
+            // SOURCE AUTHORITY (freenet/river#527), and affect only THIS room
+            // either way — never aborting the whole merge, since one
+            // conflicting copy would otherwise drop every other room and its
+            // secret rehydration until reload.
+            //
+            // The freenet/river#414 case is the EQUAL-rank one: a delegate
+            // `LoadRooms` response issued before an identity overwrite still
+            // carries the OLD `self_sk` while `map` already holds the NEW one.
+            // Equal ranks keep local, so that guarantee is unchanged.
             //
             // STILL NEEDED after the #414 in-place-swap redesign: the redesign
             // removed the empty-rebuild, but the stale-load race this guards is
@@ -1935,14 +1944,29 @@ impl Rooms {
                 // Fold the local (older-identity) state INTO the incoming copy
                 // before it replaces it, so adopting the newer identity never
                 // costs messages the older copy had.
-                let existing = self
+                //
+                // The map is NOT touched until the fold succeeds.
+                // `ChatRoomStateV1::merge` is genuinely fallible (unknown secret
+                // version, unresolvable invite chain, ...), and removing first
+                // would make the `?` below delete the room outright — dropping
+                // it from the UI for the session and abandoning the rest of this
+                // merge pass. The non-adopt branch below has the same property
+                // for free because it merges through `get_mut`.
+                let existing_state = self
                     .map
-                    .remove(&vk)
+                    .get(&vk)
+                    .map(|e| {
+                        (
+                            e.room_state.clone(),
+                            e.invitation_secrets.clone(),
+                            e.self_nickname.clone(),
+                        )
+                    })
                     .expect("AdoptIncoming implies the room is present");
                 room_data.room_state.merge(
                     &room_data.room_state.clone(),
                     &ChatRoomParametersV1 { owner: vk },
-                    &existing.room_state,
+                    &existing_state.0,
                 )?;
                 // Union the invitation-carried secrets, same rule as the save-side
                 // reconcile (`chat_delegate::reconcile_room_present`): these are
@@ -1951,12 +1975,22 @@ impl Rooms {
                 // version the newer one lacks. Dropping them wholesale would
                 // leave a private-room member unable to decrypt messages sealed
                 // under that version. The adopted (newer) copy wins on collision.
-                for (version, secret) in existing.invitation_secrets {
+                for (version, secret) in existing_state.1 {
                     room_data
                         .invitation_secrets
                         .entry(version)
                         .or_insert(secret);
                 }
+                // The chosen nickname is a user preference, not identity-bound
+                // state: an imported-identity copy carries `None` (see the
+                // field's own docs), and adopting it would silently drop the
+                // name, leaving the member-info heal to fall back to a
+                // generated handle. Keep the local one when the adopted copy
+                // has nothing to say.
+                if room_data.self_nickname.is_none() {
+                    room_data.self_nickname = existing_state.2;
+                }
+                // Only now is the map mutated; `insert` replaces the old entry.
                 self.map.insert(vk, room_data);
                 record_identity_source(
                     identity_ranks,
@@ -2668,6 +2702,15 @@ mod tests {
     /// The same two copies in the opposite arrival order must reach the SAME
     /// result. Without this, the fix would merely move the race rather than
     /// remove it.
+    ///
+    /// SCOPE: this certifies IDENTITY convergence only. Room STATE is not
+    /// order-independent — the adopt path folds the loser's state in, but the
+    /// keep-local path still discards the incoming copy's state wholesale. That
+    /// asymmetry pre-dates this fix (both orderings discarded it before), and
+    /// closing it means merging state across an identity conflict in the other
+    /// direction too, which is a behaviour change deserving its own review
+    /// rather than a rider on this one. Do not read these tests as a state
+    /// convergence guarantee.
     #[test]
     fn identity_resolution_is_independent_of_arrival_order() {
         let mut rng = rand::thread_rng();
@@ -2785,11 +2828,11 @@ mod tests {
         let msg = AuthorizedMessageV1::new(
             MessageV1 {
                 room_owner: vk.into(),
-                author: vk.into(),
+                author: old_identity.verifying_key().into(),
                 time: get_current_system_time(),
                 content: RoomMessageBody::public("only in the old copy".to_string()),
             },
-            &owner,
+            &old_identity,
         );
         old_room.room_state.recent_messages.messages.push(msg);
         let expected_messages = old_room.room_state.recent_messages.messages.len();
@@ -2901,13 +2944,13 @@ mod tests {
             self_authorized_member: _,
             invite_chain: _,
             self_member_info: _,
-            self_nickname: _,
 
             // --- Must be carried over from the local copy (identity-independent
             // state the older generation may hold and the newer may not).
             // Both are handled in the adopt path.
-            room_state: _,         // CRDT-merged, so no messages are lost
+            room_state: _,         // CRDT-merged, so the older copy's messages survive
             invitation_secrets: _, // unioned; adopted copy wins on collision
+            self_nickname: _,      // local kept when the adopted copy has none
 
             // --- `#[serde(skip)]`: not persisted, so the local values are
             // runtime-only and are rebuilt after the merge —
@@ -2923,6 +2966,76 @@ mod tests {
             last_read_message_id: _, // at worst some messages re-show as unread
             previous_contract_key: _, // re-derived by regenerate_contract_key
         } = room;
+    }
+
+    /// A FAILING fold must leave the room exactly as it was.
+    ///
+    /// `ChatRoomStateV1::merge` is genuinely fallible — "Private message
+    /// references unknown secret version N", "Cannot send public messages in
+    /// private room", unresolvable invite chains. An earlier version of the
+    /// adopt path did `map.remove()` FIRST and merged second, so any such Err
+    /// propagated out with the room already gone from the map: it vanished from
+    /// the UI, every room later in the iteration was dropped from that pass,
+    /// and if that pass was the one that re-saved to the current delegate, the
+    /// room was never written there and legacy is never probed again — a
+    /// permanently stranded room, on the exact path this fix exists to protect.
+    ///
+    /// Here the incoming copy is a PRIVATE room whose secrets do not carry the
+    /// version the older copy's message is sealed under, which is what makes
+    /// the fold fail.
+    #[test]
+    fn a_failing_fold_leaves_the_existing_room_untouched() {
+        let mut rng = rand::thread_rng();
+        let owner = SigningKey::generate(&mut rng);
+        let vk = owner.verifying_key();
+        let old_identity = SigningKey::generate(&mut rng);
+        let current_identity = SigningKey::generate(&mut rng);
+
+        // Local copy: carries a private message sealed at secret version 7.
+        let mut old_room = make_rejoin_test_room(&owner, &old_identity, true);
+        use river_core::room_state::message::{AuthorizedMessageV1, MessageV1, RoomMessageBody};
+        let msg = AuthorizedMessageV1::new(
+            MessageV1 {
+                room_owner: vk.into(),
+                author: vk.into(),
+                time: get_current_system_time(),
+                content: RoomMessageBody::Private {
+                    content_type: 0,
+                    content_version: 0,
+                    ciphertext: vec![1, 2, 3],
+                    nonce: [0u8; 12],
+                    secret_version: 7,
+                },
+            },
+            &owner,
+        );
+        old_room.room_state.recent_messages.messages.push(msg);
+
+        let mut local = empty_rooms_for_merge();
+        let mut ranks = HashMap::new();
+        local
+            .merge_from_source(rooms_holding(vk, old_room), 3, &mut ranks)
+            .expect("seeding the local copy must succeed");
+        assert!(local.map.contains_key(&vk), "precondition: room is present");
+
+        // A newer generation whose state has no secret version 7.
+        let newer = make_rejoin_test_room(&owner, &current_identity, true);
+        let result = local.merge_from_source(rooms_holding(vk, newer), 30, &mut ranks);
+
+        // Whether the fold succeeds or fails is a property of the contract's
+        // delta validation and may change; what must NEVER happen is the room
+        // disappearing. Assert the invariant, not the outcome.
+        assert!(
+            local.map.contains_key(&vk),
+            "the room must still be present regardless of whether the fold \
+             succeeded (result: {result:?}) — a failed adopt must not delete it"
+        );
+        let survivor = local.map.get(&vk).unwrap();
+        assert!(
+            survivor.self_sk.to_bytes() == current_identity.to_bytes()
+                || survivor.self_sk.to_bytes() == old_identity.to_bytes(),
+            "and it must hold one of the two real identities, not a blank"
+        );
     }
 
     /// The pairwise decision must still hold with MORE than two generations
@@ -2965,7 +3078,9 @@ mod tests {
     }
 
     /// `merge` (the single-source wrapper) must keep its historical
-    /// keep-local-on-conflict behaviour — several callers rely on it.
+    /// keep-local-on-conflict behaviour. It has no production callers left —
+    /// every load goes through `merge_from_source` — but it is the documented
+    /// single-source semantics and several tests pin behaviour through it.
     #[test]
     fn single_source_merge_still_keeps_local_on_conflict() {
         let mut rng = rand::thread_rng();

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -2873,6 +2873,97 @@ mod tests {
         );
     }
 
+    /// Adopting a newer identity REPLACES the local `RoomData` wholesale, so
+    /// every field not explicitly carried over is silently discarded. That is
+    /// how the `invitation_secrets` loss got in — caught in review, not by a
+    /// test, and only because someone happened to look.
+    ///
+    /// This destructures `RoomData` exhaustively, so ADDING A FIELD BREAKS THE
+    /// BUILD here and forces a decision about what the adopt path should do
+    /// with it. The disposition of each existing field is recorded below.
+    ///
+    /// If you are here because you added a field: decide which group it joins,
+    /// add it to that group, and if it belongs in "must be carried over" then
+    /// also update the adopt path in `merge_from_source`.
+    #[test]
+    fn adopt_path_accounts_for_every_room_data_field() {
+        let mut rng = rand::thread_rng();
+        let owner = SigningKey::generate(&mut rng);
+        let self_sk = SigningKey::generate(&mut rng);
+        let room = make_rejoin_test_room(&owner, &self_sk, true);
+
+        let RoomData {
+            // --- Identity and its derived state: correctly taken from the
+            // ADOPTED copy. Using the local values would defeat the adopt.
+            owner_vk: _,
+            self_sk: _,
+            contract_key: _,
+            self_authorized_member: _,
+            invite_chain: _,
+            self_member_info: _,
+            self_nickname: _,
+
+            // --- Must be carried over from the local copy (identity-independent
+            // state the older generation may hold and the newer may not).
+            // Both are handled in the adopt path.
+            room_state: _,         // CRDT-merged, so no messages are lost
+            invitation_secrets: _, // unioned; adopted copy wins on collision
+
+            // --- `#[serde(skip)]`: not persisted, so the local values are
+            // runtime-only and are rebuilt after the merge —
+            // `repopulate_secrets_from_state` for the secret trio, and the
+            // signing-key migration re-derives `key_migrated_to_delegate`.
+            secrets: _,
+            current_secret_version: _,
+            last_secret_rotation: _,
+            key_migrated_to_delegate: _,
+
+            // --- Deliberately taken from the adopted copy; losing the local
+            // value is cosmetic or self-correcting.
+            last_read_message_id: _, // at worst some messages re-show as unread
+            previous_contract_key: _, // re-derived by regenerate_contract_key
+        } = room;
+    }
+
+    /// The pairwise decision must still hold with MORE than two generations
+    /// answering, in any order — the real fan-out probes ~26 of them.
+    #[test]
+    fn the_newest_of_several_generations_wins_regardless_of_order() {
+        let mut rng = rand::thread_rng();
+        let owner = SigningKey::generate(&mut rng);
+        let vk = owner.verifying_key();
+        let id_old = SigningKey::generate(&mut rng);
+        let id_mid = SigningKey::generate(&mut rng);
+        let id_new = SigningKey::generate(&mut rng);
+
+        // Deliberately interleaved: newest in the middle, oldest last.
+        let arrivals = [(12u32, &id_mid), (30u32, &id_new), (3u32, &id_old)];
+
+        let mut local = empty_rooms_for_merge();
+        let mut ranks = HashMap::new();
+        for (rank, sk) in arrivals {
+            local
+                .merge_from_source(
+                    rooms_holding(vk, make_rejoin_test_room(&owner, sk, true)),
+                    rank,
+                    &mut ranks,
+                )
+                .expect("merge");
+        }
+
+        assert_eq!(
+            local.map.get(&vk).unwrap().self_sk.to_bytes(),
+            id_new.to_bytes(),
+            "the newest generation must win across three sources in any order"
+        );
+        assert_eq!(
+            ranks.get(&vk.to_bytes()),
+            Some(&30),
+            "and the recorded provenance must be the highest rank seen, so a \
+             later older response still loses"
+        );
+    }
+
     /// `merge` (the single-source wrapper) must keep its historical
     /// keep-local-on-conflict behaviour — several callers rely on it.
     #[test]

--- a/ui/src/signing.rs
+++ b/ui/src/signing.rs
@@ -296,6 +296,13 @@ pub async fn migrate_signing_key(
     // discarded and any later stale hydration for a DIFFERENT key is.
     if mark_authoritative {
         set_current_room_identity(room_key, signing_key.verifying_key());
+        // Nothing the delegates hold outranks a deliberate choice. Merge now
+        // ranks identity conflicts by delegate generation (freenet/river#527),
+        // so without this an import/accept would be overwritable by any load
+        // from a newer generation than the one that supplied the room —
+        // re-opening exactly the freenet/river#414 clobber this function's
+        // `CURRENT_ROOM_IDENTITY` guard closes for the in-session case.
+        crate::components::app::chat_delegate::mark_identity_source_authoritative(room_key);
     }
 
     // Serialize concurrent migrations for THIS room so the non-atomic


### PR DESCRIPTION
## Problem

The 2026-07-27 re-key publish (V29 → V30, for the DM retention cap in #524) forced every user through legacy delegate migration. A long-time user reported rooms coming back under identities from months earlier, on two of three nodes (#527).

`fire_legacy_migration_request` probes all **26** legacy delegate generations at once and each one holding data hydrates independently, so their responses race. Three defects turned that race into a rollback:

1. **Identity was decided by arrival order.** `Rooms::merge` kept whichever copy landed FIRST and silently skipped any later copy with a different `self_sk`. Probes are dispatched oldest-generation-first, so the oldest surviving copy usually answered first and won. Only users whose identity for a room ever changed are affected — which is why this hit a long-time user and not everyone.

2. **The signing key pushed to the delegate ignored the merge outcome.** The per-room keys were read from `loaded_rooms` BEFORE the (deferred) merge, so a room whose incoming copy the merge REJECTED still had that rejected key pushed — and `migrate_signing_key` overwrites on mismatch. The delegate was left signing with an identity the UI had already discarded, invalidating every signature it produced for that room.

3. **The migration could be sealed before the fan-out finished.** The seal ends legacy migration permanently: once set, a later session whose current delegate is still empty finds it and probes nothing. The loudest door was in `freenet_synchronizer.rs`, which sealed on any "delegate not found" API error — an error the fan-out itself provokes within milliseconds on any node missing an old delegate WASM. One absent generation spoke for the other twenty-five.

## Approach

Give the fan-out the ordering it was missing. `LEGACY_DELEGATES` is generated in age order, so an entry's index is its generation: higher is newer, and the current delegate outranks all of them.

- `resolve_identity_conflict` decides by source authority. A strictly newer generation wins; equal ranks keep local, preserving the #414 stale-load guard.
- `merge_from_source` threads the rank through and folds the local state into the incoming copy before adopting it, so no messages are lost. The map is not mutated until the fold succeeds — `ChatRoomStateV1::merge` is fallible, and mutating first meant an error deleted the room outright.
- A deliberate identity choice (import, invitation-accept) is recorded authoritative synchronously at both sites, so no load can undo it.
- Signing-key migration is deferred to run after the merge and reads the merged `ROOMS`.
- Seal doors: the two where the current delegate is authoritative stay synchronous (no fan-out is in flight, and deferring weakens the #253 guard); the two where a fan-out can be in flight are quiescence-gated, as is the delegate-not-found door. One writer, pinned.

## Scope — please read before closing #527

- **This protects nodes that have not yet hit the bug. It is NOT recovery for those that have.** An already-rolled-back user's current delegate is populated, so the per-room load path marks migration done and legacy is never re-probed. Shipping this changes nothing for them; they must re-import their identity, after which the fix keeps it.
- **A wrong ranking decision is now deterministic and permanent rather than a coin flip.** For an already-affected user, the wrong identity sits in what becomes the highest-ranked legacy generation, so it would win every conflict thereafter. That is the right trade — deterministic-correct for the overwhelming majority beats a coin flip for everyone — but it should be stated rather than discovered.

## Testing

Behavioural tests at the merge layer plus source pins for the wiring. Every pin was mutation-verified rather than trusted green; two tests were found vacuous that way and rebuilt — one of them passed with the bug fully restored, because its fixture made the fold succeed.

## Review

Four independent blind lenses (code-first, skeptical/race, testing, data-loss/migration-compat), two rounds. Three reviewers independently found the same P1 (the map mutated before a fallible merge). All findings fixed or explicitly justified; final verdict non-blocking from all four.

Deliberately not fixed here, filed instead: #531 (keep-local path discards the loser's `room_state` — pre-existing, and closing it is a behaviour change deserving its own review) and #532 (interrupted-migration recovery has no seal bypass — pre-existing).

Closes #527

[AI-assisted - Claude]
