### PR TITLE
perf(ui): make the composer in-place measurement work on phone viewports

### DIFF
--- a/ui/src/components/conversation/message_input.rs
+++ b/ui/src/components/conversation/message_input.rs
@@ -61,11 +61,34 @@ const MAX_COMPOSER_HEIGHT: i32 = 168;
 /// content overflows, i.e. only when the box is too SHORT, so it can never
 /// leave a stale too-tall composer behind.
 ///
-/// The "no writes while typing within a line" property is pinned by a Playwright
-/// test (`Composer auto-resize cost (#468)`). If the textarea's border or
-/// box-sizing ever changes such that the box fits its content exactly, the fast
-/// path stops firing — that test goes red rather than the cost silently
-/// returning.
+/// # This is a trade, not a free win
+///
+/// When the fast path applies the cost is one forced layout and no writes; when
+/// it does not, the probing read is wasted and the collapse forces a SECOND
+/// layout, which is worse than collapsing unconditionally. So the fast path has
+/// to be the common case, and that depends on the textarea's CSS, not on this
+/// function. Four properties are load-bearing:
+///
+/// - `box-sizing: border-box` and a non-zero `border`, which together create the
+///   slack that makes a content-sized box report `scrollHeight > clientHeight`;
+/// - `min-height` and `line-height`, which must not conflict — one line of text
+///   plus the vertical padding has to EXCEED `min-h-[44px]`, or min-height owns
+///   the box, the two metrics come out equal, and the fast path never applies.
+///
+/// The `min-height` half is not hypothetical. `tailwind.css` clamps the body
+/// font to 13px below 768px; at the default `line-height: 1.5` that is a 19.5px
+/// line box, so a phone-width composer measured 41.5px natural against a 44px
+/// minimum, and every keystroke on a phone paid two forced layouts instead of
+/// one — the opposite of this function's purpose, on the weakest hardware. The
+/// explicit `leading-6` on the textarea is what keeps one line above the
+/// minimum at every body font size. Do not remove it as "cosmetic".
+///
+/// Pinned by the Playwright test `Composer auto-resize cost (#468)`, which runs
+/// at BOTH a desktop and a phone viewport and asserts `scrollHeight >
+/// clientHeight` before relying on it — pinning one viewport is what let the
+/// mobile regression through, since `test.use({viewport})` overrides the
+/// project's device viewport and so varies the engine without varying the
+/// layout regime.
 fn auto_resize_message_input() {
     let Some(el) = get_message_textarea() else {
         return;
@@ -237,7 +260,16 @@ pub fn MessageInput(
                         textarea {
                             id: "message-input",
                             "data-testid": "message-input",
-                            class: "w-full px-4 py-2.5 bg-surface border border-border rounded-xl text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors resize-none min-h-[44px] overflow-y-auto",
+                            // `leading-6` is load-bearing, not cosmetic: see
+                            // `auto_resize_message_input`. It pins the line box to
+                            // 24px so one line of text plus `py-2.5` always exceeds
+                            // `min-h-[44px]`, at every body font size. Without it the
+                            // mobile font clamp (`tailwind.css`: 13px below 768px)
+                            // leaves the natural height under the minimum, min-height
+                            // takes over the box, and the in-place measurement stops
+                            // working — costing an EXTRA forced layout per keystroke
+                            // instead of saving one.
+                            class: "w-full px-4 py-2.5 leading-6 bg-surface border border-border rounded-xl text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent transition-colors resize-none min-h-[44px] overflow-y-auto",
                             style: "max-height: {MAX_COMPOSER_HEIGHT}px;",
                             placeholder: "Type your message...",
                             value: "{message_text}",

--- a/ui/tests/message-layout.spec.ts
+++ b/ui/tests/message-layout.spec.ts
@@ -470,9 +470,18 @@ const RECORD_COMPOSER_HEIGHT_WRITES = `
 })();
 `;
 
-test.describe("Composer auto-resize cost (#468)", () => {
-  test.use({ viewport: { width: 1280, height: 800 } });
-
+// The cost property has to hold in BOTH layout regimes, so this body runs at a
+// desktop width and again at a phone width. Pinning only 1280x800 (as the first
+// version of this test did) leaves the mobile regime uncovered even when the
+// suite runs under mobile-chrome / mobile-safari, because `test.use({viewport})`
+// overrides the project's device viewport — those projects then vary the ENGINE
+// but not the layout regime. That gap hid a real regression: below 768px
+// `tailwind.css` clamps the body font to 13px, which (before `leading-6` was
+// added to the textarea) put one line of text UNDER `min-h-[44px]`. min-height
+// then owned the box, `scrollHeight` and `clientHeight` were equal on every
+// keystroke, the in-place measurement never applied, and the composer paid an
+// EXTRA forced layout per keystroke rather than saving one.
+function composerAutosizeCostTest() {
   test("typing within a line writes no height; growth and shrink still resize", async ({
     page,
   }) => {
@@ -501,6 +510,29 @@ test.describe("Composer auto-resize cost (#468)", () => {
     await page.keyboard.type("a");
     const oneLine = await height();
     expect(oneLine).toBeGreaterThan(0);
+
+    // Guard the premise the rest of this test rests on, and state it in terms
+    // of the thing the code actually reads rather than re-deriving the box
+    // model. A composer sized to its own content reports
+    // `scrollHeight > clientHeight`, because the value written is a padding-box
+    // measure while `box-sizing: border-box` counts the borders inside it. If
+    // some other rule owns the box instead — `min-h-[44px]` winning over a
+    // too-small natural height was the real #468 mobile regression — the two
+    // are equal, the in-place measurement can never apply, and the assertions
+    // below would pass or fail for reasons unrelated to what they name.
+    const probe = await textarea.evaluate((el) => ({
+      scroll: el.scrollHeight,
+      client: el.clientHeight,
+      font: getComputedStyle(el).fontSize,
+      lineHeight: getComputedStyle(el).lineHeight,
+      minHeight: getComputedStyle(el).minHeight,
+    }));
+    expect(
+      probe.scroll,
+      `the composer must be sized by its content, not by min-height ` +
+        `(scrollHeight ${probe.scroll}, clientHeight ${probe.client}, ` +
+        `font ${probe.font}, line-height ${probe.lineHeight}, min-height ${probe.minHeight})`
+    ).toBeGreaterThan(probe.client);
 
     // The property the fix buys. Adding characters to a line that still fits
     // cannot change the height, so the whole burst must produce zero writes.
@@ -543,6 +575,19 @@ test.describe("Composer auto-resize cost (#468)", () => {
     await textarea.fill("a");
     expect(await height()).toBe(oneLine);
   });
+}
+
+test.describe("Composer auto-resize cost (#468) @ desktop", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+  composerAutosizeCostTest();
+});
+
+// 390x844 is an iPhone-class viewport, comfortably inside the <768px branch
+// where the body font clamps to 13px. This is the regime the desktop-only pin
+// could not see.
+test.describe("Composer auto-resize cost (#468) @ phone", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+  composerAutosizeCostTest();
 });
 
 // On page refresh, the chat scroll container must land at the bottom of the


### PR DESCRIPTION
Follow-up to #543 (issue #468). Fixes a regression that #543 introduced on
phone-width viewports, found by independent review.

## Problem

#543 sizes the composer by measuring it in place, which only works while the
textarea reports `scrollHeight > clientHeight`. Below 768px `tailwind.css`
clamps the body font to 13px; at the default `line-height: 1.5` that is a
19.5px line box, so one line plus `py-2.5` came to 41.5px against the
`min-h-[44px]` minimum. **min-height then owned the box**, the two metrics were
equal on every keystroke, and the fast path never applied.

That is not merely "no benefit" — it is worse than doing nothing. The probing
read is wasted and the collapse forces a **second** layout, where collapsing
unconditionally forced one. So #543 made its own target metric worse on the
weakest hardware.

Confirmed in the built app, not in a model of it. The recorded op trace per
keystroke at 390px:

```
pre-#543      W:height=auto  R.sh:42  W:height=42px          <- 1 forced layout
#543 merged   R.sh:42  R.ch:42  W:height=auto  R.sh:42  W:height=42px   <- 2
this change   R.sh:44  R.ch:42                                <- 1, and no writes
```

CDP `Performance.getMetrics` at 390x844 over 26 keystrokes:

| | LayoutCount | RecalcStyleCount | LayoutDuration | RecalcStyleDuration |
|---|---|---|---|---|
| pre-#543 | 78 | 99 | 7.95 ms | 17.05 ms |
| #543 as merged | 77 | 86 | **12.10 ms** | 19.49 ms |
| this change | **28** | **38** | **5.58 ms** | **3.85 ms** |

Note the honest detail: `LayoutCount` barely separates the first two rows,
because frame-level layouts coalesce and hide the extra forced one. The op
trace is the precise evidence for the forced-layout claim; `LayoutDuration`
(+52% as merged) is the metric that shows the cost.

Break-even measured by sweeping viewports: the fast path fails at 390 / 393 /
414px and works from 600px up, matching the ~587px predicted from the font
clamp.

## Approach

`leading-6` pins the line box to 24px, so one line of text plus padding clears
the 44px minimum at **every** body font size and the in-place measurement
applies everywhere. Verified across 390 / 393 / 414 / 600 / 640 / 768 / 1280:
`fastPath=true`, zero writes and zero collapses over five keystrokes at all of
them.

Resting composer height is unchanged at 44px at every viewport (min-height was
already producing 44px on phones), so there is no visual change at rest. The
only visual difference is that multi-line drafts on phones get 24px line
spacing instead of 19.5px — a 2-line draft goes 63.5px to 68px. Checked at
390x844 for horizontal overflow (none) and that the composer stays fully on
screen at the clamped maximum.

Alternatives considered: making the algorithm stateful so it could predict a
failing probe, or remembering the failure. Both add state that needs
invalidating on viewport change. Fixing the geometric inconsistency — a
composer whose natural height sits below its own minimum — is the smaller and
more durable change, and it makes the invariant unconditional rather than
configuration-dependent.

## Testing

The pin missed this because both composer tests fixed the viewport at
1280x800, and `test.use({viewport})` **overrides the project's device
viewport** — so running under mobile-chrome / mobile-safari varied the engine
but not the layout regime. There was no composer-height coverage below 768px
at all.

- The test body is now a shared function run at **both** 1280x800 and 390x844.
- It asserts `scrollHeight > clientHeight` after priming, before relying on it,
  so a configuration where the measurement cannot work **fails loudly instead
  of passing vacuously**. That guard is what makes the phone case a real
  discriminator rather than a second copy of the desktop one.

Verified non-vacuous by rebuilding the wasm and re-running: with `leading-6`
removed, the phone test fails and the desktop test still passes —

```
Error: the composer must be sized by its content, not by min-height
(scrollHeight 42, clientHeight 42, font 13px, line-height 19.5px, min-height 44px)
```

Full Playwright suite on the rebased HEAD: **707 passed, 23 skipped, 0 failed**.
The tests called out on #468 pass on all five projects: `textarea height resets
after sending a multi-line message` (#221) and `edit container fits within
viewport at narrow widths` (#205). `cargo fmt --check` clean, clippy adds no
warnings in the changed file, `cargo test -p river-ui` 792 passed.

One flake appeared on an earlier (pre-rebase) full-suite run — `mobile-touch-ux`
"React from the kebab", failing in `waitForApp` at app boot — and did not recur
on the rebased run. It passed 5/5 in isolation. I am deliberately **not**
asserting a root cause: the machine was at load 56 on 16 cores from parallel
agent jobs, which would explain it, but #545's note on #538 records that this
exact "timeout under parallel load" theory was plausible and wrong before. With
`trace: "on-first-retry"` now in place from #545, the next occurrence will
leave evidence worth reading.

## Does `leading-6` also dodge iOS Safari's zoom-on-focus?

No, and it cannot — raised on review as unverified, so answering it rather than
leaving it open.

That behaviour keys off **`font-size`**, not `line-height`: iOS Safari zooms the
page when a focused input's font size is under 16px. `leading-6` sets only
`line-height`, so it leaves the trigger condition exactly as it was. Measured
computed `font-size` on the textarea, unchanged by this PR:

| viewport | 390 | 393 | 414 | 600 | 640 | 768 | 1280 |
|---|---|---|---|---|---|---|---|
| font-size | 13px | 13px | 13px | 15px | 16px | 16px | 16px |

`clamp(13px, 2.5vw, 16px)` reaches 16px at a 640px viewport, so any width below
640px puts the composer under the threshold. If the zoom-on-focus happens today
it happened before this PR too, and it still will after.

**Out of scope here, and I could not have verified it anyway:** the harness has
no real iOS. Playwright's `mobile-safari` emulates viewport and user agent, not
the native zoom heuristic, so a green run there would have been no evidence
either way. Fixing it means raising the composer's font to 16px on phones,
which is a deliberate typography decision affecting the mobile clamp, not a
side effect to smuggle into a perf PR.

Refs #468

[AI-assisted - Claude]
