### PR TITLE
feat(cli)!: report ban enforcement as three states in `debug bans`

### DIFF
--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -4,10 +4,12 @@ use crate::output::OutputFormat;
 use anyhow::{anyhow, Result};
 use clap::Subcommand;
 use ed25519_dalek::VerifyingKey;
-use river_core::room_state::ban::BansV1;
-use river_core::room_state::member::MemberId;
+use river_core::room_state::ban::{AuthorizedUserBan, BansV1};
+use river_core::room_state::member::{AuthorizedMember, MemberId, MembersV1};
+use river_core::room_state::member_info::MemberInfoV1;
 use river_core::room_state::ChatRoomStateV1;
 use serde::Serialize;
+use std::collections::HashMap;
 
 #[derive(Subcommand)]
 pub enum DebugCommands {
@@ -40,37 +42,123 @@ pub enum DebugCommands {
     },
 }
 
+/// What a ban is currently doing, as opposed to merely being stored
+/// (freenet/river#472). Since deputy ban authority (#410) a ban can sit in
+/// state without excluding anyone, and the CLI used to render that identically
+/// to a live ban.
+///
+/// Three states rather than a boolean because the honest answer genuinely has
+/// three cases: a ban can be provably dead, provably live, or contingent on
+/// something that has not happened yet. Collapsing the third into either
+/// neighbour is a lie in one direction or the other.
+#[derive(Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum BanEnforcement {
+    /// Definitive: this ban is not keeping its target out. Either the target is
+    /// a current member the ban fails to exclude (so that person is in the room
+    /// right now), or the ban can never apply at all — its signature does not
+    /// verify against the banner's current key, or it names the room OWNER, who
+    /// `is_ban_authorized` refuses as a target unconditionally.
+    Inert,
+    /// The ban currently excludes its target: the banner's authority over them
+    /// holds against the state as it stands.
+    ///
+    /// Note exactly what this does and does not promise. Reached with the target
+    /// ABSENT, it implies an ABSOLUTE grant (the banner is the owner, or an
+    /// owner-appointed global moderator), because only those re-derive without
+    /// the target's invite chain — so the ban re-applies wherever they reattach.
+    /// Reached with the target still PRESENT, the grant may instead be positional
+    /// (a strict ancestor), which is valid now but lapses if that ancestor
+    /// leaves. So this always means "excluding them today", and additionally
+    /// means "durable across their return" only in the absent case.
+    Enforcing,
+    /// The target is not in the room, but the banner's authority came from their
+    /// POSITION relative to the target (strict ancestor, or deputy of a non-owner
+    /// ancestor) or from no grant at all. An absent member has no invite chain to
+    /// walk, so that authority cannot be re-derived now and re-derives differently
+    /// depending on who re-invites them. Not a promise either way.
+    Undetermined,
+}
+
+impl BanEnforcement {
+    /// Suffix appended to this ban's line in the human listing. `Enforcing` is
+    /// unmarked because it is the expected case; the other two are what a
+    /// moderator needs to notice.
+    fn marker(self) -> &'static str {
+        match self {
+            BanEnforcement::Enforcing => "",
+            BanEnforcement::Inert => "  [NOT ENFORCING]",
+            BanEnforcement::Undetermined => "  [UNDETERMINED]",
+        }
+    }
+}
+
 #[derive(Serialize)]
 struct BanInfo {
     banned_user_id: String,
     banned_by_id: String,
     banned_at_secs: u64,
-    /// Whether this ban is currently keeping its target out of the room, as
-    /// opposed to sitting in state while the target walks around inside. Since
-    /// deputy ban authority (freenet/river#410) a ban can go inert without being
-    /// removed: the banner left or was pruned, their deputy authority was
-    /// revoked, or (once no absolute grant applies) the target has since
-    /// deputized the banner.
+    /// See [`BanEnforcement`].
     ///
-    /// `false` is the case worth acting on, and it is unambiguous: the target is
-    /// a CURRENT member that this ban fails to exclude, so that person is in the
-    /// room right now.
-    ///
-    /// Scope, deliberately not overclaimed: for a target who is already gone this
-    /// reports `true` without re-deriving the banner's authority, because an
-    /// absent member has no invite chain to walk and `is_ban_authorized` cannot
-    /// be evaluated against a hypothetical future one. So `true` means "not in
-    /// the room", not "guaranteed to hold if they are re-invited by someone new".
-    /// Do NOT switch this to a bare `is_ban_authorized` to tighten that: every
-    /// successfully enforced ban ends with its target removed, so doing so
-    /// reports NOT ENFORCING for essentially every ban that is working. Pinned by
-    /// `legitimate_ancestor_ban_still_enforcing_after_its_target_is_removed`.
-    enforcing: bool,
+    /// Do NOT reduce this to a bare `is_ban_authorized`. That predicate returns
+    /// false for BOTH "provably unauthorized" and "authority is position-derived
+    /// and the target is gone", so folding its false into a single not-enforcing
+    /// verdict reports every strict-ancestor and non-owner-deputy ban as dead the
+    /// moment it succeeds — and a ban's success is precisely what removes the
+    /// target. Note this is NOT because absent targets are unknowable: the two
+    /// ABSOLUTE grants in `is_ban_authorized` (banner is the owner; banner is an
+    /// owner-appointed global moderator) read nothing about the target's position
+    /// and so re-derive fine with the target gone, which is exactly why
+    /// `Enforcing` is expressible here at all. Pinned in both directions by
+    /// `legitimate_ancestor_ban_becomes_undetermined_once_its_target_is_removed`
+    /// and `absolute_grants_stay_enforcing_with_the_target_absent`.
+    enforcement: BanEnforcement,
 }
 
-/// Classify every ban in `room_state` as enforcing or inert, projecting each to
-/// a `BanInfo`. Kept as a pure helper (no I/O) so the enforcement wiring is unit
-/// testable without a live node — see the tests at the bottom of this file.
+/// Classify one ban against the converged `(members + member_info)` state.
+///
+/// Order matters: the two definitive-dead cases are settled before any authority
+/// question, then a positive authority answer wins, and only a NEGATIVE authority
+/// answer is split by whether the target is present (definitive) or absent
+/// (contingent). That split is the whole point of the three states.
+fn classify_ban(
+    ban: &AuthorizedUserBan,
+    members_by_id: &HashMap<MemberId, &AuthorizedMember>,
+    member_info: &MemberInfoV1,
+    owner_id: MemberId,
+    owner_vk: &VerifyingKey,
+) -> BanEnforcement {
+    // A ban whose signature does not verify against the banner's CURRENT key
+    // never excludes anyone: `banned_member_ids` skips it, and cleanup step 5
+    // sweeps it. Settled before the authority question, which would otherwise
+    // report a forged ban as enforcing.
+    if !BansV1::ban_signature_matches_current_key(ban, members_by_id, owner_id, owner_vk) {
+        return BanEnforcement::Inert;
+    }
+    let target = ban.ban.banned_user;
+    // The owner is never a valid ban target (`is_ban_authorized` denies it
+    // outright, before any grant). Permanently dead, not contingent: the owner
+    // cannot be re-invited into a position that would make it apply, so this
+    // must not fall through to `Undetermined` merely because the owner is not
+    // in the members list.
+    if target == owner_id {
+        return BanEnforcement::Inert;
+    }
+    if MembersV1::is_ban_authorized(ban.banned_by, target, members_by_id, member_info, owner_id) {
+        return BanEnforcement::Enforcing;
+    }
+    if members_by_id.contains_key(&target) {
+        // Present AND unauthorized: the actionable #472 case. This person is in
+        // the room and the ban is not stopping them.
+        BanEnforcement::Inert
+    } else {
+        BanEnforcement::Undetermined
+    }
+}
+
+/// Classify every ban in `room_state`, projecting each to a `BanInfo`. Kept as a
+/// pure helper (no I/O) so the enforcement wiring is unit testable without a live
+/// node — see the tests at the bottom of this file.
 fn collect_ban_infos(room_state: &ChatRoomStateV1, owner_vk: &VerifyingKey) -> Vec<BanInfo> {
     let owner_id = MemberId::from(owner_vk);
     let members_by_id = room_state.members.members_by_member_id();
@@ -85,37 +173,38 @@ fn collect_ban_infos(room_state: &ChatRoomStateV1, owner_vk: &VerifyingKey) -> V
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_secs())
                 .unwrap_or(0);
-            let enforcing = BansV1::ban_is_enforcing(
-                ban,
-                &members_by_id,
-                &room_state.member_info,
-                owner_id,
-                owner_vk,
-            );
             BanInfo {
                 banned_user_id: ban.ban.banned_user.to_string(),
                 banned_by_id: ban.banned_by.to_string(),
                 banned_at_secs,
-                enforcing,
+                enforcement: classify_ban(
+                    ban,
+                    &members_by_id,
+                    &room_state.member_info,
+                    owner_id,
+                    owner_vk,
+                ),
             }
         })
         .collect()
 }
 
-/// Render the human-readable `debug bans` output as lines. Pure so the
-/// non-enforcing call-out is unit testable: this listing is the surface a
-/// moderator reads to decide whether someone is still kept out, so a ban that
-/// no longer enforces has to be visibly distinct rather than silently blending
-/// in with the live ones.
+/// Render the human-readable `debug bans` output as lines. Pure so the call-outs
+/// are unit testable: this listing is the surface a moderator reads to decide
+/// whether someone is still kept out, so a ban that is not doing that has to be
+/// visibly distinct rather than silently blending in with the live ones.
 fn ban_list_lines(bans: &[BanInfo]) -> Vec<String> {
-    let enforcing_count = bans.iter().filter(|b| b.enforcing).count();
-    let inert_count = bans.len() - enforcing_count;
+    let count = |state: BanEnforcement| bans.iter().filter(|b| b.enforcement == state).count();
+    let inert = count(BanEnforcement::Inert);
+    let undetermined = count(BanEnforcement::Undetermined);
 
     let mut lines = vec![
         format!(
-            "Ban List ({} bans, {} enforcing)",
+            "Ban List ({} bans: {} enforcing, {} not enforcing, {} undetermined)",
             bans.len(),
-            enforcing_count
+            count(BanEnforcement::Enforcing),
+            inert,
+            undetermined
         ),
         "=========".to_string(),
     ];
@@ -131,23 +220,36 @@ fn ban_list_lines(bans: &[BanInfo]) -> Vec<String> {
             ban.banned_user_id,
             ban.banned_by_id,
             ban.banned_at_secs,
-            if ban.enforcing {
-                ""
-            } else {
-                "  [NOT ENFORCING]"
-            }
+            ban.enforcement.marker()
         ));
     }
 
-    if inert_count > 0 {
+    // Each note is keyed to a state that is actually present, so the output does
+    // not explain a case this room does not have. Neither claims where the target
+    // is: a state fetched before cleanup (a full-state PUT bypasses it via
+    // `verify`) can hold an inert ban whose target is already gone.
+    if inert > 0 {
         lines.push(String::new());
         lines.push(format!(
-            "Note: {} ban(s) are stored in room state but are NOT keeping their \
-             target out, so those users are in the room. A ban stops enforcing \
-             when its banner leaves the room or loses the deputy authority it \
-             banned under. Check the banner with `riverctl member deputized-by \
-             <room> <banned_by_id>`.",
-            inert_count
+            "Note: {} ban(s) marked NOT ENFORCING are not keeping their target \
+             out. A ban lands here when its banner is no longer a member, when \
+             the deputy authority it was issued under was revoked, or when the \
+             banned user had themselves deputized the banner. Run `riverctl \
+             member deputized-by <room> <banned_by_id>` to see whether the \
+             banner still holds a grant, and from whom.",
+            inert
+        ));
+    }
+
+    if undetermined > 0 {
+        lines.push(String::new());
+        lines.push(format!(
+            "Note: {} ban(s) marked UNDETERMINED target someone who is not \
+             currently in the room. Their banner's authority came from a \
+             position in the invite tree relative to that target, which cannot \
+             be re-derived while the target is absent, so whether the ban \
+             applies on their return depends on who re-invites them.",
+            undetermined
         ));
     }
 
@@ -597,10 +699,17 @@ mod tests {
     // actually kept out.
 
     use ed25519_dalek::SigningKey;
-    use river_core::room_state::ban::{AuthorizedUserBan, UserBan};
-    use river_core::room_state::member::{AuthorizedMember, Member};
+    use river_core::room_state::ban::UserBan;
+    use river_core::room_state::member::Member;
     use river_core::room_state::member_info::{AuthorizedMemberInfo, MemberInfo};
     use river_core::room_state::ChatRoomParametersV1;
+
+    /// The single ban's verdict in a state built by these fixtures.
+    fn verdict(state: &ChatRoomStateV1, owner: &SigningKey) -> BanEnforcement {
+        let infos = collect_ban_infos(state, &owner.verifying_key());
+        assert_eq!(infos.len(), 1, "fixture must carry exactly one ban");
+        infos[0].enforcement
+    }
 
     /// The cli crate's dalek build does not enable the `rand` `generate`
     /// helper, so keys come from fixed seeds (mirrors `deputies.rs`'s tests).
@@ -667,9 +776,9 @@ mod tests {
     }
 
     #[test]
-    fn owner_ban_of_a_present_member_reports_enforcing() {
-        // Baseline for the negative cases below: without this, a test asserting
-        // `!enforcing` would pass even if `enforcing` were hardcoded to false.
+    fn owner_ban_of_a_present_member_is_enforcing() {
+        // Positive baseline. Without it, the Inert cases below would pass even
+        // against a classifier that returned Inert unconditionally.
         let owner = key(1);
         let alice = key(2);
 
@@ -681,14 +790,11 @@ mod tests {
         assert_eq!(bans.len(), 1);
         assert_eq!(bans[0].banned_user_id, id(&alice).to_string());
         assert_eq!(bans[0].banned_by_id, id(&owner).to_string());
-        assert!(
-            bans[0].enforcing,
-            "an owner's ban of a current member is authorized, so it must report as enforcing"
-        );
+        assert_eq!(bans[0].enforcement, BanEnforcement::Enforcing);
     }
 
     #[test]
-    fn deputy_ban_reports_enforcing_while_the_grant_stands() {
+    fn deputy_ban_is_enforcing_while_the_grant_stands() {
         // The other half of the revocation pair below: the SAME ban, differing
         // only in whether the owner's deputy grant is still present.
         let owner = key(1);
@@ -701,19 +807,15 @@ mod tests {
         push_info(&mut state, &owner, 0, vec![id(&bob)]);
         push_ban(&mut state, &owner, &bob, &alice);
 
-        let bans = collect_ban_infos(&state, &owner.verifying_key());
-        assert!(
-            bans[0].enforcing,
-            "bob is a current owner-appointed deputy, so his ban enforces"
-        );
+        assert_eq!(verdict(&state, &owner), BanEnforcement::Enforcing);
     }
 
     #[test]
-    fn deputy_ban_reports_not_enforcing_after_the_grant_is_revoked() {
+    fn deputy_ban_is_inert_after_the_grant_is_revoked() {
         // The issue's headline case (#472): the owner revokes bob's deputy
-        // authority by publishing a later `member_info` record without him.
-        // The ban stays in state but the contract stops excluding alice, and
-        // `debug bans` used to present it identically to a live ban.
+        // authority by publishing a later `member_info` record without him. The
+        // ban stays in state, alice stays in the room, and `debug bans` used to
+        // present this identically to a live ban.
         let owner = key(1);
         let alice = key(2);
         let bob = key(3);
@@ -726,20 +828,15 @@ mod tests {
         // Revocation: a higher-version record wins in `canonical`.
         push_info(&mut state, &owner, 1, vec![]);
 
-        let bans = collect_ban_infos(&state, &owner.verifying_key());
-        assert_eq!(bans.len(), 1, "the ban is still stored in state");
-        assert!(
-            !bans[0].enforcing,
-            "bob's authority was revoked, so his ban no longer keeps alice out"
-        );
+        assert_eq!(state.bans.0.len(), 1, "the ban is still stored in state");
+        assert_eq!(verdict(&state, &owner), BanEnforcement::Inert);
     }
 
     #[test]
-    fn ban_reports_not_enforcing_once_its_banner_is_no_longer_a_member() {
-        // Second inert path from #472: the banner left or was pruned, so the
-        // deputy-derived grants no longer apply. Alice must remain a member,
-        // otherwise `ban_is_enforcing` short-circuits to true on an absent
-        // target and the test would pass for the wrong reason.
+    fn ban_is_inert_once_its_banner_is_no_longer_a_member() {
+        // Second dead path from #472: the banner left or was pruned, so the
+        // deputy-derived grants no longer apply. Alice stays a member, so this
+        // is the definitive case rather than the contingent one.
         let owner = key(1);
         let alice = key(2);
         let carol = key(4);
@@ -750,35 +847,36 @@ mod tests {
         push_info(&mut state, &owner, 0, vec![id(&carol)]);
         push_ban(&mut state, &owner, &carol, &alice);
 
-        // Sanity: enforcing while carol is present.
-        assert!(collect_ban_infos(&state, &owner.verifying_key())[0].enforcing);
+        assert_eq!(
+            verdict(&state, &owner),
+            BanEnforcement::Enforcing,
+            "precondition: enforcing while carol is present"
+        );
 
-        // Carol leaves / is pruned.
         state
             .members
             .members
             .retain(|m| m.member.id() != id(&carol));
 
-        let bans = collect_ban_infos(&state, &owner.verifying_key());
-        assert!(
-            !bans[0].enforcing,
-            "a ban whose banner is gone is inert and must not read as active"
-        );
+        assert_eq!(verdict(&state, &owner), BanEnforcement::Inert);
     }
 
     #[test]
-    fn legitimate_ancestor_ban_still_enforcing_after_its_target_is_removed() {
-        // Regression guard for a wrong "fix" that is tempting on inspection:
-        // computing the flag from a bare `is_ban_authorized` instead of
-        // `ban_is_enforcing`, on the theory that the latter skips the authority
-        // check for an absent target.
+    fn legitimate_ancestor_ban_becomes_undetermined_once_its_target_is_removed() {
+        // Guards against collapsing the classifier back to a bare
+        // `is_ban_authorized` with a two-valued verdict.
         //
-        // It skips it for a reason. Once a ban has done its job the target is
-        // gone, so there is no invite chain left to walk and the ancestor grant
-        // that authorized the ban can no longer be re-derived. A bare
-        // `is_ban_authorized` therefore reports NOT ENFORCING for essentially
-        // every ban that is working, which is far more misleading than the
-        // narrow case it would tighten.
+        // Bob's authority over alice came from being her strict ancestor. Once
+        // the ban does its job alice is gone, there is no chain left to walk,
+        // and `is_ban_authorized` returns false — indistinguishable from "never
+        // had authority". Reading that false as "this ban is dead" would mark
+        // every working strict-ancestor and non-owner-deputy ban NOT ENFORCING,
+        // since a ban's success is exactly what removes its target.
+        //
+        // The honest verdict is Undetermined: bob's grant re-derives only if
+        // alice comes back under him. Pair with
+        // `absolute_grants_stay_enforcing_with_the_target_absent`, which stops
+        // the opposite shortcut of calling every absent target Undetermined.
         let owner = key(1);
         let alice = key(2);
         let bob = key(3);
@@ -789,9 +887,10 @@ mod tests {
         push_member(&mut state, &owner, &bob, &alice);
         push_ban(&mut state, &owner, &bob, &alice);
 
-        assert!(
-            collect_ban_infos(&state, &owner.verifying_key())[0].enforcing,
-            "an ancestor's ban of a present member enforces"
+        assert_eq!(
+            verdict(&state, &owner),
+            BanEnforcement::Enforcing,
+            "precondition: an ancestor's ban of a present member enforces"
         );
 
         // Let the contract enforce it, exactly as `post_apply_cleanup` does.
@@ -814,20 +913,117 @@ mod tests {
             "precondition: the ban removed alice"
         );
 
-        assert!(
-            collect_ban_infos(&state, &owner.verifying_key())[0].enforcing,
-            "the ban is working, so it must not read as NOT ENFORCING once its \
-             target is gone"
+        assert_eq!(verdict(&state, &owner), BanEnforcement::Undetermined);
+    }
+
+    #[test]
+    fn absolute_grants_stay_enforcing_with_the_target_absent() {
+        // The counterweight to the test above, and the reason three states are
+        // worth building rather than collapsing every absent target into
+        // Undetermined. Neither absolute grant reads the target's invite chain:
+        // `banner == owner_id` returns before the chain walk, and the
+        // owner-appointed global moderator check reads only the owner's deputy
+        // list. Both therefore re-derive with the target gone and re-apply
+        // wherever they reattach, so both are real promises.
+        let owner = key(1);
+        let alice = key(2); // absent target
+        let gmod = key(4);
+
+        // Owner's own ban of an absent alice.
+        let mut by_owner = ChatRoomStateV1::default();
+        push_member(&mut by_owner, &owner, &owner, &gmod);
+        push_ban(&mut by_owner, &owner, &owner, &alice);
+        assert_eq!(
+            verdict(&by_owner, &owner),
+            BanEnforcement::Enforcing,
+            "the owner's grant is absolute and target-independent"
+        );
+
+        // Owner-appointed global moderator's ban of an absent alice.
+        let mut by_gmod = ChatRoomStateV1::default();
+        push_member(&mut by_gmod, &owner, &owner, &gmod);
+        push_info(&mut by_gmod, &owner, 0, vec![id(&gmod)]);
+        push_ban(&mut by_gmod, &owner, &gmod, &alice);
+        assert_eq!(
+            verdict(&by_gmod, &owner),
+            BanEnforcement::Enforcing,
+            "an owner-appointed global moderator's grant is absolute too"
         );
     }
 
     #[test]
+    fn ban_signed_by_someone_other_than_its_attributed_banner_is_inert() {
+        // `verify` skips a ban's signature when the banner is absent at
+        // bans-apply time (bans apply before members), so a state can carry a
+        // ban attributed to a current, fully-authorized member but signed by
+        // someone else. `banned_member_ids` re-checks the signature against the
+        // banner's CURRENT key and refuses to enforce it (#411 round 4 A).
+        //
+        // This must be settled BEFORE the authority question: bob here is an
+        // owner-appointed global moderator, so `is_ban_authorized` says yes and
+        // the classifier would otherwise report a forged ban as Enforcing.
+        use river_core::util::sign_struct;
+
+        let owner = key(1);
+        let alice = key(2);
+        let bob = key(3); // attributed banner: a real member WITH a grant
+        let mallory = key(7); // who actually signed it
+
+        let mut state = ChatRoomStateV1::default();
+        push_member(&mut state, &owner, &owner, &alice);
+        push_member(&mut state, &owner, &owner, &bob);
+        push_info(&mut state, &owner, 0, vec![id(&bob)]);
+
+        let ban = UserBan {
+            owner_member_id: id(&owner),
+            banned_at: std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000),
+            banned_user: id(&alice),
+        };
+        let forged = sign_struct(&ban, &mallory);
+        state
+            .bans
+            .0
+            .push(AuthorizedUserBan::with_signature(ban, id(&bob), forged));
+
+        // The contract does not exclude alice on the strength of this ban.
+        let params = ChatRoomParametersV1 {
+            owner: owner.verifying_key(),
+        };
+        assert!(
+            !state
+                .members
+                .banned_member_ids(&state.bans, &state.member_info, &params)
+                .contains(&id(&alice)),
+            "precondition: the contract refuses to enforce a mis-signed ban"
+        );
+
+        assert_eq!(verdict(&state, &owner), BanEnforcement::Inert);
+    }
+
+    #[test]
+    fn ban_naming_the_room_owner_is_inert_not_undetermined() {
+        // `is_ban_authorized` denies `target == owner_id` outright, before any
+        // grant, and the owner is not in the members list. Without the explicit
+        // guard this would fall through the absent-target branch and render
+        // UNDETERMINED forever, implying it might apply if the owner "came
+        // back". It never can, so it is definitively dead.
+        let owner = key(1);
+        let bob = key(3);
+
+        let mut state = ChatRoomStateV1::default();
+        push_member(&mut state, &owner, &owner, &bob);
+        push_ban(&mut state, &owner, &bob, &owner);
+
+        assert_eq!(verdict(&state, &owner), BanEnforcement::Inert);
+    }
+
+    #[test]
     fn a_present_target_agrees_with_the_contracts_excluded_set() {
-        // `enforcing == false` is the actionable claim: the target is a current
-        // member this ban fails to exclude. Tie that to the contract's own
-        // excluded set rather than to a predicate that merely looks related.
-        // Each state holds exactly one ban, so `banned_member_ids` containing
-        // the target is precisely "this ban excludes its target".
+        // For a PRESENT target the verdict is definitive, so it can be tied to
+        // the contract's own excluded set rather than to a predicate that merely
+        // looks related. Each state holds exactly one ban, so `banned_member_ids`
+        // containing the target is precisely "this ban excludes its target".
+        // Undetermined cannot occur here and is asserted absent.
         let owner = key(1);
         let alice = key(2);
         let bob = key(3);
@@ -871,7 +1067,7 @@ mod tests {
         let mut saw_inert = false;
 
         for (label, state) in &cases {
-            let reported = collect_ban_infos(state, &owner.verifying_key())[0].enforcing;
+            let reported = verdict(state, &owner);
             let target = state.bans.0[0].ban.banned_user;
             assert!(
                 state
@@ -881,6 +1077,11 @@ mod tests {
                     .any(|m| m.member.id() == target),
                 "this equivalence only holds for a PRESENT target: {label}"
             );
+            assert_ne!(
+                reported,
+                BanEnforcement::Undetermined,
+                "a present target is never contingent: {label}"
+            );
 
             let actually_excluded = state
                 .members
@@ -888,12 +1089,13 @@ mod tests {
                 .contains(&target);
 
             assert_eq!(
-                reported, actually_excluded,
+                reported == BanEnforcement::Enforcing,
+                actually_excluded,
                 "`debug bans` disagrees with the contract's excluded set for: {label}"
             );
 
-            saw_enforcing |= reported;
-            saw_inert |= !reported;
+            saw_enforcing |= reported == BanEnforcement::Enforcing;
+            saw_inert |= reported == BanEnforcement::Inert;
         }
 
         // Guard against a vacuous pass if every case landed on one side.
@@ -901,10 +1103,56 @@ mod tests {
     }
 
     #[test]
-    fn ban_json_carries_the_enforcing_flag_alongside_the_pre_existing_shape() {
+    fn each_ban_is_classified_independently() {
+        // `collect_ban_infos` maps over the ban list, so a classifier hoisted
+        // out of the closure, or one verdict stamped onto every entry, would
+        // pass every single-ban test above. A room holding a mix is #472's
+        // actual scenario, and the order must line up with the bans as stored.
+        let owner = key(1);
+        let alice = key(2); // present, banned by a revoked deputy -> Inert
+        let bob = key(3); // the revoked deputy
+        let dave = key(5); // absent, banned by bob as a plain member -> Undetermined
+        let erin = key(6); // present, banned by the owner -> Enforcing
+
+        let mut state = ChatRoomStateV1::default();
+        push_member(&mut state, &owner, &owner, &alice);
+        push_member(&mut state, &owner, &owner, &bob);
+        push_member(&mut state, &owner, &owner, &erin);
+        // bob held a grant when he banned alice; it is revoked below.
+        push_info(&mut state, &owner, 0, vec![id(&bob)]);
+
+        push_ban(&mut state, &owner, &bob, &alice); // -> Inert after revocation
+        push_ban(&mut state, &owner, &bob, &dave); // -> Undetermined (dave absent)
+        push_ban(&mut state, &owner, &owner, &erin); // -> Enforcing
+
+        push_info(&mut state, &owner, 1, vec![]); // revoke bob
+
+        let bans = collect_ban_infos(&state, &owner.verifying_key());
+        assert_eq!(bans.len(), 3);
+
+        let by_target: Vec<(String, BanEnforcement)> = bans
+            .iter()
+            .map(|b| (b.banned_user_id.clone(), b.enforcement))
+            .collect();
+
+        assert_eq!(
+            by_target,
+            vec![
+                (id(&alice).to_string(), BanEnforcement::Inert),
+                (id(&dave).to_string(), BanEnforcement::Undetermined),
+                (id(&erin).to_string(), BanEnforcement::Enforcing),
+            ],
+            "each ban must carry its OWN verdict, in stored order"
+        );
+    }
+
+    #[test]
+    fn ban_json_keeps_the_pre_existing_fields_and_serializes_state_as_a_string() {
         // `banned_user_id` / `banned_by_id` / `banned_at_secs` are the published
-        // shape; `enforcing` is additive. Renaming or dropping any of them
-        // breaks consumers of `debug bans -f json`.
+        // shape and must not move. `enforcement` REPLACES the short-lived
+        // `enforcing` bool (#472): the key is renamed deliberately so the
+        // breaking change is visible to a consumer rather than a bool silently
+        // becoming a string under the same name.
         let owner = key(1);
         let alice = key(2);
 
@@ -919,82 +1167,163 @@ mod tests {
         assert_eq!(entry["banned_user_id"], id(&alice).to_string());
         assert_eq!(entry["banned_by_id"], id(&owner).to_string());
         assert_eq!(entry["banned_at_secs"], 1_700_000_000u64);
-        assert_eq!(
-            entry["enforcing"], true,
-            "`enforcing` must be present and boolean in the JSON output"
+        assert_eq!(entry["enforcement"], "enforcing");
+        assert!(
+            entry.get("enforcing").is_none(),
+            "the old bool key must be gone, not shadowing the new field"
         );
     }
 
     #[test]
-    fn human_output_marks_only_the_non_enforcing_bans() {
-        // The human branch is the surface the issue is about: an inert ban that
-        // renders identically to a live one is the whole bug.
-        let enforcing = BanInfo {
-            banned_user_id: "LIVEUSER".to_string(),
-            banned_by_id: "BANNERA".to_string(),
+    fn every_enforcement_state_has_a_distinct_json_spelling() {
+        // Pins the wire spelling of all three variants. A `rename_all` change or
+        // a variant rename is a breaking change for `-f json` consumers and must
+        // fail here rather than in someone's script.
+        let spell = |e: BanEnforcement| serde_json::to_value(e).unwrap();
+        assert_eq!(spell(BanEnforcement::Inert), "inert");
+        assert_eq!(spell(BanEnforcement::Enforcing), "enforcing");
+        assert_eq!(spell(BanEnforcement::Undetermined), "undetermined");
+    }
+
+    fn info(user: &str, state: BanEnforcement) -> BanInfo {
+        BanInfo {
+            banned_user_id: user.to_string(),
+            banned_by_id: "BANNER".to_string(),
             banned_at_secs: 100,
-            enforcing: true,
-        };
-        let inert = BanInfo {
-            banned_user_id: "INERTUSER".to_string(),
-            banned_by_id: "BANNERB".to_string(),
-            banned_at_secs: 200,
-            enforcing: false,
+            enforcement: state,
+        }
+    }
+
+    #[test]
+    fn human_output_marks_each_state_distinctly() {
+        // The human branch is the surface the issue is about: a ban that is not
+        // keeping anyone out must not render identically to one that is, and the
+        // contingent case must not render as either.
+        let lines = ban_list_lines(&[
+            info("LIVEUSER", BanEnforcement::Enforcing),
+            info("INERTUSER", BanEnforcement::Inert),
+            info("MAYBEUSER", BanEnforcement::Undetermined),
+        ]);
+        let line_for = |u: &str| {
+            lines
+                .iter()
+                .find(|l| l.contains(u))
+                .unwrap_or_else(|| panic!("{u} must still be listed"))
+                .clone()
         };
 
-        let lines = ban_list_lines(&[enforcing, inert]);
-        let live_line = lines
-            .iter()
-            .find(|l| l.contains("LIVEUSER"))
-            .expect("the enforcing ban must still be listed");
-        let inert_line = lines
-            .iter()
-            .find(|l| l.contains("INERTUSER"))
-            .expect("the inert ban must still be listed");
-
+        let live = line_for("LIVEUSER");
         assert!(
-            !live_line.contains("NOT ENFORCING"),
-            "an enforcing ban must not be flagged: {live_line}"
+            !live.contains("NOT ENFORCING") && !live.contains("UNDETERMINED"),
+            "an enforcing ban must be unmarked: {live}"
         );
         assert!(
-            inert_line.contains("NOT ENFORCING"),
-            "an inert ban must be visibly flagged: {inert_line}"
+            line_for("INERTUSER").contains("[NOT ENFORCING]"),
+            "an inert ban must be visibly flagged"
+        );
+        let maybe = line_for("MAYBEUSER");
+        assert!(
+            maybe.contains("[UNDETERMINED]") && !maybe.contains("NOT ENFORCING"),
+            "a contingent ban needs its own marker, not the inert one: {maybe}"
         );
 
         let rendered = lines.join("\n");
         assert!(
-            rendered.contains("2 bans, 1 enforcing"),
-            "the header must report how many bans actually enforce: {rendered}"
+            rendered.contains("3 bans: 1 enforcing, 1 not enforcing, 1 undetermined"),
+            "the header must break the count down by state: {rendered}"
         );
         assert!(
-            rendered.contains("member deputized-by"),
-            "the note must point at the command that explains why a ban went inert"
+            rendered.contains("member deputized-by <room> <banned_by_id>"),
+            "the inert note must point at the BANNER's grant, which is the party \
+             whose authority decides whether the ban still applies"
+        );
+        assert!(
+            rendered.contains("depends on who re-invites them"),
+            "the undetermined note must explain what it is contingent on"
+        );
+        assert!(
+            !rendered.contains("are in the room"),
+            "no note may claim where the target is: an uncleaned full-state PUT \
+             can hold an inert ban whose target is already gone"
         );
     }
 
     #[test]
-    fn human_output_stays_quiet_when_every_ban_enforces() {
-        // No false alarm: a room whose bans are all live must not carry the
-        // inert-ban note, or moderators learn to ignore it.
-        let lines = ban_list_lines(&[BanInfo {
-            banned_user_id: "LIVEUSER".to_string(),
-            banned_by_id: "BANNERA".to_string(),
-            banned_at_secs: 100,
-            enforcing: true,
-        }]);
-        let rendered = lines.join("\n");
-
-        assert!(rendered.contains("1 bans, 1 enforcing"));
+    fn human_output_only_explains_states_that_are_present() {
+        // No false alarms. A room whose bans are all live must carry neither
+        // note, or moderators learn to ignore both.
+        let rendered = ban_list_lines(&[info("LIVEUSER", BanEnforcement::Enforcing)]).join("\n");
+        assert!(rendered.contains("1 bans: 1 enforcing, 0 not enforcing, 0 undetermined"));
         assert!(!rendered.contains("NOT ENFORCING"));
         assert!(!rendered.contains("Note:"));
+
+        // A room with only contingent bans gets the undetermined note and NOT
+        // the inert one, which would otherwise send the reader chasing a
+        // revoked grant that does not exist.
+        let only_maybe =
+            ban_list_lines(&[info("MAYBEUSER", BanEnforcement::Undetermined)]).join("\n");
+        assert!(only_maybe.contains("UNDETERMINED"));
+        assert!(only_maybe.contains("depends on who re-invites them"));
+        assert!(
+            !only_maybe.contains("member deputized-by"),
+            "the inert remediation must not appear when no ban is inert"
+        );
     }
 
     #[test]
     fn human_output_handles_an_empty_ban_list() {
-        let lines = ban_list_lines(&[]);
-        let rendered = lines.join("\n");
-        assert!(rendered.contains("0 bans, 0 enforcing"));
+        let rendered = ban_list_lines(&[]).join("\n");
+        assert!(rendered.contains("0 bans: 0 enforcing, 0 not enforcing, 0 undetermined"));
         assert!(rendered.contains("No bans."));
         assert!(!rendered.contains("Note:"));
+    }
+
+    /// Source pin for the `debug bans` CALL SITE.
+    ///
+    /// Every other test here exercises `collect_ban_infos` and `ban_list_lines`
+    /// directly, so all of them stay green if the `Bans` arm stops calling them
+    /// — which is exactly how this feature shipped broken once already: the
+    /// salvaged first draft added the helper and left the arm building `BanInfo`
+    /// inline. A behavioural test would need a live node, so this scrapes the
+    /// source, in the idiom already used by `storage.rs` and `identity.rs`.
+    ///
+    /// The body is cut at `mod tests` so these assertions' own text cannot
+    /// satisfy them via `include_str!`.
+    #[test]
+    fn bans_command_delegates_to_the_shared_helpers() {
+        let src = include_str!("debug.rs");
+        let body = &src[..src.find("mod tests").unwrap_or(src.len())];
+
+        let arm = body
+            .find("DebugCommands::Bans { room_owner_key }")
+            .expect("the `debug bans` arm must exist");
+        let next_arm = body[arm..]
+            .find("DebugCommands::Config")
+            .map(|i| arm + i)
+            .unwrap_or(body.len());
+        let arm_src = &body[arm..next_arm];
+
+        assert!(
+            arm_src.contains("collect_ban_infos("),
+            "the Bans arm must classify via `collect_ban_infos`. Building \
+             `BanInfo` inline here is how the enforcement field shipped \
+             unpopulated the first time (freenet/river#472)."
+        );
+        assert!(
+            arm_src.contains("ban_list_lines("),
+            "the Bans arm's human branch must render via `ban_list_lines`, or \
+             the state markers this feature exists for are tested but never \
+             printed."
+        );
+        assert!(
+            arm_src.contains("serde_json::to_string_pretty(&bans)"),
+            "the JSON branch must serialize the SAME classified `bans` value, \
+             so `-f json` and the human listing cannot disagree."
+        );
+        assert!(
+            !arm_src.contains("BanInfo {"),
+            "the Bans arm must not construct `BanInfo` itself — that bypasses \
+             `classify_ban` and can reintroduce a hardcoded verdict."
+        );
     }
 }

--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -47,18 +47,38 @@ pub enum DebugCommands {
 /// state without excluding anyone, and the CLI used to render that identically
 /// to a live ban.
 ///
-/// Three states rather than a boolean because the honest answer genuinely has
-/// three cases: a ban can be provably dead, provably live, or contingent on
-/// something that has not happened yet. Collapsing the third into either
-/// neighbour is a lie in one direction or the other.
+/// Three states rather than a boolean because a boolean could not carry the
+/// authority information at all: it collapsed to `!members.contains(target)`
+/// on every state a client can fetch.
+///
+/// The split is **target present vs absent**, and it is worth being exact about
+/// that rather than claiming cleaner epistemics than the code has. It is
+/// tempting to describe it as "definitive vs contingent"; that is not true.
+/// `Inert` for a present-but-unauthorized target is ALSO contingent — re-granting
+/// the banner's deputy authority re-arms the ban (see `ban_list_lines`), which is
+/// arguably likelier than the target being re-invited under some particular
+/// member. What the states really report is what is knowable NOW: with the target
+/// present, the answer is a fact about the current room, and with the target
+/// absent, the inputs that would decide it no longer exist.
 #[derive(Serialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 enum BanEnforcement {
-    /// Definitive: this ban is not keeping its target out. Either the target is
+    /// This ban is not keeping its target out. Reached three ways: the target is
     /// a current member the ban fails to exclude (so that person is in the room
-    /// right now), or the ban can never apply at all — its signature does not
-    /// verify against the banner's current key, or it names the room OWNER, who
-    /// `is_ban_authorized` refuses as a target unconditionally.
+    /// right now); the signature does not verify against the banner's current
+    /// key; or it names the room OWNER, whom `is_ban_authorized` refuses as a
+    /// target unconditionally.
+    ///
+    /// Only the owner case is permanently dead. The other two can revive, so do
+    /// NOT read this as "this row can be ignored forever":
+    /// - `ban_signature_matches_current_key` fails for TWO reasons, and the more
+    ///   common one is benign — the banner is not a current member, so their key
+    ///   is simply unavailable to check against. A pruned moderator who rejoins
+    ///   with the same key makes every such ban verify again. Genuine
+    ///   mis-signature is the rarer, adversarial case.
+    /// - a present-but-unauthorized target re-arms if the banner's authority is
+    ///   restored, because bans are add-only and every stored ban is re-evaluated
+    ///   on every cleanup. See the operator warning in `ban_list_lines`.
     Inert,
     /// The ban currently excludes its target: the banner's authority over them
     /// holds against the state as it stands.
@@ -77,15 +97,20 @@ enum BanEnforcement {
     /// ancestor) or from no grant at all. An absent member has no invite chain to
     /// walk, so that authority cannot be re-derived now. Not a promise either way.
     ///
-    /// Why "no grant at all" belongs in the SAME state as a lapsed positional one,
-    /// rather than being split off as a definitive no: with the target absent
-    /// those two are genuinely the same case, not two. Say bob was the target's
-    /// inviter and rando never had any authority over them. Neither is decided
-    /// now — the ban applies if the target is re-invited under bob, and does not
-    /// if they are re-invited under rando. Bob's grant is not REVOKED, it is
-    /// CONTINGENT, and rando's is contingent on the mirror-image event. Splitting
-    /// them would claim knowledge of who re-invites the target, which nobody has.
-    /// This is deliberate, not a distinction lost in review.
+    /// This state deliberately does NOT say which of those applies, because the
+    /// classifier cannot tell and neither can any function with these inputs.
+    /// Given `(ban, members_by_id, member_info, owner_id, owner_vk)` and an absent
+    /// target, "the banner was their inviter", "the banner was an owner-appointed
+    /// moderator whose grant was revoked", and "the banner never had authority"
+    /// are the SAME input: the `invited_by` edge died with the target's
+    /// `AuthorizedMember`, and the superseded `member_info` record was collapsed by
+    /// `dedup_to_canonical`. Distinguishing them would require tracking grant
+    /// history, which River does not keep and this command should not add.
+    ///
+    /// So the honest content is contingency alone: the ban applies if the target
+    /// returns under someone whose grant covers them, and not otherwise. Any
+    /// message here that names a CAUSE is asserting something unknowable — that
+    /// was the bug fixed alongside this comment.
     Undetermined,
 }
 
@@ -154,6 +179,14 @@ fn classify_ban(
     // global moderator it answers yes — and this would report a forgery as
     // Enforcing. Pinned by
     // `ban_signed_by_someone_other_than_its_attributed_banner_is_inert`.
+    //
+    // Note this gate fails for TWO reasons, and forgery is the rarer one: it also
+    // returns false whenever the banner is not a current member, because their key
+    // is then unavailable to check against (`ban_signature_matches_current_key`).
+    // Most rows reaching it are that benign case — a pruned or departed moderator
+    // — which is reversible: if they rejoin with the same key, their bans verify
+    // again. Both belong in `Inert` (neither is excluding anyone now), so do not
+    // read this branch as "forgery detected".
     if !BansV1::ban_signature_matches_current_key(ban, members_by_id, owner_id, owner_vk) {
         return BanEnforcement::Inert;
     }
@@ -250,27 +283,44 @@ fn ban_list_lines(bans: &[BanInfo]) -> Vec<String> {
     // not explain a case this room does not have. Neither claims where the target
     // is: a state fetched before cleanup (a full-state PUT bypasses it via
     // `verify`) can hold an inert ban whose target is already gone.
+    //
+    // Neither may name a CAUSE for an UNDETERMINED ban either. With the target
+    // absent, "banner was their inviter", "banner's grant was revoked" and
+    // "banner never had authority" are the same input to `classify_ban`, so any
+    // specific cause here would be invented. The inert note may list causes
+    // because a present target still carries the evidence that separates them.
     if inert > 0 {
         lines.push(String::new());
         lines.push(format!(
             "Note: {} ban(s) marked NOT ENFORCING are not keeping their target \
              out. A ban lands here when its banner is no longer a member, when \
-             the deputy authority it was issued under was revoked, or when the \
-             banned user had themselves deputized the banner. Run `riverctl \
+             the deputy authority it was issued under was revoked, when the \
+             banned user had themselves deputized the banner, or when the ban \
+             names the room owner (who can never be banned). Run `riverctl \
              member deputized-by <room> <banned_by_id>` to see whether the \
              banner still holds a grant, and from whom.",
             inert
         ));
+        lines.push(String::new());
+        lines.push(
+            "WARNING: a NOT ENFORCING ban is dormant, not deleted. Bans are \
+             never removed once stored, and every one of them is re-checked \
+             each time room state is cleaned up. Restoring a moderator's \
+             authority therefore re-arms every ban they ever issued, ejecting \
+             those users AND everyone they invited at the next cleanup. Read \
+             this list before re-granting anyone."
+                .to_string(),
+        );
     }
 
     if undetermined > 0 {
         lines.push(String::new());
         lines.push(format!(
             "Note: {} ban(s) marked UNDETERMINED target someone who is not \
-             currently in the room. Their banner's authority came from a \
-             position in the invite tree relative to that target, which cannot \
-             be re-derived while the target is absent, so whether the ban \
-             applies on their return depends on who re-invites them.",
+             currently in the room, and the room no longer holds what would \
+             decide them: whether the ban applies on that person's return \
+             depends on who re-invites them. Run `riverctl member deputized-by \
+             <room> <banned_by_id>` to see what authority the banner holds now.",
             undetermined
         ));
     }
@@ -1320,16 +1370,38 @@ mod tests {
         assert!(!rendered.contains("NOT ENFORCING"));
         assert!(!rendered.contains("Note:"));
 
+        assert!(
+            !rendered.contains("dormant, not deleted"),
+            "the re-arming warning is about inert rows and must not fire without one"
+        );
+
         // A room with only contingent bans gets the undetermined note and NOT
-        // the inert one, which would otherwise send the reader chasing a
-        // revoked grant that does not exist.
+        // the inert one. The discriminator is the inert note's own claims, not
+        // the `deputized-by` hint: that hint is deliberately carried by BOTH
+        // notes, because checking the banner's current authority is the useful
+        // next step either way.
         let only_maybe =
             ban_list_lines(&[info("MAYBEUSER", BanEnforcement::Undetermined)]).join("\n");
         assert!(only_maybe.contains("UNDETERMINED"));
         assert!(only_maybe.contains("depends on who re-invites them"));
         assert!(
-            !only_maybe.contains("member deputized-by"),
-            "the inert remediation must not appear when no ban is inert"
+            only_maybe.contains("member deputized-by <room> <banned_by_id>"),
+            "the undetermined note must carry the remediation hint too: the \
+             revoked-global-moderator case lands here whenever its target has \
+             already left, and that is #472's headline scenario"
+        );
+        assert!(
+            !only_maybe.contains("are not keeping their target out")
+                && !only_maybe.contains("dormant, not deleted"),
+            "the inert note and its re-arming warning must not appear when no \
+             ban is inert"
+        );
+        // The one thing this note must never do is name a cause: with the target
+        // absent the classifier cannot tell a revoked grant from a lapsed
+        // positional one from no grant at all.
+        assert!(
+            !only_maybe.contains("invite tree"),
+            "the undetermined note must not assert a cause it cannot know"
         );
     }
 

--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -138,9 +138,22 @@ fn classify_ban(
     owner_vk: &VerifyingKey,
 ) -> BanEnforcement {
     // A ban whose signature does not verify against the banner's CURRENT key
-    // never excludes anyone: `banned_member_ids` skips it, and cleanup step 5
-    // sweeps it. Settled before the authority question, which would otherwise
-    // report a forged ban as enforcing.
+    // never excludes anyone: `banned_member_ids` skips it before asking about
+    // authority, and cleanup step 5 sweeps it.
+    //
+    // LOAD-BEARING, not defensive, and NOT redundant — do not delete it on the
+    // reasoning that cleanup step 5 makes it unconditionally true. That holds
+    // only on the CLEANED path, and a full-state PUT reaches a client without
+    // cleanup having run (`verify` accepts it, and `verify` deliberately skips a
+    // ban's signature when the banner was absent at bans-apply time, since bans
+    // apply before members). So a fetched state really can carry a ban attributed
+    // to a current, fully-authorized member but signed by somebody else.
+    //
+    // It must also come FIRST. The authority check knows nothing about who
+    // actually signed, so for a forged ban attributed to, say, an owner-appointed
+    // global moderator it answers yes — and this would report a forgery as
+    // Enforcing. Pinned by
+    // `ban_signed_by_someone_other_than_its_attributed_banner_is_inert`.
     if !BansV1::ban_signature_matches_current_key(ban, members_by_id, owner_id, owner_vk) {
         return BanEnforcement::Inert;
     }

--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -77,8 +77,11 @@ enum BanEnforcement {
     ///   with the same key makes every such ban verify again. Genuine
     ///   mis-signature is the rarer, adversarial case.
     /// - a present-but-unauthorized target re-arms if the banner's authority is
-    ///   restored, because bans are add-only and every stored ban is re-evaluated
-    ///   on every cleanup. See the operator warning in `ban_list_lines`.
+    ///   restored. Losing enforcement does not drop a ban: cleanup only sweeps
+    ///   bans whose signature no longer matches a current banner's key, and
+    ///   evicts under the `max_user_bans` cap, so a revoked deputy who stays a
+    ///   member keeps their bans stored — and `banned_member_ids` re-evaluates
+    ///   every stored ban on every cleanup. See the warning in `ban_list_lines`.
     Inert,
     /// The ban currently excludes its target: the banner's authority over them
     /// holds against the state as it stands.
@@ -103,9 +106,12 @@ enum BanEnforcement {
     /// target, "the banner was their inviter", "the banner was an owner-appointed
     /// moderator whose grant was revoked", and "the banner never had authority"
     /// are the SAME input: the `invited_by` edge died with the target's
-    /// `AuthorizedMember`, and the superseded `member_info` record was collapsed by
-    /// `dedup_to_canonical`. Distinguishing them would require tracking grant
-    /// history, which River does not keep and this command should not add.
+    /// `AuthorizedMember`, and a revoked grant is invisible because `deputies_of`
+    /// reads only `MemberInfoV1::canonical`, the highest-ranked record — so the
+    /// superseded one carrying the grant is never exposed, whether or not
+    /// `dedup_to_canonical` has since collapsed it. Distinguishing them would
+    /// require tracking grant history, which River does not keep and this command
+    /// should not add.
     ///
     /// So the honest content is contingency alone: the ban applies if the target
     /// returns under someone whose grant covers them, and not otherwise. Any
@@ -303,12 +309,13 @@ fn ban_list_lines(bans: &[BanInfo]) -> Vec<String> {
         ));
         lines.push(String::new());
         lines.push(
-            "WARNING: a NOT ENFORCING ban is dormant, not deleted. Bans are \
-             never removed once stored, and every one of them is re-checked \
-             each time room state is cleaned up. Restoring a moderator's \
-             authority therefore re-arms every ban they ever issued, ejecting \
-             those users AND everyone they invited at the next cleanup. Read \
-             this list before re-granting anyone."
+            "WARNING: a NOT ENFORCING ban is dormant, not deleted. A ban is not \
+             dropped for having stopped enforcing — while its banner remains a \
+             member it stays stored, and every stored ban is re-checked each \
+             time room state is cleaned up. Restoring a moderator's authority \
+             therefore re-arms every ban they ever issued, ejecting those users \
+             AND everyone they invited at the next cleanup. Read this list \
+             before re-granting anyone."
                 .to_string(),
         );
     }

--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -75,8 +75,17 @@ enum BanEnforcement {
     /// The target is not in the room, but the banner's authority came from their
     /// POSITION relative to the target (strict ancestor, or deputy of a non-owner
     /// ancestor) or from no grant at all. An absent member has no invite chain to
-    /// walk, so that authority cannot be re-derived now and re-derives differently
-    /// depending on who re-invites them. Not a promise either way.
+    /// walk, so that authority cannot be re-derived now. Not a promise either way.
+    ///
+    /// Why "no grant at all" belongs in the SAME state as a lapsed positional one,
+    /// rather than being split off as a definitive no: with the target absent
+    /// those two are genuinely the same case, not two. Say bob was the target's
+    /// inviter and rando never had any authority over them. Neither is decided
+    /// now — the ban applies if the target is re-invited under bob, and does not
+    /// if they are re-invited under rando. Bob's grant is not REVOKED, it is
+    /// CONTINGENT, and rando's is contingent on the mirror-image event. Splitting
+    /// them would claim knowledge of who re-invites the target, which nobody has.
+    /// This is deliberate, not a distinction lost in review.
     Undetermined,
 }
 
@@ -948,6 +957,47 @@ mod tests {
             verdict(&by_gmod, &owner),
             BanEnforcement::Enforcing,
             "an owner-appointed global moderator's grant is absolute too"
+        );
+    }
+
+    #[test]
+    fn ban_by_a_member_with_no_grant_is_undetermined_once_the_target_is_absent() {
+        // The fourth corner of the absent-target matrix, and the one that shows
+        // why "no grant at all" shares a state with a lapsed positional grant
+        // instead of being a definitive no.
+        //
+        // Rando has never had authority over alice. While she is PRESENT that is
+        // decided — Inert, she is in the room and the ban is not stopping her.
+        // Once she is gone it stops being decided: re-invited under rando he
+        // becomes her strict ancestor and the ban applies, re-invited under
+        // anyone else it does not. Same shape as the ancestor case in
+        // `legitimate_ancestor_ban_becomes_undetermined_once_its_target_is_removed`,
+        // which is why they share a verdict.
+        let owner = key(1);
+        let alice = key(2);
+        let rando = key(5);
+
+        let mut state = ChatRoomStateV1::default();
+        push_member(&mut state, &owner, &owner, &alice);
+        push_member(&mut state, &owner, &owner, &rando);
+        push_ban(&mut state, &owner, &rando, &alice);
+
+        assert_eq!(
+            verdict(&state, &owner),
+            BanEnforcement::Inert,
+            "while alice is present, an unauthorized ban is definitively dead"
+        );
+
+        state
+            .members
+            .members
+            .retain(|m| m.member.id() != id(&alice));
+
+        assert_eq!(
+            verdict(&state, &owner),
+            BanEnforcement::Undetermined,
+            "with alice gone, rando's authority is contingent on who re-invites \
+             her, not settled"
         );
     }
 


### PR DESCRIPTION
Follow-up to #540, which closed #472 with a boolean. Review of that PR showed the boolean could not carry the information the issue asked for. This replaces it.

## Problem

#540 added `enforcing: bool`, sourced from `BansV1::ban_is_enforcing`. Reviewers traced `post_apply_cleanup` gate by gate and found that in any state a user can actually fetch, the flag collapses to `!members.contains(target)` and carries **zero** authority information:

- cleanup step 5 retains only bans satisfying `ban_signature_matches_current_key`, so that gate is unconditionally true for any surviving ban;
- cleanup step 0 removes every target of an authorized ban, so a target still present implies unauthorized implies `false`;
- for an absent target, `ban.rs:274-278` returns bare `true` without ever calling `is_ban_authorized`. The authority call at `ban.rs:273` is dead on that path.

So the column told an operator whether the person was in the room, which `riverctl member list` already tells them.

Worse for the issue's actual scenario: deputy bans alice, owner revokes the grant, alice has not yet returned. That displayed ENFORCING, indefinitely, and only flipped after she walked back in — by which point `member list` shows her. #472's Problem section is "they may well be back in the room"; the boolean covered the "already back" half and missed the "free to come back" half, which is the half a moderator can still act on.

It was also attacker-inflatable: any member can mint bans naming absent ids, each rendering ENFORCING and inflating the header count. The contract's own source documents this as an abuse vector at `common/src/room_state.rs:126-134` (#413, Limitation 2).

## Approach

The honest answer has three cases, so report three. A ban can be provably dead, provably live, or contingent on something that has not happened yet, and collapsing the third into either neighbour lies in one direction or the other.

| State | Condition | Meaning |
|---|---|---|
| `inert` | target is a current member the ban fails to exclude; or the signature does not verify against the banner's current key; or it names the room owner | Definitive: not keeping anyone out. |
| `enforcing` | authority holds against current state | Excluding them today. With the target absent this additionally implies an ABSOLUTE grant, so it is durable across their return. |
| `undetermined` | target absent and the banner's grant was position-derived (strict ancestor, deputy of a non-owner ancestor) or absent entirely | Not in the room, but whether the ban applies on return depends on who re-invites them. |

The classifier is one presence check plus a single `is_ban_authorized` call, which also revives the authority call that was dead in #540:

```rust
signature mismatch          -> Inert   // settled first, or a forged ban reads as enforcing
target == owner             -> Inert   // never a valid target; permanently dead, not contingent
is_ban_authorized           -> Enforcing
target present (so !auth)   -> Inert   // the actionable #472 case: they are in the room
otherwise (target absent)   -> Undetermined
```

**Three states are buildable, not just more honest.** The two absolute grants in `is_ban_authorized` (banner is the owner; banner is an owner-appointed global moderator) read nothing about the target's position, so they re-derive with the target gone. That is what makes `enforcing` expressible for an absent target at all, and it is the hole in #540's "a stricter check would report every working ban as inert" reasoning. Only strict-ancestor and non-owner-deputy bans become undeterminable. That over-broad claim sat in a `Do NOT switch this` warning in the merged source; the warning is kept (a bare `is_ban_authorized` still must not land) but its reason is corrected.

The room-owner case resolves here too: it lands in `inert` rather than a permanent confident ENFORCING, because the owner cannot be re-invited into a position that would make the ban apply.

Human output:

```
Ban List (3 bans: 1 enforcing, 1 not enforcing, 1 undetermined)
=========
  7XSOGJTK banned by PMAQEUP5 at 1700000000
  4KDLM2NQ banned by 9WTZR6HB at 1700000042  [NOT ENFORCING]
  QW3RTY88 banned by PMAQEUP5 at 1700000099  [UNDETERMINED]
```

with a note per state, emitted only when that state is present so neither trains the reader to ignore it. Neither note claims where the target is: a full-state PUT bypasses cleanup via `verify`, so an uncleaned state can hold an inert ban whose target is already gone (#540's note asserted "those users are in the room" unconditionally).

## One deviation from the review, flagged deliberately

The review asked for the remediation hint to become `deputized-by <room> <banned_user_id>` for the target-deputized-the-banner cause. I checked the two commands' semantics in `cli/src/commands/member.rs` and did **not** make that change:

- `member deputies <room> <ID>` lists who **ID has deputized**;
- `member deputized-by <room> <ID>` lists **who has deputized ID**.

The step-4 guardrail is `deputies_of(target).contains(banner)` — the *target* deputized the *banner*. `deputized-by <banned_user_id>` asks who deputized the banned user, which is unrelated. The hint stays `deputized-by <room> <banned_by_id>`, which answers both inert causes in one command: an empty result means the banner holds no grant, and the banned user appearing in the result is the guardrail. The note now says to look for both. Happy to change it if I have misread the intent.

## A NOT ENFORCING ban is dormant, not dead

Added in review, and probably the most operationally useful thing in the PR.

Bans are add-only: nothing removes one once stored, and `MembersV1::banned_member_ids` re-evaluates **every** stored ban against current state on every cleanup. A revoked deputy who remains a member keeps passing the step-5 signature sweep, so their bans persist indefinitely in an inert state.

Which means **re-granting that deputy retroactively re-arms every ban they ever issued** — ejecting those targets and their whole invite subtrees at the next cleanup. An operator restoring a moderator's authority going forward would silently re-eject everyone that moderator had ever banned, including bans they may have considered long since undone.

`debug bans` is the only place that can warn before the re-grant, so the human output now does, under the inert note:

```
WARNING: a NOT ENFORCING ban is dormant, not deleted. Bans are never removed once
stored, and every one of them is re-checked each time room state is cleaned up.
Restoring a moderator's authority therefore re-arms every ban they ever issued,
ejecting those users AND everyone they invited at the next cleanup. Read this list
before re-granting anyone.
```

This is also why the `inert` rustdoc no longer says such bans "can never apply at all".

## The signature gate is load-bearing, not defensive

Stating this plainly because it is the piece most likely to be deleted later as redundant.

`ban_signature_matches_current_key` runs in front of the match. Cleanup step 5 retains only bans that satisfy it, so on a cleaned state it is unconditionally true and looks like dead weight. That reasoning holds **only on the cleaned path**. A full-state PUT reaches a client without cleanup having run — `verify` accepts it, and `verify` deliberately skips a ban's signature when the banner was absent at bans-apply time, since bans apply before members. So a state you can actually fetch may carry a ban attributed to a current, fully-authorized member but signed by somebody else.

It also has to come **first**, before the authority question. The authority check knows nothing about who signed: for a forgery attributed to an owner-appointed global moderator, `is_ban_authorized` answers yes, and the classifier would report a forged ban as `enforcing`. That is the #472 failure mode with an attacker holding the pen.

Worth noting how this was found: it was not in the first version of this PR. My own mutation run showed that deleting the gate killed **zero** tests, because no fixture produced a mis-signed ban. `ban_signed_by_someone_other_than_its_attributed_banner_is_inert` exists because of that, forging with `sign_struct` + `with_signature` and asserting the contract does not exclude the target either. The reasoning above is now also recorded at the call site so the next reader does not re-derive the "redundant post-cleanup" conclusion and act on it.

## Where the boundary is drawn, and the calls that were not obvious

The reviewer asked specifically whether the three-state line is in the right place, so here are the judgement calls rather than a smooth surface. Two feel settled to me and two are genuinely arguable.

**Not actually a judgement call: a lapsed positional grant and no grant at all share `undetermined`.** I first presented this as a deliberate design decision. It is stronger than that — no alternative is expressible. `classify_ban` receives `(ban, members_by_id, member_info, owner_id, owner_vk)`, and with the target absent, "the banner was their inviter", "the banner was an owner-appointed moderator whose grant was revoked" and "the banner never had authority" are the **same input tuple**: the `invited_by` edge died with the target's `AuthorizedMember`, and the superseded `member_info` record was collapsed by `dedup_to_canonical`. The real decision is "do not add grant-history tracking", which River does not keep and this command should not introduce.

Consequence, stated so the mutation table is not read as claiming more than it does: `ban_by_a_member_with_no_grant_is_undetermined_once_the_target_is_absent` **cannot kill a mutation that the ancestor test does not already kill**. Both reduce to "signature ok + target absent + no absolute grant → Undetermined", differing only in fixture history the classifier never reads. It is kept because pinning the fourth corner of the matrix is worth having explicitly, not because it is an independent pin.

**Settled: a ban naming the room owner is `inert`, not `undetermined`.** `is_ban_authorized` denies `target == owner_id` outright before any grant, and no re-invite can change that, so it is permanently dead rather than contingent. It needs an explicit guard because the owner is not in the members list and would otherwise fall through the absent-target branch and read UNDETERMINED forever.

**Was arguable, now resolved against a fourth state: mis-signature folds into `inert`.** I raised this as possibly wanting a separate "suspicious" state. Review showed that argument was about the minority sub-case. `ban_signature_matches_current_key` returns false for two reasons, and the common one is benign: the banner is not a current member, so their key is simply unavailable to check against. A fourth state would therefore fire mostly on pruned-moderator rows, not forgeries. It would also be wrong about permanence — that case reverses if the banner rejoins with the same key. Both reasons belong in `inert`, and the docs now say so rather than framing the gate as forgery defence.

**Arguable: `enforcing` covers two things that differ in durability.** With the target absent it implies an absolute grant and is durable across their return. With the target still present (only reachable in uncleaned state, since cleanup removes authorized targets) the grant may be positional and would lapse if that ancestor left. Both are truthfully "excluding them today", and the variant docs separate the two claims, but a reader who sees only the word could over-trust the present-target case. Splitting it would mean four states for a distinction that is invisible on the cleaned path, which seemed the worse trade.

**Corrected after review: the split is target present vs absent, not "definitive vs contingent".** The enum docs originally claimed the cleaner epistemics. They do not hold: an `inert` present-target ban is contingent too, since re-granting the banner's authority re-arms it, which is arguably likelier than the target being re-invited under some particular member. The boundary stays where it is (present vs absent is the informative split and the notes are present-tense and true), but the docs no longer overclaim, because a reader reasoning from "inert means definitively dead" would get the re-arming hazard wrong.

## Testing

21 tests in `cli/src/commands/debug.rs`, all mutation-verified rather than assumed. Every mutation below was applied to the committed content and confirmed to fail:

| Mutation | Killed by |
|---|---|
| `classify_ban` always `Enforcing` / `Inert` / `Undetermined` | 6 / 8 / 10 tests |
| bare `is_ban_authorized`, false collapsed to Inert (the #540 shape) | `legitimate_ancestor_ban_becomes_undetermined_once_its_target_is_removed`, `each_ban_is_classified_independently` |
| absent target => Undetermined without checking authority (the lazy three-state) | `absolute_grants_stay_enforcing_with_the_target_absent` |
| owner-as-target guard removed | `ban_naming_the_room_owner_is_inert_not_undetermined` |
| signature gate removed | `ban_signed_by_someone_other_than_its_attributed_banner_is_inert` |
| `[UNDETERMINED]` marker collapsed into `[NOT ENFORCING]` | `human_output_marks_each_state_distinctly` |
| Bans arm builds `BanInfo` inline with a hardcoded verdict | `bans_command_delegates_to_the_shared_helpers` |
| human branch stops calling `ban_list_lines` | same |
| JSON branch serializes a different value | same |

Addressing the specific gaps the testing lens found:

- **Call site is now pinned.** All three call-site mutations previously compiled and left every test green, including one restoring the original bug with a confident flag on top. `bans_command_delegates_to_the_shared_helpers` is an `include_str!` source pin in the idiom already used by `storage.rs` and `identity.rs`, cutting the body at `mod tests` so the assertions cannot satisfy themselves. This is not hypothetical: #540's salvaged first draft added the helper and left the arm building `BanInfo` inline.
- **Multi-ban coverage.** `each_ban_is_classified_independently` builds a room holding one ban of each state and asserts the verdicts line up with the bans in stored order, so a classifier hoisted out of the closure, or one verdict stamped on every entry, fails.
- **JSON branch pinned**, plus `every_enforcement_state_has_a_distinct_json_spelling` for the wire spelling of all three variants.
- **Owner-as-target** has its own test.
- The signature-gate test exists because my own mutation run found that removing the gate killed nothing. It was the one real hole in the suite.

`a_present_target_agrees_with_the_contracts_excluded_set` ties the verdict to `MembersV1::banned_member_ids` for present targets, where the equivalence genuinely holds, and asserts `Undetermined` never occurs there.

Full riverctl lib suite: 300 passed, 0 failed. `cargo fmt --check` clean, no new clippy warnings.

## JSON field change (nothing published can break)

`enforcing: bool` is replaced by `enforcement`, a string enum of `inert` / `enforcing` / `undetermined`. `banned_user_id`, `banned_by_id` and `banned_at_secs` are unchanged.

Labelled a breaking change in the commit trailer for accuracy, but it cannot break a consumer: `enforcing` shipped only in #540, and `git tag --contains d36faf3e` returns **zero** tags. The latest release is `riverctl-v0.2.5` while `cli/Cargo.toml` is at 0.2.7, so the bool has never been in a published riverctl. The key is renamed rather than changed in place so that anyone tracking `main` sees a missing field instead of a bool that silently became a string.


