### PR TITLE
perf(contract): stop re-verifying the same Ed25519 signatures on every apply

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,45 @@ strip = true        # Strip symbols from binary
 [profile.release.package."*"]
 opt-level = 'z'     # Optimize all dependencies for size as well
 
+# EXCEPT the elliptic-curve arithmetic. `opt-level = 'z'` leaves
+# curve25519-dalek's field-arithmetic hot loops un-inlined, and Ed25519
+# VERIFICATION is the room contract's dominant cost — it verifies every member's
+# invite signature, every ban, every member_info record and every message on
+# each `validate_state`. Restoring `opt-level = 3` for that one crate buys 1.6x
+# on all of it (freenet/river#422).
+#
+# Measured per verification, wasm32 under wasmtime with Cranelift at
+# `OptLevel::None` — the settings freenet-core actually runs contracts under
+# (crates/core/src/wasm_runtime/engine/wasmtime_engine.rs, chosen for safety
+# against untrusted code):
+#
+#     curve25519-dalek at 'z' : 0.4224 ms      at 3 : 0.2622 ms   (1.61x)
+#
+# Do NOT quote the native figure. Natively the same change is 46x (2.27 ms ->
+# 0.05 ms), because a native build has nothing downstream to recover the lost
+# inlining, whereas Cranelift re-optimizes the module on load and recovers most
+# of it. 46x describes `cargo test --release` on the host, NOT production.
+#
+# Cost of the exception, measured with `cargo build --locked --profile release
+# --target wasm32-unknown-unknown` against origin/main:
+#
+#     room_contract.wasm  792,831 -> 808,800  (+15,969, +2.0%)
+#     chat_delegate.wasm  737,365 -> 754,652  (+17,287, +2.3%)
+#
+# BOTH artifacts move, because the delegate depends on ed25519-dalek too and
+# `Makefile.toml` builds it `--profile release`. So a publish carrying this
+# needs a `legacy_room_contracts.toml` entry AND a `legacy_delegates.toml`
+# entry — the room contract key is BLAKE3(wasm, params) and the delegate key is
+# BLAKE3(BLAKE3(wasm) || params). CI's `check-*-migration` jobs pass on the PR
+# only because they diff the COMMITTED wasm, which no source change regenerates;
+# they do not predict the next `cargo make sync-wasm`.
+#
+# Scoped to curve25519-dalek alone: that is where the arithmetic lives and it
+# carries the whole win on its own, so widening the exception to
+# ed25519-dalek/sha2 would cost size for nothing.
+[profile.release.package.curve25519-dalek]
+opt-level = 3
+
 # Profile used by `dx build --release` for the web/WASM UI target.
 #
 # The Dioxus CLI (dx) builds the web app under a profile named `wasm-release`.

--- a/cli/examples/invite_depth_probe.rs
+++ b/cli/examples/invite_depth_probe.rs
@@ -1,0 +1,120 @@
+//! SCRATCH probe for freenet/river#422 — measure the REAL invite-tree depth of
+//! a live room, since `riverctl` exposes no `invited_by` through any command
+//! and the whole O(members x depth) justification turns on that number.
+//!
+//!   cargo run -p riverctl --example invite_depth_probe -- <ROOM_OWNER_VK>
+
+use anyhow::Result;
+use ed25519_dalek::VerifyingKey;
+use river_core::room_state::member::MemberId;
+use riverctl::api::ApiClient;
+use riverctl::config::Config;
+use std::collections::HashMap;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let owner_b58 = std::env::args()
+        .nth(1)
+        .expect("usage: invite_depth_probe <ROOM_OWNER_VK_BASE58>");
+    let node_url = std::env::var("RIVER_NODE_URL").unwrap_or_else(|_| {
+        "ws://127.0.0.1:7509/v1/contract/command?encodingProtocol=native".into()
+    });
+
+    let decoded = bs58::decode(&owner_b58).into_vec()?;
+    let bytes: [u8; 32] = decoded.as_slice().try_into()?;
+    let owner_vk = VerifyingKey::from_bytes(&bytes)?;
+    let owner_id = MemberId::from(&owner_vk);
+
+    let api = ApiClient::new(&node_url, Config::default(), None).await?;
+    let state = api.get_room(&owner_vk, false).await?;
+
+    let members = &state.members.members;
+    let by_id: HashMap<MemberId, &_> = state.members.members_by_member_id();
+
+    println!("members (vec)          : {}", members.len());
+    println!("members (by_id, deduped): {}", by_id.len());
+    println!("bans                   : {}", state.bans.0.len());
+    println!(
+        "messages               : {}",
+        state.recent_messages.messages.len()
+    );
+    println!(
+        "member_info            : {}",
+        state.member_info.member_info.len()
+    );
+    println!(
+        "max_members            : {}",
+        state.configuration.configuration.max_members
+    );
+    println!(
+        "max_user_bans          : {}",
+        state.configuration.configuration.max_user_bans
+    );
+    let mut ser = vec![];
+    ciborium::ser::into_writer(&state, &mut ser)?;
+    println!("serialized bytes       : {}", ser.len());
+
+    // Depth of each member's chain to the owner, and the total number of links
+    // — which IS the Ed25519 verification count MembersV1::verify performed
+    // before this PR (and the count it performs after is simply members.len()).
+    let mut depths: Vec<usize> = Vec::with_capacity(members.len());
+    let mut total_links = 0usize;
+    for m in members {
+        let mut cur = m;
+        let mut seen = std::collections::HashSet::new();
+        let mut d = 0usize;
+        loop {
+            d += 1;
+            if !seen.insert(cur.member.id()) {
+                break; // cycle
+            }
+            if cur.member.invited_by == owner_id {
+                break;
+            }
+            match by_id.get(&cur.member.invited_by) {
+                Some(next) => cur = next,
+                None => break,
+            }
+        }
+        depths.push(d);
+        total_links += d;
+    }
+    depths.sort_unstable();
+
+    let n = depths.len().max(1);
+    println!();
+    println!(
+        "invite depth  max      : {}",
+        depths.last().copied().unwrap_or(0)
+    );
+    println!(
+        "invite depth  mean     : {:.2}",
+        total_links as f64 / n as f64
+    );
+    println!("invite depth  median   : {}", depths[depths.len() / 2]);
+    println!(
+        "invite depth  p90      : {}",
+        depths[(depths.len() * 9) / 10]
+    );
+
+    let mut hist: HashMap<usize, usize> = HashMap::new();
+    for d in &depths {
+        *hist.entry(*d).or_default() += 1;
+    }
+    let mut ks: Vec<_> = hist.keys().copied().collect();
+    ks.sort_unstable();
+    println!(
+        "depth histogram        : {:?}",
+        ks.iter().map(|k| (*k, hist[k])).collect::<Vec<_>>()
+    );
+
+    println!();
+    println!("Ed25519 verifications in MembersV1::verify:");
+    println!("  before this PR (sum of chain lengths): {}", total_links);
+    println!("  after  this PR (one per member)      : {}", members.len());
+    println!(
+        "  saving                               : {:.2}x",
+        total_links as f64 / n as f64
+    );
+    Ok(())
+}

--- a/common/src/room_state.rs
+++ b/common/src/room_state.rs
@@ -12,7 +12,7 @@ pub mod secret;
 pub mod upgrade;
 pub mod version;
 
-use crate::room_state::ban::BansV1;
+use crate::room_state::ban::{BanSignatureCache, BansV1};
 use crate::room_state::configuration::AuthorizedConfigurationV1;
 use crate::room_state::direct_messages::DirectMessagesV1;
 use crate::room_state::member::{MemberId, MembersV1};
@@ -101,6 +101,30 @@ impl ChatRoomStateV1 {
     pub fn post_apply_cleanup(&mut self, parameters: &ChatRoomParametersV1) -> Result<(), String> {
         let owner_id = MemberId::from(&parameters.owner);
 
+        // One Ed25519 verification per (ban, banner key) for the WHOLE cleanup.
+        // Steps 0, 2 and 5 all ask `ban_signature_matches_current_key` about
+        // every stored ban, plus step 0-cap when the set is OVER the cap (a room
+        // sitting exactly AT it skips that pass). Without this each pass re-ran
+        // the verification.
+        //
+        // Measured on the live Freenet Official room's shape (496 members, 200
+        // bans, 2000 messages, 2026-07-29) by counting calls into
+        // `verify_struct`: one `update_state` carrying a single new message did
+        // 800 ban-signature verifications before this change and 400 after —
+        // 338 ms -> 169 ms at 0.4224 ms per verification under wasmtime with
+        // Cranelift at `OptLevel::None`. Real, but NOT the 5s-budget breach in
+        // freenet/river#422; see that PR for what is and is not explained.
+        //
+        // 400 rather than 200 because `MembersV1::apply_delta` runs its own ban
+        // enforcement earlier in the field order, through a separate cache. That
+        // pass cannot share this one without threading a cache through
+        // `ComposableState::apply_delta`, which is a trait-level change.
+        //
+        // Sharing the cache is safe across the member-set mutations these steps
+        // perform because the cache is keyed on the resolved banner KEY, not on
+        // the member set; see [`BanSignatureCache`].
+        let mut ban_sigs = BanSignatureCache::new();
+
         // 0-cap. Enforce `max_user_bans` FIRST — BEFORE ban enforcement (step 0)
         //     and the banner inactivity-prune exemption (step 2) — so both read
         //     the FINAL surviving (post-cap) ban set (#411 round 7 / Codex P1
@@ -158,7 +182,8 @@ impl ChatRoomStateV1 {
             // ban (not O(n log n) times inside a comparator) — #411 round 3 C.
             self.bans.0.sort_by_cached_key(|ban| {
                 (
-                    BansV1::ban_is_enforcing(
+                    BansV1::ban_is_enforcing_cached(
+                        &mut ban_sigs,
                         ban,
                         &members_by_id,
                         &self.member_info,
@@ -195,9 +220,12 @@ impl ChatRoomStateV1 {
         // converges to the same member set regardless of delta order. Kept in
         // post_apply_cleanup (NOT verify) so verify stays stable across
         // ban/deputy changes — mirrors the DM ban-sweep precedent.
-        let enforced_banned_ids =
-            self.members
-                .banned_member_ids(&self.bans, &self.member_info, parameters);
+        let enforced_banned_ids = self.members.banned_member_ids_cached(
+            &mut ban_sigs,
+            &self.bans,
+            &self.member_info,
+            parameters,
+        );
         self.members
             .members
             .retain(|m| !enforced_banned_ids.contains(&m.member.id()));
@@ -296,7 +324,7 @@ impl ChatRoomStateV1 {
             for ban in &self.bans.0 {
                 let banner = ban.banned_by;
                 if banner != owner_id
-                    && BansV1::ban_signature_matches_current_key(
+                    && ban_sigs.ban_signature_matches_current_key(
                         ban,
                         &members_by_id,
                         owner_id,
@@ -393,7 +421,7 @@ impl ChatRoomStateV1 {
         //    rebuilt here because the sweep needs each banner's `member_vk`.
         let members_by_id_for_ban_sweep = self.members.members_by_member_id();
         self.bans.0.retain(|ban| {
-            BansV1::ban_signature_matches_current_key(
+            ban_sigs.ban_signature_matches_current_key(
                 ban,
                 &members_by_id_for_ban_sweep,
                 owner_id,

--- a/common/src/room_state/ban.rs
+++ b/common/src/room_state/ban.rs
@@ -46,6 +46,112 @@ use std::time::SystemTime;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
 pub struct BansV1(pub Vec<AuthorizedUserBan>);
 
+/// Memoizes [`BansV1::ban_signature_matches_current_key`] within one state
+/// operation.
+///
+/// [`crate::room_state::ChatRoomStateV1::post_apply_cleanup`] asks the SAME
+/// question about the SAME ban three times — ban enforcement (step 0), the
+/// banner inactivity-prune exemption (step 2), and the signature sweep (step 5)
+/// — plus a fourth time under `max_user_bans` pressure (step 0-cap). Each ask
+/// used to be an independent Ed25519 verification, so a room sitting at its
+/// configured ban ceiling paid `O(bans)` verifications several times over on
+/// EVERY apply, whether or not the delta touched bans at all.
+///
+/// This is the `update_state`-side half of freenet/river#422. Note it is
+/// `update_state` ONLY: the contract's `update_state` never calls `verify`, so
+/// the ban passes cost nothing on the `validate_state` path (which pays a
+/// separate, single `BansV1::verify` sweep).
+///
+/// Measured on the live Freenet Official room's shape (496 members, 200 bans,
+/// 2000 messages, 2026-07-29) by counting calls into `verify_struct`: one
+/// `update_state` carrying a single new message did 800 ban-signature
+/// verifications before this change and 400 after — 338 ms -> 169 ms at
+/// 0.4224 ms per verification under wasmtime with Cranelift at
+/// `OptLevel::None`. A real 2x, but NOT on its own the 5s-budget breach the
+/// issue reports.
+///
+/// # Why memoizing is exactly equivalent
+///
+/// The cache key is the WHOLE ban together with the verifying key its signature
+/// is checked against. `AuthorizedUserBan::verify_signature` is a pure function
+/// of exactly that pair, so a cache hit answers a byte-for-byte identical
+/// question and the memoized answer is the answer recomputation would give.
+///
+/// This holds even though the member set — and therefore which key a given
+/// banner resolves to — CHANGES between the steps that share a cache
+/// (`post_apply_cleanup` removes members at steps 0 and 3 and rebuilds
+/// `members_by_id` afterwards). A banner that resolves to a different key, or
+/// stops resolving at all, is a different cache key (or an early `false` that
+/// never consults the cache), so a stale key can never be reused. Callers are
+/// free to share one cache across an entire operation.
+///
+/// # Why the key is the whole ban, and NOT its `BanId`
+///
+/// `BanId` is a 64-bit `fast_hash` of the signature, and both the signature and
+/// the ban body are attacker-chosen. Keying on it would let an attacker who
+/// grinds a `BanId` collision (a birthday search over their own candidate bans,
+/// ~2^33 work — not 2^64) pair a genuine ban with a garbage-signature one and
+/// have the garbage ban inherit the genuine one's `true`. That is exactly the
+/// forged-ban enforcement `ban_signature_matches_current_key` exists to stop
+/// (#411 round 4 A), so the memo must not be the thing that reopens it.
+/// `AuthorizedUserBan`'s `Hash` covers only the signature, but its `Eq` is
+/// derived over every field, so lookups compare structurally and a hash
+/// collision costs a bucket probe rather than a wrong answer. The whole struct
+/// is inline data (no heap), so keying on a clone is a flat ~120-byte memcpy
+/// against a ~422 us verification.
+#[derive(Debug, Default)]
+pub struct BanSignatureCache {
+    /// `(ban, banner verifying key bytes) -> signature verifies`.
+    verified: HashMap<(AuthorizedUserBan, [u8; 32]), bool>,
+    verifications: usize,
+}
+
+impl BanSignatureCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// How many Ed25519 verifications this cache has actually performed.
+    ///
+    /// Exposed so the regression tests for freenet/river#422 can assert the
+    /// redundancy is gone DETERMINISTICALLY, rather than by timing (which
+    /// varies with the machine and would be flaky in CI).
+    pub fn verifications_performed(&self) -> usize {
+        self.verifications
+    }
+
+    /// Cached [`BansV1::ban_signature_matches_current_key`]. Identical result;
+    /// the Ed25519 verification runs at most once per `(ban, key)` pair.
+    pub fn ban_signature_matches_current_key(
+        &mut self,
+        ban: &AuthorizedUserBan,
+        members_by_id: &HashMap<MemberId, &AuthorizedMember>,
+        owner_id: MemberId,
+        owner_vk: &VerifyingKey,
+    ) -> bool {
+        let banner = ban.banned_by;
+        let vk = if banner == owner_id {
+            *owner_vk
+        } else if let Some(member) = members_by_id.get(&banner) {
+            member.member.member_vk
+        } else {
+            // Non-member banner: unverifiable here (key unavailable). Treated as
+            // not-matching so callers classify it inert / sweep it. Deliberately
+            // NOT cached — the answer is a property of the member set, not of
+            // the (ban, key) pair, and the member set changes mid-cleanup.
+            return false;
+        };
+        let entry = (ban.clone(), vk.to_bytes());
+        if let Some(hit) = self.verified.get(&entry) {
+            return *hit;
+        }
+        let matches = ban.verify_signature(&vk).is_ok();
+        self.verifications += 1;
+        self.verified.insert(entry, matches);
+        matches
+    }
+}
+
 /// Validation errors that can occur with bans.
 ///
 /// Since #410, ban ENFORCEMENT authority (owner / ancestor / deputy) is no
@@ -219,17 +325,12 @@ impl BansV1 {
         owner_id: MemberId,
         owner_vk: &VerifyingKey,
     ) -> bool {
-        let banner = ban.banned_by;
-        let vk = if banner == owner_id {
-            *owner_vk
-        } else if let Some(member) = members_by_id.get(&banner) {
-            member.member.member_vk
-        } else {
-            // Non-member banner: unverifiable here (key unavailable). Treated as
-            // not-matching so callers classify it inert / sweep it.
-            return false;
-        };
-        ban.verify_signature(&vk).is_ok()
+        BanSignatureCache::new().ban_signature_matches_current_key(
+            ban,
+            members_by_id,
+            owner_id,
+            owner_vk,
+        )
     }
 
     /// Whether `ban` is currently ENFORCING (worth keeping under `max_user_bans`
@@ -254,6 +355,28 @@ impl BansV1 {
         owner_id: MemberId,
         owner_vk: &VerifyingKey,
     ) -> bool {
+        Self::ban_is_enforcing_cached(
+            &mut BanSignatureCache::new(),
+            ban,
+            members_by_id,
+            member_info,
+            owner_id,
+            owner_vk,
+        )
+    }
+
+    /// [`Self::ban_is_enforcing`] against a caller-owned
+    /// [`BanSignatureCache`], so a caller that asks about the same ban more
+    /// than once pays for the Ed25519 verification only the first time. See
+    /// [`BanSignatureCache`] for why sharing the cache is safe.
+    pub fn ban_is_enforcing_cached(
+        cache: &mut BanSignatureCache,
+        ban: &AuthorizedUserBan,
+        members_by_id: &HashMap<MemberId, &AuthorizedMember>,
+        member_info: &MemberInfoV1,
+        owner_id: MemberId,
+        owner_vk: &VerifyingKey,
+    ) -> bool {
         let banner = ban.banned_by;
         // A ban can only enforce while its banner is the owner or a current
         // member (#411 round 3). A non-member banner ID — a stale/pruned deputy,
@@ -265,7 +388,7 @@ impl BansV1 {
         // Re-verify the signature against the banner's CURRENT converged key
         // (#411 round 4 A). Closes the same-delta pruned-deputy-replay bypass:
         // `verify` skipped this at apply time because the banner was absent then.
-        if !Self::ban_signature_matches_current_key(ban, members_by_id, owner_id, owner_vk) {
+        if !cache.ban_signature_matches_current_key(ban, members_by_id, owner_id, owner_vk) {
             return false;
         }
         let target = ban.ban.banned_user;
@@ -446,7 +569,26 @@ pub struct AuthorizedUserBan {
 impl Eq for AuthorizedUserBan {}
 
 impl Hash for AuthorizedUserBan {
+    /// Hashes EVERY field, matching the derived `Eq`.
+    ///
+    /// This used to hash the signature alone. That was consistent with `Eq`
+    /// (equal bans do have equal signatures, so the `Hash`/`Eq` contract held)
+    /// and harmless while nothing hashed a ban. [`BanSignatureCache`] now does,
+    /// which makes bucketing load-bearing: a signature is attacker-supplied and
+    /// replayable across different ban bodies — exactly the #411 round 4 replay
+    /// shape — so an attacker could pile distinct bans into one bucket and turn
+    /// cache lookups linear. Correctness never depended on this (`Eq` compares
+    /// all three fields, so a collision costs a probe, never a wrong answer),
+    /// but hashing the whole struct is free and removes the influence.
+    ///
+    /// Safe to change: no `HashSet`/`HashMap` keyed on `AuthorizedUserBan` is
+    /// ever iterated into state, so bucket order cannot reach the wire and
+    /// cannot affect CRDT convergence.
     fn hash<H: Hasher>(&self, state: &mut H) {
+        self.ban.owner_member_id.hash(state);
+        self.ban.banned_at.hash(state);
+        self.ban.banned_user.hash(state);
+        self.banned_by.hash(state);
         self.signature.to_bytes().hash(state);
     }
 }

--- a/common/src/room_state/member.rs
+++ b/common/src/room_state/member.rs
@@ -1,4 +1,4 @@
-use crate::room_state::ban::BansV1;
+use crate::room_state::ban::{BanSignatureCache, BansV1};
 use crate::room_state::member_info::MemberInfoV1;
 use crate::room_state::ChatRoomParametersV1;
 use crate::util::{sign_struct, truncated_base32, verify_struct};
@@ -54,6 +54,10 @@ impl ComposableState for MembersV1 {
 
         let owner_id = parameters.owner_id();
         let members_by_id = self.members_by_member_id();
+        // Memoized across members so each member's own invite signature is
+        // verified ONCE, instead of once per descendant that walks through it
+        // (freenet/river#422). See [`InviteChainCache`].
+        let mut chains = InviteChainCache::new(parameters, &members_by_id);
 
         for member in &self.members {
             if member.member.id() == owner_id {
@@ -69,7 +73,7 @@ impl ComposableState for MembersV1 {
             }
 
             // Verify the full invite chain with Ed25519 signature checks
-            self.get_invite_chain_with_lookup(member, parameters, &members_by_id)?;
+            chains.validate_chain(member)?;
         }
         Ok(())
     }
@@ -122,8 +126,9 @@ impl ComposableState for MembersV1 {
             }
 
             // Verify that all new members have valid invites
+            let mut chains = InviteChainCache::new(parameters, &combined_members_by_id);
             for member in &delta.added {
-                self.verify_member_invite_with_lookup(member, parameters, &combined_members_by_id)?;
+                Self::verify_member_invite_with_lookup(&mut chains, member, parameters)?;
             }
 
             // Add ALL new members (deduplicated), let remove_excess_members handle trimming.
@@ -167,11 +172,15 @@ impl MembersV1 {
     /// The lookup map should include both existing members AND delta members
     /// when called during apply_delta, so that inviters in the same delta
     /// can be found.
+    ///
+    /// The owner-invited fast path is DELIBERATELY kept distinct from the
+    /// chain walk (and is not memoized): it checks only the signature, where
+    /// the walk additionally rejects self-invitation and cycles. Collapsing the
+    /// two would change which deltas `apply_delta` accepts.
     fn verify_member_invite_with_lookup(
-        &self,
+        chains: &mut InviteChainCache<'_>,
         member: &AuthorizedMember,
         parameters: &ChatRoomParametersV1,
-        members_by_id: &HashMap<MemberId, &AuthorizedMember>,
     ) -> Result<(), String> {
         if member.member.invited_by == parameters.owner_id() {
             // Member was invited by the owner, verify signature against owner's key
@@ -180,9 +189,259 @@ impl MembersV1 {
                 .map_err(|e| format!("Invalid signature for member invited by owner: {}", e))?;
         } else {
             // Member was invited by another member, verify the invite chain
-            self.get_invite_chain_with_lookup(member, parameters, members_by_id)?;
+            chains.validate_chain(member)?;
         }
         Ok(())
+    }
+}
+
+/// Memoizes invite-chain validation within one `verify` / `apply_delta`.
+///
+/// [`MembersV1::get_invite_chain_with_lookup`] walks from a member up to the
+/// room owner, Ed25519-verifying every link on the way. Running that per member
+/// re-verifies each ancestor's invite signature once for every descendant, so
+/// validating a room of `M` members whose invite tree is `D` deep costs
+/// `O(sum of chain lengths)` — up to `O(M^2)` — verifications where `O(M)`
+/// suffices, because a member's own invite signature is the same signature no
+/// matter who walks through it.
+///
+/// This is the `validate_state`-side half of freenet/river#422 (`update_state`
+/// never calls `verify`; it pays this only for the members a delta ADDS).
+///
+/// How much it saves depends entirely on the invite tree, and the honest range
+/// is wide. Measured by counting calls into `verify_struct`, for
+/// `MembersV1::verify`:
+///
+/// * The live Freenet Official room is a near-flat star — owner -> invite bot ->
+///   everyone — with invite depth max 4 and mean 2.02 over 496 members
+///   (2026-07-29, `cli/examples/invite_depth_probe.rs`). 1003 verifications
+///   before, 496 after: **2x**, and only ~7% of that room's whole
+///   `validate_state` because its 2000 messages dominate.
+/// * A synthetic 400-member room at invite depth 50 needs 10,700 before and 900
+///   after (**12x**, 4.52 s -> 0.38 s); at depth 200, 40,700 before
+///   (**45x**, 17.19 s). Those breach the 5s budget — but no room has been
+///   measured with a tree that deep, so treat them as the shape of the curve,
+///   not as a characterisation of any real room.
+///
+/// # Why memoizing is exactly equivalent
+///
+/// "Member `X`'s chain is valid" is a property of `X`, its ancestors, the room
+/// OWNER, and the `members_by_id` the ancestors resolve through. The first
+/// three are fixed for a cache (see "Why the context is bound at
+/// construction"), and the fourth is `X` itself — so a verdict travels between
+/// walks correctly, with ONE exception, handled by the non-canonical-start
+/// bypass in [`Self::validate_chain`]: the start's `MemberId` seeds the cycle
+/// guard, so a walk starting at a non-canonical duplicate can terminate with a
+/// circular-chain error that a memo hit would suppress. Such a start neither
+/// reads nor writes the memo. (An earlier version of this comment claimed "the
+/// starting member of a walk never enters the checks". That was false, and it
+/// is the bug this bypass fixes.)
+///
+/// For every other start, caching the walk's verdict per member and reusing it
+/// for descendants yields the same verdict the full walk would produce. Every
+/// node on a completed walk is recorded with that walk's verdict, which is
+/// sound in both directions:
+///
+/// * `Ok` — every node between the start and the owner had its own signature
+///   verified and a valid chain above it, which is exactly what a walk started
+///   at that node would check.
+/// * `Err` — the failure happened at some node `E` on the path, so every node
+///   BELOW `E` also has an invalid chain, and its walk would fail at `E` with
+///   the very same message (the messages name `E`, not the starting member).
+///
+/// Errors are surfaced by the FIRST failing member in iteration order and the
+/// callers propagate with `?`, so a later member can never observe a memoized
+/// error that a fresh walk would have phrased differently — the operation has
+/// already returned.
+///
+/// # Why the key is the whole member, and NOT its `MemberId`
+///
+/// `MemberId` is a 64-bit `fast_hash` of a verifying key. Keying the memo on it
+/// would let an attacker who grinds a `MemberId` collision between two keypairs
+/// they generated (a birthday search, ~2^33 work — not 2^64) get a SECOND,
+/// forged member entry admitted on the first one's verdict, with its own invite
+/// signature never checked. That would let them forge their position in the
+/// invite tree — claiming to be invited by the owner, or by whoever's subtree
+/// confers ban authority — which is precisely what this check exists to
+/// prevent. Ancestor RESOLUTION is still `MemberId`-keyed via `members_by_id`,
+/// exactly as it was before; this only keeps the memo from being a new way in.
+/// `AuthorizedMember`'s `Hash` covers only `member`, but its `Eq` is derived
+/// over every field, so a hash collision costs a bucket probe rather than a
+/// wrong answer. The struct is inline data (no heap), so keying on a clone is a
+/// flat memcpy — ~272 bytes, since `VerifyingKey` carries a decompressed
+/// 160-byte `EdwardsPoint` alongside the 32 compressed ones — against a
+/// ~422 us verification.
+///
+/// # Why the context is bound at construction
+///
+/// A verdict is only meaningful relative to the room OWNER it was earned under
+/// and the `members_by_id` map its ancestors were resolved through. Both are
+/// therefore taken by [`InviteChainCache::new`] and held for the cache's whole
+/// life, so one instance is structurally incapable of spanning two contexts.
+///
+/// This is not hypothetical tidiness — the type is `pub`, and there are two
+/// distinct ways a shared instance would hand out an unearned `Ok`:
+///
+/// * **Across rooms.** `Ok` means "this chain reaches THE OWNER". A member
+///   validated under owner A would inherit that verdict under owner B, whose
+///   key never signed anything in the chain.
+/// * **Across `verify` and `apply_delta` within one room.** `apply_delta`
+///   deliberately resolves inviters through a map that also contains the
+///   delta's not-yet-verified members, so the same member can earn a WEAKER
+///   `Ok` there than `verify`'s stricter map would grant. Sharing would leak
+///   the weaker verdict into the stronger context.
+///
+/// A stored-owner + `debug_assert` would not catch either: the room contract
+/// ships as a release build, where debug assertions are compiled out. Binding
+/// the borrow is checked by the compiler instead, in every build.
+#[derive(Debug)]
+pub struct InviteChainCache<'a> {
+    /// The owner every `Ok` in `verdicts` was earned against.
+    parameters: &'a ChatRoomParametersV1,
+    /// The map every ancestor in `verdicts` was resolved through.
+    members_by_id: &'a HashMap<MemberId, &'a AuthorizedMember>,
+    verdicts: HashMap<AuthorizedMember, Result<(), String>>,
+    verifications: usize,
+}
+
+impl<'a> InviteChainCache<'a> {
+    /// Binds a cache to one room owner and one member lookup. Every verdict it
+    /// memoizes is earned, and reused, under exactly these.
+    pub fn new(
+        parameters: &'a ChatRoomParametersV1,
+        members_by_id: &'a HashMap<MemberId, &'a AuthorizedMember>,
+    ) -> Self {
+        Self {
+            parameters,
+            members_by_id,
+            verdicts: HashMap::new(),
+            verifications: 0,
+        }
+    }
+
+    /// How many Ed25519 verifications this cache has actually performed.
+    ///
+    /// Exposed so the regression tests for freenet/river#422 can assert the
+    /// `O(members x depth)` blow-up is gone DETERMINISTICALLY, rather than by
+    /// timing (which varies with the machine and would be flaky in CI).
+    pub fn verifications_performed(&self) -> usize {
+        self.verifications
+    }
+
+    /// Memoized equivalent of [`MembersV1::get_invite_chain_with_lookup`]'s
+    /// validation (it discards the assembled chain, which no caller of this
+    /// path uses).
+    pub fn validate_chain(&mut self, member: &AuthorizedMember) -> Result<(), String> {
+        let parameters = self.parameters;
+        let members_by_id = self.members_by_id;
+        let owner_id = parameters.owner_id();
+
+        // The start of a walk is NOT purely an input to its ancestors' checks:
+        // its `MemberId` seeds `visited` below, so the original walk can
+        // terminate with a circular-chain error that exists only because of
+        // where the walk began. The memo is therefore unsound for exactly one
+        // class of start — a NON-CANONICAL duplicate, i.e. an entry whose
+        // `MemberId` resolves through `members_by_id` to a DIFFERENT
+        // `AuthorizedMember`. For such a start a memo hit can short-circuit
+        // above the point where the original re-entered the start's own id and
+        // errored. Every node reached AFTER the start comes out of
+        // `members_by_id` and is canonical by construction, so the start is the
+        // only place this can arise.
+        //
+        // Concretely (freenet/river#422 review): B, invited by A, mints a
+        // second entry for A's key claiming B invited it. Walking B memoizes
+        // `B -> Ok`; the duplicate's walk then hits that memo and returns `Ok`
+        // where the original walked on into A's already-visited id and errored.
+        // Note that moving the memo lookup below the cycle guard does NOT fix
+        // this — the hit lands on B before the walk ever reaches A again.
+        //
+        // Such a start bypasses the memo entirely: it neither reads a verdict
+        // nor writes one, so it runs as the untouched original walk and cannot
+        // leave a start-dependent verdict behind for anyone else. Duplicates
+        // are rare, so this costs one hash lookup per walk and does not affect
+        // the `O(members)` bound in any ordinary state.
+        let start_is_canonical = members_by_id
+            .get(&member.member.id())
+            .is_none_or(|canonical| *canonical == member);
+        // Nodes walked during THIS call, all of which share the walk's verdict.
+        let mut walked: Vec<AuthorizedMember> = Vec::new();
+        // Cycle guard, scoped to this walk exactly as in the uncached version.
+        let mut visited: HashSet<MemberId> = HashSet::new();
+        let mut current = member;
+
+        // A cycle verdict is the ONE outcome that depends on where the walk
+        // STARTED — it names the first node the walk revisits, which is the
+        // point at which this particular walk entered the cycle. Every other
+        // outcome names a specific offending node, or is a plain `Ok`, and is
+        // therefore identical whoever asks. So cycle verdicts are not memoized.
+        // That costs nothing in practice: a cyclic member set is invalid, and
+        // both `MembersV1::verify` and `MembersV1::apply_delta` propagate the
+        // first error with `?`, so at most one such walk ever runs.
+        let mut cyclic = false;
+
+        let verdict = loop {
+            let current_id = current.member.id();
+
+            if start_is_canonical {
+                if let Some(memoized) = self.verdicts.get(current) {
+                    break memoized.clone();
+                }
+            }
+
+            if !visited.insert(current_id) {
+                cyclic = true;
+                break Err(format!(
+                    "Circular invite chain detected for member {:?}",
+                    current_id
+                ));
+            }
+
+            if current.member.invited_by == current_id {
+                break Err(format!(
+                    "Self-invitation detected for member {:?}",
+                    current_id
+                ));
+            }
+
+            walked.push(current.clone());
+
+            if current.member.invited_by == owner_id {
+                self.verifications += 1;
+                break current.verify_signature(&parameters.owner).map_err(|e| {
+                    format!(
+                        "Invalid signature for member {:?} invited by owner: {}",
+                        current_id, e
+                    )
+                });
+            }
+
+            let inviter = match members_by_id.get(&current.member.invited_by) {
+                Some(inviter) => *inviter,
+                None => {
+                    break Err(format!(
+                        "Inviter {:?} not found for member {:?}",
+                        current.member.invited_by, current_id
+                    ))
+                }
+            };
+
+            self.verifications += 1;
+            if let Err(e) = current.verify_signature(&inviter.member.member_vk) {
+                break Err(format!(
+                    "Invalid signature for member {:?}: {}",
+                    current_id, e
+                ));
+            }
+
+            current = inviter;
+        };
+
+        if start_is_canonical && !cyclic {
+            for member in walked {
+                self.verdicts.insert(member, verdict.clone());
+            }
+        }
+        verdict
     }
 }
 
@@ -256,6 +515,25 @@ impl MembersV1 {
         member_info: &MemberInfoV1,
         parameters: &ChatRoomParametersV1,
     ) -> HashSet<MemberId> {
+        self.banned_member_ids_cached(
+            &mut BanSignatureCache::new(),
+            bans_v1,
+            member_info,
+            parameters,
+        )
+    }
+
+    /// [`Self::banned_member_ids`] against a caller-owned
+    /// [`BanSignatureCache`]. `post_apply_cleanup` shares one cache across all
+    /// of its ban passes so each ban's Ed25519 signature is verified once per
+    /// apply instead of once per pass (freenet/river#422).
+    pub fn banned_member_ids_cached(
+        &self,
+        cache: &mut BanSignatureCache,
+        bans_v1: &BansV1,
+        member_info: &MemberInfoV1,
+        parameters: &ChatRoomParametersV1,
+    ) -> HashSet<MemberId> {
         let owner_id = parameters.owner_id();
         let members_by_id = self.members_by_member_id();
         let mut banned_ids = HashSet::new();
@@ -268,7 +546,7 @@ impl MembersV1 {
             // them must be re-checked here — otherwise the retained deputy grant
             // would remove members via a ban forged without the deputy's key. This
             // never rejects a genuine ban (a member's id is the hash of their key).
-            if !BansV1::ban_signature_matches_current_key(
+            if !cache.ban_signature_matches_current_key(
                 ban,
                 &members_by_id,
                 owner_id,

--- a/common/tests/room_scale_bench.rs
+++ b/common/tests/room_scale_bench.rs
@@ -1,0 +1,251 @@
+//! Cost of the room contract's two heavy entry points, as a function of room
+//! shape. This is the harness that produced the numbers in freenet/river#548;
+//! it is committed so they can be re-run and disputed.
+//!
+//! Native numbers are NOT representative — `opt-level = 'z'` penalises
+//! curve25519-dalek far more severely on a native build than in WASM, where
+//! Cranelift re-optimises the module. Run it the way production runs:
+//!
+//! ```text
+//! rustup target add wasm32-wasip1
+//! CARGO_TARGET_WASM32_WASIP1_RUNNER='wasmtime -O opt-level=0' \
+//!   cargo test --release --target wasm32-wasip1 -p river-core \
+//!   --test room_scale_bench -- --nocapture --ignored
+//! ```
+//!
+//! `-O opt-level=0` matches freenet-core, which sets Cranelift to
+//! `OptLevel::None` for untrusted code
+//! (`crates/core/src/wasm_runtime/engine/wasmtime_engine.rs`).
+//!
+//! `#[ignore]`d: it is a measurement, not an assertion, and it is slow. The
+//! assertions that actually guard this behaviour live in
+//! `signature_verification_cost_test.rs` and count verifications rather than
+//! wall-clock time.
+
+use ed25519_dalek::SigningKey;
+use freenet_scaffold::ComposableState;
+use river_core::room_state::ban::{AuthorizedUserBan, BansV1, UserBan};
+use river_core::room_state::configuration::{AuthorizedConfigurationV1, Configuration};
+use river_core::room_state::member::{AuthorizedMember, Member, MemberId, MembersV1};
+use river_core::room_state::member_info::{AuthorizedMemberInfo, MemberInfo, MemberInfoV1};
+use river_core::room_state::message::{
+    AuthorizedMessageV1, MessageV1, MessagesV1, RoomMessageBody,
+};
+use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1};
+use std::time::{Duration, Instant, SystemTime};
+
+fn sk(i: u64) -> SigningKey {
+    let mut b = [0u8; 32];
+    b[0..8].copy_from_slice(&i.to_le_bytes());
+    b[8] = 0x77;
+    SigningKey::from_bytes(&b)
+}
+
+/// Builds a room with `n_members` laid out over an invite tree `depth`
+/// generations deep (generation 0 is invited by the owner), plus `n_messages`
+/// messages and `n_bans` bans issued by member 0 against non-members.
+fn build(
+    n_members: usize,
+    depth: usize,
+    n_messages: usize,
+    n_bans: usize,
+    bans_target_members: bool,
+) -> (ChatRoomStateV1, ChatRoomParametersV1) {
+    let owner_sk = sk(0);
+    let owner_id = MemberId::from(&owner_sk.verifying_key());
+    let params = ChatRoomParametersV1 {
+        owner: owner_sk.verifying_key(),
+    };
+    let keys: Vec<SigningKey> = (1..=(n_members + n_bans) as u64).map(sk).collect();
+    let sks = &keys[..n_members];
+    let ids: Vec<MemberId> = sks
+        .iter()
+        .map(|k| MemberId::from(&k.verifying_key()))
+        .collect();
+
+    let per_gen = n_members.div_ceil(depth.max(1));
+    let members: Vec<AuthorizedMember> = (0..n_members)
+        .map(|i| {
+            let gen = i / per_gen;
+            let (inviter_id, inviter_sk) = if gen == 0 {
+                (owner_id, &owner_sk)
+            } else {
+                let p = ((gen - 1) * per_gen + (i % per_gen)).min(gen * per_gen - 1);
+                (ids[p], &sks[p])
+            };
+            AuthorizedMember::new(
+                Member {
+                    owner_member_id: owner_id,
+                    invited_by: inviter_id,
+                    member_vk: sks[i].verifying_key(),
+                },
+                inviter_sk,
+            )
+        })
+        .collect();
+
+    let member_info: Vec<AuthorizedMemberInfo> = (0..n_members)
+        .map(|i| {
+            AuthorizedMemberInfo::new_with_member_key(
+                MemberInfo::new_public(ids[i], 1, format!("m{i}")),
+                &sks[i],
+            )
+        })
+        .collect();
+
+    let base = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+    let text = "x".repeat(120);
+    let messages: Vec<AuthorizedMessageV1> = (0..n_messages)
+        .map(|i| {
+            let a = i % n_members.max(1);
+            AuthorizedMessageV1::new(
+                MessageV1 {
+                    room_owner: owner_id,
+                    author: ids[a],
+                    time: base + Duration::from_secs(i as u64),
+                    content: RoomMessageBody::public(text.clone()),
+                },
+                &sks[a],
+            )
+        })
+        .collect();
+
+    let bans: Vec<AuthorizedUserBan> = (0..n_bans)
+        .map(|i| {
+            // Targeting a real member exercises `get_downstream_members`,
+            // which linear-scans the whole member vec per node of the target's
+            // subtree. Targeting a non-member (the default, and what a
+            // moderated room accumulates) returns immediately.
+            let victim = if bans_target_members {
+                ids[(i + 1) % n_members.max(1)]
+            } else {
+                MemberId::from(&keys[n_members + i].verifying_key())
+            };
+            AuthorizedUserBan::new(
+                UserBan {
+                    owner_member_id: owner_id,
+                    banned_at: base + Duration::from_secs(i as u64),
+                    banned_user: victim,
+                },
+                ids[0],
+                &sks[0],
+            )
+        })
+        .collect();
+
+    let mut state = ChatRoomStateV1 {
+        configuration: AuthorizedConfigurationV1::new(
+            Configuration {
+                owner_member_id: owner_id,
+                max_members: n_members.max(1),
+                max_recent_messages: n_messages.max(1),
+                max_user_bans: n_bans.max(1),
+                ..Default::default()
+            },
+            &owner_sk,
+        ),
+        bans: BansV1(bans),
+        members: MembersV1 { members },
+        member_info: MemberInfoV1 { member_info },
+        recent_messages: MessagesV1 {
+            messages,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    state.recent_messages.rebuild_actions_state();
+    state.members.members.sort_by_key(|m| m.member.id());
+    state
+        .member_info
+        .member_info
+        .sort_by_key(|i| i.member_info.member_id);
+    state.bans.0.sort_by(|a, b| {
+        a.ban
+            .banned_at
+            .cmp(&b.ban.banned_at)
+            .then_with(|| a.id().cmp(&b.id()))
+    });
+    (state, params)
+}
+
+fn best<T>(mut f: impl FnMut() -> T) -> f64 {
+    let mut best = f64::MAX;
+    for _ in 0..5 {
+        let t = Instant::now();
+        let out = f();
+        std::hint::black_box(out);
+        best = best.min(t.elapsed().as_secs_f64() * 1e3);
+    }
+    best
+}
+
+#[test]
+#[ignore = "measurement, not an assertion; run explicitly under wasmtime"]
+fn room_scale() {
+    // Warm the JIT.
+    {
+        let (s, p) = build(20, 2, 10, 2, false);
+        for _ in 0..3 {
+            s.verify(&s, &p).unwrap();
+        }
+    }
+
+    println!(
+        "\n{:>26} {:>8} {:>6} {:>6} {:>5} {:>9} | {:>13} {:>13}",
+        "shape", "members", "depth", "msgs", "bans", "bytes", "validate(ms)", "1msg upd(ms)"
+    );
+
+    // The first row is the LIVE Freenet Official room, measured 2026-07-29 with
+    // `cli/examples/invite_depth_probe.rs`: 496 members, invite depth max 4 /
+    // mean 2.02, 2000 messages, 200 bans, 497 member_info, 1.44 MB. The rest
+    // sweep depth to show the shape of the curve this PR flattens; they are
+    // SYNTHETIC and no measured room looks like the deep ones.
+    for &(label, m, d, msg, b, tgt) in &[
+        (
+            "official room (measured)",
+            496usize,
+            2usize,
+            2000usize,
+            200usize,
+            false,
+        ),
+        ("official, no bans", 496, 2, 2000, 0, false),
+        ("official, no messages", 496, 2, 0, 200, false),
+        ("official, bans hit members", 496, 2, 2000, 200, true),
+        ("synthetic depth 10", 400, 10, 100, 0, false),
+        ("synthetic depth 50", 400, 50, 100, 0, false),
+        ("synthetic depth 200", 400, 200, 100, 0, false),
+    ] {
+        let (state, params) = build(m, d, msg, b, tgt);
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(&state, &mut bytes).unwrap();
+
+        let t_validate = best(|| state.verify(&state, &params).unwrap());
+
+        let summary = state.summarize(&state, &params);
+        let mut modified = state.clone();
+        modified
+            .recent_messages
+            .messages
+            .push(AuthorizedMessageV1::new(
+                MessageV1 {
+                    room_owner: params.owner_id(),
+                    author: state.members.members[0].member.id(),
+                    time: SystemTime::UNIX_EPOCH + Duration::from_secs(1_900_000_000),
+                    content: RoomMessageBody::public("hi".into()),
+                },
+                &sk(1),
+            ));
+        let delta = modified.delta(&state, &params, &summary);
+        let t_update = best(|| {
+            let mut target = state.clone();
+            let parent = target.clone();
+            let _ = target.apply_delta(&parent, &params, &delta);
+        });
+
+        println!(
+            "{label:>26} {m:>8} {d:>6} {msg:>6} {b:>5} {:>9} | {t_validate:>13.1} {t_update:>13.1}",
+            bytes.len()
+        );
+    }
+}

--- a/common/tests/signature_verification_cost_test.rs
+++ b/common/tests/signature_verification_cost_test.rs
@@ -1,0 +1,1303 @@
+//! Regression tests for freenet/river#422 — the room contract must not
+//! re-verify the same Ed25519 signature over and over.
+//!
+//! # What went wrong
+//!
+//! Production forensics on the nova gateway (freenet/freenet-core#4861) found a
+//! room-shaped contract whose EVERY `update_state` merge exceeded
+//! freenet-core's 5 s WASM execution budget, so the room stopped converging
+//! network-wide while burning 14-29 % of a CPU core on every peer hosting it.
+//!
+//! Profiling the room contract under wasmtime — with Cranelift at
+//! `OptLevel::None`, the setting freenet-core runs contracts under — found two
+//! independent multipliers, on top of a 1.6x constant factor from the build
+//! profile (see the `curve25519-dalek` opt-level exception in the workspace
+//! `Cargo.toml`):
+//!
+//! 1. **Ban signatures, re-verified once per pass.** `post_apply_cleanup` asks
+//!    `ban_signature_matches_current_key` about every stored ban at step 0-cap,
+//!    step 0, step 2 and step 5, and `MembersV1::apply_delta` asks once more.
+//!    Each ask was an independent verification, so the work was
+//!    `O(passes x bans)` on EVERY apply — whether or not the delta touched bans.
+//!
+//! 2. **Invite chains, re-verified once per descendant.** `MembersV1::verify`
+//!    walked from every member up to the owner, verifying each link, so
+//!    validating `M` members over a tree of depth `D` cost `O(M x D)`
+//!    verifications (up to `O(M^2)`) where `O(M)` suffices — a member's own
+//!    invite signature is the same signature no matter who walks through it.
+//!    This was the load-bearing one. Measured under wasmtime at production
+//!    Cranelift settings, a 234 KB / 400-member room took 4,056 ms to validate
+//!    at invite depth 50 and 16,884 ms at depth 200, against a 5,000 ms budget;
+//!    after the fix both are ~150 ms and the cost no longer depends on depth
+//!    at all.
+//!
+//! # How these tests pin it
+//!
+//! Counting verifications, not wall-clock time: the counts are exact and
+//! machine-independent, where a timing threshold would be flaky in CI (and this
+//! repo treats flaky tests as broken tests). `verifications_performed()` on
+//! each cache is there for exactly this.
+//!
+//! Reverting either memoization makes the corresponding count test fail. The
+//! source pins additionally catch a regression that keeps the caches but stops
+//! ROUTING through them — the shape of the original bug, where the primitive
+//! was fine and the call sites were the problem.
+
+use ed25519_dalek::SigningKey;
+use freenet_scaffold::ComposableState;
+use river_core::room_state::ban::{AuthorizedUserBan, BanSignatureCache, BansV1, UserBan};
+use river_core::room_state::configuration::{AuthorizedConfigurationV1, Configuration};
+use river_core::room_state::member::{
+    AuthorizedMember, InviteChainCache, Member, MemberId, MembersV1,
+};
+use river_core::room_state::member_info::{AuthorizedMemberInfo, MemberInfo, MemberInfoV1};
+use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1};
+use river_core::util::sign_struct;
+use std::collections::HashMap;
+use std::time::{Duration, SystemTime};
+
+fn sk(i: u64) -> SigningKey {
+    let mut b = [0u8; 32];
+    b[0..8].copy_from_slice(&i.to_le_bytes());
+    b[8] = 0xC3;
+    SigningKey::from_bytes(&b)
+}
+
+fn id_of(k: &SigningKey) -> MemberId {
+    MemberId::from(&k.verifying_key())
+}
+
+/// Members laid out as one straight invite chain: member 0 invited by the
+/// owner, member i invited by member i-1. Chain depth == index + 1, so the
+/// uncached walk costs `n * (n + 1) / 2` verifications and the memoized one
+/// costs `n`.
+fn invite_chain(n: usize) -> (Vec<SigningKey>, Vec<AuthorizedMember>, ChatRoomParametersV1) {
+    let owner_sk = sk(0);
+    let owner_id = id_of(&owner_sk);
+    let params = ChatRoomParametersV1 {
+        owner: owner_sk.verifying_key(),
+    };
+
+    let sks: Vec<SigningKey> = (1..=n as u64).map(sk).collect();
+    let mut members = Vec::with_capacity(n);
+    for i in 0..n {
+        let (inviter_id, inviter_sk) = if i == 0 {
+            (owner_id, &owner_sk)
+        } else {
+            (id_of(&sks[i - 1]), &sks[i - 1])
+        };
+        members.push(AuthorizedMember::new(
+            Member {
+                owner_member_id: owner_id,
+                invited_by: inviter_id,
+                member_vk: sks[i].verifying_key(),
+            },
+            inviter_sk,
+        ));
+    }
+    (sks, members, params)
+}
+
+fn lookup(members: &[AuthorizedMember]) -> HashMap<MemberId, &AuthorizedMember> {
+    members.iter().map(|m| (m.member.id(), m)).collect()
+}
+
+// ---------------------------------------------------------------------------
+// 1. InviteChainCache: O(M) not O(M x D), and identical verdicts.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn invite_chain_validation_is_linear_in_members_not_members_times_depth() {
+    const N: usize = 40;
+    let (_sks, members, params) = invite_chain(N);
+    let by_id = lookup(&members);
+
+    let mut cache = InviteChainCache::new(&params, &by_id);
+    for m in &members {
+        cache
+            .validate_chain(m)
+            .expect("a well-formed invite chain must validate");
+    }
+
+    // Exactly one verification per member: each member's own invite signature,
+    // checked once. The pre-#422 walk did 1 + 2 + ... + N = 820 for N = 40.
+    assert_eq!(
+        cache.verifications_performed(),
+        N,
+        "invite-chain validation must verify each member's invite signature \
+         exactly once; anything more is the O(members x depth) blow-up from \
+         freenet/river#422 coming back"
+    );
+}
+
+#[test]
+fn invite_chain_cache_agrees_with_a_fresh_walk_on_every_member() {
+    // The memoized verdict must equal the verdict a walk starting at that
+    // member would produce — including the error text, which names the failing
+    // LINK rather than the starting member.
+    const N: usize = 12;
+    let (_sks, members, params) = invite_chain(N);
+    let by_id = lookup(&members);
+
+    let mut shared = InviteChainCache::new(&params, &by_id);
+    for m in &members {
+        let memoized = shared.validate_chain(m);
+        // A cache used for exactly one member can never take a memo hit, so it
+        // is the uncached reference implementation.
+        let fresh = InviteChainCache::new(&params, &by_id).validate_chain(m);
+        assert_eq!(memoized, fresh, "memoized verdict diverged for {:?}", m);
+    }
+}
+
+#[test]
+fn invite_chain_cache_rejects_the_same_malformed_chains_a_fresh_walk_does() {
+    let owner_sk = sk(0);
+    let owner_id = id_of(&owner_sk);
+    let params = ChatRoomParametersV1 {
+        owner: owner_sk.verifying_key(),
+    };
+    let a_sk = sk(1);
+    let b_sk = sk(2);
+    let c_sk = sk(3);
+    let (a_id, b_id, _c_id) = (id_of(&a_sk), id_of(&b_sk), id_of(&c_sk));
+
+    // `AuthorizedMember::new` asserts the signer IS the claimed inviter, so the
+    // forged cases have to be assembled with an explicit signature.
+    let mk = |member_sk: &SigningKey, invited_by: MemberId, signer: &SigningKey| {
+        let member = Member {
+            owner_member_id: owner_id,
+            invited_by,
+            member_vk: member_sk.verifying_key(),
+        };
+        let signature = sign_struct(&member, signer);
+        AuthorizedMember::with_signature(member, signature)
+    };
+
+    // (a) forged link: A claims the owner invited them, signed by B.
+    let forged = vec![mk(&a_sk, owner_id, &b_sk)];
+    // (b) missing inviter: A says B invited them, B is absent.
+    let orphan = vec![mk(&a_sk, b_id, &b_sk)];
+    // (c) cycle: A <- B, B <- A.
+    let cycle = vec![mk(&a_sk, b_id, &b_sk), mk(&b_sk, a_id, &a_sk)];
+    // (d) self-invitation deeper in the chain: C <- B, B <- B.
+    let self_invite = vec![mk(&c_sk, b_id, &b_sk), mk(&b_sk, b_id, &b_sk)];
+    // (e) good chain, for the Ok side.
+    let good = vec![mk(&a_sk, owner_id, &owner_sk), mk(&b_sk, a_id, &a_sk)];
+
+    for (label, members) in [
+        ("forged", forged),
+        ("orphan", orphan),
+        ("cycle", cycle),
+        ("self_invite", self_invite),
+        ("good", good),
+    ] {
+        let by_id = lookup(&members);
+        let mut shared = InviteChainCache::new(&params, &by_id);
+        for m in &members {
+            let memoized = shared.validate_chain(m);
+            let fresh = InviteChainCache::new(&params, &by_id).validate_chain(m);
+            assert_eq!(
+                memoized, fresh,
+                "{label}: memoized verdict diverged from a fresh walk"
+            );
+        }
+    }
+}
+
+/// `MembersV1::verify` must keep rejecting every malformed member set it
+/// rejected before the memoization landed. This is the accept/reject decision
+/// the whole contract rests on, so it is pinned at the `verify` level too, not
+/// only at the cache level.
+#[test]
+fn members_verify_still_rejects_malformed_sets() {
+    let owner_sk = sk(0);
+    let owner_id = id_of(&owner_sk);
+    let params = ChatRoomParametersV1 {
+        owner: owner_sk.verifying_key(),
+    };
+    let a_sk = sk(1);
+    let b_sk = sk(2);
+    let (a_id, b_id) = (id_of(&a_sk), id_of(&b_sk));
+
+    // `AuthorizedMember::new` asserts the signer IS the claimed inviter, so the
+    // forged case has to be assembled with an explicit signature.
+    let mk = |member_sk: &SigningKey, invited_by: MemberId, signer: &SigningKey| {
+        let member = Member {
+            owner_member_id: owner_id,
+            invited_by,
+            member_vk: member_sk.verifying_key(),
+        };
+        let signature = sign_struct(&member, signer);
+        AuthorizedMember::with_signature(member, signature)
+    };
+
+    let parent = |members: Vec<AuthorizedMember>| ChatRoomStateV1 {
+        configuration: AuthorizedConfigurationV1::new(
+            Configuration {
+                owner_member_id: owner_id,
+                max_members: 100,
+                ..Default::default()
+            },
+            &owner_sk,
+        ),
+        members: MembersV1 { members },
+        ..Default::default()
+    };
+
+    // Valid two-link chain verifies.
+    let ok = parent(vec![mk(&a_sk, owner_id, &owner_sk), mk(&b_sk, a_id, &a_sk)]);
+    assert!(
+        ok.members.verify(&ok, &params).is_ok(),
+        "a valid invite chain must verify: {:?}",
+        ok.members.verify(&ok, &params)
+    );
+
+    // Forged signature on the deeper link.
+    let forged = parent(vec![
+        mk(&a_sk, owner_id, &owner_sk),
+        mk(&b_sk, a_id, &owner_sk), // signed by owner, but claims A invited them
+    ]);
+    assert!(
+        forged.members.verify(&forged, &params).is_err(),
+        "a member whose invite signature does not match its claimed inviter \
+         must be rejected"
+    );
+
+    // Inviter absent from the member set.
+    let orphan = parent(vec![mk(&b_sk, a_id, &a_sk)]);
+    assert!(
+        orphan.members.verify(&orphan, &params).is_err(),
+        "a member whose inviter is absent must be rejected"
+    );
+
+    // Cycle with no path to the owner.
+    let cycle = parent(vec![mk(&a_sk, b_id, &b_sk), mk(&b_sk, a_id, &a_sk)]);
+    assert!(
+        cycle.members.verify(&cycle, &params).is_err(),
+        "a circular invite chain must be rejected"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. BanSignatureCache: one verification per (ban, key), and identical answers.
+// ---------------------------------------------------------------------------
+
+fn ban_by(
+    banner_id: MemberId,
+    banner_sk: &SigningKey,
+    owner_id: MemberId,
+    i: u64,
+) -> AuthorizedUserBan {
+    AuthorizedUserBan::new(
+        UserBan {
+            owner_member_id: owner_id,
+            banned_at: SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000 + i),
+            banned_user: id_of(&sk(900_000 + i)),
+        },
+        banner_id,
+        banner_sk,
+    )
+}
+
+#[test]
+fn repeated_ban_signature_questions_cost_one_verification() {
+    let owner_sk = sk(0);
+    let owner_id = id_of(&owner_sk);
+    let owner_vk = owner_sk.verifying_key();
+    let members: Vec<AuthorizedMember> = vec![];
+    let by_id = lookup(&members);
+
+    let bans: Vec<AuthorizedUserBan> = (0..25)
+        .map(|i| ban_by(owner_id, &owner_sk, owner_id, i))
+        .collect();
+
+    let mut cache = BanSignatureCache::new();
+    // Ask four times over, exactly as post_apply_cleanup's four passes do.
+    for _pass in 0..4 {
+        for ban in &bans {
+            assert!(cache.ban_signature_matches_current_key(ban, &by_id, owner_id, &owner_vk));
+        }
+    }
+
+    assert_eq!(
+        cache.verifications_performed(),
+        bans.len(),
+        "four passes over {} bans must cost {} verifications, not {}; the \
+         per-pass re-verification is what put update_state over freenet-core's \
+         5s budget in freenet/river#422",
+        bans.len(),
+        bans.len(),
+        bans.len() * 4
+    );
+}
+
+#[test]
+fn ban_signature_cache_agrees_with_the_uncached_check() {
+    let owner_sk = sk(0);
+    let owner_id = id_of(&owner_sk);
+    let owner_vk = owner_sk.verifying_key();
+
+    let m_sk = sk(1);
+    let m_id = id_of(&m_sk);
+    let member = AuthorizedMember::new(
+        Member {
+            owner_member_id: owner_id,
+            invited_by: owner_id,
+            member_vk: m_sk.verifying_key(),
+        },
+        &owner_sk,
+    );
+    let members = vec![member];
+    let by_id = lookup(&members);
+    let empty: HashMap<MemberId, &AuthorizedMember> = HashMap::new();
+
+    // Genuine owner ban, genuine member ban, and a ban whose signature is
+    // attributed to the member but was actually produced by the owner's key.
+    let owner_ban = ban_by(owner_id, &owner_sk, owner_id, 1);
+    let member_ban = ban_by(m_id, &m_sk, owner_id, 2);
+    let forged = AuthorizedUserBan::with_signature(
+        member_ban.ban.clone(),
+        m_id,
+        ban_by(owner_id, &owner_sk, owner_id, 2).signature,
+    );
+
+    for (label, ban, map) in [
+        ("owner ban / members present", &owner_ban, &by_id),
+        ("member ban / members present", &member_ban, &by_id),
+        ("forged member ban", &forged, &by_id),
+        // Banner absent: unverifiable, must answer false without caching.
+        ("member ban / banner absent", &member_ban, &empty),
+    ] {
+        let mut cache = BanSignatureCache::new();
+        let cached = cache.ban_signature_matches_current_key(ban, map, owner_id, &owner_vk);
+        let uncached = BansV1::ban_signature_matches_current_key(ban, map, owner_id, &owner_vk);
+        assert_eq!(cached, uncached, "{label}: cached answer diverged");
+        // Asking again must not change the answer.
+        let again = cache.ban_signature_matches_current_key(ban, map, owner_id, &owner_vk);
+        assert_eq!(again, uncached, "{label}: second ask diverged");
+    }
+}
+
+/// The member set — and therefore which key a banner resolves to — CHANGES
+/// between `post_apply_cleanup`'s passes. A cache shared across those passes
+/// must never answer for a key the caller is no longer asking about.
+#[test]
+fn ban_signature_cache_is_keyed_on_the_resolved_key_not_just_the_ban() {
+    let owner_sk = sk(0);
+    let owner_id = id_of(&owner_sk);
+    let owner_vk = owner_sk.verifying_key();
+
+    // A member whose id is claimed as the banner, and an impostor entry that
+    // occupies the same slot in a DIFFERENT member map with a different key.
+    let real_sk = sk(1);
+    let real_id = id_of(&real_sk);
+    let real = AuthorizedMember::new(
+        Member {
+            owner_member_id: owner_id,
+            invited_by: owner_id,
+            member_vk: real_sk.verifying_key(),
+        },
+        &owner_sk,
+    );
+    let other_sk = sk(2);
+    let other = AuthorizedMember::new(
+        Member {
+            owner_member_id: owner_id,
+            invited_by: owner_id,
+            member_vk: other_sk.verifying_key(),
+        },
+        &owner_sk,
+    );
+
+    let ban = ban_by(real_id, &real_sk, owner_id, 7);
+
+    let with_real: HashMap<MemberId, &AuthorizedMember> = [(real_id, &real)].into_iter().collect();
+    // Same banner id, different verifying key behind it.
+    let with_other: HashMap<MemberId, &AuthorizedMember> =
+        [(real_id, &other)].into_iter().collect();
+
+    let mut cache = BanSignatureCache::new();
+    assert!(
+        cache.ban_signature_matches_current_key(&ban, &with_real, owner_id, &owner_vk),
+        "the ban is genuinely signed by the real key"
+    );
+    assert!(
+        !cache.ban_signature_matches_current_key(&ban, &with_other, owner_id, &owner_vk),
+        "asking about a DIFFERENT key must re-verify and answer false, not \
+         return the cached answer for the previous key"
+    );
+    assert_eq!(
+        cache.verifications_performed(),
+        2,
+        "two distinct (ban, key) questions are two verifications"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Whole-state pin: cleanup cost must not scale with (bans x passes).
+// ---------------------------------------------------------------------------
+
+fn official_room_shape(n_members: usize, n_bans: usize) -> (ChatRoomStateV1, ChatRoomParametersV1) {
+    // Owner -> "invite bot" (member 0) -> everyone else, which is how the live
+    // Freenet Official room is shaped.
+    let owner_sk = sk(0);
+    let owner_id = id_of(&owner_sk);
+    let params = ChatRoomParametersV1 {
+        owner: owner_sk.verifying_key(),
+    };
+    let sks: Vec<SigningKey> = (1..=n_members as u64).map(sk).collect();
+    let ids: Vec<MemberId> = sks.iter().map(id_of).collect();
+
+    let members: Vec<AuthorizedMember> = (0..n_members)
+        .map(|i| {
+            let (inviter_id, inviter_sk) = if i == 0 {
+                (owner_id, &owner_sk)
+            } else {
+                (ids[0], &sks[0])
+            };
+            AuthorizedMember::new(
+                Member {
+                    owner_member_id: owner_id,
+                    invited_by: inviter_id,
+                    member_vk: sks[i].verifying_key(),
+                },
+                inviter_sk,
+            )
+        })
+        .collect();
+
+    let member_info: Vec<AuthorizedMemberInfo> = (0..n_members)
+        .map(|i| {
+            AuthorizedMemberInfo::new_with_member_key(
+                MemberInfo::new_public(ids[i], 1, format!("m{i}")),
+                &sks[i],
+            )
+        })
+        .collect();
+
+    // Bans issued by the invite bot against users who are no longer members —
+    // what a moderated room accumulates.
+    let bans: Vec<AuthorizedUserBan> = (0..n_bans as u64)
+        .map(|i| ban_by(ids[0], &sks[0], owner_id, i))
+        .collect();
+
+    let mut state = ChatRoomStateV1 {
+        configuration: AuthorizedConfigurationV1::new(
+            Configuration {
+                owner_member_id: owner_id,
+                max_members: 400,
+                max_user_bans: n_bans.max(1),
+                ..Default::default()
+            },
+            &owner_sk,
+        ),
+        bans: BansV1(bans),
+        members: MembersV1 { members },
+        member_info: MemberInfoV1 { member_info },
+        ..Default::default()
+    };
+    state.members.members.sort_by_key(|m| m.member.id());
+    state
+        .member_info
+        .member_info
+        .sort_by_key(|i| i.member_info.member_id);
+    (state, params)
+}
+
+/// `post_apply_cleanup` must stay idempotent and ban-preserving at the live
+/// room's scale. Cheap correctness backstop for the memoization: if the shared
+/// cache ever answered a stale question, bans or members would be swept.
+#[test]
+fn cleanup_at_official_room_scale_is_stable_and_idempotent() {
+    let (state, params) = official_room_shape(60, 40);
+
+    let mut once = state.clone();
+    once.post_apply_cleanup(&params).unwrap();
+    let mut twice = once.clone();
+    twice.post_apply_cleanup(&params).unwrap();
+
+    assert_eq!(
+        once, twice,
+        "post_apply_cleanup must stay idempotent with the shared ban-signature \
+         cache in place"
+    );
+    assert_eq!(
+        once.bans.0.len(),
+        40,
+        "every genuinely-signed ban by a current member must survive cleanup"
+    );
+    assert!(
+        once.members
+            .members
+            .iter()
+            .any(|m| m.member.id() == once.bans.0[0].banned_by),
+        "the banner must survive inactivity-prune via the step-2 exemption"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Source pins — the caches must actually be USED.
+// ---------------------------------------------------------------------------
+//
+// The count tests above prove the caches memoize. They cannot see a regression
+// that keeps the caches but reverts a CALL SITE to the uncached helper, which
+// is exactly the shape of the original bug: the primitives were correct and the
+// call sites did the redundant work. These pins read the real source.
+
+/// Whitespace-insensitive substring search, so `cargo fmt` re-wrapping a call
+/// cannot silently disarm a pin.
+fn squeeze(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Production source only: everything before the file's `mod tests`. Cutting at
+/// `#[cfg(test)]` instead would stop at the first cfg-gated item and leave most
+/// of the file unscanned.
+fn production_source(src: &str) -> String {
+    let cut = src
+        .find("\nmod tests")
+        .or_else(|| src.find("\n#[cfg(test)]\nmod tests"))
+        .unwrap_or(src.len());
+    squeeze(&src[..cut])
+}
+
+#[test]
+fn post_apply_cleanup_routes_every_ban_check_through_the_shared_cache() {
+    let src = production_source(include_str!("../src/room_state.rs"));
+
+    assert!(
+        src.contains("let mut ban_sigs = BanSignatureCache::new();"),
+        "post_apply_cleanup must build ONE BanSignatureCache for the whole \
+         cleanup (freenet/river#422)"
+    );
+
+    // Every ban-signature question in the cleanup must go through it.
+    for uncached in [
+        "BansV1::ban_signature_matches_current_key(",
+        "BansV1::ban_is_enforcing(",
+        ".banned_member_ids(",
+    ] {
+        assert!(
+            !src.contains(uncached),
+            "room_state.rs still calls the UNCACHED `{uncached}`. Each such \
+             call re-verifies every stored ban's Ed25519 signature; four such \
+             passes at the Freenet Official room's 200 bans is what pushed \
+             update_state past freenet-core's 5s budget (freenet/river#422). \
+             Use the `ban_sigs` cache instead."
+        );
+    }
+
+    for cached in [
+        "BansV1::ban_is_enforcing_cached( &mut ban_sigs,",
+        ".banned_member_ids_cached( &mut ban_sigs,",
+        "ban_sigs.ban_signature_matches_current_key(",
+    ] {
+        assert!(
+            src.contains(cached),
+            "expected post_apply_cleanup to use `{cached}`"
+        );
+    }
+}
+
+#[test]
+fn members_verify_and_apply_delta_memoize_invite_chains() {
+    let src = production_source(include_str!("../src/room_state/member.rs"));
+
+    assert_eq!(
+        src.matches("let mut chains = InviteChainCache::new(")
+            .count(),
+        2,
+        "MembersV1::verify and MembersV1::apply_delta must EACH build their own \
+         InviteChainCache, so a member's invite signature is verified once \
+         rather than once per descendant (freenet/river#422) — and so neither \
+         inherits the other's verdicts"
+    );
+    // Both contexts must BIND the cache: an unbound cache could be shared
+    // across rooms (inheriting an `Ok` earned under a different owner) or
+    // across verify/apply_delta (leaking apply_delta's weaker verdict, which is
+    // granted against a map that includes not-yet-verified delta members).
+    // Whitespace-insensitive and argument-NAME-insensitive: a pin that spells
+    // out locals fails open the moment someone renames one. What must hold is
+    // that each construction passes two arguments (the binding) rather than
+    // none, and that the walk still consults the cache.
+    assert_eq!(
+        src.matches("InviteChainCache::new()").count(),
+        0,
+        "an UNBOUND InviteChainCache could be shared across rooms, or across \
+         verify and apply_delta whose lookups differ, and hand out an `Ok` \
+         earned elsewhere (freenet/river#422)"
+    );
+    assert!(
+        src.contains("chains.validate_chain(member)?;"),
+        "both call sites must validate through the cache"
+    );
+    assert!(
+        !src.contains("self.get_invite_chain_with_lookup(member, parameters, &members_by_id)?;"),
+        "MembersV1::verify must not fall back to the unmemoized full-chain \
+         walk — that is the O(members x depth) blow-up from freenet/river#422"
+    );
+}
+
+#[test]
+fn crypto_is_exempt_from_the_size_optimized_profile() {
+    // `opt-level = 'z'` leaves curve25519-dalek's field arithmetic un-inlined,
+    // costing 1.6x on every Ed25519 verification the contract does (0.4224 ms
+    // vs 0.2622 ms, wasm32 under wasmtime at freenet-core's `OptLevel::None`).
+    // Losing this exception is a silent performance regression with no source
+    // change anywhere, so it is pinned here.
+    let manifest = squeeze(include_str!("../../Cargo.toml"));
+    assert!(
+        manifest.contains("[profile.release.package.curve25519-dalek] opt-level = 3"),
+        "the workspace Cargo.toml must keep curve25519-dalek at opt-level 3; \
+         under the workspace-wide `opt-level = 'z'` every Ed25519 verification \
+         in the room contract costs 1.6x more (freenet/river#422)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Memo keys must be the OBJECTS, not their 64-bit ids.
+// ---------------------------------------------------------------------------
+//
+// `BanId` is `fast_hash(signature)` and `MemberId` is `fast_hash(verifying
+// key)` — both 64-bit hashes of attacker-chosen bytes. Keying either memo on
+// the id would let a colliding forgery inherit a genuine object's "signature
+// verified" verdict and skip its own check. An attacker does not need a 2^64
+// second preimage for that, only a ~2^33 birthday search over candidates they
+// generate themselves.
+//
+// These tests do not grind anything: the collisions are constructed exactly,
+// because two bans that share a signature necessarily share a `BanId`, and two
+// members that share a verifying key necessarily share a `MemberId`.
+
+#[test]
+fn a_ban_id_collision_cannot_inherit_a_genuine_bans_verified_verdict() {
+    let owner_sk = sk(0);
+    let owner_id = id_of(&owner_sk);
+    let owner_vk = owner_sk.verifying_key();
+
+    let m_sk = sk(1);
+    let m_id = id_of(&m_sk);
+    let member = AuthorizedMember::new(
+        Member {
+            owner_member_id: owner_id,
+            invited_by: owner_id,
+            member_vk: m_sk.verifying_key(),
+        },
+        &owner_sk,
+    );
+    let members = vec![member];
+    let by_id = lookup(&members);
+
+    // Genuine ban by the member.
+    let genuine = ban_by(m_id, &m_sk, owner_id, 1);
+
+    // A DIFFERENT ban body carrying the genuine ban's signature. Its `BanId` is
+    // `fast_hash(signature)`, so it collides with `genuine` exactly — no
+    // grinding required — while its signature does not cover this body.
+    let forged = AuthorizedUserBan::with_signature(
+        UserBan {
+            owner_member_id: owner_id,
+            banned_at: SystemTime::UNIX_EPOCH + Duration::from_secs(1_900_000_000),
+            banned_user: id_of(&sk(4242)),
+        },
+        m_id,
+        genuine.signature,
+    );
+    assert_eq!(
+        genuine.id(),
+        forged.id(),
+        "test setup: the two bans must share a BanId"
+    );
+    assert_ne!(genuine.ban, forged.ban, "test setup: bodies must differ");
+
+    let mut cache = BanSignatureCache::new();
+    assert!(
+        cache.ban_signature_matches_current_key(&genuine, &by_id, owner_id, &owner_vk),
+        "the genuine ban verifies"
+    );
+    assert!(
+        !cache.ban_signature_matches_current_key(&forged, &by_id, owner_id, &owner_vk),
+        "a ban that merely SHARES a BanId with a verified ban must be checked \
+         on its own merits and rejected. Keying the memo on BanId instead of \
+         the ban itself would hand it an enforceable forged ban and reopen the \
+         forged-ban enforcement hole from freenet/river#411 round 4 A."
+    );
+    // And it must agree with the uncached reference.
+    assert!(!BansV1::ban_signature_matches_current_key(
+        &forged, &by_id, owner_id, &owner_vk
+    ));
+}
+
+#[test]
+fn a_member_id_collision_cannot_inherit_a_genuine_members_chain_verdict() {
+    let owner_sk = sk(0);
+    let owner_id = id_of(&owner_sk);
+    let params = ChatRoomParametersV1 {
+        owner: owner_sk.verifying_key(),
+    };
+
+    // A privileged member whose subtree an attacker would like to join.
+    let mod_sk = sk(1);
+    let mod_id = id_of(&mod_sk);
+    let moderator = AuthorizedMember::new(
+        Member {
+            owner_member_id: owner_id,
+            invited_by: owner_id,
+            member_vk: mod_sk.verifying_key(),
+        },
+        &owner_sk,
+    );
+
+    // The attacker's genuine, owner-invited entry.
+    let att_sk = sk(2);
+    let genuine = AuthorizedMember::new(
+        Member {
+            owner_member_id: owner_id,
+            invited_by: owner_id,
+            member_vk: att_sk.verifying_key(),
+        },
+        &owner_sk,
+    );
+
+    // A second entry for the SAME verifying key — so necessarily the same
+    // MemberId — claiming a different, unearned inviter, with a signature that
+    // does not authorise it.
+    let forged_member = Member {
+        owner_member_id: owner_id,
+        invited_by: mod_id,
+        member_vk: att_sk.verifying_key(),
+    };
+    let forged = AuthorizedMember::with_signature(
+        forged_member,
+        sign_struct(&genuine.member, &owner_sk), // signature over the OTHER body
+    );
+    assert_eq!(
+        genuine.member.id(),
+        forged.member.id(),
+        "test setup: the two entries must share a MemberId"
+    );
+    assert_ne!(genuine, forged, "test setup: the entries must differ");
+
+    // Genuine first, so a MemberId-keyed memo would already hold its `Ok`.
+    let members = vec![moderator, genuine, forged];
+    let by_id = lookup(&members);
+
+    let mut cache = InviteChainCache::new(&params, &by_id);
+    for m in &members[..2] {
+        cache
+            .validate_chain(m)
+            .expect("the genuine entries validate");
+    }
+    assert!(
+        cache.validate_chain(&members[2]).is_err(),
+        "an entry that merely SHARES a MemberId with a validated member must \
+         have its OWN invite signature checked. Keying the memo on MemberId \
+         instead of the member itself would let an attacker forge their \
+         position in the invite tree (freenet/river#422)."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6. An InviteChainCache verdict is meaningful ONLY in its own context.
+// ---------------------------------------------------------------------------
+//
+// `InviteChainCache::new` takes the room parameters and the member lookup and
+// holds them for the cache's life, so one instance cannot span two contexts —
+// the borrow checker enforces it in every build, where a stored-owner +
+// `debug_assert` would be compiled out of the release WASM the contract ships
+// as. These two tests establish that the binding is load-bearing rather than
+// decorative, by showing the verdict genuinely differs across each context a
+// shared cache could have spanned.
+
+#[test]
+fn a_chain_verdict_is_owner_specific() {
+    // `Ok` means "this chain reaches THE OWNER". Under a different owner the
+    // same member must NOT validate — so a cache shared across two rooms would
+    // hand out an `Ok` no key in the second room ever signed for.
+    let owner_a_sk = sk(0);
+    let owner_a_id = id_of(&owner_a_sk);
+    let params_a = ChatRoomParametersV1 {
+        owner: owner_a_sk.verifying_key(),
+    };
+    let params_b = ChatRoomParametersV1 {
+        owner: sk(99).verifying_key(),
+    };
+
+    let m_sk = sk(1);
+    let member = AuthorizedMember::new(
+        Member {
+            owner_member_id: owner_a_id,
+            invited_by: owner_a_id,
+            member_vk: m_sk.verifying_key(),
+        },
+        &owner_a_sk,
+    );
+    let members = vec![member];
+    let by_id = lookup(&members);
+
+    assert!(
+        InviteChainCache::new(&params_a, &by_id)
+            .validate_chain(&members[0])
+            .is_ok(),
+        "the member's chain reaches owner A"
+    );
+    assert!(
+        InviteChainCache::new(&params_b, &by_id)
+            .validate_chain(&members[0])
+            .is_err(),
+        "the SAME member must not validate under a different owner; a cache \
+         shared across rooms would let this inherit owner A's verdict"
+    );
+}
+
+#[test]
+fn a_chain_verdict_is_specific_to_the_lookup_it_was_earned_against() {
+    // `apply_delta` resolves inviters through a map that also holds the delta's
+    // members, which `verify`'s map does not. A member can therefore earn `Ok`
+    // there that `verify`'s stricter map would refuse, so a cache shared across
+    // the two would leak the weaker verdict into the stronger context.
+    let owner_sk = sk(0);
+    let owner_id = id_of(&owner_sk);
+    let params = ChatRoomParametersV1 {
+        owner: owner_sk.verifying_key(),
+    };
+
+    let a_sk = sk(1);
+    let a_id = id_of(&a_sk);
+    let b_sk = sk(2);
+    let b_id = id_of(&b_sk);
+    let c_sk = sk(3);
+
+    let a = AuthorizedMember::new(
+        Member {
+            owner_member_id: owner_id,
+            invited_by: owner_id,
+            member_vk: a_sk.verifying_key(),
+        },
+        &owner_sk,
+    );
+    // B and C arrive in the delta; C's inviter B is not yet in the state.
+    let b = AuthorizedMember::new(
+        Member {
+            owner_member_id: owner_id,
+            invited_by: a_id,
+            member_vk: b_sk.verifying_key(),
+        },
+        &a_sk,
+    );
+    let c = AuthorizedMember::new(
+        Member {
+            owner_member_id: owner_id,
+            invited_by: b_id,
+            member_vk: c_sk.verifying_key(),
+        },
+        &b_sk,
+    );
+
+    let stored = vec![a.clone()];
+    let combined = vec![a, b, c.clone()];
+
+    let combined_by_id = lookup(&combined);
+    assert!(
+        InviteChainCache::new(&params, &combined_by_id)
+            .validate_chain(&c)
+            .is_ok(),
+        "against apply_delta's combined lookup, C resolves through the delta's B"
+    );
+
+    let stored_by_id = lookup(&stored);
+    assert!(
+        InviteChainCache::new(&params, &stored_by_id)
+            .validate_chain(&c)
+            .is_err(),
+        "against verify's stored-members-only lookup, C's inviter is absent and \
+         C must be refused; a cache shared between apply_delta and verify would \
+         leak the weaker verdict into the stronger context"
+    );
+}
+
+/// `AuthorizedUserBan`'s `Hash` must cover the whole struct, not the signature
+/// alone.
+///
+/// Hashing the signature alone satisfied the `Hash`/`Eq` contract and was
+/// harmless while nothing hashed a ban. `BanSignatureCache` now does, which
+/// makes bucketing load-bearing: a signature is attacker-supplied and
+/// replayable across different ban bodies (the #411 round 4 replay shape), so
+/// signature-only hashing lets an attacker pile distinct bans into one bucket
+/// and turn cache lookups linear. Correctness never depended on it — `Eq`
+/// compares every field — but the influence is free to remove.
+#[test]
+fn ban_hash_covers_the_whole_struct_not_just_the_signature() {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let owner_sk = sk(0);
+    let owner_id = id_of(&owner_sk);
+
+    let genuine = ban_by(owner_id, &owner_sk, owner_id, 1);
+    // Same signature, different body — the replayable shape.
+    let replayed = AuthorizedUserBan::with_signature(
+        UserBan {
+            owner_member_id: owner_id,
+            banned_at: SystemTime::UNIX_EPOCH + Duration::from_secs(1_900_000_000),
+            banned_user: id_of(&sk(4242)),
+        },
+        owner_id,
+        genuine.signature,
+    );
+    assert_ne!(genuine, replayed, "test setup: the bans must differ");
+
+    let hash_of = |b: &AuthorizedUserBan| {
+        let mut h = DefaultHasher::new();
+        b.hash(&mut h);
+        h.finish()
+    };
+    assert_ne!(
+        hash_of(&genuine),
+        hash_of(&replayed),
+        "two bans sharing a signature but differing in body must land in \
+         different buckets; hashing the signature alone lets an attacker choose \
+         BanSignatureCache's bucket distribution"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 7. Differential against the implementation this PR replaced.
+// ---------------------------------------------------------------------------
+//
+// `InviteChainCache::validate_chain` is a hand re-transcription of the loop in
+// `MembersV1::get_invite_chain_with_lookup`, not a wrapper around it. Every
+// other equivalence test in this file compares the new implementation against
+// ITSELF with an empty cache, which cannot see a dropped, reordered or
+// re-scoped check — both sides would be wrong identically.
+//
+// `MembersV1::get_invite_chain` is still live and `pub` and IS the untouched
+// original, so it is the real oracle. This is the test that caught the
+// non-canonical-start divergence; it must keep passing.
+
+/// The oracle: the pre-existing full-chain walk, verdict only.
+fn oracle(
+    members: &[AuthorizedMember],
+    m: &AuthorizedMember,
+    params: &ChatRoomParametersV1,
+) -> Result<(), String> {
+    MembersV1 {
+        members: members.to_vec(),
+    }
+    .get_invite_chain(m, params)
+    .map(|_| ())
+}
+
+fn differential(members: &[AuthorizedMember], params: &ChatRoomParametersV1) {
+    let by_id = lookup(members);
+    // One SHARED cache across all members, which is how `MembersV1::verify`
+    // uses it — a per-member cache would hide every memo-hit divergence.
+    let mut shared = InviteChainCache::new(params, &by_id);
+    for m in members {
+        assert_eq!(
+            shared.validate_chain(m),
+            oracle(members, m, params),
+            "memoized verdict diverged from the original walk for {:?}",
+            m.member.id()
+        );
+    }
+}
+
+#[test]
+fn differential_against_the_original_walk_on_a_straight_chain() {
+    let (_sks, members, params) = invite_chain(8);
+    differential(&members, &params);
+}
+
+/// A member below the impersonated one mints a duplicate entry for that
+/// member's key, claiming the minter as its own inviter. The duplicate's
+/// signature is genuine (it really was signed by the minter), so nothing
+/// rejects it up front — but its chain loops back into itself.
+///
+/// This is the freenet/river#422 review counterexample: walking B memoizes
+/// B -> Ok, so a later walk from the duplicate takes a memo hit at B and
+/// short-circuits, where the original walked on and hit `id_a` already in its
+/// visited set. The memo lookup sits BEFORE the cycle guard, and the guard
+/// never fires because the hit lands on B before the walk reaches A again —
+/// so moving the lookup below the guard does NOT fix this.
+#[test]
+fn differential_when_a_walk_starts_at_a_non_canonical_duplicate() {
+    let owner_sk = sk(0);
+    let owner_id = id_of(&owner_sk);
+    let params = ChatRoomParametersV1 {
+        owner: owner_sk.verifying_key(),
+    };
+
+    let a_sk = sk(1);
+    let a_id = id_of(&a_sk);
+    let b_sk = sk(2);
+    let b_id = id_of(&b_sk);
+
+    // A invited by the owner; B invited by A.
+    let a = AuthorizedMember::new(
+        Member {
+            owner_member_id: owner_id,
+            invited_by: owner_id,
+            member_vk: a_sk.verifying_key(),
+        },
+        &owner_sk,
+    );
+    let b = AuthorizedMember::new(
+        Member {
+            owner_member_id: owner_id,
+            invited_by: a_id,
+            member_vk: b_sk.verifying_key(),
+        },
+        &a_sk,
+    );
+    // B mints a second entry for A's key, claiming B invited A.
+    let a_prime = AuthorizedMember::new(
+        Member {
+            owner_member_id: owner_id,
+            invited_by: b_id,
+            member_vk: a_sk.verifying_key(),
+        },
+        &b_sk,
+    );
+    assert_eq!(
+        a.member.id(),
+        a_prime.member.id(),
+        "test setup: the duplicate must share A's MemberId"
+    );
+    assert_ne!(a, a_prime, "test setup: the entries must differ");
+
+    // Order matters: B is walked first so its Ok is memoized, and A is LAST so
+    // `members_by_member_id`'s last-wins makes A canonical and A' the
+    // non-canonical duplicate.
+    differential(&[b, a_prime, a], &params);
+}
+
+/// Same shape through `MembersV1::verify`, which is the production entry point.
+#[test]
+fn verify_agrees_with_the_original_walk_on_a_non_canonical_duplicate() {
+    let owner_sk = sk(0);
+    let owner_id = id_of(&owner_sk);
+    let params = ChatRoomParametersV1 {
+        owner: owner_sk.verifying_key(),
+    };
+    let a_sk = sk(1);
+    let a_id = id_of(&a_sk);
+    let b_sk = sk(2);
+    let b_id = id_of(&b_sk);
+
+    let mk = |member_sk: &SigningKey, invited_by: MemberId, signer: &SigningKey| {
+        AuthorizedMember::new(
+            Member {
+                owner_member_id: owner_id,
+                invited_by,
+                member_vk: member_sk.verifying_key(),
+            },
+            signer,
+        )
+    };
+    let members = vec![
+        mk(&b_sk, a_id, &a_sk),
+        mk(&a_sk, b_id, &b_sk),
+        mk(&a_sk, owner_id, &owner_sk),
+    ];
+
+    let state = ChatRoomStateV1 {
+        configuration: AuthorizedConfigurationV1::new(
+            Configuration {
+                owner_member_id: owner_id,
+                max_members: 100,
+                ..Default::default()
+            },
+            &owner_sk,
+        ),
+        members: MembersV1 {
+            members: members.clone(),
+        },
+        ..Default::default()
+    };
+
+    // Whatever the right answer is, it must be the one the untouched walk gives.
+    let oracle_verdict: Result<(), String> = members
+        .iter()
+        .try_for_each(|m| oracle(&members, m, &params));
+    assert_eq!(
+        state.members.verify(&state, &params).is_ok(),
+        oracle_verdict.is_ok(),
+        "MembersV1::verify must agree with the original full-chain walk; \
+         a duplicate member entry whose chain loops back through its minter \
+         must not be accepted just because the minter was memoized Ok"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 8. Gaps the independent testing review identified.
+// ---------------------------------------------------------------------------
+
+/// `AuthorizedMember`'s structural `Eq` is what makes the memo key safe, and
+/// nothing else in this file pins it.
+///
+/// The ban side gets this for free: `a_ban_id_collision_...` puts a genuine and
+/// a forged ban in the SAME hash bucket (the old `Hash` covered only the
+/// signature), so it exercised `Eq` too. The member-collision test does not —
+/// its two entries differ in `invited_by`, which `AuthorizedMember`'s `Hash`
+/// covers, so they never collide and `Eq` is never consulted. Weakening `Eq` to
+/// compare only `member` therefore passed the whole suite.
+#[test]
+fn authorized_member_equality_covers_the_signature() {
+    let owner_sk = sk(0);
+    let owner_id = id_of(&owner_sk);
+    let m_sk = sk(1);
+
+    let member = Member {
+        owner_member_id: owner_id,
+        invited_by: owner_id,
+        member_vk: m_sk.verifying_key(),
+    };
+    let genuine = AuthorizedMember::new(member.clone(), &owner_sk);
+    // Identical body, different signature.
+    let garbage = AuthorizedMember::with_signature(member, sign_struct(&genuine.member, &sk(77)));
+
+    assert_ne!(
+        genuine, garbage,
+        "AuthorizedMember equality MUST cover the signature. InviteChainCache \
+         keys its memo on the whole struct precisely so a garbage-signature \
+         entry cannot collide with a validated one; if `Eq` ignored the \
+         signature, that entry would inherit the genuine verdict with its own \
+         signature never checked (freenet/river#422)."
+    );
+}
+
+/// The `Err` memo path is never exercised by the other fixtures — they are
+/// straight chains or 1-3 members, so no second walk takes a memo hit on a
+/// failed verdict. The doc on `InviteChainCache` spends a bullet justifying
+/// Err-memoization soundness; this is the fan-out shape that uses it.
+#[test]
+fn an_err_verdict_is_reused_correctly_by_siblings_of_a_broken_ancestor() {
+    let owner_sk = sk(0);
+    let owner_id = id_of(&owner_sk);
+    let params = ChatRoomParametersV1 {
+        owner: owner_sk.verifying_key(),
+    };
+
+    let e_sk = sk(1);
+    let e_id = id_of(&e_sk);
+    let x_sk = sk(2);
+    let y_sk = sk(3);
+
+    // E claims the owner invited it, but the signature is by the wrong key.
+    let e_member = Member {
+        owner_member_id: owner_id,
+        invited_by: owner_id,
+        member_vk: e_sk.verifying_key(),
+    };
+    let e = AuthorizedMember::with_signature(e_member, sign_struct(e_sk.verifying_key(), &sk(88)));
+    // X and Y are both genuinely invited by E, so both chains run through it.
+    let mk_child = |child: &SigningKey| {
+        AuthorizedMember::new(
+            Member {
+                owner_member_id: owner_id,
+                invited_by: e_id,
+                member_vk: child.verifying_key(),
+            },
+            &e_sk,
+        )
+    };
+    let members = vec![e, mk_child(&x_sk), mk_child(&y_sk)];
+    let by_id = lookup(&members);
+
+    // Both siblings must fail, and identically — the second takes an Err memo
+    // hit at E. And both must match the untouched original walk.
+    let mut shared = InviteChainCache::new(&params, &by_id);
+    let first = shared.validate_chain(&members[1]);
+    let second = shared.validate_chain(&members[2]);
+    assert!(
+        first.is_err() && second.is_err(),
+        "both chains run through a broken ancestor"
+    );
+    for m in &members {
+        assert_eq!(
+            InviteChainCache::new(&params, &by_id).validate_chain(m),
+            oracle(&members, m, &params),
+            "Err-memo reuse must match the original walk for {:?}",
+            m.member.id()
+        );
+    }
+    differential(&members, &params);
+}
+
+/// The whole safety argument for sharing ONE `BanSignatureCache` across
+/// `post_apply_cleanup`'s passes is that it survives the member-set mutations
+/// those passes perform. `cleanup_at_official_room_scale_...` uses a fixture
+/// where nothing is removed, so the cache never actually spans a mutation.
+///
+/// Here the banner IS pruned partway through cleanup, so the step-5 sweep asks
+/// about a ban whose banner no longer resolves. That must answer `false`
+/// without consulting the cache — the early return a future refactor is most
+/// likely to "optimize" into it.
+#[test]
+fn shared_ban_cache_survives_a_banner_being_pruned_mid_cleanup() {
+    let owner_sk = sk(0);
+    let owner_id = id_of(&owner_sk);
+    let params = ChatRoomParametersV1 {
+        owner: owner_sk.verifying_key(),
+    };
+
+    // The banner is a content-free member: no messages, no DMs, no secrets. Its
+    // only claim to survival is the step-2 banner exemption.
+    let banner_sk = sk(1);
+    let banner_id = id_of(&banner_sk);
+    let banner = AuthorizedMember::new(
+        Member {
+            owner_member_id: owner_id,
+            invited_by: owner_id,
+            member_vk: banner_sk.verifying_key(),
+        },
+        &owner_sk,
+    );
+    // A ban by that member with a GARBAGE signature: the step-2 exemption and
+    // the step-5 sweep must agree it does not hold, so the banner is pruned AND
+    // the ban swept — and they must agree via the shared cache.
+    let good = ban_by(banner_id, &banner_sk, owner_id, 1);
+    let forged = AuthorizedUserBan::with_signature(
+        good.ban.clone(),
+        banner_id,
+        ban_by(owner_id, &owner_sk, owner_id, 9).signature,
+    );
+
+    let mut state = ChatRoomStateV1 {
+        configuration: AuthorizedConfigurationV1::new(
+            Configuration {
+                owner_member_id: owner_id,
+                max_members: 100,
+                max_user_bans: 100,
+                ..Default::default()
+            },
+            &owner_sk,
+        ),
+        bans: BansV1(vec![forged]),
+        members: MembersV1 {
+            members: vec![banner],
+        },
+        member_info: MemberInfoV1::default(),
+        ..Default::default()
+    };
+
+    state.post_apply_cleanup(&params).unwrap();
+
+    assert!(
+        state.members.members.is_empty(),
+        "a banner whose only ban has a garbage signature is not exempt from \
+         inactivity-prune and must be removed"
+    );
+    assert!(
+        state.bans.0.is_empty(),
+        "and its ban must be swept at step 5 — the shared cache must not have \
+         handed step 5 a verdict for a banner that no longer resolves"
+    );
+
+    // Idempotent across the mutation, which is the invariant the whole cleanup
+    // rests on.
+    let mut again = state.clone();
+    again.post_apply_cleanup(&params).unwrap();
+    assert_eq!(state, again, "cleanup must stay idempotent");
+}


### PR DESCRIPTION
> **Scope correction, 2026-07-29.** An earlier revision of this description claimed the change is output-identical and that it fixes #422. **Both claims were wrong** and are corrected below: independent review found a real behavioural divergence (since fixed), and measuring the live room showed the headline table did not describe it. What follows is the corrected account. The commit is retitled `Refs #422`, not `Closes`.

## What this actually is

A **complexity cleanup** to the room contract's signature verification, worth roughly **2x on `update_state`** and **1.1x on `validate_state`** at the live Freenet Official room's measured shape, and up to **45x on `validate_state`** for invite trees far deeper than any room measured so far.

It does **not** demonstrate a fix for the 5-second-budget breach #422 reports. See "What remains unexplained".

## Measurements

All under wasmtime with Cranelift at `OptLevel::None`, which is what freenet-core sets for contracts (`crates/core/src/wasm_runtime/engine/wasmtime_engine.rs`). One Ed25519 verification costs **0.4224 ms** there. Native numbers are not usable for this — see the note at the bottom.

Verification **counts** are exact and machine-independent, so they are the primary evidence; times are `count x 0.4224 ms`.

**The live Freenet Official room, measured 2026-07-29** with `cli/examples/invite_depth_probe.rs` (in this PR): 496 members, 200 bans, 2000 messages, 497 member_info, 1.44 MB, **invite depth max 4 / mean 2.02 / median 2** (histogram: 1 member at depth 1, 484 at depth 2, 10 at depth 3, 1 at depth 4).

| entry point | verifications before | after | time before | after | |
|---|---:|---:|---:|---:|---|
| `update_state` (1-message delta) | 800 | 400 | 338 ms | 169 ms | **2.0x** |
| `validate_state` | 3440 | 3192 | 1453 ms | 1348 ms | **1.08x** |

`validate_state` barely moves because that room's 2000 message signatures dominate, and the chain fix cannot touch them — each message signature was already verified exactly once.

**Synthetic depth sweep** (400 members, 100 messages, no bans), `validate_state`:

| invite depth | before | after | |
|---|---:|---:|---|
| 10 | 2,700 (1.14 s) | 900 (0.38 s) | 3.0x |
| 50 | 10,700 (4.52 s) | 900 (0.38 s) | 11.9x |
| 200 | 40,700 (17.19 s) | 900 (0.38 s) | 45.2x |

Only the depth-50 and depth-200 rows breach the 5 s budget, and **no measured room has a tree remotely that deep.** Treat them as the shape of the curve this change flattens, not as a description of any real room. An earlier revision of this PR led with them, which was misleading.

Harness committed as `common/tests/room_scale_bench.rs` (`#[ignore]`d; it is a measurement, not an assertion) so the numbers can be re-run and disputed.

## What remains unexplained

The contract in #422 was frozen at **154,375 bytes** with every merge exceeding 5 s. At that size — an order of magnitude smaller than the Official room's 1.44 MB — neither redundancy I found gets near 5 s by these measurements. So **the cause of the reported timeouts is still open.** Candidates checked and eliminated:

- **The triage assessment's hypothesis** (quadratic loops over members in `member_info.rs`): measured at 0.06–0.14 ms at 200 members. Not the driver. Left untouched deliberately.
- **`get_downstream_members`** being `O(subtree x members)` (raised in review as the one thing a verification-count metric is structurally blind to): added a fixture where bans target real members with subtrees rather than absent users. `validate_state` 1435 -> 537 ms, `update_state` 207 -> 74 ms — no blow-up. Self-limiting, because banning a member with a large subtree cascade-removes it and the walk shortens.
- **A pathological invite tree** on that specific contract: plausible and would be fully explained by this change, but unverifiable — the contract times out before it can emit identifying log lines, and its state cannot be fetched.

The honest position: this removes real, measurable redundancy and raises the ceiling substantially for deep trees, but #422 should stay open until something reproduces its actual shape.

## The behavioural divergence found in review, and fixed

The earlier claim of output-identity rested on this, in `InviteChainCache`'s doc:

> "Member X's chain is valid" is a property of X and its ancestors ONLY — the starting member of a walk never enters the checks.

**That is false.** The start's `MemberId` seeds the cycle guard's `visited` set, and the memo lookup sat *before* that guard, so a memo hit could short-circuit a walk the original terminated with a circular-chain error. Same input, two verdicts:

```
before fix : MembersV1::verify -> Ok
origin/main : MembersV1::verify -> Err("Circular invite chain detected for member ...")
```

Trigger: the walk's start is a **non-canonical duplicate** (`members_by_id[start.member.id()]` resolves to a *different* `AuthorizedMember`) and some node on the walk is already memoized `Ok`. Reachable from both call sites — `verify`'s map is last-wins, `apply_delta`'s is `or_insert` over wire-supplied deltas. It needs only an ordinary member's own key: B, invited by A, mints a second entry for A's key claiming B invited it; with `members = [B, A', A]`, walking B memoizes `B -> Ok`, and A''s walk then hits that memo instead of walking into A's already-visited id.

**Fixed by bypassing the memo entirely for a non-canonical start** — it neither reads nor writes a verdict, so it runs as the untouched original walk. Every node reached *after* the start comes out of `members_by_id` and is canonical by construction, so the start is the only place this arises. Note that moving the memo lookup below the cycle guard does **not** fix it: the hit lands on B before the walk ever reaches A.

With that, the change is output-identical again — and now it is *tested* rather than asserted.

## Why four rounds of self-review missed it

Every equivalence test used `InviteChainCache::new(...)` as the "fresh walk" oracle — the same new implementation with an empty cache. A one-member cache reproduces the identical short-circuit, so the divergence was structurally invisible to them. `MembersV1::get_invite_chain` is still live and `pub` and is the **real** oracle: the untouched original. A differential against it catches this on the first run, and is now `differential_against_the_original_walk_on_a_straight_chain` / `differential_when_a_walk_starts_at_a_non_canonical_duplicate` / `verify_agrees_with_the_original_walk_on_a_non_canonical_duplicate`. This is the single most valuable test in the PR — `validate_chain` is a hand re-transcription of a security-critical loop, and nothing else compares it to what it replaced.

## Approach

Memoize within a single operation; nothing is cached across calls, as the contract is stateless.

- **`BanSignatureCache`** — `post_apply_cleanup` builds one and threads it through all its ban passes. Keyed on `(whole ban, resolved verifying key)`, the complete input to `verify_signature`, so a hit answers a byte-identical question. Safe across the member-set mutations the cleanup performs: a banner resolving to a different key is a different cache entry, and one that stops resolving returns `false` without consulting the cache.
- **`InviteChainCache`** — `MembersV1::verify` and `MembersV1::apply_delta` each build one, so each member's invite signature is verified once. Keyed on the whole `AuthorizedMember`, and **bound to `(parameters, members_by_id)` at construction**.
- **`[profile.release.package.curve25519-dalek] opt-level = 3`**.

Two hazards closed by construction rather than convention:

- **Memo keys are the objects, never their ids.** `BanId` is `fast_hash(signature)`, `MemberId` is `fast_hash(verifying key)` — 64-bit hashes of attacker-chosen bytes. Keying on them would let an attacker who grinds a collision (a birthday search over candidates they generate themselves, ~2^33 work, *not* 2^64) have a forgery inherit a genuine object's "verified" verdict, reopening the forged-ban enforcement hole #411 round 4 A closed and letting a forged member entry claim an unearned position in the invite tree. Pinned by two tests that construct the collisions **exactly** — two bans sharing a signature necessarily share a `BanId`; two entries sharing a verifying key necessarily share a `MemberId` — so no grinding is needed.
- **The chain cache is bound to its context.** A verdict is meaningful only under the owner it was earned against and the lookup its ancestors resolved through. Both are held for the cache's life, so one instance cannot span two rooms, nor span `verify` and `apply_delta` (whose map deliberately includes not-yet-verified delta members and can therefore grant a weaker `Ok`). Chosen over a stored `owner_id` + `debug_assert` because **the contract ships as a release build, where debug assertions are compiled out** — that would have documented the hazard while defending nothing. Verified rather than assumed: a cache-sharing test fails to compile with `error[E0716]`.

`AuthorizedUserBan`'s `Hash` now covers every field rather than the signature alone, since caching made bucketing load-bearing and a signature is attacker-supplied and replayable across bodies. Safe to change: no map keyed on the type is ever iterated into state, so bucket order cannot reach the wire or affect convergence.

## Testing

`common/tests/signature_verification_cost_test.rs`, 22 tests. They count verifications rather than measuring wall-clock time — exact, machine-independent, and not flaky.

- **Differential against `MembersV1::get_invite_chain`**, the implementation this replaced, over every fixture including the non-canonical-duplicate shape and through `MembersV1::verify` itself.
- Cost pins: one verification per member, not `1+2+...+N`; four passes over N bans cost N verifications.
- Equivalence: valid chains, forged links, missing inviters, cycles, self-invitation mid-chain; ban answers vs. the uncached function for owner / member / forged / absent-banner; re-verification when a banner resolves to a different key.
- Collision resistance: the two exact-collision tests above.
- `AuthorizedMember`'s structural `Eq`, which the memo key depends on and which nothing previously pinned — weakening it to ignore the signature passed the entire suite before this test existed.
- The `Err`-memo path, via a branching tree with a broken shared ancestor. Previously every fixture was a straight chain, so the fan-out case that makes memoization worthwhile was only tested when all-valid.
- The shared ban cache across an actual member-set mutation: banner pruned mid-cleanup, asked again by the step-5 sweep. Previously the fixture removed nobody, so the cache never spanned a mutation — the whole reason sharing it needs an argument.
- Source pins that the caches are *routed through* and that the profile exception survives; both made argument-name-insensitive after review noted a literal pin fails open on a rename.

**Mutation-tested, 10 independent reversions**, each caught by exactly one test — or by the compiler: disable either memoization; revert a `post_apply_cleanup` call site; drop the `Cargo.toml` exception; revert either memo key to the id; revert the `Hash` impl; weaken `AuthorizedMember`'s `Eq`; revert the non-canonical-start bypass; unbind the chain cache (fails to build). No test is vacuous.

Full `river-core` suite: **428 passed, 0 failed**, including the retention-monoid proptests, convergence and deputy-ban suites, all unmodified. `cargo fmt` clean; clippy warning count identical to `origin/main` (11, all pre-existing).

## Publishing implications — needs @sanity

**Both WASM artifacts move, so a publish needs two migration entries.** Measured against `origin/main` with `cargo build --locked --profile release --target wasm32-unknown-unknown`:

| artifact | before | after | delta |
|---|---:|---:|---:|
| `room_contract.wasm` | 792,831 | 808,800 | +15,969 (+2.0%) |
| `chat_delegate.wasm` | 737,365 | 754,652 | +17,287 (+2.3%) |

The delegate moves because it also depends on `ed25519-dalek` and is built `--profile release`. The room contract key is `BLAKE3(wasm, params)`; the **delegate** key is `BLAKE3(BLAKE3(wasm) || params)`. So publishing requires a `legacy_room_contracts.toml` entry **and** a `legacy_delegates.toml` entry.

`check-room-contract-migration` and `check-delegate-migration` both pass on this PR, and that is **not** evidence they would catch it: they diff the *committed* WASM, which no source change regenerates. Stated here rather than discovered at publish time. (The baseline delegate build reproduces the committed `chat_delegate.wasm` hash exactly, `6f65e45c…`, so that artifact is byte-reproducible from a standalone build — unlike the room contract, which needs `cargo make sync-wasm`.)

Also for Ian: the `curve25519-dalek` exception is inherited by the `wasm-release` profile, so the **UI** WASM gains the same faster verification and roughly the same +16 KB.

## Filed separately rather than bundled

- **#551** — `MembersV1::apply_delta` puts no bound on `delta.added.len()`, so a member can force unbounded signature verification. The ban path has had this guard since #411 round 3 item C; the member path never got it. Kept out of this PR because a length bound *rejects deltas that previously succeeded*, which is a merge-semantics change with a rollout story, and bundling it would destroy the one property that makes this PR reviewable.
- **#554** — the UI calls the uncached `banned_member_ids` on the render path, paying 200 Ed25519 verifications per call on the Official room. Same redundancy, UI-side.

## Note on native profiling

Do not characterise this contract from a native build. Natively the profile change measures as **46x** (2.27 ms vs 0.05 ms per verification, while *signing* is unaffected at 0.03 ms — which is why it stayed invisible, since the contract only ever verifies). In WASM it is **1.6x**, because Cranelift re-optimises the module on load and recovers most of the lost inlining. An earlier revision of this PR quoted 46x. Correcting it is what redirected the investigation from the constant factor to the algorithmic cause.

Refs #422

[AI-assisted - Claude]
