### PR TITLE
feat(cli): show whether each ban still enforces in `debug bans`

### DIFF
--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Result};
 use clap::Subcommand;
 use ed25519_dalek::VerifyingKey;
 use river_core::room_state::ban::BansV1;
-use river_core::room_state::member::{MemberId, MembersV1};
+use river_core::room_state::member::MemberId;
 use river_core::room_state::ChatRoomStateV1;
 use serde::Serialize;
 
@@ -45,23 +45,26 @@ struct BanInfo {
     banned_user_id: String,
     banned_by_id: String,
     banned_at_secs: u64,
-    /// Whether the contract currently EXCLUDES this ban's target, as opposed to
-    /// the ban being present in state but inert. Since deputy ban authority
-    /// (freenet/river#410) a ban can stop enforcing without being removed: the
-    /// banner left or was pruned, their deputy authority was revoked, or (once
-    /// no absolute grant applies) the target has since deputized the banner.
+    /// Whether this ban is currently keeping its target out of the room, as
+    /// opposed to sitting in state while the target walks around inside. Since
+    /// deputy ban authority (freenet/river#410) a ban can go inert without being
+    /// removed: the banner left or was pruned, their deputy authority was
+    /// revoked, or (once no absolute grant applies) the target has since
+    /// deputized the banner.
     ///
-    /// This mirrors the test `MembersV1::banned_member_ids` applies when it
-    /// builds the excluded set in `post_apply_cleanup`, so it answers the
-    /// question a moderator is actually asking: is this person kept out?
+    /// `false` is the case worth acting on, and it is unambiguous: the target is
+    /// a CURRENT member that this ban fails to exclude, so that person is in the
+    /// room right now.
     ///
-    /// Deliberately NOT `BansV1::ban_is_enforcing`, despite the name. That
-    /// predicate answers a different question — whether a ban is worth KEEPING
-    /// under `max_user_bans` eviction pressure — and to do so it returns `true`
-    /// for any signature-verified member's ban of an ABSENT target without ever
-    /// consulting `is_ban_authorized`. Reporting that as "enforcing" would tell a
-    /// moderator an unauthorized ban keeps someone out when rejoining would in
-    /// fact readmit them, which is the very confusion #472 exists to remove.
+    /// Scope, deliberately not overclaimed: for a target who is already gone this
+    /// reports `true` without re-deriving the banner's authority, because an
+    /// absent member has no invite chain to walk and `is_ban_authorized` cannot
+    /// be evaluated against a hypothetical future one. So `true` means "not in
+    /// the room", not "guaranteed to hold if they are re-invited by someone new".
+    /// Do NOT switch this to a bare `is_ban_authorized` to tighten that: every
+    /// successfully enforced ban ends with its target removed, so doing so
+    /// reports NOT ENFORCING for essentially every ban that is working. Pinned by
+    /// `legitimate_ancestor_ban_still_enforcing_after_its_target_is_removed`.
     enforcing: bool,
 }
 
@@ -82,18 +85,13 @@ fn collect_ban_infos(room_state: &ChatRoomStateV1, owner_vk: &VerifyingKey) -> V
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_secs())
                 .unwrap_or(0);
-            // The same two gates, in the same order, that `banned_member_ids`
-            // applies per ban. `ban_excludes_its_target_matches_banned_member_ids`
-            // pins the agreement so this cannot drift from the contract.
-            let enforcing =
-                BansV1::ban_signature_matches_current_key(ban, &members_by_id, owner_id, owner_vk)
-                    && MembersV1::is_ban_authorized(
-                        ban.banned_by,
-                        ban.ban.banned_user,
-                        &members_by_id,
-                        &room_state.member_info,
-                        owner_id,
-                    );
+            let enforcing = BansV1::ban_is_enforcing(
+                ban,
+                &members_by_id,
+                &room_state.member_info,
+                owner_id,
+                owner_vk,
+            );
             BanInfo {
                 banned_user_id: ban.ban.banned_user.to_string(),
                 banned_by_id: ban.banned_by.to_string(),
@@ -144,10 +142,11 @@ fn ban_list_lines(bans: &[BanInfo]) -> Vec<String> {
     if inert_count > 0 {
         lines.push(String::new());
         lines.push(format!(
-            "Note: {} ban(s) are stored in room state but NOT enforced, so those \
-             users are not kept out. A ban stops enforcing when its banner leaves \
-             the room or loses the deputy authority it banned under. Check the \
-             banner with `riverctl member deputized-by <room> <banned_by_id>`.",
+            "Note: {} ban(s) are stored in room state but are NOT keeping their \
+             target out, so those users are in the room. A ban stops enforcing \
+             when its banner leaves the room or loses the deputy authority it \
+             banned under. Check the banner with `riverctl member deputized-by \
+             <room> <banned_by_id>`.",
             inert_count
         ));
     }
@@ -768,90 +767,101 @@ mod tests {
     }
 
     #[test]
-    fn unauthorized_ban_of_an_absent_target_reports_not_enforcing() {
-        // `BansV1::ban_is_enforcing` answers "is this ban worth keeping under
-        // `max_user_bans` pressure?", and for an ABSENT target it returns true
-        // for any signature-verified member's ban WITHOUT consulting
-        // `is_ban_authorized`. Reporting that as enforcing would recreate #472's
-        // bug: bob has no authority over alice, so if alice rejoins she is NOT
-        // removed, yet the moderator would have been told the ban holds.
+    fn legitimate_ancestor_ban_still_enforcing_after_its_target_is_removed() {
+        // Regression guard for a wrong "fix" that is tempting on inspection:
+        // computing the flag from a bare `is_ban_authorized` instead of
+        // `ban_is_enforcing`, on the theory that the latter skips the authority
+        // check for an absent target.
+        //
+        // It skips it for a reason. Once a ban has done its job the target is
+        // gone, so there is no invite chain left to walk and the ancestor grant
+        // that authorized the ban can no longer be re-derived. A bare
+        // `is_ban_authorized` therefore reports NOT ENFORCING for essentially
+        // every ban that is working, which is far more misleading than the
+        // narrow case it would tighten.
         let owner = key(1);
         let alice = key(2);
         let bob = key(3);
 
+        // owner -> bob -> alice, and bob bans alice as her strict ancestor.
         let mut state = ChatRoomStateV1::default();
-        // bob is a plain member with no deputy grant; alice is absent.
         push_member(&mut state, &owner, &owner, &bob);
+        push_member(&mut state, &owner, &bob, &alice);
         push_ban(&mut state, &owner, &bob, &alice);
 
-        let members_by_id = state.members.members_by_member_id();
-        let owner_id = MemberId::from(&owner.verifying_key());
         assert!(
-            BansV1::ban_is_enforcing(
-                &state.bans.0[0],
-                &members_by_id,
-                &state.member_info,
-                owner_id,
-                &owner.verifying_key(),
-            ),
-            "guard: this test is only meaningful while `ban_is_enforcing` still \
-             returns true here; if that changes, the divergence it protects \
-             against is gone and this test should be revisited"
+            collect_ban_infos(&state, &owner.verifying_key())[0].enforcing,
+            "an ancestor's ban of a present member enforces"
         );
 
-        let bans = collect_ban_infos(&state, &owner.verifying_key());
+        // Let the contract enforce it, exactly as `post_apply_cleanup` does.
+        let params = ChatRoomParametersV1 {
+            owner: owner.verifying_key(),
+        };
+        let excluded = state
+            .members
+            .banned_member_ids(&state.bans, &state.member_info, &params);
+        state
+            .members
+            .members
+            .retain(|m| !excluded.contains(&m.member.id()));
         assert!(
-            !bans[0].enforcing,
-            "bob is not authorized to ban alice, so the ban does not keep her out"
+            !state
+                .members
+                .members
+                .iter()
+                .any(|m| m.member.id() == id(&alice)),
+            "precondition: the ban removed alice"
+        );
+
+        assert!(
+            collect_ban_infos(&state, &owner.verifying_key())[0].enforcing,
+            "the ban is working, so it must not read as NOT ENFORCING once its \
+             target is gone"
         );
     }
 
     #[test]
-    fn ban_excludes_its_target_matches_banned_member_ids() {
-        // Ties the reported flag to the contract's own excluded set rather than
-        // to a predicate that merely looks related. Each state carries exactly
-        // one ban, so `banned_member_ids` containing the target is precisely
-        // "this ban excludes its target".
+    fn a_present_target_agrees_with_the_contracts_excluded_set() {
+        // `enforcing == false` is the actionable claim: the target is a current
+        // member this ban fails to exclude. Tie that to the contract's own
+        // excluded set rather than to a predicate that merely looks related.
+        // Each state holds exactly one ban, so `banned_member_ids` containing
+        // the target is precisely "this ban excludes its target".
         let owner = key(1);
         let alice = key(2);
         let bob = key(3);
 
-        // Covers both target-present and target-absent, and both authorized and
-        // unauthorized banners.
         let mut cases: Vec<(&str, ChatRoomStateV1)> = Vec::new();
 
-        let mut owner_bans_present = ChatRoomStateV1::default();
-        push_member(&mut owner_bans_present, &owner, &owner, &alice);
-        push_ban(&mut owner_bans_present, &owner, &owner, &alice);
-        cases.push(("owner bans a present member", owner_bans_present));
+        let mut owner_bans = ChatRoomStateV1::default();
+        push_member(&mut owner_bans, &owner, &owner, &alice);
+        push_ban(&mut owner_bans, &owner, &owner, &alice);
+        cases.push(("owner bans a present member", owner_bans));
 
-        let mut deputy_bans_present = ChatRoomStateV1::default();
-        push_member(&mut deputy_bans_present, &owner, &owner, &alice);
-        push_member(&mut deputy_bans_present, &owner, &owner, &bob);
-        push_info(&mut deputy_bans_present, &owner, 0, vec![id(&bob)]);
-        push_ban(&mut deputy_bans_present, &owner, &bob, &alice);
-        cases.push(("current deputy bans a present member", deputy_bans_present));
+        let mut deputy_bans = ChatRoomStateV1::default();
+        push_member(&mut deputy_bans, &owner, &owner, &alice);
+        push_member(&mut deputy_bans, &owner, &owner, &bob);
+        push_info(&mut deputy_bans, &owner, 0, vec![id(&bob)]);
+        push_ban(&mut deputy_bans, &owner, &bob, &alice);
+        cases.push(("current deputy bans a present member", deputy_bans));
 
-        let mut revoked_bans_present = ChatRoomStateV1::default();
-        push_member(&mut revoked_bans_present, &owner, &owner, &alice);
-        push_member(&mut revoked_bans_present, &owner, &owner, &bob);
-        push_info(&mut revoked_bans_present, &owner, 0, vec![id(&bob)]);
-        push_ban(&mut revoked_bans_present, &owner, &bob, &alice);
-        push_info(&mut revoked_bans_present, &owner, 1, vec![]);
-        cases.push(("revoked deputy bans a present member", revoked_bans_present));
+        let mut revoked_bans = ChatRoomStateV1::default();
+        push_member(&mut revoked_bans, &owner, &owner, &alice);
+        push_member(&mut revoked_bans, &owner, &owner, &bob);
+        push_info(&mut revoked_bans, &owner, 0, vec![id(&bob)]);
+        push_ban(&mut revoked_bans, &owner, &bob, &alice);
+        push_info(&mut revoked_bans, &owner, 1, vec![]);
+        cases.push(("revoked deputy bans a present member", revoked_bans));
 
-        let mut stranger_bans_absent = ChatRoomStateV1::default();
-        push_member(&mut stranger_bans_absent, &owner, &owner, &bob);
-        push_ban(&mut stranger_bans_absent, &owner, &bob, &alice);
+        let mut stranger_bans = ChatRoomStateV1::default();
+        push_member(&mut stranger_bans, &owner, &owner, &alice);
+        push_member(&mut stranger_bans, &owner, &owner, &bob);
+        push_ban(&mut stranger_bans, &owner, &bob, &alice);
         cases.push((
-            "unauthorized member bans an absent target",
-            stranger_bans_absent,
+            "member with no authority bans a present member",
+            stranger_bans,
         ));
-
-        let mut owner_bans_absent = ChatRoomStateV1::default();
-        push_member(&mut owner_bans_absent, &owner, &owner, &bob);
-        push_ban(&mut owner_bans_absent, &owner, &owner, &alice);
-        cases.push(("owner bans an absent target", owner_bans_absent));
 
         let params = ChatRoomParametersV1 {
             owner: owner.verifying_key(),
@@ -863,6 +873,15 @@ mod tests {
         for (label, state) in &cases {
             let reported = collect_ban_infos(state, &owner.verifying_key())[0].enforcing;
             let target = state.bans.0[0].ban.banned_user;
+            assert!(
+                state
+                    .members
+                    .members
+                    .iter()
+                    .any(|m| m.member.id() == target),
+                "this equivalence only holds for a PRESENT target: {label}"
+            );
+
             let actually_excluded = state
                 .members
                 .banned_member_ids(&state.bans, &state.member_info, &params)

--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -4,6 +4,9 @@ use crate::output::OutputFormat;
 use anyhow::{anyhow, Result};
 use clap::Subcommand;
 use ed25519_dalek::VerifyingKey;
+use river_core::room_state::ban::BansV1;
+use river_core::room_state::member::MemberId;
+use river_core::room_state::ChatRoomStateV1;
 use serde::Serialize;
 
 #[derive(Subcommand)]
@@ -42,6 +45,99 @@ struct BanInfo {
     banned_user_id: String,
     banned_by_id: String,
     banned_at_secs: u64,
+    /// Whether the contract currently ENFORCES this ban, as opposed to it being
+    /// present in state but inert. Since deputy ban authority (freenet/river#410)
+    /// a ban can stop enforcing without being removed — e.g. the banner's deputy
+    /// authority was revoked, the banner left or was pruned, or the target has
+    /// since deputized the banner. Computed from `BansV1::ban_is_enforcing`, the
+    /// same predicate the contract uses when it decides whether a ban's target
+    /// is actually excluded.
+    enforcing: bool,
+}
+
+/// Classify every ban in `room_state` as enforcing or inert, projecting each to
+/// a `BanInfo`. Kept as a pure helper (no I/O) so the enforcement wiring is unit
+/// testable without a live node — see the tests at the bottom of this file.
+fn collect_ban_infos(room_state: &ChatRoomStateV1, owner_vk: &VerifyingKey) -> Vec<BanInfo> {
+    let owner_id = MemberId::from(owner_vk);
+    let members_by_id = room_state.members.members_by_member_id();
+    room_state
+        .bans
+        .0
+        .iter()
+        .map(|ban| {
+            let banned_at_secs = ban
+                .ban
+                .banned_at
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            let enforcing = BansV1::ban_is_enforcing(
+                ban,
+                &members_by_id,
+                &room_state.member_info,
+                owner_id,
+                owner_vk,
+            );
+            BanInfo {
+                banned_user_id: ban.ban.banned_user.to_string(),
+                banned_by_id: ban.banned_by.to_string(),
+                banned_at_secs,
+                enforcing,
+            }
+        })
+        .collect()
+}
+
+/// Render the human-readable `debug bans` output as lines. Pure so the
+/// non-enforcing call-out is unit testable: this listing is the surface a
+/// moderator reads to decide whether someone is still kept out, so a ban that
+/// no longer enforces has to be visibly distinct rather than silently blending
+/// in with the live ones.
+fn ban_list_lines(bans: &[BanInfo]) -> Vec<String> {
+    let enforcing_count = bans.iter().filter(|b| b.enforcing).count();
+    let inert_count = bans.len() - enforcing_count;
+
+    let mut lines = vec![
+        format!(
+            "Ban List ({} bans, {} enforcing)",
+            bans.len(),
+            enforcing_count
+        ),
+        "=========".to_string(),
+    ];
+
+    if bans.is_empty() {
+        lines.push("No bans.".to_string());
+        return lines;
+    }
+
+    for ban in bans {
+        lines.push(format!(
+            "  {} banned by {} at {}{}",
+            ban.banned_user_id,
+            ban.banned_by_id,
+            ban.banned_at_secs,
+            if ban.enforcing {
+                ""
+            } else {
+                "  [NOT ENFORCING]"
+            }
+        ));
+    }
+
+    if inert_count > 0 {
+        lines.push(String::new());
+        lines.push(format!(
+            "Note: {} ban(s) are stored in room state but NOT enforced, so those \
+             users are not kept out. A ban stops enforcing when its banner leaves \
+             the room or loses the deputy authority it banned under. Check the \
+             banner with `riverctl member deputized-by <room> <banned_by_id>`.",
+            inert_count
+        ));
+    }
+
+    lines
 }
 
 #[derive(Serialize)]
@@ -338,38 +434,12 @@ pub async fn execute(command: DebugCommands, api: ApiClient, format: OutputForma
             let owner_vk = parse_owner_key(&room_owner_key)?;
             let room_state = api.get_room(&owner_vk, false).await?;
 
-            let bans: Vec<BanInfo> = room_state
-                .bans
-                .0
-                .iter()
-                .map(|ban| {
-                    let banned_at_secs = ban
-                        .ban
-                        .banned_at
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map(|d| d.as_secs())
-                        .unwrap_or(0);
-                    BanInfo {
-                        banned_user_id: ban.ban.banned_user.to_string(),
-                        banned_by_id: ban.banned_by.to_string(),
-                        banned_at_secs,
-                    }
-                })
-                .collect();
+            let bans = collect_ban_infos(&room_state, &owner_vk);
 
             match format {
                 OutputFormat::Human => {
-                    println!("Ban List ({} bans)", bans.len());
-                    println!("=========");
-                    if bans.is_empty() {
-                        println!("No bans.");
-                    } else {
-                        for ban in &bans {
-                            println!(
-                                "  {} banned by {} at {}",
-                                ban.banned_user_id, ban.banned_by_id, ban.banned_at_secs
-                            );
-                        }
+                    for line in ban_list_lines(&bans) {
+                        println!("{}", line);
                     }
                 }
                 OutputFormat::Json => {
@@ -503,5 +573,279 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&serialized).unwrap();
         assert_eq!(parsed["status"], "error");
         assert_eq!(parsed["message"], raw);
+    }
+
+    // --- `debug bans` enforcement reporting (#472) ------------------------
+    //
+    // A ban can sit in room state while the contract no longer enforces it
+    // (deputy ban authority, #410). These pin that `debug bans` distinguishes
+    // the two, since a moderator reads this list to decide whether someone is
+    // actually kept out.
+
+    use ed25519_dalek::SigningKey;
+    use river_core::room_state::ban::{AuthorizedUserBan, UserBan};
+    use river_core::room_state::member::{AuthorizedMember, Member};
+    use river_core::room_state::member_info::{AuthorizedMemberInfo, MemberInfo};
+
+    /// The cli crate's dalek build does not enable the `rand` `generate`
+    /// helper, so keys come from fixed seeds (mirrors `deputies.rs`'s tests).
+    fn key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    fn id(sk: &SigningKey) -> MemberId {
+        sk.verifying_key().into()
+    }
+
+    /// Add `sk` as a member invited by `inviter`, signed by the inviter as
+    /// `AuthorizedMember::new` asserts.
+    fn push_member(
+        state: &mut ChatRoomStateV1,
+        owner: &SigningKey,
+        inviter: &SigningKey,
+        sk: &SigningKey,
+    ) {
+        let member = Member {
+            owner_member_id: id(owner),
+            invited_by: id(inviter),
+            member_vk: sk.verifying_key(),
+        };
+        state
+            .members
+            .members
+            .push(AuthorizedMember::new(member, inviter));
+    }
+
+    /// Push a signed `member_info` record for `sk` at `version` granting
+    /// `deputies`. A later version supersedes an earlier one via `canonical`,
+    /// which is how a revocation is represented.
+    fn push_info(
+        state: &mut ChatRoomStateV1,
+        sk: &SigningKey,
+        version: u32,
+        deputies: Vec<MemberId>,
+    ) {
+        let mut info = MemberInfo::new_public(id(sk), version, "member".to_string());
+        info.deputies = deputies;
+        state
+            .member_info
+            .member_info
+            .push(AuthorizedMemberInfo::new_with_member_key(info, sk));
+    }
+
+    /// A ban of `target` issued and signed by `banner`.
+    fn push_ban(
+        state: &mut ChatRoomStateV1,
+        owner: &SigningKey,
+        banner: &SigningKey,
+        target: &SigningKey,
+    ) {
+        let ban = UserBan {
+            owner_member_id: id(owner),
+            banned_at: std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000),
+            banned_user: id(target),
+        };
+        state
+            .bans
+            .0
+            .push(AuthorizedUserBan::new(ban, id(banner), banner));
+    }
+
+    #[test]
+    fn owner_ban_of_a_present_member_reports_enforcing() {
+        // Baseline for the negative cases below: without this, a test asserting
+        // `!enforcing` would pass even if `enforcing` were hardcoded to false.
+        let owner = key(1);
+        let alice = key(2);
+
+        let mut state = ChatRoomStateV1::default();
+        push_member(&mut state, &owner, &owner, &alice);
+        push_ban(&mut state, &owner, &owner, &alice);
+
+        let bans = collect_ban_infos(&state, &owner.verifying_key());
+        assert_eq!(bans.len(), 1);
+        assert_eq!(bans[0].banned_user_id, id(&alice).to_string());
+        assert_eq!(bans[0].banned_by_id, id(&owner).to_string());
+        assert!(
+            bans[0].enforcing,
+            "an owner's ban of a current member is authorized, so it must report as enforcing"
+        );
+    }
+
+    #[test]
+    fn deputy_ban_reports_enforcing_while_the_grant_stands() {
+        // The other half of the revocation pair below: the SAME ban, differing
+        // only in whether the owner's deputy grant is still present.
+        let owner = key(1);
+        let alice = key(2);
+        let bob = key(3);
+
+        let mut state = ChatRoomStateV1::default();
+        push_member(&mut state, &owner, &owner, &alice);
+        push_member(&mut state, &owner, &owner, &bob);
+        push_info(&mut state, &owner, 0, vec![id(&bob)]);
+        push_ban(&mut state, &owner, &bob, &alice);
+
+        let bans = collect_ban_infos(&state, &owner.verifying_key());
+        assert!(
+            bans[0].enforcing,
+            "bob is a current owner-appointed deputy, so his ban enforces"
+        );
+    }
+
+    #[test]
+    fn deputy_ban_reports_not_enforcing_after_the_grant_is_revoked() {
+        // The issue's headline case (#472): the owner revokes bob's deputy
+        // authority by publishing a later `member_info` record without him.
+        // The ban stays in state but the contract stops excluding alice, and
+        // `debug bans` used to present it identically to a live ban.
+        let owner = key(1);
+        let alice = key(2);
+        let bob = key(3);
+
+        let mut state = ChatRoomStateV1::default();
+        push_member(&mut state, &owner, &owner, &alice);
+        push_member(&mut state, &owner, &owner, &bob);
+        push_info(&mut state, &owner, 0, vec![id(&bob)]);
+        push_ban(&mut state, &owner, &bob, &alice);
+        // Revocation: a higher-version record wins in `canonical`.
+        push_info(&mut state, &owner, 1, vec![]);
+
+        let bans = collect_ban_infos(&state, &owner.verifying_key());
+        assert_eq!(bans.len(), 1, "the ban is still stored in state");
+        assert!(
+            !bans[0].enforcing,
+            "bob's authority was revoked, so his ban no longer keeps alice out"
+        );
+    }
+
+    #[test]
+    fn ban_reports_not_enforcing_once_its_banner_is_no_longer_a_member() {
+        // Second inert path from #472: the banner left or was pruned, so the
+        // deputy-derived grants no longer apply. Alice must remain a member,
+        // otherwise `ban_is_enforcing` short-circuits to true on an absent
+        // target and the test would pass for the wrong reason.
+        let owner = key(1);
+        let alice = key(2);
+        let carol = key(4);
+
+        let mut state = ChatRoomStateV1::default();
+        push_member(&mut state, &owner, &owner, &alice);
+        push_member(&mut state, &owner, &owner, &carol);
+        push_info(&mut state, &owner, 0, vec![id(&carol)]);
+        push_ban(&mut state, &owner, &carol, &alice);
+
+        // Sanity: enforcing while carol is present.
+        assert!(collect_ban_infos(&state, &owner.verifying_key())[0].enforcing);
+
+        // Carol leaves / is pruned.
+        state
+            .members
+            .members
+            .retain(|m| m.member.id() != id(&carol));
+
+        let bans = collect_ban_infos(&state, &owner.verifying_key());
+        assert!(
+            !bans[0].enforcing,
+            "a ban whose banner is gone is inert and must not read as active"
+        );
+    }
+
+    #[test]
+    fn ban_json_carries_the_enforcing_flag_alongside_the_pre_existing_shape() {
+        // `banned_user_id` / `banned_by_id` / `banned_at_secs` are the published
+        // shape; `enforcing` is additive. Renaming or dropping any of them
+        // breaks consumers of `debug bans -f json`.
+        let owner = key(1);
+        let alice = key(2);
+
+        let mut state = ChatRoomStateV1::default();
+        push_member(&mut state, &owner, &owner, &alice);
+        push_ban(&mut state, &owner, &owner, &alice);
+
+        let bans = collect_ban_infos(&state, &owner.verifying_key());
+        let json = serde_json::to_value(&bans).unwrap();
+        let entry = &json[0];
+
+        assert_eq!(entry["banned_user_id"], id(&alice).to_string());
+        assert_eq!(entry["banned_by_id"], id(&owner).to_string());
+        assert_eq!(entry["banned_at_secs"], 1_700_000_000u64);
+        assert_eq!(
+            entry["enforcing"], true,
+            "`enforcing` must be present and boolean in the JSON output"
+        );
+    }
+
+    #[test]
+    fn human_output_marks_only_the_non_enforcing_bans() {
+        // The human branch is the surface the issue is about: an inert ban that
+        // renders identically to a live one is the whole bug.
+        let enforcing = BanInfo {
+            banned_user_id: "LIVEUSER".to_string(),
+            banned_by_id: "BANNERA".to_string(),
+            banned_at_secs: 100,
+            enforcing: true,
+        };
+        let inert = BanInfo {
+            banned_user_id: "INERTUSER".to_string(),
+            banned_by_id: "BANNERB".to_string(),
+            banned_at_secs: 200,
+            enforcing: false,
+        };
+
+        let lines = ban_list_lines(&[enforcing, inert]);
+        let live_line = lines
+            .iter()
+            .find(|l| l.contains("LIVEUSER"))
+            .expect("the enforcing ban must still be listed");
+        let inert_line = lines
+            .iter()
+            .find(|l| l.contains("INERTUSER"))
+            .expect("the inert ban must still be listed");
+
+        assert!(
+            !live_line.contains("NOT ENFORCING"),
+            "an enforcing ban must not be flagged: {live_line}"
+        );
+        assert!(
+            inert_line.contains("NOT ENFORCING"),
+            "an inert ban must be visibly flagged: {inert_line}"
+        );
+
+        let rendered = lines.join("\n");
+        assert!(
+            rendered.contains("2 bans, 1 enforcing"),
+            "the header must report how many bans actually enforce: {rendered}"
+        );
+        assert!(
+            rendered.contains("member deputized-by"),
+            "the note must point at the command that explains why a ban went inert"
+        );
+    }
+
+    #[test]
+    fn human_output_stays_quiet_when_every_ban_enforces() {
+        // No false alarm: a room whose bans are all live must not carry the
+        // inert-ban note, or moderators learn to ignore it.
+        let lines = ban_list_lines(&[BanInfo {
+            banned_user_id: "LIVEUSER".to_string(),
+            banned_by_id: "BANNERA".to_string(),
+            banned_at_secs: 100,
+            enforcing: true,
+        }]);
+        let rendered = lines.join("\n");
+
+        assert!(rendered.contains("1 bans, 1 enforcing"));
+        assert!(!rendered.contains("NOT ENFORCING"));
+        assert!(!rendered.contains("Note:"));
+    }
+
+    #[test]
+    fn human_output_handles_an_empty_ban_list() {
+        let lines = ban_list_lines(&[]);
+        let rendered = lines.join("\n");
+        assert!(rendered.contains("0 bans, 0 enforcing"));
+        assert!(rendered.contains("No bans."));
+        assert!(!rendered.contains("Note:"));
     }
 }

--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Result};
 use clap::Subcommand;
 use ed25519_dalek::VerifyingKey;
 use river_core::room_state::ban::BansV1;
-use river_core::room_state::member::MemberId;
+use river_core::room_state::member::{MemberId, MembersV1};
 use river_core::room_state::ChatRoomStateV1;
 use serde::Serialize;
 
@@ -45,13 +45,23 @@ struct BanInfo {
     banned_user_id: String,
     banned_by_id: String,
     banned_at_secs: u64,
-    /// Whether the contract currently ENFORCES this ban, as opposed to it being
-    /// present in state but inert. Since deputy ban authority (freenet/river#410)
-    /// a ban can stop enforcing without being removed — e.g. the banner's deputy
-    /// authority was revoked, the banner left or was pruned, or the target has
-    /// since deputized the banner. Computed from `BansV1::ban_is_enforcing`, the
-    /// same predicate the contract uses when it decides whether a ban's target
-    /// is actually excluded.
+    /// Whether the contract currently EXCLUDES this ban's target, as opposed to
+    /// the ban being present in state but inert. Since deputy ban authority
+    /// (freenet/river#410) a ban can stop enforcing without being removed: the
+    /// banner left or was pruned, their deputy authority was revoked, or (once
+    /// no absolute grant applies) the target has since deputized the banner.
+    ///
+    /// This mirrors the test `MembersV1::banned_member_ids` applies when it
+    /// builds the excluded set in `post_apply_cleanup`, so it answers the
+    /// question a moderator is actually asking: is this person kept out?
+    ///
+    /// Deliberately NOT `BansV1::ban_is_enforcing`, despite the name. That
+    /// predicate answers a different question — whether a ban is worth KEEPING
+    /// under `max_user_bans` eviction pressure — and to do so it returns `true`
+    /// for any signature-verified member's ban of an ABSENT target without ever
+    /// consulting `is_ban_authorized`. Reporting that as "enforcing" would tell a
+    /// moderator an unauthorized ban keeps someone out when rejoining would in
+    /// fact readmit them, which is the very confusion #472 exists to remove.
     enforcing: bool,
 }
 
@@ -72,13 +82,18 @@ fn collect_ban_infos(room_state: &ChatRoomStateV1, owner_vk: &VerifyingKey) -> V
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_secs())
                 .unwrap_or(0);
-            let enforcing = BansV1::ban_is_enforcing(
-                ban,
-                &members_by_id,
-                &room_state.member_info,
-                owner_id,
-                owner_vk,
-            );
+            // The same two gates, in the same order, that `banned_member_ids`
+            // applies per ban. `ban_excludes_its_target_matches_banned_member_ids`
+            // pins the agreement so this cannot drift from the contract.
+            let enforcing =
+                BansV1::ban_signature_matches_current_key(ban, &members_by_id, owner_id, owner_vk)
+                    && MembersV1::is_ban_authorized(
+                        ban.banned_by,
+                        ban.ban.banned_user,
+                        &members_by_id,
+                        &room_state.member_info,
+                        owner_id,
+                    );
             BanInfo {
                 banned_user_id: ban.ban.banned_user.to_string(),
                 banned_by_id: ban.banned_by.to_string(),
@@ -586,6 +601,7 @@ mod tests {
     use river_core::room_state::ban::{AuthorizedUserBan, UserBan};
     use river_core::room_state::member::{AuthorizedMember, Member};
     use river_core::room_state::member_info::{AuthorizedMemberInfo, MemberInfo};
+    use river_core::room_state::ChatRoomParametersV1;
 
     /// The cli crate's dalek build does not enable the `rand` `generate`
     /// helper, so keys come from fixed seeds (mirrors `deputies.rs`'s tests).
@@ -749,6 +765,120 @@ mod tests {
             !bans[0].enforcing,
             "a ban whose banner is gone is inert and must not read as active"
         );
+    }
+
+    #[test]
+    fn unauthorized_ban_of_an_absent_target_reports_not_enforcing() {
+        // `BansV1::ban_is_enforcing` answers "is this ban worth keeping under
+        // `max_user_bans` pressure?", and for an ABSENT target it returns true
+        // for any signature-verified member's ban WITHOUT consulting
+        // `is_ban_authorized`. Reporting that as enforcing would recreate #472's
+        // bug: bob has no authority over alice, so if alice rejoins she is NOT
+        // removed, yet the moderator would have been told the ban holds.
+        let owner = key(1);
+        let alice = key(2);
+        let bob = key(3);
+
+        let mut state = ChatRoomStateV1::default();
+        // bob is a plain member with no deputy grant; alice is absent.
+        push_member(&mut state, &owner, &owner, &bob);
+        push_ban(&mut state, &owner, &bob, &alice);
+
+        let members_by_id = state.members.members_by_member_id();
+        let owner_id = MemberId::from(&owner.verifying_key());
+        assert!(
+            BansV1::ban_is_enforcing(
+                &state.bans.0[0],
+                &members_by_id,
+                &state.member_info,
+                owner_id,
+                &owner.verifying_key(),
+            ),
+            "guard: this test is only meaningful while `ban_is_enforcing` still \
+             returns true here; if that changes, the divergence it protects \
+             against is gone and this test should be revisited"
+        );
+
+        let bans = collect_ban_infos(&state, &owner.verifying_key());
+        assert!(
+            !bans[0].enforcing,
+            "bob is not authorized to ban alice, so the ban does not keep her out"
+        );
+    }
+
+    #[test]
+    fn ban_excludes_its_target_matches_banned_member_ids() {
+        // Ties the reported flag to the contract's own excluded set rather than
+        // to a predicate that merely looks related. Each state carries exactly
+        // one ban, so `banned_member_ids` containing the target is precisely
+        // "this ban excludes its target".
+        let owner = key(1);
+        let alice = key(2);
+        let bob = key(3);
+
+        // Covers both target-present and target-absent, and both authorized and
+        // unauthorized banners.
+        let mut cases: Vec<(&str, ChatRoomStateV1)> = Vec::new();
+
+        let mut owner_bans_present = ChatRoomStateV1::default();
+        push_member(&mut owner_bans_present, &owner, &owner, &alice);
+        push_ban(&mut owner_bans_present, &owner, &owner, &alice);
+        cases.push(("owner bans a present member", owner_bans_present));
+
+        let mut deputy_bans_present = ChatRoomStateV1::default();
+        push_member(&mut deputy_bans_present, &owner, &owner, &alice);
+        push_member(&mut deputy_bans_present, &owner, &owner, &bob);
+        push_info(&mut deputy_bans_present, &owner, 0, vec![id(&bob)]);
+        push_ban(&mut deputy_bans_present, &owner, &bob, &alice);
+        cases.push(("current deputy bans a present member", deputy_bans_present));
+
+        let mut revoked_bans_present = ChatRoomStateV1::default();
+        push_member(&mut revoked_bans_present, &owner, &owner, &alice);
+        push_member(&mut revoked_bans_present, &owner, &owner, &bob);
+        push_info(&mut revoked_bans_present, &owner, 0, vec![id(&bob)]);
+        push_ban(&mut revoked_bans_present, &owner, &bob, &alice);
+        push_info(&mut revoked_bans_present, &owner, 1, vec![]);
+        cases.push(("revoked deputy bans a present member", revoked_bans_present));
+
+        let mut stranger_bans_absent = ChatRoomStateV1::default();
+        push_member(&mut stranger_bans_absent, &owner, &owner, &bob);
+        push_ban(&mut stranger_bans_absent, &owner, &bob, &alice);
+        cases.push((
+            "unauthorized member bans an absent target",
+            stranger_bans_absent,
+        ));
+
+        let mut owner_bans_absent = ChatRoomStateV1::default();
+        push_member(&mut owner_bans_absent, &owner, &owner, &bob);
+        push_ban(&mut owner_bans_absent, &owner, &owner, &alice);
+        cases.push(("owner bans an absent target", owner_bans_absent));
+
+        let params = ChatRoomParametersV1 {
+            owner: owner.verifying_key(),
+        };
+
+        let mut saw_enforcing = false;
+        let mut saw_inert = false;
+
+        for (label, state) in &cases {
+            let reported = collect_ban_infos(state, &owner.verifying_key())[0].enforcing;
+            let target = state.bans.0[0].ban.banned_user;
+            let actually_excluded = state
+                .members
+                .banned_member_ids(&state.bans, &state.member_info, &params)
+                .contains(&target);
+
+            assert_eq!(
+                reported, actually_excluded,
+                "`debug bans` disagrees with the contract's excluded set for: {label}"
+            );
+
+            saw_enforcing |= reported;
+            saw_inert |= !reported;
+        }
+
+        // Guard against a vacuous pass if every case landed on one side.
+        assert!(saw_enforcing && saw_inert, "cases must cover both outcomes");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`riverctl debug bans <room>` printed every ban with `banned_user_id`, `banned_by_id` and `banned_at_secs`, and nothing about whether the contract still **enforces** it.

Since deputy ban authority (#410), storage and enforcement are separate. A ban goes inert without being removed when the banner leaves or is pruned, when their deputy grant is revoked, or when the step-4 deputizer guardrail trips. A moderator reading `debug bans` saw the ban listed and reasonably concluded the member was kept out. They may well be back in the room.

## Approach

Add `enforcing: bool` to `BanInfo`, computed from `BansV1::ban_is_enforcing` (already `pub`), and surface it in both output branches.

Two small pure helpers carry it so the behaviour is unit testable without a live node:

- `collect_ban_infos(&ChatRoomStateV1, &VerifyingKey) -> Vec<BanInfo>`
- `ban_list_lines(&[BanInfo]) -> Vec<String>` for the human branch

Human output now reads:

```
Ban List (2 bans, 1 enforcing)
=========
  7XSOGJTK banned by PMAQEUP5 at 1700000000
  4KDLM2NQ banned by 9WTZR6HB at 1700000042  [NOT ENFORCING]

Note: 1 ban(s) are stored in room state but are NOT keeping their target out, so
those users are in the room. A ban stops enforcing when its banner leaves the
room or loses the deputy authority it banned under. Check the banner with
`riverctl member deputized-by <room> <banned_by_id>`.
```

The JSON change is additive: `banned_user_id`, `banned_by_id` and `banned_at_secs` keep their names and types, with `enforcing` alongside. No consumer outside this file reads that shape.

### What `enforcing` claims, and what it does not

Worth stating precisely, because the review went down a wrong path here and the field docs now carry the warning.

`enforcing: false` is the actionable case and it is unambiguous: the target is a **current member** that this ban fails to exclude, so that person is in the room right now. That is exactly the situation the issue describes.

`enforcing: true` for a target who is already gone means "not in the room". It is deliberately **not** a promise that the ban would hold if a different member re-invited them. `ban_is_enforcing` skips the authority check for an absent target on purpose: once a ban has done its job the target is gone, so there is no invite chain left to walk and the ancestor grant that authorized the ban cannot be re-derived.

The middle commit on this branch tried to tighten that by computing the flag from a bare `is_ban_authorized` instead, to close the narrow case of an unauthorized banner with an absent target. Testing an ancestor ban (owner -> bob -> alice, bob bans alice) showed why that is wrong: while alice is present both agree the ban enforces, but after the contract removes her the replacement reports NOT ENFORCING. Since every successfully enforced ban ends with its target removed, that flagged essentially **every working ban** as inert, which is far more misleading than the edge case it tightened. It is reverted, and `legitimate_ancestor_ban_still_enforcing_after_its_target_is_removed` pins it so the same wrong fix cannot land again.

The optional reason-string enhancement the issue floats ("banner absent / authority revoked / guardrail") is **not** included. The note points at `member deputized-by`, which answers the same question with a command that already exists.

## Testing

Ten new tests in `cli/src/commands/debug.rs`, built on the fixed-seed key fixtures used by `cli/src/deputies.rs` (the cli crate's dalek build has no `rand` `generate` helper).

Enforcement classification:
- `owner_ban_of_a_present_member_reports_enforcing` (positive baseline, so the negative cases cannot pass against a hardcoded `false`)
- `deputy_ban_reports_enforcing_while_the_grant_stands`
- `deputy_ban_reports_not_enforcing_after_the_grant_is_revoked` (the issue's headline case: revocation via a higher-version `member_info` record, exercising `canonical`)
- `ban_reports_not_enforcing_once_its_banner_is_no_longer_a_member`
- `legitimate_ancestor_ban_still_enforcing_after_its_target_is_removed` (guards the wrong fix described above)
- `a_present_target_agrees_with_the_contracts_excluded_set` ties the flag to `MembersV1::banned_member_ids` across authorized and unauthorized banners, and asserts the target is present so the equivalence it claims actually holds

The target stays a current member in the negative cases on purpose: `ban_is_enforcing` short-circuits to `true` for an absent target, so a fixture that removed the target would have passed for the wrong reason.

Output shape:
- `ban_json_carries_the_enforcing_flag_alongside_the_pre_existing_shape`
- `human_output_marks_only_the_non_enforcing_bans`
- `human_output_stays_quiet_when_every_ban_enforces` (no false alarm on an all-live room)
- `human_output_handles_an_empty_ban_list`

Mutation-tested against the final content rather than assumed:

| Mutation | Tests killed |
|---|---|
| `enforcing` hardcoded `true` | 3 |
| `enforcing` hardcoded `false` | 6 |
| `[NOT ENFORCING]` marker removed | 1 |
| flag computed from a bare `is_ban_authorized` (the reverted approach) | 1, and only that one |

Full `riverctl` lib suite: 285 passed, 0 failed. `cargo fmt --check` clean; `cargo clippy` introduces no new warnings.

Bans have no expiry or TTL in River, so there is no expired-ban case to report on.

Closes #472

[AI-assisted - Claude]