### PR TITLE
fix(ui): close the review findings from #510's notification_status fix

### DIFF
--- a/ui/assets/tailwind.css
+++ b/ui/assets/tailwind.css
@@ -78,6 +78,12 @@
 @utility border-border { border-color: var(--color-border); }
 @utility border-border-hover { border-color: var(--color-border-hover); }
 
+/* `--color-panel` lives on `:root`, not in `@theme`, so Tailwind generates no
+   colour utilities for it automatically — every panel/surface/text utility above
+   is hand-written for the same reason. Without this, `ring-panel` is a silent
+   no-op and `ring-1` falls back to `currentColor`. */
+@utility ring-panel { --tw-ring-color: var(--color-panel); }
+
 @utility placeholder-text-muted {
   &::placeholder { color: var(--color-text-muted); }
 }

--- a/ui/src/components/app/notifications.rs
+++ b/ui/src/components/app/notifications.rs
@@ -7,7 +7,7 @@
 //! - Permission has been granted
 
 use crate::components::app::{MobileView, CURRENT_ROOM, MOBILE_VIEW, ROOMS};
-use crate::room_data::CurrentRoom;
+use crate::room_data::{CurrentRoom, NotificationMode};
 use crate::util::ecies::{decrypt_with_symmetric_key, unseal_bytes_with_secrets};
 use dioxus::logger::tracing::{debug, info, warn};
 use dioxus::prelude::*;
@@ -287,6 +287,31 @@ pub fn permission_notice(status: Option<NotificationStatus>) -> PermissionNotice
         message,
         offer_enable,
     }
+}
+
+/// Whether the bell should carry a "these preferences aren't reaching you"
+/// marker.
+///
+/// The per-room modes decide only WHEN River wants to notify. If the browser
+/// won't deliver, every one of them is inert — and until now the only place
+/// that said so was inside the modal, so a user with a blocked permission saw an
+/// ordinary bell reading "Notifications: All messages" and learned nothing
+/// unless they went looking. For an issue titled "fails silently", that is the
+/// last place the silence lives.
+///
+/// Deliberately NOT flagged:
+/// - [`NotificationMode::Muted`] — the user asked for no notifications, so
+///   warning that they won't get any is noise.
+/// - [`NotificationStatus::Unsupported`] — the platform has no Notifications API
+///   at all (mobile Safari), so the marker could never be cleared by anything
+///   the user does. A permanent badge is nagging, not informing; the modal still
+///   explains it.
+pub fn delivery_is_blocked(mode: NotificationMode, status: Option<NotificationStatus>) -> bool {
+    !matches!(mode, NotificationMode::Muted)
+        && matches!(
+            status,
+            Some(NotificationStatus::Denied | NotificationStatus::Undeliverable)
+        )
 }
 
 /// Whether a reported status should re-arm the automatic enable prompt.
@@ -1517,6 +1542,45 @@ mod notify_gate_tests {
             production.contains("Some(status)=>record_notification_status(status)"),
             "a parsed status is no longer recorded"
         );
+    }
+
+    /// The bell marker fires exactly where the user's own setting says they want
+    /// notifications and the browser will not deliver them.
+    #[test]
+    fn the_bell_is_marked_only_when_a_wanted_notification_cannot_arrive() {
+        use crate::room_data::NotificationMode::*;
+
+        for mode in [All, MentionsAndReplies] {
+            for (status, blocked) in [
+                (Some(NotificationStatus::Denied), true),
+                (Some(NotificationStatus::Undeliverable), true),
+                (Some(NotificationStatus::Granted), false),
+                (Some(NotificationStatus::Dismissed), false),
+                (Some(NotificationStatus::Undecided), false),
+                // Unsupported is excluded on purpose: nothing the user does can
+                // clear it, so the marker would be permanent nagging.
+                (Some(NotificationStatus::Unsupported), false),
+                (None, false),
+            ] {
+                assert_eq!(
+                    delivery_is_blocked(mode, status),
+                    blocked,
+                    "mode {mode:?} with status {status:?}"
+                );
+            }
+        }
+    }
+
+    /// A muted room is never marked: the user asked for no notifications, so
+    /// telling them they won't get any is noise, not information.
+    #[test]
+    fn a_muted_room_is_never_marked_as_blocked() {
+        for status in ALL_STATUSES {
+            assert!(
+                !delivery_is_blocked(crate::room_data::NotificationMode::Muted, Some(status)),
+                "muted room marked for status {status:?}"
+            );
+        }
     }
 
     /// The re-arm itself — the "reset the flag" half of #510 — is two statements

--- a/ui/src/components/app/notifications.rs
+++ b/ui/src/components/app/notifications.rs
@@ -1544,6 +1544,25 @@ mod notify_gate_tests {
         );
     }
 
+    /// The unrecognised-status log must stay at `warn!`. `release_max_level_info`
+    /// compiles `debug!` out of the build users run, and this line fires exactly
+    /// when the cross-repo status contract has drifted — the failure that reverts
+    /// #510 wholesale — so at `debug!` the one diagnostic for it is gone.
+    ///
+    /// The framed Playwright test asserts the same thing behaviourally, by
+    /// waiting for the line in the console. This pin is kept alongside it because
+    /// it fails in a second in the fast native job rather than sixteen minutes
+    /// into the browser job, and because it does not depend on Dioxus continuing
+    /// to spell the level "WARN" in the message text.
+    #[test]
+    fn an_unknown_status_is_logged_at_a_level_release_builds_keep() {
+        assert!(
+            production_source().contains("None=>warn!(\"Ignoringunrecognised"),
+            "the unrecognised-status log is no longer warn!; at debug! it is \
+             compiled out of release and the contract drift becomes invisible"
+        );
+    }
+
     /// The bell marker fires exactly where the user's own setting says they want
     /// notifications and the browser will not deliver them.
     #[test]

--- a/ui/src/components/app/notifications.rs
+++ b/ui/src/components/app/notifications.rs
@@ -561,7 +561,11 @@ pub fn install_shell_notification_listener() {
                 .and_then(NotificationStatus::from_shell_status)
             {
                 Some(status) => record_notification_status(status),
-                None => debug!("Ignoring unrecognised notification_status from shell"),
+                // `warn!`, not `debug!`: `release_max_level_info` compiles
+                // `debug!` out, and this fires exactly when the cross-repo
+                // status contract has drifted — the failure that reverts #510
+                // wholesale. It has to be diagnosable in the build users run.
+                None => warn!("Ignoring unrecognised notification_status from shell"),
             }
             return;
         }
@@ -1512,6 +1516,51 @@ mod notify_gate_tests {
         assert!(
             production.contains("Some(status)=>record_notification_status(status)"),
             "a parsed status is no longer recorded"
+        );
+    }
+
+    /// The re-arm itself — the "reset the flag" half of #510 — is two statements
+    /// against process-global atomics, which no behavioural test in this crate
+    /// can drive (native tests run in parallel threads and would corrupt each
+    /// other's view of the statics). Mutation testing showed BOTH lines could be
+    /// deleted with the whole suite still green, so each shipped a silent
+    /// regression:
+    ///
+    /// - Without `ENABLE_PROMPT_SENT.store(false, ...)` an unanswered prompt
+    ///   never re-arms, which is precisely the "no way to retry" complaint.
+    /// - Without `ENABLE_PROMPT_REARMS.fetch_add(1, ...)` the counter stays at
+    ///   0, so `rearms_used < MAX` is always true and the re-arm becomes
+    ///   UNBOUNDED — the shell's affordance bar returns on every message the
+    ///   user sends, the exact nag the cap exists to prevent.
+    ///
+    /// `the_automatic_rearm_is_bounded` does NOT cover the second one: it feeds
+    /// the predicate a caller-supplied count, so it passes with the increment
+    /// deleted. A source pin has no parallelism problem, so it is the right
+    /// instrument here.
+    #[test]
+    fn an_unanswered_prompt_actually_rearms_the_flag_it_bounds() {
+        let production = production_source();
+
+        assert!(
+            production.contains("ENABLE_PROMPT_SENT.store(false,Ordering::SeqCst);"),
+            "nothing clears ENABLE_PROMPT_SENT, so an unanswered prompt can \
+             never be re-offered — #510's 'no way to retry' is back"
+        );
+        assert!(
+            production.contains("ENABLE_PROMPT_REARMS.fetch_add(1,Ordering::SeqCst);"),
+            "nothing advances ENABLE_PROMPT_REARMS, so the cap never binds and \
+             the shell's bar returns on every message sent"
+        );
+        // Both statements, in order, behind the bounded predicate: the pin is
+        // about the wiring, not merely about the two lines existing somewhere.
+        assert!(
+            production.contains(
+                "ifstatus_rearms_auto_prompt(status,ENABLE_PROMPT_REARMS.load(Ordering::SeqCst)){\
+                 ENABLE_PROMPT_REARMS.fetch_add(1,Ordering::SeqCst);\
+                 ENABLE_PROMPT_SENT.store(false,Ordering::SeqCst);}"
+            ),
+            "the re-arm is no longer gated by status_rearms_auto_prompt, or the \
+             two statements it guards have moved apart"
         );
     }
 

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -3802,13 +3802,31 @@ pub fn Conversation() -> Element {
                                         // bell = notifying, bell-slash = muted; the tooltip names
                                         // the exact mode. Opens the compact NotificationModal.
                                         // Sized to 16px to pair with the adjacent (i) icon.
-                                        button {
-                                            "data-testid": "notification-bell-button",
-                                            class: "flex-shrink-0 p-1.5 rounded-lg text-text-muted hover:text-accent hover:bg-surface transition-colors",
-                                            title: match *current_notification_mode.read() {
+                                        {
+                                            let mode = *current_notification_mode.read();
+                                            let mode_title = match mode {
                                                 NotificationMode::All => "Notifications: All messages",
                                                 NotificationMode::MentionsAndReplies => "Notifications: Mentions & replies only",
                                                 NotificationMode::Muted => "Notifications: Muted",
+                                            };
+                                            // The browser may be refusing to deliver, which makes
+                                            // every mode above inert (freenet/river#510).
+                                            let blocked = crate::components::app::notifications::delivery_is_blocked(
+                                                mode,
+                                                crate::components::app::notifications::current_notification_status(),
+                                            );
+                                            rsx! {
+                                        button {
+                                            "data-testid": "notification-bell-button",
+                                            class: "relative flex-shrink-0 p-1.5 rounded-lg text-text-muted hover:text-accent hover:bg-surface transition-colors",
+                                            // `title` stays the MODE alone. The blocked state rides
+                                            // on `aria-label` and the dot instead, so the tooltip
+                                            // keeps naming exactly one thing.
+                                            title: mode_title,
+                                            "aria-label": if blocked {
+                                                format!("{mode_title} (your browser is not delivering notifications)")
+                                            } else {
+                                                mode_title.to_string()
                                             },
                                             onclick: move |_| {
                                                 crate::util::defer(move || {
@@ -3819,10 +3837,24 @@ pub fn Conversation() -> Element {
                                                     }
                                                 });
                                             },
-                                            if *current_notification_mode.read() == NotificationMode::Muted {
+                                            if mode == NotificationMode::Muted {
                                                 Icon { icon: FaBellSlash, width: 16, height: 16 }
                                             } else {
                                                 Icon { icon: FaBell, width: 16, height: 16 }
+                                            }
+                                            if blocked {
+                                                // Decorative: `aria-hidden` keeps it out of the
+                                                // button's accessible name, which the `aria-label`
+                                                // above already carries in full. A badge that
+                                                // announced itself separately would append to the
+                                                // button's name instead of replacing it.
+                                                span {
+                                                    "data-testid": "notification-blocked-badge",
+                                                    "aria-hidden": "true",
+                                                    class: "absolute top-0.5 right-0.5 h-2 w-2 rounded-full bg-red-500 ring-1 ring-panel",
+                                                }
+                                            }
+                                        }
                                             }
                                         }
                                     }

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -3851,6 +3851,12 @@ pub fn Conversation() -> Element {
                                                 span {
                                                     "data-testid": "notification-blocked-badge",
                                                     "aria-hidden": "true",
+                                                    // `ring-panel` needs the hand-written
+                                                    // `@utility` in tailwind.css: `--color-panel` is
+                                                    // declared on `:root`, outside `@theme`, so
+                                                    // Tailwind v4 generates no colour utility for it
+                                                    // and `ring-1` would fall back to `currentColor`
+                                                    // — a grey ring that turns blue on hover.
                                                     class: "absolute top-0.5 right-0.5 h-2 w-2 rounded-full bg-red-500 ring-1 ring-panel",
                                                 }
                                             }

--- a/ui/tests/notification-bell.spec.ts
+++ b/ui/tests/notification-bell.spec.ts
@@ -160,6 +160,36 @@ test.describe("Per-room notification bell", () => {
     }
   });
 
+  // Top-level counterpart of the framed badge test in
+  // notification-shell-status.spec.ts: served with a real origin, River reads
+  // the browser's own permission, so the marker must track that.
+  test("the bell is marked when the browser itself is blocking notifications", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await selectRoom(page, ROOM);
+
+    const state = await page.evaluate(() =>
+      typeof Notification === "undefined" ? "unsupported" : Notification.permission
+    );
+    const badge = page.getByTestId("notification-blocked-badge");
+
+    if (state === "denied") {
+      // Playwright's Chromium denies notifications by default, so this branch
+      // is genuinely exercised rather than hypothetical.
+      await expect(badge).toBeVisible();
+      await expect(
+        page.getByTestId("notification-bell-button")
+      ).toHaveAttribute("aria-label", /not delivering/i);
+    } else {
+      // "default" (Firefox, desktop WebKit) and "unsupported" (mobile Safari)
+      // are not blocked states: nothing is being withheld that the user asked
+      // for, so marking the bell would be noise.
+      await expect(badge).toHaveCount(0);
+    }
+  });
+
   test("room-details modal no longer carries the notification setting", async ({
     page,
   }) => {

--- a/ui/tests/notification-shell-status.spec.ts
+++ b/ui/tests/notification-shell-status.spec.ts
@@ -77,6 +77,11 @@ const SHELL_HTML = `<!DOCTYPE html>
 </body>
 </html>`;
 
+// The line the listener logs when it ignores a status it does not recognise.
+// Dioxus's logger writes EVERY level to console.log with the level in the text,
+// so the level is matched here rather than via `ConsoleMessage.type()`.
+const IGNORED_STATUS_WARNING = /WARN.*unrecognised notification_status/i;
+
 const message = (frame: FrameLocator) =>
   frame.getByTestId("notification-permission-message");
 const enableButton = (frame: FrameLocator) =>
@@ -88,6 +93,12 @@ test.describe("Shell notification_status handling (#510)", () => {
   test("the shell's permission outcome reaches the UI, and the retry reaches the shell", async ({
     page,
   }) => {
+    // Attached before load so nothing is missed. Playwright's page-level
+    // console event covers messages from child frames, which is where the app
+    // actually runs here.
+    const consoleLines: string[] = [];
+    page.on("console", (msg) => consoleLines.push(msg.text()));
+
     await page.setContent(SHELL_HTML);
     const frame = page.frameLocator("#river-frame");
     await frame.locator(".app-root").waitFor({ timeout: 30_000 });
@@ -117,14 +128,30 @@ test.describe("Shell notification_status handling (#510)", () => {
     // A status River doesn't recognise must be IGNORED, not guessed at: it must
     // not overwrite the state River already has.
     //
-    // This is a NON-event, so it needs a window rather than a wait. An earlier
-    // version asserted `toContainText(/blocking/i)` immediately after posting,
-    // which passed on its first poll before the message could possibly have
-    // been processed — it would have passed just as well if the junk DID
-    // clobber. The write path is a single `setTimeout(0)`, so a clobber renders
-    // well inside this window.
+    // An earlier version asserted `toContainText(/blocking/i)` immediately after
+    // posting, which passed on its first poll before the message could possibly
+    // have been processed — it would have passed equally had the junk clobbered.
+    // The version after that slept 500ms, which is better but still only
+    // APPROXIMATES "the junk has been handled": a slow clobber slips past a
+    // fixed sleep as a false pass rather than surfacing as a flake.
+    //
+    // So wait for the listener's own log line instead. That is a positive signal
+    // that the junk went through the listener, and it pins the log LEVEL as a
+    // side effect: `release_max_level_info` (ui/Cargo.toml) compiles `debug!` out
+    // of the release build these tests run against, so a revert to `debug!`
+    // produces no line at all, and an `info!` would print "INFO" where this
+    // wants "WARN". Dioxus writes every level to console.log with the level in
+    // the TEXT, so this matches text rather than `msg.type()`.
     await page.evaluate(() => window.__postStatus("not-a-real-status"));
-    await page.waitForTimeout(500);
+    await expect
+      .poll(
+        () => consoleLines.filter((line) => IGNORED_STATUS_WARNING.test(line)).length,
+        { timeout: 10_000 }
+      )
+      .toBeGreaterThan(0);
+
+    // Only now, with the junk demonstrably handled, check the state it must not
+    // have touched.
     await expect(message(frame)).toContainText(/blocking/i);
     await expect(enableButton(frame)).toHaveCount(0);
 

--- a/ui/tests/notification-shell-status.spec.ts
+++ b/ui/tests/notification-shell-status.spec.ts
@@ -114,12 +114,25 @@ test.describe("Shell notification_status handling (#510)", () => {
     await expect(message(frame)).toContainText(/blocking/i, { timeout: 10_000 });
     await expect(enableButton(frame)).toHaveCount(0);
 
-    // A status River doesn't recognise must not clobber the one it has.
+    // A status River doesn't recognise must be IGNORED, not guessed at: it must
+    // not overwrite the state River already has.
+    //
+    // This is a NON-event, so it needs a window rather than a wait. An earlier
+    // version asserted `toContainText(/blocking/i)` immediately after posting,
+    // which passed on its first poll before the message could possibly have
+    // been processed — it would have passed just as well if the junk DID
+    // clobber. The write path is a single `setTimeout(0)`, so a clobber renders
+    // well inside this window.
     await page.evaluate(() => window.__postStatus("not-a-real-status"));
+    await page.waitForTimeout(500);
     await expect(message(frame)).toContainText(/blocking/i);
+    await expect(enableButton(frame)).toHaveCount(0);
 
-    // Granting flips the explanation and keeps the button away (nothing to ask
-    // for).
+    // ...and the listener is still alive after ignoring it. Without this, a
+    // parse that THREW and killed the listener would look identical to
+    // correctly ignoring the junk: both leave the UI sitting on "blocking".
+    // Granting also flips the explanation and keeps the button away (there is
+    // nothing left to ask for).
     await page.evaluate(() => window.__postStatus("granted"));
     await expect(message(frame)).toContainText(/enabled/i, { timeout: 10_000 });
     await expect(enableButton(frame)).toHaveCount(0);
@@ -143,6 +156,42 @@ test.describe("Shell notification_status handling (#510)", () => {
     await expect
       .poll(() => page.evaluate(() => window.__prompts), { timeout: 10_000 })
       .toBeGreaterThan(after);
+  });
+
+  // The half of "fails silently" that the modal alone does not close: a user
+  // with a blocked permission has no reason to open the modal, so the bell
+  // itself has to say something.
+  test("a blocked permission shows on the bell without opening anything", async ({
+    page,
+  }) => {
+    await page.setContent(SHELL_HTML);
+    const frame = page.frameLocator("#river-frame");
+    await frame.locator(".app-root").waitFor({ timeout: 30_000 });
+
+    await frame.getByRole("button", { name: ROOM }).click();
+    await expect(frame.getByRole("heading", { name: ROOM })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const badge = frame.getByTestId("notification-blocked-badge");
+    const bell = frame.getByTestId("notification-bell-button");
+
+    // Nothing reported yet: nothing to warn about.
+    await expect(bell).toBeVisible();
+    await expect(badge).toHaveCount(0);
+
+    await page.evaluate(() => window.__postStatus("denied"));
+    await expect(badge).toBeVisible({ timeout: 10_000 });
+
+    // Not colour-only — the reason is in the accessible name, and the tooltip
+    // still names just the per-room mode.
+    await expect(bell).toHaveAttribute("aria-label", /not delivering/i);
+    await expect(bell).toHaveAttribute("title", "Notifications: All messages");
+
+    // And it clears when delivery starts working, rather than sticking.
+    await page.evaluate(() => window.__postStatus("granted"));
+    await expect(badge).toHaveCount(0, { timeout: 10_000 });
+    await expect(bell).toHaveAttribute("aria-label", "Notifications: All messages");
   });
 
   test("a browser that cannot display notifications says so instead of failing silently", async ({


### PR DESCRIPTION
Follow-up to #542 (issue #510), which had already merged as `f262d79d` by the
time independent review came back. These are that review's findings, plus the
one item it left to my judgement.

## Problem

**M1 — the "reset the flag" half of #510 had zero coverage.** Both statements of
the re-arm at `notifications.rs` could be deleted with the entire suite green:

```
baseline                                       787 passed
delete ENABLE_PROMPT_REARMS.fetch_add(1, ...)  787 passed   <-- survived
delete ENABLE_PROMPT_SENT.store(false, ...)    787 passed   <-- survived
```

Each shipped a silent regression. Without the `SENT` reset an unanswered prompt
never re-arms, which is literally the "no way to retry" the issue is about.
Without the `REARMS` increment the counter stays at 0, so `rearms_used < MAX` is
always true and the re-arm becomes **unbounded** — the shell's affordance bar
returns on every message the user sends, the exact nag the cap exists to prevent.

My own review comment on #542 claimed `the_automatic_rearm_is_bounded` covered
the second mutation. It does not: that test feeds the predicate a
caller-supplied `rearms_used`, so it passes with the increment gone. The row was
true for changing the constant, not for breaking the counter. My disclosed
reasoning ("no native test drives the real atomics — process-global statics vs
parallel test threads") correctly ruled out a behavioural test but stopped
there, missing the cheap remedy this same file already uses four times.

**m4 — a vacuous assertion** in `notification-shell-status.spec.ts`. The
unrecognised-status check asserted text that was already on screen from the
preceding `denied`, and `toContainText` passed on its first poll before the junk
could have been processed. It would have passed just as well had the junk
clobbered the stored status.

**m3 — `debug!` for an unrecognised status is compiled out in release**
(`release_max_level_info`). That line fires exactly when the cross-repo status
contract has drifted, which by my own test's rationale "reverts #510 exactly".

**m8 — the status was only visible inside the bell modal.** A user whose
permission is `Denied` saw an ordinary bell reading "Notifications: All
messages" and learned nothing unless they went looking. For an issue titled
"fails silently", that was the last place the silence lived.

## Approach

**M1**: a source pin, which has no parallelism problem. It asserts each
statement individually with its own failure message, and then the whole guarded
block as one string so the two cannot drift apart or escape the bounded
predicate.

**m4**: the junk check is a *non-event*, so it now waits out a window rather
than racing — the write path is a single `setTimeout(0)`, so a clobber renders
well inside it. It then posts a recognised status and waits for that to land,
because a parse that *threw* and killed the listener would otherwise look
identical to correctly ignoring the junk.

**m3**: `warn!`.

**m8**: I implemented it rather than declaring it out of scope. The bell gets a
small dot plus an `aria-label` explaining why. Two deliberate exclusions: a
**Muted** room is never marked (the user asked for no notifications, so warning
them they'll get none is noise), and **Unsupported** is never marked (nothing
the user does could ever clear it — a permanent badge is nagging, not
informing; the modal still explains it). The button's `title` stays the per-room
mode alone, so the tooltip keeps naming exactly one thing and the existing
exact-title assertions are untouched; the blocked state rides on `aria-label`
and the dot.

## Testing

`cargo test -p river-ui --bins`: 791 pass (4 new). Playwright: 50 pass across
chromium, firefox, webkit, mobile-chrome and mobile-safari, plus 214 in the
layout-sensitive specs (`responsive-layout`, `message-layout`,
`room-header-links`, `room-info-key-selection`) since this adds an element to
the conversation header.

Every new assertion was mutation-verified, including the two the reviewer proved
had survived:

| Mutation | Caught by |
|---|---|
| Delete `ENABLE_PROMPT_SENT.store(false, ...)` | `an_unanswered_prompt_actually_rearms_the_flag_it_bounds` |
| Delete `ENABLE_PROMPT_REARMS.fetch_add(1, ...)` | same |
| Replace the guard with a bare `matches!` | same |
| `delivery_is_blocked` always false | `the_bell_is_marked_only_when_a_wanted_notification_cannot_arrive`, plus both browser badge tests |
| Unknown status parsed as `Undecided` (clobber) | `an_unrecognised_status_is_ignored_rather_than_guessed`, and now the browser junk check at `notification-shell-status.spec.ts:128` |

That last row is the point of the m4 fix: against the clobbering build the
browser assertion fails with `Received string: "The notification prompt closed
without an answer..."`. The version it replaces passed.

Closes the review of #542.

[AI-assisted - Claude]

## On the record: two residual silent paths, on the shell side (freenet-core, not this PR)

Independent review of #542 surfaced these. I verified both against
`crates/core/src/server/path_handlers/assets/shell_bridge.js` on freenet-core
`main` rather than relaying them, since they are claims about another repo.

1. **A per-message delivery drop is never reported.** `showAppNotification`
   returns silently when the Notifications API is absent, when
   `Notification.permission !== 'granted'`, or when `contractHasConsent()` is
   false. None of those paths calls `notifyStatusToIframe`.
2. **The affordance-already-showing path returns with no status**:
   `if (notifyAffordanceShown) return;` in `maybeOfferNotifications`.

Net effect, and it is the interesting one: a `granted` recorded once can keep
River displaying "Desktop notifications are enabled" indefinitely while every
delivery is dropped — for instance after the user revokes the permission in
site settings, which River cannot observe from an opaque origin.

That is the same staleness class this PR's predecessor fixed on the *top-level*
path, where River reads the browser's live answer and ignores what it
remembered. Framed, River has no such reading available, so only the shell can
close it: it would need to report the drop rather than returning silently. The
fix therefore belongs in freenet-core, not here. Happy to file it if wanted.
