### PR TITLE
perf(ui): stop the composer autosize from forcing a layout every keystroke

### DIFF
--- a/ui/src/components/conversation/message_input.rs
+++ b/ui/src/components/conversation/message_input.rs
@@ -29,16 +29,65 @@ fn measure_draft(text: &str, reply: Option<&ReplyContext>, is_private: bool) -> 
     }
 }
 
+/// Height ceiling for the composer, in px (~7 lines). Kept in step with the
+/// textarea's `max-height`: this clamp is what stops the growth, the CSS is
+/// what leaves the overflow scrollable.
+const MAX_COMPOSER_HEIGHT: i32 = 168;
+
+/// Size the composer to its content, clamped to [`MAX_COMPOSER_HEIGHT`].
+///
+/// This runs on every keystroke, so the DOM access pattern is the whole cost.
+/// Collapsing to `height: auto` before every measurement — the obvious
+/// implementation — puts a style write immediately before a `scrollHeight`
+/// read, which forces a synchronous layout, and then writes again; measured at
+/// ~3 layouts per keystroke and ~6.6 ms of layout + style per keystroke under a
+/// 6x CPU throttle (freenet/river#468). The measuring read is unavoidable. Both
+/// writes usually are not:
+///
+/// `scrollHeight` reports `max(content height, clientHeight)`, so it is exactly
+/// the content height while the content OVERFLOWS the box, and saturates at the
+/// box height once it fits. We set `height` to the content's padding-box height
+/// while `box-sizing: border-box` counts the textarea's borders inside that
+/// number, so a correctly-sized composer sits its border-width short of its own
+/// content and keeps reporting `scrollHeight > clientHeight`. Typing therefore
+/// measures in place: no collapse, and no write at all while the height is
+/// unchanged.
+///
+/// `scrollHeight == clientHeight` means the content stopped overflowing, i.e.
+/// it shrank below the box. That is the one case where the measurement carries
+/// no information and the collapse has to be paid for.
+///
+/// Note the asymmetry that makes the fast path safe: it is taken only when the
+/// content overflows, i.e. only when the box is too SHORT, so it can never
+/// leave a stale too-tall composer behind.
+///
+/// The "no writes while typing within a line" property is pinned by a Playwright
+/// test (`Composer auto-resize cost (#468)`). If the textarea's border or
+/// box-sizing ever changes such that the box fits its content exactly, the fast
+/// path stops firing — that test goes red rather than the cost silently
+/// returning.
 fn auto_resize_message_input() {
     let Some(el) = get_message_textarea() else {
         return;
     };
-    // Reset height to auto to measure scrollHeight correctly, then clamp to ~7 lines.
-    el.style().set_property("height", "auto").ok();
-    let new_height = el.scroll_height().min(168);
-    el.style()
-        .set_property("height", &format!("{}px", new_height))
-        .ok();
+    let style = el.style();
+
+    // Both reads come off one layout; no write separates them.
+    let scroll_height = el.scroll_height();
+    let content_height = if scroll_height > el.client_height() {
+        scroll_height
+    } else {
+        style.set_property("height", "auto").ok();
+        el.scroll_height()
+    };
+
+    let target = format!("{}px", content_height.min(MAX_COMPOSER_HEIGHT));
+    // Skip a no-op write: its style invalidation is the bulk of the
+    // per-keystroke cost. After a collapse the inline value is `auto`, so that
+    // branch always writes.
+    if style.get_property_value("height").unwrap_or_default() != target {
+        style.set_property("height", &target).ok();
+    }
 }
 
 fn get_message_textarea() -> Option<web_sys::HtmlTextAreaElement> {
@@ -189,7 +238,7 @@ pub fn MessageInput(
                             id: "message-input",
                             "data-testid": "message-input",
                             class: "w-full px-4 py-2.5 bg-surface border border-border rounded-xl text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors resize-none min-h-[44px] overflow-y-auto",
-                            style: "max-height: 168px;",
+                            style: "max-height: {MAX_COMPOSER_HEIGHT}px;",
                             placeholder: "Type your message...",
                             value: "{message_text}",
                             rows: "1",

--- a/ui/tests/message-layout.spec.ts
+++ b/ui/tests/message-layout.spec.ts
@@ -442,6 +442,109 @@ test.describe("Message input auto-resize (#221)", () => {
   });
 });
 
+// #468: the composer resize runs on every keystroke, and the original
+// implementation always did collapse-to-`auto` → read `scrollHeight` → write
+// the result. The write immediately before the read forces a synchronous
+// layout, and both writes invalidate style, measured on the issue at ~3 layouts
+// per keystroke (79 layouts over 26 keystrokes) and ~6.6 ms of layout + style
+// per keystroke under a 6x CPU throttle.
+//
+// The fix measures in place and writes only when the height actually changes,
+// so typing inside a line must not touch the inline style at all. Recording
+// style writes rather than timing anything keeps this deterministic: it asserts
+// the DOM access pattern, which is what the issue is about, not a duration.
+const RECORD_COMPOSER_HEIGHT_WRITES = `
+(() => {
+  window.__heightWrites = [];
+  const setProperty = CSSStyleDeclaration.prototype.setProperty;
+  CSSStyleDeclaration.prototype.setProperty = function (name, value, priority) {
+    // element.style returns the same CSSStyleDeclaration for the element's
+    // lifetime, so identity distinguishes the composer's inline declaration
+    // from every other element's.
+    const composer = document.getElementById("message-input");
+    if (composer && this === composer.style && name === "height") {
+      window.__heightWrites.push(String(value));
+    }
+    return setProperty.call(this, name, value, priority);
+  };
+})();
+`;
+
+test.describe("Composer auto-resize cost (#468)", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("typing within a line writes no height; growth and shrink still resize", async ({
+    page,
+  }) => {
+    await page.addInitScript(RECORD_COMPOSER_HEIGHT_WRITES);
+    await page.goto("/");
+    await waitForApp(page);
+    await selectRoom(page, "Your Private Room");
+
+    const textarea = page.locator("#message-input");
+    await expect(textarea).toBeVisible({ timeout: 10_000 });
+    await textarea.focus();
+
+    const height = () =>
+      textarea.evaluate((el) => el.getBoundingClientRect().height);
+    // Collect the height writes made while `body` runs.
+    const writesDuring = async (body: () => Promise<void>) => {
+      await page.evaluate(() => ((window as any).__heightWrites = []));
+      await body();
+      return (await page.evaluate(
+        () => (window as any).__heightWrites
+      )) as string[];
+    };
+
+    // Prime with one character: the composer starts with no inline height, so
+    // the first resize has nothing to compare against and legitimately writes.
+    await page.keyboard.type("a");
+    const oneLine = await height();
+    expect(oneLine).toBeGreaterThan(0);
+
+    // The property the fix buys. Adding characters to a line that still fits
+    // cannot change the height, so the whole burst must produce zero writes.
+    // Before the fix each keystroke wrote twice: `auto`, then the same px value
+    // straight back.
+    const typingWrites = await writesDuring(async () => {
+      await page.keyboard.type("bcdefghijklmnopqrst");
+    });
+    expect(typingWrites).toEqual([]);
+    expect(await height()).toBe(oneLine);
+
+    // Growth must still resize, and must do it without the `height: auto`
+    // collapse — the collapse is the forced-synchronous-layout half of the cost.
+    const growWrites = await writesDuring(async () => {
+      await page.keyboard.press("Shift+Enter");
+      await page.keyboard.type("second line");
+    });
+    const twoLines = await height();
+    expect(twoLines).toBeGreaterThan(oneLine + 10);
+    expect(growWrites).not.toContain("auto");
+    // One write for the added line, none for the characters typed onto it.
+    expect(growWrites).toHaveLength(1);
+
+    // Shrinking is the case an in-place measurement genuinely cannot see (the
+    // box no longer overflows, so `scrollHeight` only reports the box height),
+    // so it may still collapse — but it must land back at the right height.
+    // `fill` replaces the whole value, which is also the paste path.
+    await textarea.fill("one\ntwo\nthree\nfour");
+    const fourLines = await height();
+    expect(fourLines).toBeGreaterThan(twoLines);
+
+    await textarea.fill("a");
+    expect(await height()).toBe(oneLine);
+
+    // And a shrink straight from the clamped maximum, which exercises the
+    // ceiling rather than the intermediate sizes.
+    await textarea.fill(Array.from({ length: 30 }, (_, i) => i).join("\n"));
+    const clamped = await height();
+    expect(clamped).toBeGreaterThan(fourLines);
+    await textarea.fill("a");
+    expect(await height()).toBe(oneLine);
+  });
+});
+
 // On page refresh, the chat scroll container must land at the bottom of the
 // message list, not partway down. The previous code called scrollIntoView on
 // the last bubble's MountedData, which aligns the bubble's TOP to the


### PR DESCRIPTION
## Problem

`auto_resize_message_input` runs on every `oninput`, and always did:

```rust
el.style().set_property("height", "auto").ok();      // write
let new_height = el.scroll_height().min(168);        // read  -> forced sync layout
el.style().set_property("height", &format!(...)).ok(); // write
```

The write immediately before the read forces a synchronous layout, and both
writes invalidate style. Confirmed by instrumenting `CSSStyleDeclaration.setProperty`
and the `scrollHeight`/`clientHeight` getters in a Chromium page and typing into a
real composer — the recorded trace is exactly `write height=auto` /
`read scrollHeight` / `write height=44px`, repeated once per keystroke, with no
variation. CDP `Performance.getMetrics` over 26 keystrokes reproduces the numbers
from #468: **79 layouts, 80 style recalcs** (~3 per keystroke).

## Approach

`scrollHeight` reports `max(content height, clientHeight)`. So it *is* the content
height while the content overflows the box, and saturates at the box height once
the content fits. The composer is sized to its content's padding-box height while
`box-sizing: border-box` counts the textarea's 1px borders inside that number, so a
correctly-sized composer sits 2px short of its own content and keeps reporting
`scrollHeight > clientHeight`. That makes the common case — typing, growing —
measurable in place:

- Measure first. If `scrollHeight > clientHeight` the content overflows, so
  `scrollHeight` is already the answer: no collapse.
- Only when `scrollHeight == clientHeight` (the content stopped overflowing, i.e.
  it shrank below the box) is the measurement uninformative and the collapse paid for.
- Write the height only when it actually changes.

The asymmetry is what makes the shortcut safe: the fast path is taken *only* when
the content overflows, i.e. only when the box is too **short**, so it can never
leave a stale too-tall composer behind. Shrinking always goes through the collapse.

Rejected the hidden-mirror-element alternative from the issue: it needs a second
node kept in sync with the textarea's font, padding, and width, still costs a
forced layout to read, and buys nothing over measuring in place.

Also promoted the bare `168` to `MAX_COMPOSER_HEIGHT` and interpolated it into the
textarea's `max-height`, so the clamp and the CSS ceiling can't drift apart.

## Testing

New Playwright test `Composer auto-resize cost (#468)` in `ui/tests/message-layout.spec.ts`.
It records inline-`height` writes on the composer rather than timing anything, so it
asserts the DOM access pattern (which is what the issue is about) and is not
timing-dependent:

- typing 19 characters within a line produces **zero** height writes, and the height is unchanged
- growing to a second line still resizes, in exactly one write and with no `height: auto` collapse
- `fill()` with 4-line and 30-line (clamped) content, then back to one character, returns to the exact single-line height — this covers the paste and shrink-from-clamped paths

Verified non-vacuous three ways, each by rebuilding the wasm and re-running:

| change | result |
|---|---|
| revert the fix entirely | FAILS — 38 writes recorded (`auto`/`44px` per keystroke) |
| keep the fix but never collapse (fast path always) | FAILS — height stuck at 114px instead of 44px; **also** fails the existing #221 test (138px vs `<= 48`) |
| keep the fix but always write | FAILS — 21 writes where 0 expected |

Measured improvement on the same 26-keystroke CDP probe:

| | before | after |
|---|---|---|
| LayoutCount | 79 | **27** |
| RecalcStyleCount | 80 | **28** |
| LayoutDuration | 6.94 ms | **3.89 ms** |
| RecalcStyleDuration | 10.14 ms | **1.36 ms** |

Combined layout + style time drops from 17.1 ms to 5.2 ms (-70%).

Regression coverage requested on the issue passes on all five browser projects
(chromium, firefox, webkit, mobile-chrome, mobile-safari): `textarea height resets
after sending a multi-line message` (#221) and `edit container fits within viewport
at narrow widths` (#205). Full Playwright suite: 687 passed, 23 skipped, 0 failed.
`cargo fmt --check` clean, `cargo clippy` adds no warnings in the changed file,
`cargo test -p river-ui` 780 passed.

Closes #468

[AI-assisted - Claude]