### PR TITLE
fix(ui): handle notification_status from the shell and offer a manual retry

### DIFF
--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -108,7 +108,9 @@ pub fn App() -> Element {
 
     // In the gateway iframe, notifications are shown by the shell page; listen
     // for its `notification_click` replies to route to the clicked room
-    // (freenet/river#408). No-op when served as a top-level page. Installs once.
+    // (freenet/river#408) and its `notification_status` replies to learn whether
+    // the browser will show anything at all (freenet/river#510). No-op when
+    // served as a top-level page. Installs once.
     crate::components::app::notifications::install_shell_notification_listener();
 
     // Install the document-level click interceptor that catches

--- a/ui/src/components/app/notifications.rs
+++ b/ui/src/components/app/notifications.rs
@@ -1363,13 +1363,24 @@ mod notify_gate_tests {
     /// isn't shown the shell's bar again on every message they send.
     #[test]
     fn the_automatic_rearm_is_bounded() {
+        // Concrete numbers, NOT `MAX_ENABLE_PROMPT_REARMS` itself: phrased
+        // against the constant this test passes for ANY cap, including no cap
+        // at all — it stayed green under a mutation that raised the cap to
+        // `usize::MAX`.
         assert!(
-            status_rearms_auto_prompt(NotificationStatus::Undecided, MAX_ENABLE_PROMPT_REARMS - 1),
-            "the last permitted re-arm must still be allowed"
+            MAX_ENABLE_PROMPT_REARMS <= 2,
+            "more than a couple of automatic re-asks per session is a nag; the \
+             manual button is the unbounded path"
         );
         assert!(
-            !status_rearms_auto_prompt(NotificationStatus::Undecided, MAX_ENABLE_PROMPT_REARMS),
-            "re-arming past the cap would re-prompt on every message"
+            status_rearms_auto_prompt(NotificationStatus::Undecided, 0),
+            "the first re-arm must be allowed, or an unanswered prompt is final \
+             and #510's no-retry complaint stands"
+        );
+        assert!(
+            !status_rearms_auto_prompt(NotificationStatus::Undecided, 3),
+            "the automatic ask must stop re-arming; otherwise the shell shows \
+             its bar again on every message the user sends"
         );
     }
 

--- a/ui/src/components/app/notifications.rs
+++ b/ui/src/components/app/notifications.rs
@@ -16,7 +16,7 @@ use river_core::room_state::member::MemberId;
 use river_core::room_state::member_info::MemberInfoV1;
 use river_core::room_state::message::{AuthorizedMessageV1, MessageId, RoomMessageBody};
 use std::collections::HashSet;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{
@@ -163,9 +163,137 @@ fn mark_prompted_for_permission() {
 
 /// Only send the "offer notifications" request to the shell once per session
 /// (the iframe's opaque origin can't persist a localStorage flag anyway).
+/// Cleared again by a `notification_status` of `default` — see
+/// [`status_rearms_auto_prompt`].
 static ENABLE_PROMPT_SENT: AtomicBool = AtomicBool::new(false);
+/// How many times [`ENABLE_PROMPT_SENT`] has been re-armed this session.
+static ENABLE_PROMPT_REARMS: AtomicUsize = AtomicUsize::new(0);
 /// Install the `notification_click` listener at most once.
 static CLICK_LISTENER_INSTALLED: AtomicBool = AtomicBool::new(false);
+
+/// How many times an unanswered prompt may re-arm the AUTOMATIC ask
+/// ([`request_enable_via_shell`], fired when the user sends their first
+/// message). One re-arm means at most two automatic asks per session.
+///
+/// A cap is needed because the shell re-shows its affordance every time River
+/// asks: without one, a user who keeps closing the browser's permission dialog
+/// would get the bar back on every single message they send. The manual
+/// [`request_enable_now`] is deliberately NOT capped — an explicit click is a
+/// direct request, not a nag.
+const MAX_ENABLE_PROMPT_REARMS: usize = 1;
+
+/// The permission outcomes the gateway shell reports back as
+/// `notification_status` over the `__freenet_shell__` bridge.
+///
+/// River's iframe has an opaque origin and cannot read `Notification.permission`
+/// at all, so in the gateway this message is the ONLY way it learns whether a
+/// notification it hands to the shell will actually be shown. The variants
+/// mirror `notifyStatusToIframe` in freenet-core's `shell_bridge.js`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NotificationStatus {
+    /// Permission granted and this contract has the shell's consent.
+    Granted,
+    /// The browser is blocking notifications for the origin. Only the user can
+    /// undo this, in browser settings — asking again cannot help.
+    Denied,
+    /// The offer was declined ("Not now"), or is inside the shell's snooze
+    /// window from an earlier decline.
+    Dismissed,
+    /// The permission prompt closed with no answer (the shell's `default`).
+    /// Nothing is blocked, so asking again is still worthwhile.
+    Undecided,
+    /// Permission exists but nothing could display the notification — no
+    /// service worker on mobile, an insecure-context origin, or no contract
+    /// key to gate consent on.
+    Undeliverable,
+    /// The browser has no Notifications API at all.
+    Unsupported,
+}
+
+impl NotificationStatus {
+    /// Parse the shell's `status` string.
+    ///
+    /// An unrecognised value yields `None` and is then ignored rather than
+    /// guessed at, so a newer shell adding a status can never overwrite a known
+    /// one with a wrong reading.
+    pub fn from_shell_status(status: &str) -> Option<Self> {
+        Some(match status {
+            "granted" => Self::Granted,
+            "denied" => Self::Denied,
+            "dismissed" => Self::Dismissed,
+            "default" => Self::Undecided,
+            "undeliverable" => Self::Undeliverable,
+            "unsupported" => Self::Unsupported,
+            _ => return None,
+        })
+    }
+}
+
+/// The last notification status River has learned, or `None` before it has
+/// learned any. Written only by [`record_notification_status`].
+pub static NOTIFICATION_STATUS: GlobalSignal<Option<NotificationStatus>> = Global::new(|| None);
+
+/// What the bell modal tells the user about browser-level permission, and
+/// whether it offers them a button to ask again.
+pub struct PermissionNotice {
+    pub message: &'static str,
+    pub offer_enable: bool,
+}
+
+/// The notice for a given status. Pure, so the "can asking again help?"
+/// decision is testable without a browser.
+///
+/// `offer_enable` is true exactly where a fresh ask can still change the
+/// outcome. `Denied` and `Unsupported` are the browser's decision and River
+/// cannot re-open them; `Undeliverable` means permission is already granted, so
+/// asking for it again would do nothing.
+pub fn permission_notice(status: Option<NotificationStatus>) -> PermissionNotice {
+    let (message, offer_enable) = match status {
+        None => (
+            "Desktop notifications are not set up yet for this browser.",
+            true,
+        ),
+        Some(NotificationStatus::Granted) => ("Desktop notifications are enabled.", false),
+        Some(NotificationStatus::Denied) => (
+            "Your browser is blocking notifications for this site. Turn them back on in the \
+             browser's site settings — River can't ask again once they're blocked.",
+            false,
+        ),
+        Some(NotificationStatus::Dismissed) => (
+            "You dismissed the notification prompt. You can ask for it again.",
+            true,
+        ),
+        Some(NotificationStatus::Undecided) => (
+            "The notification prompt closed without an answer, so nothing is enabled yet.",
+            true,
+        ),
+        Some(NotificationStatus::Undeliverable) => (
+            "This browser granted permission but couldn't display a notification. Unread badges \
+             and the tab title still work.",
+            false,
+        ),
+        Some(NotificationStatus::Unsupported) => (
+            "This browser doesn't support desktop notifications. Unread badges and the tab title \
+             still work.",
+            false,
+        ),
+    };
+    PermissionNotice {
+        message,
+        offer_enable,
+    }
+}
+
+/// Whether a reported status should re-arm the automatic enable prompt.
+///
+/// Only [`NotificationStatus::Undecided`] does: every other outcome is either
+/// final (`Granted`, `Denied`, `Unsupported`, `Undeliverable`) or a decision the
+/// user actively made (`Dismissed`, which the shell also snoozes for 24h — River
+/// re-asking would just bounce off that snooze). Bounded by
+/// [`MAX_ENABLE_PROMPT_REARMS`].
+fn status_rearms_auto_prompt(status: NotificationStatus, rearms_used: usize) -> bool {
+    matches!(status, NotificationStatus::Undecided) && rearms_used < MAX_ENABLE_PROMPT_REARMS
+}
 
 /// Whether River is running framed rather than as a top-level page. This
 /// detects framing in general (`window.parent !== window`); River only ever
@@ -224,6 +352,121 @@ fn request_enable_via_shell() {
     post_to_shell(&shell_message("notification_enable_prompt"));
 }
 
+/// Ask for notification permission right now, carrying the user's click as the
+/// fresh gesture browsers require. Backs the bell modal's "Enable
+/// notifications" button.
+///
+/// Deliberately NOT latched: [`request_enable_via_shell`]'s once-per-session
+/// latch exists so sending messages doesn't nag, and an explicit click is
+/// exactly the retry that latch must not swallow. Without this, a prompt that
+/// was blocked, snoozed, or mis-clicked could not be re-requested for the rest
+/// of the session (freenet/river#510).
+///
+/// MUST be called synchronously from the click handler — see
+/// [`request_permission_directly`] for why. It writes no signal synchronously
+/// (every write goes through `defer`), so calling it directly from an `onclick`
+/// is signal-safe.
+pub fn request_enable_now() {
+    if is_in_shell_iframe() {
+        // Leave the automatic latch SET: the shell is being asked right now, and
+        // its `notification_status` reply is what re-arms it.
+        ENABLE_PROMPT_SENT.store(true, Ordering::SeqCst);
+        post_to_shell(&shell_message("notification_enable_prompt"));
+        return;
+    }
+    request_permission_directly();
+}
+
+/// Top-level (dev / `no-sync`) path for [`request_enable_now`]: River has a real
+/// origin here, so it can call the Notifications API itself.
+///
+/// `Notification::request_permission()` is invoked SYNCHRONOUSLY so it runs
+/// inside the click's transient user activation — Firefox and Safari reject the
+/// request with `NotAllowedError` once that activation has lapsed. Only the
+/// awaiting of the already-created promise is deferred, which is safe because
+/// the browser has already seen the gesture by then.
+fn request_permission_directly() {
+    match Notification::request_permission() {
+        Ok(promise) => {
+            crate::util::safe_spawn_local(async move {
+                let status = match JsFuture::from(promise).await {
+                    Ok(result) => match result.as_string().as_deref() {
+                        Some("granted") => NotificationStatus::Granted,
+                        Some("denied") => NotificationStatus::Denied,
+                        // "default" — the user closed the dialog without an answer.
+                        _ => NotificationStatus::Undecided,
+                    },
+                    Err(e) => {
+                        warn!("Notification permission request failed: {:?}", e);
+                        NotificationStatus::Undecided
+                    }
+                };
+                record_notification_status(status);
+            });
+        }
+        Err(e) => {
+            warn!("Notifications API unavailable: {:?}", e);
+            record_notification_status(NotificationStatus::Unsupported);
+        }
+    }
+}
+
+/// Record a notification status and, when the prompt closed with no answer,
+/// re-arm the automatic ask so a later gesture can offer again.
+///
+/// The re-arm touches only atomics, which need no Dioxus context, so it happens
+/// immediately; only the signal write is deferred, as required for a write
+/// originating in a JS callback (`.claude/rules/dioxus-signal-safety.md`).
+fn record_notification_status(status: NotificationStatus) {
+    if status_rearms_auto_prompt(status, ENABLE_PROMPT_REARMS.load(Ordering::SeqCst)) {
+        ENABLE_PROMPT_REARMS.fetch_add(1, Ordering::SeqCst);
+        ENABLE_PROMPT_SENT.store(false, Ordering::SeqCst);
+    }
+    crate::util::defer(move || {
+        *NOTIFICATION_STATUS.write() = Some(status);
+    });
+}
+
+/// The status the UI should display.
+///
+/// In the gateway iframe only the shell can tell us, so this is whatever it last
+/// reported (`None` until it reports anything). Served top-level River has a real
+/// origin and can read the browser's own answer, so an unreported status falls
+/// back to that rather than showing the user nothing.
+pub fn current_notification_status() -> Option<NotificationStatus> {
+    // `try_read`, not `read`: this runs during render and a concurrent write
+    // would otherwise panic (dioxus-signal-safety).
+    if let Ok(stored) = NOTIFICATION_STATUS.try_read() {
+        if stored.is_some() {
+            return *stored;
+        }
+    }
+    if is_in_shell_iframe() {
+        return None;
+    }
+    if !notification_api_available() {
+        return Some(NotificationStatus::Unsupported);
+    }
+    Some(match get_permission() {
+        NotificationPermission::Granted => NotificationStatus::Granted,
+        NotificationPermission::Denied => NotificationStatus::Denied,
+        _ => NotificationStatus::Undecided,
+    })
+}
+
+/// Whether this browser exposes the Notifications API at all.
+///
+/// Must be checked before [`get_permission`]: `Notification::permission()` is a
+/// non-throwing binding, so reading `.permission` off an undefined `Notification`
+/// raises a JS `ReferenceError` that aborts the WASM module rather than
+/// returning an error. Only [`Notification::request_permission`] is a
+/// `Result`-returning (try/catch-wrapped) binding.
+fn notification_api_available() -> bool {
+    js_sys::Reflect::get(&js_sys::global(), &JsValue::from_str("Notification"))
+        .map(|v| !v.is_undefined() && !v.is_null())
+        .unwrap_or(false)
+}
+
 /// Proxy a new-message notification to the shell (gateway iframe path).
 fn post_notification_to_shell(room_key: VerifyingKey, room_name: &str, body: &str) {
     let o = shell_message("notification");
@@ -241,7 +484,8 @@ fn post_notification_to_shell(room_key: VerifyingKey, room_name: &str, body: &st
     post_to_shell(&o);
 }
 
-/// Listen for `notification_click` replies from the shell and route to the room.
+/// Listen for the shell's replies: `notification_click` (route to the clicked
+/// room) and `notification_status` (record the permission outcome).
 /// No-op when not in the shell iframe, and installs the listener at most once.
 /// Accepts messages only from the parent shell window and validates the payload
 /// defensively.
@@ -280,6 +524,22 @@ pub fn install_shell_notification_listener() {
             .ok()
             .and_then(|v| v.as_string())
             .unwrap_or_default();
+        // The shell reports the outcome of its permission offer here. Without
+        // this arm every outcome was discarded identically, so a blocked or
+        // dismissed permission failed silently with no explanation and no
+        // retry (freenet/river#510).
+        if kind == "notification_status" {
+            match js_sys::Reflect::get(&data, &JsValue::from_str("status"))
+                .ok()
+                .and_then(|v| v.as_string())
+                .as_deref()
+                .and_then(NotificationStatus::from_shell_status)
+            {
+                Some(status) => record_notification_status(status),
+                None => debug!("Ignoring unrecognised notification_status from shell"),
+            }
+            return;
+        }
         if kind != "notification_click" {
             return;
         }
@@ -1033,6 +1293,214 @@ mod notify_gate_tests {
             "a notification path re-inlined the `sender: message` join, which \
              skips the line-break strip that only `notification_body` applies"
         );
+    }
+
+    /// Every status the shell can report, so a matrix test cannot silently skip
+    /// a variant that a later edit adds.
+    const ALL_STATUSES: [NotificationStatus; 6] = [
+        NotificationStatus::Granted,
+        NotificationStatus::Denied,
+        NotificationStatus::Dismissed,
+        NotificationStatus::Undecided,
+        NotificationStatus::Undeliverable,
+        NotificationStatus::Unsupported,
+    ];
+
+    /// The exact strings freenet-core's shell sends (`notifyStatusToIframe` in
+    /// `shell_bridge.js`). This is a cross-repo wire contract: a rename on
+    /// either side reverts #510 exactly — every status parses as `None`, is
+    /// ignored, and the user is back to a silent failure with no retry.
+    #[test]
+    fn every_shell_status_string_parses() {
+        for (sent, expected) in [
+            ("granted", NotificationStatus::Granted),
+            ("denied", NotificationStatus::Denied),
+            ("dismissed", NotificationStatus::Dismissed),
+            ("default", NotificationStatus::Undecided),
+            ("undeliverable", NotificationStatus::Undeliverable),
+            ("unsupported", NotificationStatus::Unsupported),
+        ] {
+            assert_eq!(
+                NotificationStatus::from_shell_status(sent),
+                Some(expected),
+                "the shell sends {sent:?}; River must understand it"
+            );
+        }
+    }
+
+    /// A status River doesn't know is ignored, not guessed at: overwriting a
+    /// known state with a wrong reading is worse than keeping the old one.
+    #[test]
+    fn an_unrecognised_status_is_ignored_rather_than_guessed() {
+        // Matching is deliberately case- and whitespace-sensitive: the shell
+        // sends exact lowercase tokens, so anything else is a different message.
+        for junk in ["", "GRANTED", "granted ", "prompt", "blocked", "undefined"] {
+            assert_eq!(
+                NotificationStatus::from_shell_status(junk),
+                None,
+                "{junk:?} is not a status the shell sends"
+            );
+        }
+    }
+
+    /// Only an unanswered prompt re-arms the automatic ask. Re-arming on
+    /// `Dismissed` would fight the shell's own 24h snooze (River would re-ask on
+    /// every message and the shell would bounce each one straight back), and
+    /// re-arming on a final answer would nag about a decision already made.
+    #[test]
+    fn only_an_unanswered_prompt_rearms_the_automatic_ask() {
+        for status in ALL_STATUSES {
+            let should_rearm = status == NotificationStatus::Undecided;
+            assert_eq!(
+                status_rearms_auto_prompt(status, 0),
+                should_rearm,
+                "{status:?} re-arm decision"
+            );
+        }
+    }
+
+    /// The re-arm is bounded, so a user who keeps closing the browser dialog
+    /// isn't shown the shell's bar again on every message they send.
+    #[test]
+    fn the_automatic_rearm_is_bounded() {
+        assert!(
+            status_rearms_auto_prompt(NotificationStatus::Undecided, MAX_ENABLE_PROMPT_REARMS - 1),
+            "the last permitted re-arm must still be allowed"
+        );
+        assert!(
+            !status_rearms_auto_prompt(NotificationStatus::Undecided, MAX_ENABLE_PROMPT_REARMS),
+            "re-arming past the cap would re-prompt on every message"
+        );
+    }
+
+    /// The retry button appears exactly where asking again can change the
+    /// answer. Offering it against a browser-level block or an already-granted
+    /// permission gives the user a button that does nothing — the same silent
+    /// dead end #510 is about, just moved.
+    #[test]
+    fn enable_is_offered_exactly_where_asking_again_can_help() {
+        assert!(
+            permission_notice(None).offer_enable,
+            "nothing known yet: the user must be able to ask"
+        );
+        for (status, offered) in [
+            (NotificationStatus::Granted, false),
+            (NotificationStatus::Denied, false),
+            (NotificationStatus::Dismissed, true),
+            (NotificationStatus::Undecided, true),
+            (NotificationStatus::Undeliverable, false),
+            (NotificationStatus::Unsupported, false),
+        ] {
+            assert_eq!(
+                permission_notice(Some(status)).offer_enable,
+                offered,
+                "{status:?} enable-offer decision"
+            );
+        }
+    }
+
+    /// Every state says something, and no two states say the SAME thing —
+    /// mapping a blocked permission onto the "enabled" text would leave the user
+    /// with a confidently wrong answer, which is worse than the silence #510
+    /// replaces.
+    #[test]
+    fn every_state_has_its_own_explanation() {
+        let mut seen: Vec<&str> = Vec::new();
+        for status in ALL_STATUSES.map(Some).into_iter().chain([None]) {
+            let message = permission_notice(status).message;
+            assert!(
+                !message.trim().is_empty(),
+                "{status:?} explains nothing to the user"
+            );
+            assert!(
+                !seen.contains(&message),
+                "{status:?} reuses another state's explanation: {message:?}"
+            );
+            seen.push(message);
+        }
+    }
+
+    /// The listener body is a JS `MessageEvent` closure, so no native test in
+    /// this crate can reach it: deleting the `notification_status` arm restores
+    /// #510 exactly (every outcome discarded, nothing surfaced, no retry) with
+    /// every behavioural test above still green. Pinned by source instead.
+    #[test]
+    fn the_shell_listener_consumes_notification_status() {
+        let production = production_source();
+        assert!(
+            production.contains("ifkind==\"notification_status\""),
+            "the shell listener stopped handling notification_status; #510 is back"
+        );
+        assert!(
+            production.contains("Some(status)=>record_notification_status(status)"),
+            "a parsed status is no longer recorded"
+        );
+    }
+
+    /// The status write originates in a JS callback, so it must go through
+    /// `crate::util::defer` — a direct write is the Firefox-mobile RefCell
+    /// re-entrancy crash path (`.claude/rules/dioxus-signal-safety.md`).
+    /// Routing every write through `record_notification_status` also keeps the
+    /// re-arm from being bypassed by a second writer.
+    #[test]
+    fn the_status_write_is_deferred_and_has_one_writer() {
+        let production = production_source();
+        assert!(
+            production.contains(
+                "crate::util::defer(move||{*NOTIFICATION_STATUS.write()=Some(status);});"
+            ),
+            "the NOTIFICATION_STATUS write must stay inside crate::util::defer"
+        );
+        assert_eq!(
+            production.matches("NOTIFICATION_STATUS.write()").count(),
+            1,
+            "NOTIFICATION_STATUS must have exactly one writer \
+             (record_notification_status), so no path can skip the re-arm"
+        );
+    }
+
+    /// `Notification::request_permission()` must be called BEFORE the spawn, so
+    /// it runs inside the click's transient user activation. Moving it inside
+    /// `safe_spawn_local` (a `setTimeout(0)`) loses that activation and Firefox
+    /// and Safari reject the request with `NotAllowedError`, which the caller
+    /// only sees as a warning — the exact latent failure #510 describes for the
+    /// existing auto path.
+    #[test]
+    fn the_direct_permission_request_stays_inside_the_click_gesture() {
+        let source = include_str!("notifications.rs");
+        let (production, _) = source
+            .split_once("mod notify_gate_tests")
+            .expect("this test module's own declaration marks the end of production code");
+        let body = production
+            .split_once("fn request_permission_directly() {")
+            .expect("request_permission_directly is the direct-path entry point")
+            .1
+            .split_once("\n}\n")
+            .expect("a top-level fn ends with a column-zero closing brace")
+            .0;
+        let body: String = body.chars().filter(|c| !c.is_whitespace()).collect();
+
+        let request = body
+            .find("Notification::request_permission()")
+            .expect("the direct path must request permission");
+        let spawn = body
+            .find("safe_spawn_local")
+            .expect("the promise must be awaited off the click stack");
+        assert!(
+            request < spawn,
+            "request_permission() moved inside the spawn, so the browser no \
+             longer sees the click's user activation"
+        );
+    }
+
+    /// This file's production source with whitespace stripped, so the source
+    /// pins above survive `cargo fmt` re-wrapping.
+    fn production_source() -> String {
+        let source = include_str!("notifications.rs");
+        let (production, _) = source
+            .split_once("mod notify_gate_tests")
+            .expect("this test module's own declaration marks the end of production code");
+        production.chars().filter(|c| !c.is_whitespace()).collect()
     }
 
     #[test]

--- a/ui/src/components/app/notifications.rs
+++ b/ui/src/components/app/notifications.rs
@@ -259,8 +259,13 @@ pub fn permission_notice(status: Option<NotificationStatus>) -> PermissionNotice
              browser's site settings — River can't ask again once they're blocked.",
             false,
         ),
+        // Honest about the delay: `dismissed` also covers "inside the gateway's
+        // snooze window from an earlier decline", during which asking again
+        // provably shows nothing. Promising an immediate retry would put the
+        // user back in front of a control that silently does nothing.
         Some(NotificationStatus::Dismissed) => (
-            "You dismissed the notification prompt. You can ask for it again.",
+            "You chose not to enable notifications. You can ask again, though the prompt may not \
+             reappear straight away.",
             true,
         ),
         Some(NotificationStatus::Undecided) => (
@@ -428,30 +433,50 @@ fn record_notification_status(status: NotificationStatus) {
 }
 
 /// The status the UI should display.
-///
-/// In the gateway iframe only the shell can tell us, so this is whatever it last
-/// reported (`None` until it reports anything). Served top-level River has a real
-/// origin and can read the browser's own answer, so an unreported status falls
-/// back to that rather than showing the user nothing.
 pub fn current_notification_status() -> Option<NotificationStatus> {
-    // `try_read`, not `read`: this runs during render and a concurrent write
-    // would otherwise panic (dioxus-signal-safety).
-    if let Ok(stored) = NOTIFICATION_STATUS.try_read() {
-        if stored.is_some() {
-            return *stored;
-        }
+    // Read unconditionally, even on the path that then ignores the value: the
+    // read is what subscribes this render to the signal, so the modal
+    // re-renders when a permission request completes. `try_read`, not `read`,
+    // because a concurrent write would otherwise panic (dioxus-signal-safety).
+    let stored = NOTIFICATION_STATUS.try_read().ok().and_then(|s| *s);
+    let framed = is_in_shell_iframe();
+    resolve_status(framed, stored, (!framed).then(read_browser_permission))
+}
+
+/// Which answer the UI shows: the shell's last report when framed, the
+/// browser's own when not.
+///
+/// Framed, River's origin is opaque and the shell's report is the only source
+/// there is. Served top-level the browser is authoritative and STAYS
+/// authoritative — the user can flip the permission in site settings at any
+/// time, and a remembered answer from an earlier request would then be wrong
+/// for the rest of the session. So `stored` is deliberately ignored there
+/// rather than preferred; its only job on that path is to trigger the re-render.
+///
+/// `live` is `None` exactly when framed, since there is nothing to read.
+fn resolve_status(
+    framed: bool,
+    stored: Option<NotificationStatus>,
+    live: Option<NotificationStatus>,
+) -> Option<NotificationStatus> {
+    if framed {
+        stored
+    } else {
+        live
     }
-    if is_in_shell_iframe() {
-        return None;
-    }
+}
+
+/// The browser's own answer. Top-level only — the framed path must not call
+/// this, since an opaque origin has no meaningful permission to read.
+fn read_browser_permission() -> NotificationStatus {
     if !notification_api_available() {
-        return Some(NotificationStatus::Unsupported);
+        return NotificationStatus::Unsupported;
     }
-    Some(match get_permission() {
+    match get_permission() {
         NotificationPermission::Granted => NotificationStatus::Granted,
         NotificationPermission::Denied => NotificationStatus::Denied,
         _ => NotificationStatus::Undecided,
-    })
+    }
 }
 
 /// Whether this browser exposes the Notifications API at all.
@@ -1381,6 +1406,48 @@ mod notify_gate_tests {
             !status_rearms_auto_prompt(NotificationStatus::Undecided, 3),
             "the automatic ask must stop re-arming; otherwise the shell shows \
              its bar again on every message the user sends"
+        );
+    }
+
+    /// Served top-level, the browser's live answer wins over anything River
+    /// remembered. A user who flips the permission in site settings would
+    /// otherwise be told "your browser is blocking notifications" for the rest
+    /// of the session, with the Enable button withheld — a stale silent failure
+    /// of the same shape #510 removes.
+    #[test]
+    fn the_browser_answer_wins_over_a_remembered_one_when_unframed() {
+        assert_eq!(
+            resolve_status(
+                false,
+                Some(NotificationStatus::Denied),
+                Some(NotificationStatus::Granted)
+            ),
+            Some(NotificationStatus::Granted),
+            "a remembered Denied must not survive the user allowing notifications"
+        );
+        assert_eq!(
+            resolve_status(
+                false,
+                Some(NotificationStatus::Granted),
+                Some(NotificationStatus::Denied)
+            ),
+            Some(NotificationStatus::Denied),
+            "a remembered Granted must not survive the user blocking notifications"
+        );
+    }
+
+    /// Framed, the shell's report is the only source there is: River's origin is
+    /// opaque, so there is no browser answer to read.
+    #[test]
+    fn the_shell_report_is_the_only_source_when_framed() {
+        assert_eq!(
+            resolve_status(true, Some(NotificationStatus::Denied), None),
+            Some(NotificationStatus::Denied)
+        );
+        assert_eq!(
+            resolve_status(true, None, None),
+            None,
+            "nothing reported yet is its own state, not a guess"
         );
     }
 

--- a/ui/src/components/room_list/notification_modal.rs
+++ b/ui/src/components/room_list/notification_modal.rs
@@ -13,6 +13,9 @@
 //! so the help text says "your devices", not "this device only".
 
 use crate::components::app::chat_delegate::save_rooms_to_delegate;
+use crate::components::app::notifications::{
+    current_notification_status, permission_notice, request_enable_now,
+};
 use crate::components::app::{NOTIFICATION_MODAL, ROOMS};
 use crate::room_data::NotificationMode;
 use dioxus::logger::tracing::error;
@@ -157,6 +160,40 @@ pub fn NotificationModal() -> Element {
                     p { class: "text-xs text-text-muted mt-4",
                         "Applies to this room and syncs across your devices."
                     }
+                    // Browser-level permission. The modes above only decide
+                    // WHEN River wants to notify; if the browser is blocking
+                    // notifications none of them can fire, and before #510
+                    // that failure was invisible with no way to retry.
+                    {
+                        let notice = permission_notice(current_notification_status());
+                        rsx! {
+                            div { class: "mt-4 pt-4 border-t border-border",
+                                div { class: "text-xs font-medium text-text mb-1", "Browser permission" }
+                                p {
+                                    "data-testid": "notification-permission-message",
+                                    class: "text-xs text-text-muted",
+                                    "{notice.message}"
+                                }
+                                if notice.offer_enable {
+                                    button {
+                                        "data-testid": "notification-enable-button",
+                                        class: "mt-2 px-3 py-1.5 rounded-lg bg-accent text-white text-xs font-medium hover:opacity-90 transition-opacity",
+                                        // NOT deferred, and that is load-bearing:
+                                        // the browser only honours a permission
+                                        // request made inside the click's transient
+                                        // user activation, which a `defer` (a
+                                        // `setTimeout(0)`) would have already lost.
+                                        // Safe because `request_enable_now` writes
+                                        // no signal synchronously.
+                                        onclick: move |_| {
+                                            request_enable_now();
+                                        },
+                                        "Enable notifications"
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -169,5 +206,32 @@ fn mode_icon(mode: NotificationMode) -> Element {
         NotificationMode::All => rsx! { Icon { icon: FaBell, width: 16, height: 16 } },
         NotificationMode::MentionsAndReplies => rsx! { Icon { icon: FaAt, width: 16, height: 16 } },
         NotificationMode::Muted => rsx! { Icon { icon: FaBellSlash, width: 16, height: 16 } },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// The permission request must run inside the click's transient user
+    /// activation. Wrapping the call in `crate::util::defer` — which every OTHER
+    /// handler in this file correctly does, so the wrapping looks like a
+    /// consistency fix — is a `setTimeout(0)`: the activation is gone by the
+    /// time it runs, and Firefox and Safari reject the request with
+    /// `NotAllowedError`. The button would then silently do nothing, which is
+    /// the failure mode freenet/river#510 exists to remove. The button is rsx,
+    /// so no native test can click it; pinned by source.
+    #[test]
+    fn the_enable_click_is_not_deferred() {
+        let source = include_str!("notification_modal.rs");
+        let (production, _) = source
+            .split_once("mod tests")
+            .expect("this test module's own declaration marks the end of production code");
+        // Whitespace-stripped so the pin survives `cargo fmt` re-wrapping.
+        let production: String = production.chars().filter(|c| !c.is_whitespace()).collect();
+
+        assert!(
+            production.contains("onclick:move|_|{request_enable_now();}"),
+            "the Enable-notifications click must call request_enable_now() \
+             directly, with no defer between the click and the request"
+        );
     }
 }

--- a/ui/tests/notification-bell.spec.ts
+++ b/ui/tests/notification-bell.spec.ts
@@ -114,6 +114,52 @@ test.describe("Per-room notification bell", () => {
     ).toHaveAttribute("title", "Notifications: All messages");
   });
 
+  // freenet/river#510: the modes above only decide WHEN River wants to notify.
+  // If the browser is blocking notifications none of them can fire, and River
+  // used to discard every status the shell reported — so that failure was
+  // invisible and there was no way to ask again.
+  test("the modal explains browser permission and offers a way to enable it", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectRoom(page, ROOM);
+
+    await page.getByTestId("notification-bell-button").click();
+    const modal = page.getByTestId("notification-modal");
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+
+    // Whatever the browser's state, the user is told something about it.
+    const message = modal.getByTestId("notification-permission-message");
+    await expect(message).toBeVisible();
+    await expect(message).not.toHaveText(/^\s*$/);
+
+    // The projects cover all three real states, so this branches on the
+    // browser's actual answer rather than assuming one: Playwright's Chromium
+    // reports "denied", Firefox and desktop WebKit "default", and mobile Safari
+    // has no Notifications API at all.
+    const state = await page.evaluate(() =>
+      typeof Notification === "undefined" ? "unsupported" : Notification.permission
+    );
+    const enable = modal.getByTestId("notification-enable-button");
+
+    if (state === "default") {
+      // Nothing is blocked, so the retry #510 asks for must be there.
+      await expect(enable).toBeVisible();
+      await expect(enable).toBeEnabled();
+    } else {
+      // Blocked at the browser level, already granted, or no API at all —
+      // asking again cannot change the answer, so River must not offer a
+      // button that silently does nothing.
+      await expect(enable).toHaveCount(0);
+      if (state === "denied") {
+        await expect(message).toContainText(/blocking/i);
+      } else if (state === "unsupported") {
+        await expect(message).toContainText(/support/i);
+      }
+    }
+  });
+
   test("room-details modal no longer carries the notification setting", async ({
     page,
   }) => {

--- a/ui/tests/notification-shell-status.spec.ts
+++ b/ui/tests/notification-shell-status.spec.ts
@@ -1,0 +1,186 @@
+import { test, expect, FrameLocator } from "@playwright/test";
+
+// Regression coverage for issue #510, in the shape the bug actually occurs:
+// River running framed inside the gateway shell.
+//
+// THE BUG: River's shell-bridge listener dropped every message whose `type` was
+// not `notification_click`. The shell reports the outcome of its permission
+// offer as `{__freenet_shell__: true, type: 'notification_status', status}`
+// (`notifyStatusToIframe` in freenet-core's `shell_bridge.js`), with `granted` /
+// `denied` / `dismissed` / `undeliverable` / `unsupported` / `default`. All of
+// them were discarded identically, so River could not tell a granted permission
+// from a blocked one and surfaced nothing. A one-way `ENABLE_PROMPT_SENT` latch
+// then meant a blocked or mis-clicked prompt could never be re-requested for the
+// rest of the session.
+//
+// THIS TEST stands up a minimal "gateway shell" parent page (the same fixture
+// shape as invitation-sandbox.spec.ts) that does the two things the fix talks
+// to: it can post a `notification_status` down to the iframe, and it records the
+// `notification_enable_prompt` messages the iframe posts up. It then drives the
+// bell modal through the real statuses and asserts what the user is told, and
+// that the manual retry actually reaches the shell.
+//
+// The unit tests in `notifications.rs` pin the decisions; this pins that they
+// are wired to a real postMessage from a real parent frame — the connection no
+// native test in a WASM crate can reach.
+//
+// Sandbox caveat, identical to invitation-sandbox.spec.ts: the real gateway
+// omits `allow-same-origin`, but a different-origin sandboxed iframe cannot load
+// WASM from the dev server, so it is added here. It does not weaken what is
+// under test — the path exercised is the postMessage bridge (parent !== self),
+// exactly as in the opaque-origin gateway.
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8082";
+
+const SANDBOX_ATTRS =
+  "allow-scripts allow-forms allow-popups allow-same-origin";
+
+const ROOM = "Public Discussion Room";
+
+// Minimal stand-in for the gateway shell. Implements only the two notification
+// behaviours the fix depends on:
+//   1. `window.__postStatus(status)` posts a `notification_status` to the iframe,
+//      byte-identical to the real shell's `notifyStatusToIframe`.
+//   2. It records every `notification_enable_prompt` the iframe posts up, on
+//      `window.__prompts`, so a test can assert the manual retry got through.
+const SHELL_HTML = `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;height:100vh;">
+  <script>
+    window.__prompts = 0;
+
+    var iframe = document.createElement("iframe");
+    iframe.id = "river-frame";
+    iframe.setAttribute("sandbox", ${JSON.stringify(SANDBOX_ATTRS)});
+    iframe.style.cssText = "width:100%;height:100%;border:none;";
+    iframe.src = ${JSON.stringify(BASE + "/")};
+    document.body.appendChild(iframe);
+
+    // The shell's half of the bridge: count the app's requests to be offered
+    // notifications.
+    window.addEventListener("message", function (event) {
+      if (event.source !== iframe.contentWindow) return;
+      var msg = event.data;
+      if (!msg || !msg.__freenet_shell__) return;
+      if (msg.type === "notification_enable_prompt") window.__prompts++;
+    });
+
+    // Mirror notifyStatusToIframe exactly.
+    window.__postStatus = function (status) {
+      iframe.contentWindow.postMessage(
+        { __freenet_shell__: true, type: "notification_status", status: status },
+        "*"
+      );
+    };
+  </script>
+</body>
+</html>`;
+
+const message = (frame: FrameLocator) =>
+  frame.getByTestId("notification-permission-message");
+const enableButton = (frame: FrameLocator) =>
+  frame.getByTestId("notification-enable-button");
+
+test.describe("Shell notification_status handling (#510)", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("the shell's permission outcome reaches the UI, and the retry reaches the shell", async ({
+    page,
+  }) => {
+    await page.setContent(SHELL_HTML);
+    const frame = page.frameLocator("#river-frame");
+    await frame.locator(".app-root").waitFor({ timeout: 30_000 });
+
+    // Open the bell modal for a room.
+    await frame.getByRole("button", { name: ROOM }).click();
+    await expect(frame.getByRole("heading", { name: ROOM })).toBeVisible({
+      timeout: 10_000,
+    });
+    await frame.getByTestId("notification-bell-button").click();
+    await expect(frame.getByTestId("notification-modal")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Framed with nothing reported yet: the shell is the only possible source,
+    // so River says so and offers to ask.
+    await expect(message(frame)).toBeVisible();
+    await expect(enableButton(frame)).toBeVisible();
+
+    // A blocked permission must be explained, and must NOT offer a button that
+    // cannot change the answer. Before the fix this status was discarded and the
+    // user saw nothing at all.
+    await page.evaluate(() => window.__postStatus("denied"));
+    await expect(message(frame)).toContainText(/blocking/i, { timeout: 10_000 });
+    await expect(enableButton(frame)).toHaveCount(0);
+
+    // A status River doesn't recognise must not clobber the one it has.
+    await page.evaluate(() => window.__postStatus("not-a-real-status"));
+    await expect(message(frame)).toContainText(/blocking/i);
+
+    // Granting flips the explanation and keeps the button away (nothing to ask
+    // for).
+    await page.evaluate(() => window.__postStatus("granted"));
+    await expect(message(frame)).toContainText(/enabled/i, { timeout: 10_000 });
+    await expect(enableButton(frame)).toHaveCount(0);
+
+    // A dismissal is recoverable, so the retry comes back...
+    await page.evaluate(() => window.__postStatus("dismissed"));
+    await expect(enableButton(frame)).toBeVisible({ timeout: 10_000 });
+
+    // ...and clicking it actually asks the shell again. This is the half of
+    // #510 that the once-per-session latch made impossible: River had already
+    // sent its one prompt, so nothing reached the shell.
+    const before = await page.evaluate(() => window.__prompts);
+    await enableButton(frame).click();
+    await expect
+      .poll(() => page.evaluate(() => window.__prompts), { timeout: 10_000 })
+      .toBeGreaterThan(before);
+
+    // A second click asks again: the manual path is deliberately un-latched.
+    const after = await page.evaluate(() => window.__prompts);
+    await enableButton(frame).click();
+    await expect
+      .poll(() => page.evaluate(() => window.__prompts), { timeout: 10_000 })
+      .toBeGreaterThan(after);
+  });
+
+  test("a browser that cannot display notifications says so instead of failing silently", async ({
+    page,
+  }) => {
+    await page.setContent(SHELL_HTML);
+    const frame = page.frameLocator("#river-frame");
+    await frame.locator(".app-root").waitFor({ timeout: 30_000 });
+
+    await frame.getByRole("button", { name: ROOM }).click();
+    await expect(frame.getByRole("heading", { name: ROOM })).toBeVisible({
+      timeout: 10_000,
+    });
+    await frame.getByTestId("notification-bell-button").click();
+    await expect(frame.getByTestId("notification-modal")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Permission exists but nothing could show the notification. The user is
+    // told the in-app surfaces still work, and is not offered a re-ask that
+    // would change nothing.
+    await page.evaluate(() => window.__postStatus("undeliverable"));
+    await expect(message(frame)).toContainText(/couldn't display/i, {
+      timeout: 10_000,
+    });
+    await expect(enableButton(frame)).toHaveCount(0);
+
+    await page.evaluate(() => window.__postStatus("unsupported"));
+    await expect(message(frame)).toContainText(/doesn't support/i, {
+      timeout: 10_000,
+    });
+    await expect(enableButton(frame)).toHaveCount(0);
+  });
+});
+
+declare global {
+  interface Window {
+    __postStatus: (status: string) => void;
+    __prompts: number;
+  }
+}


### PR DESCRIPTION
## Problem

River's shell-bridge listener (`ui/src/components/app/notifications.rs`) dropped
every message whose `type` was not `notification_click`:

```rust
if kind != "notification_click" {
    return;
}
```

The gateway shell reports the outcome of its permission offer as
`notification_status` (`notifyStatusToIframe` in freenet-core's
`shell_bridge.js`), with `granted` / `denied` / `dismissed` / `undeliverable` /
`unsupported` / `default`. All six were discarded identically, and
`notification_status` appeared nowhere in `ui/src`. River could not tell a
granted permission from a blocked one and surfaced nothing to the user.

Worse, `request_enable_via_shell` was latched by a `ENABLE_PROMPT_SENT`
`AtomicBool` with no reset, and the bell modal only chose All / Mentions /
Muted — so a prompt that was blocked, snoozed, or mis-clicked could not be
re-requested for the rest of the session. Net effect: notifications silently
never worked, with no explanation and no path to fix it.

This is River's half only. The shell-side defect is freenet/freenet-core#4966;
nothing here depends on it — the shell already sends `notification_status` on
`main`.

## Approach

**Consume the status.** A new `notification_status` arm parses the shell's
`status` string into a `NotificationStatus` enum and records it in a
`NOTIFICATION_STATUS` global. An unrecognised string is ignored rather than
guessed at, so a newer shell adding a status can never overwrite a known one
with a wrong reading. The signal write goes through `crate::util::defer`, as
required for a write originating in a JS `MessageEvent` callback
(`.claude/rules/dioxus-signal-safety.md`), and `record_notification_status` is
the only writer so no path can bypass the re-arm below.

**Re-arm the ask, bounded.** A status of `default` (the prompt closed with no
answer) clears `ENABLE_PROMPT_SENT` so a later gesture can offer again. The
re-arm is capped at one, because the shell re-shows its affordance every time
River asks: uncapped, a user who keeps closing the browser dialog would get the
bar back on every message they send. `dismissed` deliberately does NOT re-arm —
the shell also snoozes it for 24h, so River re-asking would just bounce off that
snooze.

**Surface it, and offer a retry.** The bell modal grows a "Browser permission"
section with a short explanation and an "Enable notifications" button. The
button is offered exactly where asking again can change the answer (`dismissed`,
`default`, or nothing known yet) — offering it against a browser-level block or
an already-granted permission would just move the silent dead end. Its click
calls `request_enable_now()` **directly**, not through `crate::util::defer`,
because the browser only honours a permission request made inside the click's
transient user activation and `defer` is a `setTimeout(0)`.

The manual path is deliberately not latched: the once-per-session latch exists
so sending messages doesn't nag, and an explicit click is exactly the retry it
must not swallow.

Served top-level (dev / `no-sync`) River has a real origin, so the same button
calls the Notifications API directly. `Notification::request_permission()` is
invoked synchronously inside the click for the activation reason above; only the
awaiting of the already-created promise is deferred. This incidentally avoids
the lost-activation problem the issue notes for the existing auto path, which is
otherwise unchanged.

**One bug found while writing this:** `current_notification_status` reads
`Notification.permission` on every modal render, and `web_sys`'s binding for it
is not `Result`-returning — reading `.permission` off an undefined `Notification`
raises a JS `ReferenceError` that aborts the WASM module. Guarded by
`notification_api_available()`. Playwright's mobile-safari project has no
Notifications API at all, so this was reachable.

## Testing

`cargo test -p river-ui --bins`: 785 pass (10 new). New coverage:

- The six shell status strings parse to distinct variants (a cross-repo wire
  contract — a rename on either side reverts the fix exactly), and unrecognised
  strings are ignored.
- Only an unanswered prompt re-arms the automatic ask, and the re-arm is bounded.
- The Enable button is offered exactly where asking again can help, and every
  state has its own non-empty explanation.
- Source pins for the parts no native test can reach (a JS closure and rsx): the
  listener consumes `notification_status`; the status write stays inside
  `defer` and has exactly one writer; `request_permission()` is called before the
  spawn; the Enable click is not deferred.

Every new test was mutation-tested — the fix reverted or subtly broken in eight
ways, each caught by a named test. One of the eight (raising the re-arm cap to
`usize::MAX`) initially passed, because the bound assertion was phrased against
the constant it was testing and so held for any cap at all; that vacuous test is
fixed in its own commit.

Playwright `notification-bell.spec.ts`: 30 pass across chromium, firefox, webkit,
mobile-chrome and mobile-safari. The new spec asserts the explanation always
renders and that the button appears iff the browser state is one where asking
again helps. The five projects cover all three branches — Chromium reports
`denied`, Firefox and desktop WebKit `default`, mobile Safari has no API. Both
new `data-testid`s are absent on `main`, so the spec fails there.

Manually verified in Firefox that clicking the button leaves the app alive and
the modal rendered, with no new console error.

Closes #510

[AI-assisted - Claude]