### PR TITLE
fix(ui): stop rendering quoted text black inside own message bubbles

### DIFF
--- a/ui/assets/tailwind.css
+++ b/ui/assets/tailwind.css
@@ -35,6 +35,7 @@
   --color-border-hover: #d0d0d4;
   --color-text: #1a1a1a;
   --color-text-muted: #6b6b6b;
+  --color-text-quote: #5c5c5c;
   --color-text-inverse: #ffffff;
   --color-success-bg: #f0fdf4;
   --color-warning-bg: #fefce8;
@@ -53,6 +54,7 @@
     --color-border-hover: #3a3a3e;
     --color-text: #f0f0f2;
     --color-text-muted: #9a9a9e;
+    --color-text-quote: #b4b4b9;
     --color-text-inverse: #1a1a1a;
     --color-success-bg: #052e16;
     --color-warning-bg: #422006;
@@ -181,19 +183,49 @@ html, body {
   padding: 0;
 }
 
-/* Blockquotes in prose */
+/* Blockquotes in prose (received bubbles, DM bubbles, room descriptions).
+ *
+ * `--color-text-quote` rather than `--color-text-muted`: a quote must stay
+ * READABLE while reading as secondary, and the muted token — which is tuned
+ * for timestamps and field labels, i.e. glanceable metadata — lands just under
+ * the 4.5:1 WCAG AA floor on two of the backgrounds a quote actually appears
+ * over (4.47:1 on light-mode `--color-surface`, 4.40:1 on a dark-mode
+ * `bg-accent/20` DM bubble). The quote token is one step further from the
+ * background in each mode, which clears AA on every quote surface while
+ * staying well clear of `--color-text` so the muted look survives. It is
+ * deliberately a SEPARATE token: nudging `--color-text-muted` itself would
+ * repaint every timestamp, placeholder and label in the app. */
 .prose blockquote {
   border-left: 3px solid var(--color-accent);
   padding-left: 1rem;
   margin-left: 0;
-  color: var(--color-text-muted);
+  color: var(--color-text-quote);
   font-style: italic;
 }
 
-/* Blockquotes in own message bubbles (blue bg) */
+/* Blockquotes in own message bubbles (solid brand-blue bg, white text).
+ *
+ * This rule used to paint the quote `rgba(0, 0, 0, 0.8)` — near-black text in
+ * a bubble whose every other word is white. That is the same failure the
+ * `.bg-accent .river-mention` / `.bg-accent .prose a` overrides in main.css
+ * exist to prevent, just for a different element: `.bg-accent` is the SAME
+ * brand blue in light and dark mode, so the quote read as black-on-blue in
+ * BOTH (3.52:1, under the 4.5:1 WCAG AA floor, against 5.23:1 for the normal
+ * text right beside it). The `--color-accent-hover` border made it worse — at
+ * 1.29:1 against the accent background it was invisible, so a quote in a sent
+ * bubble had no marker at all beyond the indent.
+ *
+ * Take the bubble's own text colour (`inherit` → white) rather than a
+ * hardcoded one, so the quote can never drift from the bubble's palette again.
+ * Dimming is deliberately NOT how the quote is distinguished here: white on
+ * the accent blue is only 5.23:1 to begin with, so any meaningful reduction
+ * drops under AA. The affordance is carried by the border + the inherited
+ * `font-style: italic` instead — the same convention `.bg-accent .prose a`
+ * (white + underline) and the reply strip (`bg-white/25 text-white/90`) use
+ * for sent bubbles. */
 .bg-accent .prose blockquote {
-  border-left: 3px solid var(--color-accent-hover);
-  color: rgba(0, 0, 0, 0.8);
+  border-left-color: rgba(255, 255, 255, 0.7);
+  color: inherit;
 }
 
 /* Lists in prose (Tailwind reset strips list-style) */

--- a/ui/assets/tailwind.css
+++ b/ui/assets/tailwind.css
@@ -187,14 +187,25 @@ html, body {
  *
  * `--color-text-quote` rather than `--color-text-muted`: a quote must stay
  * READABLE while reading as secondary, and the muted token — which is tuned
- * for timestamps and field labels, i.e. glanceable metadata — lands just under
- * the 4.5:1 WCAG AA floor on two of the backgrounds a quote actually appears
- * over (4.47:1 on light-mode `--color-surface`, 4.40:1 on a dark-mode
- * `bg-accent/20` DM bubble). The quote token is one step further from the
- * background in each mode, which clears AA on every quote surface while
- * staying well clear of `--color-text` so the muted look survives. It is
- * deliberately a SEPARATE token: nudging `--color-text-muted` itself would
- * repaint every timestamp, placeholder and label in the app. */
+ * for timestamps and field labels, i.e. glanceable metadata — falls under the
+ * 4.5:1 WCAG AA floor on two of the backgrounds a quote actually appears over,
+ * BOTH of them in light mode: 4.47:1 on `--color-surface` (a received bubble)
+ * and 3.96:1 on the `bg-accent/20` outgoing DM bubble, which is the worst
+ * quote surface in the app. The dark-mode equivalents were already fine
+ * (5.93:1 and 5.56:1). The quote token is one step further from the background
+ * in each mode, which clears AA on every quote surface (5.61:1 / 4.97:1 light,
+ * 8.05:1 / 7.55:1 dark) while staying well clear of `--color-text` so the
+ * muted look survives. It is deliberately a SEPARATE token: nudging
+ * `--color-text-muted` itself would repaint every timestamp, placeholder and
+ * label in the app.
+ *
+ * Those numbers are measured against the REAL DM modal, not a stand-in. An
+ * earlier revision of this comment claimed "4.40:1 on a dark-mode DM bubble",
+ * which was wrong in both the scheme and the value: it came from a synthetic
+ * page that put the bubble on `--color-bg` instead of the modal's panel, read
+ * through a colour helper that un-premultiplied an already-straight-alpha
+ * canvas readback. Both errors inflated a translucent background. Measure a
+ * translucent surface where it actually renders. */
 .prose blockquote {
   border-left: 3px solid var(--color-accent);
   padding-left: 1rem;

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -6671,6 +6671,110 @@ mod tests {
         );
     }
 
+    /// The `> quoted` Markdown a reader types has to reach the stylesheet as a
+    /// `<blockquote>` for any of the blockquote rules below to apply at all.
+    /// `message_to_html` rewrites every single newline to a hard break
+    /// (`"  \n"`) before Markdown runs, so pin that the block construct still
+    /// parses through that rewrite.
+    #[test]
+    fn markdown_quote_renders_as_blockquote() {
+        let html = message_to_html("> quoted line\n\nnormal line");
+        assert!(
+            html.contains("<blockquote>"),
+            "`> …` must render as a <blockquote> for the blockquote CSS to \
+             apply: {html}"
+        );
+    }
+
+    /// Extract the declaration body of a CSS rule by its exact selector text.
+    ///
+    /// Anchored on a LINE START (`"\n{selector} {{"`), not a bare substring:
+    /// `.prose blockquote {` is a suffix of `.bg-accent .prose blockquote {`,
+    /// so a substring search would silently return the wrong rule's body if
+    /// the two were ever reordered in the file.
+    fn css_rule_body<'a>(css: &'a str, selector: &str) -> &'a str {
+        let needle = format!("\n{selector} {{");
+        let start = css
+            .find(&needle)
+            .unwrap_or_else(|| panic!("tailwind.css should contain a `{selector}` rule"))
+            + needle.len();
+        let end = start
+            + css[start..]
+                .find('}')
+                .unwrap_or_else(|| panic!("`{selector}` rule should be closed"));
+        &css[start..end]
+    }
+
+    /// A quote inside the local user's own bubble must take the bubble's own
+    /// text colour, not a hardcoded one.
+    ///
+    /// `.bg-accent` is the solid brand-blue sent-message bubble, whose text is
+    /// `text-white`, and it is the SAME blue in light and dark mode. The rule
+    /// used to paint the quote `rgba(0, 0, 0, 0.8)`, so quoted text rendered
+    /// near-black inside a bubble of white text — 3.52:1 against the bubble,
+    /// under the 4.5:1 WCAG AA floor, in BOTH colour schemes. Pinning
+    /// `color: inherit` is what keeps the quote tied to the bubble's palette
+    /// instead of drifting from it again.
+    ///
+    /// The browser-side counterpart, which measures the real composited
+    /// contrast in both colour schemes rather than the declaration text, is
+    /// `ui/tests/blockquote-contrast.spec.ts`.
+    #[test]
+    fn sent_bubble_blockquote_inherits_bubble_text_colour() {
+        const TAILWIND_CSS: &str = include_str!("../../assets/tailwind.css");
+        let body = css_rule_body(TAILWIND_CSS, ".bg-accent .prose blockquote");
+
+        assert!(
+            body.contains("color: inherit"),
+            "`.bg-accent .prose blockquote` must take the sent bubble's own \
+             text colour (`color: inherit`); a hardcoded colour is what made \
+             quoted text render black-on-blue beside white text. Found: {body}"
+        );
+        // The specific regression: any near-black literal here reproduces it.
+        for banned in ["rgba(0, 0, 0", "rgba(0,0,0", "#000"] {
+            assert!(
+                !body.contains(banned),
+                "`.bg-accent .prose blockquote` must not hardcode a dark text \
+                 colour (`{banned}`): the bubble is brand blue with white text \
+                 in BOTH light and dark mode. Found: {body}"
+            );
+        }
+    }
+
+    /// Quotes outside the sent bubble use a dedicated `--color-text-quote`
+    /// token rather than the app-wide `--color-text-muted`.
+    ///
+    /// The muted token is tuned for glanceable metadata (timestamps, field
+    /// labels) and lands just under 4.5:1 on two of the backgrounds a quote
+    /// actually appears over: light-mode `--color-surface` (4.47:1) and a
+    /// dark-mode `bg-accent/20` DM bubble (4.40:1). The token must be declared
+    /// in BOTH colour schemes — a missing dark-mode value makes the `var()`
+    /// invalid at computed-value time, which silently falls back to the
+    /// inherited body colour and loses the muted look entirely.
+    #[test]
+    fn blockquote_uses_dedicated_quote_colour_token_in_both_schemes() {
+        const TAILWIND_CSS: &str = include_str!("../../assets/tailwind.css");
+
+        let body = css_rule_body(TAILWIND_CSS, ".prose blockquote");
+        assert!(
+            body.contains("color: var(--color-text-quote)"),
+            "`.prose blockquote` must use `--color-text-quote`, not the \
+             app-wide muted token, so a quote stays above the WCAG AA floor \
+             without repainting every timestamp and label. Found: {body}"
+        );
+
+        // `:root` carries the light-mode values; the dark-mode overrides live
+        // in the `prefers-color-scheme: dark` block. Both must define the
+        // token, so count declarations rather than merely finding one.
+        let declarations = TAILWIND_CSS.matches("--color-text-quote:").count();
+        assert_eq!(
+            declarations, 2,
+            "`--color-text-quote` must be declared exactly twice — once in \
+             `:root` (light) and once under `prefers-color-scheme: dark` — \
+             found {declarations}"
+        );
+    }
+
     const SAMPLE_ID: &str = "UDzGbcWrKN748tYbhvbPCCCQrZc9r9xkN3tUuun5Rts";
     /// Real-shape 44-char base58 ID for tests that need a second distinct ID.
     const SAMPLE_ID_2: &str = "EqJ5YpEEV3XLqEvKWLQHFhGAac2qXzSUoE6k2zbdnXBr";

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -6724,33 +6724,52 @@ mod tests {
         const TAILWIND_CSS: &str = include_str!("../../assets/tailwind.css");
         let body = css_rule_body(TAILWIND_CSS, ".bg-accent .prose blockquote");
 
-        assert!(
-            body.contains("color: inherit"),
-            "`.bg-accent .prose blockquote` must take the sent bubble's own \
-             text colour (`color: inherit`); a hardcoded colour is what made \
-             quoted text render black-on-blue beside white text. Found: {body}"
+        // Check the LAST `color:` declaration, not merely that `inherit`
+        // appears somewhere in the body. CSS is last-one-wins within a rule,
+        // so `color: inherit; color: #111;` reintroduces the bug in full while
+        // a `contains("color: inherit")` check happily passes — a substring
+        // search cannot model the cascade. Take the final declaration, which
+        // is the one that actually paints.
+        //
+        // `border-left-color:` also ends in `color:`, hence the `-` guard.
+        let last_color = body
+            .split(';')
+            .map(str::trim)
+            .filter(|d| d.starts_with("color:"))
+            .next_back()
+            .unwrap_or_else(|| {
+                panic!("`.bg-accent .prose blockquote` should declare a colour. Found: {body}")
+            });
+
+        assert_eq!(
+            last_color, "color: inherit",
+            "the winning `color` declaration in `.bg-accent .prose blockquote` \
+             must be `inherit` so the quote takes the sent bubble's own text \
+             colour; a hardcoded colour is what made quoted text render \
+             black-on-blue beside white text. Full rule: {body}"
         );
-        // The specific regression: any near-black literal here reproduces it.
-        for banned in ["rgba(0, 0, 0", "rgba(0,0,0", "#000"] {
-            assert!(
-                !body.contains(banned),
-                "`.bg-accent .prose blockquote` must not hardcode a dark text \
-                 colour (`{banned}`): the bubble is brand blue with white text \
-                 in BOTH light and dark mode. Found: {body}"
-            );
-        }
     }
 
     /// Quotes outside the sent bubble use a dedicated `--color-text-quote`
     /// token rather than the app-wide `--color-text-muted`.
     ///
     /// The muted token is tuned for glanceable metadata (timestamps, field
-    /// labels) and lands just under 4.5:1 on two of the backgrounds a quote
-    /// actually appears over: light-mode `--color-surface` (4.47:1) and a
-    /// dark-mode `bg-accent/20` DM bubble (4.40:1). The token must be declared
-    /// in BOTH colour schemes — a missing dark-mode value makes the `var()`
-    /// invalid at computed-value time, which silently falls back to the
-    /// inherited body colour and loses the muted look entirely.
+    /// labels) and falls under 4.5:1 on two of the backgrounds a quote
+    /// actually appears over, both in LIGHT mode: `--color-surface` (4.47:1)
+    /// and the `bg-accent/20` outgoing DM bubble (3.96:1, the worst quote
+    /// surface in the app). The dark-mode equivalents were already fine.
+    ///
+    /// The token must be declared in BOTH colour schemes, and the two ways to
+    /// break that fail DIFFERENTLY — which is why this counts declarations
+    /// instead of asserting either symptom:
+    ///
+    /// - Drop the DARK value and `:root`'s light value still resolves, so
+    ///   every dark-mode quote silently paints the light colour (2.49:1 on a
+    ///   dark received bubble — worse than the bug this PR fixes).
+    /// - Drop the LIGHT value and the token is undefined everywhere `:root`
+    ///   would have supplied it, so `var()` is invalid at computed-value time,
+    ///   `color` inherits the body text colour, and the muted look vanishes
+    ///   entirely while contrast stays high enough that no AA floor notices.
     #[test]
     fn blockquote_uses_dedicated_quote_colour_token_in_both_schemes() {
         const TAILWIND_CSS: &str = include_str!("../../assets/tailwind.css");

--- a/ui/tests/blockquote-contrast.spec.ts
+++ b/ui/tests/blockquote-contrast.spec.ts
@@ -8,12 +8,13 @@ import { test, expect, Page } from "@playwright/test";
 // Quoted text rendered near-black beside white text at 3.52:1, under the 4.5:1
 // WCAG AA floor. `.bg-accent` is the same blue in light and dark mode, so the
 // bug was present in BOTH schemes even though it was reported against dark.
+// Both schemes are exercised below for exactly that reason: the assertion is
+// duplicative by construction, and it is there to keep it that way.
 //
-// The Rust pin (`conversation.rs::sent_bubble_blockquote_inherits_bubble_text_colour`)
-// asserts the declaration text. This spec asserts what a reader actually sees:
-// it injects a blockquote into a REAL rendered bubble, so the class list, the
-// cascade and the compiled stylesheet are all the app's own, then composites
-// the colours the browser computed and measures the contrast.
+// The Rust pins in `conversation.rs` assert the declaration TEXT. This spec
+// asserts what a reader actually sees: it puts a quote in a REAL rendered
+// bubble, so the class list, the cascade and the compiled stylesheet are all
+// the app's own, then composites the colours the browser computed.
 
 // ── WCAG 2.x relative luminance / contrast ──────────────────────────────────
 
@@ -34,6 +35,11 @@ function contrast(fg: Rgb, bg: Rgb): number {
   return (hi + 0.05) / (lo + 0.05);
 }
 
+// WCAG 2.1 AA: 4.5:1 for body text, 3:1 for the non-text graphics that carry
+// meaning (here, the bar marking a quote as a quote).
+const AA_TEXT = 4.5;
+const AA_NON_TEXT = 3;
+
 // ── Sampling the live DOM ───────────────────────────────────────────────────
 
 interface Sample {
@@ -43,45 +49,60 @@ interface Sample {
   quoteBorder: Rgb;
 }
 
+/** Which real surface to measure. */
+type Surface = "sent" | "received" | "dm";
+
 /**
- * Inject a blockquote into a real message bubble, read back what the browser
- * computed, and remove it again.
+ * Put a blockquote in a real bubble on `surface`, read back what the browser
+ * computed for it, and clean up after.
  *
- * `kind` picks the bubble by the class the app itself renders: `bg-accent` is
- * the local user's own bubble (white text on brand blue), `bg-surface` is a
- * received one.
+ * The room-message surfaces are probed by injecting into an existing bubble's
+ * body; the DM surface has no example-data messages at all, so its bubble is
+ * created by actually sending a DM (see `openDmThread`).
  */
-async function sampleBubbleQuote(
-  page: Page,
-  kind: "bg-accent" | "bg-surface"
-): Promise<Sample> {
-  return page.evaluate((bubbleClass) => {
+async function sampleQuote(page: Page, surface: Surface): Promise<Sample> {
+  const raw = await page.evaluate((which: Surface) => {
+    // A colour the app never uses, so "fillStyle did not change" is
+    // unambiguous. `fillStyle` normalises to lowercase hex.
+    const SENTINEL = "#ff00ff";
+
     // Resolve any CSS colour string — rgb(), oklab(), color-mix(), color() —
-    // to straight-alpha sRGB by painting one pixel and reading it back.
+    // to sRGB by painting one pixel and reading it back.
     const canvas = document.createElement("canvas");
     canvas.width = canvas.height = 1;
     const ctx = canvas.getContext("2d", { willReadFrequently: true })!;
     const resolve = (css: string): { rgb: number[]; a: number } => {
       ctx.clearRect(0, 0, 1, 1);
+      // Assigning an unparseable value to `fillStyle` is a no-op — it keeps
+      // the PREVIOUS value, in chromium, firefox and webkit alike. Without a
+      // sentinel, a colour syntax some engine doesn't support would silently
+      // measure whatever was sampled before it, which reads as a real number.
+      ctx.fillStyle = SENTINEL;
       ctx.fillStyle = css;
+      if (ctx.fillStyle === SENTINEL && css.toLowerCase() !== SENTINEL) {
+        throw new Error(`browser could not parse the colour: ${css}`);
+      }
       ctx.fillRect(0, 0, 1, 1);
       const d = ctx.getImageData(0, 0, 1, 1).data;
-      const a = d[3] / 255;
-      const straight = (c: number) => (a === 0 ? 0 : Math.min(255, c / a));
-      return { rgb: [straight(d[0]), straight(d[1]), straight(d[2])], a };
+      // `getImageData` returns STRAIGHT (non-premultiplied) alpha — verified
+      // in all three engines: `rgba(255,0,0,0.2)` reads back as [255,0,0,51],
+      // not [51,0,0,51]. Do NOT divide by alpha here. An earlier revision did,
+      // which inflated and clamped every translucent colour: the
+      // `bg-accent/20` DM bubble resolved to a nonsense rgb(204,255,255)
+      // instead of rgb(204,224,250), and the fabricated contrast number that
+      // produced was quoted as evidence before anyone measured the real modal.
+      return { rgb: [d[0], d[1], d[2]], a: d[3] / 255 };
     };
 
-    const composite = (
-      fg: { rgb: number[]; a: number },
-      bg: number[]
-    ): number[] => fg.rgb.map((c, i) => c * fg.a + bg[i] * (1 - fg.a));
+    const over = (fg: { rgb: number[]; a: number }, bg: number[]): number[] =>
+      fg.rgb.map((c, i) => c * fg.a + bg[i] * (1 - fg.a));
 
     /**
      * The opaque colour actually behind `el`: walk ancestors collecting
      * backgrounds until an opaque one is found, then composite back down.
-     * A bubble's own background can be translucent (the DM rail uses
-     * `bg-accent/20`), so reading only the nearest one would measure against
-     * a colour no pixel ever has.
+     * A bubble's own background can be translucent — the outgoing DM bubble
+     * is `bg-accent/20` — so reading only the nearest one would measure
+     * against a colour no pixel ever has.
      */
     const effectiveBackground = (el: Element): number[] => {
       const layers: { rgb: number[]; a: number }[] = [];
@@ -96,53 +117,81 @@ async function sampleBubbleQuote(
       }
       // Nothing opaque anywhere up the chain: the canvas is white.
       let base = [255, 255, 255];
-      for (let i = layers.length - 1; i >= 0; i--) base = composite(layers[i], base);
+      for (let i = layers.length - 1; i >= 0; i--) base = over(layers[i], base);
       return base;
     };
 
-    const history = document.querySelector('[data-testid="conversation-history"]');
-    if (!history) throw new Error("no conversation-history container rendered");
+    let bubble: Element;
+    let quoteEl: Element;
+    let normalEl: Element;
+    let cleanup = () => {};
 
-    // Find the message body whose NEAREST bubble ancestor is the requested
-    // kind. A `.${bubbleClass} .prose` descendant selector would be wrong: it
-    // matches whenever the class appears ANYWHERE above the body, so a sent
-    // (`bg-accent`) bubble nested under some unrelated `bg-surface` wrapper
-    // would answer to the received query and the test would silently measure
-    // the wrong bubble.
-    const prose = Array.from(history.querySelectorAll(".prose")).find((el) => {
-      const bubble = el.closest(".bg-accent, .bg-surface");
-      return bubble?.classList.contains(bubbleClass) ?? false;
-    });
-    if (!prose) {
-      throw new Error(`no .${bubbleClass} bubble with a .prose body rendered`);
+    if (which === "dm") {
+      // The outgoing DM bubble IS the `.prose` container (dm_thread_modal.rs),
+      // and it already holds a real `<blockquote>` — `openDmThread` sent one.
+      const container = document.querySelector("#dm-scroll-container");
+      if (!container) throw new Error("DM thread modal is not open");
+      const bq = container.querySelector("blockquote");
+      if (!bq) throw new Error("no blockquote in the DM thread");
+      bubble = bq.closest("[class*='bg-accent']") ?? bq.parentElement!;
+      quoteEl = bq;
+      const p = Array.from(bubble.querySelectorAll("p")).find(
+        (el) => !el.closest("blockquote")
+      );
+      if (!p) throw new Error("DM bubble has no non-quoted paragraph");
+      normalEl = p;
+    } else {
+      const history = document.querySelector(
+        '[data-testid="conversation-history"]'
+      );
+      if (!history) throw new Error("no conversation-history container");
+
+      // Find the message body whose NEAREST bubble ancestor is the requested
+      // kind. A `.bg-accent .prose` descendant selector would be wrong: it
+      // matches whenever the class appears ANYWHERE above the body, so a sent
+      // bubble nested under an unrelated `bg-surface` wrapper would answer to
+      // the received query and the test would measure the wrong bubble.
+      const wanted = which === "sent" ? "bg-accent" : "bg-surface";
+      const prose = Array.from(history.querySelectorAll(".prose")).find((el) => {
+        const b = el.closest(".bg-accent, .bg-surface");
+        return b?.classList.contains(wanted) ?? false;
+      });
+      if (!prose) throw new Error(`no .${wanted} bubble with a .prose body`);
+
+      // Inject a quote and an ordinary paragraph as siblings inside the real
+      // body container, so both are measured under the identical cascade.
+      const probe = document.createElement("div");
+      probe.innerHTML =
+        "<p data-probe-normal>normal</p>" +
+        "<blockquote data-probe-quote><p>quoted</p></blockquote>";
+      prose.appendChild(probe);
+      cleanup = () => probe.remove();
+
+      bubble = prose;
+      normalEl = probe.querySelector("[data-probe-normal]")!;
+      quoteEl = probe.querySelector("[data-probe-quote]")!;
     }
 
-    // Inject a quote and an ordinary paragraph as siblings inside the real
-    // body container, so both are measured under the identical cascade.
-    const probe = document.createElement("div");
-    probe.innerHTML =
-      "<p data-probe-normal>normal</p>" +
-      "<blockquote data-probe-quote><p>quoted</p></blockquote>";
-    prose.appendChild(probe);
+    try {
+      const background = effectiveBackground(bubble);
+      return {
+        background,
+        normal: over(resolve(getComputedStyle(normalEl).color), background),
+        quote: over(resolve(getComputedStyle(quoteEl).color), background),
+        quoteBorder: over(
+          resolve(getComputedStyle(quoteEl).borderLeftColor),
+          background
+        ),
+      };
+    } finally {
+      cleanup();
+    }
+  }, surface);
 
-    const normalEl = probe.querySelector("[data-probe-normal]")!;
-    const quoteEl = probe.querySelector("[data-probe-quote]")!;
-
-    const background = effectiveBackground(prose);
-    const out = {
-      background,
-      normal: composite(resolve(getComputedStyle(normalEl).color), background),
-      quote: composite(resolve(getComputedStyle(quoteEl).color), background),
-      quoteBorder: composite(
-        resolve(getComputedStyle(quoteEl).borderLeftColor),
-        background
-      ),
-    };
-
-    probe.remove();
-    return out;
-  }, kind) as Promise<Sample>;
+  return raw as Sample;
 }
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
 
 async function openRoomWithMessages(page: Page) {
   await page.goto("/");
@@ -158,10 +207,62 @@ async function openRoomWithMessages(page: Page) {
   ).not.toHaveCount(0, { timeout: 15_000 });
 }
 
-// WCAG 2.1 AA: 4.5:1 for body text, 3:1 for the non-text graphics that carry
-// meaning (here, the bar marking a quote as a quote).
-const AA_TEXT = 4.5;
-const AA_NON_TEXT = 3;
+/**
+ * Open a DM thread and send one quoted message into it.
+ *
+ * Example data ships zero DMs, so the outgoing bubble has to be created. The
+ * member-info → "Send direct message" route mirrors `dm-thread-modal.spec.ts`.
+ */
+async function openDmThread(page: Page) {
+  await page.goto("/");
+  await page.waitForSelector(".app-root", { timeout: 30_000 });
+  await page.getByText("Team Chat Room").first().click();
+
+  const members = page.locator('button[title^="Member ID"]');
+  await members.first().waitFor({ state: "visible", timeout: 15_000 });
+
+  // Member names are randomised per load and the local user's "(You)" row can
+  // appear anywhere, so pick the first row that is not us.
+  const count = await members.count();
+  let opened = false;
+  for (let i = 0; i < count; i++) {
+    const text = (await members.nth(i).textContent()) ?? "";
+    if (!/\(You\)/i.test(text)) {
+      await members.nth(i).click();
+      opened = true;
+      break;
+    }
+  }
+  expect(opened, "example data should list at least one other member").toBe(true);
+
+  await page.locator('button[aria-label="Send direct message"]').first().click();
+  await page.waitForSelector("#dm-scroll-container", { timeout: 15_000 });
+
+  const composer = page.getByPlaceholder("Type a direct message...");
+  await composer.fill("They wrote:\n\n> this is quoted text\n\nMy reply.");
+  await page.keyboard.press("Enter");
+  await page
+    .locator("#dm-scroll-container blockquote")
+    .first()
+    .waitFor({ timeout: 15_000 });
+}
+
+// ── Assertions shared by every surface ──────────────────────────────────────
+
+function expectNotInverted(s: Sample) {
+  // The reported symptom, stated directly: the sent bubble is white text on
+  // brand blue, and the quote used to be near-black — i.e. it sat on the
+  // OPPOSITE side of the background's luminance from every other word in the
+  // same bubble. This fails on that regression even if some future palette
+  // happened to keep the raw ratio above AA.
+  const bg = luminance(s.background);
+  expect(
+    Math.sign(luminance(s.quote) - bg),
+    `quoted text must not invert against its own bubble: normal text ` +
+      `rgb(${s.normal.map(Math.round)}) vs quote ` +
+      `rgb(${s.quote.map(Math.round)}) over rgb(${s.background.map(Math.round)})`
+  ).toBe(Math.sign(luminance(s.normal) - bg));
+}
 
 for (const colorScheme of ["dark", "light"] as const) {
   test.describe(`Blockquote contrast (${colorScheme} mode)`, () => {
@@ -174,24 +275,12 @@ for (const colorScheme of ["dark", "light"] as const) {
       page,
     }) => {
       await openRoomWithMessages(page);
-      const s = await sampleBubbleQuote(page, "bg-accent");
+      const s = await sampleQuote(page, "sent");
 
       const quote = contrast(s.quote, s.background);
       const normal = contrast(s.normal, s.background);
 
-      // The reported symptom, stated directly: the sent bubble is white text
-      // on brand blue, and the quote used to be near-black — i.e. it sat on
-      // the OPPOSITE side of the background's luminance from every other word
-      // in the same bubble. This assertion fails on that regression even if
-      // some future palette happened to keep the raw ratio above AA.
-      const bgLum = luminance(s.background);
-      expect(
-        Math.sign(luminance(s.quote) - bgLum),
-        `quoted text must not invert against its own bubble: normal text ` +
-          `rgb(${s.normal.map(Math.round)}) vs quote ` +
-          `rgb(${s.quote.map(Math.round)}) over rgb(${s.background.map(Math.round)})`
-      ).toBe(Math.sign(luminance(s.normal) - bgLum));
-
+      expectNotInverted(s);
       expect(quote, "quoted text must clear the WCAG AA floor").toBeGreaterThanOrEqual(
         AA_TEXT
       );
@@ -214,27 +303,38 @@ for (const colorScheme of ["dark", "light"] as const) {
       ).toBeGreaterThanOrEqual(AA_NON_TEXT);
     });
 
-    test("quoted text in a received (surface) bubble stays readable", async ({
-      page,
-    }) => {
-      await openRoomWithMessages(page);
-      const s = await sampleBubbleQuote(page, "bg-surface");
+    // The two muted surfaces. A quote here is deliberately dimmer than its
+    // normal text — it just has to stay above AA while doing it, which the
+    // app-wide `--color-text-muted` did not in light mode (4.47:1 received,
+    // 3.96:1 DM). Both bounds are asserted: without the upper one, deleting
+    // `--color-text-quote`'s light value makes `var()` invalid, the quote
+    // inherits full body colour, and every floor-only assertion still passes.
+    for (const surface of ["received", "dm"] as const) {
+      const label = surface === "received" ? "a received (surface)" : "an outgoing DM";
+      test(`quoted text in ${label} bubble is readable and still muted`, async ({
+        page,
+      }) => {
+        if (surface === "dm") {
+          await openDmThread(page);
+        } else {
+          await openRoomWithMessages(page);
+        }
+        const s = await sampleQuote(page, surface);
 
-      const bgLum = luminance(s.background);
-      expect(
-        Math.sign(luminance(s.quote) - bgLum),
-        `quoted text must not invert against its own bubble: normal text ` +
-          `rgb(${s.normal.map(Math.round)}) vs quote ` +
-          `rgb(${s.quote.map(Math.round)}) over rgb(${s.background.map(Math.round)})`
-      ).toBe(Math.sign(luminance(s.normal) - bgLum));
+        const quote = contrast(s.quote, s.background);
+        const normal = contrast(s.normal, s.background);
 
-      // A received quote IS deliberately muted relative to its normal text —
-      // it just has to stay above AA while doing it, which the app-wide
-      // `--color-text-muted` did not (4.47:1 in light mode).
-      expect(
-        contrast(s.quote, s.background),
-        "quoted text must clear the WCAG AA floor"
-      ).toBeGreaterThanOrEqual(AA_TEXT);
-    });
+        expectNotInverted(s);
+        expect(
+          quote,
+          "quoted text must clear the WCAG AA floor"
+        ).toBeGreaterThanOrEqual(AA_TEXT);
+        expect(
+          quote,
+          "a quote outside the accent bubble must stay visibly secondary to " +
+            "its normal text, not collapse into the body colour"
+        ).toBeLessThan(normal * 0.8);
+      });
+    }
   });
 }

--- a/ui/tests/blockquote-contrast.spec.ts
+++ b/ui/tests/blockquote-contrast.spec.ts
@@ -1,0 +1,240 @@
+import { test, expect, Page } from "@playwright/test";
+
+// Regression test: quoted text (`> …` Markdown) inside a message bubble must
+// stay legible, and must not invert against the bubble it sits in.
+//
+// The reported bug: in a SENT bubble — solid brand blue, every other word
+// white — `.bg-accent .prose blockquote` painted the quote `rgba(0, 0, 0, 0.8)`.
+// Quoted text rendered near-black beside white text at 3.52:1, under the 4.5:1
+// WCAG AA floor. `.bg-accent` is the same blue in light and dark mode, so the
+// bug was present in BOTH schemes even though it was reported against dark.
+//
+// The Rust pin (`conversation.rs::sent_bubble_blockquote_inherits_bubble_text_colour`)
+// asserts the declaration text. This spec asserts what a reader actually sees:
+// it injects a blockquote into a REAL rendered bubble, so the class list, the
+// cascade and the compiled stylesheet are all the app's own, then composites
+// the colours the browser computed and measures the contrast.
+
+// ── WCAG 2.x relative luminance / contrast ──────────────────────────────────
+
+type Rgb = [number, number, number];
+
+function luminance([r, g, b]: Rgb): number {
+  const channel = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+function contrast(fg: Rgb, bg: Rgb): number {
+  const a = luminance(fg);
+  const b = luminance(bg);
+  const [hi, lo] = a > b ? [a, b] : [b, a];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// ── Sampling the live DOM ───────────────────────────────────────────────────
+
+interface Sample {
+  background: Rgb;
+  normal: Rgb;
+  quote: Rgb;
+  quoteBorder: Rgb;
+}
+
+/**
+ * Inject a blockquote into a real message bubble, read back what the browser
+ * computed, and remove it again.
+ *
+ * `kind` picks the bubble by the class the app itself renders: `bg-accent` is
+ * the local user's own bubble (white text on brand blue), `bg-surface` is a
+ * received one.
+ */
+async function sampleBubbleQuote(
+  page: Page,
+  kind: "bg-accent" | "bg-surface"
+): Promise<Sample> {
+  return page.evaluate((bubbleClass) => {
+    // Resolve any CSS colour string — rgb(), oklab(), color-mix(), color() —
+    // to straight-alpha sRGB by painting one pixel and reading it back.
+    const canvas = document.createElement("canvas");
+    canvas.width = canvas.height = 1;
+    const ctx = canvas.getContext("2d", { willReadFrequently: true })!;
+    const resolve = (css: string): { rgb: number[]; a: number } => {
+      ctx.clearRect(0, 0, 1, 1);
+      ctx.fillStyle = css;
+      ctx.fillRect(0, 0, 1, 1);
+      const d = ctx.getImageData(0, 0, 1, 1).data;
+      const a = d[3] / 255;
+      const straight = (c: number) => (a === 0 ? 0 : Math.min(255, c / a));
+      return { rgb: [straight(d[0]), straight(d[1]), straight(d[2])], a };
+    };
+
+    const composite = (
+      fg: { rgb: number[]; a: number },
+      bg: number[]
+    ): number[] => fg.rgb.map((c, i) => c * fg.a + bg[i] * (1 - fg.a));
+
+    /**
+     * The opaque colour actually behind `el`: walk ancestors collecting
+     * backgrounds until an opaque one is found, then composite back down.
+     * A bubble's own background can be translucent (the DM rail uses
+     * `bg-accent/20`), so reading only the nearest one would measure against
+     * a colour no pixel ever has.
+     */
+    const effectiveBackground = (el: Element): number[] => {
+      const layers: { rgb: number[]; a: number }[] = [];
+      let node: Element | null = el;
+      while (node) {
+        const c = resolve(getComputedStyle(node).backgroundColor);
+        if (c.a > 0) {
+          layers.push(c);
+          if (c.a === 1) break;
+        }
+        node = node.parentElement;
+      }
+      // Nothing opaque anywhere up the chain: the canvas is white.
+      let base = [255, 255, 255];
+      for (let i = layers.length - 1; i >= 0; i--) base = composite(layers[i], base);
+      return base;
+    };
+
+    const history = document.querySelector('[data-testid="conversation-history"]');
+    if (!history) throw new Error("no conversation-history container rendered");
+
+    // Find the message body whose NEAREST bubble ancestor is the requested
+    // kind. A `.${bubbleClass} .prose` descendant selector would be wrong: it
+    // matches whenever the class appears ANYWHERE above the body, so a sent
+    // (`bg-accent`) bubble nested under some unrelated `bg-surface` wrapper
+    // would answer to the received query and the test would silently measure
+    // the wrong bubble.
+    const prose = Array.from(history.querySelectorAll(".prose")).find((el) => {
+      const bubble = el.closest(".bg-accent, .bg-surface");
+      return bubble?.classList.contains(bubbleClass) ?? false;
+    });
+    if (!prose) {
+      throw new Error(`no .${bubbleClass} bubble with a .prose body rendered`);
+    }
+
+    // Inject a quote and an ordinary paragraph as siblings inside the real
+    // body container, so both are measured under the identical cascade.
+    const probe = document.createElement("div");
+    probe.innerHTML =
+      "<p data-probe-normal>normal</p>" +
+      "<blockquote data-probe-quote><p>quoted</p></blockquote>";
+    prose.appendChild(probe);
+
+    const normalEl = probe.querySelector("[data-probe-normal]")!;
+    const quoteEl = probe.querySelector("[data-probe-quote]")!;
+
+    const background = effectiveBackground(prose);
+    const out = {
+      background,
+      normal: composite(resolve(getComputedStyle(normalEl).color), background),
+      quote: composite(resolve(getComputedStyle(quoteEl).color), background),
+      quoteBorder: composite(
+        resolve(getComputedStyle(quoteEl).borderLeftColor),
+        background
+      ),
+    };
+
+    probe.remove();
+    return out;
+  }, kind) as Promise<Sample>;
+}
+
+async function openRoomWithMessages(page: Page) {
+  await page.goto("/");
+  await page.waitForSelector(".app-root", { timeout: 30_000 });
+
+  // "Your Private Room" is the example-data room the local user owns, so it
+  // carries both self-authored (bg-accent) and received (bg-surface) bubbles.
+  const roomBtn = page.getByRole("button", { name: "Your Private Room" });
+  await expect(roomBtn).toBeVisible({ timeout: 15_000 });
+  await roomBtn.click();
+  await expect(
+    page.locator('[data-testid="conversation-history"] .prose')
+  ).not.toHaveCount(0, { timeout: 15_000 });
+}
+
+// WCAG 2.1 AA: 4.5:1 for body text, 3:1 for the non-text graphics that carry
+// meaning (here, the bar marking a quote as a quote).
+const AA_TEXT = 4.5;
+const AA_NON_TEXT = 3;
+
+for (const colorScheme of ["dark", "light"] as const) {
+  test.describe(`Blockquote contrast (${colorScheme} mode)`, () => {
+    // A desktop viewport on every project: the mobile projects hide the
+    // conversation pane behind view switching, which this test has no reason
+    // to exercise — the stylesheet under test is viewport-independent.
+    test.use({ colorScheme, viewport: { width: 1280, height: 900 } });
+
+    test("quoted text in an own (accent) bubble matches the bubble's text", async ({
+      page,
+    }) => {
+      await openRoomWithMessages(page);
+      const s = await sampleBubbleQuote(page, "bg-accent");
+
+      const quote = contrast(s.quote, s.background);
+      const normal = contrast(s.normal, s.background);
+
+      // The reported symptom, stated directly: the sent bubble is white text
+      // on brand blue, and the quote used to be near-black — i.e. it sat on
+      // the OPPOSITE side of the background's luminance from every other word
+      // in the same bubble. This assertion fails on that regression even if
+      // some future palette happened to keep the raw ratio above AA.
+      const bgLum = luminance(s.background);
+      expect(
+        Math.sign(luminance(s.quote) - bgLum),
+        `quoted text must not invert against its own bubble: normal text ` +
+          `rgb(${s.normal.map(Math.round)}) vs quote ` +
+          `rgb(${s.quote.map(Math.round)}) over rgb(${s.background.map(Math.round)})`
+      ).toBe(Math.sign(luminance(s.normal) - bgLum));
+
+      expect(quote, "quoted text must clear the WCAG AA floor").toBeGreaterThanOrEqual(
+        AA_TEXT
+      );
+
+      // Inside the sent bubble the quote takes the bubble's own colour, so it
+      // should read as no dimmer than the surrounding text. White on the
+      // accent blue is only ~5.2:1 to begin with, which leaves no headroom to
+      // dim a quote and stay above AA — hence `inherit` rather than a tint.
+      expect(
+        quote,
+        "quoted text in an own bubble must be no dimmer than its normal text"
+      ).toBeGreaterThanOrEqual(normal * 0.95);
+
+      // The quote bar is the only marker left once the text colour matches;
+      // it used to be `--color-accent-hover` on `--color-accent`, i.e. 1.29:1
+      // and effectively invisible.
+      expect(
+        contrast(s.quoteBorder, s.background),
+        "the quote bar must be visible against the bubble"
+      ).toBeGreaterThanOrEqual(AA_NON_TEXT);
+    });
+
+    test("quoted text in a received (surface) bubble stays readable", async ({
+      page,
+    }) => {
+      await openRoomWithMessages(page);
+      const s = await sampleBubbleQuote(page, "bg-surface");
+
+      const bgLum = luminance(s.background);
+      expect(
+        Math.sign(luminance(s.quote) - bgLum),
+        `quoted text must not invert against its own bubble: normal text ` +
+          `rgb(${s.normal.map(Math.round)}) vs quote ` +
+          `rgb(${s.quote.map(Math.round)}) over rgb(${s.background.map(Math.round)})`
+      ).toBe(Math.sign(luminance(s.normal) - bgLum));
+
+      // A received quote IS deliberately muted relative to its normal text —
+      // it just has to stay above AA while doing it, which the app-wide
+      // `--color-text-muted` did not (4.47:1 in light mode).
+      expect(
+        contrast(s.quote, s.background),
+        "quoted text must clear the WCAG AA floor"
+      ).toBeGreaterThanOrEqual(AA_TEXT);
+    });
+  });
+}

--- a/ui/tests/responsive-layout.spec.ts
+++ b/ui/tests/responsive-layout.spec.ts
@@ -294,6 +294,16 @@ test.describe("Sandboxed iframe embedding", () => {
   const sandboxAttrs =
     "allow-scripts allow-forms allow-popups allow-same-origin";
 
+  // These two tests build their own page with `setContent`, so the iframe
+  // `src` is the only thing pointing at the app — `baseURL` does not apply to
+  // it automatically. Hardcoding `http://localhost:8082` made them test
+  // whatever happened to be on the suite's DEFAULT port rather than the build
+  // under test, which is exactly the shared-port trap AGENTS.md warns about:
+  // run the suite against a second checkout on another port (or with 8082
+  // already taken by someone else's server) and these two silently measured a
+  // different build. Read the same env var the other specs use.
+  const APP_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8082";
+
   test("app renders inside a sandboxed iframe", async ({ page }) => {
     await page.setContent(`
       <!DOCTYPE html>
@@ -301,7 +311,7 @@ test.describe("Sandboxed iframe embedding", () => {
       <body style="margin:0;padding:0;height:100vh;">
         <iframe
           sandbox="${sandboxAttrs}"
-          src="http://localhost:8082"
+          src="${APP_URL}"
           style="width:100%;height:100%;border:none;"
         ></iframe>
       </body>
@@ -325,7 +335,7 @@ test.describe("Sandboxed iframe embedding", () => {
       <body style="margin:0;padding:0;height:100vh;">
         <iframe
           sandbox="${sandboxAttrs}"
-          src="http://localhost:8082"
+          src="${APP_URL}"
           style="width:100%;height:100%;border:none;"
         ></iframe>
       </body>


### PR DESCRIPTION
## Problem

A `> quoted` line inside the local user's **own** message bubble rendered near-black while every other word in the same bubble was white.

`.bg-accent` is the sent-message bubble — solid brand blue with `text-white`. The blockquote override painted the quote `rgba(0, 0, 0, 0.8)`:

```css
.bg-accent .prose blockquote {
  border-left: 3px solid var(--color-accent-hover);
  color: rgba(0, 0, 0, 0.8);
}
```

That composites to **3.52:1** against the bubble — under the 4.5:1 WCAG AA floor, and *inverted* relative to the 5.23:1 white text right beside it. `--color-accent` is the same blue in light and dark mode, so this was broken in **both** schemes, not only the dark mode it was reported against. The border made it worse: `--color-accent-hover` on `--color-accent` is **1.29:1**, effectively invisible, so a quote in a sent bubble had no marker beyond the indent.

Measuring the other quote surfaces turned up two more sub-AA cases, both from `--color-text-muted` — and both in **light** mode:

| surface | before | after |
|---|---|---|
| sent bubble, dark | **3.52:1** | 5.23:1 (matches its normal text) |
| sent bubble, light | **3.52:1** | 5.23:1 (matches its normal text) |
| outgoing DM bubble, light | **3.96:1** ← worst in the app | 4.97:1 |
| received bubble, light | **4.47:1** | 5.61:1 |
| outgoing DM bubble, dark | 5.56:1 | 7.55:1 |
| received bubble, dark | 5.93:1 | 8.05:1 |
| sent-bubble quote bar | **1.29:1** | 3.34:1 |

## Approach

**Sent bubbles take the bubble's own text colour** (`color: inherit`) instead of a hardcoded one, so the quote can't drift from the bubble's palette again, plus a translucent-white bar for the affordance. Dimming is deliberately *not* how the quote is marked here: white on the accent blue is only 5.23:1 to begin with, so any meaningful reduction falls under AA. This is the same convention `.bg-accent .prose a` (white + underline) and the reply strip (`bg-white/25 text-white/90`) already use.

**A dedicated `--color-text-quote` token** for the non-accent surfaces, rather than nudging `--color-text-muted`. The muted token is tuned for glanceable metadata (timestamps, field labels) and changing it would repaint every timestamp, placeholder and label in the app; a quote is body text and needs to clear AA. This part goes beyond the literal report — it is the "any similar issue in light mode" half — and is easy to drop if you'd rather keep the muted colour.

## Testing

`ui/tests/blockquote-contrast.spec.ts` (new) measures three real surfaces × both colour schemes: the sent bubble, the received bubble, and the outgoing DM bubble (which has no example data, so the test sends a real DM to create one). It composites the colours the browser computed and measures WCAG contrast. Beyond the AA floor it asserts:

- the quote must not sit on the opposite side of the background's luminance from the normal text in the same bubble — the reported symptom, stated directly;
- outside the accent bubble, the quote must stay visibly *secondary* to its normal text, so a change that makes it merely legible by collapsing it into the body colour also fails.

**Every assertion is mutation-verified** against the served stylesheet:

| mutation | caught by | observed |
|---|---|---|
| revert the sent-bubble rule | accent tests, both schemes | quote `rgb(0,20,46)` vs normal `rgb(255,255,255)` over `rgb(2,101,231)` |
| revert the base rule to `--color-text-muted` | light received + light DM | 4.470 and 3.961 vs the 4.5 floor |
| delete the **light** `--color-text-quote` | light received + light DM | quote collapses to body colour, 14.60 vs a 11.68 ceiling |
| delete the **dark** `--color-text-quote` | dark received + dark DM | 2.487 and 2.331 vs the 4.5 floor |
| revert the border only | accent tests, both schemes | 1.285 vs the 3.0 floor |
| `color: inherit; color: #111;` (cascade) | Rust sent-bubble pin | winning declaration is `#111`, not `inherit` |

The Rust pins in `conversation.rs` cover the declarations themselves — parsing the *winning* `color` declaration rather than substring-matching, since CSS is last-one-wins — and that `> …` still reaches the stylesheet as a `<blockquote>` through `message_to_html`'s hard-break rewrite.

Full suite: `cargo test -p river-ui --bins` (817) and `--features example-data,no-sync` (822) pass; Playwright passes across chromium / firefox / webkit / mobile-chrome / mobile-safari.

## A wrong number in the first revision of this PR

The original description claimed `--color-text-muted` gave **4.40:1 on a dark-mode DM bubble**. That was wrong in both the scheme and the value, and review caught it. Two compounding causes, both mine:

1. I measured a synthetic page that put the DM bubble on `--color-bg`, not the modal's panel background.
2. My colour helper divided by alpha to "un-premultiply" a `getImageData` readback. `getImageData` already returns straight alpha (verified: `rgba(255,0,0,0.2)` reads back as `[255,0,0,51]`, not `[51,0,0,51]` — in chromium, firefox and webkit alike), so every translucent colour was inflated and clamped. `bg-accent/20` resolved to `rgb(204,255,255)` instead of `rgb(204,224,250)`.

The real DM modal measures **5.56:1 dark** (already fine) and **3.96:1 light** — the worst quote surface in the app, which the wrong number hid entirely. The fix helps it either way, but the justification named the wrong scheme. The spec now measures that surface directly, so the number can't drift from reality again.

## Drive-by: two Playwright tests were measuring the wrong build

`responsive-layout.spec.ts`'s two sandboxed-iframe tests hardcoded `src="http://localhost:8082"` and ignored `PLAYWRIGHT_BASE_URL`, so running the suite on any other port silently pointed them at whatever build occupied 8082 — the shared-port trap AGENTS.md warns about. They failed for exactly that reason during this work (10 failures across all 5 projects) and pass once pointed at the configured base URL, which is what the other specs already do. With the variable unset the fallback is byte-identical to the old literal, so CI behaviour is unchanged.

## Not changed, but measured

- The quote bar in a **dark-mode DM bubble** is 2.36:1 (`--color-accent` on a `bg-accent/20` tint). Decorative, and the quote is identifiable without it, so I left the received/DM bar alone rather than restyling a surface this bug isn't about.
- `.river-mention` in dark mode is ~3.2:1 (accent text on a dark surface). Separate element, separate call — flagging it, not touching it here.
- Two pre-existing flakes surfaced during full-suite runs under heavy CPU load, each passing on retry and each a different test (`invitation-sandbox.spec.ts:197` and `message-layout.spec.ts:485`, both mobile-safari). Neither reproduced on focused repeats (8/8 and clean respectively); unrelated to this diff.

[AI-assisted - Claude]
