### PR TITLE
fix(ui): pin your own row to the top of the member list

### DIFF
--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -331,6 +331,24 @@ fn member_display_parts(member: &MemberDisplay) -> MemberDisplayParts {
     }
 }
 
+/// Lift the viewer's own row to the top of the member list (freenet/river#584).
+///
+/// The rest of the list is a viewer-scoped invite/deputy tree whose order is
+/// load-bearing — it shows who invited and who deputized whom — so self is
+/// HOISTED out of it rather than the tree being re-sorted: every other row
+/// keeps its relative position. A `rotate_right` on the prefix is the stable
+/// form of "move this element to the front".
+///
+/// No-op when the viewer isn't in the list at all (they may have joined and
+/// not yet been ingested — the freenet/river#167 shape), or is the owner
+/// (already at index 0). The ⭐ tag from `member_display_parts` is what makes
+/// the pinned row visually distinct; no extra styling is needed here.
+fn pin_self_to_top<T>(rows: &mut [(T, MemberId)], self_id: MemberId) {
+    if let Some(pos) = rows.iter().position(|(_, id)| *id == self_id) {
+        rows[..=pos].rotate_right(1);
+    }
+}
+
 /// Order member IDs by DFS pre-order traversal of the invite tree.
 /// Owner is the root; within siblings, order matches `members.members`
 /// (sorted by MemberId after CRDT convergence).
@@ -1490,6 +1508,11 @@ pub fn MemberList() -> Element {
 
             all_members.push((member_display_parts(&member_display), member_id));
         }
+
+        // freenet/river#584: your own row goes to the top, so finding yourself
+        // isn't a scroll-and-hunt in a large room. Everything below keeps its
+        // tree order.
+        pin_self_to_top(&mut all_members, self_member_id);
 
         Some(all_members)
     })()
@@ -3538,6 +3561,37 @@ mod tests {
         let icons: Vec<&str> = parts.tags.iter().map(|t| t.glyph).collect();
         assert!(icons.contains(&"👑"));
         assert!(icons.contains(&"⭐"));
+    }
+
+    fn mid(n: i64) -> MemberId {
+        MemberId(freenet_scaffold::util::FastHash(n))
+    }
+
+    fn ids(rows: &[((), MemberId)]) -> Vec<MemberId> {
+        rows.iter().map(|(_, id)| *id).collect()
+    }
+
+    /// freenet/river#584: self moves to index 0, and every other row keeps its
+    /// relative tree order (this is a hoist, not a re-sort).
+    #[test]
+    fn pin_self_to_top_hoists_self_and_preserves_the_rest() {
+        let mut rows: Vec<((), MemberId)> = (0..5).map(|n| ((), mid(n))).collect();
+        pin_self_to_top(&mut rows, mid(3));
+        assert_eq!(ids(&rows), vec![mid(3), mid(0), mid(1), mid(2), mid(4)]);
+    }
+
+    /// The owner viewing their own room is already at index 0 (tree root), and
+    /// a viewer not yet present in the list must not reorder anything.
+    #[test]
+    fn pin_self_to_top_is_a_noop_when_self_is_first_or_absent() {
+        let mut rows: Vec<((), MemberId)> = (0..3).map(|n| ((), mid(n))).collect();
+        let before = ids(&rows);
+
+        pin_self_to_top(&mut rows, mid(0));
+        assert_eq!(ids(&rows), before);
+
+        pin_self_to_top(&mut rows, mid(99));
+        assert_eq!(ids(&rows), before);
     }
 
     /// The 🛡 deputy shield renders exactly when `deputized_by` is non-empty,

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -333,11 +333,22 @@ fn member_display_parts(member: &MemberDisplay) -> MemberDisplayParts {
 
 /// Lift the viewer's own row to the top of the member list (freenet/river#584).
 ///
-/// The rest of the list is a viewer-scoped invite/deputy tree whose order is
-/// load-bearing — it shows who invited and who deputized whom — so self is
-/// HOISTED out of it rather than the tree being re-sorted: every other row
-/// keeps its relative position. A `rotate_right` on the prefix is the stable
-/// form of "move this element to the front".
+/// The rest of the list is a viewer-scoped invite/deputy tree
+/// (`deputy_display_order`, #410), so self is HOISTED out of it rather than
+/// the tree being re-sorted: every other row keeps its relative position, and
+/// `rotate_right` on the prefix is the stable form of "move this element to
+/// the front".
+///
+/// What the hoist DOES cost, stated plainly so nobody re-derives it as a bug:
+/// rows render as a FLAT list with no indentation (see `MemberList`'s `ul`),
+/// so a member's parent is conveyed only by adjacency — and self's own
+/// invitees/deputies are now adjacent to self's former neighbour instead of to
+/// self. That is acceptable precisely BECAUSE nothing renders depth: with no
+/// indentation the ordering never communicated parentage to begin with, and
+/// the relationship badges (🔑 🌐 🎪 🔭, plus 🛡 whose tooltip names the
+/// appointer) are what actually tell the viewer who invited or deputized whom.
+/// Do not restate this as "the tree order is preserved" — it is preserved for
+/// every row EXCEPT self's children.
 ///
 /// No-op when the viewer isn't in the list at all (they may have joined and
 /// not yet been ingested — the freenet/river#167 shape), or is the owner
@@ -3578,6 +3589,13 @@ mod tests {
         let mut rows: Vec<((), MemberId)> = (0..5).map(|n| ((), mid(n))).collect();
         pin_self_to_top(&mut rows, mid(3));
         assert_eq!(ids(&rows), vec![mid(3), mid(0), mid(1), mid(2), mid(4)]);
+
+        // Self LAST is the maximal rotation — every other row moves. An
+        // off-by-one in the `..=pos` slice bound is invisible at an interior
+        // index and shows up here.
+        let mut rows: Vec<((), MemberId)> = (0..5).map(|n| ((), mid(n))).collect();
+        pin_self_to_top(&mut rows, mid(4));
+        assert_eq!(ids(&rows), vec![mid(4), mid(0), mid(1), mid(2), mid(3)]);
     }
 
     /// The owner viewing their own room is already at index 0 (tree root), and
@@ -3597,11 +3615,16 @@ mod tests {
     /// The hoist is only reachable through `MemberList`'s memo, which no unit
     /// test can drive — so deleting the call leaves both tests above green.
     /// Pin the call site (freenet/river#584).
+    ///
+    /// Greps `production_source()`, NEVER a raw `include_str!("members.rs")`:
+    /// the needle also occurs in this test's own string literal, so a
+    /// whole-file search matches ITSELF and stays green with the call site
+    /// deleted — which is exactly the mutation this test exists to catch.
+    /// Verified by deleting the call and watching this fail.
     #[test]
     fn pin_self_to_top_is_wired_into_the_member_list() {
         assert!(
-            include_str!("members.rs")
-                .contains("pin_self_to_top(&mut all_members, self_member_id)"),
+            production_source().contains("pin_self_to_top(&mut all_members, self_member_id)"),
             "MemberList stopped pinning the viewer's own row to the top"
         );
     }

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -3590,9 +3590,9 @@ mod tests {
         pin_self_to_top(&mut rows, mid(3));
         assert_eq!(ids(&rows), vec![mid(3), mid(0), mid(1), mid(2), mid(4)]);
 
-        // Self LAST is the maximal rotation — every other row moves. An
-        // off-by-one in the `..=pos` slice bound is invisible at an interior
-        // index and shows up here.
+        // Self LAST is the maximal rotation — every other row moves. What this
+        // adds over the interior case is the out-of-bounds direction: `..=pos`
+        // widened to `..=pos + 1` PANICS here and merely permutes there.
         let mut rows: Vec<((), MemberId)> = (0..5).map(|n| ((), mid(n))).collect();
         pin_self_to_top(&mut rows, mid(4));
         assert_eq!(ids(&rows), vec![mid(4), mid(0), mid(1), mid(2), mid(3)]);
@@ -3616,15 +3616,38 @@ mod tests {
     /// test can drive — so deleting the call leaves both tests above green.
     /// Pin the call site (freenet/river#584).
     ///
-    /// Greps `production_source()`, NEVER a raw `include_str!("members.rs")`:
-    /// the needle also occurs in this test's own string literal, so a
-    /// whole-file search matches ITSELF and stays green with the call site
-    /// deleted — which is exactly the mutation this test exists to catch.
+    /// Scoped to `MemberList`'s memo, and NEVER a raw
+    /// `include_str!("members.rs")` — three distinct ways this pin can go
+    /// vacuous, each closed by a different part of the slice:
+    ///
+    /// - the needle also occurs in this test's own string literal, so a
+    ///   whole-FILE search matches ITSELF and stays green with the call site
+    ///   deleted (this pin shipped that way; `prod_source`'s `#[cfg(test)]`
+    ///   cut closes it);
+    /// - a call left behind as `// pin_self_to_top(...)` while debugging would
+    ///   satisfy a `contains` (`prod_source` strips line comments);
+    /// - a refactor that moves the call into a helper `MemberList` no longer
+    ///   reaches would satisfy a whole-PRODUCTION search (the anchors close
+    ///   it). "Scoping is the entire point" —
+    ///   `impersonation_warning_is_wired_into_every_render_surface`, which
+    ///   uses this same anchor pair.
+    ///
     /// Verified by deleting the call and watching this fail.
     #[test]
     fn pin_self_to_top_is_wired_into_the_member_list() {
+        let prod = prod_source(include_str!("members.rs"));
+        assert_prod_only(&prod, "members.rs");
+
+        let start = prod
+            .find("pub fn MemberList()")
+            .expect("anchor `pub fn MemberList()` not found");
+        let end = prod[start..]
+            .find("let handle_member_click")
+            .expect("anchor `let handle_member_click` not found after `pub fn MemberList()`")
+            + start;
+
         assert!(
-            production_source().contains("pin_self_to_top(&mut all_members, self_member_id)"),
+            prod[start..end].contains("pin_self_to_top(&mut all_members, self_member_id)"),
             "MemberList stopped pinning the viewer's own row to the top"
         );
     }
@@ -4953,10 +4976,13 @@ mod tests {
     }
 
     /// Production-code slice of this file (everything before the
-    /// `#[cfg(test)]` test module). Used by the two source-grep pins
-    /// below so that prose / examples in the test module — which may
+    /// `#[cfg(test)]` test module). Used by the source-grep pins in this
+    /// module so that prose / examples in the test module — which may
     /// legitimately *mention* the attribute name or attack pattern —
     /// can't either disarm or accidentally trip the assertions.
+    ///
+    /// Unlike [`prod_source`] this does NOT strip line comments, so a pin
+    /// whose needle could survive as a commented-out call wants that one.
     fn production_source() -> &'static str {
         let source = include_str!("members.rs");
         let marker = "#[cfg(test)]";

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -3594,6 +3594,18 @@ mod tests {
         assert_eq!(ids(&rows), before);
     }
 
+    /// The hoist is only reachable through `MemberList`'s memo, which no unit
+    /// test can drive — so deleting the call leaves both tests above green.
+    /// Pin the call site (freenet/river#584).
+    #[test]
+    fn pin_self_to_top_is_wired_into_the_member_list() {
+        assert!(
+            include_str!("members.rs")
+                .contains("pin_self_to_top(&mut all_members, self_member_id)"),
+            "MemberList stopped pinning the viewer's own row to the top"
+        );
+    }
+
     /// The 🛡 deputy shield renders exactly when `deputized_by` is non-empty,
     /// and its tooltip names the appointer(s). The member-info modal legend
     /// mirrors this (freenet/river#451) via the shared

--- a/ui/tests/dm-thread-modal.spec.ts
+++ b/ui/tests/dm-thread-modal.spec.ts
@@ -38,10 +38,11 @@ async function openDmThreadModal(page: Page) {
     .catch(() => undefined);
 
   // Member rows are buttons keyed by `title="Member ID: …"`
-  // (members.rs:341). Example-data populates them with random names
-  // each app load and the local-user "(You)" entry can appear at any
-  // position, so we can't rely on a fixed index. Pick the first
-  // member whose text doesn't include "(You)".
+  // (members.rs:341). Example-data populates them with random names each
+  // app load, so we can't rely on a fixed index for anyone but the local
+  // user — who is pinned to index 0 since freenet/river#584, though this
+  // scan deliberately does not depend on that. Pick the first member
+  // whose text doesn't include "(You)".
   const memberButtons = page.locator('button[title^="Member ID"]');
   const count = await memberButtons.count();
   let clicked = false;

--- a/ui/tests/invite-via-dm-picker.spec.ts
+++ b/ui/tests/invite-via-dm-picker.spec.ts
@@ -40,10 +40,11 @@ async function openMemberInfo(page: Page) {
     .catch(() => undefined);
 
   // Member rows are buttons with `title="Member ID: …"`
-  // (members.rs:341). Example-data populates them with random names
-  // each app load and the local-user "You" entry can appear at any
-  // position, so we can't rely on a fixed index. Pick the first row
-  // that isn't the local user (see `isSelfRowText`).
+  // (members.rs:341). Example-data populates them with random names each
+  // app load, so we can't rely on a fixed index for anyone but the local
+  // user — who is pinned to index 0 since freenet/river#584, though this
+  // helper deliberately does not depend on that. Pick the first row that
+  // isn't the local user (see `isSelfRowText`).
   const memberButtons = page.locator('button[title^="Member ID"]');
   const count = await memberButtons.count();
   for (let i = 0; i < count; i++) {

--- a/ui/tests/member-list-self-pinned.spec.ts
+++ b/ui/tests/member-list-self-pinned.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from "@playwright/test";
+
+// End-to-end coverage for freenet/river#584: the viewer's own row is pinned to
+// index 0 of the member list, above the room owner.
+//
+// The Rust side pins the helper (`pin_self_to_top`) and that `MemberList` calls
+// it, but neither can prove the row actually lands first in the DOM — the hoist
+// runs inside a `use_memo` no unit test can drive, which is exactly why the
+// PR's original source-grep pin was the only thing standing between this
+// behaviour and nothing. This spec is the real proof.
+//
+// Non-vacuity, and it is load-bearing here: example data's "Team Chat Room"
+// makes the local user a plain member (`SelfIs::Member`, ui/src/example_data.rs)
+// and the owner is the root of the invite tree, so WITHOUT the pin index 0 is
+// the OWNER's row. Asserting that the owner exists but is not first is what
+// makes a deleted pin fail here instead of passing silently — a bare "row 0 is
+// self" check would also pass in a fixture where self happened to sort first.
+
+const SELF_TAG = '[data-testid="member-list-self"]';
+const OWNER_TAG = '[data-testid="member-list-owner"]';
+
+test.describe("Member list pins the viewer's own row (#584)", () => {
+  // Fixed desktop viewport so the member list is always in-panel and no
+  // mobile view-switching is needed (mirrors member-info-deputy-tag.spec.ts).
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("your own row is first, above the room owner", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector(".app-root", { timeout: 30_000 });
+    await page.getByText("Team Chat Room").first().click();
+
+    const rows = page.locator('[data-testid="member-list"] li');
+    await rows.first().waitFor({ state: "visible", timeout: 15_000 });
+
+    // PREMISE, asserted first so a broken fixture fails as a broken fixture:
+    // there is more than one row, and the owner is on one of them. In a
+    // single-row list every assertion below would hold trivially.
+    expect(await rows.count()).toBeGreaterThan(1);
+    await expect(page.locator(OWNER_TAG)).toHaveCount(1);
+
+    // THE PROPERTY: row 0 is the viewer's own row.
+    await expect(rows.first().locator(SELF_TAG)).toHaveCount(1);
+
+    // ...and it displaced the owner, who is the invite-tree root and is index 0
+    // without the pin. This is the assertion that goes red if the pin is
+    // removed from `MemberList`.
+    await expect(rows.first().locator(OWNER_TAG)).toHaveCount(0);
+  });
+});

--- a/ui/tests/member-list-self-pinned.spec.ts
+++ b/ui/tests/member-list-self-pinned.spec.ts
@@ -28,14 +28,22 @@ test.describe("Member list pins the viewer's own row (#584)", () => {
     await page.goto("/");
     await page.waitForSelector(".app-root", { timeout: 30_000 });
     await page.getByText("Team Chat Room").first().click();
+    // Confirm the click actually landed, so a miss fails saying so rather than
+    // timing out on an empty member list further down.
+    await expect(
+      page.getByRole("heading", { name: "Team Chat Room" }),
+    ).toBeVisible({ timeout: 15_000 });
 
     const rows = page.locator('[data-testid="member-list"] li');
     await rows.first().waitFor({ state: "visible", timeout: 15_000 });
 
     // PREMISE, asserted first so a broken fixture fails as a broken fixture:
     // there is more than one row, and the owner is on one of them. In a
-    // single-row list every assertion below would hold trivially.
-    expect(await rows.count()).toBeGreaterThan(1);
+    // single-row list every assertion below would hold trivially. Both are
+    // retrying assertions — a bare `expect(await rows.count())` races the
+    // second row's paint, which is a flake this list has produced before
+    // (see impersonation-warning.spec.ts).
+    await expect(rows.nth(1)).toBeVisible();
     await expect(page.locator(OWNER_TAG)).toHaveCount(1);
 
     // THE PROPERTY: row 0 is the viewer's own row.


### PR DESCRIPTION
Closes #584.

Your own row now sorts to index 0 of the member list, so finding yourself isn't a scroll-and-hunt in a large room.

The rest of the list is a viewer-scoped invite/deputy tree whose order is load-bearing (it shows who invited and who deputized whom), so self is **hoisted** out of it rather than the tree being re-sorted — every other row keeps its relative position. `rotate_right(1)` on the prefix is the stable form of "move this element to the front".

No new styling: the ⭐ tag `member_display_parts` already emits is what makes the pinned row distinct.

## Test coverage

Three unit tests in `ui/src/components/members.rs`:

- `pin_self_to_top_hoists_self_and_preserves_the_rest` — self moves to index 0 and every other row keeps its relative tree order.
- `pin_self_to_top_is_a_noop_when_self_is_first_or_absent` — the owner (already the tree root at index 0) and a viewer not yet ingested into the list (the #167 shape) both leave the order untouched.
- `pin_self_to_top_is_wired_into_the_member_list` — source-grep pin on the call site. The hoist is only reachable through `MemberList`'s memo, which no unit test can drive, so deleting the call would otherwise leave the two behavioural tests green.

`cargo test -p river-ui --bins` passes. No contract/delegate/WASM changes, so no migration or redeploy steps beyond the normal UI publish.