### PR TITLE
feat(cli): expose WHO reacted, not just how many

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4766,7 +4766,7 @@ dependencies = [
 
 [[package]]
 name = "riverctl"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riverctl"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 authors = ["Freenet Project"]
 description = "Command-line interface for River decentralized chat on Freenet"

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -4450,11 +4450,19 @@ impl ApiClient {
         Ok(())
     }
 
-    /// Emit a `reaction` event carrying the message's *current* reactions map
-    /// (`emoji -> count`), so a downstream relay can reconcile the new state
-    /// without tracking per-reactor deltas. JSON `type: "reaction"`; the human
-    /// line is `[reaction]`-prefixed. The map is empty when the last reaction was
-    /// removed. freenet/river#325.
+    /// Emit a `reaction` event carrying the message's *current* reactions, so a
+    /// downstream relay can reconcile the new state without tracking per-reactor
+    /// deltas. JSON `type: "reaction"`; the human line is `[reaction]`-prefixed.
+    /// Both maps are empty when the last reaction was removed. freenet/river#325.
+    ///
+    /// Two fields describe the reactions:
+    /// * `reactions` — `emoji -> count`, unchanged for existing consumers.
+    /// * `reactors`  — `emoji -> [member_id]`, who actually reacted.
+    ///
+    /// CAUTION: `author` is the author of the message that was REACTED TO, not
+    /// the person who reacted. A reaction event is emitted against the target
+    /// message, so anything attributing the reaction itself must read
+    /// `reactors`; `author` will name an innocent party.
     fn output_reaction_change(
         room_state: &ChatRoomStateV1,
         msg: &river_core::room_state::message::AuthorizedMessageV1,
@@ -4501,8 +4509,27 @@ impl ApiClient {
                 let reactions_map: std::collections::HashMap<String, usize> = reactions
                     .map(|r| r.iter().map(|(k, v)| (k.clone(), v.len())).collect())
                     .unwrap_or_default();
+                // WHO reacted, not just how many. `reactions` reports counts and
+                // is kept unchanged for existing consumers, but a count cannot
+                // attribute a reaction to anyone, which made reactions
+                // unmoderatable: nothing downstream could tell who to act on.
+                // The room state has always held this (`reactions()` returns
+                // `HashMap<String, Vec<MemberId>>`); only this boundary dropped it.
+                let reactors_map: std::collections::HashMap<String, Vec<String>> = reactions
+                    .map(|r| {
+                        r.iter()
+                            .map(|(emoji, reactors)| {
+                                (
+                                    emoji.clone(),
+                                    reactors.iter().map(|id| id.to_string()).collect(),
+                                )
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
                 let json_msg = json!({
                     "type": "reaction",
+                    "reactors": reactors_map,
                     "message_id": msg_id.0 .0.to_string(),
                     "room": bs58::encode(room_owner_key.as_bytes()).into_string(),
                     "author": author_str,

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -3399,7 +3399,7 @@ impl ApiClient {
         room_owner_key: &VerifyingKey,
         message_content: String,
         signing_key: &SigningKey,
-    ) -> Result<()> {
+    ) -> Result<river_core::room_state::message::MessageId> {
         info!(
             "Sending message (with explicit key) to room owned by: {}",
             bs58::encode(room_owner_key.as_bytes()).into_string()
@@ -3449,6 +3449,8 @@ impl ApiClient {
         // Sign the message
         let auth_message =
             river_core::room_state::message::AuthorizedMessageV1::new(message, signing_key);
+        // Captured before `auth_message` moves into the delta below.
+        let sent_message_id = auth_message.id();
 
         // Check if we need to re-add ourselves (pruned for inactivity)
         let (members_delta, member_info_delta) =
@@ -3514,7 +3516,9 @@ impl ApiClient {
         match response {
             HostResponse::ContractResponse(ContractResponse::UpdateResponse { key, .. }) => {
                 info!("Message sent successfully to contract: {}", key.id());
-                Ok(())
+                // Hand back the new message's ID so callers can act on their own
+                // message later -- editing, deleting, or checking it is still there.
+                Ok(sent_message_id)
             }
             _ => Err(anyhow!("Unexpected response type: {:?}", response)),
         }
@@ -3524,7 +3528,7 @@ impl ApiClient {
         &self,
         room_owner_key: &VerifyingKey,
         message_content: String,
-    ) -> Result<()> {
+    ) -> Result<river_core::room_state::message::MessageId> {
         info!(
             "Sending message to room owned by: {}",
             bs58::encode(room_owner_key.as_bytes()).into_string()
@@ -3569,6 +3573,8 @@ impl ApiClient {
         // Sign the message
         let auth_message =
             river_core::room_state::message::AuthorizedMessageV1::new(message, &signing_key);
+        // Captured before `auth_message` moves into the delta below.
+        let sent_message_id = auth_message.id();
 
         // Check if we need to re-add ourselves (pruned for inactivity)
         let (members_delta, member_info_delta) =
@@ -3633,7 +3639,9 @@ impl ApiClient {
         match response {
             HostResponse::ContractResponse(ContractResponse::UpdateResponse { key, .. }) => {
                 info!("Message sent successfully to contract: {}", key.id());
-                Ok(())
+                // Hand back the new message's ID so callers can act on their own
+                // message later -- editing, deleting, or checking it is still there.
+                Ok(sent_message_id)
             }
             _ => Err(anyhow!("Unexpected response type: {:?}", response)),
         }

--- a/cli/src/commands/message.rs
+++ b/cli/src/commands/message.rs
@@ -136,7 +136,7 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
                     .map_err(|e| anyhow::anyhow!("Invalid room ID: {}", e))?;
 
             // Send the message - use explicit signing key if provided, otherwise use storage
-            if let Some(signing_key_str) = signing_key {
+            let sent_message_id = if let Some(signing_key_str) = signing_key {
                 // Parse signing key (base64-encoded)
                 let signing_key_bytes = base64::engine::general_purpose::STANDARD
                     .decode(&signing_key_str)
@@ -159,15 +159,23 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
 
                 // Send using the provided signing key (fetches room state from network)
                 api.send_message_with_key(&room_owner_key, message.clone(), &signing_key)
-                    .await?;
+                    .await?
             } else {
                 // Send using signing key from local storage
-                api.send_message(&room_owner_key, message.clone()).await?;
-            }
+                api.send_message(&room_owner_key, message.clone()).await?
+            };
 
             match format {
-                OutputFormat::Human => println!("Message sent successfully"),
-                OutputFormat::Json => println!(r#"{{"status":"success","message":"sent"}}"#),
+                OutputFormat::Human => {
+                    println!("Message sent successfully (id: {})", sent_message_id.0 .0)
+                }
+                // Same inner-i64 form `message list` prints and `message delete`
+                // accepts, so a caller can retract its own message without a
+                // round trip to find it.
+                OutputFormat::Json => println!(
+                    r#"{{"status":"success","message":"sent","message_id":"{}"}}"#,
+                    sent_message_id.0 .0
+                ),
             }
             Ok(())
         }
@@ -617,6 +625,31 @@ mod tests {
         assert!(
             squashed.contains(r#""reactors":reactors,"#),
             "message list must expose who reacted, not only a count"
+        );
+    }
+
+    /// `message send` must return the new message's ID for the same reason
+    /// `message reply` does: a caller that posts a notice needs to retract it
+    /// once it stops being relevant, and only the author may delete a message.
+    #[test]
+    fn send_json_returns_the_new_message_id() {
+        let source = include_str!("message.rs");
+        let production = source
+            .split_once("mod tests")
+            .map(|(before, _)| before)
+            .expect("test module marker missing; the cut would scan everything");
+        let squashed: String = production.chars().filter(|c| !c.is_whitespace()).collect();
+        assert!(
+            squashed.contains(r#""status":"success","message":"sent""#),
+            "send JSON arm not found; the pin would pass vacuously"
+        );
+        assert!(
+            squashed.contains(r#""message":"sent","message_id":"{}""#),
+            "send must return message_id"
+        );
+        assert!(
+            squashed.contains("sent_message_id.0.0"),
+            "send must emit the inner i64, matching what `message delete` accepts"
         );
     }
 

--- a/cli/src/commands/message.rs
+++ b/cli/src/commands/message.rs
@@ -347,6 +347,24 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
                                 .reactions(&msg_id)
                                 .map(|r| r.iter().map(|(k, v)| (k.clone(), v.len())).collect())
                                 .unwrap_or_default();
+                            // Who reacted, alongside the counts. See
+                            // `output_reaction_change` for why a count alone is
+                            // not enough to act on a reaction.
+                            let reactors: std::collections::HashMap<String, Vec<String>> =
+                                room_state
+                                    .recent_messages
+                                    .reactions(&msg_id)
+                                    .map(|r| {
+                                        r.iter()
+                                            .map(|(emoji, ids)| {
+                                                (
+                                                    emoji.clone(),
+                                                    ids.iter().map(|id| id.to_string()).collect(),
+                                                )
+                                            })
+                                            .collect()
+                                    })
+                                    .unwrap_or_default();
 
                             // Encode message ID for use in edit/delete/react commands
                             let message_id_str = msg_id.0 .0.to_string();
@@ -372,6 +390,7 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
                                 "edited": edited,
                                 "reply_to": reply_to,
                                 "reactions": reactions,
+                                "reactors": reactors,
                             })
                         })
                         .collect();
@@ -572,6 +591,35 @@ mod tests {
     /// Source-scrape rather than a live round trip, because sending a reply
     /// requires a node and a room. Whitespace is squashed so rustfmt cannot
     /// silently disarm the pin.
+
+    /// Reactions must be attributable. Room state has always held
+    /// `HashMap<String, Vec<MemberId>>`, but both JSON boundaries collapsed it
+    /// to a count via `v.len()`, so nothing downstream could tell WHO reacted --
+    /// which made reactions impossible to moderate rather than merely awkward.
+    ///
+    /// `reactions` (counts) is retained unchanged so existing consumers keep
+    /// working; `reactors` is additive.
+    #[test]
+    fn reaction_json_exposes_who_reacted_not_just_how_many() {
+        let source = include_str!("message.rs");
+        // Scan production only: without this cut the needles below match their
+        // own literals in this test and the pin passes vacuously.
+        let production = source
+            .split_once("mod tests")
+            .map(|(before, _)| before)
+            .expect("test module marker missing; the cut would scan everything");
+        let squashed: String = production.chars().filter(|c| !c.is_whitespace()).collect();
+
+        assert!(
+            squashed.contains(r#""reactions":reactions,"#),
+            "count field not found; the pin would pass vacuously"
+        );
+        assert!(
+            squashed.contains(r#""reactors":reactors,"#),
+            "message list must expose who reacted, not only a count"
+        );
+    }
+
     #[test]
     fn reply_json_returns_the_new_message_id() {
         let source = include_str!("message.rs");


### PR DESCRIPTION
## Problem

Room state has always held `HashMap<String, Vec<MemberId>>` for reactions (`common/src/room_state/message.rs::reactions`), but **both** JSON boundaries collapsed it to a count via `v.len()`:

- `message list --format json` → `reactions: {emoji: count}`
- the monitor stream's `type: "reaction"` event → same

A count cannot attribute a reaction to anyone, so nothing downstream could tell **who** reacted. That made reactions **impossible** to moderate rather than merely awkward — an automated moderator could see that a bad reaction existed but had nobody to act on.

The data was never missing. Only these two boundaries discarded it.

## Approach

Both sites gain an additive `reactors: {emoji: [member_id]}`. `reactions` is unchanged, so existing consumers keep working (the River moderator's own response parser ignores unknown fields).

**Footgun documented while here:** the reaction event's `author` is the author of the message that was *reacted to*, not the person who reacted — a reaction event is emitted against its target message. Anything attributing the reaction itself must read `reactors`; `author` names an innocent party. The field can't be renamed without breaking consumers, so the rustdoc now says so explicitly.

## Testing

Source-scrape pin asserting both fields are emitted, with the scan **cut at `mod tests`** so the needles can't match their own literals — the trap that made the first version of the sibling `message reply` pin vacuous.

Verified by mutation:

```
reactors removed  -> test FAILED
restored          -> test ok
```

riverctl bumped **0.2.8 → 0.2.9**. 315 tests pass; fmt clean.

## Context

Motivated by multi-character reactions appearing in the Freenet Official room. The root cause is that `ReactionPayload { emoji: String }` (`content.rs:269`) is an unvalidated free-text field with no cap on reaction count or size — the UI picker was the only thing making arbitrary payloads "impossible", and `riverctl message react` takes any string.

Ian's call was to handle it via **moderation rather than CLI validation**, since a CLI check is bypassable by any custom client and would falsely imply the field is bounded. Moderation genuinely remediates here: a reaction is stored as an action *message*, so banning the author sweeps it and `rebuild_actions_state` regenerates without it. This PR is what makes that moderation possible at all. A contract-side bound remains the only non-bypassable fix and is deferred to ride along with the next re-key.

[AI-assisted - Claude]