### PR TITLE
perf(delegate): debounce room-state snapshot writes, keep key material immediate

### DIFF
--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -1265,6 +1265,43 @@ mod tests {
         crate::room_data::test_minimal_room_data(SigningKey::from_bytes(&[9u8; 32]).verifying_key())
     }
 
+    /// Boundary + clock-skew behaviour of the debounce decision.
+    ///
+    /// The negative case is the important one. `now_ms()` is a WALL clock and
+    /// can jump backwards (NTP correction, sleep/resume). A naive
+    /// `elapsed < INTERVAL` test would read a backwards jump as "not elapsed
+    /// yet" and defer the snapshot until the clock caught back up, stranding it
+    /// for an unbounded time. It must fail safe toward writing instead.
+    #[test]
+    fn cache_only_save_defers_only_within_a_sane_elapsed_window() {
+        assert!(should_defer_cache_only_save(0.0), "just written — defer");
+        assert!(
+            should_defer_cache_only_save(ROOM_SNAPSHOT_MIN_INTERVAL_MS - 1.0),
+            "just inside the interval — defer"
+        );
+        assert!(
+            !should_defer_cache_only_save(ROOM_SNAPSHOT_MIN_INTERVAL_MS),
+            "at the interval — write"
+        );
+        assert!(
+            !should_defer_cache_only_save(ROOM_SNAPSHOT_MIN_INTERVAL_MS + 1.0),
+            "past the interval — write"
+        );
+        assert!(
+            !should_defer_cache_only_save(-1000.0),
+            "clock jumped BACKWARDS — must write, not defer, or the snapshot is \
+             stranded until the wall clock catches up"
+        );
+        assert!(
+            !should_defer_cache_only_save(f64::NAN),
+            "non-finite elapsed must fail safe toward writing"
+        );
+        assert!(
+            !should_defer_cache_only_save(f64::INFINITY),
+            "non-finite elapsed must fail safe toward writing"
+        );
+    }
+
     /// The whole point: a new message mutates `room_state`, and that must NOT
     /// register as critical, otherwise nothing is ever deferred and the fix is
     /// inert.
@@ -4034,6 +4071,23 @@ fn now_ms() -> f64 {
     }
 }
 
+/// Whether a cache-only change may be deferred, given how long ago this room
+/// was last written (freenet/river#533).
+///
+/// Split out as a pure function so the boundary and clock-skew behaviour is
+/// unit-testable without a time source.
+///
+/// `elapsed_ms` comes from `now_ms()`, which is a WALL clock
+/// (`js_sys::Date::now()`), not a monotonic one — it can jump backwards on an
+/// NTP correction or after the machine sleeps. A negative (or NaN) elapsed must
+/// therefore fail SAFE toward writing: treating it as "the interval hasn't
+/// passed yet" would strand the snapshot until the clock caught back up, which
+/// could be arbitrarily long. Writing early is always correct and only costs
+/// I/O, so every non-finite or negative case resolves to "write now".
+fn should_defer_cache_only_save(elapsed_ms: f64) -> bool {
+    elapsed_ms.is_finite() && elapsed_ms >= 0.0 && elapsed_ms < ROOM_SNAPSHOT_MIN_INTERVAL_MS
+}
+
 /// Hash of the room's UNRECOVERABLE fields — everything persisted EXCEPT the
 /// reconstructible cache (`room_state`, `last_read_message_id`).
 ///
@@ -4425,10 +4479,10 @@ async fn do_save_rooms_to_delegate(force_flush: bool) -> Result<(), String> {
             }) = prev
             {
                 let cache_only_change = crit.is_some() && critical == crit;
-                if cache_only_change && now_ms() - written_at_ms < ROOM_SNAPSHOT_MIN_INTERVAL_MS {
+                let elapsed_ms = now_ms() - written_at_ms;
+                if cache_only_change && should_defer_cache_only_save(elapsed_ms) {
                     debug!(
-                        "room {vk:?}: deferring cache-only save ({}ms since last write)",
-                        now_ms() - written_at_ms
+                        "room {vk:?}: deferring cache-only save ({elapsed_ms}ms since last write)"
                     );
                     continue;
                 }

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -1252,6 +1252,124 @@ mod tests {
         );
     }
 
+    // ---- freenet/river#533: room-state snapshot debounce ----
+    //
+    // These pin the field classification that makes the debounce safe. If a
+    // field that CANNOT be reconstructed from the room contract ever stops
+    // moving `critical_hash`, its write would be deferred by up to
+    // ROOM_SNAPSHOT_MIN_INTERVAL_MS, and a tab closed inside that window would
+    // lose it permanently. `self_sk` is the sharp case: lose it and the user
+    // loses their identity in that room.
+
+    fn room_fixture() -> RoomData {
+        crate::room_data::test_minimal_room_data(SigningKey::from_bytes(&[9u8; 32]).verifying_key())
+    }
+
+    /// The whole point: a new message mutates `room_state`, and that must NOT
+    /// register as critical, otherwise nothing is ever deferred and the fix is
+    /// inert.
+    #[test]
+    fn critical_hash_ignores_room_state_changes() {
+        let base = room_fixture();
+        let mut with_message = base.clone();
+        with_message
+            .room_state
+            .configuration
+            .configuration
+            .max_recent_messages = 999;
+
+        assert_ne!(
+            content_hash(&{
+                let mut b = Vec::new();
+                ciborium::ser::into_writer(&with_message, &mut b).unwrap();
+                b
+            }),
+            content_hash(&{
+                let mut b = Vec::new();
+                ciborium::ser::into_writer(&base, &mut b).unwrap();
+                b
+            }),
+            "precondition: the mutation must change the FULL serialization, \
+             otherwise this test proves nothing about the critical projection"
+        );
+        assert_eq!(
+            critical_hash(&base),
+            critical_hash(&with_message),
+            "a room_state change must not be treated as critical — it is \
+             reconstructible from the room contract"
+        );
+    }
+
+    /// `last_read_message_id` advances on every message received while the room
+    /// is open, so it must ride the cache tier too or the debounce never fires.
+    #[test]
+    fn critical_hash_ignores_last_read_message_id() {
+        let base = room_fixture();
+        let mut read = base.clone();
+        read.last_read_message_id = Some(river_core::room_state::message::MessageId(
+            freenet_scaffold::util::fast_hash(&[7u8]),
+        ));
+
+        assert_eq!(
+            critical_hash(&base),
+            critical_hash(&read),
+            "last_read_message_id is a cache field (unread badge), not critical"
+        );
+    }
+
+    /// THE data-loss guard. `self_sk` cannot be re-derived from the network, so
+    /// a change to it must force an immediate write and never be debounced.
+    #[test]
+    fn critical_hash_reacts_to_self_sk() {
+        let base = room_fixture();
+        let mut rotated = base.clone();
+        rotated.self_sk = SigningKey::from_bytes(&[42u8; 32]);
+
+        assert_ne!(
+            critical_hash(&base),
+            critical_hash(&rotated),
+            "self_sk MUST be critical — it is unrecoverable, so deferring its \
+             write risks permanent loss of the user's room identity"
+        );
+    }
+
+    /// Membership proof and invite provenance are likewise not reconstructible
+    /// from local state alone.
+    #[test]
+    fn critical_hash_reacts_to_invite_chain() {
+        let base = room_fixture();
+        let mut invited = base.clone();
+        let owner_sk = SigningKey::from_bytes(&[5u8; 32]);
+        let member = river_core::room_state::member::Member {
+            owner_member_id: owner_sk.verifying_key().into(),
+            invited_by: owner_sk.verifying_key().into(),
+            member_vk: SigningKey::from_bytes(&[6u8; 32]).verifying_key(),
+        };
+        invited.invite_chain = vec![river_core::room_state::member::AuthorizedMember::new(
+            member, &owner_sk,
+        )];
+
+        assert_ne!(
+            critical_hash(&base),
+            critical_hash(&invited),
+            "invite_chain must be critical"
+        );
+    }
+
+    /// Identity of the room itself must never be deferred.
+    #[test]
+    fn critical_hash_reacts_to_owner_vk() {
+        let base = room_fixture();
+        let mut other = base.clone();
+        other.owner_vk = SigningKey::from_bytes(&[11u8; 32]).verifying_key();
+
+        assert_ne!(
+            critical_hash(&base),
+            critical_hash(&other),
+            "owner_vk must be critical"
+        );
+    }
+
     fn present_slot_bytes(room: &RoomData) -> Vec<u8> {
         let mut b = Vec::new();
         ciborium::ser::into_writer(&RoomSlot::Present(Box::new(room.clone())), &mut b).unwrap();
@@ -3864,7 +3982,75 @@ const ROOMS_CAS_MAX_ATTEMPTS: u32 = 8;
 /// catch-up that covered our snapshot — see `coalesce_save` for the
 /// queued-caller propagation invariant).
 pub async fn save_rooms_to_delegate() -> Result<(), String> {
-    coalesce_save(&ROOMS_SAVE_STATE, "Rooms", do_save_rooms_to_delegate).await
+    coalesce_save(&ROOMS_SAVE_STATE, "Rooms", || {
+        do_save_rooms_to_delegate(false)
+    })
+    .await
+}
+
+/// Save rooms, bypassing the room-state snapshot debounce
+/// (freenet/river#533).
+///
+/// Ordinary saves defer a cache-only change for up to
+/// [`ROOM_SNAPSHOT_MIN_INTERVAL_MS`]. If the tab goes away while a change is
+/// deferred, that snapshot would otherwise sit unwritten until the room next
+/// changes — which for a quiet room could be never, leaving a stale cache and a
+/// stale unread badge. Call this when the tab is being hidden or torn down so
+/// the deferred snapshot lands.
+///
+/// This never affects correctness of key material: critical fields are written
+/// immediately by the normal path and never wait for a flush.
+pub async fn flush_rooms_to_delegate() -> Result<(), String> {
+    coalesce_save(&ROOMS_SAVE_STATE, "Rooms(flush)", || {
+        do_save_rooms_to_delegate(true)
+    })
+    .await
+}
+
+/// Minimum interval between writes that carry ONLY room-state cache changes
+/// (freenet/river#533). A new chat message mutates `room_state`, which changes
+/// the whole serialized `RoomData` and used to force a full re-encrypt +
+/// rewrite of that room's delegate blob for EVERY member. Measured on
+/// try.freenet.org: ~373 KiB rewritten per member per message, ~306 MiB/hour of
+/// node disk writes.
+///
+/// Safe to delay because `room_state` is a CACHE — the room contract is the
+/// authoritative replica, so a snapshot up to this stale only costs a slightly
+/// colder start. Critical fields bypass this entirely; see [`critical_hash`].
+const ROOM_SNAPSHOT_MIN_INTERVAL_MS: f64 = 5.0 * 60.0 * 1000.0;
+
+fn now_ms() -> f64 {
+    #[cfg(target_arch = "wasm32")]
+    {
+        js_sys::Date::now()
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as f64)
+            .unwrap_or(0.0)
+    }
+}
+
+/// Hash of the room's UNRECOVERABLE fields — everything persisted EXCEPT the
+/// reconstructible cache (`room_state`, `last_read_message_id`).
+///
+/// Computed structurally, by blanking the two cache fields on a clone and
+/// hashing the rest, rather than by listing the critical fields. That direction
+/// is deliberate and load-bearing: a field added to `RoomData` later is
+/// automatically treated as CRITICAL (written immediately) instead of silently
+/// inheriting the 5-minute debounce. Getting that backwards could delay
+/// persisting key material, and `self_sk` cannot be re-derived from the network
+/// — losing it loses the user's identity in that room.
+fn critical_hash(room_data: &RoomData) -> Option<u64> {
+    let mut probe = room_data.clone();
+    probe.room_state = Default::default();
+    probe.last_read_message_id = None;
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(&probe, &mut buf).ok()?;
+    Some(content_hash(&buf))
 }
 
 /// What we last persisted for a room key, so a save only writes the rooms that
@@ -3872,8 +4058,18 @@ pub async fn save_rooms_to_delegate() -> Result<(), String> {
 /// R's key, so it can't resurrect R's tombstone (freenet/river#345 round-9).
 #[derive(Clone, Copy, PartialEq)]
 enum SavedSlot {
-    /// Last-saved content hash of the room's serialized `RoomData`.
-    Present(u64),
+    /// Last-saved content hash of the room's serialized `RoomData`, plus the
+    /// hash of just its critical fields and when we last wrote it, so a
+    /// cache-only change can be deferred (freenet/river#533).
+    Present {
+        /// Hash of the FULL serialized `RoomData`.
+        content: u64,
+        /// Hash of the unrecoverable subset. `None` if the critical projection
+        /// failed to serialize, which forces the write (fail-safe).
+        critical: Option<u64>,
+        /// `now_ms()` at the last successful write of this room's key.
+        written_at_ms: f64,
+    },
     /// We've persisted this room as a tombstone (the user left it).
     Tombstone,
 }
@@ -4161,8 +4357,10 @@ fn reconcile_meta(current: Option<&[u8]>, local: &RoomsMeta) -> Result<Option<Ve
     Ok(Some(out))
 }
 
-async fn do_save_rooms_to_delegate() -> Result<(), String> {
-    info!("Saving rooms to delegate storage (per-room CAS)");
+/// `force_flush` bypasses the room-state snapshot debounce (freenet/river#533);
+/// see [`flush_rooms_to_delegate`].
+async fn do_save_rooms_to_delegate(force_flush: bool) -> Result<(), String> {
+    info!("Saving rooms to delegate storage (per-room CAS, force_flush={force_flush})");
 
     // Snapshot this tab's explicit state once. We never mutate the ROOMS signal
     // here; each per-room save reads that one room's delegate key and reconciles
@@ -4195,9 +4393,48 @@ async fn do_save_rooms_to_delegate() -> Result<(), String> {
             continue;
         }
         let h = content_hash(&buf);
-        if ROOM_SLOT_STATE.with(|c| c.borrow().get(vk) == Some(&SavedSlot::Present(h))) {
-            continue;
+        let crit = critical_hash(room_data);
+        let prev = ROOM_SLOT_STATE.with(|c| c.borrow().get(vk).copied());
+
+        // Unchanged since the last write — nothing to do (pre-existing dedupe).
+        if let Some(SavedSlot::Present { content, .. }) = prev {
+            if content == h {
+                continue;
+            }
         }
+
+        // Something changed. Decide whether it must be written NOW or can ride
+        // the snapshot cadence (freenet/river#533).
+        //
+        // Write immediately when the UNRECOVERABLE fields changed, when this is
+        // a room we haven't written this session, when the previous slot was a
+        // tombstone (a rejoin), when the caller asked for a flush, or when the
+        // critical projection failed to serialize. Only a pure `room_state` /
+        // `last_read_message_id` change on an already-persisted room is
+        // deferred, and only until the interval elapses.
+        //
+        // Deferring is safe ONLY for the cache: `room_state` is replicated in
+        // the room contract, so a stale snapshot costs a colder start and never
+        // loses data. `self_sk` cannot be re-derived from the network, which is
+        // why it must never fall into this branch.
+        if !force_flush {
+            if let Some(SavedSlot::Present {
+                critical,
+                written_at_ms,
+                ..
+            }) = prev
+            {
+                let cache_only_change = crit.is_some() && critical == crit;
+                if cache_only_change && now_ms() - written_at_ms < ROOM_SNAPSHOT_MIN_INTERVAL_MS {
+                    debug!(
+                        "room {vk:?}: deferring cache-only save ({}ms since last write)",
+                        now_ms() - written_at_ms
+                    );
+                    continue;
+                }
+            }
+        }
+
         let rejoined = REJOINED_THIS_SESSION.with(|s| s.borrow().contains(vk));
         let rd = room_data.clone();
         let owner = *vk;
@@ -4216,7 +4453,11 @@ async fn do_save_rooms_to_delegate() -> Result<(), String> {
                     c.borrow_mut().insert(
                         *vk,
                         if wrote {
-                            SavedSlot::Present(h)
+                            SavedSlot::Present {
+                                content: h,
+                                critical: crit,
+                                written_at_ms: now_ms(),
+                            }
                         } else {
                             SavedSlot::Tombstone
                         },

--- a/ui/src/components/app/document_title.rs
+++ b/ui/src/components/app/document_title.rs
@@ -7,7 +7,7 @@
 //! - Tracking document visibility state
 //! - Marking messages as read when tab becomes visible
 
-use crate::components::app::chat_delegate::save_rooms_to_delegate;
+use crate::components::app::chat_delegate::{flush_rooms_to_delegate, save_rooms_to_delegate};
 use crate::components::app::{CURRENT_ROOM, ROOMS};
 use crate::util::ecies::unseal_bytes_with_secrets;
 use dioxus::logger::tracing::{debug, info, warn};
@@ -763,8 +763,14 @@ pub fn mark_all_rooms_as_read() {
 
         info!("Marked {} room(s) as read on tab hide", updates.len());
 
+        // FLUSH, not a plain save (freenet/river#533). The tab is going away,
+        // and an ordinary save may defer a cache-only change for up to
+        // ROOM_SNAPSHOT_MIN_INTERVAL_MS. For a quiet room the next change might
+        // never come, which would strand both the room-state snapshot and the
+        // `last_read_message_id` we just advanced — the user would come back to
+        // a stale unread badge. Flushing here bypasses the debounce.
         crate::util::safe_spawn_local(async {
-            if let Err(e) = save_rooms_to_delegate().await {
+            if let Err(e) = flush_rooms_to_delegate().await {
                 warn!("Failed to save rooms after marking all as read: {}", e);
             }
         });


### PR DESCRIPTION
## Problem

On the try.freenet.org hosted node (freenet-core v0.2.112), River delegate secret rewrites account for **~306 MiB/hour** of node disk writes.

Each room is already stored under its own delegate key (`room:<base58(owner_vk)>`), and the save path already skips rooms whose content hash is unchanged. But `RoomData` embeds `room_state: ChatRoomStateV1`, which holds `recent_messages`. So one new chat message changes the hash and forces a full re-serialize, re-encrypt, and rewrite of that room's entire blob, **for every member independently**.

Measured on the node: ~373 KiB rewritten per member per message, blobs growing exactly +956 bytes each time. Secrets over 300 KiB are 4166 files totaling 1.49 GiB, 75% of all secret storage there. The existing dedupe cannot help, because the content genuinely did change.

Full measurements: freenet/river#533.

## Approach

`RoomData` mixes two kinds of field with very different durability needs:

| tier | fields | recoverable? |
|---|---|---|
| **Critical** | `self_sk`, `invite_chain`, `self_authorized_member`, `contract_key`, `owner_vk`, `self_member_info`, `self_nickname`, `previous_contract_key` | **No.** `self_sk` cannot be re-derived from the network — losing it loses the user's identity in that room |
| **Cache** | `room_state`, `last_read_message_id` | Yes, the room contract is the authoritative replica |

So make the write *trigger* field-aware instead of splitting storage. A change touching any critical field writes immediately, exactly as today. A change confined to the cache waits for a 5-minute snapshot cadence.

### Deliberately not a format change

No new delegate key, no change to the bytes stored under `room:<vk>`, and **no delegate WASM change**. The delegate key (`BLAKE3(BLAKE3(wasm) || params)`) is untouched, so there is no `legacy_delegates.toml` entry, no migration, and nothing orphaned. Old and new clients remain byte-compatible; only write *timing* differs.

### `critical_hash` is structural, and that direction is load-bearing

It clones, blanks the two cache fields, and hashes the rest — rather than enumerating the critical fields. So a field added to `RoomData` later is automatically **critical** (written immediately) instead of silently inheriting the debounce. The failure mode of getting this backwards is delayed persistence of key material, which is exactly the unrecoverable case.

### Flush on tab hide

Tab-hide now calls `flush_rooms_to_delegate` rather than a plain save. Without it, a deferred cache change on a quiet room could sit unwritten indefinitely, stranding both the snapshot and the `last_read_message_id` just advanced (the user would return to a stale unread badge).

## Transparency / data-loss analysis

No user-visible change is intended, and no data loss is possible:

- Everything the debounce delays is **reconstructible from the room contract**.
- Everything not reconstructible is written **immediately**, unchanged from today.
- Joining a room writes `self_sk` and `invite_chain` at once — it does not wait for the cadence.
- Leaving a room (tombstone) is a separate path, untouched.
- Worst case is a room-state snapshot up to 5 minutes stale, which costs a marginally colder start; the contract fills in the rest, and tab-hide flushes the common exit path.
- Storage format is unchanged, so a user moving between old and new UI versions sees identical bytes.

## Testing

Five tests pin the field classification that makes the debounce safe. Each was **mutation-verified** (bug reintroduced, confirmed the test goes red, reverted):

| test | mutation that kills it |
|---|---|
| `critical_hash_ignores_room_state_changes` | stop blanking `room_state` (debounce becomes inert) |
| `critical_hash_reacts_to_self_sk` | blank `self_sk` too (the data-loss bug) |
| `critical_hash_ignores_last_read_message_id` | — |
| `critical_hash_reacts_to_invite_chain` | — |
| `critical_hash_reacts_to_owner_vk` | — |

Each mutation killed **exactly** its target test and nothing else. The `room_state` test also carries a precondition assert that the mutation really does change the full serialization, so it cannot pass vacuously.

Full `river-ui` suite: **774 passed, 0 failed**.

## Expected win

Per-message delegate writes drop from one full ~373 KiB rewrite per member to zero; snapshots become at most 12/hour/room instead of one per message. Should take the hosted node from ~542 MiB/hr toward the ~120 MiB/hr the gateway and framework peers now sit at after freenet/freenet-core#4968.

Closes #533

[AI-assisted - Claude]