### PR TITLE
feat(ui): make Share Invite the primary invite action, demote invite links

### DIFF
--- a/ui/src/components.rs
+++ b/ui/src/components.rs
@@ -97,6 +97,8 @@ mod volatile_value_binding_audit {
         r#"components/conversation.rs <textarea> "{edit_text}""#,
         r#"components/conversation/message_input.rs <textarea> "{message_text}""#,
         r#"components/direct_messages/dm_thread_modal.rs <textarea> "{draft.read()}""#,
+        r#"components/direct_messages/invite_contact_picker_modal.rs <input> "{query_value}""#,
+        r#"components/direct_messages/invite_contact_picker_modal.rs <textarea> "{personal_message_value}""#,
         r#"components/direct_messages/invite_via_dm_picker_modal.rs <textarea> "{personal_message_value}""#,
         r#"components/members.rs <textarea> "{token_input}""#,
         r#"components/members/member_info_modal/nickname_field.rs <input> "{temp_nickname}""#,

--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -10,7 +10,9 @@ use crate::components::app::document_title::DocumentTitleUpdater;
 use crate::components::app::freenet_api::freenet_synchronizer::SynchronizerMessage;
 use crate::components::app::freenet_api::freenet_synchronizer::SynchronizerStatus;
 use crate::components::app::freenet_api::FreenetSynchronizer;
-use crate::components::direct_messages::{DmThreadModal, InviteViaDmPickerModal};
+use crate::components::direct_messages::{
+    DmThreadModal, InviteContactPickerModal, InviteViaDmPickerModal,
+};
 use crate::components::members::member_info_modal::MemberInfoModal;
 use crate::components::members::Invitation;
 use crate::components::room_list::create_room_modal::CreateRoomModal;
@@ -506,6 +508,7 @@ pub fn App() -> Element {
         CreateRoomModal {}
         DmThreadModal {}
         InviteViaDmPickerModal {}
+        InviteContactPickerModal {}
         ReceiveInvitationModal {
             invitation: receive_invitation
         }

--- a/ui/src/components/direct_messages.rs
+++ b/ui/src/components/direct_messages.rs
@@ -19,9 +19,14 @@
 //! back as unread on every page load.
 
 mod dm_thread_modal;
+mod invite_contact_picker_modal;
+mod invite_dm;
 mod invite_via_dm_picker_modal;
 
 pub use dm_thread_modal::DmThreadModal;
+pub use invite_contact_picker_modal::{
+    has_invitable_contacts, open_invite_contact_picker_for_current_room, InviteContactPickerModal,
+};
 pub use invite_via_dm_picker_modal::InviteViaDmPickerModal;
 
 use dioxus::prelude::*;
@@ -126,6 +131,33 @@ pub struct InvitePickInflight {
 }
 
 pub static INVITE_VIA_DM_PICKER_INFLIGHT: GlobalSignal<Option<InvitePickInflight>> =
+    Global::new(|| None);
+
+/// "Share Invite" contact-picker state (#566). `Some(room)` means the
+/// [`InviteContactPickerModal`] is open and offers to DM an invitation for
+/// `room` to somebody the local user already shares a DIFFERENT room with.
+///
+/// The mirror of [`INVITE_VIA_DM_PICKER`]: that one fixes the person and
+/// picks the room, this one fixes the room and picks the person. Two
+/// signals rather than one two-mode signal so neither picker can be
+/// rendered into a state the other's invariants assume.
+pub static INVITE_CONTACT_PICKER: GlobalSignal<Option<VerifyingKey>> = Global::new(|| None);
+
+/// Currently in-flight pick from [`InviteContactPickerModal`]. Module-scope
+/// for the same reason as [`InvitePickInflight`]: a watchdog task can
+/// outlive the picker's close.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct ContactPickInflight {
+    /// Monotonic counter — every fresh send bumps it. Watchdogs capture it
+    /// at scheduling time and no-op once it has moved on.
+    pub generation: u64,
+    /// Room whose DM channel is carrying the invitation.
+    pub carrier_room: VerifyingKey,
+    /// Recipient of the invitation DM.
+    pub peer: MemberId,
+}
+
+pub static INVITE_CONTACT_PICKER_INFLIGHT: GlobalSignal<Option<ContactPickInflight>> =
     Global::new(|| None);
 
 /// Body to pre-fill into the DM composer the next time

--- a/ui/src/components/direct_messages/invite_contact_picker_modal.rs
+++ b/ui/src/components/direct_messages/invite_contact_picker_modal.rs
@@ -1,0 +1,820 @@
+//! "Share Invite" contact picker (#566).
+//!
+//! The mirror image of [`super::invite_via_dm_picker_modal`]. That picker
+//! starts from a PERSON (a member of the room you're looking at) and asks
+//! which of your other rooms to invite them to. This one starts from the
+//! ROOM you're looking at and asks WHO to invite — which is the direction
+//! users actually arrive from, because the invite control lives at the
+//! bottom of that room's member list.
+//!
+//! Why this exists: the only discoverable way to invite someone used to be
+//! "Invite Member", which mints a link. That link is a bearer credential
+//! for exactly one person, and in the field people share one link with
+//! several people, at which point everyone who used it shares an identity
+//! and none of them work. The DM route has none of that failure mode — the
+//! recipient gets an Accept button inside a DM thread and no credential
+//! ever leaves River — but it was three clicks deep behind a member's card
+//! in a *different* room, so nobody found it. This surfaces it as the
+//! primary invite action.
+//!
+//! Candidates are every member of every OTHER room the local user is in
+//! (the current room is excluded — its members are already in). Per-room
+//! identities mean the same human has a different `member_vk` per room, so
+//! we cannot dedupe a person across rooms, and cannot tell whether they
+//! are already a member of the target room. Each row therefore names both
+//! the person and the room the DM would be sent in, and the local user —
+//! who has the context — picks.
+//!
+//! In-flight / watchdog machinery mirrors the sibling picker for the same
+//! reasons documented there: the component is mounted unconditionally in
+//! `app.rs` and never unmounts, so a send can outlive a close, and a
+//! generation counter lets superseded picks short-circuit.
+
+use crate::components::app::{CURRENT_ROOM, ROOMS};
+use crate::components::direct_messages::invite_dm::compose_and_send_invite_dm;
+use crate::components::direct_messages::{
+    ContactPickInflight, INVITE_CONTACT_PICKER, INVITE_CONTACT_PICKER_INFLIGHT,
+};
+use crate::util::ecies::unseal_bytes_with_secrets;
+use dioxus::logger::tracing::{error, info, warn};
+use dioxus::prelude::*;
+use ed25519_dalek::VerifyingKey;
+use river_core::room_state::member::MemberId;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// One person the local user could DM an invitation to, together with the
+/// room whose DM channel would carry it.
+#[derive(Clone, PartialEq, Debug)]
+pub(crate) struct ContactCandidate {
+    /// Room the DM is sent inside. Both the local user and `peer` are
+    /// members of it. NEVER the invitation's target room.
+    pub carrier_room: VerifyingKey,
+    /// Display name of `carrier_room`.
+    pub room_label: String,
+    pub peer: MemberId,
+    /// Display name of `peer` in `carrier_room`.
+    pub peer_label: String,
+    /// The pair already has DM history in `carrier_room`. A person you've
+    /// actually talked to is far more likely to be who you meant than a
+    /// stranger who happens to share a large room, so these sort first.
+    pub has_dm_history: bool,
+}
+
+/// Watchdog timeout, matching the sibling picker. `sign_member_with_fallback`
+/// caps at 10s before its local-signing fallback; this is the catch-all for
+/// "something else got wedged".
+const PICKER_WATCHDOG_SECS: u64 = 15;
+
+/// Cap on the personal-message field — a UX cap against a runaway paste,
+/// not a wire-format cap. Matches the sibling picker.
+const PERSONAL_MESSAGE_CHAR_CAP: usize = 4_000;
+
+/// Most rows rendered at once. A user in a large room has hundreds of
+/// co-members, and rendering all of them makes the list unusable and the
+/// per-keystroke render cost real. Anything beyond this is reachable by
+/// typing in the filter box, and the count of what's hidden is shown so
+/// the truncation is never silent.
+const MAX_RENDERED_CANDIDATES: usize = 40;
+
+/// Monotonic pick generation, outside any component scope so it can never
+/// panic on access.
+static PICK_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+/// Order candidates: people you have DM history with first, then by
+/// display name, then by room name, then by member id so the order is
+/// total and stable across renders (two members can share a nickname —
+/// nicknames are not unique — and a non-total comparator would let rows
+/// swap between renders).
+pub(crate) fn sort_contacts(candidates: &mut [ContactCandidate]) {
+    candidates.sort_by(|a, b| {
+        b.has_dm_history
+            .cmp(&a.has_dm_history)
+            .then_with(|| {
+                a.peer_label
+                    .to_lowercase()
+                    .cmp(&b.peer_label.to_lowercase())
+            })
+            .then_with(|| {
+                a.room_label
+                    .to_lowercase()
+                    .cmp(&b.room_label.to_lowercase())
+            })
+            .then_with(|| a.peer.to_string().cmp(&b.peer.to_string()))
+    });
+}
+
+/// Case-insensitive substring match against the person's name OR the
+/// room's name — a user who remembers "someone from the dev room" can get
+/// there by typing the room.
+pub(crate) fn contact_matches_query(candidate: &ContactCandidate, query: &str) -> bool {
+    let q = query.trim().to_lowercase();
+    if q.is_empty() {
+        return true;
+    }
+    candidate.peer_label.to_lowercase().contains(&q)
+        || candidate.room_label.to_lowercase().contains(&q)
+}
+
+/// Apply the filter and the render cap. Returns the rows to render plus
+/// how many further matches were withheld, so the caller can say so.
+pub(crate) fn visible_contacts(
+    all: &[ContactCandidate],
+    query: &str,
+    cap: usize,
+) -> (Vec<ContactCandidate>, usize) {
+    let matching: Vec<ContactCandidate> = all
+        .iter()
+        .filter(|c| contact_matches_query(c, query))
+        .cloned()
+        .collect();
+    let hidden = matching.len().saturating_sub(cap);
+    let mut shown = matching;
+    shown.truncate(cap);
+    (shown, hidden)
+}
+
+/// Open the contact picker for `target_room` — the room the invitation
+/// will grant access to.
+pub fn open_invite_contact_picker(target_room: VerifyingKey) {
+    crate::util::defer(move || {
+        *INVITE_CONTACT_PICKER.write() = Some(target_room);
+    });
+}
+
+/// Is there anybody the local user could DM an invite to for
+/// `target_room`? Drives the enabled state of the "Share Invite" button so
+/// it doesn't lead to an empty picker.
+///
+/// Returns `None` when `ROOMS` can't be read — the caller decides what to
+/// do with "don't know" (the member panel leaves the button enabled, so a
+/// contended read never hides a working action; the picker's own empty
+/// state covers the case where it really was empty).
+pub fn has_invitable_contacts(target_room: VerifyingKey) -> Option<bool> {
+    let rooms = ROOMS.try_read().ok()?;
+    Some(rooms.map.iter().any(|(owner_vk, room_data)| {
+        if *owner_vk == target_room {
+            return false;
+        }
+        let self_id: MemberId = room_data.self_sk.verifying_key().into();
+        let owner_id = MemberId::from(owner_vk);
+        (owner_id != self_id)
+            || room_data
+                .room_state
+                .members
+                .members
+                .iter()
+                .any(|m| m.member.id() != self_id)
+    }))
+}
+
+#[component]
+pub fn InviteContactPickerModal() -> Element {
+    // --- Hooks first (Rules of Hooks) --------------------------------
+    // ALL hooks must run unconditionally, BEFORE the early return below.
+    // This component renders 0 hooks when closed and N when open, which
+    // is only sound as strict all-or-nothing — a hook after the guard
+    // would shift the sequence on the first close→reopen and panic.
+    //
+    // The selection is tagged with the target room it was made for, so a
+    // selection left over from a previous open (the `use_signal`s survive
+    // close: the component never unmounts) can't arm the Send button.
+    let mut selected: Signal<Option<(VerifyingKey, VerifyingKey, MemberId)>> = use_signal(|| None);
+    let mut query = use_signal(String::new);
+    let mut personal_message = use_signal(String::new);
+    let mut send_error: Signal<Option<String>> = use_signal(|| None);
+    let mut last_success_label: Signal<Option<String>> = use_signal(|| None);
+
+    // Reset scratch state on every open/close/target transition. Reads
+    // only `INVITE_CONTACT_PICKER`, so it can't feed back on the signals
+    // it writes. Uses `.read()` deliberately, not `try_read()`: this is
+    // the effect's sole subscription and a miss would silently drop it,
+    // permanently disabling the reset (see AGENTS.md).
+    use_effect(move || {
+        let _ = INVITE_CONTACT_PICKER.read();
+        selected.set(None);
+        query.set(String::new());
+        personal_message.set(String::new());
+        send_error.set(None);
+        last_success_label.set(None);
+    });
+
+    // --- Early return: render nothing while the picker is closed ------
+    let active = *INVITE_CONTACT_PICKER.read();
+    let Some(target_room) = active else {
+        return rsx! {};
+    };
+
+    let in_flight = *INVITE_CONTACT_PICKER_INFLIGHT.read();
+    let any_pending = in_flight.is_some();
+
+    let close = move |_| {
+        // Don't close mid-send.
+        if INVITE_CONTACT_PICKER_INFLIGHT.read().is_some() {
+            return;
+        }
+        crate::util::defer(move || {
+            *INVITE_CONTACT_PICKER.write() = None;
+        });
+    };
+
+    // Target-room label and data. Computed inline every render, NOT via
+    // `use_memo`: a memo subscribes only to the signals it reads
+    // (`ROOMS`), and `target_room` is a plain captured value, so reopening
+    // for a different room would keep handing back the first room's label
+    // for the life of the session (the #291 bug, same shape).
+    let target_room_data = ROOMS
+        .try_read()
+        .ok()
+        .and_then(|r| r.map.get(&target_room).cloned());
+    let target_label = target_room_data
+        .as_ref()
+        .map(room_display_label)
+        .unwrap_or_else(|| "this room".to_string());
+
+    // Candidate list, also built inline for the same reason.
+    let all_candidates = build_contact_candidates(target_room);
+    let query_value = query.read().clone();
+    let (rows, hidden_count) =
+        visible_contacts(&all_candidates, &query_value, MAX_RENDERED_CANDIDATES);
+
+    // Two synchronous render-time checks, so the Send button is never
+    // armed by a stale selection — not even on the first frame after
+    // reopen, before the reset effect runs: the selection must be tagged
+    // with the current target room, and must still be a live candidate.
+    let selected_value = (*selected.read())
+        .filter(|(tag, _, _)| *tag == target_room)
+        .map(|(_, carrier, peer)| (carrier, peer))
+        .filter(|(carrier, peer)| {
+            all_candidates
+                .iter()
+                .any(|c| c.carrier_room == *carrier && c.peer == *peer)
+        });
+    let personal_message_value = personal_message.read().clone();
+    let send_error_value = send_error.read().clone();
+    let last_success_label_value = last_success_label.read().clone();
+    let pmessage_chars = personal_message_value.chars().count();
+    let can_send = selected_value.is_some() && !any_pending;
+
+    let candidates_for_send = all_candidates.clone();
+    let target_label_for_send = target_label.clone();
+    let do_send = move |_| {
+        // Re-check pending; a click can race the disabled attribute.
+        if INVITE_CONTACT_PICKER_INFLIGHT.peek().is_some() {
+            return;
+        }
+        // Guard the send path directly rather than trusting the button's
+        // disabled state — same two checks as the render filter above.
+        let (carrier_room, peer) = match *selected.peek() {
+            Some((tag, carrier, peer))
+                if tag == target_room
+                    && candidates_for_send
+                        .iter()
+                        .any(|c| c.carrier_room == carrier && c.peer == peer) =>
+            {
+                (carrier, peer)
+            }
+            _ => {
+                send_error.set(Some("Pick someone to invite first.".into()));
+                return;
+            }
+        };
+        send_error.set(None);
+
+        let pmessage = personal_message.peek().clone();
+        let pmessage_opt = if pmessage.trim().is_empty() {
+            None
+        } else {
+            Some(pmessage.trim().to_string())
+        };
+
+        // The invitation is signed against the TARGET room, so its data
+        // (identity + secrets) is what the send needs — re-read here so a
+        // room unloaded since render fails loudly instead of signing
+        // against stale state.
+        let Some(target_data) = ROOMS
+            .try_read()
+            .ok()
+            .and_then(|r| r.map.get(&target_room).cloned())
+        else {
+            error!("invite-contact-picker: target room data missing");
+            send_error.set(Some(
+                "This room is no longer loaded. Reopen it and try again.".into(),
+            ));
+            return;
+        };
+        let peer_label = candidates_for_send
+            .iter()
+            .find(|c| c.carrier_room == carrier_room && c.peer == peer)
+            .map(|c| c.peer_label.clone())
+            .unwrap_or_else(|| "them".to_string());
+
+        let my_generation = PICK_GENERATION.fetch_add(1, Ordering::Relaxed) + 1;
+        crate::util::defer(move || {
+            *INVITE_CONTACT_PICKER_INFLIGHT.write() = Some(ContactPickInflight {
+                generation: my_generation,
+                carrier_room,
+                peer,
+            });
+        });
+
+        let target_label_for_task = target_label_for_send.clone();
+        crate::util::safe_spawn_local(async move {
+            // carrier_room carries the DM; target_room is what the
+            // invitation grants — the opposite assignment from the
+            // sibling picker, which is the whole point of this surface.
+            let outcome =
+                compose_and_send_invite_dm(carrier_room, peer, target_data, pmessage_opt).await;
+
+            crate::util::defer(move || {
+                // This pick may have been superseded while awaiting: the
+                // watchdog may have fired, or the user may have started a
+                // newer pick. Applying picker-local UI updates then would
+                // clobber a newer session or resurrect a closed one, so
+                // gate them on the generation still being ours and do
+                // only the global INFLIGHT cleanup otherwise.
+                let still_mine = matches!(
+                    *INVITE_CONTACT_PICKER_INFLIGHT.peek(),
+                    Some(p) if p.generation == my_generation
+                );
+                clear_inflight_if_matches(my_generation);
+                match outcome {
+                    Ok(()) => {
+                        info!("invite-contact-picker: sent invite for room {target_room:?}");
+                        if still_mine {
+                            last_success_label.set(Some(format!(
+                                "{peer_label} — invitation to \"{target_label_for_task}\" sent"
+                            )));
+                            *INVITE_CONTACT_PICKER.write() = None;
+                        } else {
+                            // The send DID succeed — `send_structured_dm`
+                            // already wrote to ROOMS and queued sync, so
+                            // the recipient gets it regardless. Only the
+                            // picker-local feedback is skipped.
+                            info!(
+                                "invite-contact-picker: send completed after watchdog \
+                                 fired — skipping picker-local UI updates"
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        warn!("invite-contact-picker: send failed: {e}");
+                        if still_mine {
+                            send_error.set(Some(e));
+                        } else {
+                            warn!(
+                                "invite-contact-picker: error arrived after watchdog \
+                                 fired; not surfacing to closed picker"
+                            );
+                        }
+                    }
+                }
+            });
+        });
+
+        schedule_watchdog(my_generation);
+    };
+
+    rsx! {
+        div {
+            class: "fixed inset-0 z-50 flex items-center justify-center",
+            div {
+                class: "absolute inset-0 bg-black/50",
+                onclick: close,
+            }
+            div {
+                "data-testid": "invite-contact-picker-modal",
+                class: "relative z-10 w-full max-w-md mx-4 bg-panel rounded-xl shadow-xl border border-border flex flex-col max-h-[80vh]",
+                div { class: "flex items-center justify-between px-5 py-4 border-b border-border",
+                    h2 { class: "text-base font-semibold text-text",
+                        "Invite someone to "
+                        span { class: "text-accent", "{target_label}" }
+                    }
+                    button {
+                        "data-testid": "invite-contact-picker-close-button",
+                        class: format!(
+                            "p-1 text-text-muted hover:text-text transition-colors text-xl {}",
+                            if any_pending { "opacity-40 cursor-not-allowed" } else { "" }
+                        ),
+                        disabled: any_pending,
+                        "aria-label": "Close invite picker",
+                        onclick: close,
+                        "✕"
+                    }
+                }
+                div { class: "flex-1 overflow-y-auto px-5 py-4 space-y-3",
+                    if all_candidates.is_empty() {
+                        div {
+                            "data-testid": "invite-contact-picker-empty",
+                            class: "text-sm text-text-muted space-y-2",
+                            p {
+                                "There's nobody to send an invitation to yet — River can only DM an \
+                                 invite to someone you already share a room with."
+                            }
+                            p {
+                                "Use "
+                                span { class: "text-text font-medium", "Invite by link" }
+                                " instead. That link works for "
+                                span { class: "text-text font-medium", "one person only" }
+                                " — generate a fresh one for each person you invite."
+                            }
+                        }
+                    } else {
+                        p { class: "text-xs text-text-muted",
+                            "River sends them an invitation card in a DM, with an Accept button. \
+                             Nothing to copy, paste, or leak."
+                        }
+                        div { class: "space-y-1",
+                            label { class: "text-xs text-text-muted block", "Who?" }
+                            input {
+                                "data-testid": "invite-contact-picker-search",
+                                class: "w-full px-3 py-2 bg-surface border border-border rounded-lg text-sm text-text",
+                                r#type: "text",
+                                placeholder: "Search by name or room…",
+                                value: "{query_value}",
+                                disabled: any_pending,
+                                oninput: move |e| query.set(e.value()),
+                            }
+                            if rows.is_empty() {
+                                p {
+                                    "data-testid": "invite-contact-picker-no-matches",
+                                    class: "text-xs text-text-muted py-2",
+                                    "Nobody matches that."
+                                }
+                            }
+                            for row in rows.iter() {
+                                ContactRow {
+                                    key: "{row.carrier_room:x?}-{row.peer}",
+                                    candidate: row.clone(),
+                                    is_selected: selected_value == Some((row.carrier_room, row.peer)),
+                                    any_pending,
+                                    on_select: {
+                                        let carrier = row.carrier_room;
+                                        let peer = row.peer;
+                                        move |_| {
+                                            selected.set(Some((target_room, carrier, peer)));
+                                        }
+                                    },
+                                }
+                            }
+                            if hidden_count > 0 {
+                                p { class: "text-[10px] text-text-muted pt-1",
+                                    "{hidden_count} more — narrow the search to see them."
+                                }
+                            }
+                        }
+                        div { class: "space-y-1",
+                            label { class: "text-xs text-text-muted block",
+                                "Add a personal message (optional)"
+                            }
+                            textarea {
+                                class: "w-full px-3 py-2 bg-surface border border-border rounded-lg text-sm text-text resize-none min-h-[3rem] max-h-32",
+                                placeholder: "e.g. \"Thought you'd enjoy this room\"",
+                                value: "{personal_message_value}",
+                                disabled: any_pending,
+                                oninput: move |e| {
+                                    let v = e.value();
+                                    // Soft-cap: trim rather than reject so a
+                                    // paste of something bigger still leaves
+                                    // text the user can edit.
+                                    let trimmed: String = if v.chars().count() > PERSONAL_MESSAGE_CHAR_CAP {
+                                        v.chars().take(PERSONAL_MESSAGE_CHAR_CAP).collect()
+                                    } else {
+                                        v
+                                    };
+                                    personal_message.set(trimmed);
+                                },
+                            }
+                            div { class: "flex justify-end",
+                                span { class: "text-[10px] text-text-muted",
+                                    "{pmessage_chars}/{PERSONAL_MESSAGE_CHAR_CAP}"
+                                }
+                            }
+                        }
+                    }
+                    if let Some(err) = send_error_value.as_ref() {
+                        div { class: "text-xs text-red-400", "{err}" }
+                    }
+                    if let Some(label) = last_success_label_value.as_ref() {
+                        div { class: "text-xs text-emerald-400", "{label}" }
+                    }
+                }
+                if !all_candidates.is_empty() {
+                    div { class: "border-t border-border px-5 py-3 flex items-center justify-between",
+                        if any_pending {
+                            div { class: "flex items-center gap-2 text-xs text-text-muted",
+                                div { class: "animate-spin w-3 h-3 border-2 border-text-muted border-t-transparent rounded-full" }
+                                "Sending invite…"
+                            }
+                        } else {
+                            span { class: "text-[10px] text-text-muted" }
+                        }
+                        button {
+                            "data-testid": "invite-contact-picker-send-button",
+                            class: "px-4 py-2 bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors",
+                            disabled: !can_send,
+                            onclick: do_send,
+                            "Send invite"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn ContactRow(
+    candidate: ContactCandidate,
+    is_selected: bool,
+    any_pending: bool,
+    on_select: EventHandler<()>,
+) -> Element {
+    let peer_label = candidate.peer_label.clone();
+    let room_label = candidate.room_label.clone();
+    let has_dm_history = candidate.has_dm_history;
+
+    let aria = format!("Send the invitation to {peer_label}, in a DM inside {room_label}");
+    let select_class = if is_selected {
+        "border-accent bg-accent/10"
+    } else if any_pending {
+        "border-border opacity-60 cursor-not-allowed"
+    } else {
+        "border-border hover:bg-surface cursor-pointer"
+    };
+    rsx! {
+        button {
+            class: format!(
+                "w-full text-left px-3 py-2 rounded-lg border text-sm text-text flex items-center gap-2 transition-colors {}",
+                select_class
+            ),
+            disabled: any_pending,
+            "aria-label": "{aria}",
+            "aria-pressed": "{is_selected}",
+            onclick: move |_| on_select.call(()),
+            div { class: "flex-1 min-w-0",
+                div { class: "truncate", "{peer_label}" }
+                div { class: "text-[10px] text-text-muted truncate",
+                    if has_dm_history {
+                        "you've DM'd them · via {room_label}"
+                    } else {
+                        "via {room_label}"
+                    }
+                }
+            }
+            if is_selected {
+                span {
+                    class: "text-accent text-xs flex-shrink-0",
+                    "aria-label": "Selected",
+                    "✓"
+                }
+            }
+        }
+    }
+}
+
+/// Display name for a room, unsealing the private-room case.
+fn room_display_label(room_data: &crate::room_data::RoomData) -> String {
+    let sealed = &room_data
+        .room_state
+        .configuration
+        .configuration
+        .display
+        .name;
+    match unseal_bytes_with_secrets(sealed, &room_data.secrets) {
+        Ok(bytes) => String::from_utf8_lossy(&bytes).to_string(),
+        Err(_) => sealed.to_string_lossy(),
+    }
+}
+
+/// Every person the local user could DM an invitation for `target_room`
+/// to, sorted for display. Excludes `target_room` itself (its members are
+/// already in) and the local user's own per-room identity in each room.
+///
+/// Returns an empty list rather than failing when `ROOMS` is contended;
+/// the picker renders its empty state and the next render recovers.
+fn build_contact_candidates(target_room: VerifyingKey) -> Vec<ContactCandidate> {
+    let Ok(rooms) = ROOMS.try_read() else {
+        return Vec::new();
+    };
+    let mut out: Vec<ContactCandidate> = Vec::new();
+    for (owner_vk, room_data) in rooms.map.iter() {
+        if *owner_vk == target_room {
+            continue;
+        }
+        let room_label = room_display_label(room_data);
+        let self_id: MemberId = room_data.self_sk.verifying_key().into();
+        let owner_id = MemberId::from(owner_vk);
+        // The owner is not in `members.members` (membership is implicit
+        // for them) but IS a valid DM recipient — `send_structured_dm`
+        // special-cases them — so add them explicitly or the one person
+        // most likely to be able to help a newcomer is missing.
+        let peers = std::iter::once(owner_id).chain(
+            room_data
+                .room_state
+                .members
+                .members
+                .iter()
+                .map(|m| m.member.id()),
+        );
+        for peer in peers {
+            if peer == self_id {
+                continue;
+            }
+            let peer_label = room_data
+                .room_state
+                .member_info
+                .canonical(peer)
+                .map(|mi| {
+                    crate::util::display_name::display_nickname(
+                        &mi.member_info.preferred_nickname,
+                        &room_data.secrets,
+                    )
+                })
+                .unwrap_or_else(|| peer.to_string().chars().take(8).collect());
+            let has_dm_history = room_data
+                .room_state
+                .direct_messages
+                .messages
+                .iter()
+                .any(|m| {
+                    let (sender, recipient) = (m.message.sender, m.message.recipient);
+                    (sender == self_id && recipient == peer)
+                        || (sender == peer && recipient == self_id)
+                });
+            out.push(ContactCandidate {
+                carrier_room: *owner_vk,
+                room_label: room_label.clone(),
+                peer,
+                peer_label,
+                has_dm_history,
+            });
+        }
+    }
+    sort_contacts(&mut out);
+    out
+}
+
+/// Clear `INVITE_CONTACT_PICKER_INFLIGHT` only if it still names this
+/// pick's generation, so a stale terminal-defer can't wipe a newer pick's
+/// marker.
+fn clear_inflight_if_matches(my_generation: u64) {
+    let still_mine = matches!(
+        *INVITE_CONTACT_PICKER_INFLIGHT.peek(),
+        Some(p) if p.generation == my_generation
+    );
+    if still_mine {
+        *INVITE_CONTACT_PICKER_INFLIGHT.write() = None;
+    }
+}
+
+/// Clear the in-flight marker AND force-close the picker if this
+/// generation is still pending after `PICKER_WATCHDOG_SECS`.
+///
+/// Force-closing (rather than merely clearing the marker) avoids the
+/// "picker open but its pick already abandoned" state: every late
+/// completion then finds INFLIGHT cleared, its still-mine gate skips the
+/// UI updates, and the user sees a closed modal — a clear signal to check
+/// the DM thread — instead of a modal with no feedback and a retry that
+/// could double-send. Same trade-off as the sibling picker: a timeout
+/// loses the typed personal message.
+fn schedule_watchdog(my_generation: u64) {
+    use std::time::Duration;
+    crate::util::safe_spawn_local(async move {
+        crate::util::sleep(Duration::from_secs(PICKER_WATCHDOG_SECS)).await;
+        crate::util::defer(move || {
+            let still_mine = matches!(
+                *INVITE_CONTACT_PICKER_INFLIGHT.peek(),
+                Some(p) if p.generation == my_generation
+            );
+            if !still_mine {
+                return;
+            }
+            warn!(
+                "invite-contact-picker: watchdog fired after {PICKER_WATCHDOG_SECS}s; \
+                 force-closing picker"
+            );
+            clear_inflight_if_matches(my_generation);
+            *INVITE_CONTACT_PICKER.write() = None;
+        });
+    });
+}
+
+/// Open the contact picker for whatever room is currently being viewed.
+/// Returns `false` (and does nothing) when no room is selected, so a
+/// caller can fall back rather than opening an unanchored picker.
+pub fn open_invite_contact_picker_for_current_room() -> bool {
+    let Some(room) = CURRENT_ROOM.read().owner_key else {
+        return false;
+    };
+    open_invite_contact_picker(room);
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    fn vk(seed: u8) -> VerifyingKey {
+        SigningKey::from_bytes(&[seed; 32]).verifying_key()
+    }
+
+    fn member(seed: u8) -> MemberId {
+        MemberId::from(&vk(seed))
+    }
+
+    fn candidate(peer_seed: u8, peer_label: &str, room_label: &str, dm: bool) -> ContactCandidate {
+        ContactCandidate {
+            carrier_room: vk(peer_seed.wrapping_add(100)),
+            room_label: room_label.to_string(),
+            peer: member(peer_seed),
+            peer_label: peer_label.to_string(),
+            has_dm_history: dm,
+        }
+    }
+
+    #[test]
+    fn dm_history_sorts_ahead_of_strangers() {
+        let mut v = vec![
+            candidate(1, "Alice", "Room A", false),
+            candidate(2, "Zoe", "Room A", true),
+        ];
+        sort_contacts(&mut v);
+        // Zoe sorts first despite the later name: a person you've actually
+        // DM'd is far more likely to be who you meant.
+        assert_eq!(v[0].peer_label, "Zoe");
+        assert_eq!(v[1].peer_label, "Alice");
+    }
+
+    #[test]
+    fn names_sort_case_insensitively_then_by_room() {
+        let mut v = vec![
+            candidate(3, "bob", "Zed Room", false),
+            candidate(4, "Bob", "Alpha Room", false),
+            candidate(5, "alice", "Zed Room", false),
+        ];
+        sort_contacts(&mut v);
+        assert_eq!(v[0].peer_label, "alice");
+        // Same name (case-insensitively) → the room name breaks the tie.
+        assert_eq!(v[1].room_label, "Alpha Room");
+        assert_eq!(v[2].room_label, "Zed Room");
+    }
+
+    #[test]
+    fn sort_is_total_so_duplicate_names_and_rooms_cannot_swap() {
+        // Nicknames are NOT unique, and two members of the SAME room can
+        // share one. Without the member-id tiebreak the comparator is not
+        // total and rows could reorder between renders.
+        let a = ContactCandidate {
+            carrier_room: vk(9),
+            room_label: "Same Room".into(),
+            peer: member(1),
+            peer_label: "Ian".into(),
+            has_dm_history: false,
+        };
+        let b = ContactCandidate {
+            carrier_room: vk(9),
+            room_label: "Same Room".into(),
+            peer: member(2),
+            peer_label: "Ian".into(),
+            has_dm_history: false,
+        };
+        let mut forward = vec![a.clone(), b.clone()];
+        let mut reverse = vec![b, a];
+        sort_contacts(&mut forward);
+        sort_contacts(&mut reverse);
+        assert_eq!(forward, reverse);
+    }
+
+    #[test]
+    fn query_matches_person_or_room_case_insensitively() {
+        let c = candidate(6, "Nacho", "Freenet Devs", false);
+        assert!(contact_matches_query(&c, ""));
+        assert!(contact_matches_query(&c, "  "));
+        assert!(contact_matches_query(&c, "nach"));
+        assert!(contact_matches_query(&c, "NACH"));
+        // Matching on the ROOM is deliberate: "someone from the dev room"
+        // is how people remember contacts they haven't named.
+        assert!(contact_matches_query(&c, "devs"));
+        assert!(!contact_matches_query(&c, "hector"));
+    }
+
+    #[test]
+    fn visible_contacts_caps_and_reports_what_it_withheld() {
+        let all: Vec<ContactCandidate> = (0u8..10)
+            .map(|i| candidate(i, &format!("Person {i}"), "Room A", false))
+            .collect();
+        let (shown, hidden) = visible_contacts(&all, "", 4);
+        assert_eq!(shown.len(), 4);
+        // Truncation is never silent — the caller renders this count.
+        assert_eq!(hidden, 6);
+
+        let (shown, hidden) = visible_contacts(&all, "Person 3", 4);
+        assert_eq!(shown.len(), 1);
+        assert_eq!(hidden, 0);
+
+        let (shown, hidden) = visible_contacts(&all, "nobody", 4);
+        assert!(shown.is_empty());
+        assert_eq!(hidden, 0);
+    }
+}

--- a/ui/src/components/direct_messages/invite_contact_picker_modal.rs
+++ b/ui/src/components/direct_messages/invite_contact_picker_modal.rs
@@ -35,6 +35,11 @@ use crate::components::direct_messages::invite_dm::compose_and_send_invite_dm;
 use crate::components::direct_messages::{
     ContactPickInflight, INVITE_CONTACT_PICKER, INVITE_CONTACT_PICKER_INFLIGHT,
 };
+use crate::components::members::{
+    deputy_badges_for_viewer, impersonation_checker_for_viewer, impersonation_warning_for_display,
+    privilege_in_view,
+};
+use crate::util::confusable::WARNING_GLYPH;
 use crate::util::ecies::unseal_bytes_with_secrets;
 use dioxus::logger::tracing::{error, info, warn};
 use dioxus::prelude::*;
@@ -58,6 +63,16 @@ pub(crate) struct ContactCandidate {
     /// actually talked to is far more likely to be who you meant than a
     /// stranger who happens to share a large room, so these sort first.
     pub has_dm_history: bool,
+    /// Tooltip for the ⚠ badge when this person's display name is visually
+    /// identical to a privileged member's in `carrier_room`; `None` when
+    /// there is nothing to warn about.
+    ///
+    /// The member list carries this badge, and before this picker existed
+    /// the only route to a DM invite went THROUGH the member list — so the
+    /// user had seen the badge before choosing anyone. Picking from here
+    /// skips that list entirely, so the warning has to travel with the row
+    /// or promoting this surface would quietly remove a protection.
+    pub warning_tooltip: Option<String>,
 }
 
 /// Watchdog timeout, matching the sibling picker. `sign_member_with_fallback`
@@ -532,8 +547,22 @@ fn ContactRow(
     let peer_label = candidate.peer_label.clone();
     let room_label = candidate.room_label.clone();
     let has_dm_history = candidate.has_dm_history;
+    let warning_tooltip = candidate.warning_tooltip.clone();
 
-    let aria = format!("Send the invitation to {peer_label}, in a DM inside {room_label}");
+    // The accessible name must carry the warning too. The glyph is a child
+    // of a button with an explicit `aria-label`, and an explicit label
+    // REPLACES the element's content for naming purposes — so a badge
+    // rendered inside is invisible to a screen reader unless it is said
+    // here. Tests read `data-person` / `data-room` instead of parsing this
+    // string, so the copy is free to grow without breaking them.
+    let aria = match warning_tooltip.as_deref() {
+        Some(_) => format!(
+            "Send the invitation to {peer_label}, in a DM inside {room_label}. \
+             Warning: this name is visually identical to a privileged \
+             member's — check the member ID before inviting"
+        ),
+        None => format!("Send the invitation to {peer_label}, in a DM inside {room_label}"),
+    };
     let select_class = if is_selected {
         "border-accent bg-accent/10"
     } else if any_pending {
@@ -543,6 +572,12 @@ fn ContactRow(
     };
     rsx! {
         button {
+            "data-testid": "invite-contact-row",
+            // Addressing hooks for automation, so a spec never has to
+            // parse the accessible name (which carries prose that is
+            // expected to change).
+            "data-person": "{peer_label}",
+            "data-room": "{room_label}",
             class: format!(
                 "w-full text-left px-3 py-2 rounded-lg border text-sm text-text flex items-center gap-2 transition-colors {}",
                 select_class
@@ -550,6 +585,10 @@ fn ContactRow(
             disabled: any_pending,
             "aria-label": "{aria}",
             "aria-pressed": "{is_selected}",
+            // Member ID on hover — the remedy the warning tooltip tells
+            // the reader to use, and the only way to tell two members with
+            // the same display name apart.
+            title: "Member ID: {candidate.peer}",
             onclick: move |_| on_select.call(()),
             div { class: "flex-1 min-w-0",
                 div { class: "truncate", "{peer_label}" }
@@ -559,6 +598,14 @@ fn ContactRow(
                     } else {
                         "via {room_label}"
                     }
+                }
+            }
+            if let Some(tooltip) = warning_tooltip {
+                span {
+                    "data-testid": "invite-contact-impersonation-warning",
+                    class: "member-icon flex-shrink-0",
+                    title: "{tooltip}",
+                    " {WARNING_GLYPH}"
                 }
             }
             if is_selected {
@@ -604,6 +651,23 @@ fn build_contact_candidates(target_room: VerifyingKey) -> Vec<ContactCandidate> 
         let room_label = room_display_label(room_data);
         let self_id: MemberId = room_data.self_sk.verifying_key().into();
         let owner_id = MemberId::from(owner_vk);
+        // Both built ONCE per room, BEFORE the per-peer loop. Rebuilding
+        // either per peer re-folds every protected name and, in a private
+        // room, re-unseals every protected nickname, once per row — the
+        // same cost rule `MemberList` follows.
+        let deputy_badges = deputy_badges_for_viewer(
+            &room_data.room_state.members,
+            &room_data.room_state.member_info,
+            &room_data.secrets,
+            owner_id,
+            self_id,
+        );
+        let impersonation = impersonation_checker_for_viewer(
+            &room_data.room_state.member_info,
+            &room_data.secrets,
+            owner_id,
+            &deputy_badges,
+        );
         // The owner is not in `members.members` (membership is implicit
         // for them) but IS a valid DM recipient — `send_structured_dm`
         // special-cases them — so add them explicitly or the one person
@@ -641,12 +705,23 @@ fn build_contact_candidates(target_room: VerifyingKey) -> Vec<ContactCandidate> 
                     (sender == self_id && recipient == peer)
                         || (sender == peer && recipient == self_id)
                 });
+            // `peer`, not `self_id` — passing any other id flags the
+            // genuine owner and every genuine moderator instead of the
+            // imitator. Same argument trap the member list is pinned for.
+            let warning_tooltip = impersonation_warning_for_display(
+                &impersonation,
+                peer,
+                &peer_label,
+                privilege_in_view(peer, owner_id, &deputy_badges),
+            )
+            .map(|w| w.tooltip());
             out.push(ContactCandidate {
                 carrier_room: *owner_vk,
                 room_label: room_label.clone(),
                 peer,
                 peer_label,
                 has_dm_history,
+                warning_tooltip,
             });
         }
     }
@@ -730,6 +805,7 @@ mod tests {
             peer: member(peer_seed),
             peer_label: peer_label.to_string(),
             has_dm_history: dm,
+            warning_tooltip: None,
         }
     }
 
@@ -771,6 +847,7 @@ mod tests {
             peer: member(1),
             peer_label: "Ian".into(),
             has_dm_history: false,
+            warning_tooltip: None,
         };
         let b = ContactCandidate {
             carrier_room: vk(9),
@@ -778,6 +855,7 @@ mod tests {
             peer: member(2),
             peer_label: "Ian".into(),
             has_dm_history: false,
+            warning_tooltip: None,
         };
         let mut forward = vec![a.clone(), b.clone()];
         let mut reverse = vec![b, a];

--- a/ui/src/components/direct_messages/invite_dm.rs
+++ b/ui/src/components/direct_messages/invite_dm.rs
@@ -1,0 +1,126 @@
+//! Shared "send an invitation card as a DM" machinery.
+//!
+//! Two surfaces produce an invitation-card DM, from opposite starting
+//! points:
+//!
+//! * [`super::invite_via_dm_picker_modal`] — we know the PERSON (a member
+//!   of the room being viewed) and the user picks which of their OTHER
+//!   rooms to invite them to (#252).
+//! * [`super::invite_contact_picker_modal`] — we know the ROOM (the one
+//!   being viewed) and the user picks WHICH person they already share a
+//!   room with to send it to (#566).
+//!
+//! Both reduce to the same operation: sign a fresh membership claim
+//! against the *target* room, wrap it in a
+//! [`DirectMessageBody::Invite`], and DM it to a peer inside a *carrier*
+//! room the local user shares with them. That single operation lives here
+//! so the two pickers cannot drift — an invitation the recipient can't
+//! accept is indistinguishable from a working one until they try.
+
+use crate::components::direct_messages::{send_structured_dm, SendDmOutcome};
+use crate::components::members::{collect_invitation_secrets, Invitation};
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use river_core::room_state::dm_body::{DirectMessageBody, InvitePayload};
+use river_core::room_state::member::{AuthorizedMember, Member, MemberId};
+
+/// Mint an invitation for `target_room`, then deliver it to `peer` as a
+/// structured `Invite` DM sent inside `carrier_room`.
+///
+/// `carrier_room` is the room whose DM channel carries the message — the
+/// local user and `peer` must both be members of it. `target_room` is the
+/// room the invitation grants access to; it supplies the signing identity
+/// (`self_sk`) and, for a private room, the secrets the invitee needs to
+/// read it immediately on join.
+///
+/// The two may not be the same room: inviting someone to a room they are
+/// already in is a no-op, and the callers both exclude that case when
+/// building their candidate lists.
+///
+/// Returns a user-facing error string on failure — every arm is safe to
+/// render verbatim in a modal.
+pub(super) async fn compose_and_send_invite_dm(
+    carrier_room: VerifyingKey,
+    peer: MemberId,
+    target_room: crate::room_data::RoomData,
+    personal_message: Option<String>,
+) -> Result<(), String> {
+    // A fresh identity per invitation — this is the bearer credential the
+    // recipient becomes. Never reused across invitations (two people
+    // holding one identity is exactly the failure the link flow keeps
+    // producing in the wild).
+    let invitee_signing_key = SigningKey::generate(&mut rand::thread_rng());
+    let member = Member {
+        owner_member_id: target_room.owner_vk.into(),
+        invited_by: target_room.self_sk.verifying_key().into(),
+        member_vk: invitee_signing_key.verifying_key(),
+    };
+
+    // Sign the member-claim via the delegate-backed signing path. Same
+    // semantics as the link flow in `invite_member_modal.rs`.
+    let mut member_bytes = Vec::new();
+    if ciborium::ser::into_writer(&member, &mut member_bytes).is_err() {
+        return Err("Couldn't serialize membership claim. Try again.".into());
+    }
+    let signature = crate::signing::sign_member_with_fallback(
+        target_room.room_key(),
+        member_bytes,
+        &target_room.self_sk,
+    )
+    .await;
+    let authorized = AuthorizedMember::with_signature(member, signature);
+
+    // For a private room, embed the room secrets the inviter holds so the
+    // invitee can decrypt the room immediately on join. Empty for a public
+    // room or an empty secrets map.
+    let room_secrets = if target_room.is_private() {
+        collect_invitation_secrets(&target_room.secrets)
+    } else {
+        Vec::new()
+    };
+    let invitation = Invitation {
+        room: target_room.owner_vk,
+        invitee_signing_key,
+        invitee: authorized,
+        room_secrets,
+    };
+
+    // Encode the Invitation as CBOR — same bytes the URL form base58-
+    // encodes. The recipient decodes these bytes back to `Invitation`.
+    let mut invitation_payload = Vec::new();
+    ciborium::ser::into_writer(&invitation, &mut invitation_payload)
+        .map_err(|e| format!("Couldn't encode invitation: {}", e))?;
+
+    let body = DirectMessageBody::Invite(Box::new(InvitePayload {
+        room_owner_vk: target_room.owner_vk,
+        invitation_payload,
+        personal_message,
+    }));
+
+    match send_structured_dm(carrier_room, peer, body).await {
+        SendDmOutcome::Sent => Ok(()),
+        SendDmOutcome::RoomGone => Err("The room you're DM'ing in is no longer loaded.".into()),
+        SendDmOutcome::RecipientNotMember => {
+            Err("The recipient is no longer a member of this room.".into())
+        }
+        SendDmOutcome::SelfDm => Err("Cannot send a DM to yourself.".into()),
+        SendDmOutcome::SenderMissingRejoin => Err(
+            "You're not currently in this room's member list and no rejoin \
+             credentials are stored locally. Reload the room or re-accept your \
+             invitation before sending an invite DM."
+                .into(),
+        ),
+        SendDmOutcome::BodyTooLargeOrEncodeFailed(e) => Err(format!(
+            "Couldn't send invite — body too large or encode failed: {}",
+            e
+        )),
+        SendDmOutcome::DeltaFailed(e) => Err(format!(
+            "Couldn't send invite — local apply_delta failed: {}",
+            e
+        )),
+        SendDmOutcome::SilentDrop => Err(
+            "Invite couldn't be added to the room (your member entry may be \
+             missing). Try posting a message in the room first, then retry."
+                .into(),
+        ),
+    }
+}

--- a/ui/src/components/direct_messages/invite_dm.rs
+++ b/ui/src/components/direct_messages/invite_dm.rs
@@ -124,3 +124,66 @@ pub(super) async fn compose_and_send_invite_dm(
         ),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    /// Whitespace-squashed so rustfmt's line-wrapping choices can't disarm
+    /// the pins below.
+    fn squashed(source: &str) -> String {
+        source.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
+    /// Production slice of a picker module — everything before its test
+    /// module, so test prose can neither disarm nor trip a pin.
+    fn prod(source: &str) -> String {
+        let end = source.find("#[cfg(test)]").unwrap_or(source.len());
+        squashed(&source[..end])
+    }
+
+    /// The two pickers pass the SAME two rooms to
+    /// [`super::compose_and_send_invite_dm`] in OPPOSITE positions, and
+    /// swapping them at either call site compiles cleanly.
+    ///
+    /// What a swap does: the invitation gets signed against the room the DM
+    /// is merely travelling through, and the DM gets sent inside the room
+    /// the invitation was meant to grant — where the recipient is, by
+    /// construction, not yet a member. So the user is told
+    /// "The recipient is no longer a member of this room", for a room they
+    /// can see the recipient in, and no invitation is delivered.
+    ///
+    /// Nothing else catches it. Both arguments are the right types, every
+    /// unit test here is on pure helpers, and the browser specs cannot
+    /// reach a send (no chat delegate under `no-sync`). A source pin on the
+    /// argument NAMES is the available gate, and the mutation it guards is
+    /// the most damaging one this change admits.
+    #[test]
+    fn each_picker_passes_the_carrier_room_first_and_the_target_room_third() {
+        let contact = prod(include_str!("invite_contact_picker_modal.rs"));
+        assert!(
+            contact.contains(
+                "compose_and_send_invite_dm(carrier_room, peer, target_data, pmessage_opt)"
+            ),
+            "the contact picker must sign the invitation against the room \
+             being VIEWED (`target_data`) and send the DM inside the room it \
+             shares with the recipient (`carrier_room`). Passing \
+             `target_room` as the carrier sends the DM into a room the \
+             recipient is not in yet, which fails with a message naming the \
+             wrong room"
+        );
+
+        let by_room = prod(include_str!("invite_via_dm_picker_modal.rs"));
+        assert!(
+            by_room.contains(
+                "compose_and_send_invite_dm( current_room, target_peer, candidate_data, \
+                 pmessage_opt, )"
+            ) || by_room.contains(
+                "compose_and_send_invite_dm(current_room, target_peer, candidate_data, \
+                 pmessage_opt)"
+            ),
+            "the member-card picker must sign against the room the user \
+             PICKED (`candidate_data`) and send the DM inside the room being \
+             viewed (`current_room`) — the mirror image of the contact \
+             picker, and the reason both go through one helper"
+        );
+    }
+}

--- a/ui/src/components/direct_messages/invite_via_dm_picker_modal.rs
+++ b/ui/src/components/direct_messages/invite_via_dm_picker_modal.rs
@@ -35,18 +35,16 @@
 //! short-circuit immediately when a newer pick has taken over.
 
 use crate::components::app::{MEMBER_INFO_MODAL, ROOMS};
+use crate::components::direct_messages::invite_dm::compose_and_send_invite_dm;
 use crate::components::direct_messages::{
-    send_structured_dm, InvitePickInflight, SendDmOutcome, INVITE_VIA_DM_PICKER,
-    INVITE_VIA_DM_PICKER_INFLIGHT,
+    InvitePickInflight, INVITE_VIA_DM_PICKER, INVITE_VIA_DM_PICKER_INFLIGHT,
 };
-use crate::components::members::{collect_invitation_secrets, Invitation};
 use crate::util::ecies::unseal_bytes_with_secrets;
 use dioxus::logger::tracing::{error, info, warn};
 use dioxus::prelude::*;
 use dioxus_free_icons::{icons::fa_solid_icons::FaLock, Icon};
-use ed25519_dalek::{SigningKey, VerifyingKey};
-use river_core::room_state::dm_body::{DirectMessageBody, InvitePayload};
-use river_core::room_state::member::{AuthorizedMember, Member, MemberId};
+use ed25519_dalek::VerifyingKey;
+use river_core::room_state::member::MemberId;
 use river_core::room_state::privacy::PrivacyMode;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -310,19 +308,6 @@ pub fn InviteViaDmPickerModal() -> Element {
             .map(|c| c.label.clone())
             .unwrap_or_else(|| "Unknown room".to_string());
 
-        let invitee_signing_key = SigningKey::generate(&mut rand::thread_rng());
-        let invitee_vk = invitee_signing_key.verifying_key();
-        let invited_by: MemberId = candidate_data.self_sk.verifying_key().into();
-        let owner_id: MemberId = candidate_data.owner_vk.into();
-
-        let member = Member {
-            owner_member_id: owner_id,
-            invited_by,
-            member_vk: invitee_vk,
-        };
-        let room_key = candidate_data.room_key();
-        let inviter_sk = candidate_data.self_sk.clone();
-
         let my_generation = PICK_GENERATION.fetch_add(1, Ordering::Relaxed) + 1;
 
         crate::util::defer(move || {
@@ -334,17 +319,11 @@ pub fn InviteViaDmPickerModal() -> Element {
 
         let candidate_label_for_task = candidate_label.clone();
         crate::util::safe_spawn_local(async move {
-            let outcome = drive_send(
-                current_room,
-                target_peer,
-                candidate_data,
-                member,
-                room_key,
-                inviter_sk,
-                invitee_signing_key,
-                pmessage_opt,
-            )
-            .await;
+            // The room the user PICKED is the invitation's target; the room
+            // currently being viewed is only the DM carrier.
+            let outcome =
+                compose_and_send_invite_dm(current_room, target_peer, candidate_data, pmessage_opt)
+                    .await;
 
             crate::util::defer(move || {
                 // This pick may have been superseded while `drive_send`
@@ -614,85 +593,6 @@ fn clear_inflight_if_matches(my_generation: u64) {
     );
     if still_mine {
         *INVITE_VIA_DM_PICKER_INFLIGHT.write() = None;
-    }
-}
-
-/// Sign the invitation, encode it, and dispatch a structured
-/// `DirectMessageBody::Invite` DM. Returns a user-facing error string
-/// on failure or `Ok(())` on success.
-#[allow(clippy::too_many_arguments)]
-async fn drive_send(
-    current_room: VerifyingKey,
-    target_peer: MemberId,
-    candidate_data: crate::room_data::RoomData,
-    member: Member,
-    room_key: river_core::chat_delegate::RoomKey,
-    inviter_sk: SigningKey,
-    invitee_signing_key: SigningKey,
-    personal_message: Option<String>,
-) -> Result<(), String> {
-    // Sign the member-claim via the delegate-backed signing path. Same
-    // semantics as the legacy URL-paste flow.
-    let mut member_bytes = Vec::new();
-    if ciborium::ser::into_writer(&member, &mut member_bytes).is_err() {
-        return Err("Couldn't serialize membership claim. Try again.".into());
-    }
-    let signature =
-        crate::signing::sign_member_with_fallback(room_key, member_bytes, &inviter_sk).await;
-    let authorized = AuthorizedMember::with_signature(member, signature);
-    // For a private room, embed the room secrets the inviter holds so the
-    // invitee can decrypt the room immediately on join. Empty for a public
-    // room or an empty secrets map.
-    let room_secrets = if candidate_data.is_private() {
-        collect_invitation_secrets(&candidate_data.secrets)
-    } else {
-        Vec::new()
-    };
-    let invitation = Invitation {
-        room: candidate_data.owner_vk,
-        invitee_signing_key,
-        invitee: authorized,
-        room_secrets,
-    };
-
-    // Encode the Invitation as CBOR — same bytes the URL form base58-
-    // encodes. The recipient decodes these bytes back to `Invitation`.
-    let mut invitation_payload = Vec::new();
-    ciborium::ser::into_writer(&invitation, &mut invitation_payload)
-        .map_err(|e| format!("Couldn't encode invitation: {}", e))?;
-
-    let body = DirectMessageBody::Invite(Box::new(InvitePayload {
-        room_owner_vk: candidate_data.owner_vk,
-        invitation_payload,
-        personal_message,
-    }));
-
-    match send_structured_dm(current_room, target_peer, body).await {
-        SendDmOutcome::Sent => Ok(()),
-        SendDmOutcome::RoomGone => Err("The room you're DM'ing in is no longer loaded.".into()),
-        SendDmOutcome::RecipientNotMember => {
-            Err("The recipient is no longer a member of this room.".into())
-        }
-        SendDmOutcome::SelfDm => Err("Cannot send a DM to yourself.".into()),
-        SendDmOutcome::SenderMissingRejoin => Err(
-            "You're not currently in this room's member list and no rejoin \
-             credentials are stored locally. Reload the room or re-accept your \
-             invitation before sending an invite DM."
-                .into(),
-        ),
-        SendDmOutcome::BodyTooLargeOrEncodeFailed(e) => Err(format!(
-            "Couldn't send invite — body too large or encode failed: {}",
-            e
-        )),
-        SendDmOutcome::DeltaFailed(e) => Err(format!(
-            "Couldn't send invite — local apply_delta failed: {}",
-            e
-        )),
-        SendDmOutcome::SilentDrop => Err(
-            "Invite couldn't be added to the room (your member entry may be \
-             missing). Try posting a message in the room first, then retry."
-                .into(),
-        ),
     }
 }
 

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -2,13 +2,18 @@ use crate::components::app::freenet_api::freenet_synchronizer::SynchronizerStatu
 use crate::components::app::{
     MobileView, CURRENT_ROOM, MEMBER_INFO_MODAL, MOBILE_VIEW, ROOMS, SYNC_STATUS,
 };
+use crate::components::direct_messages::{
+    has_invitable_contacts, open_invite_contact_picker_for_current_room,
+};
 use crate::util::confusable::{
     ConfusableTier, ImpersonationChecker, ImpersonationWarning, ProtectedName, ProtectedRole,
 };
 use crate::util::display_name::display_nickname;
 use crate::util::ecies::unseal_bytes_with_secrets;
 use dioxus::prelude::*;
-use dioxus_free_icons::icons::fa_solid_icons::{FaArrowLeft, FaFileExport, FaUserPlus, FaUsers};
+use dioxus_free_icons::icons::fa_solid_icons::{
+    FaArrowLeft, FaFileExport, FaLink, FaUserPlus, FaUsers,
+};
 use dioxus_free_icons::Icon;
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use river_core::room_state::identity::IdentityExport;
@@ -1587,26 +1592,97 @@ pub fn MemberList() -> Element {
                 }
             }
 
-            // Action buttons - fixed at bottom
+            // Action buttons - fixed at bottom.
+            //
+            // "Share Invite" is the PRIMARY action and the link flow is
+            // deliberately secondary (Ian, 2026-07-29). An invite link is a
+            // bearer credential good for exactly ONE person, and in the
+            // field people share one link with several people: everyone who
+            // used it then holds the same identity and none of them work.
+            // The DM route cannot fail that way — the recipient gets an
+            // Accept button inside a DM thread and no credential travels
+            // through an outside channel — but it used to be three clicks
+            // deep behind a member's card in a DIFFERENT room, so nobody
+            // found it. Promoting it here is the fix. The link stays
+            // reachable because it is still the only way to invite somebody
+            // who is not on River yet. Do NOT restore the link flow to
+            // primary without a better answer to the shared-link failure.
             div { class: "p-3 border-t border-border flex-shrink-0 space-y-2",
-                button {
-                    "data-testid": "invite-member-button",
-                    class: "w-full flex items-center justify-center gap-2 px-3 py-2 bg-accent hover:bg-accent-hover text-white text-sm font-medium rounded-lg transition-colors",
-                    onclick: move |_| invite_modal_active.set(true),
-                    Icon { icon: FaUserPlus, width: 14, height: 14 }
-                    span { "Invite Member" }
+                {
+                    // `None` from `has_invitable_contacts` means ROOMS was
+                    // contended for this render. Treat "don't know" as
+                    // enabled: a contended read must never hide a working
+                    // action, and the picker's own empty state covers the
+                    // case where there really is nobody to invite.
+                    let has_contacts = CURRENT_ROOM
+                        .read()
+                        .owner_key
+                        .and_then(has_invitable_contacts)
+                        .unwrap_or(true);
+                    rsx! {
+                        button {
+                            "data-testid": "share-invite-button",
+                            class: format!(
+                                "w-full flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium rounded-lg transition-colors {}",
+                                if has_contacts {
+                                    "bg-accent hover:bg-accent-hover text-white"
+                                } else {
+                                    "bg-surface text-text-muted opacity-60 cursor-not-allowed border border-border"
+                                }
+                            ),
+                            disabled: !has_contacts,
+                            title: if has_contacts {
+                                "Send an invitation card in a DM to someone you already share a room with — they accept in one click"
+                            } else {
+                                "You aren't a member of any other rooms yet, so there's nobody to DM — use Invite by link"
+                            },
+                            // Accessible name deliberately leads with the
+                            // visible label ("Label in Name") but must NOT
+                            // contain the phrase "share an invite": that is
+                            // how `invite-via-dm-picker.spec.ts` addresses
+                            // the member-card button, and this panel button
+                            // renders earlier in the DOM, so an overlapping
+                            // name silently retargets that whole spec file
+                            // at this button instead.
+                            "aria-label": if has_contacts {
+                                "Share Invite — invite someone to this room by direct message"
+                            } else {
+                                "Share Invite is disabled — you are not a member of any other rooms"
+                            },
+                            onclick: move |_| {
+                                if has_contacts {
+                                    open_invite_contact_picker_for_current_room();
+                                }
+                            },
+                            Icon { icon: FaUserPlus, width: 14, height: 14 }
+                            span { "Share Invite" }
+                        }
+                    }
                 }
                 // The "Direct Messages" button used to live here, but
                 // zorolin (#244 feedback, 2026-05-16) and Ian agreed it
                 // belonged in the left rail next to Rooms — that's where
                 // it now lives via `DmRailSection`. Per-room and
                 // cross-room DM discovery are both surfaced there.
-                button {
-                    "data-testid": "export-id-button",
-                    class: "w-full flex items-center justify-center gap-1.5 px-2 py-1.5 bg-surface hover:bg-surface-hover text-text-muted text-xs font-medium rounded-lg transition-colors border border-border",
-                    onclick: move |_| export_modal_active.set(true),
-                    Icon { icon: FaFileExport, width: 12, height: 12 }
-                    span { "Export ID" }
+                div { class: "flex gap-2",
+                    button {
+                        // Testid kept from when this was the primary
+                        // "Invite Member" button so existing specs keep
+                        // pointing at the link flow they were written for.
+                        "data-testid": "invite-member-button",
+                        class: "flex-1 flex items-center justify-center gap-1.5 px-2 py-1.5 bg-surface hover:bg-surface-hover text-text-muted text-xs font-medium rounded-lg transition-colors border border-border",
+                        title: "Generate a one-person invite link — for someone not on River yet",
+                        onclick: move |_| invite_modal_active.set(true),
+                        Icon { icon: FaLink, width: 12, height: 12 }
+                        span { "Invite by link" }
+                    }
+                    button {
+                        "data-testid": "export-id-button",
+                        class: "flex-1 flex items-center justify-center gap-1.5 px-2 py-1.5 bg-surface hover:bg-surface-hover text-text-muted text-xs font-medium rounded-lg transition-colors border border-border",
+                        onclick: move |_| export_modal_active.set(true),
+                        Icon { icon: FaFileExport, width: 12, height: 12 }
+                        span { "Export ID" }
+                    }
                 }
             }
 
@@ -4912,6 +4988,82 @@ mod tests {
             );
             search = &after[1..];
         }
+    }
+
+    /// Source-scrape pin: the members panel's PRIMARY invite action is the
+    /// DM route ("Share Invite"), and the link route is secondary.
+    ///
+    /// Why pin it. An invite link carries a private key and is good for
+    /// exactly ONE person; in the field people share one link with several
+    /// people, and everyone who used it then holds the same identity, so
+    /// none of them work. For a long time the link was the only
+    /// *discoverable* way to invite anyone — the DM route existed but sat
+    /// three clicks deep behind a member's card in a DIFFERENT room. A
+    /// refactor that gives the link button the accent fill back, or drops
+    /// the Share Invite button, silently restores that state; nothing else
+    /// in the suite would notice.
+    ///
+    /// Source-scrape because the property is visual weight (which button
+    /// carries `bg-accent`, this codebase's primary-button marker) plus
+    /// wiring (which flow each button opens), in a Dioxus tree with no
+    /// headless harness. `invite-priority.spec.ts` checks the rendered
+    /// result in a browser; this catches it at `cargo test` time.
+    #[test]
+    fn share_invite_is_the_primary_invite_action_and_the_link_flow_is_secondary() {
+        let prod = production_source();
+        assert_prod_only(prod, "members.rs action buttons");
+        let start = prod
+            .find("// Action buttons")
+            .expect("MemberList should have an action-button block");
+        let end = prod[start..]
+            .find("// Connection status indicator")
+            .expect("action-button block should end before the connection-status note")
+            + start;
+        let block = &prod[start..end];
+
+        let share_at = block.find("\"share-invite-button\"").expect(
+            "the members panel must offer a Share Invite button — the DM route \
+             is the only invite path that cannot be broken by being shared \
+             with more than one person",
+        );
+        let link_at = block.find("\"invite-member-button\"").expect(
+            "the invite-link flow must stay reachable: it is still the only \
+             way to invite somebody who is not on River yet",
+        );
+        assert!(
+            share_at < link_at,
+            "Share Invite must come FIRST in the action block. Order is the \
+             cheap half of the demotion — a user reads the top button as the \
+             thing to do"
+        );
+
+        // Each button must open the flow it claims to. Swapping these
+        // compiles, renders, and passes every other test in this file.
+        let share_block = &block[share_at..link_at];
+        assert!(
+            share_block.contains("open_invite_contact_picker_for_current_room("),
+            "the Share Invite button no longer opens the contact picker, so \
+             the promoted action does not do the promoted thing"
+        );
+        let link_block = &block[link_at..];
+        assert!(
+            link_block.contains("invite_modal_active.set(true)"),
+            "the Invite-by-link button no longer opens the link modal"
+        );
+
+        // Visual weight. This is the assertion that actually pins the
+        // deprioritisation, and the one a well-meaning restyle undoes.
+        assert!(
+            share_block.contains("bg-accent hover:bg-accent-hover"),
+            "the Share Invite button lost its accent fill, so it no longer \
+             reads as the primary action"
+        );
+        assert!(
+            !link_block.contains("bg-accent"),
+            "the invite-link button is accent-filled again — that makes \
+             minting a one-person bearer credential look like the default \
+             way to invite people, which is the failure this pin exists for"
+        );
     }
 
     /// **SHOULD-FIX E — the warning must not be clippable.**

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -7268,5 +7268,67 @@ mod tests {
             "the member-info modal no longer renders the warning's explanation \
              element"
         );
+
+        // --- Share-Invite contact picker ---------------------------------
+        //
+        // The FOURTH surface (freenet/river#566), and it is here because
+        // promoting it created a route that BYPASSES the other three. Until
+        // #566 the only way to reach the DM-invite flow was through the member
+        // list, so a user had already been shown the ⚠ before picking anyone.
+        // The picker lists members of rooms the user may not have opened, so
+        // without this the primary invite action is the one surface where an
+        // imitator's name renders clean.
+        let picker_src =
+            include_str!("../components/direct_messages/invite_contact_picker_modal.rs");
+        let picker = &picker_src[..picker_src
+            .find("#[cfg(test)]")
+            .expect("the contact picker should have a `#[cfg(test)]` block")];
+        assert!(
+            picker.contains("impersonation_warning_for_display("),
+            "the Share-Invite contact picker no longer computes an \
+             impersonation warning. It is the PRIMARY invite action, and it \
+             lists members of rooms the user need never have opened, so \
+             dropping the badge here means picking an imitator looks \
+             identical to picking the real member"
+        );
+        // Same argument trap as the other three: `self_id` compiles here and
+        // flags the genuine owner and every genuine moderator instead.
+        assert!(
+            squashed(picker).contains(
+                "impersonation_warning_for_display( &impersonation, peer, &peer_label, \
+                 privilege_in_view(peer, owner_id, &deputy_badges), )"
+            ),
+            "the contact picker no longer passes `peer` (and that peer's own \
+             privilege) to `impersonation_warning_for_display`"
+        );
+        // Built once per ROOM, before the per-peer loop. This picker sweeps
+        // every other room the user is in, so building per peer multiplies
+        // the refold by the whole candidate set rather than one room's.
+        assert!(
+            between(
+                picker,
+                "fn build_contact_candidates(",
+                "for peer in peers",
+                "contact-candidate per-peer loop",
+            )
+            .contains("impersonation_checker_for_viewer("),
+            "the contact picker must build the impersonation checker BEFORE \
+             its per-peer loop, not inside it"
+        );
+        assert!(
+            picker.contains("\"data-testid\": \"invite-contact-impersonation-warning\""),
+            "the contact-picker row's warning lost its `data-testid`, leaving \
+             a spec only glyph-matching to reach it"
+        );
+        assert!(
+            between(
+                picker,
+                "\"data-testid\": \"invite-contact-impersonation-warning\"",
+                "if is_selected",
+                "contact-row warning element",
+            )
+            .contains("WARNING_GLYPH"),
+            "the contact-picker warning element no longer renders the glyph"
+        );
     }
 }

--- a/ui/src/components/members/invite_member_modal.rs
+++ b/ui/src/components/members/invite_member_modal.rs
@@ -196,19 +196,19 @@ pub fn InviteMemberModal(is_active: Signal<bool>) -> Element {
                             rsx! {
                                 // Recommended path first: ask, then send the
                                 // invitation as a DM via the built-in
-                                // "Share invite" flow (#252, #457). It hands
-                                // the recipient a one-click Accept card and
-                                // never puts a bearer credential through an
-                                // outside channel, so it belongs ABOVE the
+                                // "Share Invite" flow (#252, #457, #566). It
+                                // hands the recipient a one-click Accept card
+                                // and never puts a bearer credential through
+                                // an outside channel, so it belongs ABOVE the
                                 // link/code it is meant to displace.
                                 div {
                                     "data-testid": "invite-dm-recommendation",
                                     class: "mb-4 p-3 bg-accent-soft border-l-4 border-accent rounded-r-lg",
                                     p { class: "text-sm text-text",
-                                        span { class: "font-medium", "Best way to invite someone: send the invitation in a DM. " }
-                                        "Ask whether they'd like to join first. Then, in any room you already share with them, click their name in the member list, choose "
-                                        span { class: "font-medium", "Share invite" }
-                                        ", and pick this room. River drops an invitation card into your DM thread that they accept in one click — nothing to copy, paste, or leak."
+                                        span { class: "font-medium", "Already on River? Send the invitation in a DM instead. " }
+                                        "Close this and click "
+                                        span { class: "font-medium", "Share Invite" }
+                                        " under the member list: pick anyone you already share a room with and River drops an invitation card into a DM that they accept in one click — nothing to copy, paste, or leak."
                                     }
                                 }
 
@@ -220,8 +220,8 @@ pub fn InviteMemberModal(is_active: Signal<bool>) -> Element {
                                     "data-testid": "invite-share-warning",
                                     class: "mb-4 p-3 bg-warning-bg border-l-4 border-yellow-500 rounded-r-lg",
                                     p { class: "text-sm text-text",
-                                        span { class: "font-medium", "No DM yet? Share the link or code below privately, with one person only. " }
-                                        "Each invitation creates a unique identity and is good for exactly one person. If two people use the same link or code, they share one identity and neither works correctly. Click "
+                                        span { class: "font-medium", "Not on River yet? Share the link or code below privately, with one person only. " }
+                                        "Each invitation contains a private key and is good for exactly one person. If two people use the same link or code, they share one identity and neither works correctly — this is the most common way invites go wrong. Click "
                                         span { class: "font-medium", "New Invitation" }
                                         " for every additional person."
                                     }

--- a/ui/tests/invite-modal-guidance.spec.ts
+++ b/ui/tests/invite-modal-guidance.spec.ts
@@ -1,12 +1,13 @@
 import { test, expect, Page } from "@playwright/test";
 
-// Copy test for the invite-member modal's guidance blocks.
+// Copy test for the invite-by-link modal's guidance blocks.
 //
 // The modal used to warn ONLY about the link being single-use, never
 // mentioning that River can send an invitation directly in a DM (#252,
-// #457) — which is the recommended flow: ask the person first, then use
-// "Share invite" from their member card in a room you already share, so
-// no bearer credential travels through an outside channel.
+// #457) — which is the recommended flow, because no bearer credential
+// travels through an outside channel. Since #566 that flow has a primary
+// button of its own ("Share Invite", under the member list), and this
+// modal's job is to point at it and to be blunt about what the link is.
 //
 // These assertions pin BOTH blocks and their order, so a future refactor
 // of this modal can't silently drop the recommendation and leave
@@ -17,7 +18,7 @@ async function waitForApp(page: Page) {
   await expect(page.locator("aside, .app-root button")).not.toHaveCount(0);
 }
 
-// A room where the test user is a member, so "Invite Member" can generate
+// A room where the test user is a member, so "Invite by link" can generate
 // an invitation (matches the portable-invite-code spec).
 const ROOM_NAME = "Public Discussion Room";
 
@@ -47,7 +48,7 @@ async function openInviteModal(page: Page) {
 test.describe("Invite-member modal guidance copy", () => {
   test.use({ viewport: { width: 1280, height: 800 } });
 
-  test("recommends sending the invitation via DM, naming Share invite", async ({
+  test("recommends sending the invitation via DM, naming Share Invite", async ({
     page,
   }) => {
     await page.goto("/");
@@ -57,7 +58,9 @@ test.describe("Invite-member modal guidance copy", () => {
     const rec = page.getByTestId("invite-dm-recommendation");
     await expect(rec).toBeVisible();
     await expect(rec).toContainText(/in a DM/i);
-    await expect(rec).toContainText(/Share invite/);
+    // Must name the button by the label it actually carries — a pointer to
+    // a control the reader can't find is worse than no pointer.
+    await expect(rec).toContainText(/Share Invite/);
   });
 
   test("still warns that the link or code is for one person only", async ({

--- a/ui/tests/invite-priority.spec.ts
+++ b/ui/tests/invite-priority.spec.ts
@@ -1,0 +1,218 @@
+import { test, expect, Page } from "@playwright/test";
+
+// #566 — the members panel's invite priority.
+//
+// Background: "Invite Member" minted an invite link and was the panel's
+// only accent-filled action, so it was what everyone clicked. That link
+// contains a private key and is good for exactly ONE person; in the field
+// people share one link with several people, and everyone who used it then
+// holds the same identity, so none of them work. The DM route has no such
+// failure mode — the recipient gets an Accept button inside a DM thread and
+// nothing is copied anywhere — but it lived behind a member's card in a
+// DIFFERENT room, three clicks deep, so nobody found it.
+//
+// This file pins the resulting arrangement: "Share Invite" is the primary
+// action and opens a contact picker for the CURRENT room; the link flow is
+// still reachable, but secondary. `members.rs`'s
+// `share_invite_is_the_primary_invite_action_and_the_link_flow_is_secondary`
+// pins the same thing at the source level; this one checks the rendered
+// result a user actually meets.
+//
+// Not covered here: the send itself. Under `no-sync` the chat delegate is
+// not running, so the outbound-DM save fails — the same limitation
+// `invite-via-dm-picker.spec.ts` documents. Everything up to and including
+// "Send is armed" is covered.
+
+const ROOM_NAME = "Public Discussion Room";
+
+async function waitForApp(page: Page) {
+  await page.waitForSelector(".app-root", { timeout: 30_000 });
+  await expect(page.locator("aside, .app-root button")).not.toHaveCount(0);
+}
+
+async function openRoom(page: Page, name: string = ROOM_NAME) {
+  const vp = page.viewportSize();
+  if (vp && vp.width < 1024) {
+    await page.setViewportSize({ width: 1280, height: vp.height });
+  }
+  const roomBtn = page.getByRole("button", { name });
+  await expect(roomBtn).toBeVisible({ timeout: 5_000 });
+  await roomBtn.click();
+  await expect(page.getByRole("heading", { name })).toBeVisible({
+    timeout: 5_000,
+  });
+}
+
+// Read the "via <room>" sub-labels off the picker's contact rows. Each row
+// is a button whose aria-label is
+// "Send the invitation to <person>, in a DM inside <room>".
+async function readContactRows(
+  page: Page,
+): Promise<{ person: string; room: string }[]> {
+  const rows = page.locator('button[aria-label^="Send the invitation to"]');
+  const count = await rows.count();
+  const out: { person: string; room: string }[] = [];
+  for (let i = 0; i < count; i++) {
+    const aria = (await rows.nth(i).getAttribute("aria-label")) || "";
+    const m = aria.match(/^Send the invitation to (.+), in a DM inside (.+)$/);
+    if (m) out.push({ person: m[1], room: m[2] });
+  }
+  return out;
+}
+
+test.describe("Invite priority: DM route primary, link route secondary", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("Share Invite sits above Invite by link in the members panel", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await openRoom(page);
+
+    const share = page.getByTestId("share-invite-button");
+    const link = page.getByTestId("invite-member-button");
+    await expect(share).toBeVisible();
+    await expect(link).toBeVisible();
+
+    const shareBox = await share.boundingBox();
+    const linkBox = await link.boundingBox();
+    expect(shareBox).not.toBeNull();
+    expect(linkBox).not.toBeNull();
+    // Primary above secondary. A user reads the top control as the thing
+    // to do, which is the whole point of the reordering.
+    expect(shareBox!.y).toBeLessThan(linkBox!.y);
+
+    // ...and it must LOOK primary. The link button used to carry the
+    // accent fill; if it ever does again, minting a one-person bearer
+    // credential reads as the default way to invite people.
+    const shareBg = await share.evaluate(
+      (el) => getComputedStyle(el).backgroundColor,
+    );
+    const linkBg = await link.evaluate(
+      (el) => getComputedStyle(el).backgroundColor,
+    );
+    expect(shareBg).not.toEqual(linkBg);
+  });
+
+  test("Share Invite opens a contact picker for the current room", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await openRoom(page);
+
+    await page.getByTestId("share-invite-button").click();
+    const modal = page.getByTestId("invite-contact-picker-modal");
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+    // The header names the room the invitation is FOR — the direction that
+    // distinguishes this picker from the member-card one, which invites a
+    // known person to some OTHER room.
+    await expect(modal).toContainText(`Invite someone to ${ROOM_NAME}`);
+
+    // Candidates come from the user's OTHER rooms: you cannot invite
+    // somebody to a room they are already in.
+    const rows = await readContactRows(page);
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(row.room).not.toEqual(ROOM_NAME);
+    }
+    expect(rows.some((r) => r.room === "Team Chat Room")).toBeTruthy();
+  });
+
+  test("Send is armed only once a contact is picked", async ({ page }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await openRoom(page);
+
+    await page.getByTestId("share-invite-button").click();
+    await expect(
+      page.getByTestId("invite-contact-picker-modal"),
+    ).toBeVisible({ timeout: 5_000 });
+
+    const send = page.getByTestId("invite-contact-picker-send-button");
+    await expect(send).toBeDisabled();
+
+    const firstRow = page
+      .locator('button[aria-label^="Send the invitation to"]')
+      .first();
+    await expect(firstRow).toHaveAttribute("aria-pressed", "false");
+    await firstRow.click();
+    await expect(firstRow).toHaveAttribute("aria-pressed", "true");
+    await expect(send).toBeEnabled();
+  });
+
+  test("the contact picker filters by person and by room", async ({ page }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await openRoom(page);
+
+    await page.getByTestId("share-invite-button").click();
+    await expect(
+      page.getByTestId("invite-contact-picker-modal"),
+    ).toBeVisible({ timeout: 5_000 });
+
+    const all = await readContactRows(page);
+    expect(all.length).toBeGreaterThan(0);
+
+    // Filtering by ROOM is deliberate: "someone from the team room" is how
+    // people remember a contact whose name they don't recall.
+    const search = page.getByTestId("invite-contact-picker-search");
+    await search.fill("Team Chat");
+    await expect
+      .poll(async () => (await readContactRows(page)).length)
+      .toBeGreaterThan(0);
+    for (const row of await readContactRows(page)) {
+      expect(row.room).toEqual("Team Chat Room");
+    }
+
+    // Filtering by PERSON narrows to that person.
+    const target = all[0].person;
+    await search.fill(target);
+    await expect
+      .poll(async () => (await readContactRows(page)).length)
+      .toBeGreaterThan(0);
+    for (const row of await readContactRows(page)) {
+      expect(row.person.toLowerCase()).toContain(target.toLowerCase());
+    }
+
+    // A query that matches nobody says so, rather than rendering an
+    // unexplained empty list.
+    await search.fill("zzzzz-nobody-zzzzz");
+    await expect(
+      page.getByTestId("invite-contact-picker-no-matches"),
+    ).toBeVisible();
+    expect(await readContactRows(page)).toHaveLength(0);
+  });
+
+  test("closing the picker leaves no picker behind", async ({ page }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await openRoom(page);
+
+    await page.getByTestId("share-invite-button").click();
+    await expect(
+      page.getByTestId("invite-contact-picker-modal"),
+    ).toBeVisible({ timeout: 5_000 });
+    await page.getByTestId("invite-contact-picker-close-button").click();
+    await expect(
+      page.getByTestId("invite-contact-picker-modal"),
+    ).toHaveCount(0);
+  });
+
+  test("Invite by link still opens the link modal", async ({ page }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await openRoom(page);
+
+    // Demoted, not removed: a link is still the only way to invite
+    // somebody who is not on River yet.
+    await page.getByTestId("invite-member-button").click();
+    await expect(page.getByTestId("invite-member-modal")).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByTestId("invite-link-input")).not.toHaveValue("", {
+      timeout: 10_000,
+    });
+  });
+});

--- a/ui/tests/invite-priority.spec.ts
+++ b/ui/tests/invite-priority.spec.ts
@@ -43,19 +43,20 @@ async function openRoom(page: Page, name: string = ROOM_NAME) {
   });
 }
 
-// Read the "via <room>" sub-labels off the picker's contact rows. Each row
-// is a button whose aria-label is
-// "Send the invitation to <person>, in a DM inside <room>".
+// Read the picker's contact rows. The row carries `data-person` /
+// `data-room` precisely so this does not have to parse the accessible name:
+// that string also carries the impersonation warning when there is one, and
+// prose is expected to change.
 async function readContactRows(
   page: Page,
 ): Promise<{ person: string; room: string }[]> {
-  const rows = page.locator('button[aria-label^="Send the invitation to"]');
+  const rows = page.getByTestId("invite-contact-row");
   const count = await rows.count();
   const out: { person: string; room: string }[] = [];
   for (let i = 0; i < count; i++) {
-    const aria = (await rows.nth(i).getAttribute("aria-label")) || "";
-    const m = aria.match(/^Send the invitation to (.+), in a DM inside (.+)$/);
-    if (m) out.push({ person: m[1], room: m[2] });
+    const person = (await rows.nth(i).getAttribute("data-person")) || "";
+    const room = (await rows.nth(i).getAttribute("data-room")) || "";
+    out.push({ person, room });
   }
   return out;
 }
@@ -133,9 +134,7 @@ test.describe("Invite priority: DM route primary, link route secondary", () => {
     const send = page.getByTestId("invite-contact-picker-send-button");
     await expect(send).toBeDisabled();
 
-    const firstRow = page
-      .locator('button[aria-label^="Send the invitation to"]')
-      .first();
+    const firstRow = page.getByTestId("invite-contact-row").first();
     await expect(firstRow).toHaveAttribute("aria-pressed", "false");
     await firstRow.click();
     await expect(firstRow).toHaveAttribute("aria-pressed", "true");
@@ -183,6 +182,45 @@ test.describe("Invite priority: DM route primary, link route secondary", () => {
       page.getByTestId("invite-contact-picker-no-matches"),
     ).toBeVisible();
     expect(await readContactRows(page)).toHaveLength(0);
+  });
+
+  // The picker is now the primary invite action, and it lists members of
+  // rooms the user may never have opened — so it is the one surface where a
+  // name-imitation could otherwise render clean. The example fixture seeds
+  // two confusable names (#494), which is what makes this reachable.
+  test("a confusable name carries the impersonation warning in the picker", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForApp(page);
+    await openRoom(page);
+
+    await page.getByTestId("share-invite-button").click();
+    await expect(page.getByTestId("invite-contact-picker-modal")).toBeVisible({
+      timeout: 5_000,
+    });
+
+    const warned = page.getByTestId("invite-contact-impersonation-warning");
+    expect(await warned.count()).toBeGreaterThan(0);
+    // The badge must explain itself. `title=` does not fire on touch, but it
+    // is the same affordance the member list uses, and the row's accessible
+    // name repeats the warning for screen readers (asserted below).
+    const tip = await warned.first().getAttribute("title");
+    expect(tip).toBeTruthy();
+
+    // An explicit aria-label on the button REPLACES its content for naming,
+    // so a badge rendered inside is invisible to a screen reader unless the
+    // label says it too.
+    const warnedRow = page
+      .getByTestId("invite-contact-row")
+      .filter({ has: page.getByTestId("invite-contact-impersonation-warning") })
+      .first();
+    await expect(warnedRow).toHaveAttribute(
+      "aria-label",
+      /visually identical/i,
+    );
+    // The remedy the tooltip names — the member ID — must be reachable.
+    await expect(warnedRow).toHaveAttribute("title", /^Member ID: /);
   });
 
   test("closing the picker leaves no picker behind", async ({ page }) => {

--- a/ui/tests/responsive-layout.spec.ts
+++ b/ui/tests/responsive-layout.spec.ts
@@ -294,6 +294,16 @@ test.describe("Sandboxed iframe embedding", () => {
   const sandboxAttrs =
     "allow-scripts allow-forms allow-popups allow-same-origin";
 
+  // These two tests build their own page with `setContent`, so the iframe
+  // src cannot come from the config's `baseURL` implicitly — it has to be
+  // read here. It used to be the literal "http://localhost:8082", which
+  // silently ignored PLAYWRIGHT_BASE_URL: running the suite on any other
+  // port (what AGENTS.md tells you to do, since 8082 is shared between
+  // worktrees) pointed the iframe at whatever build happened to be on
+  // 8082, or at nothing, and these two failed for a reason that had
+  // nothing to do with the change under test.
+  const BASE = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8082";
+
   test("app renders inside a sandboxed iframe", async ({ page }) => {
     await page.setContent(`
       <!DOCTYPE html>
@@ -301,7 +311,7 @@ test.describe("Sandboxed iframe embedding", () => {
       <body style="margin:0;padding:0;height:100vh;">
         <iframe
           sandbox="${sandboxAttrs}"
-          src="http://localhost:8082"
+          src="${BASE}"
           style="width:100%;height:100%;border:none;"
         ></iframe>
       </body>
@@ -325,7 +335,7 @@ test.describe("Sandboxed iframe embedding", () => {
       <body style="margin:0;padding:0;height:100vh;">
         <iframe
           sandbox="${sandboxAttrs}"
-          src="http://localhost:8082"
+          src="${BASE}"
           style="width:100%;height:100%;border:none;"
         ></iframe>
       </body>


### PR DESCRIPTION
## Problem

The members panel's primary action was **Invite Member**, which mints an invite link. That link embeds `invitee_signing_key` — a private key — and is good for **exactly one person**. In practice people share one link with several people; everyone who used it then holds the same identity, and none of them work.

Ian, 2026-07-29:

> Invite Member button is a bad idea, gives people links, they don't understand that they can't share with multiple people and it's ruined because private key in link. instead we deprioritise this and direct users to use "Share Invite" button, maybe make it more discoverable

River already had a route with none of that failure mode — DM an invitation card the recipient accepts in one click, no credential leaving River (#252, #457). But it was undiscoverable **and pointed the wrong way**: it starts from a *person in the room you are viewing* and asks which of your *other* rooms to invite them to. Somebody standing in room X wanting to invite Alice to room X had to first navigate to another room where Alice is a member, click her name there, and pick room X from a list. So the only *discoverable* invite path was the one that breaks when shared.

## Approach

**1. "Share Invite" becomes the primary action** (accent-filled, first in the panel). It opens a new contact picker running the direction users actually arrive from: the room is fixed (the one being viewed) and you pick *who*, from the members of your other rooms. Search filters by person **or by room** ("someone from the team room" is how people remember a contact); people you have DM history with sort first; the list caps at 40 rows and states how many it withheld.

**2. The link flow is demoted, not removed** — a small secondary "Invite by link" button beside "Export ID". It is still the only way to invite somebody who is not on River yet. Its `data-testid` is unchanged so existing specs keep pointing at the link flow they were written for.

**3. Copy is blunter** about what the link is ("contains a private key", "one person only", "the most common way invites go wrong") and names Share Invite by the label it actually carries.

Why a second picker rather than a mode on the existing one: the two run in opposite directions and each has non-trivial per-open invariants (session-tagged selection, generation-gated watchdog). Two components with one shared send path keeps each set of invariants local. The shared path is `invite_dm.rs::compose_and_send_invite_dm`, so an invitation minted from one entry point cannot drift from the other.

### Impersonation warning (second commit)

Promoting the picker created a route that **bypasses the member list**. Until now every path to the DM-invite flow went through that list, so the user had already been shown the ⚠ before choosing anyone. The picker lists members of rooms the user may never have opened, so without the badge the primary invite action became the one surface where an imitator's name renders clean — and picking the wrong "Finn Clarke" sends a stranger an invitation to your room.

Each row now carries the same warning, from the same helpers, with the checker and badge map built **once per candidate room** rather than per peer. The row's `aria-label` repeats the warning, because an explicit `aria-label` replaces element content for naming — a badge inside a labelled button is invisible to a screen reader otherwise. Member ID is on hover, which is the remedy the tooltip names.

## Testing

**Unit (`cargo test -p river-ui --bins`, 805 pass):** 5 tests for the candidate sort/filter, including that the comparator is *total* — two members of one room can share a nickname, and a non-total comparator lets rows swap between renders.

**Source pins:**
- `share_invite_is_the_primary_invite_action_and_the_link_flow_is_secondary` — order, which handler each button opens, and that the link button never gets `bg-accent` back.
- `impersonation_warning_is_wired_into_every_render_surface` extended to a fourth surface, including the argument pin (`self_id` for `peer` compiles and flags the genuine owner and every real moderator).
- `each_picker_passes_the_carrier_room_first_and_the_target_room_third` — the two pickers hand the same two rooms to `compose_and_send_invite_dm` in opposite positions and a swap compiles. A swap signs the invitation against the room the DM is merely travelling through and sends the DM into the room the recipient is not in yet, so the user is told "the recipient is no longer a member of this room" about a room they can see them in. Nothing else can reach it — the send needs the chat delegate, which is absent under `no-sync` — so the argument names are pinned.

**Browser (`invite-priority.spec.ts`, 7 cases × 5 projects):** button order and that the two really differ in computed background; the picker's header names the target room and no candidate row is from it; Send arms only after a pick; filtering by person and by room, and the no-matches state; the ⚠ badge with its tooltip, aria text and member-ID hover; close; and that the link flow still opens.

**Full suite: 752 passed, 23 skipped, 0 failed** across chromium, firefox, webkit, mobile-chrome, mobile-safari.

**Mutation-tested** (11 mutations, each caught by the test named): dropping the DM-history sort priority, dropping the member-id tiebreak, filtering on person only, reporting 0 withheld, giving the link button the accent fill back, pointing Share Invite at the link modal, removing Share Invite's accent, swapping carrier/target at either call site, computing the warning from `self_id`, and — the case that justifies the browser spec — suppressing the badge while every source pin still matches.

### Incidental fix

`responsive-layout.spec.ts`'s two sandboxed-iframe tests hardcoded `http://localhost:8082`, silently ignoring `PLAYWRIGHT_BASE_URL`. Running the suite on any other port — which `AGENTS.md` tells you to do, since 8082 is shared between worktrees — pointed the iframe at whatever build happened to be on 8082, or at nothing, and failed those two for reasons unrelated to the change under test.

## Not in scope

- **#506** — invite button inside the DM thread modal. A third entry point into the same machinery; still open.
- **#513** — a public, non-secret room address. The underlying reason every room reference in circulation is a one-shot bearer token.

No WASM, contract, or delegate change — UI only, so no migration.

Closes #566

[AI-assisted - Claude]
