### PR TITLE
fix(dm): stop ordinary sync churn from destroying DM archives

### DIFF
--- a/.claude/rules/direct-messages.md
+++ b/.claude/rules/direct-messages.md
@@ -162,11 +162,104 @@ field with `#[serde(default)]` so old bytes still decode. **Do not add
 a second top-level delegate storage key for hide state**: a new key
 needs its own probe in `fire_legacy_migration_request` and routing in
 `response_handler.rs`, AND splits the multi-device save path into two
-writes that can race. Filter helper `chat_delegate::is_thread_hidden`
+writes that can race. Filter helper `direct_messages::is_thread_hidden_for`
 uses strict `<=`; rail-side pure helper
 `dm_rail_section::filter_rail_entries` is pinned by
 `filter_rail_entries_*` tests; the "click Archive again after revival
 must re-hide" branch is pinned by `hide_unhide_rehide_round_trip`.
+
+### Two coupled invariants — do not change one without the other (#526)
+
+**1. `hidden_at_ts` is the newest INBOUND message timestamp**, computed as
+`max(rendered row value, live recompute from ROOMS)` and NOT clamped against
+wall-clock time.
+
+*Inbound-only.* `last_any_ts` also covers our OWN outbound DMs, whose
+timestamp is our local wall clock — so a thread where we replied last would be
+archived against OUR clock while the gate below compares a SENDER's timestamp,
+and a peer DM already in flight across the click would land at or below the
+cutoff and vanish from the rail, the unread badge, and everything else (DMs
+raise no notification). Our own sends revive the thread through the
+unconditional `unhide_dm_thread` in `do_send` / `send_structured_dm` — on the
+SENDING DEVICE only: hydration never propagates a removal, and `riverctl dm
+send` does not call it, so archiving on a laptop and replying from a phone
+leaves the laptop archived until the peer writes.
+
+*Live recompute.* The rendered row can lag (`LAST_GOOD_RAIL`, or a DM landing
+between the memo's last clean pass and the click), and while the membership
+sweep is atomic per pair, the RE-LAND is not — a peer may restore only a
+subset. A cutoff below the pair's true inbound max lets the rest re-land
+looking newer than the archive. Cost: the live read can cover an inbound DM
+that was never rendered, so archiving may swallow one message until the peer
+writes again.
+
+*Not clamped.* An earlier revision clamped the cutoff at
+`now + MAX_DM_FUTURE_SKEW_SECS`. That broke the load-bearing invariant **every
+existing inbound DM satisfies `ts <= cutoff`**: the rail filter compares the
+UNCLAMPED observed clock, so Archive became a visible no-op that still showed a
+success toast, AND the next sweep-and-re-offer saw `ts > cutoff` and destroyed
+the persisted archive — #526 itself, narrowed to skew-violating peers. Clamping
+one side of a comparison is what created the hole. The forged-timestamp concern
+is handled where it cannot break the invariant instead: the GATE bounds the
+incoming timestamp. That bound is narrow — it binds only once a forgery has
+already inflated the cutoff, stopping a peer escalating to a larger one; a
+first forgery can still revive a normally-archived thread. It is
+safe-directional regardless (the bounded value is never above the raw one, so
+it can only make the gate more conservative).
+
+The inbound-only anchoring works because `sweep_after_membership_change`
+retains on `alive(sender) && alive(recipient)` and every DM in a pair shares
+the same sender/recipient set, so the sweep is **all-or-nothing per pair** — it
+can never leave a thread partially swept.
+
+The sweep is atomic; the RE-LAND is not. If a peer re-offers only part of a
+swept pair and the rail memo refreshes cleanly in between, both the row and the
+live read agree on a value below the pair's true max, and a later re-offer of
+the rest fires the gate and destroys that archive. `max(row, live)` covers a
+row stale from BEFORE the sweep, not a cutoff taken inside the partial window.
+Narrow, but a residual — do not restate this invariant as absolute.
+
+Pinned by `archive_cutoff_*`, `archive_row_uses_inbound_and_live_cutoff`,
+`rail_row_passes_the_inbound_clock_to_archive_row`,
+`rail_filter_compares_inbound_timestamp`, and
+`archived_projections_use_the_inbound_clock`.
+
+**2. Inbound-sync paths must use the cutoff-gated unhide; explicit user
+actions must not.** The two `room_synchronizer` sites (`apply_delta_inner`,
+`update_room_state_inner`) call `unhide_dm_thread_if_dm_is_newer`, which drops
+the archive entry only when the DM's timestamp is strictly past
+`hidden_at_ts`. Their "newly landed" predicate is a diff against **local
+state**, which cannot distinguish a genuinely new DM from an old one the sweep
+removed and a peer re-offered — nor, on the full-state path, from the case
+where the pre-merge snapshot is empty because DM state has not hydrated yet
+(there, *every* DM reads as newly landed). Calling the unconditional
+`unhide_dm_thread` from either site destroys the archive on ordinary sync
+churn and **persists** the destruction (it also writes a session
+`RECENTLY_UNHIDDEN` tombstone, which then suppresses the entry when the
+delegate blob hydrates).
+
+The four explicit-user-action call sites — Undo toast and Archived-panel
+Un-archive (`dm_rail_section.rs`), and the outbound sends in `do_send`
+(`dm_thread_modal.rs`) and `send_structured_dm` (`direct_messages.rs`) — keep
+the UNCONDITIONAL form. Routing any through the gated one makes it a silent
+no-op, because at that moment the inbound clock is by construction at or below
+the cutoff. Each file pins its own sites:
+`explicit_user_actions_keep_the_unconditional_unhide` (rail) and
+`outbound_send_keeps_the_unconditional_unhide` (both send files). Those pins
+were briefly lost to a `git checkout` during mutation testing and restored —
+if you touch them, confirm they still exist rather than trusting a green run.
+
+Accepted residuals — all defer messages from one peer the user already chose
+to archive, none destroys state: a new inbound DM in the same unix second as
+the peer's previous one; a peer whose clock moves backward relative to their
+own previous message; and a peer who stamps far in the future, whose later
+genuine DMs wait until real time passes that stamp. Irreducible under
+timestamp gating — the real remedy is a block/ignore list, #461.
+
+Two narrower cases can still cost an archive ENTRY (not just defer a message):
+a cutoff taken inside a partial re-land window, and a DM the live read missed
+because `ROOMS` was contended AND the rendered row lagged. Both need an archive
+clicked inside a specific race; neither is the systematic churn #526 is about.
 
 The per-row rollover ✕ in `DmRailSection` is the archive control (the
 old modal-header "Hide" button next to close ✕ was repeatedly

--- a/common/src/chat_delegate.rs
+++ b/common/src/chat_delegate.rs
@@ -346,8 +346,9 @@ pub enum CasStoreResult {
 /// thread AND no message in the thread has `timestamp > hidden_at_ts`.
 /// The strict `>` (not `>=`) on `max_message_ts` ensures that the
 /// message used to populate `hidden_at_ts` does not itself revive the
-/// thread. Any newer DM (inbound or outbound) crosses the threshold
-/// and revives.
+/// thread. Any newer INBOUND DM crosses the threshold and revives;
+/// outbound sends revive via the explicit `unhide_dm_thread` instead,
+/// since freenet/river#526 made the archive clock inbound-only.
 ///
 /// `hidden_threads` is the full slice as loaded from the delegate;
 /// the lookup is linear because the list is tiny (bounded by the

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -2518,6 +2518,175 @@ mod tests {
         assert_eq!(to_insert[0].1.hidden_at_ts, 5_000);
     }
 
+    // ===== should_unhide_for_inbound_dm (issue freenet/river#526) =====
+    //
+    // The inbound-sync paths in `room_synchronizer` used to call
+    // `unhide_dm_thread` unconditionally for every DM that crossed the
+    // merge dedupe. "Crossed the dedupe" means "was not in LOCAL state a
+    // moment ago", which is a different question from "is new content":
+    // `post_apply_cleanup`'s membership sweep removes DMs whose
+    // counterparty is momentarily absent from `members`, peers re-offer
+    // them, and they re-land. Every such re-landing destroyed the user's
+    // archive — and `unhide_dm_thread` persists the removal, so the loss
+    // survived a reload. These tests pin the replacement decision.
+
+    /// A pair with no archive entry has nothing to revive. This is the
+    /// load-bearing case for the full-state path: when `HIDDEN_DM_THREADS`
+    /// has not hydrated from the delegate yet, EVERY pair looks like this,
+    /// and the pre-merge DM snapshot is simultaneously empty (so every DM
+    /// reads as newly landed). Returning false here is what stops a startup
+    /// race from wiping every archive in the room.
+    #[test]
+    fn should_unhide_for_inbound_dm_is_false_when_not_archived() {
+        assert!(!should_unhide_for_inbound_dm(None, 9_999, 1_000_000));
+        assert!(!should_unhide_for_inbound_dm(None, 0, 1_000_000));
+    }
+
+    /// A DM strictly past the cutoff is a genuine revival.
+    #[test]
+    fn should_unhide_for_inbound_dm_is_true_past_cutoff() {
+        assert!(should_unhide_for_inbound_dm(Some(1_000), 1_001, 1_000_000));
+    }
+
+    /// A DM at or below the cutoff is content the archive already covers.
+    /// The `<=` half is the #526 fix: an old DM that was swept out of local
+    /// state and re-offered by a peer arrives here with its ORIGINAL
+    /// timestamp, which is at or below the cutoff `archive_row` recorded.
+    #[test]
+    fn should_unhide_for_inbound_dm_is_false_at_or_below_cutoff() {
+        assert!(
+            !should_unhide_for_inbound_dm(Some(1_000), 999, 1_000_000),
+            "an older re-landed DM must not un-archive the thread"
+        );
+        assert!(
+            !should_unhide_for_inbound_dm(Some(1_000), 1_000, 1_000_000),
+            "a DM at exactly the cutoff is the newest INBOUND message that \
+             existed when the user archived, so it must not revive the thread. \
+             This is the accepted #267 residual: a genuinely new DM stamped in \
+             the same second as the peer's previous one waits for the next \
+             message."
+        );
+    }
+
+    /// End-to-end shape of the #526 bug, driven through the same decision the
+    /// sync path makes and applying its effect to a real map, so the "the
+    /// archive survived" assertion can actually fail.
+    ///
+    /// Archive a thread holding DMs at ts=800 and ts=1000 (so the cutoff is
+    /// 1000), then have the whole pair swept and re-offered — the sweep is
+    /// all-or-nothing per pair, so BOTH re-land carrying original timestamps.
+    #[test]
+    fn relanded_old_dms_do_not_destroy_the_archive() {
+        use crate::components::direct_messages::is_thread_hidden_for;
+        let room = sk(1).verifying_key();
+        let peer = MemberId(FastHash(11));
+        let key = (room, peer);
+
+        // `archive_row` records the thread's newest MESSAGE timestamp.
+        let thread_ts = [800u64, 1_000u64];
+        let cutoff = *thread_ts.iter().max().unwrap();
+
+        let mut hidden: HashMap<(ed25519_dalek::VerifyingKey, MemberId), HiddenDmThreadEntry> =
+            HashMap::new();
+        hidden.insert(key, make_hidden_entry(room, peer, cutoff));
+
+        // Replay the sync path's decision for each re-landed DM, applying the
+        // real effect (entry removal) so a wrong decision is observable.
+        for ts in thread_ts {
+            if should_unhide_for_inbound_dm(hidden.get(&key).map(|e| e.hidden_at_ts), ts, 1_000_000)
+            {
+                hidden.remove(&key);
+            }
+        }
+
+        assert!(
+            hidden.contains_key(&key),
+            "re-landed DMs must not drop the archive entry (#526) — this is \
+             the assertion that fails if the gate is removed"
+        );
+        assert!(
+            is_thread_hidden_for(&hidden, &room, peer, cutoff),
+            "the thread must stay archived after the re-land (#526)"
+        );
+
+        // A genuinely new DM, sent after the archive click, still revives it.
+        let new_dm_ts = cutoff + 1;
+        if should_unhide_for_inbound_dm(
+            hidden.get(&key).map(|e| e.hidden_at_ts),
+            new_dm_ts,
+            1_000_000,
+        ) {
+            hidden.remove(&key);
+        }
+        assert!(
+            !hidden.contains_key(&key),
+            "a genuinely new DM must still revive the thread (#267)"
+        );
+        assert!(!is_thread_hidden_for(&hidden, &room, peer, new_dm_ts));
+    }
+
+    /// Issue freenet/river#526 BLOCKING gap found in review: the wrapper's
+    /// BODY is what both sync call sites actually invoke, so deleting the
+    /// gate inside it re-opens #526 in full while every other test — which
+    /// calls the pure helper directly — stays green.
+    ///
+    /// The wrapper reads a signal, so it cannot be unit-tested; this is a
+    /// segment-bounded source pin over the production half of the file.
+    #[test]
+    fn gated_unhide_wrapper_consults_the_cutoff() {
+        // NOTE: this file interleaves `#[cfg(test)]` modules with production
+        // code (the first `mod tests {` is at ~line 640, the function under
+        // test at ~4492), so the usual cut-at-`mod tests` trick would discard
+        // the very thing being pinned. Instead the marker is assembled at
+        // runtime — so it cannot match this test's own source — and the
+        // segment is bounded at the next item, which keeps the assertion
+        // literals below out of the searched region.
+        let src: String = include_str!("chat_delegate.rs")
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+        let marker = format!("fn{}{}", "unhide_dm_thread_if_dm_is_newer", "(");
+        let split_at = src
+            .find(&marker)
+            .expect("unhide_dm_thread_if_dm_is_newer must exist in this file");
+        let rest = &src[split_at + marker.len()..];
+        // Bound at the next item. NOT `"pubfn"`: the next item is
+        // `pub async fn save_outbound_dms_to_delegate`, which strips to
+        // `pubasyncfn` and would be skipped, silently widening the segment.
+        let end = rest.find("///Coalescingstate").unwrap_or(rest.len());
+        let seg = &rest[..end];
+
+        assert!(
+            seg.contains(&format!("if{}{}", "should_unhide_for_inbound_dm", "(")),
+            "unhide_dm_thread_if_dm_is_newer must gate on \
+             should_unhide_for_inbound_dm (#526). Without the gate both sync \
+             paths unhide unconditionally again — including the full-state \
+             path, where an empty pre-merge snapshot destroys every archive \
+             in the room at once."
+        );
+        assert!(
+            seg.contains("hidden.get(&(room_owner_vk,peer)).map(|e|e.hidden_at_ts)"),
+            "the gate must be fed the pair's ACTUAL persisted cutoff (#526); \
+             passing a freshly-read `now` would make every re-landed DM look \
+             newer and silently re-regress."
+        );
+        assert!(
+            seg.contains(&format!(
+                "{}{}",
+                "should_unhide_for_inbound_dm", "(cutoff,dm_timestamp,unix_now_secs())"
+            )),
+            "the gate must actually receive the read cutoff AND the DM's \
+             timestamp. `should_unhide_for_inbound_dm(None, ts)` would satisfy \
+             a looser pin while making the wrapper a permanent no-op."
+        );
+        assert!(
+            seg.contains(&format!("{}{}", "unhide_dm_thread", "(room_owner_vk,peer)")),
+            "the guarded branch must still CALL unhide_dm_thread - this is the \
+             only reachable revival from either sync path, so deleting it kills \
+             #267 revival entirely while the gate assertions above still pass."
+        );
+    }
+
     // ===== decide_hide_action + hide-unhide-rehide round-trip =====
     // Tests for the testing-reviewer's BLOCKING gap on PR #265: the
     // "click Hide again should re-hide, not no-op" path through
@@ -4596,9 +4765,15 @@ pub(crate) fn decide_hide_action(
 /// Hide the DM thread for `(room, peer)` from the left rail (issue
 /// freenet/river#261).
 ///
-/// `hidden_at_ts` is the most-recent message timestamp in the thread
-/// at the moment the user clicked "Hide thread"; the filter rule uses
-/// `<=` so any message strictly later revives the thread.
+/// `hidden_at_ts` is the most-recent MESSAGE timestamp in the thread at the
+/// moment the user clicked Archive (wall-clock seconds only when the thread
+/// is empty); the filter rule uses `<=` so any message strictly later revives
+/// the thread.
+///
+/// That it is a message timestamp and not wall-clock `now` is load-bearing
+/// for issue freenet/river#526 — see `dm_rail_section::archive_row`, which is
+/// this function's only caller, for why, and
+/// [`should_unhide_for_inbound_dm`] for the gate that depends on it.
 ///
 /// Delegates to the pure helper [`decide_hide_action`] so the
 /// "advance vs no-op" decision can be unit-tested without the Dioxus
@@ -4675,6 +4850,187 @@ pub fn unhide_dm_thread(room_owner_vk: ed25519_dalek::VerifyingKey, peer: Member
             }
         });
     });
+}
+
+/// Current unix time in SECONDS, matching `DirectMessage::timestamp`'s unit.
+fn unix_now_secs() -> u64 {
+    crate::util::get_current_system_time()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Decide whether an inbound DM that just landed should drop the pair's
+/// archive entry.
+///
+/// `cutoff` is the pair's current `hidden_at_ts`, or `None` when the pair
+/// is not archived (which includes "the archive list hasn't hydrated from
+/// the delegate yet" — see [`unhide_dm_thread_if_dm_is_newer`] for why the
+/// two must be treated identically).
+///
+/// Strictly-greater is the load-bearing comparison (issue
+/// freenet/river#526), and it is safe because of what `archive_row` writes:
+/// the cutoff is the newest timestamp the PEER sent us, recomputed from live
+/// room state at click time. It is deliberately NOT clamped — see below.
+///
+/// `post_apply_cleanup`'s membership sweep retains DMs on
+/// `alive(sender) && alive(recipient)`, and every DM in a pair shares the
+/// same sender/recipient set, so the sweep is all-or-nothing per pair — it
+/// cannot leave a thread partially swept. Combined with the live recompute
+/// (which covers the case where the rendered row lags a DM already in
+/// `ROOMS`), the cutoff is the pair's true inbound maximum in the steady
+/// state, and every inbound DM that already exists satisfies `ts <= cutoff`.
+///
+/// That is a steady-state property, not an absolute one. It assumes local
+/// state holds the pair's complete set at click time. The sweep is atomic per
+/// pair, but the RE-LAND is not: if a peer re-offers only part of a swept pair
+/// and the rail memo refreshes cleanly in between, the row and the live read
+/// agree on a value BELOW the pair's true max, and a later re-offer of the
+/// rest fires the gate and destroys that archive. `max(row, live)` covers a
+/// row that is stale from BEFORE the sweep; it cannot cover a cutoff taken
+/// inside the partial window. Narrow (only an archive clicked inside that
+/// window is lost) but real, and listed as a residual rather than claimed
+/// closed. A DM that left local state and was re-offered therefore
+/// re-lands at or below the cutoff and is inert here, which is the #526 fix.
+/// Only a timestamp strictly past the cutoff is content the user had not
+/// archived.
+///
+/// Accepted residuals, both bounded and neither silent-and-permanent:
+///
+/// * A genuinely new inbound DM stamped in the same unix second as the
+///   peer's previous one waits for their next message. This is the remainder
+///   of issue #267, which bought that second at the price of #526's silent,
+///   permanent archive destruction.
+/// * A peer whose clock moves BACKWARD relative to their own previous
+///   message is likewise deferred.
+/// * A peer who stamps a DM far in the FUTURE sets a correspondingly
+///   far-future cutoff when the user archives, so their later genuine DMs stay
+///   archived until real time passes it. This function clamps the INCOMING
+///   timestamp at `now + MAX_DM_FUTURE_SKEW_SECS` so such a DM can never
+///   trigger an unhide and destroy the archive; the cutoff itself is
+///   deliberately NOT clamped, because clamping one side of the comparison
+///   breaks `every existing inbound DM is <= cutoff` and both re-opens #526
+///   and turns Archive into a no-op (see `dm_rail_section::archive_cutoff`).
+///
+/// * If OUR clock runs more than `MAX_DM_FUTURE_SKEW_SECS` behind real time,
+///   every honest inbound DM clamps to `now + MAX`, below any cutoff derived
+///   from real-clock peer timestamps, so the gate never fires. The rail filter
+///   compares the UNCLAMPED clock, so the thread still shows; only the entry
+///   cleanup is skipped.
+///
+/// These defer messages from one peer the user already chose to archive, and
+/// none destroys state. Two narrow cases CAN still cost an archive entry: a
+/// cutoff taken inside a partial re-land window (above), and a DM that the
+/// live read missed because `ROOMS` was contended AND the rendered row lagged.
+/// Both require an archive clicked inside a specific race; neither is the
+/// systematic churn #526 is about. Irreducible under timestamp gating; the
+/// real remedy for a hostile peer is a block/ignore list, freenet/river#461.
+///
+/// Pinned by the `should_unhide_for_inbound_dm_*` tests, and its use by
+/// [`unhide_dm_thread_if_dm_is_newer`] by
+/// `gated_unhide_wrapper_consults_the_cutoff`.
+pub(crate) fn should_unhide_for_inbound_dm(
+    cutoff: Option<u64>,
+    dm_timestamp: u64,
+    now_secs: u64,
+) -> bool {
+    // Bound the incoming timestamp at `now + MAX_DM_FUTURE_SKEW_SECS`.
+    //
+    // The CUTOFF is deliberately unclamped (`dm_rail_section::archive_cutoff`),
+    // because clamping the side the rail filter does not clamp breaks
+    // `every existing inbound DM is <= cutoff`. Bounding this side instead is
+    // safe in the only direction that matters: `effective <= dm_timestamp`
+    // always, so this can only make the gate MORE conservative and can never
+    // destroy state the unclamped comparison would have kept.
+    //
+    // What it actually buys is narrow, and worth stating precisely: it binds
+    // only when `cutoff >= now + MAX`, i.e. against a peer who has ALREADY
+    // forged a far-future timestamp and inflated the cutoff. It stops them
+    // escalating to a larger forgery to drop the archive. It does NOT stop a
+    // first forgery from reviving a normally-archived thread, because an
+    // ordinary cutoff sits below `now + MAX`. An honest DM is never affected.
+    let effective = dm_timestamp.min(
+        now_secs.saturating_add(river_core::room_state::direct_messages::MAX_DM_FUTURE_SKEW_SECS),
+    );
+    matches!(cutoff, Some(c) if effective > c)
+}
+
+/// Drop the archive entry for `(room, peer)` **only if** `dm_timestamp` is
+/// strictly past the pair's archive cutoff — the inbound-sync counterpart
+/// of [`unhide_dm_thread`] (issue freenet/river#526).
+///
+/// The four explicit-user-action call sites — the Undo toast, the Archived
+/// panel's Un-archive, and the outbound sends in `dm_thread_modal::do_send`
+/// and `direct_messages::send_structured_dm` (invite-via-DM) — keep calling
+/// the unconditional [`unhide_dm_thread`]. Routing any of them through this
+/// gated form would make it a silent no-op: at that moment the thread's
+/// inbound clock is by construction at or below the cutoff.
+///
+/// Scope caveat: that mechanism is per-device. `unhide_dm_thread` removes the
+/// entry locally and saves the blob, but `resolve_hidden_thread_hydration`
+/// only ever INSERTS, so nothing propagates a removal to another device — and
+/// `riverctl dm send` never calls it at all. Archiving on a laptop and then
+/// replying from a phone (or riverctl) therefore leaves the laptop's copy
+/// archived until the peer writes again. Bounded, and strictly better than
+/// #526's permanent destruction, but "our own sends revive the thread" is
+/// true of the SENDING device only. The two
+/// inbound-sync call sites in `room_synchronizer` must NOT, because their
+/// "newly landed" predicate is a diff against **local state**, not against
+/// the archive cutoff:
+///
+/// * `post_apply_cleanup` sweeps every DM whose counterparty is momentarily
+///   absent from `members` (`room_state.rs` ->
+///   `direct_messages::sweep_after_membership_change`). Peers re-offer the
+///   swept DMs and they re-land, which the diff cannot distinguish from a
+///   genuinely new message. Unconditionally unhiding there destroyed the
+///   archive on ordinary sync churn.
+/// * On the full-state path a pre-merge snapshot taken before the room blob
+///   has hydrated is EMPTY, so every DM in the incoming state reads as newly
+///   landed and every archive in the room was destroyed at once.
+///
+/// Both are neutralised here: a pair with no archive entry — whether it was
+/// never archived or `HIDDEN_DM_THREADS` simply hasn't hydrated yet — has
+/// nothing to revive, so we return without touching the signal and, crucially,
+/// **without writing a `RECENTLY_UNHIDDEN` tombstone**. Writing one would
+/// suppress the archive entry when it does hydrate a moment later, turning a
+/// startup race into permanent data loss.
+///
+/// A contended `try_read` skips the unhide. That is safe to lose *visually*:
+/// the rail filter already reveals a thread whose newest DM is past the
+/// cutoff (`is_thread_hidden_for` is `max_message_ts <= hidden_at_ts`), so
+/// the thread still shows. Dropping the entry is durability housekeeping — it
+/// stops a later membership sweep, which drives `last_any_ts` to 0 (and
+/// `0 <= hidden_at_ts` always holds), from re-hiding an already-revived
+/// thread. The same applies to the `cutoff == None` branch when
+/// `HIDDEN_DM_THREADS` has not hydrated yet.
+///
+/// Recovery is by the next inbound or re-offered DM past the cutoff, NOT by a
+/// reload: no save is queued on either skip, so the delegate blob still holds
+/// the entry and a reload re-hydrates it verbatim.
+pub fn unhide_dm_thread_if_dm_is_newer(
+    room_owner_vk: ed25519_dalek::VerifyingKey,
+    peer: MemberId,
+    dm_timestamp: u64,
+) {
+    use crate::components::direct_messages::HIDDEN_DM_THREADS;
+
+    let Ok(hidden) = HIDDEN_DM_THREADS.try_read() else {
+        return;
+    };
+    let cutoff = hidden.get(&(room_owner_vk, peer)).map(|e| e.hidden_at_ts);
+    // Release the read borrow before `unhide_dm_thread` touches the same
+    // signal. This is load-bearing, not belt-and-braces: on non-wasm targets
+    // `crate::util::defer` runs its closure SYNCHRONOUSLY (`util.rs`), which
+    // is how the native test suite executes, so without this drop the
+    // `with_mut` inside `unhide_dm_thread` takes a write borrow while this
+    // read guard is still alive - a re-entrant RefCell panic. On wasm the
+    // setTimeout(0) defer would cover it, which is exactly why a future
+    // reader might think the drop is deletable. It is not.
+    drop(hidden);
+
+    if should_unhide_for_inbound_dm(cutoff, dm_timestamp, unix_now_secs()) {
+        unhide_dm_thread(room_owner_vk, peer);
+    }
 }
 
 /// Coalescing state for [`save_outbound_dms_to_delegate`]. Single-flight

--- a/ui/src/components/app/document_title.rs
+++ b/ui/src/components/app/document_title.rs
@@ -496,8 +496,8 @@ fn count_unread_dms(rooms: &crate::room_data::Rooms) -> usize {
 /// the thread is actually visible in the panel. A hidden (archived)
 /// thread is skipped unless a message STRICTLY newer than its
 /// `hidden_at_ts` revived it — the same `is_thread_hidden_for` rule
-/// `filter_rail_entries` applies, and revival considers messages in both
-/// directions, exactly like the rail's `last_any_ts`. Without this
+/// `filter_rail_entries` applies. Revival is INBOUND-only, exactly like the
+/// rail's `last_inbound_ts` (issue freenet/river#526). Without this
 /// filter the unread tallies (title, hamburger badge) count messages the
 /// user has no visible thread for and no way to clear.
 fn count_unread_dms_with(
@@ -513,9 +513,11 @@ fn count_unread_dms_with(
         let self_id: MemberId = room_data.self_sk.verifying_key().into();
 
         // Per-peer accumulation: unread inbound messages plus the newest
-        // timestamp in either direction (the revival clock).
+        // INBOUND timestamp (the revival clock — see the rail's
+        // `last_inbound_ts` and issue freenet/river#526 for why our own
+        // outbound sends must not feed it).
         struct Acc {
-            last_any_ts: u64,
+            last_inbound_ts: u64,
             unread: usize,
         }
         let mut per_peer: std::collections::HashMap<MemberId, Acc> =
@@ -532,13 +534,13 @@ fn count_unread_dms_with(
                 msg.message.sender
             };
             let acc = per_peer.entry(peer).or_insert(Acc {
-                last_any_ts: 0,
+                last_inbound_ts: 0,
                 unread: 0,
             });
-            if msg.message.timestamp > acc.last_any_ts {
-                acc.last_any_ts = msg.message.timestamp;
-            }
             if is_self_recipient {
+                if msg.message.timestamp > acc.last_inbound_ts {
+                    acc.last_inbound_ts = msg.message.timestamp;
+                }
                 let cutoff = last_seen.get(&(*owner_key, peer)).copied().unwrap_or(0);
                 if msg.message.timestamp > cutoff {
                     acc.unread += 1;
@@ -547,11 +549,15 @@ fn count_unread_dms_with(
         }
 
         for (peer, acc) in per_peer {
+            // INBOUND-only, matching the rail filter (issue freenet/river#526).
+            // Using `last_any_ts` here would let our OWN outbound DM's
+            // locally-clocked timestamp decide whether a peer's message counts
+            // as unread, which is how an in-flight inbound DM lost its badge.
             if crate::components::direct_messages::is_thread_hidden_for(
                 hidden,
                 owner_key,
                 peer,
-                acc.last_any_ts,
+                acc.last_inbound_ts,
             ) {
                 continue;
             }
@@ -1927,10 +1933,18 @@ mod tests {
     }
 
     #[test]
-    fn dm_unread_outbound_message_revives_hidden_thread() {
-        // The revival clock counts BOTH directions (the rail's
-        // `last_any_ts`): replying into a hidden thread makes it visible
-        // again, so its older unread inbound must count again too.
+    fn dm_unread_outbound_message_does_not_by_itself_revive_a_hidden_thread() {
+        // Issue freenet/river#526: the revival clock is INBOUND-only. This
+        // test previously asserted the opposite (that replying revived the
+        // thread for unread purposes) because the clock covered both
+        // directions — and that is exactly what made an in-flight inbound DM
+        // invisible: our own outbound timestamp is our LOCAL wall clock, so it
+        // decided whether a PEER's message counted.
+        //
+        // Replying still revives the thread in practice, but through the
+        // unconditional `unhide_dm_thread` in `do_send` / `send_structured_dm`
+        // — i.e. by REMOVING the entry, which the second half asserts. That is
+        // a stronger mechanism than the timestamp race it replaces.
         let (self_sk, self_vk) = keypair();
         let (_owner_sk, owner_vk) = keypair();
         let (peer_sk, peer_vk) = keypair();
@@ -1954,9 +1968,54 @@ mod tests {
                 hidden_at_ts: 90,
             },
         );
-        // last_any_ts = 150 (outbound) > hidden_at 90 → revived → the
-        // ts=90 inbound counts.
-        assert_eq!(count_unread_dms_with(&map, &HashMap::new(), &hidden), 1);
+
+        // last_inbound_ts = 90 <= hidden_at 90 -> still archived. The
+        // outbound at 150 does NOT drag it back into the tally.
+        assert_eq!(
+            count_unread_dms_with(&map, &HashMap::new(), &hidden),
+            0,
+            "an outbound reply must not revive the thread via the timestamp \
+             filter (#526) - revival comes from the explicit unhide"
+        );
+
+        // What `do_send` actually does: drop the entry. Now it counts.
+        hidden.remove(&(owner_vk, peer_id));
+        assert_eq!(
+            count_unread_dms_with(&map, &HashMap::new(), &hidden),
+            1,
+            "the explicit unhide on outbound send is what revives the thread"
+        );
+    }
+
+    #[test]
+    fn dm_unread_inbound_message_revives_hidden_thread() {
+        // The other half of #526: a genuinely new INBOUND DM past the cutoff
+        // still revives the thread through the filter, unchanged.
+        let (self_sk, self_vk) = keypair();
+        let (_owner_sk, owner_vk) = keypair();
+        let (peer_sk, peer_vk) = keypair();
+        let self_id: MemberId = (&self_vk).into();
+        let peer_id: MemberId = (&peer_vk).into();
+
+        let mut rd = room(self_sk, owner_vk, vec![], None);
+        rd.room_state.direct_messages.messages = vec![
+            dm(peer_id, self_id, 90, &peer_sk),  // inbound, archived over
+            dm(peer_id, self_id, 150, &peer_sk), // inbound, after the archive
+        ];
+        let mut map = HashMap::new();
+        map.insert(owner_vk, rd);
+
+        let mut hidden = HashMap::new();
+        hidden.insert(
+            (owner_vk, peer_id),
+            river_core::chat_delegate::HiddenDmThreadEntry {
+                room_owner_vk: owner_vk.to_bytes(),
+                peer: peer_id,
+                hidden_at_ts: 90,
+            },
+        );
+        // last_inbound_ts = 150 > 90 -> revived, and BOTH inbound DMs count.
+        assert_eq!(count_unread_dms_with(&map, &HashMap::new(), &hidden), 2);
     }
 
     #[test]

--- a/ui/src/components/app/freenet_api/room_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/room_synchronizer.rs
@@ -285,6 +285,35 @@ pub(crate) fn send_member_info_heal_update(
     });
 }
 
+/// Collapse a batch of newly-landed `(sender, timestamp)` inbound DMs to one
+/// entry per sender, keeping the sender's LARGEST timestamp.
+///
+/// One merge can land several DMs from the same peer, and after issue
+/// freenet/river#526 the archive decision is made against a timestamp rather
+/// than fired unconditionally — so the batch must be reduced by `max`, not by
+/// "first seen wins". A batch mixing a re-landed old DM with a genuinely new
+/// one has to revive the thread; picking an arbitrary member of the batch
+/// would make that outcome depend on merge order.
+///
+/// De-duplicating also keeps one delegate save per peer per merge, which is
+/// what the pre-#526 `HashSet` pass was for.
+///
+/// Pinned by the `fold_newly_landed_to_max_ts_*` tests.
+fn fold_newly_landed_to_max_ts(landed: Vec<(MemberId, u64)>) -> Vec<(MemberId, u64)> {
+    let mut best: HashMap<MemberId, u64> = HashMap::new();
+    for (sender, ts) in landed {
+        let slot = best.entry(sender).or_insert(ts);
+        if ts > *slot {
+            *slot = ts;
+        }
+    }
+    let mut out: Vec<(MemberId, u64)> = best.into_iter().collect();
+    // `HashMap` iteration order is per-process random; sort so the resulting
+    // sequence of unhide/save calls is deterministic.
+    out.sort_by_key(|(sender, _)| *sender);
+    out
+}
+
 /// Identifies contracts that have changed in order to send state updates to Freene
 #[derive(Clone)]
 pub struct RoomSynchronizer {
@@ -328,7 +357,7 @@ impl RoomSynchronizer {
         // diffing the post-merge `direct_messages.messages` list
         // against a pre-merge signature snapshot, we only unhide for
         // DMs that genuinely just landed.
-        let mut newly_landed_inbound_senders: Vec<MemberId> = Vec::new();
+        let mut newly_landed_inbound_senders: Vec<(MemberId, u64)> = Vec::new();
 
         // Will be populated inside with_mut if new messages need notification
         let mut pending_notification: Option<(
@@ -475,7 +504,8 @@ impl RoomSynchronizer {
                                 // but defence-in-depth.
                                 continue;
                             }
-                            newly_landed_inbound_senders.push(msg.message.sender);
+                            newly_landed_inbound_senders
+                                .push((msg.message.sender, msg.message.timestamp));
                         }
 
                         // NOTE: We do not update last_synced_state in the delta path.
@@ -528,17 +558,19 @@ impl RoomSynchronizer {
         // their own `unhide_dm_thread` call site in
         // `dm_thread_modal::do_send` / `direct_messages::send_structured_dm`,
         // so we don't need a self-id filter on this path.
-        if !newly_landed_inbound_senders.is_empty() {
-            // De-duplicate before firing the unhide (multiple inbound
-            // DMs from the same peer in one batch only need one unhide
-            // call). `unhide_dm_thread` is idempotent, so duplicates
-            // are safe, but de-duping avoids redundant delegate saves.
-            let mut seen: std::collections::HashSet<MemberId> = std::collections::HashSet::new();
-            for sender in newly_landed_inbound_senders {
-                if seen.insert(sender) {
-                    crate::components::app::chat_delegate::unhide_dm_thread(owner_vk, sender);
-                }
-            }
+        //
+        // Issue freenet/river#526: crossing the dedupe means "was not in
+        // LOCAL state a moment ago", which is NOT the same as "is new
+        // content". `post_apply_cleanup`'s membership sweep removes DMs
+        // whose counterparty is momentarily absent from `members`, peers
+        // re-offer them, and they re-land — indistinguishable here from a
+        // genuinely new message. So the timestamp goes with the sender and
+        // the decision is made against the pair's archive cutoff by
+        // `unhide_dm_thread_if_dm_is_newer`, never unconditionally.
+        for (sender, dm_ts) in fold_newly_landed_to_max_ts(newly_landed_inbound_senders) {
+            crate::components::app::chat_delegate::unhide_dm_thread_if_dm_is_newer(
+                owner_vk, sender, dm_ts,
+            );
         }
 
         // freenet/river#295: a private-room secret arrived in this delta and
@@ -1256,7 +1288,7 @@ impl RoomSynchronizer {
         // Issue freenet/river#267 (full-state path): post-merge inbound
         // DM senders for hidden-thread revival. Same shape as the
         // delta-path local in apply_delta_inner.
-        let mut newly_landed_inbound_senders: Vec<MemberId> = Vec::new();
+        let mut newly_landed_inbound_senders: Vec<(MemberId, u64)> = Vec::new();
         // freenet/river#295 (full-state path): same shape as the delta-path
         // local in apply_delta_inner — a newly-arrived private-room secret may
         // let us finally seal & publish our own member_info.
@@ -1387,7 +1419,8 @@ impl RoomSynchronizer {
                                 if msg.message.sender == self_id {
                                     continue;
                                 }
-                                newly_landed_inbound_senders.push(msg.message.sender);
+                                newly_landed_inbound_senders
+                                    .push((msg.message.sender, msg.message.timestamp));
                             }
                         }
 
@@ -1486,13 +1519,26 @@ impl RoomSynchronizer {
         // whose post-merge DM set gained a new inbound DM from the
         // peer. Symmetric with the apply_delta_inner path. Codex
         // review finding on PR #286.
-        if !newly_landed_inbound_senders.is_empty() {
-            let mut seen: std::collections::HashSet<MemberId> = std::collections::HashSet::new();
-            for sender in newly_landed_inbound_senders {
-                if seen.insert(sender) {
-                    crate::components::app::chat_delegate::unhide_dm_thread(room_owner_vk, sender);
-                }
-            }
+        //
+        // Issue freenet/river#526: this path is the WORSE of the two. Its
+        // pre-merge snapshot is empty whenever the room is present in `ROOMS`
+        // but its DM state has not hydrated yet — a full-state GET can land
+        // first. Every DM in the incoming state then reads as newly landed,
+        // so the old unconditional unhide destroyed EVERY archive in the room
+        // at once. (The room-NOT-found branch above is inert for a different
+        // reason: it nulls `self_member_id` too, so the collection loop is
+        // skipped entirely and no sender is ever gathered.)
+        //
+        // Now the timestamps decide: an already-existing DM is at or below
+        // the pair's cutoff, so it cannot revive the thread, and a pair whose
+        // archive entry has not hydrated yet is inert with no tombstone
+        // written.
+        for (sender, dm_ts) in fold_newly_landed_to_max_ts(newly_landed_inbound_senders) {
+            crate::components::app::chat_delegate::unhide_dm_thread_if_dm_is_newer(
+                room_owner_vk,
+                sender,
+                dm_ts,
+            );
         }
 
         // freenet/river#295 (full-state path): publish the self-heal built
@@ -1674,6 +1720,7 @@ pub struct ContractSyncInfo {
 mod tests {
     use super::*;
     use ed25519_dalek::SigningKey;
+    use freenet_scaffold::util::FastHash;
     use river_core::room_state::message::{AuthorizedMessageV1, MessageV1, RoomMessageBody};
     use std::time::SystemTime;
 
@@ -1939,7 +1986,19 @@ mod tests {
     // -----------------------------------------------------------------
     #[test]
     fn apply_delta_inner_revives_hidden_thread_for_inbound_dm_sender() {
-        let src = include_str!("room_synchronizer.rs");
+        // Slice at the function head so this pin genuinely scopes to
+        // `apply_delta_inner` — without it, wiring present only in
+        // `update_room_state_inner` would satisfy every assertion below while
+        // the delta path had none.
+        let whole = production_source_whitespace_stripped();
+        let split_at = whole
+            .find("fnapply_delta_inner(")
+            .expect("apply_delta_inner must exist in this file");
+        let tail = &whole[split_at..];
+        let end = tail
+            .find("fnupdate_room_state_inner(")
+            .unwrap_or(tail.len());
+        let src = &tail[..end];
         // The unhide MUST be computed from the post-merge signature
         // diff, NOT from the raw delta. The raw delta can carry
         // re-deliveries that the contract silently drops; firing
@@ -1957,12 +2016,126 @@ mod tests {
              can diff against the post-merge set to find genuinely new DMs (#267)."
         );
         assert!(
-            src.contains("chat_delegate::unhide_dm_thread("),
-            "apply_delta_inner must call unhide_dm_thread on each newly-landed \
-             inbound DM sender so a hidden thread is revived even when the new \
-             DM's timestamp matches the hide cutoff exactly (#267). The filter's \
-             strict-`<=` rule alone is not sufficient for the same-second case."
+            src.contains(&gated_unhide_needle()),
+            "apply_delta_inner must route each newly-landed inbound DM through \
+             unhide_dm_thread_if_dm_is_newer so a hidden thread is revived when \
+             the DM is past the archive cutoff (#267)."
         );
+    }
+
+    /// Needle for the GATED unhide call, assembled at runtime so this pin
+    /// cannot match its own source text via `include_str!` (the trap the
+    /// pre-#526 version of these tests fell into: it searched for a literal
+    /// that its own assertion contained, making it vacuous).
+    fn gated_unhide_needle() -> String {
+        format!(
+            "chat_delegate::{}{}",
+            "unhide_dm_thread_if_dm_is_newer", "("
+        )
+    }
+
+    /// Needle for the UNCONDITIONAL unhide call, assembled the same way.
+    ///
+    /// Deliberately NOT prefixed with `chat_delegate::`: every other caller in
+    /// the codebase imports the function and calls it bare
+    /// (`dm_rail_section.rs`, `dm_thread_modal.rs`, `direct_messages.rs`), so
+    /// a fully-qualified-only needle would miss the most likely re-regression
+    /// — someone adding a `use` and a bare call. Safe against false positives
+    /// because the gated name has `_if_dm_is_newer` between `thread` and `(`.
+    fn unconditional_unhide_needle() -> String {
+        format!("{}{}", "unhide_dm_thread", "(")
+    }
+
+    /// This file's source with the test module and all whitespace removed.
+    ///
+    /// Cutting at `mod tests` (not `#[cfg(test)]`) is what keeps these pins
+    /// from matching their own assertion literals. Stripping whitespace keeps
+    /// them alive across a rustfmt pass that splits a growing call's arguments
+    /// over several lines.
+    fn production_source_whitespace_stripped() -> String {
+        let src = include_str!("room_synchronizer.rs");
+        let cut = src
+            .find("mod tests {")
+            .expect("this file must have a `mod tests {` to cut at");
+        src[..cut].chars().filter(|c| !c.is_whitespace()).collect()
+    }
+
+    /// Issue freenet/river#526 regression guard.
+    ///
+    /// The two inbound-sync call sites must use the CUTOFF-GATED unhide.
+    /// Their "newly landed" predicate is a diff against local state, which
+    /// cannot tell a genuinely new DM from an old one that left local state
+    /// (`post_apply_cleanup`'s membership sweep) and was re-offered by a peer
+    /// — nor from the empty-pre-merge-snapshot case on the full-state path,
+    /// where EVERY DM reads as newly landed. Calling the unconditional
+    /// `unhide_dm_thread` from either site destroys the user's archive on
+    /// ordinary sync churn, and persists the destruction.
+    ///
+    /// The unconditional variant is still correct for the explicit-user-action
+    /// call sites (Undo toast, Archived-panel Un-archive, outbound send) —
+    /// those live in other files, so this pin is scoped to this one.
+    #[test]
+    fn inbound_sync_paths_never_unhide_unconditionally() {
+        let src = production_source_whitespace_stripped();
+        assert!(
+            !src.contains(&unconditional_unhide_needle()),
+            "room_synchronizer must never call the unconditional \
+             chat_delegate::unhide_dm_thread — an inbound DM that merely \
+             RE-landed after a membership sweep would destroy the pair's \
+             archive entry (#526). Use unhide_dm_thread_if_dm_is_newer, which \
+             compares the DM's timestamp against the archive cutoff."
+        );
+        assert_eq!(
+            src.matches(&gated_unhide_needle()).count(),
+            2,
+            "both inbound-sync paths (apply_delta_inner and \
+             update_room_state_inner) must route through the gated unhide \
+             (#526). A dropped call site silently re-regresses one of them."
+        );
+    }
+
+    /// The batch fold keeps the LARGEST timestamp per sender, so a merge that
+    /// mixes a re-landed old DM with a genuinely new one still revives the
+    /// thread (#526).
+    #[test]
+    fn fold_newly_landed_to_max_ts_keeps_largest_per_sender() {
+        let a = MemberId(FastHash(1));
+        let b = MemberId(FastHash(2));
+        let folded = fold_newly_landed_to_max_ts(vec![(a, 500), (b, 10), (a, 1_500), (a, 900)]);
+        assert_eq!(folded.len(), 2, "one entry per sender");
+        let a_ts = folded.iter().find(|(s, _)| *s == a).unwrap().1;
+        let b_ts = folded.iter().find(|(s, _)| *s == b).unwrap().1;
+        assert_eq!(
+            a_ts, 1_500,
+            "the newest DM in the batch must win — picking an arbitrary member \
+             would make revival depend on merge order"
+        );
+        assert_eq!(b_ts, 10);
+    }
+
+    /// Order must not depend on `HashMap` iteration order, so the sequence of
+    /// unhide/save calls is deterministic across runs.
+    #[test]
+    fn fold_newly_landed_to_max_ts_is_deterministically_ordered() {
+        // Eight senders, not three: with three keys a HashMap fold would
+        // coincidentally match the sorted order on roughly one run in six, so
+        // dropping the sort would survive the mutation a meaningful fraction
+        // of the time. Eight makes that ~1e-5.
+        let ids: Vec<MemberId> = (1..=8).map(|i| MemberId(FastHash(i))).collect();
+        let input: Vec<(MemberId, u64)> = ids.iter().map(|id| (*id, 10u64)).collect();
+        let mut expected = input.clone();
+        expected.sort_by_key(|(s, _)| *s);
+
+        assert_eq!(fold_newly_landed_to_max_ts(input.clone()), expected);
+        let mut reversed = input;
+        reversed.reverse();
+        assert_eq!(fold_newly_landed_to_max_ts(reversed), expected);
+    }
+
+    /// An empty batch produces no unhide calls at all.
+    #[test]
+    fn fold_newly_landed_to_max_ts_empty_is_empty() {
+        assert!(fold_newly_landed_to_max_ts(Vec::new()).is_empty());
     }
 
     /// Codex review finding on PR #286: the delta-path unhide alone
@@ -1972,13 +2145,18 @@ mod tests {
     /// apply the same diff-and-unhide logic.
     #[test]
     fn update_room_state_inner_also_revives_hidden_thread_for_inbound_dm() {
-        let src = include_str!("room_synchronizer.rs");
         // Find the update_room_state_inner function body and assert
         // the pre-merge snapshot + post-merge collection + unhide
         // call all appear AFTER its declaration. We don't try to
         // parse Rust; instead we split the file at the function
         // signature and look at the suffix.
-        let marker = "fn update_room_state_inner(";
+        //
+        // The slice is taken from the TEST-STRIPPED source (#526): the test
+        // module sits after this function in the file, so a suffix of the raw
+        // source would include these assertions' own literals and the pin
+        // would pass no matter what the production code did.
+        let src = production_source_whitespace_stripped();
+        let marker = "fnupdate_room_state_inner(";
         let split_at = src.find(marker).expect(
             "update_room_state_inner must exist in this file — the test is targeting the wrong path",
         );
@@ -1996,11 +2174,11 @@ mod tests {
              senders post-merge (#267)."
         );
         assert!(
-            suffix.contains("chat_delegate::unhide_dm_thread("),
-            "update_room_state_inner must call unhide_dm_thread on each \
-             newly-landed inbound DM sender so the #267 fix covers both the \
-             delta path AND the full-state merge path. Without this, a \
-             refresh GET that delivers a new inbound DM into a hidden thread \
+            suffix.contains(&gated_unhide_needle()),
+            "update_room_state_inner must route each newly-landed inbound DM \
+             through unhide_dm_thread_if_dm_is_newer so the #267 fix covers \
+             both the delta path AND the full-state merge path. Without this, \
+             a refresh GET that delivers a new inbound DM into a hidden thread \
              leaves the thread archived."
         );
     }

--- a/ui/src/components/direct_messages.rs
+++ b/ui/src/components/direct_messages.rs
@@ -695,6 +695,38 @@ pub fn seed_dm_last_seen_if_needed() {
 
 #[cfg(test)]
 mod tests {
+
+    /// Issue freenet/river#526: the archive clock is INBOUND-only, so an
+    /// outbound send no longer revives an archived thread through the
+    /// timestamp filter. The unconditional `unhide_dm_thread` call in
+    /// `send_structured_dm` is now the ONLY mechanism that does, which makes it
+    /// load-bearing rather than belt-and-braces.
+    ///
+    /// Routing it through the cutoff-gated `unhide_dm_thread_if_dm_is_newer`
+    /// - the "consistency" refactor - would make replying stop reviving
+    /// archived threads entirely, with a green suite: at that moment the
+    /// thread's inbound clock is by construction at or below the cutoff.
+    #[test]
+    fn outbound_send_keeps_the_unconditional_unhide() {
+        let raw = include_str!("direct_messages.rs");
+        let cut = raw
+            .find("mod tests {")
+            .expect("this file must have a `mod tests {`");
+        let src: String = raw[..cut].chars().filter(|c| !c.is_whitespace()).collect();
+        assert!(
+            !src.contains(&format!("{}{}", "unhide_dm_thread_if_dm_is_newer", "(")),
+            "the outbound send must NOT use the cutoff-gated unhide (#526) - \
+             replying would silently stop reviving archived threads."
+        );
+        assert_eq!(
+            src.matches(&format!("{}{}", "unhide_dm_thread", "("))
+                .count(),
+            1,
+            "the outbound send must keep calling the unconditional \
+             unhide_dm_thread (#526); it is the only remaining mechanism that \
+             revives an archived thread on reply."
+        );
+    }
     /// The DM send path in this file must NOT carry a client-side per-pair cap
     /// guard.
     ///

--- a/ui/src/components/direct_messages/dm_thread_modal.rs
+++ b/ui/src/components/direct_messages/dm_thread_modal.rs
@@ -1401,6 +1401,38 @@ fn merge_invite_into_draft(existing: &str, body: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+
+    /// Issue freenet/river#526: the archive clock is INBOUND-only, so an
+    /// outbound send no longer revives an archived thread through the
+    /// timestamp filter. The unconditional `unhide_dm_thread` call in
+    /// `do_send` is now the ONLY mechanism that does, which makes it
+    /// load-bearing rather than belt-and-braces.
+    ///
+    /// Routing it through the cutoff-gated `unhide_dm_thread_if_dm_is_newer`
+    /// - the "consistency" refactor - would make replying stop reviving
+    /// archived threads entirely, with a green suite: at that moment the
+    /// thread's inbound clock is by construction at or below the cutoff.
+    #[test]
+    fn outbound_send_keeps_the_unconditional_unhide() {
+        let raw = include_str!("dm_thread_modal.rs");
+        let cut = raw
+            .find("mod tests {")
+            .expect("this file must have a `mod tests {`");
+        let src: String = raw[..cut].chars().filter(|c| !c.is_whitespace()).collect();
+        assert!(
+            !src.contains(&format!("{}{}", "unhide_dm_thread_if_dm_is_newer", "(")),
+            "the outbound send must NOT use the cutoff-gated unhide (#526) - \
+             replying would silently stop reviving archived threads."
+        );
+        assert_eq!(
+            src.matches(&format!("{}{}", "unhide_dm_thread", "("))
+                .count(),
+            1,
+            "the outbound send must keep calling the unconditional \
+             unhide_dm_thread (#526); it is the only remaining mechanism that \
+             revives an archived thread on reply."
+        );
+    }
     /// The DM send path in this file must NOT carry a client-side per-pair cap
     /// guard.
     ///

--- a/ui/src/components/room_list/dm_rail_section.rs
+++ b/ui/src/components/room_list/dm_rail_section.rs
@@ -181,7 +181,7 @@ fn DmRailRow(entry: DmRailEntry) -> Element {
     let room = entry.room;
     let peer = entry.peer;
     let nickname = entry.peer_nickname.clone();
-    let last_any_ts = entry.last_any_ts;
+    let last_inbound_ts = entry.last_inbound_ts;
     let click = move |_| {
         open_dm_thread(room, peer);
     };
@@ -202,7 +202,7 @@ fn DmRailRow(entry: DmRailEntry) -> Element {
         // container — without it, archiving from such a container
         // would open the thread on the same click.
         evt.stop_propagation();
-        archive_row(room, peer, &nickname, last_any_ts);
+        archive_row(room, peer, &nickname, last_inbound_ts);
     };
 
     let archive_title =
@@ -269,18 +269,108 @@ fn build_archive_toast(
     }
 }
 
+/// Max timestamp of a DM the peer sent US for `(room, peer)`, read from live
+/// `ROOMS` state rather than from a rendered rail row.
+///
+/// Returns `None` when `ROOMS` is contended or the room is absent, so the
+/// caller can fall back to the row's value (issue freenet/river#526 — see
+/// [`archive_row`] property 2 for why the rendered prop alone is not enough).
+///
+/// Pure-ish: the scan itself is exercised through
+/// [`max_inbound_ts_from_triples`], which is unit-tested; this wrapper only
+/// does the signal read.
+fn current_last_inbound_ts(room: &VerifyingKey, peer: MemberId) -> Option<u64> {
+    use dioxus::prelude::ReadableExt;
+    let rooms = ROOMS.try_read().ok()?;
+    let room_data = rooms.map.get(room)?;
+    let self_id = MemberId::from(&room_data.self_sk.verifying_key());
+    Some(max_inbound_ts_from_triples(
+        dm_message_triples(room_data),
+        self_id,
+        peer,
+    ))
+}
+
+/// Pure helper behind [`current_last_inbound_ts`]: max timestamp over DMs
+/// sent BY `peer` TO `self_id`. Zero when the pair has no inbound DMs.
+///
+/// Pinned by the `max_inbound_ts_from_triples_*` tests.
+pub(crate) fn max_inbound_ts_from_triples(
+    messages: impl IntoIterator<Item = (MemberId, MemberId, u64)>,
+    self_id: MemberId,
+    peer: MemberId,
+) -> u64 {
+    messages
+        .into_iter()
+        .filter(|(sender, recipient, _)| *sender == peer && *recipient == self_id)
+        .map(|(_, _, ts)| ts)
+        .max()
+        .unwrap_or(0)
+}
+
+/// The `hidden_at_ts` an Archive click records, from the row's rendered
+/// inbound clock and the live one (`None` when `ROOMS` was contended).
+///
+/// Issue freenet/river#526 turns on two properties, both of them here:
+///
+/// 1. INBOUND-ONLY inputs. `last_any_ts` also covers our own outbound DMs,
+///    whose timestamp is our LOCAL wall clock. A thread where we replied last
+///    would then be archived against OUR clock while
+///    `should_unhide_for_inbound_dm` compares a SENDER's timestamp — so a peer
+///    DM already in flight across the click lands at or below the cutoff and
+///    goes invisible on every surface: no rail row, no unread badge
+///    (`document_title::count_unread_dms_with` applies the same filter), no
+///    notification (DMs never raise one).
+///
+/// 2. MAX of rendered and live. The row prop can lag — `build_view` serves
+///    `LAST_GOOD_RAIL` verbatim on a contended pass, and a DM can land in
+///    `ROOMS` between the memo's last clean pass and the click. The membership
+///    sweep is atomic per pair but the RE-LAND is not, so a peer restoring
+///    only a subset also leaves the row low. A cutoff below the pair's true
+///    inbound max lets the rest re-land looking newer than the archive, which
+///    is #526 itself. Live wins when it is readable, the row is the fallback
+///    when it is not.
+///
+///    Cost, stated precisely: the live read can include an inbound DM that
+///    landed in `ROOMS` after the memo's last pass and so was never RENDERED.
+///    Archiving then covers a message the user never saw, and it stays hidden
+///    until the peer writes again. That is a deliberate trade — swallowing one
+///    message until the next beats destroying the archive outright — but it is
+///    NOT, as an earlier draft of this comment claimed, limited to messages the
+///    user had already seen.
+///
+/// The result is never clamped against wall-clock time, and that is
+/// deliberate. An earlier revision clamped it at `now + MAX_DM_FUTURE_SKEW_SECS`
+/// to blunt a forged-future timestamp, which broke the load-bearing invariant
+/// `every existing inbound DM satisfies ts <= cutoff`: the rail filter compares
+/// the UNCLAMPED observed clock, so the row stayed visible (Archive became a
+/// no-op that still showed an "Archived" toast) AND the next sweep-and-re-offer
+/// saw `ts > cutoff` and destroyed the persisted archive — #526 itself,
+/// narrowed to skew-violating peers. Clamping one side of a comparison is what
+/// created the hole. The forged-timestamp concern is instead handled where it
+/// cannot break this invariant: [`should_unhide_for_inbound_dm`] bounds the
+/// INCOMING timestamp instead. That bound is narrower than it sounds — it
+/// binds only once a forgery has already inflated the cutoff, stopping a peer
+/// escalating to a larger forgery; a first forgery can still revive a
+/// normally-archived thread. It is safe-directional either way: the bounded
+/// value is never above the raw one, so it can only make the gate more
+/// conservative.
+///
+/// Residual, documented rather than clamped: a peer who stamps a DM far in the
+/// future sets a correspondingly far-future cutoff, so their later genuine DMs
+/// stay archived until real time passes it. That hides messages from ONE peer
+/// the user already chose to archive, and never destroys state. The real remedy
+/// for a hostile peer is a block/ignore list, freenet/river#461.
+///
+/// Pinned by the `archive_cutoff_*` tests.
+pub(crate) fn archive_cutoff(row_inbound_ts: u64, live_inbound_ts: Option<u64>) -> u64 {
+    std::cmp::max(row_inbound_ts, live_inbound_ts.unwrap_or(0))
+}
+
 /// Wire up: archive the (room, peer) thread, schedule the toast, and
 /// schedule the auto-dismiss. Called from the ✕ rollover button.
-fn archive_row(room: VerifyingKey, peer: MemberId, peer_nickname: &str, last_any_ts: u64) {
-    // The `hidden_at_ts` follows the same semantics as the modal-driven
-    // hide: capture the most-recent message timestamp (or wall-clock
-    // seconds if the thread is empty) so the rail filter's strict-`<=`
-    // check revives the thread the moment a fresher message lands.
-    let cutoff = if last_any_ts > 0 {
-        last_any_ts
-    } else {
-        unix_now_secs()
-    };
+fn archive_row(room: VerifyingKey, peer: MemberId, peer_nickname: &str, row_last_inbound_ts: u64) {
+    let cutoff = archive_cutoff(row_last_inbound_ts, current_last_inbound_ts(&room, peer));
 
     let now_ms = unix_now_ms();
     let toast = build_archive_toast(room, peer, peer_nickname, now_ms);
@@ -412,6 +502,8 @@ pub(crate) struct DmRailEntry {
     pub(crate) peer_nickname: String,
     pub(crate) room_name: String,
     pub(crate) last_any_ts: u64,
+    /// Newest INBOUND timestamp — what the archive filter compares against.
+    pub(crate) last_inbound_ts: u64,
     pub(crate) unread: usize,
 }
 
@@ -435,9 +527,16 @@ struct ArchivedEntry {
 ///
 /// Rules (matches `chat_delegate::is_thread_hidden` strict `<=`):
 /// - Entry's `(room, peer)` absent from `hidden` → present.
-/// - Entry's `last_any_ts > hidden_at_ts` → present (newer message
+/// - Entry's `last_inbound_ts > hidden_at_ts` → present (newer message
 ///   revived the thread, regardless of direction).
-/// - Entry's `last_any_ts <= hidden_at_ts` → omitted.
+/// The comparison is INBOUND-only (issue freenet/river#526): archive means
+/// "hidden until the peer writes again". Our own outbound sends revive the
+/// thread through the unconditional `unhide_dm_thread` in `do_send` /
+/// `send_structured_dm`, so they need no representation here - and including
+/// them would put a locally-clocked timestamp on one side of the comparison,
+/// which is what made an in-flight inbound DM invisible on every surface.
+///
+/// - Entry's `last_inbound_ts <= hidden_at_ts` → omitted.
 ///
 /// Pinned by `filter_rail_entries_*` tests in this module.
 pub(crate) fn filter_rail_entries(
@@ -446,7 +545,7 @@ pub(crate) fn filter_rail_entries(
 ) -> Vec<DmRailEntry> {
     entries
         .into_iter()
-        .filter(|e| !is_thread_hidden_for(hidden, &e.room, e.peer, e.last_any_ts))
+        .filter(|e| !is_thread_hidden_for(hidden, &e.room, e.peer, e.last_inbound_ts))
         .collect()
 }
 
@@ -501,7 +600,13 @@ pub(crate) fn sort_rail_entries(entries: &mut [DmRailEntry]) {
 /// Per-peer DM activity accumulated from one room's message list.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub(crate) struct PeerDmActivity {
+    /// Newest timestamp in EITHER direction. Drives recency sorting.
     pub(crate) last_any_ts: u64,
+    /// Newest timestamp of a DM the PEER sent to us. Drives the archive
+    /// filter (issue freenet/river#526) — see [`archive_row`] for why the
+    /// archive question is "has the peer written since I archived", and
+    /// never "has anything happened".
+    pub(crate) last_inbound_ts: u64,
     pub(crate) unread: usize,
 }
 
@@ -536,12 +641,16 @@ pub(crate) fn accumulate_peer_activity(
         let peer = if is_self_sender { recipient } else { sender };
         let acc = per_peer.entry(peer).or_insert(PeerDmActivity {
             last_any_ts: 0,
+            last_inbound_ts: 0,
             unread: 0,
         });
         if timestamp > acc.last_any_ts {
             acc.last_any_ts = timestamp;
         }
         if is_self_recipient {
+            if timestamp > acc.last_inbound_ts {
+                acc.last_inbound_ts = timestamp;
+            }
             if let Some(seen) = last_seen {
                 let cutoff = seen.get(&(*room, peer)).copied().unwrap_or(0);
                 if timestamp > cutoff {
@@ -679,7 +788,7 @@ fn schedule_rail_nudge() {
 
 /// Pure helper: project the archived viewer's rows from the in-memory
 /// hide map plus the per-room display data and a per-pair
-/// `last_any_ts` map (the max DM timestamp for each `(room, peer)` in
+/// `last_inbound_ts` map (max INBOUND DM timestamp per `(room, peer)` in
 /// current room state). Entries whose thread has been revived by a
 /// strictly-newer message (`is_thread_hidden_for` returns false) are
 /// SKIPPED so the viewer agrees with the rail filter — without this,
@@ -693,7 +802,7 @@ fn schedule_rail_nudge() {
 fn build_archived_rows(
     hidden: &HashMap<(VerifyingKey, MemberId), HiddenDmThreadEntry>,
     room_meta: &HashMap<VerifyingKey, ArchivedRoomMeta>,
-    last_any_ts: &HashMap<(VerifyingKey, MemberId), u64>,
+    last_inbound_ts: &HashMap<(VerifyingKey, MemberId), u64>,
 ) -> Vec<ArchivedEntry> {
     let mut out: Vec<ArchivedEntry> = hidden
         .iter()
@@ -705,7 +814,7 @@ fn build_archived_rows(
             // loaded — fall back to 0 so the strict-`<=` rule still
             // treats them as hidden (the rail filter would otherwise
             // not surface them either).
-            let ts = last_any_ts.get(&(*room, *peer)).copied().unwrap_or(0);
+            let ts = last_inbound_ts.get(&(*room, *peer)).copied().unwrap_or(0);
             is_thread_hidden_for(hidden, room, *peer, ts)
         })
         .map(|((room, peer), _entry)| {
@@ -740,12 +849,12 @@ fn build_archived_rows(
 /// nickname / room-name decrypt per entry).
 fn count_currently_archived(
     hidden: &HashMap<(VerifyingKey, MemberId), HiddenDmThreadEntry>,
-    last_any_ts: &HashMap<(VerifyingKey, MemberId), u64>,
+    last_inbound_ts: &HashMap<(VerifyingKey, MemberId), u64>,
 ) -> usize {
     hidden
         .iter()
         .filter(|((room, peer), _)| {
-            let ts = last_any_ts.get(&(*room, *peer)).copied().unwrap_or(0);
+            let ts = last_inbound_ts.get(&(*room, *peer)).copied().unwrap_or(0);
             is_thread_hidden_for(hidden, room, *peer, ts)
         })
         .count()
@@ -789,7 +898,7 @@ fn build_archived_view() -> Option<Vec<ArchivedEntry>> {
     // revived thread shows on the rail AND in the archived viewer,
     // confusing the user about whether it's archived.
     let mut room_meta: HashMap<VerifyingKey, ArchivedRoomMeta> = HashMap::new();
-    let mut last_any_ts: HashMap<(VerifyingKey, MemberId), u64> = HashMap::new();
+    let mut last_inbound_ts: HashMap<(VerifyingKey, MemberId), u64> = HashMap::new();
     for (owner_vk, room_data) in &rooms.map {
         let self_id: MemberId = room_data.self_sk.verifying_key().into();
         let sealed_name = &room_data
@@ -833,11 +942,11 @@ fn build_archived_view() -> Option<Vec<ArchivedEntry>> {
         for (peer, activity) in
             accumulate_peer_activity(owner_vk, self_id, dm_message_triples(room_data), None)
         {
-            last_any_ts.insert((*owner_vk, peer), activity.last_any_ts);
+            last_inbound_ts.insert((*owner_vk, peer), activity.last_inbound_ts);
         }
     }
 
-    Some(build_archived_rows(&hidden, &room_meta, &last_any_ts))
+    Some(build_archived_rows(&hidden, &room_meta, &last_inbound_ts))
 }
 
 /// Compute the current archived count (post revival-filter) for the
@@ -866,16 +975,16 @@ fn current_archived_count() -> usize {
         schedule_rail_nudge();
         return last_good_archived_count();
     };
-    let mut last_any_ts: HashMap<(VerifyingKey, MemberId), u64> = HashMap::new();
+    let mut last_inbound_ts: HashMap<(VerifyingKey, MemberId), u64> = HashMap::new();
     for (owner_vk, room_data) in &rooms.map {
         let self_id: MemberId = room_data.self_sk.verifying_key().into();
         for (peer, activity) in
             accumulate_peer_activity(owner_vk, self_id, dm_message_triples(room_data), None)
         {
-            last_any_ts.insert((*owner_vk, peer), activity.last_any_ts);
+            last_inbound_ts.insert((*owner_vk, peer), activity.last_inbound_ts);
         }
     }
-    let count = count_currently_archived(&hidden, &last_any_ts);
+    let count = count_currently_archived(&hidden, &last_inbound_ts);
     set_last_good_archived_count(count);
     count
 }
@@ -983,8 +1092,9 @@ fn build_view() -> Vec<DmRailEntry> {
         // step runs once at the end (over all rooms' candidates) so it
         // is pure and unit-testable via `filter_rail_entries`. See
         // that helper's doc-comment for the #261 strict-`<=` semantics
-        // and the `filter_rail_entries_newer_outbound_revives_hidden`
-        // test for the "outbound revives" invariant.
+        // and, since #526, the
+        // `filter_rail_entries_newer_outbound_does_not_revive_hidden`
+        // test for why that clock is inbound-only.
         for (peer, activity) in per_peer {
             entries.push(DmRailEntry {
                 room: *owner_vk,
@@ -995,6 +1105,7 @@ fn build_view() -> Vec<DmRailEntry> {
                     .unwrap_or_else(|| short_member_id(&peer)),
                 room_name: room_name.clone(),
                 last_any_ts: activity.last_any_ts,
+                last_inbound_ts: activity.last_inbound_ts,
                 unread: activity.unread,
             });
         }
@@ -1069,6 +1180,281 @@ mod tests {
         ed25519_dalek::SigningKey::from_bytes(&[seed; 32])
     }
 
+    // ===== archive_cutoff (issue freenet/river#526) =====
+
+    /// The rendered row wins when it is ahead of live state.
+    #[test]
+    fn archive_cutoff_takes_the_row_when_it_leads() {
+        assert_eq!(archive_cutoff(1_500, Some(1_000)), 1_500);
+    }
+
+    /// Live state wins when it is ahead — the row can lag behind a DM that
+    /// landed in `ROOMS` after the memo's last clean pass.
+    #[test]
+    fn archive_cutoff_takes_live_when_it_leads() {
+        assert_eq!(archive_cutoff(1_000, Some(1_500)), 1_500);
+    }
+
+    /// A contended `ROOMS` read degrades to the rendered row, never to zero.
+    #[test]
+    fn archive_cutoff_falls_back_to_the_row_when_live_is_unreadable() {
+        assert_eq!(archive_cutoff(1_200, None), 1_200);
+    }
+
+    /// A thread the peer has never written to archives at 0, which the
+    /// `<=` filter still treats as hidden.
+    #[test]
+    fn archive_cutoff_is_zero_when_peer_never_wrote() {
+        assert_eq!(archive_cutoff(0, Some(0)), 0);
+    }
+
+    /// The invariant the gate depends on: the cutoff is never BELOW the
+    /// pair's true inbound maximum, so no already-existing inbound DM can
+    /// look newer than the archive when it re-lands.
+    ///
+    /// An earlier revision clamped the cutoff at `now + MAX_DM_FUTURE_SKEW_SECS`,
+    /// which broke exactly this for a peer whose clock leads ours: Archive
+    /// became a visible no-op AND the next sweep-and-re-offer destroyed the
+    /// persisted archive.
+    #[test]
+    fn archive_cutoff_is_never_below_the_true_inbound_max() {
+        let now = 5_000u64;
+        let skew = river_core::room_state::direct_messages::MAX_DM_FUTURE_SKEW_SECS;
+        // A peer stamping well beyond the skew bound.
+        let forged = now + skew + 100_000;
+        let cutoff = archive_cutoff(forged, Some(forged));
+        assert!(
+            cutoff >= forged,
+            "the cutoff must cover every inbound DM that exists, however \
+             implausibly stamped - otherwise the rail keeps showing the row \
+             and a re-land destroys the archive (#526)"
+        );
+    }
+
+    /// Issue freenet/river#526: `archive_row` must feed `archive_cutoff` the
+    /// row's INBOUND clock and the LIVE recompute, and must not reintroduce a
+    /// wall-clock term. `archive_row` needs the Dioxus runtime, so this is a
+    /// source pin.
+    #[test]
+    fn archive_row_uses_inbound_and_live_cutoff() {
+        let src = dm_rail_production_stripped();
+        let marker = "fnarchive_row(";
+        let split_at = src
+            .find(marker)
+            .expect("archive_row must exist - this pin is targeting the wrong path");
+        let rest = &src[split_at + marker.len()..];
+        // `ArchiveToastView` is the next item AFTER `archive_row`; the
+        // previously-used `build_archive_toast` is defined BEFORE it, so that
+        // bound never matched and the "segment" was the rest of the file.
+        let end = rest
+            .find("fnArchiveToastView")
+            .expect("ArchiveToastView must follow archive_row - bound is stale");
+        let seg = &rest[..end];
+
+        assert!(
+            seg.contains("archive_cutoff(row_last_inbound_ts,current_last_inbound_ts(&room,peer))"),
+            "archive_row must build the cutoff from the row's inbound clock \
+             and the LIVE recompute (#526)."
+        );
+        assert!(
+            !seg.contains("unix_now_secs()"),
+            "the cutoff must carry no wall-clock term (#526): clamping one \
+             side of the comparison breaks `every existing inbound DM is <= \
+             cutoff` and both re-opens the bug and makes Archive a no-op."
+        );
+    }
+
+    /// The row must hand `archive_row` its INBOUND clock. `DmRailEntry` still
+    /// carries `last_any_ts` for sorting, so passing the wrong field compiles
+    /// silently and restores the pre-fix cutoff.
+    #[test]
+    fn rail_row_passes_the_inbound_clock_to_archive_row() {
+        let src = dm_rail_production_stripped();
+        assert!(
+            src.contains("archive_row(room,peer,&nickname,last_inbound_ts)"),
+            "DmRailRow must pass last_inbound_ts to archive_row (#526); \
+             last_any_ts includes our own outbound DMs and their local clock."
+        );
+        assert!(
+            src.contains("letlast_inbound_ts=entry.last_inbound_ts;"),
+            "the row must read the inbound clock off the entry (#526)."
+        );
+    }
+
+    /// Both archived-view projections must feed the INBOUND clock, or the
+    /// "Archived (N)" badge and the panel desynchronise from the rail: a
+    /// thread with a newer outbound would drop out of the panel while the rail
+    /// still hides it, leaving it invisible in both places with no un-archive.
+    #[test]
+    fn archived_projections_use_the_inbound_clock() {
+        let src = dm_rail_production_stripped();
+        assert_eq!(
+            src.matches("last_inbound_ts.insert((*owner_vk,peer),activity.last_inbound_ts);")
+                .count(),
+            2,
+            "build_archived_view and current_archived_count must both project \
+             the inbound clock (#526)."
+        );
+        assert!(
+            src.contains("last_inbound_ts:activity.last_inbound_ts,"),
+            "build_view must carry the inbound clock onto each DmRailEntry (#526)."
+        );
+    }
+
+    /// Issue freenet/river#526: `archive_cutoff` must carry NO wall-clock
+    /// term.
+    ///
+    /// This has to be a source pin. `archive_cutoff` takes no injectable
+    /// `now`, so a behavioural test can only feed it fixture timestamps —
+    /// which sit astronomically below real `unix_now_secs()`, making any
+    /// re-introduced `.min(now + skew)` inert and the test green. A clamp
+    /// mutation survived exactly that way in an earlier round.
+    ///
+    /// Why it must stay clamp-free: the rail filter compares the UNCLAMPED
+    /// observed inbound clock against this value. Clamping only this side
+    /// breaks `every existing inbound DM is <= cutoff`, which makes Archive a
+    /// visible no-op that still shows a success toast AND lets the next
+    /// sweep-and-re-offer destroy the persisted archive. The forged-timestamp
+    /// concern belongs on the INCOMING timestamp in
+    /// `should_unhide_for_inbound_dm`, where it cannot break the invariant.
+    #[test]
+    fn archive_cutoff_carries_no_wall_clock_term() {
+        let src = dm_rail_production_stripped();
+        let marker = "fnarchive_cutoff(";
+        let split_at = src
+            .find(marker)
+            .expect("archive_cutoff must exist - this pin targets the wrong path");
+        let rest = &src[split_at + marker.len()..];
+        let end = rest
+            .find("fnarchive_row(")
+            .expect("archive_row must follow archive_cutoff - bound is stale");
+        let seg = &rest[..end];
+
+        assert!(
+            !seg.contains("unix_now_secs()"),
+            "archive_cutoff must not clamp against wall-clock time (#526): \
+             clamping one side of the comparison re-opens the bug and turns \
+             Archive into a no-op that still reports success."
+        );
+        assert!(
+            !seg.contains("MAX_DM_FUTURE_SKEW_SECS"),
+            "the skew bound belongs on the INCOMING timestamp in \
+             should_unhide_for_inbound_dm, not on the cutoff (#526)."
+        );
+        assert!(
+            seg.contains("std::cmp::max(row_inbound_ts,live_inbound_ts.unwrap_or(0))"),
+            "archive_cutoff must be the plain max of the rendered and live \
+             inbound clocks (#526)."
+        );
+    }
+
+    /// Issue freenet/river#526: the Undo toast and the Archived-panel
+    /// Un-archive are explicit USER ACTIONS and must keep calling the
+    /// UNCONDITIONAL `unhide_dm_thread`.
+    ///
+    /// Routing them through `unhide_dm_thread_if_dm_is_newer` for
+    /// "consistency" would make both silent no-ops: at the moment the user
+    /// clicks Undo, the thread's inbound clock is by construction at or below
+    /// the cutoff just written, so the gate returns false and the entry
+    /// survives. The button would appear to do nothing.
+    #[test]
+    fn explicit_user_actions_keep_the_unconditional_unhide() {
+        let src = dm_rail_production_stripped();
+        assert!(
+            !src.contains(&format!("{}{}", "unhide_dm_thread_if_dm_is_newer", "(")),
+            "the rail's user-action unhides must NOT use the cutoff-gated form \
+             (#526) - Undo and Un-archive would become silent no-ops."
+        );
+        assert_eq!(
+            src.matches(&format!("{}{}", "unhide_dm_thread", "("))
+                .count(),
+            2,
+            "exactly two unconditional unhide call sites are expected in the \
+             rail: the Undo toast and the Archived-panel Un-archive."
+        );
+    }
+
+    /// The rail filter must compare the INBOUND clock, never `last_any_ts`.
+    #[test]
+    fn rail_filter_compares_inbound_timestamp() {
+        let src = dm_rail_production_stripped();
+        assert!(
+            src.contains("is_thread_hidden_for(hidden,&e.room,e.peer,e.last_inbound_ts)"),
+            "filter_rail_entries must compare last_inbound_ts (#526). Using \
+             last_any_ts lets our own outbound DM's local-clock timestamp \
+             decide whether a peer's message is visible."
+        );
+    }
+
+    // ===== max_inbound_ts_from_triples =====
+
+    #[test]
+    fn max_inbound_ts_ignores_outbound_and_third_parties() {
+        let me = MemberId(FastHash(1));
+        let peer = MemberId(FastHash(2));
+        let other = MemberId(FastHash(3));
+        let msgs = vec![
+            (peer, me, 100),    // inbound  - counts
+            (me, peer, 900),    // outbound - must NOT count
+            (other, me, 800),   // inbound from someone else - must NOT count
+            (peer, other, 700), // third-party - must NOT count
+            (peer, me, 250),    // inbound  - counts, newest
+        ];
+        assert_eq!(max_inbound_ts_from_triples(msgs, me, peer), 250);
+    }
+
+    #[test]
+    fn max_inbound_ts_is_zero_when_peer_never_wrote() {
+        let me = MemberId(FastHash(1));
+        let peer = MemberId(FastHash(2));
+        // A thread that is entirely our own outbound DMs.
+        let msgs = vec![(me, peer, 500), (me, peer, 900)];
+        assert_eq!(max_inbound_ts_from_triples(msgs, me, peer), 0);
+    }
+
+    /// The reply-then-archive scenario that this revision exists to fix: the
+    /// thread's newest message is OUTBOUND, so `last_any_ts` is our own clock.
+    /// Archiving must not hide a peer DM whose timestamp sits below it.
+    #[test]
+    fn filter_does_not_hide_thread_on_a_newer_outbound_message() {
+        let room = sk(1).verifying_key();
+        // Peer's newest inbound is 1010; our reply at 1012 is newer overall.
+        let e = entry_with_inbound(room, 11, 1_012, 1_010, 1);
+        // Archived at 1000 (the peer's previous DM). Their 1010 must revive it.
+        let mut hidden = HashMap::new();
+        hidden.insert(
+            (room, e.peer),
+            HiddenDmThreadEntry {
+                room_owner_vk: room.to_bytes(),
+                peer: e.peer,
+                hidden_at_ts: 1_000,
+            },
+        );
+        let out = filter_rail_entries(vec![e.clone()], &hidden);
+        assert_eq!(
+            out.len(),
+            1,
+            "the peer's DM at 1010 is past the 1000 cutoff, so the thread must \
+             be visible even though our own reply at 1012 is newer (#526)"
+        );
+
+        // And the inbound clock, not the outbound one, is what decides: with
+        // the cutoff above the peer's newest inbound, it stays archived.
+        let mut hidden2 = HashMap::new();
+        hidden2.insert(
+            (room, e.peer),
+            HiddenDmThreadEntry {
+                room_owner_vk: room.to_bytes(),
+                peer: e.peer,
+                hidden_at_ts: 1_010,
+            },
+        );
+        assert!(
+            filter_rail_entries(vec![e], &hidden2).is_empty(),
+            "our outbound at 1012 must NOT drag the thread back into the rail"
+        );
+    }
+
     fn entry(room: VerifyingKey, peer_seed: i64, last_any_ts: u64, unread: usize) -> DmRailEntry {
         DmRailEntry {
             room,
@@ -1076,7 +1462,28 @@ mod tests {
             peer_nickname: format!("peer-{peer_seed}"),
             room_name: "room".into(),
             last_any_ts,
+            // Default fixture: treat the whole thread as inbound, which is
+            // what these tests meant before the archive filter became
+            // inbound-only (issue freenet/river#526). Cases that need the two
+            // to differ use `entry_with_inbound`.
+            last_inbound_ts: last_any_ts,
             unread,
+        }
+    }
+
+    /// Rail entry whose newest message is OUTBOUND: `last_any_ts` is above
+    /// `last_inbound_ts`. This is the shape that made an in-flight inbound DM
+    /// invisible before the archive filter became inbound-only (#526).
+    fn entry_with_inbound(
+        room: VerifyingKey,
+        peer_seed: i64,
+        last_any_ts: u64,
+        last_inbound_ts: u64,
+        unread: usize,
+    ) -> DmRailEntry {
+        DmRailEntry {
+            last_inbound_ts,
+            ..entry(room, peer_seed, last_any_ts, unread)
         }
     }
 
@@ -1131,26 +1538,29 @@ mod tests {
         );
     }
 
-    /// #261 "outbound revives": an outbound DM (reflected purely
-    /// through `last_any_ts > hidden_at_ts` since outbound messages
-    /// also bump `acc.last_any_ts` in `build_view`) MUST re-surface
-    /// the thread. This is the rail-side mirror of the Codex P1
-    /// explicit `unhide_dm_thread` call in `dm_thread_modal::do_send`.
-    /// Even if the hide map were never cleared, a strictly-newer
-    /// outbound timestamp must override.
+    /// Issue freenet/river#526 INVERTED this test. It previously asserted that
+    /// an outbound DM revives a hidden thread through
+    /// `last_any_ts > hidden_at_ts` — which is precisely the behaviour that
+    /// made an in-flight INBOUND DM invisible, because our own outbound
+    /// timestamp is our LOCAL wall clock and it was deciding whether a peer's
+    /// message showed.
+    ///
+    /// Outbound sends still revive the thread, but through the unconditional
+    /// `unhide_dm_thread` in `do_send` / `send_structured_dm` — i.e. by
+    /// REMOVING the entry, which `filter_rail_entries_unhide_reappears`
+    /// covers. The filter itself must ignore outbound entirely.
     #[test]
-    fn filter_rail_entries_newer_outbound_revives_hidden() {
+    fn filter_rail_entries_newer_outbound_does_not_revive_hidden() {
         let room = sk(1).verifying_key();
-        // Outbound: zero unread (sender's own message), but
-        // last_any_ts moved past the hide cutoff.
-        let entries = vec![entry(room, 11, 1_500, 0)];
+        // Our reply at 1_500 is the newest message; the peer's newest is 900.
+        let entries = vec![entry_with_inbound(room, 11, 1_500, 900, 0)];
         let hidden = HashMap::from([hidden_at(room, 11, 1_000)]);
 
-        let result = filter_rail_entries(entries, &hidden);
-        assert_eq!(
-            result.len(),
-            1,
-            "newer outbound DM must revive thread (last_any_ts > hidden_at_ts)"
+        assert!(
+            filter_rail_entries(entries, &hidden).is_empty(),
+            "our own outbound DM at 1500 must NOT revive the thread: the \
+             archive clock is inbound-only, and the peer's newest (900) is \
+             below the 1000 cutoff (#526)"
         );
     }
 
@@ -1461,6 +1871,7 @@ mod tests {
             (self_id, peer, 100u64),    // outbound: recency only
             (peer, self_id, 150u64),    // inbound, <= cutoff: read
             (peer, self_id, 250u64),    // inbound, > cutoff: unread
+            (self_id, peer, 400u64),    // outbound, NEWEST overall
             (third_a, third_b, 999u64), // not ours: skipped
         ];
         let mut last_seen = HashMap::new();
@@ -1473,7 +1884,18 @@ mod tests {
             "third-party traffic must not create entries"
         );
         assert_eq!(result[&peer].unread, 1);
-        assert_eq!(result[&peer].last_any_ts, 250);
+        // Recency covers BOTH directions, so our own 400 wins.
+        assert_eq!(result[&peer].last_any_ts, 400);
+        // The ARCHIVE clock covers inbound only (issue freenet/river#526).
+        // The outbound-newest fixture above is what makes this assertion able
+        // to fail: hoisting the `last_inbound_ts` bump out of the
+        // `is_self_recipient` branch - a plausible "fold the two maxes
+        // together" simplification - would yield 400 here and silently restore
+        // the bug for the rail, the archived panel and the archived count.
+        assert_eq!(
+            result[&peer].last_inbound_ts, 250,
+            "our own outbound DM must NOT advance the archive clock (#526)"
+        );
     }
 
     /// Clean hide-list read: `resolve_active_entries` applies the #261
@@ -1821,6 +2243,15 @@ mod tests {
         &DM_RAIL_SRC[..DM_RAIL_SRC
             .find("mod tests")
             .expect("dm_rail_section.rs has exactly one `mod tests`")]
+    }
+
+    /// [`dm_rail_production`] with all whitespace removed, so a source pin
+    /// survives a rustfmt pass that re-wraps the code it matches.
+    fn dm_rail_production_stripped() -> String {
+        dm_rail_production()
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect()
     }
 
     /// The archive ✕ must gate its reveal on pointer capability, not the


### PR DESCRIPTION
## Problem

Archiving a DM writes a `(room, peer, hidden_at_ts)` entry and the rail hides the thread while the peer's newest message is at or below it. A new inbound DM is meant to revive it (#267), but the revival was implemented as a **hard delete** of the archive entry, fired whenever a DM crossed the merge dedupe.

"Crossed the dedupe" means *"was not in LOCAL state a moment ago"*, which is a different question from *"is new content"* — and the decision never consulted `hidden_at_ts` at all. Two ways it misfired:

- **Ordinary sync churn.** `post_apply_cleanup` sweeps DMs whose counterparty is momentarily absent from `members` on every merge. Peers re-offer them, they re-land with their original timestamps, and the diff can't tell them from a new message.
- **Empty pre-merge snapshot.** On the full-state path, when the room is in `ROOMS` but its DM state hasn't hydrated, every DM in the incoming state reads as newly landed — so **every archive in the room** was destroyed at once.

`unhide_dm_thread` also writes a session `RECENTLY_UNHIDDEN` tombstone and queues a delegate save, so the loss was **persisted** and a later hydration carrying the archive was suppressed. Archiving looked like it did nothing.

## Approach

`ui/`-only — no `common/`, delegate, or contract WASM change, so **no migration**.

`unhide_dm_thread_if_dm_is_newer` replaces the unconditional call at both inbound-sync sites, dropping the entry only when the DM's timestamp is strictly past the cutoff. A pair with **no** entry is inert — deliberately including "hasn't hydrated yet", so no unhide *and no tombstone*, which defuses the startup race. `fold_newly_landed_to_max_ts` reduces a merge batch to one entry per sender keeping the largest timestamp.

### The archive clock is inbound-only

A gate is only as good as its cutoff. `last_any_ts` covers our **own outbound** DMs too, and an outbound DM's timestamp is our *local wall clock*. So a thread where we replied last was archived against **our** clock while the gate compares a **sender's** timestamp — and a peer DM already in flight across the click landed at or below the cutoff and went invisible on every surface: no rail row, no unread badge (`count_unread_dms_with` applies the same filter), no notification (DMs raise none).

The clock is now `last_inbound_ts` everywhere the archive decides visibility: `filter_rail_entries`, both archived-view projections, and the unread tally. Outbound revival comes solely from the unconditional `unhide_dm_thread` in `do_send` / `send_structured_dm` — **on the sending device only**; hydration never propagates a removal and `riverctl dm send` doesn't call it, which the docs now state rather than gloss.

The cutoff is also recomputed from live `ROOMS` state, maxed with the rendered row so a contended read falls back. The row can lag, and while the membership sweep is atomic per pair, the **re-land** is not — a peer restoring only a subset would otherwise leave the cutoff low.

### Why the cutoff is NOT clamped

An earlier revision clamped it at `now + MAX_DM_FUTURE_SKEW_SECS` to blunt a forged-future timestamp. Two reviewers independently found that this **broke the load-bearing invariant** *every existing inbound DM satisfies `ts <= cutoff`*: the rail filter compares the **unclamped** observed clock, so Archive became a visible no-op that still showed a success toast, **and** the next sweep-and-re-offer saw `ts > cutoff` and destroyed the persisted archive — this bug again, narrowed to skew-violating peers. Clamping one side of a comparison was what created the hole.

The forged-timestamp concern is handled where it cannot break the invariant: `should_unhide_for_inbound_dm` clamps the **incoming** timestamp, so an implausible-future DM can never trigger an unhide.

### Accepted residuals

All defer messages from one peer the user already chose to archive; none destroys state.

- A new inbound DM in the same unix second as the peer's previous one.
- A peer whose clock moves backward relative to their own previous message.
- A peer who stamps far in the future: their later genuine DMs wait until real time passes it.
- One never-rendered DM that the live recompute may cover.

The real remedy for a hostile peer is a block/ignore list — #461.

## Testing

`cargo test -p river-ui --bins` — 768 pass; 772 with `--features example-data,no-sync`. `cargo fmt --all -- --check` clean, wasm target clean. Full Playwright suite green (605 passed, 15 skipped) across Chromium, Firefox, WebKit, mobile Chrome and mobile Safari.

Note the example-data build contains **no DMs** (populating them needs a real ECIES envelope per DM), so Playwright cannot drive the archive flow end-to-end; it covers the surfaces this PR touches against regression, and the behaviour is pinned in Rust.

**Mutation-checked**, each reverted independently against the committed fix — all caught:

| Mutation | Result |
|---|---|
| gate always `true` (pre-fix behaviour) | red |
| gate deleted from the wrapper body | red |
| sync site calls bare imported `unhide_dm_thread` | red |
| filter compares `last_any_ts` (the outbound-anchor bug) | red |
| accumulator hoists the inbound bump out of `is_self_recipient` | red |
| row passes `last_any_ts` to `archive_row` | red |
| archived-count projection reverts to `last_any_ts` | red |
| no live recompute (trust the rendered prop) | red |
| wall-clock clamp reintroduced on the cutoff | red |
| `do_send` routed through the gated unhide | red |
| Undo toast routed through the gated unhide | red |
| determinism sort dropped | red |

Two mutations initially reported *green* and both turned out to be measurement bugs worth recording: one didn't compile (so no tests ran), and one was inert because the pin's needle matched its own explanatory comment rather than the code. Both are fixed; the clamp is now pinned structurally, because `archive_cutoff` takes no injectable `now` and fixture timestamps sit far below real wall-clock time, which makes any re-introduced clamp invisible to a behavioural test.

### Repaired two vacuous pins

The existing #267 pins searched `include_str!` for literals their own assertions contained, so all three assertions in each were tautologies. They now cut at `mod tests`, match whitespace-stripped, assemble needles at runtime, and the delta-path pin is sliced to its own function.

## Review

Three full rounds, independent blind lenses each time. Every round found a real defect in my own work; all are addressed:

- **Round 1** — killed a `max(last_any_ts, now)` cutoff as unnecessary and harmful.
- **Round 2** — found that removing it wasn't enough, because `last_any_ts` includes outbound. That produced the inbound-only rework above.
- **Round 3** — found the one-sided clamp (HIGH, both reviewers independently), the unpinned inbound producer and outbound-send sites (HIGH), a dead segment bound, a stale test asserting removed behaviour, a probabilistic determinism test, and several inaccurate comments including a rules-doc citation of a renamed test. All fixed.

Also filed **#530** — a pre-existing bug two reviewers surfaced: a save that runs before the delegate blob hydrates persists a truncated store, permanently losing archives and outbound-DM plaintexts. It reproduces two of this issue's symptoms by a different mechanism, so #526 alone does not fully close the user complaint.

Closes #526

[AI-assisted - Claude]
