### PR TITLE
fix(ui): stop re-renders wiping in-progress typing in room dialogs

### DIFF
--- a/.claude/rules/dioxus-signal-safety.md
+++ b/.claude/rules/dioxus-signal-safety.md
@@ -190,6 +190,56 @@ Signal clears that the effect subscribes to must be synchronous.
 Deferring causes an infinite loop (set remains non-empty → effect
 re-runs → defers clear → effect re-runs...).
 
+## Bind `oninput` on every EDITABLE `value:` field
+
+`value` on `input` / `textarea` / `select` is a **volatile** attribute in
+dioxus-html (`elements.rs:1488,1571,1594`). dioxus-core re-writes volatile
+attributes to the DOM on every re-render, even when the rendered string has
+not changed:
+
+```text
+// dioxus-core-0.7.9/src/diff/node.rs:463
+if volatile || attribute_changed { self.write_attribute(...) }
+```
+
+and the interpreter then assigns the value whenever the LIVE DOM value differs
+from the VDOM value:
+
+```text
+// dioxus-interpreter-js-0.7.9/src/ts/set_attribute.ts:31-33
+case "value": ... else if (node.value !== value) node.value = value;
+```
+
+`onchange` fires on blur, not per keystroke. So a field bound only through
+`onchange` still holds the PRE-TYPING text for as long as the user is typing,
+and the next re-render resets the control and discards the edit.
+
+```rust
+// WRONG — any re-render wipes what the user has typed so far
+textarea { value: "{description}", onchange: save }
+
+// RIGHT — the signal tracks the DOM, so the re-write is a no-op
+textarea {
+    value: "{description}",
+    oninput: move |evt| description.set(evt.value().to_string()),
+    onchange: save,
+}
+```
+
+Nothing about the broken call site looks wrong, and reasoning about the
+component in isolation will not reveal it: the trigger is whatever unrelated
+signal that component happens to read. `RoomDescriptionField` reads
+`CURRENT_ROOM` and `ROOMS` in its render body, so every room-state write
+re-rendered it, and the owner's half-typed room description vanished every few
+seconds (freenet/river#564).
+
+Display-only controls may bind `value:` with no `oninput`, but must declare
+themselves with a literal `readonly: true`. A conditional
+`readonly: !is_owner` does NOT count: the field is editable for somebody, and
+that somebody is exactly who loses their typing.
+`components.rs::volatile_value_binding_audit` enforces this across the whole
+`ui/src` tree, so a new field cannot reintroduce the class.
+
 ## Don't `use_memo` against non-signal values in an always-mounted component
 
 The modals in `app.rs` (`MemberInfoModal`, `DmThreadModal`,

--- a/.claude/rules/dioxus-signal-safety.md
+++ b/.claude/rules/dioxus-signal-safety.md
@@ -230,15 +230,42 @@ Nothing about the broken call site looks wrong, and reasoning about the
 component in isolation will not reveal it: the trigger is whatever unrelated
 signal that component happens to read. `RoomDescriptionField` reads
 `CURRENT_ROOM` and `ROOMS` in its render body, so every room-state write
-re-rendered it, and the owner's half-typed room description vanished every few
-seconds (freenet/river#564).
+re-rendered it, and the owner's half-typed room description vanished
+(freenet/river#564). There is no single timer behind that cadence: the
+recurring ROOMS writers are the ~60 s idle liveness probe whose GET reply
+merges unconditionally, the ~21 s `ProcessRooms` loop while a room awaits
+subscription, and every subscription `UpdateNotification`. Do not go looking
+for one interval to blame.
+
+**This is the documented exception to the `defer()` rule above.** A controlled
+input's bound signal must be written SYNCHRONOUSLY from `oninput`. Deferring it
+lags the DOM by a `setTimeout(0)`, so a re-render landing in that window writes
+the pre-keystroke value back and drops characters, which is the very bug this
+section exists to prevent. The rule above targets GLOBAL signals (`ROOMS`,
+`CURRENT_ROOM`, ...) with external subscribers; `util.rs`'s
+`event_handlers_never_write_a_global_signal_without_defer` pin is scoped to
+those deliberately and does not match `oninput`. Local `use_signal` handles
+have no external subscribers and are set directly. See also the note at
+`members.rs`'s import-token `oninput`.
 
 Display-only controls may bind `value:` with no `oninput`, but must declare
-themselves with a literal `readonly: true`. A conditional
-`readonly: !is_owner` does NOT count: the field is editable for somebody, and
-that somebody is exactly who loses their typing.
-`components.rs::volatile_value_binding_audit` enforces this across the whole
-`ui/src` tree, so a new field cannot reintroduce the class.
+themselves with a literal `readonly: true` (or `readonly: "true"`). A
+conditional `readonly: !is_owner` does NOT count: the field is editable for
+somebody, and that somebody is exactly who loses their typing.
+`type="checkbox"` and `type="radio"` are exempt too, for the opposite reason:
+dioxus reports their `evt.value()` as `"true"`/`"false"`, never the DOM's
+`"on"`, so tracking a `value:` binding there would CAUSE a rewrite every
+render. Bind `checked:`, which is not volatile.
+
+`components.rs::volatile_value_binding_audit` scans every `.rs` file under
+`ui/src` for this and pins the exact set of bindings it finds, so a field that
+drops out of the scan fails loudly rather than quietly losing coverage. Two
+limits worth knowing: it proves `oninput` is present and not a no-op, but not
+that the handler writes the signal the `value:` binding reads; and it says
+nothing about the OTHER route to the same symptom, where a parent unmounts the
+field (a contended `try_read` memo returning `None`) and the remount re-seeds
+`use_signal`. That second route is the #499/#555 contention family and
+`oninput` does not help there.
 
 ## Don't `use_memo` against non-signal values in an always-mounted component
 

--- a/.claude/rules/dioxus-signal-safety.md
+++ b/.claude/rules/dioxus-signal-safety.md
@@ -228,25 +228,34 @@ textarea {
 
 Nothing about the broken call site looks wrong, and reasoning about the
 component in isolation will not reveal it: the trigger is whatever unrelated
-signal that component happens to read. `RoomDescriptionField` reads
+signal that component happens to read. `RoomDescriptionField` read
 `CURRENT_ROOM` and `ROOMS` in its render body, so every room-state write
 re-rendered it, and the owner's half-typed room description vanished
-(freenet/river#564). There is no single timer behind that cadence: the
+(freenet/river#564). It no longer reads them there, so today the trigger is a
+prop change instead. That is exactly why the handler is the fix rather than
+removing the subscription: `oninput` makes a field correct under ANY
+re-render, and the trigger is never local to the component. There is no single
+timer behind that cadence either: the
 recurring ROOMS writers are the ~60 s idle liveness probe whose GET reply
 merges unconditionally, the ~21 s `ProcessRooms` loop while a room awaits
 subscription, and every subscription `UpdateNotification`. Do not go looking
 for one interval to blame.
 
-**This is the documented exception to the `defer()` rule above.** A controlled
-input's bound signal must be written SYNCHRONOUSLY from `oninput`. Deferring it
-lags the DOM by a `setTimeout(0)`, so a re-render landing in that window writes
-the pre-keystroke value back and drops characters, which is the very bug this
-section exists to prevent. The rule above targets GLOBAL signals (`ROOMS`,
-`CURRENT_ROOM`, ...) with external subscribers; `util.rs`'s
-`event_handlers_never_write_a_global_signal_without_defer` pin is scoped to
-those deliberately and does not match `oninput`. Local `use_signal` handles
-have no external subscribers and are set directly. See also the note at
-`members.rs`'s import-token `oninput`.
+**This is the documented exception to the `defer()` rule above, and it is
+narrow.** A controlled input's bound LOCAL signal must be written
+SYNCHRONOUSLY from `oninput`. Deferring it lags the DOM by a `setTimeout(0)`,
+so a re-render landing in that window writes the pre-keystroke value back and
+drops characters, which is the very bug this section exists to prevent.
+
+The exception covers local `use_signal` handles only. They have no external
+subscribers, which is why `util.rs`'s
+`event_handlers_never_write_a_global_signal_without_defer` does not object to
+them. It is NOT a blanket `oninput` exemption: that pin does scan `oninput:`
+(both inline closures and named handlers) and still requires `defer()` around a
+write to a GLOBAL signal such as `ROOMS` or `CURRENT_ROOM`. If you need a
+keystroke to reach global state, track the local signal synchronously and
+defer the global write. See also the note at `members.rs`'s import-token
+`oninput`.
 
 Display-only controls may bind `value:` with no `oninput`, but must declare
 themselves with a literal `readonly: true` (or `readonly: "true"`). A

--- a/ui/src/components.rs
+++ b/ui/src/components.rs
@@ -77,21 +77,23 @@ mod volatile_value_binding_audit {
     use std::collections::BTreeSet;
     use std::path::{Path, PathBuf};
 
-    /// Elements whose `value` (or `option`'s `selected`) dioxus marks volatile.
+    /// Elements carrying a volatile attribute. Which attribute differs:
+    /// `input`/`select`/`textarea` mark `value`, `option` marks `selected`
+    /// (its `value` is NOT volatile) - dioxus-html `elements.rs:1488,1536,1571,1594`.
     const VOLATILE_ELEMENTS: [&str; 4] = ["input", "textarea", "select", "option"];
 
     /// Every editable volatile binding in `ui/src`, as
-    /// `path <element> value-expression`.
+    /// `path <element> bound-expression`.
     ///
-    /// This is pinned as an EXACT SET, not a count with slack. A loose
-    /// threshold is how a scanner rots silently: if a future edit makes a file
-    /// (or a whole region of one) invisible to the scan, its entries simply
-    /// disappear and a `>=` floor keeps passing with the fields it was written
-    /// to protect no longer covered. An exact set turns that into a loud diff.
+    /// Pinned as an EXACT SET, not a count with slack. A loose threshold is how
+    /// a scanner rots silently: if a future edit makes a file (or a region of
+    /// one) invisible to the scan, its entries simply disappear and a `>=`
+    /// floor keeps passing with the fields it was written to protect no longer
+    /// covered. An exact set turns that into a loud diff.
     ///
-    /// Adding a form control to the UI is expected to fail this test. Add the
-    /// line, having first confirmed the control handles `oninput`.
-    const EXPECTED_EDITABLE: [&str; 14] = [
+    /// Adding a form control is EXPECTED to fail this test. Add the line, once
+    /// you have confirmed the control handles `oninput`.
+    const EXPECTED_EDITABLE: &[&str] = &[
         r#"components/conversation.rs <textarea> "{edit_text}""#,
         r#"components/conversation/message_input.rs <textarea> "{message_text}""#,
         r#"components/direct_messages/dm_thread_modal.rs <textarea> "{draft.read()}""#,
@@ -108,18 +110,32 @@ mod volatile_value_binding_audit {
         r#"components/room_list/room_name_field.rs <input> "{room_name}""#,
     ];
 
-    /// Read-only display controls, same pinning rationale.
-    const EXPECTED_DISPLAY_ONLY: usize = 8;
+    /// Read-only display controls, pinned exactly for the same reason: a bare
+    /// count cannot say WHICH one changed.
+    const EXPECTED_DISPLAY_ONLY: &[&str] = &[
+        r#"components/conversation/not_member_notification.rs <input> "{encoded_key}""#,
+        r#"components/members.rs <textarea> "{token_text}""#,
+        r#"components/members/invite_member_modal.rs <input> invitation_code"#,
+        r#"components/members/invite_member_modal.rs <input> invitation_url"#,
+        r#"components/members/member_info_modal.rs <input> "{member_id_str}""#,
+        r#"components/room_list/edit_room_modal.rs <input> "{bs58::encode(room_data.owner_vk.as_bytes()).into_string()}""#,
+        r#"components/room_list/edit_room_modal.rs <input> "{room_data.contract_key.id()}""#,
+        r#"components/room_list/edit_room_modal.rs <input> "{secret_version}""#,
+    ];
 
     // ---------------------------------------------------------------- lexing
 
     /// Per-character classification of a Rust source file.
     ///
-    /// Brace depth must be tracked outside comments AND string literals, or a
-    /// `{` in a class string or a `//` in a URL corrupts every block boundary
-    /// after it. Attribute TEXT keeps string literals (they are the values)
-    /// but drops comments, or a doc comment sitting above an attribute is
-    /// glued onto the front of it and the attribute name no longer parses.
+    /// Brace depth must be tracked outside comments, string literals AND char
+    /// literals, or a `{` in a class string, a `//` in a URL, or a `'"'` in a
+    /// match arm corrupts every block boundary after it. A missing char-literal
+    /// arm is not hypothetical: `conversation.rs` matches on `'"'`, which flips
+    /// string/code polarity for the rest of the file and silently un-audits it.
+    ///
+    /// Attribute TEXT keeps string literals (they are the values) but drops
+    /// comments, or a doc comment above an attribute is glued onto the front of
+    /// it and the attribute name no longer parses.
     struct Lexed {
         chars: Vec<char>,
         in_comment: Vec<bool>,
@@ -143,18 +159,36 @@ mod volatile_value_binding_audit {
                     }
                     i = j;
                 } else if c == '/' && i + 1 < n && chars[i + 1] == '*' {
+                    // Rust block comments nest.
+                    let mut depth = 0usize;
                     let mut j = i;
                     while j < n {
-                        in_comment[j] = true;
-                        if j > i && chars[j - 1] == '*' && chars[j] == '/' {
-                            j += 1;
-                            break;
+                        if chars[j] == '/' && j + 1 < n && chars[j + 1] == '*' {
+                            depth += 1;
+                            in_comment[j] = true;
+                            in_comment[j + 1] = true;
+                            j += 2;
+                            continue;
                         }
+                        if chars[j] == '*' && j + 1 < n && chars[j + 1] == '/' {
+                            in_comment[j] = true;
+                            in_comment[j + 1] = true;
+                            j += 2;
+                            depth -= 1;
+                            if depth == 0 {
+                                break;
+                            }
+                            continue;
+                        }
+                        in_comment[j] = true;
                         j += 1;
                     }
                     i = j;
-                } else if c == 'r' && i + 1 < n && (chars[i + 1] == '"' || chars[i + 1] == '#') {
-                    // Raw string: r"..." / r#"..."# / r##"..."##
+                } else if (c == 'r' || c == 'b')
+                    && i + 1 < n
+                    && (chars[i + 1] == '"' || chars[i + 1] == '#')
+                {
+                    // Raw / byte string: r"..", r#".."#, b"..".
                     let mut hashes = 0;
                     let mut k = i + 1;
                     while k < n && chars[k] == '#' {
@@ -163,16 +197,12 @@ mod volatile_value_binding_audit {
                     }
                     if k < n && chars[k] == '"' {
                         let mut j = k + 1;
-                        loop {
-                            if j >= n {
+                        while j < n {
+                            if chars[j] == '"'
+                                && (1..=hashes).all(|h| chars.get(j + h) == Some(&'#'))
+                            {
+                                j += hashes + 1;
                                 break;
-                            }
-                            if chars[j] == '"' {
-                                let closed = (1..=hashes).all(|h| chars.get(j + h) == Some(&'#'));
-                                if closed {
-                                    j += hashes + 1;
-                                    break;
-                                }
                             }
                             j += 1;
                         }
@@ -200,6 +230,33 @@ mod volatile_value_binding_audit {
                         *s = true;
                     }
                     i = j;
+                } else if c == '\'' {
+                    // Char literal, or a lifetime (`&'static str`), which is
+                    // ordinary code. An escape always means a literal;
+                    // otherwise it is only a literal if a quote closes it
+                    // immediately.
+                    let escaped = chars.get(i + 1) == Some(&'\\');
+                    let single = chars.get(i + 2) == Some(&'\'');
+                    if escaped || single {
+                        let mut j = i + 1;
+                        while j < n {
+                            if chars[j] == '\\' {
+                                j += 2;
+                                continue;
+                            }
+                            if chars[j] == '\'' {
+                                j += 1;
+                                break;
+                            }
+                            j += 1;
+                        }
+                        for s in in_string.iter_mut().take(j.min(n)).skip(i) {
+                            *s = true;
+                        }
+                        i = j;
+                    } else {
+                        i += 1;
+                    }
                 } else {
                     i += 1;
                 }
@@ -221,28 +278,57 @@ mod volatile_value_binding_audit {
                 .enumerate()
                 .all(|(k, c)| self.chars.get(i + k) == Some(&c))
         }
+
+        /// The identifier immediately preceding `i` in CODE (comments and
+        /// strings skipped), used to tell rsx `input {` from `match input {`.
+        fn prev_code_ident(&self, i: usize) -> String {
+            let mut j = i;
+            while j > 0 {
+                j -= 1;
+                if self.is_code(j) && !self.chars[j].is_whitespace() {
+                    break;
+                }
+                if j == 0 {
+                    return String::new();
+                }
+            }
+            let mut ident: Vec<char> = Vec::new();
+            let mut k = j as isize;
+            while k >= 0 {
+                let idx = k as usize;
+                let ch = self.chars[idx];
+                if self.is_code(idx) && (ch.is_alphanumeric() || ch == '_') {
+                    ident.push(ch);
+                    k -= 1;
+                } else {
+                    break;
+                }
+            }
+            ident.reverse();
+            ident.into_iter().collect()
+        }
     }
 
     // -------------------------------------------------------- cfg(test) cull
 
-    /// Remove `#[cfg(test)]` ITEMS, wherever they appear.
+    /// Blank out `#[cfg(test)]` ITEMS wherever they appear, PRESERVING LINE
+    /// NUMBERS so reported positions match the real file.
     ///
     /// Deliberately not `src.find("#[cfg(test)]")` and not
     /// `find("#[cfg(test)]\nmod tests {")`. The first is the trap
     /// `conversation.rs` and `members.rs` both document: the first occurrence
-    /// there is a test-only HELPER function a thousand lines up, so cutting at
-    /// it discards most of the file. Those pins assert a needle is PRESENT, so
-    /// an over-short slice fails loudly for them; this audit asserts a needle
-    /// is ABSENT, so an over-short slice passes SILENTLY. The polarity is
-    /// reversed and the heuristic does not carry over.
+    /// there is a test-only HELPER a thousand lines up, so cutting at it
+    /// discards most of the file. Those pins survive it because they assert a
+    /// needle is PRESENT, so an over-short slice fails loudly; this audit
+    /// asserts a needle is ABSENT, where an over-short slice passes SILENTLY.
+    /// The polarity is reversed and the heuristic does not carry over.
     ///
-    /// The `mod tests {` variant is also wrong here: this repo has at least
-    /// one mid-file `mod tests` (`chat_delegate.rs`), so cutting there would
-    /// discard production code below it.
+    /// The `mod tests {` variant is wrong here too: this repo has a mid-file
+    /// `mod tests` (`chat_delegate.rs`) whose production code would be lost.
     ///
-    /// Removing each annotated item individually is exact, and keeps
-    /// production rsx that lives after a test module. It also removes THIS
-    /// module, so the fixtures below cannot satisfy the audit's own needles.
+    /// Removing each annotated item individually is exact, and keeps production
+    /// rsx that follows a test module. It also removes THIS module, so the
+    /// fixtures below cannot satisfy the audit's own needles.
     fn strip_cfg_test_items(src: &str) -> String {
         const NEEDLE: &str = "#[cfg(test)]";
         let lx = Lexed::new(src);
@@ -251,26 +337,36 @@ mod volatile_value_binding_audit {
         let mut i = 0;
         while i < n {
             if lx.is_code(i) && lx.starts_with_at(i, NEEDLE) {
-                // Skip forward past the annotated item: either a brace-delimited
-                // body, or a `;`-terminated one (`#[cfg(test)] use foo::Bar;`).
                 let mut j = i + NEEDLE.chars().count();
-                let mut depth = 0usize;
+                let mut braces = 0usize;
+                let mut brackets = 0usize;
                 let mut opened = false;
                 while j < n {
                     if lx.is_code(j) {
                         match lx.chars[j] {
                             '{' => {
-                                depth += 1;
+                                braces += 1;
                                 opened = true;
                             }
                             '}' => {
-                                depth -= 1;
-                                if opened && depth == 0 {
+                                // A `}` before any `{` means the annotation sat
+                                // on a struct field / enum variant / match arm,
+                                // and we have run into the enclosing block's
+                                // close. Stop rather than underflow.
+                                if braces == 0 {
+                                    break;
+                                }
+                                braces -= 1;
+                                if opened && braces == 0 {
                                     j += 1;
                                     break;
                                 }
                             }
-                            ';' if !opened => {
+                            '[' | '(' => brackets += 1,
+                            ']' | ')' => brackets = brackets.saturating_sub(1),
+                            // Only a `;` at top level ends the item: one inside
+                            // brackets is part of a type like `[u8; 4]`.
+                            ';' if !opened && brackets == 0 => {
                                 j += 1;
                                 break;
                             }
@@ -278,6 +374,12 @@ mod volatile_value_binding_audit {
                         }
                     }
                     j += 1;
+                }
+                // Preserve newlines so line numbers stay truthful.
+                for k in i..j.min(n) {
+                    if lx.chars[k] == '\n' {
+                        out.push('\n');
+                    }
                 }
                 i = j;
                 continue;
@@ -312,34 +414,38 @@ mod volatile_value_binding_audit {
     ///
     /// Character-based rather than line-based: a line-based split cannot see
     /// the opening line's attributes, silently skips single-line elements, and
-    /// mis-reads two attributes written on one line.
+    /// mis-reads two attributes written on one line. Commas inside `(...)` or
+    /// `[...]` do not separate attributes.
     fn parse_attrs(lx: &Lexed, open: usize, close: usize) -> Vec<(String, String)> {
         let mut segments: Vec<String> = Vec::new();
         let mut cur = String::new();
-        let mut depth = 0usize;
+        let mut braces = 0usize;
+        let mut brackets = 0usize;
         for (i, ch) in lx.chars.iter().enumerate().take(close + 1).skip(open) {
             if lx.is_code(i) {
                 match ch {
                     '{' => {
-                        depth += 1;
-                        if depth == 1 {
+                        braces += 1;
+                        if braces == 1 {
                             continue;
                         }
                     }
                     '}' => {
-                        depth -= 1;
-                        if depth == 0 {
+                        braces -= 1;
+                        if braces == 0 {
                             break;
                         }
                     }
-                    ',' if depth == 1 => {
+                    '(' | '[' => brackets += 1,
+                    ')' | ']' => brackets = brackets.saturating_sub(1),
+                    ',' if braces == 1 && brackets == 0 => {
                         segments.push(std::mem::take(&mut cur));
                         continue;
                     }
                     _ => {}
                 }
             }
-            if depth >= 1 && !lx.in_comment[i] {
+            if braces >= 1 && !lx.in_comment[i] {
                 cur.push(*ch);
             }
         }
@@ -386,7 +492,6 @@ mod volatile_value_binding_audit {
                     i += 1;
                     continue;
                 }
-                // Token boundary before the name.
                 let prev = if i == 0 { ' ' } else { lx.chars[i - 1] };
                 if prev.is_alphanumeric()
                     || prev == '_'
@@ -397,7 +502,6 @@ mod volatile_value_binding_audit {
                     i += 1;
                     continue;
                 }
-                // `{` after optional whitespace (including newlines).
                 let mut j = i + len;
                 while j < n && lx.chars[j].is_whitespace() {
                     j += 1;
@@ -407,17 +511,16 @@ mod volatile_value_binding_audit {
                     continue;
                 }
                 // Reject `match input {`, `if input {`, ... which are not rsx.
-                let head: String = lx.chars[..i].iter().rev().take(24).collect::<String>();
-                let head: String = head.chars().rev().collect();
-                let head = head.trim_end();
-                if ["match", "if", "while", "for", "let", "in"]
-                    .iter()
-                    .any(|kw| head.ends_with(kw))
+                // Matched as a whole preceding CODE identifier: a substring
+                // test over raw text would also fire on a comment ending in
+                // "...for" and silently drop a real element.
+                let prev_ident = lx.prev_code_ident(i);
+                if ["match", "if", "while", "for", "let", "in", "else"]
+                    .contains(&prev_ident.as_str())
                 {
                     i += 1;
                     continue;
                 }
-                // Balanced block.
                 let mut depth = 0usize;
                 let mut k = j;
                 let mut close = j;
@@ -453,7 +556,7 @@ mod volatile_value_binding_audit {
         el.attr("readonly")
             .map(|v| {
                 let v = v.trim();
-                v.starts_with("true") || v.starts_with("\"true\"")
+                v == "true" || v == "\"true\""
             })
             .unwrap_or(false)
     }
@@ -468,22 +571,25 @@ mod volatile_value_binding_audit {
             .unwrap_or(false)
     }
 
-    /// The volatile binding this element carries, if any.
+    /// The VOLATILE binding this element carries, if any.
+    ///
+    /// `option` is the odd one out: dioxus marks its `selected` volatile and
+    /// its `value` NOT volatile (`elements.rs:1536`). Consulting `value` first
+    /// for every element both flagged ordinary `option { value: "us" }` as a
+    /// violation and hid the one attribute on `option` that actually is.
     fn volatile_binding(el: &Element) -> Option<&str> {
-        el.attr("value").or_else(|| {
-            if el.name == "option" {
-                el.attr("selected")
-            } else {
-                None
-            }
-        })
+        if el.name == "option" {
+            el.attr("selected")
+        } else {
+            el.attr("value")
+        }
     }
 
     /// An `oninput` that provably does nothing is worse than none: it satisfies
     /// a presence check while the field keeps losing keystrokes.
     fn is_noop_handler(body: &str) -> bool {
         let squished: String = body.chars().filter(|c| !c.is_whitespace()).collect();
-        squished.ends_with("{}") && squished.contains('|')
+        squished.contains('|') && (squished.ends_with("{}") || squished.ends_with("|()"))
     }
 
     // ----------------------------------------------------------------- files
@@ -505,8 +611,8 @@ mod volatile_value_binding_audit {
 
     struct Audit {
         editable: BTreeSet<String>,
+        display_only: BTreeSet<String>,
         violations: Vec<String>,
-        display_only: usize,
     }
 
     fn run_audit() -> Audit {
@@ -522,8 +628,8 @@ mod volatile_value_binding_audit {
 
         let mut audit = Audit {
             editable: BTreeSet::new(),
+            display_only: BTreeSet::new(),
             violations: Vec::new(),
-            display_only: 0,
         };
 
         for path in &files {
@@ -542,12 +648,12 @@ mod volatile_value_binding_audit {
                 if is_toggle(&el) {
                     continue;
                 }
+                let id = format!("{rel} <{}> {binding}", el.name);
                 if is_display_only(&el) {
-                    audit.display_only += 1;
+                    audit.display_only.insert(id);
                     continue;
                 }
-                let id = format!("{rel} <{}> {binding}", el.name);
-                audit.editable.insert(id.clone());
+                audit.editable.insert(id);
 
                 match el.attr("oninput") {
                     None => audit
@@ -559,10 +665,17 @@ mod volatile_value_binding_audit {
                     )),
                     Some(_) => {}
                 }
-                let _ = el.has("oninput");
             }
         }
         audit
+    }
+
+    fn diff_sets(expected: &[&str], actual: &BTreeSet<String>) -> (Vec<String>, Vec<String>) {
+        let expected: BTreeSet<String> = expected.iter().map(|s| s.to_string()).collect();
+        (
+            expected.difference(actual).cloned().collect(),
+            actual.difference(&expected).cloned().collect(),
+        )
     }
 
     // ----------------------------------------------------------------- tests
@@ -570,10 +683,9 @@ mod volatile_value_binding_audit {
     #[test]
     fn every_editable_value_binding_tracks_input() {
         let audit = run_audit();
-
         assert!(
             audit.violations.is_empty(),
-            "freenet/river#564: these editable controls bind a volatile `value:` \
+            "freenet/river#564: these editable controls bind a volatile attribute \
              without tracking it in `oninput`, so any unrelated re-render will \
              re-write the attribute and wipe whatever the user has typed but not \
              yet committed:\n  {}\n\nAdd `oninput` so the bound signal tracks the \
@@ -584,72 +696,119 @@ mod volatile_value_binding_audit {
         );
     }
 
-    /// Anti-vacuity. Pinned as an exact set so a scan that stops seeing a file
+    /// Anti-vacuity. Pinned as exact sets so a scan that stops seeing a file
     /// fails loudly instead of quietly auditing less.
     #[test]
     fn the_audit_still_sees_every_known_binding() {
         let audit = run_audit();
-        let expected: BTreeSet<String> = EXPECTED_EDITABLE.iter().map(|s| s.to_string()).collect();
 
-        let missing: Vec<_> = expected.difference(&audit.editable).collect();
-        let unexpected: Vec<_> = audit.editable.difference(&expected).collect();
-
+        let (missing, unexpected) = diff_sets(EXPECTED_EDITABLE, &audit.editable);
         assert!(
             missing.is_empty(),
             "the audit STOPPED SEEING these bindings, so they are no longer \
              protected against freenet/river#564. Either they were removed (drop \
              them from EXPECTED_EDITABLE) or, far more likely, the scanner no \
-             longer matches this tree:\n  {:?}",
-            missing
+             longer matches this tree:\n  {}",
+            missing.join("\n  ")
         );
         assert!(
             unexpected.is_empty(),
-            "new editable volatile bindings found. Confirm each one handles \
+            "new editable volatile bindings found. Confirm each handles \
              `oninput` (see the module docs), then add it to \
-             EXPECTED_EDITABLE:\n  {:?}",
-            unexpected
+             EXPECTED_EDITABLE:\n  {}",
+            unexpected.join("\n  ")
         );
-        assert_eq!(
-            audit.display_only, EXPECTED_DISPLAY_ONLY,
-            "the number of readonly display bindings changed; update \
-             EXPECTED_DISPLAY_ONLY deliberately"
+
+        let (missing_ro, unexpected_ro) = diff_sets(EXPECTED_DISPLAY_ONLY, &audit.display_only);
+        assert!(
+            missing_ro.is_empty() && unexpected_ro.is_empty(),
+            "the set of readonly display bindings changed; update \
+             EXPECTED_DISPLAY_ONLY deliberately.\n  no longer seen: {}\n  newly \
+             seen: {}",
+            missing_ro.join(", "),
+            unexpected_ro.join(", ")
         );
     }
 
-    /// The cull must remove test items WHEREVER they appear, and must not
-    /// discard production code that follows one. Cutting at the first
-    /// `#[cfg(test)]` (the trap documented in `conversation.rs`) would drop
-    /// `KEEP_ME` here; cutting at `#[cfg(test)]\nmod tests {` would drop it too.
+    /// A char literal must not flip string/code polarity. `conversation.rs`
+    /// matches on `'"'`, which without a char-literal arm silently un-audits
+    /// the rest of the file - the same blindness class as the naive cfg(test)
+    /// cut, reached a different way.
     #[test]
-    fn cfg_test_cull_keeps_production_code_after_a_test_item() {
-        let src = r#"
-fn before() {}
-#[cfg(test)]
-fn helper() { let x = 1; }
-#[cfg(test)]
-mod tests { fn t() {} }
-fn KEEP_ME() { textarea { value: "{v}" } }
-"#;
+    fn char_literals_do_not_blind_the_scanner() {
+        let src = "fn esc(c: char) -> &'static str {\n    match c {\n        '\"' => \"&quot;\",\n        '{' => \"brace\",\n        _ => \"\",\n    }\n}\nfn later() { textarea { value: \"{draft}\" } }\n";
+        let els = scan_elements(src);
+        let ta = els.iter().find(|e| e.name == "textarea");
+        assert!(
+            ta.is_some(),
+            "an element after a `'\"'` / `'{{'` char literal must still be found"
+        );
+        assert_eq!(volatile_binding(ta.unwrap()), Some("\"{draft}\""));
+        assert!(!ta.unwrap().has("oninput"), "and must be flagged");
+    }
+
+    /// Lifetimes are not char literals and must stay ordinary code.
+    #[test]
+    fn lifetimes_are_not_char_literals() {
+        let src = "fn f(s: &'static str) -> &'a str { textarea { value: \"{d}\" } }";
+        let els = scan_elements(src);
+        assert_eq!(els.len(), 1, "the lifetime must not swallow the element");
+        assert_eq!(volatile_binding(&els[0]), Some("\"{d}\""));
+    }
+
+    /// The cull must remove test items WHEREVER they appear, must not discard
+    /// production code that follows one, and must keep line numbers truthful.
+    #[test]
+    fn cfg_test_cull_keeps_production_code_and_line_numbers() {
+        let src = "fn before() {}\n#[cfg(test)]\nfn helper() { let x = 1; }\n#[cfg(test)]\nmod tests { fn t() {} }\nfn keep_me() { textarea { value: \"{v}\" } }\n";
         let out = strip_cfg_test_items(src);
         assert!(
-            out.contains("KEEP_ME"),
-            "production code after a test item must survive: {out}"
+            out.contains("keep_me"),
+            "production code must survive: {out}"
         );
-        assert!(
-            !out.contains("helper"),
-            "test-only helper must be removed: {out}"
+        assert!(!out.contains("helper"), "test helper must go: {out}");
+        assert!(!out.contains("fn t()"), "test module must go: {out}");
+        assert_eq!(
+            out.matches('\n').count(),
+            src.matches('\n').count(),
+            "line numbering must be preserved so reported positions are real"
         );
-        assert!(
-            !out.contains("fn t()"),
-            "test module must be removed: {out}"
-        );
+        let el = &scan_elements(&out)[0];
+        assert_eq!(el.line, 6, "the textarea is on line 6 of the ORIGINAL file");
 
-        // And the naive heuristics really would have lost it, so this test is
-        // guarding something real.
-        let naive = &src[..src.find("#[cfg(test)]").unwrap()];
-        assert!(!naive.contains("KEEP_ME"));
-        let mod_needle = &src[..src.find("#[cfg(test)]\nmod tests {").unwrap()];
-        assert!(!mod_needle.contains("KEEP_ME"));
+        // The naive heuristics really would have lost it.
+        assert!(!src[..src.find("#[cfg(test)]").unwrap()].contains("keep_me"));
+        assert!(!src[..src.find("#[cfg(test)]\nmod tests {").unwrap()].contains("keep_me"));
+    }
+
+    /// `#[cfg(test)]` on a struct field, enum variant or match arm reaches the
+    /// enclosing block's `}` before any `{`. That must not underflow.
+    #[test]
+    fn cfg_test_on_a_field_does_not_underflow() {
+        for src in [
+            "struct S {\n    #[cfg(test)]\n    probe: u8,\n}\nfn f() { input { value: \"{v}\" } }",
+            "enum E {\n    #[cfg(test)]\n    Probe,\n}\nfn f() { input { value: \"{v}\" } }",
+            "fn m(x: u8) { match x {\n    #[cfg(test)]\n    0 => {}\n    _ => {}\n} }\nfn f() { input { value: \"{v}\" } }",
+        ] {
+            let out = strip_cfg_test_items(src);
+            assert!(
+                scan_elements(&out).iter().any(|e| e.name == "input"),
+                "must not lose the element after a field-level cfg(test): {out}"
+            );
+        }
+    }
+
+    /// A `;` inside a type like `[u8; 4]` must not end the item early and leak
+    /// test-only rsx into the audited source.
+    #[test]
+    fn cfg_test_item_with_a_semicolon_in_its_signature_is_fully_removed() {
+        let src = "#[cfg(test)]\nfn fixture() -> [u8; 4] { let _ = input { value: \"{leaked}\" }; [0; 4] }\nfn keep() {}";
+        let out = strip_cfg_test_items(src);
+        assert!(
+            !out.contains("leaked"),
+            "test-only rsx must not leak: {out}"
+        );
+        assert!(out.contains("keep"));
     }
 
     /// The audit must detect the shape #564 actually shipped.
@@ -682,16 +841,15 @@ fn KEEP_ME() { textarea { value: "{v}" } }
             "onchange: update_description,",
             "oninput: move |e| description.set(e.value()), onchange: update_description,",
         );
-        let fixed_els = scan_elements(&fixed);
-        let fixed_el = fixed_els.iter().find(|e| e.name == "textarea").unwrap();
+        let fixed_el = scan_elements(&fixed)
+            .into_iter()
+            .find(|e| e.name == "textarea")
+            .unwrap();
         assert!(fixed_el.has("oninput"), "the fixed field must pass");
         assert!(!is_noop_handler(fixed_el.attr("oninput").unwrap()));
     }
 
-    /// Shapes the previous line-based scanner got wrong: attributes on the
-    /// element's opening line, a whole element on one line, and two attributes
-    /// sharing a line. Each was silently skipped (a missed violation) or
-    /// mis-read as readonly (a false alarm).
+    /// Shapes the previous line-based scanner got wrong.
     #[test]
     fn attributes_are_parsed_regardless_of_line_layout() {
         let one_line = r#"input { r#type: "text", value: "{n}" }"#;
@@ -712,9 +870,8 @@ fn KEEP_ME() { textarea { value: "{v}" } }
         );
 
         let readonly_below = "input {\n    readonly: true,\n    value: \"{link}\",\n}";
-        let el = &scan_elements(readonly_below)[0];
         assert!(
-            is_display_only(el),
+            is_display_only(&scan_elements(readonly_below)[0]),
             "readonly must be seen wherever it sits"
         );
     }
@@ -724,18 +881,55 @@ fn KEEP_ME() { textarea { value: "{v}" } }
     #[test]
     fn strings_and_comments_do_not_corrupt_parsing() {
         let tricky = "input {\n    onclick: move |_| { open(\"https://freenet.org\") },\n    value: \"{room_name}\",\n}";
-        let el = &scan_elements(tricky)[0];
         assert_eq!(
-            volatile_binding(el),
+            volatile_binding(&scan_elements(tricky)[0]),
             Some("\"{room_name}\""),
             "a `//` inside a string literal must not unbalance the block"
         );
 
         let commented = "input {\n    value: \"{n}\",\n    // Track the live value so Enter can commit it.\n    oninput: move |e| n.set(e.value()),\n}";
-        let el = &scan_elements(commented)[0];
         assert!(
-            el.has("oninput"),
+            scan_elements(commented)[0].has("oninput"),
             "a comment above an attribute must not be glued onto its name"
+        );
+    }
+
+    /// The keyword guard must key on the preceding CODE identifier. Matching
+    /// raw text would let a comment ending in "...for" / "...in" delete a real
+    /// element from the audit, silently.
+    #[test]
+    fn a_comment_above_an_element_does_not_suppress_it() {
+        let src = "// Only visible to the room admin\ninput { value: \"{secret_draft}\" }";
+        let els = scan_elements(src);
+        assert_eq!(
+            els.len(),
+            1,
+            "comment ending in `in` must not hide the input"
+        );
+        assert_eq!(volatile_binding(&els[0]), Some("\"{secret_draft}\""));
+
+        let real_match = "match input {\n    _ => {}\n}";
+        assert!(
+            scan_elements(real_match).is_empty(),
+            "`match input {{` is still not an rsx element"
+        );
+    }
+
+    /// `option`'s VALUE is not volatile; its `selected` is.
+    #[test]
+    fn option_is_audited_on_selected_not_value() {
+        let plain = r#"option { value: "us", "United States" }"#;
+        assert_eq!(
+            volatile_binding(&scan_elements(plain)[0]),
+            None,
+            "an ordinary option value must not be reported as a #564 violation"
+        );
+
+        let bound = r#"option { value: "uk", selected: "{is_uk}" }"#;
+        assert_eq!(
+            volatile_binding(&scan_elements(bound)[0]),
+            Some("\"{is_uk}\""),
+            "option's volatile `selected` must be audited even when `value` is present"
         );
     }
 
@@ -764,6 +958,7 @@ fn KEEP_ME() { textarea { value: "{v}" } }
     fn noop_handlers_are_rejected() {
         assert!(is_noop_handler("move |_| {}"));
         assert!(is_noop_handler("move |evt| { }"));
+        assert!(is_noop_handler("move |_| ()"));
         assert!(!is_noop_handler("move |e| n.set(e.value())"));
         assert!(!is_noop_handler("on_input"));
     }
@@ -774,11 +969,31 @@ fn KEEP_ME() { textarea { value: "{v}" } }
     /// the rewrite it is meant to prevent.
     #[test]
     fn checkbox_and_radio_are_exempt() {
-        let cb = r#"input { r#type: "checkbox", value: "{flag}" }"#;
-        assert!(is_toggle(&scan_elements(cb)[0]));
-        let radio = r#"input { r#type: "radio", value: "{choice}" }"#;
-        assert!(is_toggle(&scan_elements(radio)[0]));
-        let text = r#"input { r#type: "text", value: "{name}" }"#;
-        assert!(!is_toggle(&scan_elements(text)[0]));
+        assert!(is_toggle(
+            &scan_elements(r#"input { r#type: "checkbox", value: "{flag}" }"#)[0]
+        ));
+        assert!(is_toggle(
+            &scan_elements(r#"input { r#type: "radio", value: "{choice}" }"#)[0]
+        ));
+        assert!(!is_toggle(
+            &scan_elements(r#"input { r#type: "text", value: "{name}" }"#)[0]
+        ));
+    }
+
+    /// `readonly:` must be an exemption only when it is literally true.
+    #[test]
+    fn conditional_readonly_is_not_an_exemption() {
+        for src in [
+            r#"input { readonly: !is_owner, value: "{n}" }"#,
+            r#"input { readonly: true_when_locked, value: "{n}" }"#,
+        ] {
+            assert!(
+                !is_display_only(&scan_elements(src)[0]),
+                "only a literal `true` exempts a field: {src}"
+            );
+        }
+        assert!(is_display_only(
+            &scan_elements(r#"input { readonly: true, value: "{n}" }"#)[0]
+        ));
     }
 }

--- a/ui/src/components.rs
+++ b/ui/src/components.rs
@@ -5,3 +5,320 @@ pub mod invite_click_interceptor;
 pub mod members;
 pub mod mention_click_interceptor;
 pub mod room_list;
+
+/// Tree-wide audit for freenet/river#564: every EDITABLE form control that
+/// binds `value:` must also handle `oninput`.
+///
+/// ## Why this is a whole-class rule, not a per-field style preference
+///
+/// `value` on `input` / `textarea` / `select` is declared **volatile** in
+/// dioxus-html (`elements.rs:1488,1571,1594`). dioxus-core writes volatile
+/// attributes to the DOM on EVERY re-render, even when the rendered string is
+/// unchanged:
+///
+/// ```text
+/// // dioxus-core-0.7.9/src/diff/node.rs:463
+/// if volatile || attribute_changed { self.write_attribute(...) }
+/// ```
+///
+/// and the interpreter then assigns the value whenever the LIVE DOM value
+/// differs from the VDOM value:
+///
+/// ```text
+/// // dioxus-interpreter-js-0.7.9/src/ts/set_attribute.ts:31-33
+/// case "value": ... else if (node.value !== value) node.value = value;
+/// ```
+///
+/// A field whose signal is written only in `onchange` (which fires on
+/// blur/commit, not per keystroke) therefore holds the PRE-TYPING text for as
+/// long as the user is typing. Any re-render in that window sees
+/// `node.value !== value` and resets the control, silently discarding the
+/// in-progress edit. Nothing about the field looks wrong at the call site,
+/// and no amount of local reasoning about that component reveals it: the
+/// trigger is whatever unrelated signal the component happens to read.
+///
+/// That is how #564 shipped. `RoomDescriptionField` reads `CURRENT_ROOM` and
+/// `ROOMS` in its render body, so it re-rendered on every room-state write and
+/// wiped the owner's half-typed description every few seconds.
+///
+/// ## What is exempt
+///
+/// Display-only controls (invite link, invite code, room public key, contract
+/// ID, member ID, export token) legitimately bind `value:` with no `oninput`,
+/// because nothing types into them. They are recognised by a literal
+/// `readonly: true` / `readonly: "true"` on the element itself. A CONDITIONAL
+/// readonly (`readonly: !is_owner`) is NOT an exemption: it is editable for
+/// somebody, and that somebody is exactly who loses their typing.
+#[cfg(test)]
+mod volatile_value_binding_audit {
+    use std::path::{Path, PathBuf};
+
+    /// Elements whose `value` attribute dioxus marks volatile.
+    const VOLATILE_VALUE_ELEMENTS: [&str; 3] = ["input", "textarea", "select"];
+
+    fn ui_src_dir() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+    }
+
+    fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+        for entry in std::fs::read_dir(dir).expect("ui/src must be readable") {
+            let path = entry.expect("readable dir entry").path();
+            if path.is_dir() {
+                rust_sources(&path, out);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                out.push(path);
+            }
+        }
+    }
+
+    /// Production source only.
+    ///
+    /// Test modules are cut away, both so this audit cannot flag rsx written
+    /// inside a test and so it cannot flag ITSELF: this very module contains
+    /// the string `input {` in its fixtures, and a scanner that matched its
+    /// own needle would be a permanently-green pin
+    /// (`feedback_source_pin_needle_matches_itself`).
+    fn production_source(path: &Path) -> String {
+        let src = std::fs::read_to_string(path).expect("source file must be readable");
+        let cut = src.find("#[cfg(test)]").unwrap_or(src.len());
+        strip_line_comments(&src[..cut])
+    }
+
+    /// Drop `//` comments so prose mentioning `input {` cannot trip the scan.
+    /// Deliberately naive about `//` inside string literals: over-stripping can
+    /// only cause a MISSED violation in a line that also opens an element,
+    /// which does not occur in this tree, and never a false positive.
+    fn strip_line_comments(src: &str) -> String {
+        src.lines()
+            .map(|line| match line.find("//") {
+                Some(idx) => &line[..idx],
+                None => line,
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// The `{ ... }` block opened at `open_idx`, brace-matched.
+    fn balanced_block(src: &str, open_idx: usize) -> &str {
+        let bytes = src.as_bytes();
+        let mut depth = 0usize;
+        let mut i = open_idx;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &src[open_idx..=i];
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        &src[open_idx..]
+    }
+
+    /// Attribute lines belonging to the element ITSELF (brace depth 1), so a
+    /// nested child element's handlers can never be mistaken for the parent's.
+    fn own_attribute_lines(block: &str) -> Vec<&str> {
+        let mut depth = 0usize;
+        let mut lines = Vec::new();
+        for line in block.lines() {
+            let starts_at_depth_one = depth == 1;
+            for ch in line.chars() {
+                match ch {
+                    '{' => depth += 1,
+                    '}' => depth = depth.saturating_sub(1),
+                    _ => {}
+                }
+            }
+            if starts_at_depth_one {
+                lines.push(line);
+            }
+        }
+        lines
+    }
+
+    fn has_attribute(attrs: &[&str], name: &str) -> bool {
+        let needle = format!("{name}:");
+        attrs.iter().any(|l| l.trim_start().starts_with(&needle))
+    }
+
+    fn is_display_only(attrs: &[&str]) -> bool {
+        attrs.iter().any(|l| {
+            let t = l.trim_start();
+            t.starts_with("readonly: true") || t.starts_with("readonly: \"true\"")
+        })
+    }
+
+    /// Locate rsx element openings: an element name at a token boundary,
+    /// followed by `{`.
+    fn element_openings(src: &str, element: &str) -> Vec<usize> {
+        let mut out = Vec::new();
+        let mut from = 0usize;
+        while let Some(rel) = src[from..].find(element) {
+            let start = from + rel;
+            from = start + element.len();
+
+            let preceded_by_ident = src[..start]
+                .chars()
+                .next_back()
+                .is_some_and(|c| c.is_alphanumeric() || c == '_' || c == '.' || c == ':');
+            if preceded_by_ident {
+                continue;
+            }
+            let rest = &src[from..];
+            let trimmed = rest.trim_start();
+            if !trimmed.starts_with('{') {
+                continue;
+            }
+            // Only same-line `{`, which is how every rsx element in this tree
+            // is written; requiring it keeps `let input = ...\n{` out.
+            if rest[..rest.len() - trimmed.len()].contains('\n') {
+                continue;
+            }
+            out.push(from + (rest.len() - trimmed.len()));
+        }
+        out
+    }
+
+    #[test]
+    fn every_editable_value_binding_tracks_input() {
+        let src_dir = ui_src_dir();
+        let mut files = Vec::new();
+        rust_sources(&src_dir, &mut files);
+        assert!(
+            files.len() > 20,
+            "the audit must actually walk the ui/src tree; found only {} files",
+            files.len()
+        );
+
+        let mut violations = Vec::new();
+        let mut editable_checked = 0usize;
+        let mut display_only = 0usize;
+
+        for path in &files {
+            let src = production_source(path);
+            for element in VOLATILE_VALUE_ELEMENTS {
+                for open_idx in element_openings(&src, element) {
+                    let block = balanced_block(&src, open_idx);
+                    let attrs = own_attribute_lines(block);
+                    if !has_attribute(&attrs, "value") {
+                        continue;
+                    }
+                    if is_display_only(&attrs) {
+                        display_only += 1;
+                        continue;
+                    }
+                    editable_checked += 1;
+                    if !has_attribute(&attrs, "oninput") {
+                        let line = src[..open_idx].matches('\n').count() + 1;
+                        let rel = path.strip_prefix(&src_dir).unwrap_or(path);
+                        violations.push(format!("ui/src/{}:{line} <{element}>", rel.display()));
+                    }
+                }
+            }
+        }
+
+        // Anti-vacuity: the scanner must be finding real bindings of both
+        // kinds. A refactor that renames attributes or reformats rsx could
+        // otherwise leave this test green while inspecting nothing.
+        assert!(
+            editable_checked >= 8,
+            "expected the audit to inspect the known editable value-bound \
+             controls; only found {editable_checked}. The scanner is probably \
+             no longer matching this tree's rsx"
+        );
+        assert!(
+            display_only >= 4,
+            "expected to find the readonly display fields (invite link, invite \
+             code, public key, contract id, ...); only found {display_only}"
+        );
+
+        assert!(
+            violations.is_empty(),
+            "freenet/river#564: these editable controls bind `value:` with no \
+             `oninput:`, so any unrelated re-render will re-write the volatile \
+             `value` attribute and wipe whatever the user has typed but not yet \
+             committed:\n  {}\n\nAdd `oninput` so the bound signal tracks the \
+             live value (making the re-write a no-op). `onchange` alone is NOT \
+             enough: it fires on blur, long after the damage. If the control is \
+             genuinely display-only, mark it `readonly: true`.",
+            violations.join("\n  ")
+        );
+    }
+
+    /// The audit is worthless if it cannot see the bug it was written for, so
+    /// run the scanner over the pre-fix shape of the field from #564 and
+    /// require a hit. This is the mutation the real fix removed.
+    #[test]
+    fn audit_detects_the_original_regression() {
+        let pre_fix = r#"
+            rsx! {
+                div { class: "mb-4",
+                    label { class: "block", "Room Description" }
+                    textarea {
+                        class: "w-full",
+                        rows: "3",
+                        value: "{description}",
+                        readonly: !is_owner,
+                        disabled: !is_owner,
+                        onchange: update_description,
+                    }
+                }
+            }
+        "#;
+        let openings = element_openings(pre_fix, "textarea");
+        assert_eq!(openings.len(), 1, "scanner must locate the textarea");
+
+        let attrs = own_attribute_lines(balanced_block(pre_fix, openings[0]));
+        assert!(has_attribute(&attrs, "value"), "must see the value binding");
+        assert!(
+            !is_display_only(&attrs),
+            "`readonly: !is_owner` must NOT count as display-only: the field is \
+             editable for the owner, who is exactly who loses their typing"
+        );
+        assert!(
+            !has_attribute(&attrs, "oninput"),
+            "the pre-fix field had no oninput, so the audit must flag it"
+        );
+
+        // ...and the fixed shape must pass.
+        let fixed = pre_fix.replace(
+            "onchange: update_description,",
+            "oninput: move |evt| description.set(evt.value().to_string()),\n\
+             onchange: update_description,",
+        );
+        let fixed_attrs = own_attribute_lines(balanced_block(
+            &fixed,
+            element_openings(&fixed, "textarea")[0],
+        ));
+        assert!(
+            has_attribute(&fixed_attrs, "oninput"),
+            "the fixed field must satisfy the audit"
+        );
+    }
+
+    /// A nested child's `oninput` must not satisfy the parent's requirement.
+    #[test]
+    fn nested_child_handler_does_not_satisfy_parent() {
+        let nested = r#"
+            select {
+                value: "{choice}",
+                option {
+                    oninput: move |_| {},
+                }
+            }
+        "#;
+        let attrs = own_attribute_lines(balanced_block(
+            nested,
+            element_openings(nested, "select")[0],
+        ));
+        assert!(has_attribute(&attrs, "value"));
+        assert!(
+            !has_attribute(&attrs, "oninput"),
+            "depth-1 scoping must ignore the nested option's handler"
+        );
+    }
+}

--- a/ui/src/components.rs
+++ b/ui/src/components.rs
@@ -11,10 +11,10 @@ pub mod room_list;
 ///
 /// ## Why this is a whole-class rule, not a per-field style preference
 ///
-/// `value` on `input` / `textarea` / `select` is declared **volatile** in
-/// dioxus-html (`elements.rs:1488,1571,1594`). dioxus-core writes volatile
-/// attributes to the DOM on EVERY re-render, even when the rendered string is
-/// unchanged:
+/// `value` on `input` / `textarea` / `select` (and `selected` on `option`) is
+/// declared **volatile** in dioxus-html (`elements.rs:1488,1536,1571,1594`).
+/// dioxus-core writes volatile attributes to the DOM on EVERY re-render, even
+/// when the rendered string is unchanged:
 ///
 /// ```text
 /// // dioxus-core-0.7.9/src/diff/node.rs:463
@@ -39,7 +39,23 @@ pub mod room_list;
 ///
 /// That is how #564 shipped. `RoomDescriptionField` reads `CURRENT_ROOM` and
 /// `ROOMS` in its render body, so it re-rendered on every room-state write and
-/// wiped the owner's half-typed description every few seconds.
+/// wiped the owner's half-typed description.
+///
+/// ## What this audit does and does NOT prove
+///
+/// It proves an `oninput` handler is PRESENT and is not a no-op closure. It
+/// does **not** prove the handler writes the same signal the `value:` binding
+/// reads. That dataflow check was tried and rejected: it false-positives on
+/// two legitimate existing handlers, `nickname_field.rs` (which passes a named
+/// handler, `oninput: on_input`) and `invite_via_dm_picker_modal.rs` (whose
+/// `value:` binds a local derived from the signal the handler writes). A
+/// reviewer must still confirm the handler updates the bound value.
+///
+/// It also does not cover the OTHER route to the same symptom: if a parent
+/// unmounts the field (e.g. `EditRoomModal` rendering `rsx!{}` when its
+/// `ROOMS.try_read()` memo is contended), the remount re-seeds `use_signal`
+/// and the draft is lost regardless of `oninput`. That is the #499/#555
+/// contention family, tracked separately.
 ///
 /// ## What is exempt
 ///
@@ -49,12 +65,428 @@ pub mod room_list;
 /// `readonly: true` / `readonly: "true"` on the element itself. A CONDITIONAL
 /// readonly (`readonly: !is_owner`) is NOT an exemption: it is editable for
 /// somebody, and that somebody is exactly who loses their typing.
+///
+/// `type="checkbox"` / `type="radio"` are also exempt. dioxus reports
+/// `evt.value()` as `"true"`/`"false"` for a checkbox
+/// (`dioxus-web-0.7.9/src/events/form.rs`), which is never equal to the DOM's
+/// `node.value` (`"on"`), so wiring `oninput` into a `value:` binding there
+/// would CAUSE a rewrite every render rather than prevent one. Bind `checked:`
+/// instead, which dioxus does not mark volatile.
 #[cfg(test)]
 mod volatile_value_binding_audit {
+    use std::collections::BTreeSet;
     use std::path::{Path, PathBuf};
 
-    /// Elements whose `value` attribute dioxus marks volatile.
-    const VOLATILE_VALUE_ELEMENTS: [&str; 3] = ["input", "textarea", "select"];
+    /// Elements whose `value` (or `option`'s `selected`) dioxus marks volatile.
+    const VOLATILE_ELEMENTS: [&str; 4] = ["input", "textarea", "select", "option"];
+
+    /// Every editable volatile binding in `ui/src`, as
+    /// `path <element> value-expression`.
+    ///
+    /// This is pinned as an EXACT SET, not a count with slack. A loose
+    /// threshold is how a scanner rots silently: if a future edit makes a file
+    /// (or a whole region of one) invisible to the scan, its entries simply
+    /// disappear and a `>=` floor keeps passing with the fields it was written
+    /// to protect no longer covered. An exact set turns that into a loud diff.
+    ///
+    /// Adding a form control to the UI is expected to fail this test. Add the
+    /// line, having first confirmed the control handles `oninput`.
+    const EXPECTED_EDITABLE: [&str; 14] = [
+        r#"components/conversation.rs <textarea> "{edit_text}""#,
+        r#"components/conversation/message_input.rs <textarea> "{message_text}""#,
+        r#"components/direct_messages/dm_thread_modal.rs <textarea> "{draft.read()}""#,
+        r#"components/direct_messages/invite_via_dm_picker_modal.rs <textarea> "{personal_message_value}""#,
+        r#"components/members.rs <textarea> "{token_input}""#,
+        r#"components/members/member_info_modal/nickname_field.rs <input> "{temp_nickname}""#,
+        r#"components/room_list/create_room_modal.rs <input> "{nickname}""#,
+        r#"components/room_list/create_room_modal.rs <input> "{room_name}""#,
+        r#"components/room_list/edit_room_modal.rs <input> "{input_value}""#,
+        r#"components/room_list/edit_room_modal.rs <input> "{max_members_input}""#,
+        r#"components/room_list/edit_room_modal.rs <textarea> "{description}""#,
+        r#"components/room_list/join_with_code_modal.rs <textarea> "{code_input}""#,
+        r#"components/room_list/receive_invitation_modal.rs <input> "{nickname}""#,
+        r#"components/room_list/room_name_field.rs <input> "{room_name}""#,
+    ];
+
+    /// Read-only display controls, same pinning rationale.
+    const EXPECTED_DISPLAY_ONLY: usize = 8;
+
+    // ---------------------------------------------------------------- lexing
+
+    /// Per-character classification of a Rust source file.
+    ///
+    /// Brace depth must be tracked outside comments AND string literals, or a
+    /// `{` in a class string or a `//` in a URL corrupts every block boundary
+    /// after it. Attribute TEXT keeps string literals (they are the values)
+    /// but drops comments, or a doc comment sitting above an attribute is
+    /// glued onto the front of it and the attribute name no longer parses.
+    struct Lexed {
+        chars: Vec<char>,
+        in_comment: Vec<bool>,
+        in_string: Vec<bool>,
+    }
+
+    impl Lexed {
+        fn new(src: &str) -> Self {
+            let chars: Vec<char> = src.chars().collect();
+            let n = chars.len();
+            let mut in_comment = vec![false; n];
+            let mut in_string = vec![false; n];
+            let mut i = 0;
+            while i < n {
+                let c = chars[i];
+                if c == '/' && i + 1 < n && chars[i + 1] == '/' {
+                    let mut j = i;
+                    while j < n && chars[j] != '\n' {
+                        in_comment[j] = true;
+                        j += 1;
+                    }
+                    i = j;
+                } else if c == '/' && i + 1 < n && chars[i + 1] == '*' {
+                    let mut j = i;
+                    while j < n {
+                        in_comment[j] = true;
+                        if j > i && chars[j - 1] == '*' && chars[j] == '/' {
+                            j += 1;
+                            break;
+                        }
+                        j += 1;
+                    }
+                    i = j;
+                } else if c == 'r' && i + 1 < n && (chars[i + 1] == '"' || chars[i + 1] == '#') {
+                    // Raw string: r"..." / r#"..."# / r##"..."##
+                    let mut hashes = 0;
+                    let mut k = i + 1;
+                    while k < n && chars[k] == '#' {
+                        hashes += 1;
+                        k += 1;
+                    }
+                    if k < n && chars[k] == '"' {
+                        let mut j = k + 1;
+                        loop {
+                            if j >= n {
+                                break;
+                            }
+                            if chars[j] == '"' {
+                                let closed = (1..=hashes).all(|h| chars.get(j + h) == Some(&'#'));
+                                if closed {
+                                    j += hashes + 1;
+                                    break;
+                                }
+                            }
+                            j += 1;
+                        }
+                        for s in in_string.iter_mut().take(j.min(n)).skip(i) {
+                            *s = true;
+                        }
+                        i = j;
+                    } else {
+                        i += 1;
+                    }
+                } else if c == '"' {
+                    let mut j = i + 1;
+                    while j < n {
+                        if chars[j] == '\\' {
+                            j += 2;
+                            continue;
+                        }
+                        if chars[j] == '"' {
+                            j += 1;
+                            break;
+                        }
+                        j += 1;
+                    }
+                    for s in in_string.iter_mut().take(j.min(n)).skip(i) {
+                        *s = true;
+                    }
+                    i = j;
+                } else {
+                    i += 1;
+                }
+            }
+            Lexed {
+                chars,
+                in_comment,
+                in_string,
+            }
+        }
+
+        fn is_code(&self, i: usize) -> bool {
+            !self.in_comment[i] && !self.in_string[i]
+        }
+
+        fn starts_with_at(&self, i: usize, needle: &str) -> bool {
+            needle
+                .chars()
+                .enumerate()
+                .all(|(k, c)| self.chars.get(i + k) == Some(&c))
+        }
+    }
+
+    // -------------------------------------------------------- cfg(test) cull
+
+    /// Remove `#[cfg(test)]` ITEMS, wherever they appear.
+    ///
+    /// Deliberately not `src.find("#[cfg(test)]")` and not
+    /// `find("#[cfg(test)]\nmod tests {")`. The first is the trap
+    /// `conversation.rs` and `members.rs` both document: the first occurrence
+    /// there is a test-only HELPER function a thousand lines up, so cutting at
+    /// it discards most of the file. Those pins assert a needle is PRESENT, so
+    /// an over-short slice fails loudly for them; this audit asserts a needle
+    /// is ABSENT, so an over-short slice passes SILENTLY. The polarity is
+    /// reversed and the heuristic does not carry over.
+    ///
+    /// The `mod tests {` variant is also wrong here: this repo has at least
+    /// one mid-file `mod tests` (`chat_delegate.rs`), so cutting there would
+    /// discard production code below it.
+    ///
+    /// Removing each annotated item individually is exact, and keeps
+    /// production rsx that lives after a test module. It also removes THIS
+    /// module, so the fixtures below cannot satisfy the audit's own needles.
+    fn strip_cfg_test_items(src: &str) -> String {
+        const NEEDLE: &str = "#[cfg(test)]";
+        let lx = Lexed::new(src);
+        let n = lx.chars.len();
+        let mut out = String::with_capacity(src.len());
+        let mut i = 0;
+        while i < n {
+            if lx.is_code(i) && lx.starts_with_at(i, NEEDLE) {
+                // Skip forward past the annotated item: either a brace-delimited
+                // body, or a `;`-terminated one (`#[cfg(test)] use foo::Bar;`).
+                let mut j = i + NEEDLE.chars().count();
+                let mut depth = 0usize;
+                let mut opened = false;
+                while j < n {
+                    if lx.is_code(j) {
+                        match lx.chars[j] {
+                            '{' => {
+                                depth += 1;
+                                opened = true;
+                            }
+                            '}' => {
+                                depth -= 1;
+                                if opened && depth == 0 {
+                                    j += 1;
+                                    break;
+                                }
+                            }
+                            ';' if !opened => {
+                                j += 1;
+                                break;
+                            }
+                            _ => {}
+                        }
+                    }
+                    j += 1;
+                }
+                i = j;
+                continue;
+            }
+            out.push(lx.chars[i]);
+            i += 1;
+        }
+        out
+    }
+
+    // -------------------------------------------------------------- scanning
+
+    struct Element {
+        line: usize,
+        name: &'static str,
+        attrs: Vec<(String, String)>,
+    }
+
+    impl Element {
+        fn attr(&self, name: &str) -> Option<&str> {
+            self.attrs
+                .iter()
+                .find(|(k, _)| k == name)
+                .map(|(_, v)| v.as_str())
+        }
+        fn has(&self, name: &str) -> bool {
+            self.attrs.iter().any(|(k, _)| k == name)
+        }
+    }
+
+    /// Split an rsx element block into its OWN attributes (brace depth 1).
+    ///
+    /// Character-based rather than line-based: a line-based split cannot see
+    /// the opening line's attributes, silently skips single-line elements, and
+    /// mis-reads two attributes written on one line.
+    fn parse_attrs(lx: &Lexed, open: usize, close: usize) -> Vec<(String, String)> {
+        let mut segments: Vec<String> = Vec::new();
+        let mut cur = String::new();
+        let mut depth = 0usize;
+        for (i, ch) in lx.chars.iter().enumerate().take(close + 1).skip(open) {
+            if lx.is_code(i) {
+                match ch {
+                    '{' => {
+                        depth += 1;
+                        if depth == 1 {
+                            continue;
+                        }
+                    }
+                    '}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            break;
+                        }
+                    }
+                    ',' if depth == 1 => {
+                        segments.push(std::mem::take(&mut cur));
+                        continue;
+                    }
+                    _ => {}
+                }
+            }
+            if depth >= 1 && !lx.in_comment[i] {
+                cur.push(*ch);
+            }
+        }
+        segments.push(cur);
+
+        let mut attrs = Vec::new();
+        for seg in segments {
+            let t = seg.trim();
+            if t.is_empty() {
+                continue;
+            }
+            // Quoted attribute name, e.g. `"data-testid": "x"`.
+            if let Some(rest) = t.strip_prefix('"') {
+                if let Some(end) = rest.find('"') {
+                    if rest[end + 1..].starts_with(':') {
+                        attrs.push((rest[..end].to_string(), rest[end + 2..].trim().to_string()));
+                        continue;
+                    }
+                }
+            }
+            if let Some(colon) = t.find(':') {
+                let name = t[..colon].trim();
+                let bare = name.strip_prefix("r#").unwrap_or(name);
+                if !bare.is_empty()
+                    && bare.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+                    && !bare.starts_with(|c: char| c.is_ascii_digit())
+                {
+                    attrs.push((bare.to_string(), t[colon + 1..].trim().to_string()));
+                }
+            }
+        }
+        attrs
+    }
+
+    fn scan_elements(src: &str) -> Vec<Element> {
+        let lx = Lexed::new(src);
+        let n = lx.chars.len();
+        let mut found = Vec::new();
+        for name in VOLATILE_ELEMENTS {
+            let len = name.chars().count();
+            let mut i = 0;
+            while i < n {
+                if !lx.is_code(i) || !lx.starts_with_at(i, name) {
+                    i += 1;
+                    continue;
+                }
+                // Token boundary before the name.
+                let prev = if i == 0 { ' ' } else { lx.chars[i - 1] };
+                if prev.is_alphanumeric()
+                    || prev == '_'
+                    || prev == '.'
+                    || prev == ':'
+                    || prev == '#'
+                {
+                    i += 1;
+                    continue;
+                }
+                // `{` after optional whitespace (including newlines).
+                let mut j = i + len;
+                while j < n && lx.chars[j].is_whitespace() {
+                    j += 1;
+                }
+                if j >= n || lx.chars[j] != '{' {
+                    i += 1;
+                    continue;
+                }
+                // Reject `match input {`, `if input {`, ... which are not rsx.
+                let head: String = lx.chars[..i].iter().rev().take(24).collect::<String>();
+                let head: String = head.chars().rev().collect();
+                let head = head.trim_end();
+                if ["match", "if", "while", "for", "let", "in"]
+                    .iter()
+                    .any(|kw| head.ends_with(kw))
+                {
+                    i += 1;
+                    continue;
+                }
+                // Balanced block.
+                let mut depth = 0usize;
+                let mut k = j;
+                let mut close = j;
+                while k < n {
+                    if lx.is_code(k) {
+                        if lx.chars[k] == '{' {
+                            depth += 1;
+                        } else if lx.chars[k] == '}' {
+                            depth -= 1;
+                            if depth == 0 {
+                                close = k;
+                                break;
+                            }
+                        }
+                    }
+                    k += 1;
+                }
+                let line = lx.chars[..i].iter().filter(|c| **c == '\n').count() + 1;
+                found.push(Element {
+                    line,
+                    name,
+                    attrs: parse_attrs(&lx, j, close),
+                });
+                i = j;
+            }
+        }
+        found
+    }
+
+    // ------------------------------------------------------------ predicates
+
+    fn is_display_only(el: &Element) -> bool {
+        el.attr("readonly")
+            .map(|v| {
+                let v = v.trim();
+                v.starts_with("true") || v.starts_with("\"true\"")
+            })
+            .unwrap_or(false)
+    }
+
+    /// Checkboxes and radios bind `checked:`, not `value:` (see the module doc).
+    fn is_toggle(el: &Element) -> bool {
+        el.attr("type")
+            .map(|v| {
+                let v = v.trim().trim_matches('"');
+                v == "checkbox" || v == "radio"
+            })
+            .unwrap_or(false)
+    }
+
+    /// The volatile binding this element carries, if any.
+    fn volatile_binding(el: &Element) -> Option<&str> {
+        el.attr("value").or_else(|| {
+            if el.name == "option" {
+                el.attr("selected")
+            } else {
+                None
+            }
+        })
+    }
+
+    /// An `oninput` that provably does nothing is worse than none: it satisfies
+    /// a presence check while the field keeps losing keystrokes.
+    fn is_noop_handler(body: &str) -> bool {
+        let squished: String = body.chars().filter(|c| !c.is_whitespace()).collect();
+        squished.ends_with("{}") && squished.contains('|')
+    }
+
+    // ----------------------------------------------------------------- files
 
     fn ui_src_dir() -> PathBuf {
         Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
@@ -71,232 +503,239 @@ mod volatile_value_binding_audit {
         }
     }
 
-    /// Production source only.
-    ///
-    /// Test modules are cut away, both so this audit cannot flag rsx written
-    /// inside a test and so it cannot flag ITSELF: this very module contains
-    /// the string `input {` in its fixtures, and a scanner that matched its
-    /// own needle would be a permanently-green pin
-    /// (`feedback_source_pin_needle_matches_itself`).
-    fn production_source(path: &Path) -> String {
-        let src = std::fs::read_to_string(path).expect("source file must be readable");
-        let cut = src.find("#[cfg(test)]").unwrap_or(src.len());
-        strip_line_comments(&src[..cut])
+    struct Audit {
+        editable: BTreeSet<String>,
+        violations: Vec<String>,
+        display_only: usize,
     }
 
-    /// Drop `//` comments so prose mentioning `input {` cannot trip the scan.
-    /// Deliberately naive about `//` inside string literals: over-stripping can
-    /// only cause a MISSED violation in a line that also opens an element,
-    /// which does not occur in this tree, and never a false positive.
-    fn strip_line_comments(src: &str) -> String {
-        src.lines()
-            .map(|line| match line.find("//") {
-                Some(idx) => &line[..idx],
-                None => line,
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
-    }
-
-    /// The `{ ... }` block opened at `open_idx`, brace-matched.
-    fn balanced_block(src: &str, open_idx: usize) -> &str {
-        let bytes = src.as_bytes();
-        let mut depth = 0usize;
-        let mut i = open_idx;
-        while i < bytes.len() {
-            match bytes[i] {
-                b'{' => depth += 1,
-                b'}' => {
-                    depth -= 1;
-                    if depth == 0 {
-                        return &src[open_idx..=i];
-                    }
-                }
-                _ => {}
-            }
-            i += 1;
-        }
-        &src[open_idx..]
-    }
-
-    /// Attribute lines belonging to the element ITSELF (brace depth 1), so a
-    /// nested child element's handlers can never be mistaken for the parent's.
-    fn own_attribute_lines(block: &str) -> Vec<&str> {
-        let mut depth = 0usize;
-        let mut lines = Vec::new();
-        for line in block.lines() {
-            let starts_at_depth_one = depth == 1;
-            for ch in line.chars() {
-                match ch {
-                    '{' => depth += 1,
-                    '}' => depth = depth.saturating_sub(1),
-                    _ => {}
-                }
-            }
-            if starts_at_depth_one {
-                lines.push(line);
-            }
-        }
-        lines
-    }
-
-    fn has_attribute(attrs: &[&str], name: &str) -> bool {
-        let needle = format!("{name}:");
-        attrs.iter().any(|l| l.trim_start().starts_with(&needle))
-    }
-
-    fn is_display_only(attrs: &[&str]) -> bool {
-        attrs.iter().any(|l| {
-            let t = l.trim_start();
-            t.starts_with("readonly: true") || t.starts_with("readonly: \"true\"")
-        })
-    }
-
-    /// Locate rsx element openings: an element name at a token boundary,
-    /// followed by `{`.
-    fn element_openings(src: &str, element: &str) -> Vec<usize> {
-        let mut out = Vec::new();
-        let mut from = 0usize;
-        while let Some(rel) = src[from..].find(element) {
-            let start = from + rel;
-            from = start + element.len();
-
-            let preceded_by_ident = src[..start]
-                .chars()
-                .next_back()
-                .is_some_and(|c| c.is_alphanumeric() || c == '_' || c == '.' || c == ':');
-            if preceded_by_ident {
-                continue;
-            }
-            let rest = &src[from..];
-            let trimmed = rest.trim_start();
-            if !trimmed.starts_with('{') {
-                continue;
-            }
-            // Only same-line `{`, which is how every rsx element in this tree
-            // is written; requiring it keeps `let input = ...\n{` out.
-            if rest[..rest.len() - trimmed.len()].contains('\n') {
-                continue;
-            }
-            out.push(from + (rest.len() - trimmed.len()));
-        }
-        out
-    }
-
-    #[test]
-    fn every_editable_value_binding_tracks_input() {
+    fn run_audit() -> Audit {
         let src_dir = ui_src_dir();
         let mut files = Vec::new();
         rust_sources(&src_dir, &mut files);
         assert!(
-            files.len() > 20,
-            "the audit must actually walk the ui/src tree; found only {} files",
+            files.len() > 40,
+            "the audit must walk the whole ui/src tree; found only {} files",
             files.len()
         );
+        files.sort();
 
-        let mut violations = Vec::new();
-        let mut editable_checked = 0usize;
-        let mut display_only = 0usize;
+        let mut audit = Audit {
+            editable: BTreeSet::new(),
+            violations: Vec::new(),
+            display_only: 0,
+        };
 
         for path in &files {
-            let src = production_source(path);
-            for element in VOLATILE_VALUE_ELEMENTS {
-                for open_idx in element_openings(&src, element) {
-                    let block = balanced_block(&src, open_idx);
-                    let attrs = own_attribute_lines(block);
-                    if !has_attribute(&attrs, "value") {
-                        continue;
-                    }
-                    if is_display_only(&attrs) {
-                        display_only += 1;
-                        continue;
-                    }
-                    editable_checked += 1;
-                    if !has_attribute(&attrs, "oninput") {
-                        let line = src[..open_idx].matches('\n').count() + 1;
-                        let rel = path.strip_prefix(&src_dir).unwrap_or(path);
-                        violations.push(format!("ui/src/{}:{line} <{element}>", rel.display()));
-                    }
+            let raw = std::fs::read_to_string(path).expect("source file must be readable");
+            let production = strip_cfg_test_items(&raw);
+            let rel = path
+                .strip_prefix(&src_dir)
+                .unwrap_or(path)
+                .display()
+                .to_string();
+
+            for el in scan_elements(&production) {
+                let Some(binding) = volatile_binding(&el) else {
+                    continue;
+                };
+                if is_toggle(&el) {
+                    continue;
                 }
+                if is_display_only(&el) {
+                    audit.display_only += 1;
+                    continue;
+                }
+                let id = format!("{rel} <{}> {binding}", el.name);
+                audit.editable.insert(id.clone());
+
+                match el.attr("oninput") {
+                    None => audit
+                        .violations
+                        .push(format!("{rel}:{} <{}> has no `oninput`", el.line, el.name)),
+                    Some(body) if is_noop_handler(body) => audit.violations.push(format!(
+                        "{rel}:{} <{}> has a no-op `oninput`",
+                        el.line, el.name
+                    )),
+                    Some(_) => {}
+                }
+                let _ = el.has("oninput");
             }
         }
+        audit
+    }
 
-        // Anti-vacuity: the scanner must be finding real bindings of both
-        // kinds. A refactor that renames attributes or reformats rsx could
-        // otherwise leave this test green while inspecting nothing.
-        assert!(
-            editable_checked >= 8,
-            "expected the audit to inspect the known editable value-bound \
-             controls; only found {editable_checked}. The scanner is probably \
-             no longer matching this tree's rsx"
-        );
-        assert!(
-            display_only >= 4,
-            "expected to find the readonly display fields (invite link, invite \
-             code, public key, contract id, ...); only found {display_only}"
-        );
+    // ----------------------------------------------------------------- tests
+
+    #[test]
+    fn every_editable_value_binding_tracks_input() {
+        let audit = run_audit();
 
         assert!(
-            violations.is_empty(),
-            "freenet/river#564: these editable controls bind `value:` with no \
-             `oninput:`, so any unrelated re-render will re-write the volatile \
-             `value` attribute and wipe whatever the user has typed but not yet \
-             committed:\n  {}\n\nAdd `oninput` so the bound signal tracks the \
+            audit.violations.is_empty(),
+            "freenet/river#564: these editable controls bind a volatile `value:` \
+             without tracking it in `oninput`, so any unrelated re-render will \
+             re-write the attribute and wipe whatever the user has typed but not \
+             yet committed:\n  {}\n\nAdd `oninput` so the bound signal tracks the \
              live value (making the re-write a no-op). `onchange` alone is NOT \
              enough: it fires on blur, long after the damage. If the control is \
              genuinely display-only, mark it `readonly: true`.",
-            violations.join("\n  ")
+            audit.violations.join("\n  ")
         );
     }
 
-    /// The audit is worthless if it cannot see the bug it was written for, so
-    /// run the scanner over the pre-fix shape of the field from #564 and
-    /// require a hit. This is the mutation the real fix removed.
+    /// Anti-vacuity. Pinned as an exact set so a scan that stops seeing a file
+    /// fails loudly instead of quietly auditing less.
+    #[test]
+    fn the_audit_still_sees_every_known_binding() {
+        let audit = run_audit();
+        let expected: BTreeSet<String> = EXPECTED_EDITABLE.iter().map(|s| s.to_string()).collect();
+
+        let missing: Vec<_> = expected.difference(&audit.editable).collect();
+        let unexpected: Vec<_> = audit.editable.difference(&expected).collect();
+
+        assert!(
+            missing.is_empty(),
+            "the audit STOPPED SEEING these bindings, so they are no longer \
+             protected against freenet/river#564. Either they were removed (drop \
+             them from EXPECTED_EDITABLE) or, far more likely, the scanner no \
+             longer matches this tree:\n  {:?}",
+            missing
+        );
+        assert!(
+            unexpected.is_empty(),
+            "new editable volatile bindings found. Confirm each one handles \
+             `oninput` (see the module docs), then add it to \
+             EXPECTED_EDITABLE:\n  {:?}",
+            unexpected
+        );
+        assert_eq!(
+            audit.display_only, EXPECTED_DISPLAY_ONLY,
+            "the number of readonly display bindings changed; update \
+             EXPECTED_DISPLAY_ONLY deliberately"
+        );
+    }
+
+    /// The cull must remove test items WHEREVER they appear, and must not
+    /// discard production code that follows one. Cutting at the first
+    /// `#[cfg(test)]` (the trap documented in `conversation.rs`) would drop
+    /// `KEEP_ME` here; cutting at `#[cfg(test)]\nmod tests {` would drop it too.
+    #[test]
+    fn cfg_test_cull_keeps_production_code_after_a_test_item() {
+        let src = r#"
+fn before() {}
+#[cfg(test)]
+fn helper() { let x = 1; }
+#[cfg(test)]
+mod tests { fn t() {} }
+fn KEEP_ME() { textarea { value: "{v}" } }
+"#;
+        let out = strip_cfg_test_items(src);
+        assert!(
+            out.contains("KEEP_ME"),
+            "production code after a test item must survive: {out}"
+        );
+        assert!(
+            !out.contains("helper"),
+            "test-only helper must be removed: {out}"
+        );
+        assert!(
+            !out.contains("fn t()"),
+            "test module must be removed: {out}"
+        );
+
+        // And the naive heuristics really would have lost it, so this test is
+        // guarding something real.
+        let naive = &src[..src.find("#[cfg(test)]").unwrap()];
+        assert!(!naive.contains("KEEP_ME"));
+        let mod_needle = &src[..src.find("#[cfg(test)]\nmod tests {").unwrap()];
+        assert!(!mod_needle.contains("KEEP_ME"));
+    }
+
+    /// The audit must detect the shape #564 actually shipped.
     #[test]
     fn audit_detects_the_original_regression() {
         let pre_fix = r#"
             rsx! {
-                div { class: "mb-4",
-                    label { class: "block", "Room Description" }
-                    textarea {
-                        class: "w-full",
-                        rows: "3",
-                        value: "{description}",
-                        readonly: !is_owner,
-                        disabled: !is_owner,
-                        onchange: update_description,
-                    }
+                textarea {
+                    class: "w-full",
+                    value: "{description}",
+                    readonly: !is_owner,
+                    onchange: update_description,
                 }
             }
         "#;
-        let openings = element_openings(pre_fix, "textarea");
-        assert_eq!(openings.len(), 1, "scanner must locate the textarea");
-
-        let attrs = own_attribute_lines(balanced_block(pre_fix, openings[0]));
-        assert!(has_attribute(&attrs, "value"), "must see the value binding");
+        let els = scan_elements(pre_fix);
+        let el = els
+            .iter()
+            .find(|e| e.name == "textarea")
+            .expect("finds textarea");
+        assert_eq!(volatile_binding(el), Some("\"{description}\""));
         assert!(
-            !is_display_only(&attrs),
+            !is_display_only(el),
             "`readonly: !is_owner` must NOT count as display-only: the field is \
              editable for the owner, who is exactly who loses their typing"
         );
-        assert!(
-            !has_attribute(&attrs, "oninput"),
-            "the pre-fix field had no oninput, so the audit must flag it"
-        );
+        assert!(!el.has("oninput"), "the pre-fix field must be flagged");
 
-        // ...and the fixed shape must pass.
         let fixed = pre_fix.replace(
             "onchange: update_description,",
-            "oninput: move |evt| description.set(evt.value().to_string()),\n\
-             onchange: update_description,",
+            "oninput: move |e| description.set(e.value()), onchange: update_description,",
         );
-        let fixed_attrs = own_attribute_lines(balanced_block(
-            &fixed,
-            element_openings(&fixed, "textarea")[0],
-        ));
+        let fixed_els = scan_elements(&fixed);
+        let fixed_el = fixed_els.iter().find(|e| e.name == "textarea").unwrap();
+        assert!(fixed_el.has("oninput"), "the fixed field must pass");
+        assert!(!is_noop_handler(fixed_el.attr("oninput").unwrap()));
+    }
+
+    /// Shapes the previous line-based scanner got wrong: attributes on the
+    /// element's opening line, a whole element on one line, and two attributes
+    /// sharing a line. Each was silently skipped (a missed violation) or
+    /// mis-read as readonly (a false alarm).
+    #[test]
+    fn attributes_are_parsed_regardless_of_line_layout() {
+        let one_line = r#"input { r#type: "text", value: "{n}" }"#;
+        let el = &scan_elements(one_line)[0];
+        assert_eq!(
+            volatile_binding(el),
+            Some("\"{n}\""),
+            "single-line element must be seen"
+        );
+        assert!(!el.has("oninput"), "and must be flagged as a violation");
+
+        let opening_line = "input { value: \"{n}\",\n    oninput: move |e| n.set(e.value()),\n}";
+        let el = &scan_elements(opening_line)[0];
+        assert_eq!(volatile_binding(el), Some("\"{n}\""));
         assert!(
-            has_attribute(&fixed_attrs, "oninput"),
-            "the fixed field must satisfy the audit"
+            el.has("oninput"),
+            "attribute on the opening line must be seen"
+        );
+
+        let readonly_below = "input {\n    readonly: true,\n    value: \"{link}\",\n}";
+        let el = &scan_elements(readonly_below)[0];
+        assert!(
+            is_display_only(el),
+            "readonly must be seen wherever it sits"
+        );
+    }
+
+    /// A `//` inside a string literal must not corrupt brace matching, and a
+    /// comment above an attribute must not be glued onto its name.
+    #[test]
+    fn strings_and_comments_do_not_corrupt_parsing() {
+        let tricky = "input {\n    onclick: move |_| { open(\"https://freenet.org\") },\n    value: \"{room_name}\",\n}";
+        let el = &scan_elements(tricky)[0];
+        assert_eq!(
+            volatile_binding(el),
+            Some("\"{room_name}\""),
+            "a `//` inside a string literal must not unbalance the block"
+        );
+
+        let commented = "input {\n    value: \"{n}\",\n    // Track the live value so Enter can commit it.\n    oninput: move |e| n.set(e.value()),\n}";
+        let el = &scan_elements(commented)[0];
+        assert!(
+            el.has("oninput"),
+            "a comment above an attribute must not be glued onto its name"
         );
     }
 
@@ -311,14 +750,35 @@ mod volatile_value_binding_audit {
                 }
             }
         "#;
-        let attrs = own_attribute_lines(balanced_block(
-            nested,
-            element_openings(nested, "select")[0],
-        ));
-        assert!(has_attribute(&attrs, "value"));
+        let els = scan_elements(nested);
+        let sel = els.iter().find(|e| e.name == "select").unwrap();
+        assert!(sel.has("value"));
         assert!(
-            !has_attribute(&attrs, "oninput"),
+            !sel.has("oninput"),
             "depth-1 scoping must ignore the nested option's handler"
         );
+    }
+
+    /// A handler that exists but does nothing must not satisfy the audit.
+    #[test]
+    fn noop_handlers_are_rejected() {
+        assert!(is_noop_handler("move |_| {}"));
+        assert!(is_noop_handler("move |evt| { }"));
+        assert!(!is_noop_handler("move |e| n.set(e.value())"));
+        assert!(!is_noop_handler("on_input"));
+    }
+
+    /// Toggles are exempt for a REASON, and the reason must stay checked:
+    /// dioxus reports a checkbox's `evt.value()` as "true"/"false", never the
+    /// DOM's "on", so an `oninput`-tracked `value:` binding there would cause
+    /// the rewrite it is meant to prevent.
+    #[test]
+    fn checkbox_and_radio_are_exempt() {
+        let cb = r#"input { r#type: "checkbox", value: "{flag}" }"#;
+        assert!(is_toggle(&scan_elements(cb)[0]));
+        let radio = r#"input { r#type: "radio", value: "{choice}" }"#;
+        assert!(is_toggle(&scan_elements(radio)[0]));
+        let text = r#"input { r#type: "text", value: "{name}" }"#;
+        assert!(!is_toggle(&scan_elements(text)[0]));
     }
 }

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -3891,6 +3891,7 @@ pub fn Conversation() -> Element {
                                     }
                                     if let Some(desc_html) = current_room_description_html.read().as_ref() {
                                         div {
+                                            "data-testid": "room-header-description",
                                             class: "prose prose-sm dark:prose-invert max-w-none text-xs text-text-muted truncate [&>p]:m-0 [&>p]:inline",
                                             dangerous_inner_html: "{desc_html}"
                                         }

--- a/ui/src/components/room_list/create_room_modal.rs
+++ b/ui/src/components/room_list/create_room_modal.rs
@@ -169,7 +169,13 @@ pub fn CreateRoomModal() -> Element {
                             class: "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent",
                             value: "{room_name}",
                             placeholder: "Enter room name",
-                            onchange: move |evt| room_name.set(evt.value().to_string())
+                            // `oninput`, not `onchange`, so the signal tracks
+                            // the live value (freenet/river#564). `value` is a
+                            // volatile attribute, so any re-render re-writes it
+                            // to the DOM; with `onchange` alone the signal still
+                            // held the pre-typing text and the re-write reset
+                            // the field. Matches the nickname input below.
+                            oninput: move |evt| room_name.set(evt.value().to_string())
                         }
                     }
 

--- a/ui/src/components/room_list/create_room_modal.rs
+++ b/ui/src/components/room_list/create_room_modal.rs
@@ -172,18 +172,19 @@ pub fn CreateRoomModal() -> Element {
                             // `oninput` tracks the live value so a re-render
                             // cannot re-write this volatile `value` attribute
                             // with stale text (freenet/river#564). Defensive
-                            // here rather than a reproduced bug: this component
-                            // reads no room-state signal and takes no props, so
-                            // nothing but the user's own typing re-renders it.
-                            // It matches the nickname input below and removes
-                            // the field from the class entirely.
+                            // here rather than a reproduced bug: this modal does
+                            // re-render (it reads CREATE_ROOM_MODAL, and the
+                            // private-room checkbox re-renders it), but every
+                            // route to that blurs this input first, firing
+                            // `onchange` before the render. `oninput` removes
+                            // the field from the class regardless.
                             //
-                            // `onchange` is KEPT alongside it, unlike the
-                            // nickname input: dropping it would lose the value
-                            // from anything that sets `.value` and fires only
-                            // `change` (some password managers, and synthetic
-                            // events), and the failure is silent — `create_room`
-                            // returns on an empty name with only a log line.
+                            // `onchange` is KEPT alongside it: dropping it would
+                            // lose the value from anything that sets `.value`
+                            // and fires only `change` (some password managers,
+                            // and synthetic events), and the failure is silent,
+                            // since `create_room` returns on an empty name with
+                            // only a log line.
                             oninput: move |evt| room_name.set(evt.value().to_string()),
                             onchange: move |evt| room_name.set(evt.value().to_string())
                         }
@@ -201,7 +202,12 @@ pub fn CreateRoomModal() -> Element {
                             "aria-invalid": if nickname_has_emoji { "true" } else { "false" },
                             value: "{nickname}",
                             placeholder: "Enter your nickname",
-                            oninput: move |evt| nickname.set(evt.value().to_string())
+                            // Both handlers, for the same reason as the room
+                            // name above: an empty nickname is accepted
+                            // silently, so a `change`-only writer must not be
+                            // able to drop the value.
+                            oninput: move |evt| nickname.set(evt.value().to_string()),
+                            onchange: move |evt| nickname.set(evt.value().to_string())
                         }
                         if nickname_has_emoji {
                             p {

--- a/ui/src/components/room_list/create_room_modal.rs
+++ b/ui/src/components/room_list/create_room_modal.rs
@@ -169,13 +169,23 @@ pub fn CreateRoomModal() -> Element {
                             class: "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-accent",
                             value: "{room_name}",
                             placeholder: "Enter room name",
-                            // `oninput`, not `onchange`, so the signal tracks
-                            // the live value (freenet/river#564). `value` is a
-                            // volatile attribute, so any re-render re-writes it
-                            // to the DOM; with `onchange` alone the signal still
-                            // held the pre-typing text and the re-write reset
-                            // the field. Matches the nickname input below.
-                            oninput: move |evt| room_name.set(evt.value().to_string())
+                            // `oninput` tracks the live value so a re-render
+                            // cannot re-write this volatile `value` attribute
+                            // with stale text (freenet/river#564). Defensive
+                            // here rather than a reproduced bug: this component
+                            // reads no room-state signal and takes no props, so
+                            // nothing but the user's own typing re-renders it.
+                            // It matches the nickname input below and removes
+                            // the field from the class entirely.
+                            //
+                            // `onchange` is KEPT alongside it, unlike the
+                            // nickname input: dropping it would lose the value
+                            // from anything that sets `.value` and fires only
+                            // `change` (some password managers, and synthetic
+                            // events), and the failure is silent — `create_room`
+                            // returns on an empty name with only a log line.
+                            oninput: move |evt| room_name.set(evt.value().to_string()),
+                            onchange: move |evt| room_name.set(evt.value().to_string())
                         }
                     }
 

--- a/ui/src/components/room_list/edit_room_modal.rs
+++ b/ui/src/components/room_list/edit_room_modal.rs
@@ -591,12 +591,27 @@ fn RoomDescriptionField(config: Configuration, is_owner: bool) -> Element {
         div { class: "mb-4",
             label { class: "block text-sm font-medium text-text-muted mb-2", "Room Description" }
             textarea {
+                "data-testid": "room-description-input",
                 class: "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed resize-y",
                 rows: "3",
                 placeholder: "Optional room description",
                 value: "{description}",
                 readonly: !is_owner,
                 disabled: !is_owner,
+                // Track the live value on every keystroke (freenet/river#564).
+                // `value` is a VOLATILE attribute in dioxus-html, so dioxus
+                // re-writes it to the DOM on every re-render even when the
+                // rendered string is unchanged (dioxus-core
+                // `diff/node.rs:463`), and the interpreter then assigns
+                // `node.value = value` whenever the live DOM value differs
+                // (`set_attribute.ts:31`). This component reads CURRENT_ROOM
+                // and ROOMS in its body, so it re-renders on EVERY room-state
+                // write. With `onchange` alone the signal still held the
+                // pre-typing text, so each of those re-renders reset the
+                // textarea and the owner lost whatever they had typed but not
+                // yet committed. Tracking the live value makes the re-write a
+                // no-op, which is why the sibling name field never had this.
+                oninput: move |evt: Event<FormData>| description.set(evt.value().to_string()),
                 onchange: update_description,
             }
         }
@@ -742,6 +757,12 @@ fn NumericConfigField(
                 min: "1",
                 class: "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent",
                 value: "{input_value}",
+                // Track the live value so a re-render cannot reset the field
+                // mid-typing (freenet/river#564). See the RoomDescriptionField
+                // textarea above for the full mechanism: `value` is volatile,
+                // so it is re-written to the DOM on every re-render, and this
+                // field re-renders whenever its `config` prop changes.
+                oninput: move |evt: Event<FormData>| input_value.set(evt.value().to_string()),
                 onchange: update_value,
             }
         }
@@ -860,10 +881,16 @@ fn MaxMembersField(
             }
             if is_owner {
                 input {
+                    "data-testid": "max-members-input",
                     r#type: "number",
                     min: "1",
                     class: "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent",
                     value: "{max_members_input}",
+                    // Track the live value so a re-render cannot reset the
+                    // field mid-typing (freenet/river#564). This one re-renders
+                    // on its `member_count` prop too, so a member joining while
+                    // the owner was editing the cap was enough to wipe it.
+                    oninput: move |evt: Event<FormData>| max_members_input.set(evt.value().to_string()),
                     onchange: update_max_members,
                 }
             }

--- a/ui/src/components/room_list/edit_room_modal.rs
+++ b/ui/src/components/room_list/edit_room_modal.rs
@@ -448,31 +448,40 @@ fn CopyButton(value: String, testid: String, label: String) -> Element {
     }
 }
 
+/// The room's stored description, decrypted with whatever room secrets are
+/// available locally.
+///
+/// Kept out of the render body deliberately. It clones the room's whole secret
+/// set and runs an ECIES unseal, and now that `oninput` re-renders the field on
+/// every keystroke (freenet/river#564) that would be per-character work on the
+/// typing path. It is only ever needed twice: to seed the editing signal when
+/// the field mounts, and to revert a save the privacy guard refuses.
+fn stored_description(config: &Configuration) -> String {
+    let owner_key = CURRENT_ROOM.read().owner_key;
+    let secrets = ROOMS
+        .try_read()
+        .ok()
+        .and_then(|rooms| {
+            owner_key
+                .and_then(|key| rooms.map.get(&key))
+                .map(|room_data| room_data.secrets.clone())
+        })
+        .unwrap_or_default();
+    config
+        .display
+        .description
+        .as_ref()
+        .map(|sealed| match unseal_bytes_with_secrets(sealed, &secrets) {
+            Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
+            Err(_) => sealed.to_string_lossy(),
+        })
+        .unwrap_or_default()
+}
+
 #[component]
 fn RoomDescriptionField(config: Configuration, is_owner: bool) -> Element {
-    let initial_desc = {
-        let owner_key = CURRENT_ROOM.read().owner_key;
-        let secrets = ROOMS
-            .try_read()
-            .ok()
-            .and_then(|rooms| {
-                owner_key
-                    .and_then(|key| rooms.map.get(&key))
-                    .map(|room_data| room_data.secrets.clone())
-            })
-            .unwrap_or_default();
-        config
-            .display
-            .description
-            .as_ref()
-            .map(|sealed| match unseal_bytes_with_secrets(sealed, &secrets) {
-                Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
-                Err(_) => sealed.to_string_lossy(),
-            })
-            .unwrap_or_default()
-    };
-    let initial_desc_for_revert = initial_desc.clone();
-    let mut description = use_signal(|| initial_desc);
+    let seed_config = config.clone();
+    let mut description = use_signal(move || stored_description(&seed_config));
 
     let update_description = move |evt: Event<FormData>| {
         if !is_owner {
@@ -520,7 +529,7 @@ fn RoomDescriptionField(config: Configuration, is_owner: bool) -> Element {
                      room description edit deferred to avoid leaking a \
                      plaintext configuration delta (freenet/river#299)."
                 );
-                description.set(initial_desc_for_revert.clone());
+                description.set(stored_description(&config));
                 return;
             };
             Some(sealed)
@@ -611,7 +620,17 @@ fn RoomDescriptionField(config: Configuration, is_owner: bool) -> Element {
                 // textarea and the owner lost whatever they had typed but not
                 // yet committed. Tracking the live value makes the re-write a
                 // no-op, which is why the sibling name field never had this.
-                oninput: move |evt: Event<FormData>| description.set(evt.value().to_string()),
+                // Guarded like `update_description` below. The field is
+                // `disabled` for non-owners so this cannot fire from real
+                // input, but leaving the signal un-tracked for them is the
+                // correct behaviour: the volatile re-write then restores the
+                // stored value rather than letting a synthetic event drift the
+                // display away from what is actually saved.
+                oninput: move |evt: Event<FormData>| {
+                    if is_owner {
+                        description.set(evt.value().to_string());
+                    }
+                },
                 onchange: update_description,
             }
         }

--- a/ui/src/components/room_list/edit_room_modal.rs
+++ b/ui/src/components/room_list/edit_room_modal.rs
@@ -456,6 +456,9 @@ fn CopyButton(value: String, testid: String, label: String) -> Element {
 /// every keystroke (freenet/river#564) that would be per-character work on the
 /// typing path. It is only ever needed twice: to seed the editing signal when
 /// the field mounts, and to revert a save the privacy guard refuses.
+///
+/// Must not call any hook: it runs inside `use_signal`'s initializer, which
+/// evaluates while the scope's hook list is mutably borrowed.
 fn stored_description(config: &Configuration) -> String {
     let owner_key = CURRENT_ROOM.read().owner_key;
     let secrets = ROOMS
@@ -613,13 +616,20 @@ fn RoomDescriptionField(config: Configuration, is_owner: bool) -> Element {
                 // rendered string is unchanged (dioxus-core
                 // `diff/node.rs:463`), and the interpreter then assigns
                 // `node.value = value` whenever the live DOM value differs
-                // (`set_attribute.ts:31`). This component reads CURRENT_ROOM
-                // and ROOMS in its body, so it re-renders on EVERY room-state
-                // write. With `onchange` alone the signal still held the
-                // pre-typing text, so each of those re-renders reset the
+                // (`set_attribute.ts:31`). With `onchange` alone the signal
+                // still held the pre-typing text, so each re-render reset the
                 // textarea and the owner lost whatever they had typed but not
                 // yet committed. Tracking the live value makes the re-write a
                 // no-op, which is why the sibling name field never had this.
+                //
+                // As shipped, the re-render came on every room-state write:
+                // this component read CURRENT_ROOM and ROOMS in its render
+                // body. It no longer does (that moved into
+                // `stored_description`, called from the `use_signal` seed), so
+                // today the trigger is a `config`/`is_owner` prop change. The
+                // handler is required either way: `oninput` makes the field
+                // correct under ANY re-render, which is the point, since the
+                // trigger is never local to the component.
                 // Guarded like `update_description` below. The field is
                 // `disabled` for non-owners so this cannot fire from real
                 // input, but leaving the signal un-tracked for them is the

--- a/ui/src/components/room_list/room_name_field.rs
+++ b/ui/src/components/room_list/room_name_field.rs
@@ -173,6 +173,7 @@ pub fn RoomNameField(config: Configuration, is_owner: bool) -> Element {
         div { class: "mb-4",
             label { class: "block text-sm font-medium text-text-muted mb-2", "Room Name" }
             input {
+                "data-testid": "room-name-input",
                 class: "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed",
                 value: "{room_name}",
                 readonly: !is_owner,

--- a/ui/src/components/room_list/room_name_field.rs
+++ b/ui/src/components/room_list/room_name_field.rs
@@ -20,27 +20,39 @@ fn enter_commits_and_closes(key: &Key) -> bool {
     key == &Key::Enter
 }
 
+/// The room's stored name, decrypted with whatever room secrets are available
+/// locally.
+///
+/// Kept out of the render body deliberately, for the same reason as
+/// `edit_room_modal::stored_description`: it clones the room's whole secret set
+/// and runs an ECIES unseal, and `oninput` re-renders this field on every
+/// keystroke, so in the render body that is per-character work on the typing
+/// path. It is needed only to seed the editing signal at mount and to revert a
+/// save the privacy guard refuses.
+///
+/// Must not call any hook: it runs inside `use_signal`'s initializer, which
+/// evaluates while the scope's hook list is mutably borrowed.
+fn stored_room_name(config: &Configuration) -> String {
+    let owner_key = CURRENT_ROOM.read().owner_key;
+    let secrets = ROOMS
+        .try_read()
+        .ok()
+        .and_then(|rooms| {
+            owner_key
+                .and_then(|key| rooms.map.get(&key))
+                .map(|room_data| room_data.secrets.clone())
+        })
+        .unwrap_or_default();
+    match unseal_bytes_with_secrets(&config.display.name, &secrets) {
+        Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
+        Err(_) => config.display.name.to_string_lossy(),
+    }
+}
+
 #[component]
 pub fn RoomNameField(config: Configuration, is_owner: bool) -> Element {
-    // Extract and decrypt the room name using version-aware decryption
-    let initial_name = {
-        let owner_key = CURRENT_ROOM.read().owner_key;
-        let secrets = ROOMS
-            .try_read()
-            .ok()
-            .and_then(|rooms| {
-                owner_key
-                    .and_then(|key| rooms.map.get(&key))
-                    .map(|room_data| room_data.secrets.clone())
-            })
-            .unwrap_or_default();
-        match unseal_bytes_with_secrets(&config.display.name, &secrets) {
-            Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
-            Err(_) => config.display.name.to_string_lossy(),
-        }
-    };
-    let initial_name_for_revert = initial_name.clone();
-    let mut room_name = use_signal(|| initial_name);
+    let seed_config = config.clone();
+    let mut room_name = use_signal(move || stored_room_name(&seed_config));
 
     // Save the room name. Takes the value as a `String` (rather than a raw
     // form event) so the same logic can be driven from both `onchange` (commit
@@ -97,7 +109,7 @@ pub fn RoomNameField(config: Configuration, is_owner: bool) -> Element {
                      room name edit deferred to avoid leaking a plaintext \
                      configuration delta (freenet/river#299)."
                 );
-                room_name.set(initial_name_for_revert.clone());
+                room_name.set(stored_room_name(&config));
                 return;
             };
 

--- a/ui/tests/room-details-typing-survives-rerender.spec.ts
+++ b/ui/tests/room-details-typing-survives-rerender.spec.ts
@@ -89,9 +89,11 @@ test.describe("Room Details: in-progress typing survives room-state updates", ()
     // Read the current cap so the write we trigger is guaranteed to change it
     // (`update_max_members` early-returns when the value is unchanged, which
     // would leave nothing to re-render and make this test vacuous).
+    // `Number("")` is 0 and finite, so assert a real positive cap rather than
+    // just finiteness, or an empty read would silently change what we assert.
     const maxMembers = page.getByTestId("max-members-input");
     const currentCap = Number(await maxMembers.inputValue());
-    expect(Number.isFinite(currentCap)).toBe(true);
+    expect(currentCap).toBeGreaterThan(0);
     const newCap = currentCap + 7;
 
     await commitMaxMembersWithoutBlurring(page, newCap);
@@ -109,6 +111,41 @@ test.describe("Room Details: in-progress typing survives room-state updates", ()
     // (empty, for this fixture room).
     await expect(description).toHaveValue(DRAFT);
     await expect(description).toBeFocused();
+  });
+
+  test("the max-members field also survives a room-state write", async ({ page }) => {
+    // MaxMembersField re-renders on its `member_count` prop as well as on
+    // `config`, so a member joining while the owner edited the cap was enough
+    // to wipe it. Covered separately because test 1 drives the room-state write
+    // THROUGH this field, so it can never observe this field being clobbered.
+    await openRoomDetails(page);
+
+    const maxMembers = page.getByTestId("max-members-input");
+    const typedCap = String(Number(await maxMembers.inputValue()) + 42);
+    await maxMembers.click();
+    await maxMembers.fill("");
+    await maxMembers.pressSequentially(typedCap, { delay: 10 });
+    await expect(maxMembers).toHaveValue(typedCap);
+    await expect(maxMembers).toBeFocused();
+
+    // Symmetric trick: commit a description change without moving focus, which
+    // signs a config delta and writes ROOMS exactly as a remote update would.
+    const newDescription = "description set from elsewhere";
+    await page.getByTestId("room-description-input").evaluate((el, value) => {
+      const ta = el as HTMLTextAreaElement;
+      ta.value = value;
+      ta.dispatchEvent(new Event("change", { bubbles: true }));
+    }, newDescription);
+
+    // Anti-vacuity: the write only shows up here once the delta has been
+    // applied and the dialog re-rendered from the new room state.
+    await expect(page.getByTestId("room-description-input")).toHaveValue(newDescription, {
+      timeout: 15_000,
+    });
+
+    // The cap being typed must still be there, and still uncommitted.
+    await expect(maxMembers).toHaveValue(typedCap);
+    await expect(maxMembers).toBeFocused();
   });
 
   test("the draft still commits normally on blur after a room-state write", async ({ page }) => {
@@ -133,6 +170,17 @@ test.describe("Room Details: in-progress typing survives room-state updates", ()
     // back if the save actually landed.
     await page.getByTestId("room-name-input").click();
     await expect(description).not.toBeFocused();
+
+    // Wait for the save to actually land before closing. The description save
+    // is async (sign -> defer -> ROOMS write) and each config delta must beat
+    // the next `configuration_version`, so a reopen that wins this race would
+    // reseed the remounted field from the OLD config and never recover —
+    // a permanent failure that the retry below could not rescue. Reopening the
+    // Members label is the observable proof the config round-tripped.
+    await expect(
+      page.getByTestId("edit-room-modal").getByText(new RegExp(`Members \\(\\d+/${newCap}\\)`)),
+    ).toBeVisible({ timeout: 15_000 });
+
     await page.getByTestId("edit-room-close-button").click();
     await expect(page.getByTestId("edit-room-modal")).toBeHidden({ timeout: 5_000 });
 

--- a/ui/tests/room-details-typing-survives-rerender.spec.ts
+++ b/ui/tests/room-details-typing-survives-rerender.spec.ts
@@ -12,10 +12,12 @@ import { test, expect, Page } from "@playwright/test";
 //
 // The Room Description textarea updated its bound signal only in `onchange`,
 // which fires on blur. So while the owner typed, the signal still held the
-// pre-typing text, and the next re-render reset the textarea to it.
-// `RoomDescriptionField` reads CURRENT_ROOM and ROOMS in its render body, so
-// ANY room-state write re-rendered it — which is what supplied the periodic
-// trigger in the bug report.
+// pre-typing text, and the next re-render reset the textarea to it. As
+// reported, `RoomDescriptionField` read CURRENT_ROOM and ROOMS in its render
+// body, so ANY room-state write re-rendered it, which is what supplied the
+// periodic trigger. (It no longer reads them there, so the trigger is now a
+// prop change; the fix is the handler either way, because it makes the field
+// correct under any re-render.)
 //
 // The test drives a real room-state write from inside the open dialog and
 // asserts the in-progress edit survives it.
@@ -173,15 +175,19 @@ test.describe("Room Details: in-progress typing survives room-state updates", ()
     await page.getByTestId("room-name-input").click();
     await expect(description).not.toBeFocused();
 
-    // Wait for the save to actually land before closing. The description save
-    // is async (sign -> defer -> ROOMS write) and each config delta must beat
-    // the next `configuration_version`, so a reopen that wins this race would
-    // reseed the remounted field from the OLD config and never recover —
-    // a permanent failure that the retry below could not rescue. Reopening the
-    // Members label is the observable proof the config round-tripped.
-    await expect(
-      page.getByTestId("edit-room-modal").getByText(new RegExp(`Members \\(\\d+/${newCap}\\)`)),
-    ).toBeVisible({ timeout: 15_000 });
+    // Wait for the DESCRIPTION save specifically to land before closing. It is
+    // async (sign -> defer -> ROOMS write), and a reopen that won that race
+    // would reseed the remounted field from the OLD config and never recover,
+    // since `use_signal` seeds once: a permanent failure the retry below could
+    // not rescue.
+    //
+    // The room header renders the description from room state, and this test
+    // never writes there, so it is real proof the save round-tripped. (Gating
+    // on the Members label instead would be a no-op: it already reached
+    // `newCap` above and the description save cannot move it.)
+    await expect(page.getByTestId("room-header-description")).toContainText(DRAFT, {
+      timeout: 15_000,
+    });
 
     await page.getByTestId("edit-room-close-button").click();
     await expect(page.getByTestId("edit-room-modal")).toBeHidden({ timeout: 5_000 });

--- a/ui/tests/room-details-typing-survives-rerender.spec.ts
+++ b/ui/tests/room-details-typing-survives-rerender.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect, Page } from "@playwright/test";
+
+// Regression test for freenet/river#564: typing in the Room Details dialog was
+// wiped every few seconds by unrelated room-state updates.
+//
+// `value` on `input`/`textarea` is a VOLATILE attribute in dioxus-html
+// (`elements.rs:1488,1594`), so dioxus re-writes it to the DOM on every
+// re-render even when the rendered string has not changed
+// (`dioxus-core-0.7.9/src/diff/node.rs:463`), and the interpreter assigns
+// `node.value = value` whenever the live DOM value differs
+// (`dioxus-interpreter-js-0.7.9/src/ts/set_attribute.ts:31-33`).
+//
+// The Room Description textarea updated its bound signal only in `onchange`,
+// which fires on blur. So while the owner typed, the signal still held the
+// pre-typing text, and the next re-render reset the textarea to it.
+// `RoomDescriptionField` reads CURRENT_ROOM and ROOMS in its render body, so
+// ANY room-state write re-rendered it — which is what supplied the periodic
+// trigger in the bug report.
+//
+// The test drives a real room-state write from inside the open dialog and
+// asserts the in-progress edit survives it.
+
+const OWNED_ROOM = "Your Private Room";
+const DRAFT = "A description I am still in the middle of typing";
+
+async function waitForApp(page: Page) {
+  await page.waitForSelector(".app-root", { timeout: 30_000 });
+  await expect(page.locator("aside, .app-root button")).not.toHaveCount(0);
+}
+
+async function openRoomDetails(page: Page) {
+  const vp = page.viewportSize();
+  if (vp && vp.width < 1024) {
+    await page.setViewportSize({ width: 1280, height: vp.height });
+  }
+
+  // Scope to the room list: once a room is selected the header button carries
+  // the room name as its accessible name too, which would be a second match.
+  const roomBtn = page.getByTestId("room-list").getByRole("button", { name: OWNED_ROOM });
+  await expect(roomBtn).toBeVisible({ timeout: 10_000 });
+  await roomBtn.click();
+  await expect(page.getByRole("heading", { name: OWNED_ROOM })).toBeVisible({ timeout: 5_000 });
+
+  await page.getByTitle("Room details").click();
+  await expect(page.getByTestId("edit-room-modal")).toBeVisible({ timeout: 5_000 });
+}
+
+/**
+ * Commit a new max-members value WITHOUT moving focus.
+ *
+ * This is the whole point of the setup. Clicking or tabbing to another field
+ * would blur the description textarea, which fires its `onchange` and commits
+ * the draft — the field would then hold the right text for the wrong reason and
+ * the test would pass even against the broken build. Dispatching the event
+ * programmatically leaves focus (and the uncommitted draft) exactly where the
+ * user had it.
+ *
+ * `change` bubbles, so dioxus's delegated root listener picks it up and runs
+ * the real `update_max_members` handler: sign the config, apply the delta to
+ * ROOMS, mark the room for sync. A genuine room-state write, not a fake one.
+ */
+async function commitMaxMembersWithoutBlurring(page: Page, newValue: number) {
+  await page.getByTestId("max-members-input").evaluate((el, value) => {
+    const input = el as HTMLInputElement;
+    input.value = String(value);
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+  }, newValue);
+}
+
+test.describe("Room Details: in-progress typing survives room-state updates", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await waitForApp(page);
+  });
+
+  test("a room-state write does not wipe the half-typed description", async ({ page }) => {
+    await openRoomDetails(page);
+
+    const description = page.getByTestId("room-description-input");
+    await expect(description).toBeVisible();
+    await expect(description).toBeEnabled();
+
+    // Type like a user: real keystrokes, no blur, nothing committed yet.
+    await description.click();
+    await description.pressSequentially(DRAFT, { delay: 10 });
+    await expect(description).toHaveValue(DRAFT);
+    await expect(description).toBeFocused();
+
+    // Read the current cap so the write we trigger is guaranteed to change it
+    // (`update_max_members` early-returns when the value is unchanged, which
+    // would leave nothing to re-render and make this test vacuous).
+    const maxMembers = page.getByTestId("max-members-input");
+    const currentCap = Number(await maxMembers.inputValue());
+    expect(Number.isFinite(currentCap)).toBe(true);
+    const newCap = currentCap + 7;
+
+    await commitMaxMembersWithoutBlurring(page, newCap);
+
+    // ANTI-VACUITY GATE. The label is rendered from the room state, so it only
+    // reaches the new cap once the delta has actually been signed, applied to
+    // ROOMS and re-rendered through the dialog. If this fails the write never
+    // landed and the assertion below would prove nothing.
+    await expect(
+      page.getByTestId("edit-room-modal").getByText(new RegExp(`Members \\(\\d+/${newCap}\\)`)),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // The actual regression: the description must still hold the uncommitted
+    // draft. Before the fix the re-render above reset it to the stored value
+    // (empty, for this fixture room).
+    await expect(description).toHaveValue(DRAFT);
+    await expect(description).toBeFocused();
+  });
+
+  test("the draft still commits normally on blur after a room-state write", async ({ page }) => {
+    // Guards the other direction: `oninput` must not have broken the `onchange`
+    // save path, so a description typed through an update still persists.
+    await openRoomDetails(page);
+
+    const description = page.getByTestId("room-description-input");
+    await description.click();
+    await description.pressSequentially(DRAFT, { delay: 10 });
+
+    const maxMembers = page.getByTestId("max-members-input");
+    const newCap = Number(await maxMembers.inputValue()) + 3;
+    await commitMaxMembersWithoutBlurring(page, newCap);
+    await expect(
+      page.getByTestId("edit-room-modal").getByText(new RegExp(`Members \\(\\d+/${newCap}\\)`)),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Blur to commit (the description saves on `onchange`), then close and
+    // reopen the dialog. Reopening remounts RoomDescriptionField, so it seeds
+    // its signal afresh from the stored configuration: the value can only come
+    // back if the save actually landed.
+    await page.getByTestId("room-name-input").click();
+    await expect(description).not.toBeFocused();
+    await page.getByTestId("edit-room-close-button").click();
+    await expect(page.getByTestId("edit-room-modal")).toBeHidden({ timeout: 5_000 });
+
+    await page.getByTitle("Room details").click();
+    await expect(page.getByTestId("edit-room-modal")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("room-description-input")).toHaveValue(DRAFT, {
+      timeout: 10_000,
+    });
+  });
+});

--- a/ui/tests/room-details-typing-survives-rerender.spec.ts
+++ b/ui/tests/room-details-typing-survives-rerender.spec.ts
@@ -128,20 +128,22 @@ test.describe("Room Details: in-progress typing survives room-state updates", ()
     await expect(maxMembers).toHaveValue(typedCap);
     await expect(maxMembers).toBeFocused();
 
-    // Symmetric trick: commit a description change without moving focus, which
-    // signs a config delta and writes ROOMS exactly as a remote update would.
-    const newDescription = "description set from elsewhere";
-    await page.getByTestId("room-description-input").evaluate((el, value) => {
-      const ta = el as HTMLTextAreaElement;
-      ta.value = value;
-      ta.dispatchEvent(new Event("change", { bubbles: true }));
-    }, newDescription);
+    // Same trick as test 1, but driven through the ROOM NAME field, so the
+    // write is observable somewhere this test did not write to itself.
+    // Committing the description here instead would be a vacuous gate: the
+    // synthetic event sets the textarea's DOM value directly, so asserting
+    // that value proves only that the test wrote it.
+    const renamed = "Renamed While Editing";
+    await page.getByTestId("room-name-input").evaluate((el, value) => {
+      const input = el as HTMLInputElement;
+      input.value = value;
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    }, renamed);
 
-    // Anti-vacuity: the write only shows up here once the delta has been
-    // applied and the dialog re-rendered from the new room state.
-    await expect(page.getByTestId("room-description-input")).toHaveValue(newDescription, {
-      timeout: 15_000,
-    });
+    // ANTI-VACUITY GATE: the room heading renders from room state, so it can
+    // only show the new name once the delta was signed, applied to ROOMS and
+    // re-rendered through the tree.
+    await expect(page.getByRole("heading", { name: renamed })).toBeVisible({ timeout: 15_000 });
 
     // The cap being typed must still be there, and still uncommitted.
     await expect(maxMembers).toHaveValue(typedCap);


### PR DESCRIPTION
Closes #564

## Problem

Editing the **Room Description** in the Room Details dialog, the field cleared itself every few seconds while typing (reported by Ian).

Three facts combine:

1. `value` on `input` / `textarea` / `select` is declared **volatile** in dioxus-html (`dioxus-html-0.7.9/src/elements.rs:1488,1571,1594`).
2. dioxus-core writes volatile attributes to the DOM on **every** re-render, even when the rendered string has not changed: `if volatile || attribute_changed { self.write_attribute(...) }` (`dioxus-core-0.7.9/src/diff/node.rs:463`).
3. The interpreter then assigns the value whenever the *live DOM* value differs from the VDOM value: `case "value": ... else if (node.value !== value) node.value = value;` (`dioxus-interpreter-js-0.7.9/src/ts/set_attribute.ts:31-33`).

`onchange` fires on blur, not per keystroke. So a field bound only through `onchange` still held the **pre-typing** text while the user typed, and any re-render in that window saw `node.value !== value` and reset the control.

`RoomDescriptionField` reads `CURRENT_ROOM` and `ROOMS` in its render body, so it is subscribed to both and re-renders on every room-state write. That is what supplied the periodic trigger in the report.

The sibling `RoomNameField` was never affected because it already has `oninput` (added for the Enter-to-commit handler in #21), which keeps the signal equal to the DOM value and makes the re-write a no-op.

## Approach

Ian asked me to check whether this affected more than the reported field, so I audited **every** `input` / `textarea` / `select` in `ui/src` rather than patching the one report. Added `oninput` to each editable control that bound `value:` without it:

| Field | Why it re-rendered |
|---|---|
| `RoomDescriptionField` (Room Description) | reads `CURRENT_ROOM` + `ROOMS` in its body, so every room-state write |
| `NumericConfigField` — renders **6** fields (Max Recent Messages, Max Message Size, Max User Bans, Max Nickname Size, Max Room Name, Max Room Description) | its `config` prop changes |
| `MaxMembersField` | its `config` prop, and also `member_count`, so a member joining mid-edit was enough |
| Create Room "Room Name" | its sibling nickname input already used `oninput`, so this was a plain oversight |

**Not affected, and deliberately left alone:**

- Read-only display controls (invite link, invite code, room public key, contract ID, member ID, export token) bind `value:` with no `oninput`, but nothing types into them. They declare `readonly: true`.
- The private-room checkbox binds `checked:`, which dioxus does **not** mark volatile, and is updated by `onchange` on click.
- No `contenteditable` and no real `select`/`option` elements exist in the tree.

Alternative considered and rejected: stopping `RoomDescriptionField` from subscribing to `ROOMS`/`CURRENT_ROOM` (e.g. via `peek()`). That removes one trigger but not the class, and it would stop the field from picking up a room secret that arrives after the dialog opens. `oninput` makes the volatile re-write a no-op regardless of what triggers the render, which is the actual invariant.

## Testing

**`components.rs::volatile_value_binding_audit`** — source-scrape audit over the whole `ui/src` tree, so a newly-added field cannot reintroduce the class.

- **Verified it fails on the pre-fix source**, reporting exactly `ui/src/components/room_list/edit_room_modal.rs:593 <textarea>`.
- Anti-vacuity floors on how many editable and display-only bindings it must find, so a refactor that stops the scanner matching this tree fails loudly instead of going green.
- Cuts each file at `#[cfg(test)]` so it cannot match its own fixtures (`feedback_source_pin_needle_matches_itself`).
- A self-test runs the scanner over the pre-fix *shape* of the field and asserts it is flagged, plus that the fixed shape passes.
- A third test asserts a nested child's `oninput` cannot satisfy its parent's requirement.
- Treats a literal `readonly: true` as display-only but **not** a conditional `readonly: !is_owner`, since that field is editable for the owner, who is exactly who loses their typing.

**`ui/tests/room-details-typing-survives-rerender.spec.ts`** — browser regression test.

- Types into the description with real keystrokes, then drives a genuine room-state write (a max-members change: sign config, apply delta to `ROOMS`, mark for sync) from inside the open dialog **without moving focus**, so the draft stays uncommitted. Clicking or tabbing would blur the textarea and fire its `onchange`, which would make the test pass against the broken build too.
- Gates on the `Members (n/NEW)` label reaching the new cap **before** asserting anything, so a write that never landed fails loudly rather than passing vacuously.
- **Verified it fails against the pre-fix build** with `Expected: "A description I am still in the middle of typing" / Received: ""` — the exact reported symptom.
- A second case asserts `oninput` did not break the `onchange` save path: blur to commit, close, reopen (which remounts the field and reseeds it from the stored configuration), and confirm the description round-tripped.

**Suites:**

- `cargo test -p river-ui --bins` — 801 passed
- `cargo test -p river-ui --bins --features example-data,no-sync` — 806 passed
- Full Playwright suite on chromium — 144 passed, 6 skipped, 0 failed
- `cargo fmt` and `cargo clippy` clean (no findings in changed files)

Also documented the hazard in `.claude/rules/dioxus-signal-safety.md`, since nothing about the broken call site looks wrong and reasoning about the component in isolation will not reveal it.

[AI-assisted - Claude]