### PR TITLE
feat(cli): return the new message ID from `message reply`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4766,7 +4766,7 @@ dependencies = [
 
 [[package]]
 name = "riverctl"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riverctl"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 authors = ["Freenet Project"]
 description = "Command-line interface for River decentralized chat on Freenet"

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -3984,7 +3984,7 @@ impl ApiClient {
         room_owner_key: &VerifyingKey,
         target_message_id: river_core::room_state::message::MessageId,
         reply_text: String,
-    ) -> Result<()> {
+    ) -> Result<river_core::room_state::message::MessageId> {
         info!(
             "Sending reply in room owned by: {}",
             bs58::encode(room_owner_key.as_bytes()).into_string()
@@ -4074,6 +4074,11 @@ impl ApiClient {
         let (members_delta, member_info_delta) =
             self.build_rejoin_delta(&room_state, room_owner_key, &signing_key);
 
+        // Capture the ID before `auth_message` moves into the delta below.
+        // Callers need it to act on their own reply afterwards -- editing it,
+        // deleting it, or tracking whether it is still present.
+        let reply_message_id = auth_message.id();
+
         // Create a delta with the reply message
         let delta = ChatRoomStateV1Delta {
             recent_messages: Some(vec![auth_message]),
@@ -4093,8 +4098,9 @@ impl ApiClient {
         // Update the stored state
         self.storage.update_room_state(room_owner_key, room_state)?;
 
-        // Send the delta to the network
-        self.send_delta(room_owner_key, delta).await
+        // Send the delta to the network, then hand back the new message's ID.
+        self.send_delta(room_owner_key, delta).await?;
+        Ok(reply_message_id)
     }
 
     /// Helper to send a delta to the network.

--- a/cli/src/commands/message.rs
+++ b/cli/src/commands/message.rs
@@ -511,12 +511,22 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
             let room_owner_key = parse_room_id(&room_id)?;
             let target_message_id = parse_message_id(&message_id)?;
 
-            api.send_reply(&room_owner_key, target_message_id, message.clone())
+            let reply_message_id = api
+                .send_reply(&room_owner_key, target_message_id, message.clone())
                 .await?;
 
             match format {
-                OutputFormat::Human => println!("Reply sent successfully"),
-                OutputFormat::Json => println!(r#"{{"status":"success","action":"reply"}}"#),
+                OutputFormat::Human => {
+                    println!("Reply sent successfully (id: {})", reply_message_id.0 .0)
+                }
+                // Emit the ID in the SAME form `message list` prints and
+                // `message delete` accepts (the inner i64), so a caller can act
+                // on its own reply without a second round trip to find it.
+                // Automated moderation needs this to delete a reply it sent.
+                OutputFormat::Json => println!(
+                    r#"{{"status":"success","action":"reply","message_id":"{}"}}"#,
+                    reply_message_id.0 .0
+                ),
             }
             Ok(())
         }
@@ -547,4 +557,51 @@ fn parse_message_id(message_id: &str) -> Result<MessageId> {
         .map_err(|e| anyhow::anyhow!("Invalid message ID (expected integer): {}", e))?;
 
     Ok(MessageId(freenet_scaffold::util::FastHash(hash_value)))
+}
+
+#[cfg(test)]
+mod tests {
+    /// `message reply --format json` must return the new message's ID, and in
+    /// the SAME form `message list` prints and `message delete` accepts.
+    ///
+    /// Without it a caller cannot act on a reply it just sent: the response was
+    /// `{"status":"success","action":"reply"}` and nothing else, so identifying
+    /// your own reply meant scanning the room and guessing. Automated moderation
+    /// needs to delete a reply it posted, which is what motivated this.
+    ///
+    /// Source-scrape rather than a live round trip, because sending a reply
+    /// requires a node and a room. Whitespace is squashed so rustfmt cannot
+    /// silently disarm the pin.
+    #[test]
+    fn reply_json_returns_the_new_message_id() {
+        let source = include_str!("message.rs");
+        // Scan ONLY production code. Without this cut the assertions below match
+        // their OWN string literals in this test, so the pin passes no matter
+        // what the reply arm actually prints -- verified by mutation.
+        let production = source
+            .split_once("mod tests")
+            .map(|(before, _)| before)
+            .expect("test module marker missing; the cut would scan everything");
+        let squashed: String = production.chars().filter(|c| !c.is_whitespace()).collect();
+
+        // Vacuity guard: if the reply arm is ever renamed or moved out of this
+        // file, every assertion below would pass without checking anything.
+        assert!(
+            squashed.contains(r#""status":"success","action":"reply""#),
+            "reply JSON arm not found in this file; the pin would pass vacuously"
+        );
+
+        assert!(
+            squashed.contains(r#""action":"reply","message_id":"{}""#),
+            "reply JSON must carry message_id"
+        );
+
+        // `message list` emits the inner i64 (`msg_id.0 .0`) and `message
+        // delete` parses that same form, so the reply must not print the
+        // Display form of MessageId, which is the debug-formatted FastHash.
+        assert!(
+            squashed.contains("reply_message_id.0.0"),
+            "reply must emit the inner i64, matching what `message delete` accepts"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

`riverctl message reply --format json` printed only

```json
{"status":"success","action":"reply"}
```

so a caller could not identify the reply it had just sent. Acting on your own reply afterwards — editing it, deleting it, checking it is still there — meant fetching the room and guessing which message was yours.

This blocks automated moderation. The River moderator posts a public nudge and, when the member deletes the offending message, should remove its own now-orphaned reply. **Only the author can delete a message** (`common/src/room_state/message.rs`: *"Only the original author can delete their message"*), so the moderator must know its own message ID — there is no other route.

## Approach

`ApiClient::send_reply` already builds `auth_message`, so the ID was available and simply being dropped. It now returns `MessageId`, and the CLI prints it:

```json
{"status":"success","action":"reply","message_id":"-5834489367457911236"}
```

The ID is emitted as the inner `i64` (`reply_message_id.0 .0`) — **the same form `message list` prints and `message delete` parses** — so it can be passed straight back to `message delete` without conversion. `MessageId`'s `Display` impl is the debug-formatted `FastHash` and would *not* round trip, which is why the test pins the exact form.

Purely additive to the JSON. `serde` ignores unknown fields by default, so existing consumers deserializing only `status`/`action` are unaffected (verified against the moderator's `ActionResponse`, which has no `deny_unknown_fields`).

**Scope:** `reply` only, which is what the moderator needs. `send` has the same gap and is deliberately left for a follow-up rather than widening this change.

## Testing

Source-scrape pin, because sending a reply needs a live node and a room.

**The first version of that pin was vacuous, and mutation testing caught it.** `include_str!` pulls in the test's own assertion literals, so the needles matched themselves and the test passed even with `message_id` stripped from the output:

```
mutation applied (message_id removed) -> test PASSED   # vacuous
```

It now cuts the source at `mod tests` and scans only production code. Re-verified:

```
mutation applied (message_id removed) -> test FAILED   # load-bearing
restored                              -> test ok
```

Also pins the inner-i64 form, and carries a vacuity guard that fails loudly if the reply arm is renamed or moved out of the file.

## Release

riverctl bumped **0.2.7 → 0.2.8**. 329 tests pass, fmt clean. The two clippy warnings in `cli/src/api.rs` (lines 7862, 7922) are pre-existing and unrelated to this diff (River CI has clippy disabled with a known backlog).

[AI-assisted - Claude]