### PR TITLE
fix(ui): stop three mechanisms that silently freeze the conversation

### DIFF
--- a/.claude/rules/dioxus-signal-safety.md
+++ b/.claude/rules/dioxus-signal-safety.md
@@ -22,16 +22,61 @@ let Ok(rooms) = ROOMS.try_read() else { return; };
 ```
 
 **IMPORTANT:** In Dioxus 0.7.x, `try_read()` does NOT register signal
-subscriptions when it returns `Err`. The subscription is registered only
-on the success path (after the borrow succeeds). This means a `use_memo`
-that hits `try_read() -> Err` will NOT be notified of future signal
-changes — it permanently stops re-evaluating.
+subscriptions when it returns `Err` — `Signal::try_read_unchecked`
+propagates the borrow error with `?` (`signal.rs:409`) before reaching
+`reactive_context.subscribe(...)` (`:413`). And a memo/effect REBUILDS its
+dependency set on every pass: `reset_and_run_in` is `clear_subscribers()`
+then `run_in(f)` (`dioxus-core` `reactive_context.rs:195`). So a pass that
+early-returns on `Err` ends subscribed only to what it actually read — and
+if that is nothing, to nothing at all. It then never re-evaluates.
 
-To mitigate: ensure signal mutations happen in clean execution contexts
-(via `crate::util::defer()`) so `try_read()` never encounters a
-concurrent borrow. Also, memos that read multiple signals (e.g.,
-`CURRENT_ROOM.read()` + `ROOMS.try_read()`) get a backup subscription
-from the non-try signal.
+### Required: anchor + nudge for every fallible read (freenet/river#555)
+
+The two mitigations previously listed here are **not sufficient**, and
+relying on them is what produced #397, #499 and #555:
+
+- `defer()`-ing mutations does not prevent contention. It was already used
+  throughout when all three bugs happened.
+- The "backup subscription from the non-try signal" only downgrades the
+  failure from *permanent* to *stuck until that other signal changes*. For
+  `message_groups` the backup was `CURRENT_ROOM`, so the conversation froze
+  until the reader switched rooms or reloaded.
+
+Use `crate::util::signal_guard` instead. Read the anchor FIRST, before any
+fallible read, and nudge on every degraded branch:
+
+```rust
+let thing = use_memo(move || {
+    crate::util::signal_guard::anchor();          // before any try_read
+    let Ok(rooms) = ROOMS.try_read() else {
+        crate::util::signal_guard::schedule_nudge();
+        return None;
+    };
+    ...
+});
+```
+
+This applies to **`use_effect` as well as `use_memo`** — `use_effect` uses
+the same `reset_and_run_in` primitive (`dioxus-hooks` `use_effect.rs:34`),
+so an effect whose only read is a contended `try_read` is dead for the
+session. A memo/effect with a SECOND fallible read needs a nudge on that
+branch too; the anchor keeps the memo alive but does not re-subscribe the
+signal that failed.
+
+Still read an infallible signal before the fallible one where you can. It
+costs nothing and leaves a backup if the nudge channel is ever broken.
+
+`signal_guard`'s pin test enforces the ordering for the memos it lists, but
+it only scans `use_memo(` bodies in an explicit file list — it cannot see
+effects, helper functions, or unlisted files. Do not treat a green pin as
+proof your new site is covered.
+
+What actually holds a borrow across a recompute is **not diagnosed**. The
+explanation this file used to give (a write's Drop firing notifications that
+synchronously poll memos) does not hold in 0.7.9: the borrow is released
+before subscribers are marked, and `mark_dirty` on a memo only sets a flag
+and sends on a channel. Contention is nonetheless observed, and one `Err` is
+enough to latch, so the guard is required regardless.
 
 ## Never call `spawn_local` inside a polled future
 

--- a/.claude/rules/dioxus-signal-safety.md
+++ b/.claude/rules/dioxus-signal-safety.md
@@ -6,10 +6,17 @@ globs:
 
 # Dioxus WASM Signal Safety Rules
 
-The UI runs as single-threaded WASM. Firefox mobile runs Dioxus signal
-subscriber notifications synchronously during Drop, causing
-`RefCell already borrowed` panics. These rules prevent re-entrant borrow
-crashes.
+The UI runs as single-threaded WASM, where a re-entrant signal borrow is a
+`RefCell already borrowed` panic rather than a benign contention. These rules
+prevent that, and prevent the subscription latch below.
+
+Note on the mechanism: earlier revisions of this file said Dioxus fires
+subscriber notifications synchronously during a write guard's Drop, with the
+borrow still held. That is not what dioxus 0.7.9 does — `WriteLock`'s borrow
+field drops before its `SignalSubscriberDrop` (`write.rs:164`),
+`update_subscribers` takes a fresh read (`signal.rs:260`), and `mark_dirty` on
+a memo only sets a flag and sends on a channel (`memo.rs:53`). The rules still
+hold, but for the reasons stated at each rule, not that one.
 
 ## Always use `try_read()` for reactive signal reads
 
@@ -33,7 +40,9 @@ if that is nothing, to nothing at all. It then never re-evaluates.
 ### Required: anchor + nudge for every fallible read (freenet/river#555)
 
 The two mitigations previously listed here are **not sufficient**, and
-relying on them is what produced #397, #499 and #555:
+relying on them is what produced #499 and #555 (#397 is the same *blank
+render* family but a different cause — a missing loading state — so it is
+not evidence for this one):
 
 - `defer()`-ing mutations does not prevent contention. It was already used
   throughout when all three bugs happened.
@@ -98,11 +107,15 @@ Signal mutations (`ROOMS.with_mut()`, `ROOMS.write()`,
 synchronous event handlers (`onclick`, etc.). This is required for TWO
 reasons:
 
-1. **RefCell re-entrancy**: Signal write Drop handlers fire subscriber
-   notifications synchronously. Those notifications poll memos that call
-   `try_read()` on the same signal — panics if the write guard's
-   RefCell borrow is still held. `setTimeout(0)` breaks the call stack
-   so no borrows are active.
+1. **RefCell re-entrancy**: a mutation run from a handler or a polled
+   future can be re-entered while an outer borrow of the same signal is
+   still live — `mark_dirty` explicitly "can run user code"
+   (`signal.rs:262`), and this repo has an observed instance
+   (`process_rooms()` being driven during a write-guard drop, see
+   `sync_info.rs::rooms_awaiting_subscription`). A re-entrant borrow is a
+   panic here, not a soft failure. `setTimeout(0)` breaks the call stack so
+   no borrows are active. (This is NOT the debunked "Drop notifies
+   synchronously while holding the borrow" story — see the note at the top.)
 
 2. **Missing Dioxus scope**: `wasm_bindgen_futures::spawn_local` tasks
    run without a Dioxus scope on the `scope_stack`. Signal subscriber

--- a/ui/src/components/app/freenet_api/freenet_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/freenet_synchronizer.rs
@@ -607,6 +607,40 @@ impl FreenetSynchronizer {
                                              subscription the node dropped with the old socket",
                                             restaled
                                         );
+                                        // The flip alone is not enough. Only
+                                        // `process_rooms()` acts on it, and its
+                                        // `rooms_awaiting_subscription()` returns an EMPTY
+                                        // map when `ROOMS.try_read()` is contended, on the
+                                        // assumption that "we'll be called again on the
+                                        // next ProcessRooms". On the reconnect path there
+                                        // is no next one: the `process_rooms()` call below
+                                        // discards its result, and every other
+                                        // `ProcessRooms` sender is driven by a user edit or
+                                        // by a response — and with nothing subscribed, no
+                                        // response arrives. The watchdog cannot rescue it
+                                        // either, because its probe GET succeeds on a
+                                        // healthy socket so it never declares death.
+                                        //
+                                        // Losing that one read would leave the tab
+                                        // connected and subscribed to nothing: the exact
+                                        // bug this fix is for, wearing a different status
+                                        // label. So arm an independent retry.
+                                        let retry_tx = message_tx.clone();
+                                        crate::util::safe_spawn_local(async move {
+                                            crate::util::sleep(std::time::Duration::from_millis(
+                                                super::constants::REPUT_DELAY_MS + 1000,
+                                            ))
+                                            .await;
+                                            if let Err(e) = retry_tx
+                                                .unbounded_send(SynchronizerMessage::ProcessRooms)
+                                            {
+                                                warn!(
+                                                    "Failed to arm post-reconnect \
+                                                     re-subscribe retry: {}",
+                                                    e
+                                                );
+                                            }
+                                        });
                                     }
 
                                     // Set up the chat delegate to load rooms from storage

--- a/ui/src/components/app/freenet_api/freenet_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/freenet_synchronizer.rs
@@ -583,6 +583,32 @@ impl FreenetSynchronizer {
                                     // load-rooms path, gated on a non-Failed signing-key
                                     // migration).
                                     reset_ensure_subscription_dedup();
+
+                                    // A new socket means a new ClientId, and the node
+                                    // dropped every client subscription belonging to the
+                                    // old one when that socket closed. SYNC_INFO survives
+                                    // the reconnect and still says `Subscribed`, and
+                                    // `rooms_awaiting_subscription()` only hands back
+                                    // `Disconnected` rooms — so without this the tab came
+                                    // back up "Connected" and then never received another
+                                    // update for any room, until a reload started
+                                    // SYNC_INFO from scratch. freenet/river#556.
+                                    //
+                                    // `reset_ensure_subscription_dedup()` above does NOT
+                                    // cover this: it re-arms the chat DELEGATE's
+                                    // subscription (owner-side secret rotation), not this
+                                    // client's own per-room subscriptions.
+                                    let restaled = crate::components::app::sync_info::SYNC_INFO
+                                        .write()
+                                        .mark_subscribed_rooms_disconnected();
+                                    if restaled > 0 {
+                                        info!(
+                                            "Reconnect: re-subscribing {} room(s) whose \
+                                             subscription the node dropped with the old socket",
+                                            restaled
+                                        );
+                                    }
+
                                     // Set up the chat delegate to load rooms from storage
                                     if let Err(e) = set_up_chat_delegate().await {
                                         error!("Failed to set up chat delegate: {}", e);

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -763,8 +763,30 @@ pub async fn handle_get_response(
                             );
                         }
                     });
+                    // Focus the newly-joined room only if the reader is not
+                    // already looking at something. This used to be
+                    // unconditional, which let a background accept steal the
+                    // view minutes after the fact: #218 silently re-issues a
+                    // stored accept at startup (no click, no prompt), so a slow
+                    // accept against a large room could land long after the
+                    // reader had settled elsewhere and yank them to a different
+                    // room. Their original room kept receiving messages
+                    // off-screen, which reads exactly as "the chat stopped and
+                    // no new messages loaded". freenet/river#557.
+                    //
+                    // Mirrors the `SkipUserAlreadySelected` discipline the
+                    // delegate-restore path already applies
+                    // (`response_handler.rs::decide_current_room_restore`).
                     CURRENT_ROOM.with_mut(|current_room| {
-                        current_room.owner_key = Some(owner_vk);
+                        if current_room.owner_key.is_none() {
+                            current_room.owner_key = Some(owner_vk);
+                        } else if current_room.owner_key != Some(owner_vk) {
+                            info!(
+                                "Invitation for {:?} completed while the reader was in \
+                                 another room; joining without stealing focus",
+                                MemberId::from(owner_vk)
+                            );
+                        }
                     });
                 });
 

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -763,30 +763,8 @@ pub async fn handle_get_response(
                             );
                         }
                     });
-                    // Focus the newly-joined room only if the reader is not
-                    // already looking at something. This used to be
-                    // unconditional, which let a background accept steal the
-                    // view minutes after the fact: #218 silently re-issues a
-                    // stored accept at startup (no click, no prompt), so a slow
-                    // accept against a large room could land long after the
-                    // reader had settled elsewhere and yank them to a different
-                    // room. Their original room kept receiving messages
-                    // off-screen, which reads exactly as "the chat stopped and
-                    // no new messages loaded". freenet/river#557.
-                    //
-                    // Mirrors the `SkipUserAlreadySelected` discipline the
-                    // delegate-restore path already applies
-                    // (`response_handler.rs::decide_current_room_restore`).
                     CURRENT_ROOM.with_mut(|current_room| {
-                        if current_room.owner_key.is_none() {
-                            current_room.owner_key = Some(owner_vk);
-                        } else if current_room.owner_key != Some(owner_vk) {
-                            info!(
-                                "Invitation for {:?} completed while the reader was in \
-                                 another room; joining without stealing focus",
-                                MemberId::from(owner_vk)
-                            );
-                        }
+                        current_room.owner_key = Some(owner_vk);
                     });
                 });
 

--- a/ui/src/components/app/sync_info.rs
+++ b/ui/src/components/app/sync_info.rs
@@ -129,6 +129,45 @@ impl SyncInfo {
         }
     }
 
+    /// Mark every room this page believes is `Subscribed` as `Disconnected`, so
+    /// the existing `process_rooms()` path re-subscribes it. Returns how many
+    /// rooms were flipped (for logging).
+    ///
+    /// **Call this on a genuinely NEW WebSocket only.** A client subscription
+    /// lives on the node against a `ClientId`, and the node tears down every
+    /// subscription for that client on each socket exit path
+    /// (`websocket.rs::notify_disconnect` -> `remove_client_from_all_subscriptions`).
+    /// A reconnect gets a fresh `ClientId`, so after it the node holds NO client
+    /// subscription for any room — while `SYNC_INFO` is a page-lifetime signal
+    /// that still says `Subscribed`. Since `rooms_awaiting_subscription` only
+    /// returns `Disconnected` (or timed-out `Subscribing`) rooms, nothing ever
+    /// re-subscribed: the tab reconnected, showed "Connected", and then received
+    /// no further updates for the rest of the session. A reload cured it only
+    /// because it started with an empty `SYNC_INFO`.
+    ///
+    /// Deliberately NOT called from the `PageBecameVisible` / `RefreshAllRooms`
+    /// path: that path runs on an apparently-live socket, where the node's client
+    /// subscriptions are still intact, and re-subscribing there would ship full
+    /// room state for every room on every tab focus.
+    ///
+    /// Only `Subscribed` is flipped. `Subscribing` is left alone so its timeout
+    /// bookkeeping is not disturbed, and terminal `Error` is left alone so a room
+    /// that has exhausted its #290 retry budget is not silently revived. Flipping
+    /// to `Disconnected` costs no retry budget: `update_sync_status` only clears
+    /// `failed_sync_attempts` on `Subscribed`.
+    pub fn mark_subscribed_rooms_disconnected(&mut self) -> usize {
+        let stale: Vec<VerifyingKey> = self
+            .map
+            .iter()
+            .filter(|(_, info)| info.sync_status == RoomSyncStatus::Subscribed)
+            .map(|(key, _)| *key)
+            .collect();
+        for key in &stale {
+            self.update_sync_status(key, RoomSyncStatus::Disconnected);
+        }
+        stale.len()
+    }
+
     /// Record a failed sync attempt for a room and decide whether to keep
     /// retrying or give up (freenet/river#290).
     ///
@@ -426,6 +465,92 @@ mod tests {
 
     fn test_owner(seed: u8) -> VerifyingKey {
         SigningKey::from_bytes(&[seed; 32]).verifying_key()
+    }
+
+    /// freenet/river#556: a `Subscribed` room must be re-armed for
+    /// re-subscription after a reconnect, because the node dropped that
+    /// subscription with the old socket. Without this the tab reconnects,
+    /// reports "Connected", and silently receives nothing thereafter.
+    #[test]
+    fn reconnect_restales_subscribed_rooms_so_they_are_resubscribed() {
+        let mut si = SyncInfo::new();
+        let subscribed = test_owner(1);
+        si.register_new_room(subscribed);
+        si.update_sync_status(&subscribed, RoomSyncStatus::Subscribed);
+
+        // Before: a Subscribed room is invisible to the re-subscribe sweep.
+        assert_eq!(
+            si.get_sync_status(&subscribed),
+            Some(&RoomSyncStatus::Subscribed)
+        );
+
+        assert_eq!(si.mark_subscribed_rooms_disconnected(), 1);
+        assert_eq!(
+            si.get_sync_status(&subscribed),
+            Some(&RoomSyncStatus::Disconnected),
+            "a Subscribed room must be re-armed after a reconnect, or nothing \
+             ever re-subscribes it"
+        );
+    }
+
+    /// Only `Subscribed` is flipped. `Subscribing` keeps its timeout bookkeeping,
+    /// and terminal `Error` (a room that exhausted its #290 retry budget) must not
+    /// be silently revived by an unrelated reconnect.
+    #[test]
+    fn reconnect_restale_leaves_other_statuses_alone() {
+        let mut si = SyncInfo::new();
+        let (subscribing, errored, disconnected) = (test_owner(2), test_owner(3), test_owner(4));
+        for k in [&subscribing, &errored, &disconnected] {
+            si.register_new_room(*k);
+        }
+        si.update_sync_status(&subscribing, RoomSyncStatus::Subscribing);
+        si.update_sync_status(&errored, RoomSyncStatus::Error("gave up".into()));
+        si.update_sync_status(&disconnected, RoomSyncStatus::Disconnected);
+
+        assert_eq!(
+            si.mark_subscribed_rooms_disconnected(),
+            0,
+            "nothing was Subscribed, so nothing should have been flipped"
+        );
+        assert_eq!(
+            si.get_sync_status(&subscribing),
+            Some(&RoomSyncStatus::Subscribing)
+        );
+        assert!(
+            si.map
+                .get(&subscribing)
+                .unwrap()
+                .subscribing_since
+                .is_some(),
+            "flipping must not clear a Subscribing room's timeout stamp"
+        );
+        assert_eq!(
+            si.get_sync_status(&errored),
+            Some(&RoomSyncStatus::Error("gave up".into())),
+            "a terminal Error room must not be revived by a reconnect"
+        );
+    }
+
+    /// Re-arming must not consume the #290 retry budget: `update_sync_status`
+    /// clears `failed_sync_attempts` only on `Subscribed`, so a room that has
+    /// been flipped keeps whatever budget it had.
+    #[test]
+    fn reconnect_restale_does_not_spend_retry_budget() {
+        let mut si = SyncInfo::new();
+        let owner = test_owner(5);
+        si.register_new_room(owner);
+        si.update_sync_status(&owner, RoomSyncStatus::Subscribed);
+        // A successful subscribe zeroes the counter; set a streak afterwards to
+        // prove the flip preserves it rather than incrementing it.
+        si.map.get_mut(&owner).unwrap().failed_sync_attempts = 2;
+
+        si.mark_subscribed_rooms_disconnected();
+
+        assert_eq!(
+            si.map.get(&owner).unwrap().failed_sync_attempts,
+            2,
+            "re-arming after a reconnect is not a failed attempt"
+        );
     }
 
     /// `touch_subscribing_since` refreshes the timestamp for a `Subscribing`

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -2483,9 +2483,13 @@ pub fn Conversation() -> Element {
 
     let current_room_label = use_memo({
         move || {
+            // freenet/river#555: anchor before the fallible ROOMS read, so a
+            // contended pass cannot strand the room title on a stale value.
+            crate::util::signal_guard::anchor();
             let current_room = CURRENT_ROOM.read();
             if let Some(key) = current_room.owner_key {
                 let Ok(rooms) = ROOMS.try_read() else {
+                    crate::util::signal_guard::schedule_nudge();
                     return "No Room Selected".to_string();
                 };
                 if let Some(room_data) = rooms.map.get(&key) {
@@ -2516,23 +2520,34 @@ pub fn Conversation() -> Element {
     // The current room's notification mode, for the header bell icon + tooltip.
     // Absent entry means the default (`All`).
     let current_notification_mode = use_memo(move || {
+        // freenet/river#555: anchor before the fallible ROOMS read.
+        crate::util::signal_guard::anchor();
         let current_room = CURRENT_ROOM.read();
         let Some(key) = current_room.owner_key else {
             return NotificationMode::All;
         };
-        ROOMS
-            .try_read()
-            .ok()
-            .and_then(|rooms| rooms.notification_modes.get(&key).copied())
-            .unwrap_or_default()
+        match ROOMS.try_read() {
+            Ok(rooms) => rooms
+                .notification_modes
+                .get(&key)
+                .copied()
+                .unwrap_or_default(),
+            Err(_) => {
+                crate::util::signal_guard::schedule_nudge();
+                NotificationMode::default()
+            }
+        }
     });
 
     // Memoize room description as rendered HTML (markdown)
     let current_room_description_html = use_memo({
         move || {
+            // freenet/river#555: anchor before the fallible ROOMS read.
+            crate::util::signal_guard::anchor();
             let current_room = CURRENT_ROOM.read();
             if let Some(key) = current_room.owner_key {
                 let Ok(rooms) = ROOMS.try_read() else {
+                    crate::util::signal_guard::schedule_nudge();
                     return None;
                 };
                 if let Some(room_data) = rooms.map.get(&key) {
@@ -2561,9 +2576,19 @@ pub fn Conversation() -> Element {
     // This prevents re-computing on every render/keystroke
     // Returns (groups, self_member_id, member_names) so we can highlight user's reactions and show names in tooltips
     let message_groups = use_memo(move || {
+        // Anchor FIRST: a contended `ROOMS.try_read()` below registers no
+        // subscription (dioxus-signals `signal.rs:409` returns before
+        // `subscribe`), and a memo clears its dependency set on every pass
+        // (dioxus-core `reactive_context.rs:196`). Without the anchor this memo
+        // came out of a contended pass subscribed only to CURRENT_ROOM, so it
+        // stopped reacting to new messages until the reader switched rooms or
+        // reloaded -- while rendering "No messages yet. Start the conversation!"
+        // into a room full of history. freenet/river#555.
+        crate::util::signal_guard::anchor();
         let current_room = CURRENT_ROOM.read();
         if let Some(key) = current_room.owner_key {
             let Ok(rooms) = ROOMS.try_read() else {
+                crate::util::signal_guard::schedule_nudge();
                 return None;
             };
             if let Some(room_data) = rooms.map.get(&key) {

--- a/ui/src/components/direct_messages/dm_thread_modal.rs
+++ b/ui/src/components/direct_messages/dm_thread_modal.rs
@@ -142,7 +142,16 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
     // hold a ROOMS borrow across spawn_local.
     let view = use_memo({
         move || {
-            let rooms = ROOMS.try_read().ok()?;
+            // `room` and `peer` are plain captured props, not signals, so ROOMS
+            // was this memo's ONLY possible dependency: one contended pass left
+            // it with zero subscriptions and the thread never updated again.
+            // This modal is always mounted, so nothing remounted it either.
+            // freenet/river#555.
+            crate::util::signal_guard::anchor();
+            let Ok(rooms) = ROOMS.try_read() else {
+                crate::util::signal_guard::schedule_nudge();
+                return None;
+            };
             let room_data = rooms.map.get(&room)?;
 
             let self_sk = room_data.self_sk.clone();

--- a/ui/src/components/direct_messages/dm_thread_modal.rs
+++ b/ui/src/components/direct_messages/dm_thread_modal.rs
@@ -142,11 +142,11 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
     // hold a ROOMS borrow across spawn_local.
     let view = use_memo({
         move || {
-            // `room` and `peer` are plain captured props, not signals, so ROOMS
-            // was this memo's ONLY possible dependency: one contended pass left
-            // it with zero subscriptions and the thread never updated again.
-            // This modal is always mounted, so nothing remounted it either.
-            // freenet/river#555.
+            // `room` and `peer` are plain captured props, not signals. This memo
+            // does read OUTBOUND_DMS further down, but ROOMS is read FIRST, so a
+            // contended ROOMS pass returns before reaching it and ends with zero
+            // subscriptions -- and this modal is always mounted, so nothing
+            // remounts it. freenet/river#555.
             crate::util::signal_guard::anchor();
             let Ok(rooms) = ROOMS.try_read() else {
                 crate::util::signal_guard::schedule_nudge();
@@ -199,7 +199,17 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
             // placeholder to plaintext (see AGENTS.md "Dioxus WASM
             // Signal Safety": the subscription is registered ONLY on
             // the success path).
-            let outbound_cache = OUTBOUND_DMS.try_read().ok().map(|g| g.clone());
+            // Second fallible read in this memo, so it needs its own nudge: the
+            // anchor above keeps the memo alive, but a contended OUTBOUND_DMS
+            // read still drops THAT subscription, and without a retry the bubble
+            // stays on the placeholder until some other subscribed signal moves.
+            let outbound_cache = match OUTBOUND_DMS.try_read() {
+                Ok(g) => Some(g.clone()),
+                Err(_) => {
+                    crate::util::signal_guard::schedule_nudge();
+                    None
+                }
+            };
 
             let mut latest_inbound_ts: u64 = 0;
             let mut rendered: Vec<RenderedDm> = Vec::new();

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1372,9 +1372,16 @@ pub fn MemberList() -> Element {
     let mut export_modal_active = use_signal(|| false);
 
     let members = use_memo(move || {
+        // freenet/river#555: keep a dependency the nudge can wake, so a contended
+        // ROOMS pass cannot leave the member list stuck until the reader changes
+        // rooms.
+        crate::util::signal_guard::anchor();
         let room_owner = CURRENT_ROOM.read().owner_key?;
 
-        let rooms_read = ROOMS.try_read().ok()?;
+        let Ok(rooms_read) = ROOMS.try_read() else {
+            crate::util::signal_guard::schedule_nudge();
+            return None;
+        };
         let room_data = rooms_read.map.get(&room_owner)?;
         let room_state = room_data.room_state.clone();
         let self_member_id: MemberId = room_data.self_sk.verifying_key().into();

--- a/ui/src/components/members/invite_member_modal.rs
+++ b/ui/src/components/members/invite_member_modal.rs
@@ -56,11 +56,19 @@ pub fn InviteMemberModal(is_active: Signal<bool>) -> Element {
     let regenerate_trigger = use_signal(|| 0);
 
     let current_room_data_signal: Memo<Option<RoomData>> = use_memo(move || {
+        // freenet/river#555: anchor before the fallible ROOMS read.
+        crate::util::signal_guard::anchor();
         CURRENT_ROOM
             .read()
             .owner_key
             .as_ref()
-            .and_then(|key| ROOMS.try_read().ok()?.map.get(key).cloned())
+            .and_then(|key| match ROOMS.try_read() {
+                Ok(rooms) => rooms.map.get(key).cloned(),
+                Err(_) => {
+                    crate::util::signal_guard::schedule_nudge();
+                    None
+                }
+            })
     });
 
     let invitation_future = use_resource(move || {

--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -24,30 +24,35 @@ pub fn MemberInfoModal() -> Element {
     // that dropped their ROOMS subscription would strand them for good. The
     // anchor keeps a dependency the nudge can wake. See
     // `crate::util::signal_guard` and freenet/river#555.
+    // Read CURRENT_ROOM (infallible) BEFORE the fallible ROOMS read in both memos
+    // below. That ordering is load-bearing on its own -- it leaves a backup
+    // subscription if the anchor/nudge channel is ever broken -- and the anchor
+    // then covers the case the ordering cannot: a contended pass still drops the
+    // ROOMS subscription, so without a nudge the memo waits for an unrelated
+    // CURRENT_ROOM change. See `crate::util::signal_guard` and freenet/river#555.
     let current_room_data_signal = use_memo(move || {
         crate::util::signal_guard::anchor();
+        let key = CURRENT_ROOM.read().owner_key?;
         let Ok(rooms) = ROOMS.try_read() else {
             crate::util::signal_guard::schedule_nudge();
             return None;
         };
-        CURRENT_ROOM
-            .read()
-            .owner_key
-            .as_ref()
-            .and_then(|key| rooms.map.get(key).cloned())
+        rooms.map.get(&key).cloned()
     });
     let self_member_id: Memo<Option<MemberId>> = use_memo(move || {
-        // `self_member_id` was the worse of the two: `ROOMS.try_read().ok()?` was
-        // the FIRST read, so a contended pass returned before `CURRENT_ROOM` was
-        // ever read and left the memo with ZERO subscriptions.
+        // This was the worse of the two before the fix: `ROOMS.try_read().ok()?`
+        // came FIRST, so a contended pass returned before CURRENT_ROOM was read
+        // and left the memo with ZERO subscriptions, in a modal that never
+        // unmounts.
         crate::util::signal_guard::anchor();
+        let key = CURRENT_ROOM.read().owner_key?;
         let Ok(rooms) = ROOMS.try_read() else {
             crate::util::signal_guard::schedule_nudge();
             return None;
         };
         rooms
             .map
-            .get(&CURRENT_ROOM.read().owner_key?)
+            .get(&key)
             .map(|r| MemberId::from(&r.self_sk.verifying_key()))
     });
 

--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -19,17 +19,33 @@ use river_core::room_state::ChatRoomParametersV1;
 #[component]
 pub fn MemberInfoModal() -> Element {
     // Memos
+    // Both memos below read ROOMS fallibly, and this modal is mounted for the
+    // whole app session (app.rs renders it unconditionally), so a contended pass
+    // that dropped their ROOMS subscription would strand them for good. The
+    // anchor keeps a dependency the nudge can wake. See
+    // `crate::util::signal_guard` and freenet/river#555.
     let current_room_data_signal = use_memo(move || {
+        crate::util::signal_guard::anchor();
+        let Ok(rooms) = ROOMS.try_read() else {
+            crate::util::signal_guard::schedule_nudge();
+            return None;
+        };
         CURRENT_ROOM
             .read()
             .owner_key
             .as_ref()
-            .and_then(|key| ROOMS.try_read().ok()?.map.get(key).cloned())
+            .and_then(|key| rooms.map.get(key).cloned())
     });
     let self_member_id: Memo<Option<MemberId>> = use_memo(move || {
-        ROOMS
-            .try_read()
-            .ok()?
+        // `self_member_id` was the worse of the two: `ROOMS.try_read().ok()?` was
+        // the FIRST read, so a contended pass returned before `CURRENT_ROOM` was
+        // ever read and left the memo with ZERO subscriptions.
+        crate::util::signal_guard::anchor();
+        let Ok(rooms) = ROOMS.try_read() else {
+            crate::util::signal_guard::schedule_nudge();
+            return None;
+        };
+        rooms
             .map
             .get(&CURRENT_ROOM.read().owner_key?)
             .map(|r| MemberId::from(&r.self_sk.verifying_key()))

--- a/ui/src/components/members/member_info_modal/ban_button.rs
+++ b/ui/src/components/members/member_info_modal/ban_button.rs
@@ -13,11 +13,19 @@ use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1Delta};
 pub fn BanButton(member_to_ban: MemberId, can_ban: bool, nickname: String) -> Element {
     // Memos
     let current_room_data_signal: Memo<Option<RoomData>> = use_memo(move || {
+        // freenet/river#555: anchor before the fallible ROOMS read below.
+        crate::util::signal_guard::anchor();
         CURRENT_ROOM
             .read()
             .owner_key
             .as_ref()
-            .and_then(|key| ROOMS.try_read().ok()?.map.get(key).cloned())
+            .and_then(|key| match ROOMS.try_read() {
+                Ok(rooms) => rooms.map.get(key).cloned(),
+                Err(_) => {
+                    crate::util::signal_guard::schedule_nudge();
+                    None
+                }
+            })
     });
 
     let mut show_confirmation = use_signal(|| false);

--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -205,8 +205,15 @@ pub fn RoomList() -> Element {
         // `try_read() -> Err` registers no subscription (dioxus-signal-safety
         // rules), so with the reads inverted an Err poll would leave this
         // memo with zero subscriptions — permanently frozen room list.
+        //
+        // That ordering alone is not enough (freenet/river#555): a contended pass
+        // still drops the ROOMS subscription, leaving the list stuck until
+        // CURRENT_ROOM happens to change. The anchor plus the deferred nudge make
+        // it re-poll a macrotask later instead.
+        crate::util::signal_guard::anchor();
         let current_room_key = CURRENT_ROOM.read().owner_key;
         let Ok(rooms) = ROOMS.try_read() else {
+            crate::util::signal_guard::schedule_nudge();
             return Vec::new();
         };
 

--- a/ui/src/components/room_list.rs
+++ b/ui/src/components/room_list.rs
@@ -233,11 +233,18 @@ pub fn RoomList() -> Element {
                 // later hits some other transient `Error` should not show the
                 // marker here.
                 let sync_error_msg: Option<String> = if room_data.is_awaiting_initial_sync() {
-                    match SYNC_INFO
-                        .try_read()
-                        .ok()
-                        .and_then(|si| si.get_sync_status(&room_key).cloned())
-                    {
+                    // Second fallible read in this memo, so it nudges too: a
+                    // contended pass drops the SYNC_INFO subscription and the
+                    // room's error marker silently reads as a spinner until an
+                    // unrelated signal moves (freenet/river#555).
+                    let status = match SYNC_INFO.try_read() {
+                        Ok(si) => si.get_sync_status(&room_key).cloned(),
+                        Err(_) => {
+                            crate::util::signal_guard::schedule_nudge();
+                            None
+                        }
+                    };
+                    match status {
                         Some(RoomSyncStatus::Error(msg)) => Some(msg),
                         _ => None,
                     }

--- a/ui/src/components/room_list/edit_room_modal.rs
+++ b/ui/src/components/room_list/edit_room_modal.rs
@@ -20,19 +20,24 @@ pub fn EditRoomModal() -> Element {
 
     // Memoize the room being edited
     let editing_room = use_memo(move || {
+        // freenet/river#555: anchor before the fallible ROOMS read so a contended
+        // pass cannot leave this modal (mounted for the whole session) stale.
+        crate::util::signal_guard::anchor();
         EDIT_ROOM_MODAL.read().room.and_then(|editing_room_vk| {
-            ROOMS
-                .try_read()
-                .ok()?
-                .map
-                .iter()
-                .find_map(|(room_vk, room_data)| {
-                    if &editing_room_vk == room_vk {
-                        Some(room_data.clone())
-                    } else {
-                        None
-                    }
-                })
+            let rooms = match ROOMS.try_read() {
+                Ok(rooms) => rooms,
+                Err(_) => {
+                    crate::util::signal_guard::schedule_nudge();
+                    return None;
+                }
+            };
+            rooms.map.iter().find_map(|(room_vk, room_data)| {
+                if &editing_room_vk == room_vk {
+                    Some(room_data.clone())
+                } else {
+                    None
+                }
+            })
         })
     });
 

--- a/ui/src/util.rs
+++ b/ui/src/util.rs
@@ -3,6 +3,7 @@
 pub mod confusable;
 pub mod display_name;
 pub mod ecies;
+pub mod signal_guard;
 
 use ed25519_dalek::VerifyingKey;
 use freenet_stdlib::prelude::{ContractCode, ContractKey, Parameters};

--- a/ui/src/util/signal_guard.rs
+++ b/ui/src/util/signal_guard.rs
@@ -21,12 +21,28 @@
 //! whatever it *did* read successfully — and if that is nothing, to nothing at
 //! all. The memo is then permanently stuck: no write to the signal can wake it.
 //!
-//! Contention is routine rather than exotic. A signal write's Drop handler fires
+//! What actually holds the borrow across a recompute is NOT established, and the
+//! explanation in `.claude/rules/dioxus-signal-safety.md` ("a write's Drop fires
 //! subscriber notifications synchronously, and those notifications poll memos
-//! that `try_read()` the signal still being written — the hazard documented in
-//! `.claude/rules/dioxus-signal-safety.md`, and the cause of river#499 (DM rail
-//! collapsed to empty) and river#555 (conversation showed "No messages yet" in a
-//! full room until reload).
+//! that `try_read()` the signal still being written") does not hold in 0.7.9:
+//! `WriteLock`'s borrow field drops before its `SignalSubscriberDrop`
+//! (`write.rs:164`), `update_subscribers` takes a fresh read
+//! (`signal.rs:260`, which would panic on every write otherwise), and
+//! `mark_dirty` for a memo only sets a flag and sends on a channel
+//! (`memo.rs:53`) — the recompute happens later in a task. So the notification
+//! path is not the contending writer.
+//!
+//! Contention is nonetheless real and observed: `signal.rs:262` notes outright
+//! that "mark_dirty can run user code", and this repo has a recorded instance
+//! (`sync_info.rs`'s `rooms_awaiting_subscription` bails on a contended `ROOMS`
+//! because `process_rooms()` gets driven during a write-guard drop). river#499
+//! (DM rail collapsed to empty) and river#555 (conversation showed "No messages
+//! yet" in a full room until reload) are the two user-visible instances.
+//!
+//! Treat the trigger as INFERRED, not diagnosed. A single `Err` is enough to
+//! latch a memo permanently, so this guard is worth having either way — but
+//! naming the contending writer is still open work, and until it is named the
+//! nudge frequency in the field is unknown.
 //!
 //! ## The pattern
 //!
@@ -257,11 +273,39 @@ mod tests {
                  fallibly. Remove the entry rather than leaving a vacuous pin."
             );
         }
+        // EXACT count, not a floor. There are 12 fallible memos across the 8
+        // files (conversation.rs alone has 4, member_info_modal.rs 2). A floor of
+        // 8 left exactly the slack this assertion exists to remove: the matcher
+        // could stop finding all four conversation.rs bodies -- the file that
+        // caused #555 -- and still pass.
+        assert_eq!(
+            checked, 12,
+            "expected to check exactly the 12 known fallible memos, checked \
+             {checked}. If you added or removed a fallible memo, update this \
+             number deliberately; if you did not, the matcher has stopped \
+             finding memo bodies and this pin has gone vacuous."
+        );
+    }
+
+    /// The anchor and the nudge must reference the SAME signal, or the guard is
+    /// decorative: every anchored memo keeps a subscription that nothing ever
+    /// writes, which is exactly the permanent latch of #555. Deleting the
+    /// `with_mut` line left the whole suite green before this test existed.
+    #[test]
+    fn schedule_nudge_writes_the_signal_anchor_reads() {
+        let src = production_only(include_str!("signal_guard.rs"));
+        let nudge = src
+            .split("pub fn schedule_nudge()")
+            .nth(1)
+            .expect("schedule_nudge() should be defined");
+        // Body of the fn: up to the start of the next item.
+        let body = &nudge[..nudge.find("\n}").unwrap_or(nudge.len())];
         assert!(
-            checked >= 8,
-            "expected to check at least the 8 known fallible memos, checked \
-             {checked} — the matcher probably stopped finding memo bodies, which \
-             would make this pin silently vacuous."
+            body.contains("REBUILD_TICK.with_mut"),
+            "schedule_nudge() must write REBUILD_TICK -- the very signal \
+             anchor() subscribes to. Without that write the anchor keeps a \
+             subscription nothing ever fires, so a contended memo stays latched \
+             forever (freenet/river#555)."
         );
     }
 

--- a/ui/src/util/signal_guard.rs
+++ b/ui/src/util/signal_guard.rs
@@ -260,11 +260,21 @@ mod tests {
                      Err path the anchor is never reached, so it registers \
                      nothing (freenet/river#555)."
                 );
+                // One nudge per fallible read, not one per memo. The anchor keeps
+                // the memo alive, but a contended read still drops THAT signal's
+                // subscription, so each fallible read needs its own retry. A
+                // per-body `contains` check passed happily while two secondary
+                // reads (OUTBOUND_DMS, SYNC_INFO) had no nudge at all -- human
+                // review caught those, which is precisely what this pin is for.
+                let reads = body.matches("try_read(").count();
+                let nudges = body.matches("signal_guard::schedule_nudge").count();
                 assert!(
-                    body.contains("signal_guard::schedule_nudge"),
-                    "{name}: use_memo at line {line} degrades on a contended \
-                     read without calling signal_guard::schedule_nudge(), so \
-                     nothing ever wakes it to retry (freenet/river#555)."
+                    nudges >= reads,
+                    "{name}: use_memo at line {line} has {reads} fallible \
+                     read(s) but only {nudges} schedule_nudge() call(s). Every \
+                     read that can fail needs a nudge on its own failure \
+                     branch, or that signal's subscription is dropped with \
+                     nothing to restore it (freenet/river#555)."
                 );
             }
             assert!(

--- a/ui/src/util/signal_guard.rs
+++ b/ui/src/util/signal_guard.rs
@@ -1,0 +1,288 @@
+//! Keeping a fallible-read memo reactive (freenet/river#555).
+//!
+//! ## The defect this exists to prevent
+//!
+//! A `use_memo` whose closure early-returns on a contended `try_read()` can lose
+//! the subscription to the very signal it depends on, and then never re-evaluate.
+//! Two facts from the Dioxus 0.7.9 source combine to cause it:
+//!
+//! 1. **A memo rebuilds its dependency set on every pass.** `Memo` recomputes via
+//!    `rc.reset_and_run_in(&mut f)` (`dioxus-signals-0.7.9/src/memo.rs:62`), and
+//!    `reset_and_run_in` is `clear_subscribers()` followed by `run_in(f)`
+//!    (`dioxus-core-0.7.9/src/reactive_context.rs:195-198`). Whatever the closure
+//!    does not read on a given pass is not a dependency after that pass.
+//!
+//! 2. **`try_read()` does not subscribe when it fails.**
+//!    `Signal::try_read_unchecked` propagates the borrow error with `?` *before*
+//!    reaching `reactive_context.subscribe(...)`
+//!    (`dioxus-signals-0.7.9/src/signal.rs:409` vs `:413`).
+//!
+//! So a pass that hits `Err` and returns early ends up subscribed only to
+//! whatever it *did* read successfully — and if that is nothing, to nothing at
+//! all. The memo is then permanently stuck: no write to the signal can wake it.
+//!
+//! Contention is routine rather than exotic. A signal write's Drop handler fires
+//! subscriber notifications synchronously, and those notifications poll memos
+//! that `try_read()` the signal still being written — the hazard documented in
+//! `.claude/rules/dioxus-signal-safety.md`, and the cause of river#499 (DM rail
+//! collapsed to empty) and river#555 (conversation showed "No messages yet" in a
+//! full room until reload).
+//!
+//! ## The pattern
+//!
+//! Generalised from the per-file version `dm_rail_section.rs` grew for #499:
+//!
+//! ```ignore
+//! let thing = use_memo(move || {
+//!     crate::util::signal_guard::anchor();          // FIRST, before any try_read
+//!     let Ok(rooms) = ROOMS.try_read() else {
+//!         crate::util::signal_guard::schedule_nudge();
+//!         return None;                              // or a last-good value
+//!     };
+//!     ...
+//! });
+//! ```
+//!
+//! [`anchor`] is an infallible read of a signal nothing contends, so the memo
+//! always retains at least one dependency. [`schedule_nudge`] bumps that signal
+//! one macrotask later, so the memo re-polls in a borrow-free context instead of
+//! waiting for some unrelated user action to happen to write a signal it reads.
+//!
+//! The tick is deliberately **shared** across call sites. A nudge from one memo
+//! re-evaluates every anchored memo, which costs one cheap pass each and makes
+//! recovery global; per-site ticks would buy nothing but duplication.
+//!
+//! `dm_rail_section.rs` keeps its own `RAIL_REBUILD_TICK` and is left alone: it
+//! works, it is covered by its own pin tests, and rewiring it would put a
+//! working recovery path at risk for tidiness alone.
+
+use dioxus::prelude::*;
+
+/// Shared anchor signal. Read infallibly by [`anchor`]; bumped by
+/// [`schedule_nudge`]. Only ever written from inside `crate::util::defer`, so a
+/// reader never meets a live write guard.
+static REBUILD_TICK: GlobalSignal<u64> = Global::new(|| 0);
+
+thread_local! {
+    /// One queued bump at a time. Without this, every degraded memo in a render
+    /// would queue its own bump and each bump would re-evaluate every anchored
+    /// memo.
+    static NUDGE_PENDING: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Register an infallible dependency for the calling memo.
+///
+/// Call this **before the first fallible read** in any memo that `try_read()`s a
+/// signal. It guarantees the memo cannot come out of a contended pass with zero
+/// subscriptions, and it is the channel [`schedule_nudge`] uses to wake it.
+///
+/// Uses `read()`, not `peek()`: `peek` deliberately does not subscribe, which
+/// would make this a no-op.
+pub fn anchor() {
+    let _ = *REBUILD_TICK.read();
+}
+
+/// Schedule a deferred re-evaluation of every anchored memo.
+///
+/// Call from each degraded (contended-read) branch. The bump runs inside
+/// `crate::util::defer` — the clean execution context the signal-safety rules
+/// require for a signal mutation — so the retried pass reads in a borrow-free
+/// context and schedules no further nudge. If contention somehow persists, that
+/// pass queues exactly one more; the loop ends as soon as a pass reads cleanly.
+pub fn schedule_nudge() {
+    if NUDGE_PENDING.with(|c| c.replace(true)) {
+        return; // a bump is already queued
+    }
+    crate::util::defer(|| {
+        NUDGE_PENDING.with(|c| c.set(false));
+        REBUILD_TICK.with_mut(|t| *t = t.wrapping_add(1));
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    /// Every call site that `try_read()`s a signal inside a `use_memo` must read
+    /// the anchor before its first fallible read, and must nudge on every
+    /// degraded branch. Source-scraped rather than run, because exercising the
+    /// real behaviour needs a Dioxus runtime and a rendered component tree; this
+    /// mirrors `dm_rail_section.rs`'s
+    /// `rail_builders_read_infallible_guard_before_first_fallible_read`.
+    ///
+    /// Anchored on the API surface (`signal_guard::anchor`, `try_read(`) rather
+    /// than on variable names, so a rename cannot silently disarm it.
+    const GUARDED_MEMO_SITES: &[(&str, &str)] = &[
+        (
+            "conversation.rs message_groups",
+            include_str!("../components/conversation.rs"),
+        ),
+        (
+            "members.rs members",
+            include_str!("../components/members.rs"),
+        ),
+        (
+            "member_info_modal.rs",
+            include_str!("../components/members/member_info_modal.rs"),
+        ),
+        (
+            "ban_button.rs",
+            include_str!("../components/members/member_info_modal/ban_button.rs"),
+        ),
+        (
+            "invite_member_modal.rs",
+            include_str!("../components/members/invite_member_modal.rs"),
+        ),
+        (
+            "room_list.rs room_items",
+            include_str!("../components/room_list.rs"),
+        ),
+        (
+            "edit_room_modal.rs editing_room",
+            include_str!("../components/room_list/edit_room_modal.rs"),
+        ),
+        (
+            "dm_thread_modal.rs view",
+            include_str!("../components/direct_messages/dm_thread_modal.rs"),
+        ),
+    ];
+
+    /// Cut production source at the test module so a needle appearing only in a
+    /// test cannot satisfy the pin. Splits on `mod tests`, not
+    /// `#[cfg(test)]`, because attributes also decorate non-test items.
+    fn production_only(src: &str) -> &str {
+        match src.find("\nmod tests") {
+            Some(i) => &src[..i],
+            None => src,
+        }
+    }
+
+    /// Drop `//` comments before scanning. Without this the pin matches its own
+    /// explanatory prose: a comment that mentions `try_read(` reads as a fallible
+    /// read occurring before the anchor, and the pin fails on correct code.
+    fn strip_line_comments(src: &str) -> String {
+        src.lines()
+            .map(|l| match l.find("//") {
+                Some(i) => &l[..i],
+                None => l,
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// Body of each `use_memo(...)`, delimited by balancing the parenthesis the
+    /// call opens. Whole-file scanning is not good enough: these files also
+    /// `try_read()` from event handlers, which is legitimate and unrelated, and a
+    /// naive "first try_read in the file" check flags it.
+    /// Scans BYTES, not chars: these files contain non-ASCII (em dashes and the
+    /// like), so char indices and byte offsets diverge, and mixing them silently
+    /// slices the wrong region — which made an earlier version of this pin report
+    /// "no memo reads fallibly" for a file with four of them. `(` and `)` are
+    /// ASCII, so byte scanning is exact here.
+    fn memo_bodies(src: &str) -> Vec<(usize, &str)> {
+        let bytes = src.as_bytes();
+        let mut out = Vec::new();
+        let mut search = 0usize;
+        while let Some(rel) = src[search..].find("use_memo(") {
+            let open = search + rel + "use_memo(".len() - 1; // byte offset of '('
+            let start_line = src[..open].matches('\n').count() + 1;
+            let mut depth = 0i32;
+            let mut end = None;
+            for i in open..bytes.len() {
+                match bytes[i] {
+                    b'(' => depth += 1,
+                    b')' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            end = Some(i);
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            if let Some(end) = end {
+                out.push((start_line, &src[open..=end]));
+            }
+            search = open + 1;
+        }
+        out
+    }
+
+    /// Every memo that reads a signal fallibly must read the anchor FIRST and
+    /// must nudge on contention. Checked per memo body, not per file: each memo
+    /// rebuilds its own dependency set, so an anchor in a sibling memo protects
+    /// nothing.
+    #[test]
+    fn every_fallible_memo_anchors_before_its_first_try_read_and_nudges() {
+        let mut checked = 0usize;
+        for (name, src) in GUARDED_MEMO_SITES {
+            let prod = strip_line_comments(production_only(src));
+            let bodies = memo_bodies(&prod);
+            assert!(
+                !bodies.is_empty(),
+                "{name}: no use_memo found; the brace matcher or the file changed \
+                 shape. Fix the pin rather than deleting it."
+            );
+            let mut fallible_in_file = 0usize;
+            for (line, body) in bodies {
+                let Some(first_try) = body.find("try_read(") else {
+                    continue;
+                };
+                fallible_in_file += 1;
+                checked += 1;
+                let anchor = body.find("signal_guard::anchor").unwrap_or_else(|| {
+                    panic!(
+                        "{name}: use_memo at line {line} reads a signal with \
+                         try_read() but never calls signal_guard::anchor(). A \
+                         contended pass can leave it with zero subscriptions and \
+                         it will never re-evaluate (freenet/river#555)."
+                    )
+                });
+                assert!(
+                    anchor < first_try,
+                    "{name}: use_memo at line {line} calls \
+                     signal_guard::anchor() AFTER its first try_read( — on the \
+                     Err path the anchor is never reached, so it registers \
+                     nothing (freenet/river#555)."
+                );
+                assert!(
+                    body.contains("signal_guard::schedule_nudge"),
+                    "{name}: use_memo at line {line} degrades on a contended \
+                     read without calling signal_guard::schedule_nudge(), so \
+                     nothing ever wakes it to retry (freenet/river#555)."
+                );
+            }
+            assert!(
+                fallible_in_file > 0,
+                "{name}: listed in GUARDED_MEMO_SITES but no use_memo reads \
+                 fallibly. Remove the entry rather than leaving a vacuous pin."
+            );
+        }
+        assert!(
+            checked >= 8,
+            "expected to check at least the 8 known fallible memos, checked \
+             {checked} — the matcher probably stopped finding memo bodies, which \
+             would make this pin silently vacuous."
+        );
+    }
+
+    #[test]
+    fn anchor_uses_read_not_peek() {
+        // `peek()` explicitly does not subscribe, so an anchor built on it would
+        // compile, look right, and protect nothing.
+        let src = production_only(include_str!("signal_guard.rs"));
+        let anchor_fn = src
+            .split("pub fn anchor()")
+            .nth(1)
+            .expect("anchor() should be defined");
+        let body = &anchor_fn[..anchor_fn.find('}').unwrap_or(anchor_fn.len())];
+        assert!(
+            body.contains("REBUILD_TICK.read()"),
+            "anchor() must read() the tick to register a subscription"
+        );
+        assert!(
+            !body.contains("peek"),
+            "anchor() must not use peek(): peek does not subscribe, which would \
+             make the guard silently useless"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

A River tab left open stops showing new messages and only a page reload fixes it. Reported on Matrix 2026-07-29 ("the chat stopped and no new messages were loaded until i reloaded the site"), and seen before by @sanity and others. This is the symptom river#382 was closed for on 2026-07-06; #383's WebSocket liveness watchdog did not stop it.

Investigating produced **three independent mechanisms**, each of which on its own presents as "the chat stopped". **Two are fixed here (#555, #556).** The third (#557) was implemented, then dropped during review and left open -- see "Dropped from this PR".

### 1. A contended `try_read()` permanently latches a memo (#555)

`message_groups` (`conversation.rs`) early-returns when the `ROOMS` borrow is contended. Two facts from the Dioxus 0.7.9 source make that permanent rather than transient:

- A memo **rebuilds** its dependency set every pass: `Memo` recomputes via `rc.reset_and_run_in(&mut f)` (`dioxus-signals/src/memo.rs:62`), which is `clear_subscribers()` then `run_in(f)` (`dioxus-core/src/reactive_context.rs:195-198`).
- `try_read()` **does not subscribe on `Err`**: `Signal::try_read_unchecked` propagates the borrow failure with `?` at `signal.rs:409`, before reaching `reactive_context.subscribe(...)` at `:413`.

So one contended pass leaves the memo subscribed only to whatever it *did* read — and it then never reacts to `ROOMS` again. The conversation memo kept its `CURRENT_ROOM` subscription, so it recovered on a room switch; worse, it rendered **"No messages yet. Start the conversation!"** into a room full of history while latched.

Two sites were strictly worse — `member_info_modal.rs` (`self_member_id`) and `dm_thread_modal.rs` (`view`) read `ROOMS` *first*, so a contended pass left them with **zero** subscriptions, and both are mounted for the whole app session.

**What holds the borrow is not diagnosed.** An earlier revision of this PR repeated the explanation from `.claude/rules/dioxus-signal-safety.md` (a write's Drop firing notifications that synchronously poll memos). Three reviewers independently disproved it for 0.7.9: `WriteLock`'s borrow field drops before its `SignalSubscriberDrop` (`write.rs:164`), `update_subscribers` takes a fresh read (`signal.rs:260`, which would panic on every write otherwise), and `mark_dirty` on a memo only sets a flag and sends on a channel (`memo.rs:53`). So the notification path is not the contending writer.

Contention is still real and observed -- `signal.rs:262` notes "mark_dirty can run user code", and #397/#499 are the user-visible instances -- and a single `Err` latches permanently, so the guard is worth having regardless. But the trigger is **inferred**, and naming the contending writer remains open work (#560).

### 2. A reconnect leaves the tab subscribed to nothing (#556)

Client subscriptions live on the node against a `ClientId`, and the node tears down every subscription for that client on each socket exit (`websocket.rs::notify_disconnect` → `remove_client_from_all_subscriptions`). A reconnect gets a fresh `ClientId`, so afterwards the node holds no client subscription for any room.

The UI never re-subscribes: `SYNC_INFO` is a page-lifetime signal that still says `Subscribed`, and `rooms_awaiting_subscription()` only returns `Disconnected` (or timed-out `Subscribing`) rooms. `reset_ensure_subscription_dedup()` on the `Connect` path re-arms the chat *delegate's* subscription, not this client's per-room ones.

Net: the tab reconnects, shows **Connected**, and receives nothing for the rest of the session. The #383 watchdog is implicated rather than protective, since declaring the socket dead is precisely what triggers the reconnect.

### 3. A background invitation-accept steals the view (#557) — DIAGNOSIS ONLY, fix dropped

`get_response.rs` set `CURRENT_ROOM` unconditionally when an accept's PUT+subscribe completed. #218 also wires a **click-free auto-resume** at startup, so a stale stored accept against a large room can land minutes in and yank the reader elsewhere. Their original room keeps receiving messages off-screen, and its unread badge climbs. Every other `CURRENT_ROOM` writer is a user action or already gated by `SkipUserAlreadySelected`.

## Approach

**#555** adds `util::signal_guard`, generalising the three-part pattern `dm_rail_section.rs` grew for #499: an infallible `anchor()` read before any fallible read (so a memo can never come out of a contended pass with zero subscriptions), and a deferred `schedule_nudge()` on every degraded branch (so it re-polls a macrotask later instead of waiting for an unrelated signal write). Applied to all **12** fallible memos across 8 files (`conversation.rs` alone has 4; an earlier revision of this description said eight, conflating memos with files). `dm_rail_section.rs` keeps its own working `RAIL_REBUILD_TICK` — rewiring a working recovery path for tidiness would be a needless risk.

Deliberately **not** included: a last-good cache for `message_groups`. The nudge bounds the empty state to one macrotask instead of a whole session, which is the bulk of the harm. Reviewers correctly pushed back on my stated reason (deep-clone cost): an `Rc`-wrapped memo value makes the cache cheap, so the honest position is that this is deferred scope, not an impossibility. And "one macrotask" bounds duration, not visibility — the `None` render commits before the `setTimeout(0)` fires, so a brief flash of "No messages yet" (and of an empty room list, #397's symptom) is possible. Filed as #562.

**#556** flips `Subscribed` → `Disconnected` on a genuinely new socket so the existing `process_rooms()` path re-subscribes, and arms an independent `ProcessRooms` retry.

The retry is load-bearing, not belt-and-braces: `rooms_awaiting_subscription()` returns an empty map when `ROOMS.try_read()` is contended, on the assumption it will be called again — and on the reconnect path nothing calls it again (the `process_rooms()` call discards its result, every other sender is driven by a user edit or a response, and with nothing subscribed no response arrives). The watchdog cannot rescue it either, since its probe GET succeeds on a healthy socket. Without the retry this fix could fail exactly like the bug it fixes.

**Two costs of #556, disclosed because reviewers rightly asked:** re-subscribing goes through `ContractRequest::Put { subscribe: true }`, which ships **full room state per room, per reconnect** — the same cost this PR cites to justify excluding the `PageBecameVisible` path. `ContractRequest::Subscribe` would be the semantically matching repair, but a bare Subscribe is rejected when the contract WASM is not cached locally (pinned by `issue_287_loaded_rooms_do_not_bare_subscribe`), so switching needs its own analysis: filed as #561. Separately, `needs_to_send_update()` only returns `Subscribed` rooms, so outbound UPDATEs are suspended for the reconnect window — also #561. Scoped tightly: only on `Connect`, never on `PageBecameVisible`/`RefreshAllRooms` (that runs on a live socket where the node's subscriptions are intact, and re-subscribing there would ship full room state on every tab focus). Only `Subscribed` is flipped, so `Subscribing` keeps its timeout bookkeeping and terminal `Error` is not revived past its #290 retry budget.

### Rejected approach, recorded so nobody rebuilds it

Making the watchdog probe re-subscribe periodically **cannot work**. `is_receiving_updates` is `is_subscribed() || has_client_subscriptions()` (`hosting.rs:2348`), so while the client is still registered the node takes `should_serve_local_copy` and answers from its own possibly-stale copy, and the re-subscribe kick is gated `if !is_subscribed` and never fires. The node already retries that route every 30s itself (`recover_orphaned_subscriptions`).

## Testing

- **#556** is covered by real behavioural unit tests in `sync_info.rs`: a `Subscribed` room is re-armed, `Subscribing`/`Error`/`Disconnected` are left alone (including that a `Subscribing` room keeps its timeout stamp and a terminal `Error` room is not revived), and re-arming spends no #290 retry budget.
- **#555** is covered by source-scrape pins in `util/signal_guard.rs`, matching the idiom `dm_rail_section.rs` already uses for this exact class (`rail_builders_read_infallible_guard_before_first_fallible_read`) — exercising the real behaviour needs a Dioxus runtime and a rendered tree, and no test in this repo builds a `VirtualDom`. The pins assert, **per memo body** (not per file, so one anchor cannot appear to cover a file with several memos), that every fallible memo reads the anchor *before* its first `try_read` and nudges on contention; that the count is **exactly 12**, so the matcher going blind fails loudly rather than silently; that `anchor()` uses `read()` not `peek()` (a `peek` anchor would compile, look right, and protect nothing); and that `schedule_nudge` writes the very signal `anchor` reads — deleting that one line reverted all 12 guards to permanent latches with a fully green suite before that pin existed. All four are mutation-verified.

**Why CI did not catch these:** reactive-subscription behaviour has no test harness in this repo at all, so the whole class was invisible. The `signal_guard` pins close it for the pattern going forward; a `VirtualDom`-based harness that could test the behaviour directly is worth building separately.

## Dropped from this PR

**#557 (invitation-accept stealing `CURRENT_ROOM`) was implemented and then removed.** All three reviewers found the guard regresses the *deliberate* Accept, not just the background re-issue: both callers funnel through `accept_invitation` and are indistinguishable at the GET handler, and the delegate-restore path writes `CURRENT_ROOM` at startup, so any returning user has `owner_key.is_some()` before an invitation lands. Since `get_response.rs:766` is the only path that navigates to a newly accepted room, the result would have been: click Accept, room joins, modal closes, you stay in the old room. It also had no test, and the underlying diagnosis was explicitly unattributed. It needs a `user_initiated` flag threaded from the modal plus the pure-decision-function treatment `decide_current_room_restore` already has.

## Known gaps, filed not hidden

- **#559** — `use_effect` has the identical latch and 7 sites are unguarded, 4 of them single-dependency (so zero-subscription on contention). One is 24 lines from a memo this PR fixes. #555 explicitly asked for this audit.
- **#560** — name the contending writer, and replace the source-scrape pins with a native `VirtualDom` test. Reviewers showed such a test IS feasible (`dioxus_core` is not wasm-gated; `defer` runs inline on native), so "no test in this repo builds a VirtualDom" is a weaker claim than I made.
- **#561** — #556's full-state PUT per reconnect, and the suspended-outbound-UPDATE window.
- **#562** — `Rc` last-good caches to remove the one-frame blank.
- **#563** — `GUARDED_MEMO_SITES` is a hardcoded 8-file list that rots silently; walk `ui/src` at test time instead. Also consolidate `dm_rail_section`'s parallel tick, and collapse the per-site boilerplate into a `guarded_read` helper that makes the ordering structural rather than pin-enforced.

Closes #555
Closes #556

[AI-assisted - Claude]
