### PR TITLE
fix(ui): stop a legacy delegate generation from deleting or dropping rooms

### DIFF
--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -1445,6 +1445,105 @@ mod tests {
         );
     }
 
+    /// freenet/river#590 — THE SESSION BOUNDARY, end to end.
+    ///
+    /// Every other test for this fix stops at one side of the boundary: the
+    /// merge tests prove the room comes back in memory, and the
+    /// `reconcile_room_present` tests prove an explicit rejoin overwrites a
+    /// tombstone. Neither exercises the seam BETWEEN them, and the seam is where
+    /// the bug lived — the merge restored the room, nothing carried that across
+    /// to the save path, and `reconcile_room_present` read the delegate's
+    /// tombstone and wrote nothing. The room then survived exactly one session.
+    ///
+    /// So drive the whole path: merge an older generation's tombstone and a
+    /// newer generation's `Present` through ONE shared `MergeRanks`, drain the
+    /// resurrections the way `hydrate_loaded_rooms` does, and check that the
+    /// delegate write actually happens against a stored `Tombstone`.
+    #[test]
+    fn a_ranked_resurrection_survives_into_the_delegate_write() {
+        use crate::room_data::{MergeAuthority, MergeRanks, Rooms};
+
+        let vk = SigningKey::from_bytes(&[23u8; 32]).verifying_key();
+        let local = crate::room_data::test_minimal_room_data(vk);
+        // NB: do NOT "reset" with `clear_room_rejoined` here. It stamps
+        // SOURCE_RANK_AUTHORITATIVE on the tombstone rank, which is exactly what
+        // makes an in-session leave unresurrectable — it would defeat the
+        // scenario under test. The key is unique to this test, so there is
+        // nothing to reset.
+
+        let mut live = Rooms {
+            map: HashMap::new(),
+            current_room_key: None,
+            removed_rooms: std::collections::HashSet::new(),
+            notification_modes: Default::default(),
+            room_order: Vec::new(),
+            migrated_rooms: Vec::new(),
+        };
+
+        // Merge through the SHARED registry, as `hydrate_loaded_rooms` does — the
+        // resurrection has to survive in the same place the drain reads from, and
+        // a locally-owned `MergeRanks` would prove nothing about that wiring.
+        //
+        // G3 (older) says the user left.
+        let mut g3 = live.clone();
+        g3.removed_rooms.insert(vk);
+        with_identity_source_ranks(|r| {
+            live.merge_from_source(g3, 3, MergeAuthority::OlderSnapshot, r)
+        })
+        .expect("merge must succeed");
+
+        // G20 (newer) says the room is present — a ranked resurrection.
+        let mut g20 = live.clone();
+        g20.removed_rooms.clear();
+        g20.map.insert(vk, local.clone());
+        with_identity_source_ranks(|r| {
+            live.merge_from_source(g20, 20, MergeAuthority::OlderSnapshot, r)
+        })
+        .expect("merge must succeed");
+        assert!(live.map.contains_key(&vk), "restored in memory");
+
+        // The drain, exactly as the production call site does it: COLLECT OUT of
+        // the ranks closure first. `mark_room_rejoined` takes the same
+        // non-reentrant mutex, so marking inside the closure deadlocks — on
+        // single-threaded WASM that hangs the tab rather than failing here.
+        //
+        // The registry is a process-wide static, so assert about THIS room's key
+        // rather than the set's total size; a concurrently-running test may hold
+        // resurrections of its own.
+        let resurrected: Vec<[u8; 32]> =
+            with_identity_source_ranks(|r| r.resurrected.drain().collect());
+        assert!(
+            resurrected.contains(&vk.to_bytes()),
+            "the resurrection must be recorded where the drain can find it"
+        );
+        for k in resurrected {
+            mark_room_rejoined(VerifyingKey::from_bytes(&k).expect("valid key"));
+        }
+        // A second drain must not see it again: `drain()` EMPTIES the set, where a
+        // plain iteration would re-mark every past resurrection on every later
+        // response — the over-broad marking arriving by the back door.
+        assert!(
+            !with_identity_source_ranks(|r| r.resurrected.contains(&vk.to_bytes())),
+            "the drain must REMOVE the key, not merely read it"
+        );
+
+        // The save path is rank-blind: all it has is this flag.
+        let rejoined = REJOINED_THIS_SESSION.with(|s| s.borrow().contains(&vk));
+        assert!(rejoined, "the drain must reach REJOINED_THIS_SESSION");
+
+        let out = reconcile_room_present(Some(&tombstone_slot_bytes()), &vk, &local, rejoined)
+            .expect("reconcile must succeed");
+        let bytes = out.expect(
+            "a ranked resurrection MUST overwrite the delegate's tombstone — \
+             without it the room lives one session and is then gone for good",
+        );
+        match ciborium::de::from_reader::<RoomSlot, _>(&bytes[..]).expect("slot must decode") {
+            RoomSlot::Present(r) => assert_eq!(r.owner_vk, vk),
+            RoomSlot::Tombstone => panic!("wrote a tombstone over a resurrected room"),
+        }
+        clear_room_rejoined(&vk);
+    }
+
     fn present_slot_bytes(room: &RoomData) -> Vec<u8> {
         let mut b = Vec::new();
         ciborium::ser::into_writer(&RoomSlot::Present(Box::new(room.clone())), &mut b).unwrap();

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -297,11 +297,13 @@ pub(crate) fn source_rank_for_delegate_key(key_bytes: &[u8]) -> u32 {
 /// `with_mut`, and from spawned tasks with no Dioxus runtime, where reading a
 /// `GlobalSignal` would panic (the same reasoning as `CURRENT_ROOM_IDENTITY` in
 /// `signing.rs`). Single-threaded WASM, so it never contends.
-static ROOM_IDENTITY_SOURCE_RANKS: LazyLock<Mutex<HashMap<RoomKey, u32>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+static ROOM_IDENTITY_SOURCE_RANKS: LazyLock<Mutex<crate::room_data::MergeRanks>> =
+    LazyLock::new(|| Mutex::new(crate::room_data::MergeRanks::default()));
 
 /// Run `f` against the identity-source-rank registry.
-pub(crate) fn with_identity_source_ranks<R>(f: impl FnOnce(&mut HashMap<RoomKey, u32>) -> R) -> R {
+pub(crate) fn with_identity_source_ranks<R>(
+    f: impl FnOnce(&mut crate::room_data::MergeRanks) -> R,
+) -> R {
     let mut guard = ROOM_IDENTITY_SOURCE_RANKS
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -315,7 +317,9 @@ pub(crate) fn with_identity_source_ranks<R>(f: impl FnOnce(&mut HashMap<RoomKey,
 /// freenet/river#414 guarantee now that merge can adopt an incoming identity).
 pub(crate) fn mark_identity_source_authoritative(room_key: RoomKey) {
     with_identity_source_ranks(|ranks| {
-        ranks.insert(room_key, crate::room_data::SOURCE_RANK_AUTHORITATIVE);
+        ranks
+            .identity
+            .insert(room_key, crate::room_data::SOURCE_RANK_AUTHORITATIVE);
     });
 }
 
@@ -705,6 +709,40 @@ mod tests {
     use super::*;
     use ed25519_dalek::SigningKey;
 
+    /// freenet/river#590: leaving a room must record an AUTHORITATIVE tombstone
+    /// rank, and rejoining must clear it.
+    ///
+    /// This is the hole a reviewer actively cleared as safe before probing it, so
+    /// it is exactly the one that gets tidied away later. Without the stamp, an
+    /// in-session leave sits UNRANKED, a legacy generation that AGREES the room
+    /// is gone stamps its own concrete rank over the implicit maximum, and a
+    /// higher-ranked `Present` from a later generation then resurrects the room —
+    /// which the migration's re-save persists.
+    #[test]
+    fn leaving_records_an_authoritative_tombstone_rank_and_rejoining_clears_it() {
+        // A room key no other test uses: the registry is a process-global.
+        let vk = SigningKey::from_bytes(&[0x7Eu8; 32]).verifying_key();
+        let key = vk.to_bytes();
+
+        clear_room_rejoined(&vk);
+        let after_leave = with_identity_source_ranks(|r| r.tombstone.get(&key).copied());
+        assert_eq!(
+            after_leave,
+            Some(crate::room_data::SOURCE_RANK_AUTHORITATIVE),
+            "an in-session leave must be recorded as authoritative, not left to \
+             the `unwrap_or` default that any agreeing source can displace"
+        );
+
+        mark_room_rejoined(vk);
+        let after_rejoin = with_identity_source_ranks(|r| r.tombstone.get(&key).copied());
+        assert_eq!(
+            after_rejoin, None,
+            "rejoining must clear the tombstone rank — `removed_rooms` and the \
+             rank are two halves of one record and must be cleared together, or a \
+             stale high rank suppresses a later legitimate Present"
+        );
+    }
+
     /// freenet/river#527: the whole generation-ranked identity fix rests on
     /// `LEGACY_DELEGATES` being in AGE order (oldest first), because an entry's
     /// INDEX is used as its authority. `legacy_delegates.toml` is append-only
@@ -1042,7 +1080,7 @@ mod tests {
         // A room key no other test uses: the registry is a process-global.
         let room_key = [0x5Au8; 32];
         mark_identity_source_authoritative(room_key);
-        let rank = with_identity_source_ranks(|ranks| ranks.get(&room_key).copied());
+        let rank = with_identity_source_ranks(|ranks| ranks.identity.get(&room_key).copied());
         assert_eq!(rank, Some(crate::room_data::SOURCE_RANK_AUTHORITATIVE));
         assert!(
             rank.unwrap() > current_delegate_source_rank(),
@@ -4152,6 +4190,22 @@ thread_local! {
     /// re-added). Only an explicit rejoin may overwrite a remote `Tombstone`
     /// slot with `Present`; a background content update to a remotely-left room
     /// adopts the leave rather than resurrecting it (freenet/river#345 round-9).
+    ///
+    /// **freenet/river#590 widens this deliberately, and narrows round-9's
+    /// guarantee.** A ranked MERGE resurrection now also marks the room rejoined
+    /// (see `MergeRanks::resurrected`), because the ranked model cannot cross the
+    /// session boundary — `MergeRanks` is never persisted and `RoomSlot::Tombstone`
+    /// carries no rank — so without it the save path answers `AbortAdoptLeave`
+    /// and the room, correctly restored in memory, stays tombstoned on the
+    /// delegate for good.
+    ///
+    /// The cost, stated rather than inherited silently: a leave performed in
+    /// ANOTHER TAB during the legacy fan-out can now be overwritten by a legacy
+    /// generation's `Present`, which is precisely the case round-9 bought
+    /// `AbortAdoptLeave` to prevent. It is the right trade under this change's
+    /// own asymmetry — a resurrected room can be left again, a deleted `self_sk`
+    /// cannot be recovered — but it IS a narrowing, and a future change that
+    /// widens the marking further should re-argue it here.
     static REJOINED_THIS_SESSION: std::cell::RefCell<HashSet<VerifyingKey>> =
         std::cell::RefCell::new(HashSet::new());
 }
@@ -4172,6 +4226,14 @@ pub fn mark_room_rejoined(owner_vk: VerifyingKey) {
     ROOM_SLOT_STATE.with(|c| {
         c.borrow_mut().remove(&owner_vk);
     });
+    // freenet/river#590: drop any tombstone rank the room carried. `removed_rooms`
+    // has two clearers outside the merge (the explicit-rejoin paths in
+    // `get_response.rs` and `members.rs`, which both call this), and a rank left
+    // behind would suppress a later legitimate `Present` if the room is evicted
+    // again. Both halves of the tombstone record must be cleared together.
+    with_identity_source_ranks(|ranks| {
+        ranks.tombstone.remove(&owner_vk.to_bytes());
+    });
 }
 
 /// Forget that `owner_vk` was rejoined this session. Called when the user leaves
@@ -4183,6 +4245,20 @@ pub fn mark_room_rejoined(owner_vk: VerifyingKey) {
 pub fn clear_room_rejoined(owner_vk: &VerifyingKey) {
     REJOINED_THIS_SESSION.with(|s| {
         s.borrow_mut().remove(owner_vk);
+    });
+    // freenet/river#590: an in-session leave is AUTHORITATIVE, and saying so
+    // explicitly is what makes `presence_survives_tombstone`'s
+    // `unwrap_or(SOURCE_RANK_AUTHORITATIVE)` a defensive default rather than the
+    // load-bearing mechanism. Without this, a legacy generation's tombstone for
+    // the same room — a source that AGREES with the leave — records ITS rank
+    // over the unranked entry, and a higher-ranked `Present` then resurrects the
+    // room and the re-save persists it. Paired with the leave site the same way
+    // `mark_identity_source_authoritative` is.
+    with_identity_source_ranks(|ranks| {
+        ranks.tombstone.insert(
+            owner_vk.to_bytes(),
+            crate::room_data::SOURCE_RANK_AUTHORITATIVE,
+        );
     });
 }
 

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -1065,10 +1065,20 @@ async fn migrate_current_blob_to_per_room(recovery: bool) {
                 // live rooms writes `Loaded` — a zero-live-room completion writes
                 // NOTHING so it can't stomp a concurrent legacy probe's `Migrating`
                 // into a false Empty; the universal backstop owns that terminal.
-                let had_rooms = hydrate_loaded_rooms(
+                // freenet/river#590: the blob is a frozen SNAPSHOT that lives on
+                // the current delegate — not the live current delegate, and not a
+                // legacy delegate either. Under the interrupted-migration
+                // recovery the per-room load has already merged live rooms, and
+                // the blob deliberately survives alongside the per-room keys as a
+                // rollback fallback, so a tombstone it carries for a room the user
+                // has since rejoined would evict the live room and re-save the
+                // tombstone. `OlderSnapshot` at the current delegate's own rank
+                // ties with those rooms, and a tie does not evict.
+                let had_rooms = hydrate_loaded_rooms_with_authority(
                     loaded,
                     false,
                     current_delegate_source_rank(),
+                    crate::room_data::MergeAuthority::OlderSnapshot,
                     worker.attempt(),
                 );
                 if had_rooms {
@@ -1347,6 +1357,32 @@ fn hydrate_loaded_rooms(
     source_rank: u32,
     attempt: u32,
 ) -> bool {
+    // The usual derivation: a legacy delegate is an older snapshot, the current
+    // delegate is authoritative. `migrate_current_blob_to_per_room` is the one
+    // caller that needs neither (freenet/river#590) and uses the explicit form.
+    let authority = if is_legacy_delegate {
+        crate::room_data::MergeAuthority::OlderSnapshot
+    } else {
+        crate::room_data::MergeAuthority::Authoritative
+    };
+    hydrate_loaded_rooms_with_authority(
+        loaded_rooms,
+        is_legacy_delegate,
+        source_rank,
+        authority,
+        attempt,
+    )
+}
+
+/// [`hydrate_loaded_rooms`] with the merge authority stated explicitly, for the
+/// caller whose source is neither the live current delegate nor a legacy one.
+fn hydrate_loaded_rooms_with_authority(
+    loaded_rooms: Rooms,
+    is_legacy_delegate: bool,
+    source_rank: u32,
+    authority: crate::room_data::MergeAuthority,
+    attempt: u32,
+) -> bool {
     // freenet/river#397: a legacy-delegate response means we found the user's
     // rooms under an OLD delegate key and are about to migrate them (Ivvor's
     // case). Announce `Migrating` BEFORE the ROOMS merge below (which is
@@ -1365,16 +1401,51 @@ fn hydrate_loaded_rooms(
     // Tombstone filter for all downstream loops.
     // Includes both: (a) tombstones in the
     // incoming loaded_rooms, and (b) tombstones
-    // already in the current in-memory ROOMS —
-    // because legacy delegates predate the
-    // tombstone field, the receiver's set is
-    // the authoritative one (freenet/river#247).
+    // already in the current in-memory ROOMS.
+    //
+    // NOTE (freenet/river#590): this local set is
+    // used only to filter `room_keys` for the
+    // sync/subscribe loops below — it is NOT what
+    // decides removal. The #247 rationale it used
+    // to carry ("legacy delegates predate the
+    // tombstone field, so the receiver's set is
+    // authoritative") has outlived its premise:
+    // `legacy_delegates.toml` gains an entry on
+    // every WASM bump, so recent legacy
+    // generations carry per-room tombstones
+    // routinely. Removal is decided in
+    // `Rooms::merge_from_source`, where tombstones
+    // are RANKED against the copy held.
+    //
+    // freenet/river#590 follow-up: a room in `ROOMS.removed_rooms` can now come
+    // BACK OUT of it — that is the whole point of ranking tombstones. So a room
+    // this response will RESTORE must not be filtered out here, or it is rescued
+    // from deletion and then arrives inert: never subscribed, never synced, its
+    // signing key never migrated to the delegate. The survival rule is asked of
+    // `MergeRanks` rather than re-derived, so this filter cannot drift from the
+    // merge that runs (deferred) a moment later.
+    //
+    // This filter is answering ahead of a deferred merge, so an INDIVIDUAL answer
+    // can be wrong in either direction when responses interleave — and it is
+    // still sufficient, for a reason worth writing down because nobody will
+    // reconstruct it. Over-inclusion is benign: a duplicate `mark_needs_sync` is
+    // idempotent, and the signing loop reads `ROOMS` at defer time so it migrates
+    // whichever identity actually won. Under-inclusion cannot lose a room,
+    // because a tombstone rank only ever RISES (`.max()`) or is removed, and
+    // removal happens solely in the restore branch — which only a response
+    // carrying `Present` for that room can take, and whose own filter therefore
+    // included it. So every room that ends up in the map appeared in at least one
+    // response's `room_keys`, which is all the per-key, idempotent loops need.
+    let incoming_rank = authority.rank_for(source_rank);
     let tombstoned: std::collections::HashSet<ed25519_dalek::VerifyingKey> = {
         let mut t = loaded_rooms.removed_rooms.clone();
         let cur = ROOMS.read();
         for vk in &cur.removed_rooms {
             t.insert(*vk);
         }
+        crate::components::app::chat_delegate::with_identity_source_ranks(|ranks| {
+            t.retain(|vk| !ranks.presence_survives_tombstone(&vk.to_bytes(), incoming_rank));
+        });
         t
     };
 
@@ -1444,14 +1515,46 @@ fn hydrate_loaded_rooms(
             // came from.
             let merged = crate::components::app::chat_delegate::with_identity_source_ranks(
                 |identity_ranks| {
-                    current_rooms.merge_from_source(loaded_rooms, source_rank, identity_ranks)
+                    current_rooms.merge_from_source(
+                        loaded_rooms,
+                        source_rank,
+                        authority,
+                        identity_ranks,
+                    )
                 },
             );
+            // freenet/river#591: report the failure, then run the post-processing
+            // ANYWAY. The merge is now per-room isolated, so an `Err` means "one
+            // or more rooms failed" and not "nothing merged" — skipping the two
+            // loops below would leave every room that DID merge without its
+            // decrypted secrets or its rebuilt actions_state, rendering
+            // `[Encrypted message - secret vN not available]` until reload.
             if let Err(e) = merged {
-                error!("Failed to merge rooms: {}", e);
+                error!("Failed to merge one or more rooms (others still merged): {e}");
             } else {
                 info!("Successfully merged rooms from delegate");
-
+            }
+            // freenet/river#590: tell the SAVE path about any room the ranked
+            // merge just brought back. It cannot infer it — `MergeRanks` is never
+            // persisted and `RoomSlot::Tombstone` carries no rank, so
+            // `reconcile_room_present` would see a delegate tombstone, answer
+            // `AbortAdoptLeave` and write nothing. The room would then be alive in
+            // memory for this session and tombstoned on the delegate for good,
+            // which is #590's symptom with an extra session in front of it.
+            //
+            // Drained outside the ranks lock: `mark_room_rejoined` takes it too,
+            // and the mutex is not reentrant.
+            let resurrected: Vec<[u8; 32]> =
+                crate::components::app::chat_delegate::with_identity_source_ranks(|ranks| {
+                    ranks.resurrected.drain().collect()
+                });
+            for room_key in resurrected {
+                if let Ok(vk) = ed25519_dalek::VerifyingKey::from_bytes(&room_key) {
+                    info!("Merge resurrected a room a newer generation still holds; marking rejoined so the save path adopts it");
+                    crate::components::app::chat_delegate::mark_room_rejoined(vk);
+                }
+            }
+            {
                 // Re-decrypt ALL secret versions for each room (secrets are #[serde(skip)])
                 for room_data in current_rooms.map.values_mut() {
                     let decrypted = room_data.repopulate_secrets_from_state();
@@ -3078,6 +3181,40 @@ mod tests {
     ///      original bug) is back.
     ///
     /// So pin the wiring itself: the shared registry, the threaded rank, and
+    /// freenet/river#590: a ranked resurrection must be drained into
+    /// `mark_room_rejoined`, or the save path never learns of it.
+    ///
+    /// The merge restoring a room in memory is only half the fix. The save path
+    /// is rank-blind by construction — `MergeRanks` is never persisted and
+    /// `RoomSlot::Tombstone` carries no rank — so `reconcile_room_present` sees
+    /// the delegate's tombstone, answers `AbortAdoptLeave`, and writes nothing.
+    /// The room then lives for exactly one session and is gone for good, which is
+    /// #590's symptom with an extra session in front of it.
+    #[test]
+    fn a_ranked_resurrection_is_drained_into_mark_room_rejoined() {
+        let src = include_str!("response_handler.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+        let body = production
+            .find("fn hydrate_loaded_rooms_with_authority(")
+            .map(|i| &production[i..])
+            .expect("hydrate must exist");
+        let body = &body[..body.find("\n}\n").expect("terminates")];
+        let drain = body
+            .find("ranks.resurrected.drain()")
+            .expect("the resurrection set must be drained after the merge");
+        let mark = body
+            .find("mark_room_rejoined(vk)")
+            .expect("and fed to mark_room_rejoined, which also clears ROOM_SLOT_STATE");
+        assert!(
+            drain < mark,
+            "drain before marking — and the drain must be OUTSIDE the ranks lock, \
+             since mark_room_rejoined takes it too and the mutex is not reentrant"
+        );
+    }
+
     /// the per-generation rank at the legacy call site.
     #[test]
     fn hydrate_wires_the_shared_registry_and_a_per_generation_rank() {
@@ -3100,12 +3237,116 @@ mod tests {
              per hydration makes every conflict keep local and silently reverts #527"
         );
 
-        // (2) The rank passed to the merge is the THREADED parameter.
+        // (2) The rank passed to the merge is the THREADED parameter, and the
+        // authority is derived from whether the RESPONDING delegate is legacy —
+        // a hard-coded `Authoritative` here would let an older generation's
+        // tombstone evict a live room again (freenet/river#590).
         assert!(
             squeezed.contains(&strip_ws(
-                "current_rooms.merge_from_source(loaded_rooms, source_rank, identity_ranks)"
+                "current_rooms.merge_from_source( loaded_rooms, source_rank, authority, identity_ranks,)"
             )),
-            "the merge must be given the threaded per-response source_rank"
+            "the merge must be given the threaded per-response source_rank and authority"
+        );
+        // The authority must be DERIVED in the wrapper and THREADED to the merge —
+        // asserting the derivation exists somewhere in the file is not enough, it
+        // has to be what actually reaches `merge_from_source`.
+        let wrapper = production
+            .find("fn hydrate_loaded_rooms(")
+            .map(|i| &production[i..])
+            .expect("hydrate_loaded_rooms must exist");
+        let wrapper = &wrapper[..wrapper.find("\n}\n").expect("wrapper terminates")];
+        assert!(
+            strip_ws(wrapper).contains(&strip_ws(
+                "let authority = if is_legacy_delegate { crate::room_data::MergeAuthority::OlderSnapshot } else { crate::room_data::MergeAuthority::Authoritative };"
+            )),
+            "the wrapper must derive the authority from is_legacy_delegate"
+        );
+        assert!(
+            strip_ws(wrapper).contains(&strip_ws("hydrate_loaded_rooms_with_authority(")),
+            "and pass it on rather than deriving it a second time downstream"
+        );
+        let inner = production
+            .find("fn hydrate_loaded_rooms_with_authority(")
+            .map(|i| &production[i..])
+            .expect("the explicit form must exist");
+        let inner = &inner[..inner.find("\n}\n").expect("terminates")];
+        assert!(
+            !inner.contains("if is_legacy_delegate {\n        crate::room_data::MergeAuthority"),
+            "the merge must use the PASSED authority, not re-derive it — that would \
+             silently override the blob caller's explicit OlderSnapshot"
+        );
+
+        // freenet/river#590 follow-up: the pre-merge `tombstoned` filter must ask
+        // `MergeRanks` whether a `Present` at this rank survives, not just whether
+        // the room is currently tombstoned. Ranking tombstones created a path
+        // that did not exist before — a room can come BACK OUT of
+        // `removed_rooms` — and a filter blind to it drops the restored room from
+        // `room_keys`, so it is never subscribed, never synced, and its signing
+        // key is never migrated. Rescued from deletion, then inert.
+        let tomb = production
+            .find("let tombstoned: std::collections::HashSet")
+            .map(|i| &production[i..])
+            .expect("the tombstone filter must exist");
+        let tomb = &tomb[..tomb.find("\n    };").expect("filter terminates")];
+        assert!(
+            tomb.contains("presence_survives_tombstone("),
+            "the filter must use the merge's own survival rule, or a room the \
+             merge restores is dropped from the sync/subscribe loops"
+        );
+        assert!(
+            strip_ws(production).contains(&strip_ws(
+                "let incoming_rank = authority.rank_for(source_rank);"
+            )),
+            "and it must rank the response the same way the merge does"
+        );
+
+        // freenet/river#590: EVERY `hydrate_loaded_rooms` call site's
+        // `is_legacy_delegate` argument, pinned by value. Flipping the legacy
+        // per-room site from `true` to `false` restores #590 on the exact path it
+        // was reported for — the derivation and threading pins above both stay
+        // green, because they say nothing about what is fed IN.
+        let sites: Vec<&str> = production
+            .match_indices("hydrate_loaded_rooms(")
+            .map(|(i, _)| {
+                let tail = &production[i..];
+                &tail[..tail
+                    .find(')')
+                    .map(|j| j + 1)
+                    .unwrap_or(tail.len())
+                    .min(tail.len())]
+            })
+            .filter(|c| !c.starts_with("hydrate_loaded_rooms(\n    loaded_rooms"))
+            .collect();
+        assert_eq!(
+            sites.len(),
+            3,
+            "expected three hydrate_loaded_rooms call sites (the blob site uses \
+             the explicit-authority form); got {sites:?}"
+        );
+        let legacy_sites = sites
+            .iter()
+            .filter(|c| strip_ws(c).contains("true,"))
+            .count();
+        assert_eq!(
+            legacy_sites, 1,
+            "exactly ONE call site is the legacy per-room migration and must pass \
+             is_legacy_delegate = true; got {sites:?}"
+        );
+
+        // freenet/river#590: a `rooms_data` blob is a frozen snapshot living on
+        // the current delegate. Classifying it `Authoritative` lets a tombstone it
+        // carries evict a room the user has since rejoined, during the very
+        // interrupted-migration recovery that re-reads it.
+        let blob = production
+            .find("async fn migrate_current_blob_to_per_room(")
+            .map(|i| &production[i..])
+            .expect("blob migration must exist");
+        let blob = &blob[..blob.find("\n}\n").expect("terminates")];
+        assert!(
+            strip_ws(blob).contains(&strip_ws(
+                "crate::room_data::MergeAuthority::OlderSnapshot,"
+            )),
+            "the current-delegate blob must merge as an OlderSnapshot"
         );
 
         // (3) The legacy per-room call site derives the rank from THAT

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -1548,6 +1548,17 @@ fn hydrate_loaded_rooms_with_authority(
                 crate::components::app::chat_delegate::with_identity_source_ranks(|ranks| {
                     ranks.resurrected.drain().collect()
                 });
+            // NOTE — this widens what `REJOINED_THIS_SESSION` means. It used to
+            // say only "the user deliberately did something" (accepted an
+            // invitation, imported an identity); it now also says "the ranks
+            // concluded this room should come back". That is what makes
+            // `present_action(Tombstone, true) = StoreFresh` overwrite the
+            // delegate's tombstone — so a WRONG resurrection is no longer
+            // session-local, it is persisted. The known wrong-resurrection case
+            // is a version downgrade (rank is a proxy for wall-clock, which
+            // running an older build after a newer one breaks). Accepted
+            // deliberately: a wrongly-resurrected room is one the user leaves
+            // again, whereas #590 destroys `self_sk`, which is unrecoverable.
             for room_key in resurrected {
                 if let Ok(vk) = ed25519_dalek::VerifyingKey::from_bytes(&room_key) {
                     info!("Merge resurrected a room a newer generation still holds; marking rejoined so the save path adopts it");
@@ -3199,6 +3210,20 @@ mod tests {
         let drain = body
             .find("ranks.resurrected.drain()")
             .expect("the resurrection set must be drained after the merge");
+        // Anchor the drain to the thing that POPULATES the set, not just to the
+        // marking that consumes it. Hoisting the drain to the top of this
+        // function — next to the `tombstoned` computation, which also takes the
+        // ranks lock, so it is a natural place to consolidate the two
+        // acquisitions — preserves every shape asserted here while draining an
+        // EMPTY set. Nothing is ever marked, `reconcile_room_present` goes back
+        // to `AbortAdoptLeave`, and #590 is silently restored.
+        let merge = body
+            .find("merge_from_source(")
+            .expect("the merge that populates the set must be in this slice");
+        assert!(
+            merge < drain,
+            "the drain must run AFTER the merge that populates the resurrection set"
+        );
         let closure_end = body[drain..]
             .find("});")
             .map(|i| drain + i + 3)

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -3165,22 +3165,6 @@ mod tests {
         );
     }
 
-    /// freenet/river#527 — THE WIRING PIN.
-    ///
-    /// Every behavioural test for the fix lives at the `Rooms::merge_from_source`
-    /// layer and supplies its own ranks map, so they all keep passing if the
-    /// production CALL SITE stops feeding that layer real inputs. Two one-line
-    /// edits revert the entire fix with green CI:
-    ///
-    ///   1. `with_identity_source_ranks(...)` -> `&mut HashMap::new()`. Every
-    ///      conflict then reads `unwrap_or(SOURCE_RANK_AUTHORITATIVE)` for the
-    ///      local rank, so nothing ever outranks it and merge keeps local
-    ///      always — exactly the pre-fix behaviour.
-    ///   2. the threaded `source_rank` -> a constant. Every generation then
-    ///      ranks equal, equal ranks keep local, and first-responder-wins (the
-    ///      original bug) is back.
-    ///
-    /// So pin the wiring itself: the shared registry, the threaded rank, and
     /// freenet/river#590: a ranked resurrection must be drained into
     /// `mark_room_rejoined`, or the save path never learns of it.
     ///
@@ -3202,19 +3186,49 @@ mod tests {
             .map(|i| &production[i..])
             .expect("hydrate must exist");
         let body = &body[..body.find("\n}\n").expect("terminates")];
+        // The drain must COLLECT OUT of the ranks closure, and the marking must
+        // happen after that closure has closed. Textual `drain < mark` ordering
+        // is NOT enough: calling `mark_room_rejoined` inside the closure also
+        // satisfies it, and `mark_room_rejoined` takes the same non-reentrant
+        // `Mutex` — which on single-threaded WASM deadlocks the tab rather than
+        // failing a test.
+        assert!(
+            body.contains("let resurrected: Vec<[u8; 32]> ="),
+            "the drain must collect OUT of the ranks closure into a local"
+        );
         let drain = body
             .find("ranks.resurrected.drain()")
             .expect("the resurrection set must be drained after the merge");
+        let closure_end = body[drain..]
+            .find("});")
+            .map(|i| drain + i + 3)
+            .expect("the ranks closure must close");
         let mark = body
             .find("mark_room_rejoined(vk)")
             .expect("and fed to mark_room_rejoined, which also clears ROOM_SLOT_STATE");
         assert!(
-            drain < mark,
-            "drain before marking — and the drain must be OUTSIDE the ranks lock, \
-             since mark_room_rejoined takes it too and the mutex is not reentrant"
+            mark > closure_end,
+            "mark_room_rejoined must be called AFTER the ranks lock is released — \
+             inside the closure it re-locks a non-reentrant Mutex and hangs the tab"
         );
     }
 
+    /// freenet/river#527 — THE WIRING PIN.
+    ///
+    /// Every behavioural test for the fix lives at the `Rooms::merge_from_source`
+    /// layer and supplies its own ranks map, so they all keep passing if the
+    /// production CALL SITE stops feeding that layer real inputs. Two one-line
+    /// edits revert the entire fix with green CI:
+    ///
+    ///   1. `with_identity_source_ranks(...)` -> `&mut HashMap::new()`. Every
+    ///      conflict then reads `unwrap_or(SOURCE_RANK_AUTHORITATIVE)` for the
+    ///      local rank, so nothing ever outranks it and merge keeps local
+    ///      always — exactly the pre-fix behaviour.
+    ///   2. the threaded `source_rank` -> a constant. Every generation then
+    ///      ranks equal, equal ranks keep local, and first-responder-wins (the
+    ///      original bug) is back.
+    ///
+    /// So pin the wiring itself: the shared registry, the threaded rank, and
     /// the per-generation rank at the legacy call site.
     #[test]
     fn hydrate_wires_the_shared_registry_and_a_per_generation_rank() {

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -38,6 +38,100 @@ pub enum SendMessageError {
 /// (freenet/river#414).
 pub const SOURCE_RANK_AUTHORITATIVE: u32 = u32::MAX;
 
+/// Which delegate generation supplied each room's identity, and each tombstone.
+///
+/// Runtime-only (never persisted): it describes where the in-memory view came
+/// from THIS session. Both halves are needed because a legacy generation's
+/// ABSENCES are older evidence exactly as its presences are (freenet/river#590).
+#[derive(Default, Debug)]
+pub struct MergeRanks {
+    /// Rank of the source that supplied each present room's identity.
+    pub identity: HashMap<RoomKey, u32>,
+    /// Rank of the source that contributed each tombstone.
+    pub tombstone: HashMap<RoomKey, u32>,
+    /// Rooms this merge brought back OUT of `removed_rooms` because a strictly
+    /// newer source held them.
+    ///
+    /// The ranked model stops at the session boundary: `MergeRanks` is never
+    /// persisted and `RoomSlot::Tombstone` is a unit variant that cannot carry a
+    /// rank. So the SAVE path is necessarily rank-blind, and its one
+    /// tombstone-vs-present decision — `reconcile_room_present`'s
+    /// `explicitly_rejoined` flag — would answer `AbortAdoptLeave` and write
+    /// nothing, leaving the room alive in memory for exactly one session and
+    /// tombstoned on the delegate for good.
+    ///
+    /// Drained by `hydrate_loaded_rooms` into `mark_room_rejoined`, which both
+    /// sets that flag and clears the `ROOM_SLOT_STATE` cache entry so the
+    /// content-hash skip cannot suppress the write.
+    pub resurrected: std::collections::HashSet<RoomKey>,
+}
+
+impl MergeRanks {
+    /// Will a `Present` observation at `incoming_rank` survive whatever tombstone
+    /// is currently recorded for `vk`?
+    ///
+    /// This is the merge's own rule, exposed because `hydrate_loaded_rooms` has
+    /// to decide which rooms a response contributed BEFORE the (deferred) merge
+    /// runs. Re-deriving that predicate at the call site is how the read side
+    /// drifts from the write side, so there is exactly one implementation.
+    ///
+    /// An unranked tombstone defaults to `SOURCE_RANK_AUTHORITATIVE`, i.e.
+    /// maximally protected: the only way to be tombstoned without a rank is
+    /// `leave_room` in THIS session, and nothing loaded may undo a leave the user
+    /// just performed.
+    pub fn presence_survives_tombstone(&self, vk: &RoomKey, incoming_rank: u32) -> bool {
+        let tomb = self
+            .tombstone
+            .get(vk)
+            .copied()
+            .unwrap_or(SOURCE_RANK_AUTHORITATIVE);
+        incoming_rank > tomb
+    }
+}
+
+/// What a merge source is permitted to do to the live room set.
+///
+/// freenet/river#590: `merge_from_source` used to treat every source as a peer —
+/// it unioned the incoming `removed_rooms` and then evicted the map against the
+/// combined set. That is right for the current delegate and for an explicit
+/// in-session action, and wrong for a LEGACY delegate generation, which is a
+/// strictly OLDER snapshot: its tombstone for a room the user has since rejoined
+/// would delete the live room, and the migration's re-save would then write that
+/// tombstone over the current delegate's `Present` slot. A room's `self_sk`
+/// cannot be re-derived from the network, so that loss is permanent.
+///
+/// The asymmetry is deliberate and one-directional: an older snapshot may ADD a
+/// room the live set lacks, never remove or replace one it has. Worst case a
+/// room the user left reappears, which they can leave again; the alternative is
+/// unrecoverable.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum MergeAuthority {
+    /// The current delegate, or a deliberate in-session action. Fully
+    /// authoritative: its tombstones remove rooms.
+    Authoritative,
+    /// A legacy delegate generation — a strictly older snapshot. Additive only.
+    OlderSnapshot,
+}
+
+impl MergeAuthority {
+    /// The rank an observation from this source carries.
+    ///
+    /// Note the two scales meet deliberately at the current delegate's number: an
+    /// `Authoritative` source ranks `SOURCE_RANK_AUTHORITATIVE`, while
+    /// `record_identity_source` stores the raw generation number, so a
+    /// current-delegate room sits at `current_delegate_source_rank()` and a
+    /// snapshot merged at that same rank TIES with it — and a tie does not evict.
+    /// That is what makes the `rooms_data` blob safe to merge as an
+    /// `OlderSnapshot` at the current delegate's rank. Do not "tidy" either scale
+    /// without re-checking that tie.
+    pub fn rank_for(self, source_rank: u32) -> u32 {
+        match self {
+            MergeAuthority::Authoritative => SOURCE_RANK_AUTHORITATIVE,
+            MergeAuthority::OlderSnapshot => source_rank,
+        }
+    }
+}
+
 /// What to do with an incoming room copy whose `self_sk` differs from the copy
 /// already in memory.
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -1797,28 +1891,33 @@ impl Rooms {
 
     /// Merge the other Rooms into this Rooms (eg. when Rooms are loaded from storage)
     ///
-    /// Union of `removed_rooms` tombstones: any room key the user has
-    /// explicitly left on either side stays left. Rooms in `removed_rooms`
-    /// are filtered out of the merge — that prevents a legacy delegate's
-    /// stale `rooms_data` from re-adding a room the user has already
-    /// removed (see freenet/river#247).
+    /// Tombstones are RANKED, not unioned (freenet/river#590): a room the user has
+    /// explicitly left stays left, but only against evidence that is not NEWER.
+    /// A legacy delegate's stale `rooms_data` still cannot re-add a room the user
+    /// removed (freenet/river#247), while a strictly newer generation's `Present`
+    /// can override an older generation's tombstone — which is what stops an
+    /// ancient "you left this" from deleting a room you have since rejoined. This
+    /// entry point is fully `Authoritative`; see [`MergeAuthority`].
     ///
-    /// Known limitation (skeptical review, freenet/river#345): the per-room loop
-    /// below `return`s `Err` on the first room whose `room_state.merge` fails,
-    /// so rooms not yet iterated are dropped from THIS merge (they survive only
-    /// if already present). A DIVERGING `self_sk` is not such a case — it is
-    /// resolved per-room by source authority and never returns `Err`. The per-room SAVE path got
-    /// the M1 scoping fix (`reconcile_room_present` keeps local for the one
-    /// diverged room without wedging the others); the load-side merge did not.
-    /// The trigger is rare (it requires the SAME room to already be in memory
-    /// with a different identity than the loaded copy — not the cold-start case,
-    /// where memory is empty), and a re-load recovers the rest, so per-room
-    /// scoping here is left as follow-up rather than risking this broadly-used
-    /// path. Note the consequence is slightly broader than just dropping the
-    /// un-iterated rooms: when this returns `Err`, the caller
-    /// (`hydrate_loaded_rooms`) skips `repopulate_secrets_from_state` for the
-    /// rooms that DID merge in that pass, so a private room can render
-    /// "[Encrypted message - secret vN not available]" until a clean reload.
+    /// The per-room loop is failure-ISOLATED (freenet/river#591): a room whose
+    /// `room_state.merge` fails is logged, skipped, and the loop continues, with
+    /// the accumulated failures returned as one aggregate at the end. It used to
+    /// `return Err` on the first failure, dropping every room later in
+    /// `other.map`'s arbitrary `HashMap` order — and a room absent from the map is
+    /// exactly where the freenet/river#527 rank check does not run, so the next
+    /// legacy generation's copy was then adopted unranked.
+    ///
+    /// Because an `Err` now means "one or more rooms failed" rather than "nothing
+    /// merged", `hydrate_loaded_rooms` runs `repopulate_secrets_from_state` and
+    /// the actions_state rebuild REGARDLESS of the result; skipping them would
+    /// leave the rooms that merged cleanly rendering
+    /// "[Encrypted message - secret vN not available]" until a reload.
+    ///
+    /// Caveat worth knowing: `ChatRoomStateV1::merge` is `apply_delta`, which the
+    /// `#[composable]` macro generates as sequential per-field `?`, so it is not
+    /// atomic — the already-present branch merges through `get_mut`, and a
+    /// failure can leave that one room half-merged. Unchanged by the isolation
+    /// work, and confined to the failing room.
     pub fn merge(&mut self, other: Rooms) -> Result<(), String> {
         // Single-source merge: rank the incoming copy equal to whatever is
         // already in memory, so an identity conflict always keeps local — the
@@ -1831,14 +1930,19 @@ impl Rooms {
         // u32::MAX and permanently disable generation ranking for that session.
         // If you need a caller that records provenance, call `merge_from_source`
         // directly rather than widening this one.
-        let mut ranks = HashMap::new();
-        self.merge_from_source(other, SOURCE_RANK_AUTHORITATIVE, &mut ranks)
+        let mut ranks = MergeRanks::default();
+        self.merge_from_source(
+            other,
+            SOURCE_RANK_AUTHORITATIVE,
+            MergeAuthority::Authoritative,
+            &mut ranks,
+        )
     }
 
     /// Merge a copy of the user's rooms that came from a specific source,
     /// ranked by [`resolve_identity_conflict`] (freenet/river#527).
     ///
-    /// `identity_ranks` records which source supplied the identity each room in
+    /// `ranks` records which source supplied the identity each room in
     /// `self` currently carries, so a copy arriving later from a NEWER delegate
     /// generation can correct one that merely arrived FIRST. A room already in
     /// memory with no recorded rank is treated as authoritative (it was created
@@ -1847,16 +1951,82 @@ impl Rooms {
         &mut self,
         other: Rooms,
         source_rank: u32,
-        identity_ranks: &mut HashMap<RoomKey, u32>,
+        authority: MergeAuthority,
+        ranks: &mut MergeRanks,
     ) -> Result<(), String> {
-        // Tombstones first: take the union before anything else, so the
-        // filter below sees the combined set.
+        // Tombstones are RANKED OBSERVATIONS, not a union (freenet/river#590).
+        //
+        // The fan-out probes every delegate generation at once and each answers
+        // independently, so for one room we may see `Present` from one generation
+        // and `Tombstone` from another. The correct answer is simply whichever
+        // observation came from the NEWEST generation — a legacy generation's
+        // absences are older evidence exactly as its presences are.
+        //
+        // The old code unioned every incoming tombstone and then evicted the map
+        // against the combined set, which lost that ordering entirely: an ancient
+        // "you left this room" deleted a room you had since rejoined, and the
+        // migration's re-save wrote the tombstone to the current delegate, taking
+        // `self_sk` with it. Probes dispatch oldest-first, so the oldest
+        // generation usually answers while the map is still empty — which is why
+        // guarding only "is it in the map right now" is not enough.
+        //
+        // An `Authoritative` source (the current delegate, or a deliberate
+        // in-session action) outranks every generation and is recorded as such.
+        let incoming_rank = authority.rank_for(source_rank);
         for vk in other.removed_rooms {
+            // A room present in the map is held by whichever source supplied it;
+            // an older tombstone must not evict it.
+            if let Some(live_rank) = ranks.identity.get(&vk.to_bytes()).copied() {
+                if self.map.contains_key(&vk) && incoming_rank <= live_rank {
+                    use dioxus::logger::tracing::warn;
+                    warn!(
+                        "Ignoring a tombstone for room {:?} from source rank {} — the \
+                         copy held came from rank {} (freenet/river#590)",
+                        MemberId::from(&vk),
+                        incoming_rank,
+                        live_rank
+                    );
+                    continue;
+                }
+            } else if self.map.contains_key(&vk) && authority == MergeAuthority::OlderSnapshot {
+                // Present with no recorded rank means it was created or imported
+                // in-session, which nothing loaded may override.
+                use dioxus::logger::tracing::warn;
+                warn!(
+                    "Ignoring a legacy tombstone (source rank {}) for room {:?}, which \
+                     was created or imported in-session (freenet/river#590)",
+                    incoming_rank,
+                    MemberId::from(&vk)
+                );
+                continue;
+            }
+            // Record the tombstone at its own rank so a strictly NEWER generation
+            // answering later can still bring the room back.
+            //
+            // An existing UNRANKED tombstone is an in-session `leave_room`, which
+            // `presence_survives_tombstone` reads as `SOURCE_RANK_AUTHORITATIVE`.
+            // Stamping `incoming_rank` over it would DOWNGRADE that leave to some
+            // generation's number, after which a higher-ranked `Present` from the
+            // fan-out resurrects the room and the re-save persists it. The
+            // inversion is the point: it takes a source that AGREES with the
+            // leave to unlock it. `clear_room_rejoined` stamps the rank
+            // explicitly at the leave site; this keeps the invariant true even if
+            // a future leave path forgets to.
+            let implicit_authoritative =
+                self.removed_rooms.contains(&vk) && !ranks.tombstone.contains_key(&vk.to_bytes());
+            let recorded = if implicit_authoritative {
+                SOURCE_RANK_AUTHORITATIVE
+            } else {
+                incoming_rank
+            };
+            let entry = ranks.tombstone.entry(vk.to_bytes()).or_insert(recorded);
+            *entry = (*entry).max(recorded);
             self.removed_rooms.insert(vk);
         }
         // Defensive: if a room ended up in both `map` and `removed_rooms`
         // (shouldn't happen — leave path adds to removed and removes from
-        // map atomically), the tombstone wins.
+        // map atomically), the tombstone wins. After the ranking above this can
+        // only evict on a tombstone that outranks the copy held.
         self.map.retain(|vk, _| !self.removed_rooms.contains(vk));
 
         // Notification preferences: keep this device's choice on conflict (a
@@ -1866,10 +2036,27 @@ impl Rooms {
             self.notification_modes.entry(vk).or_insert(mode);
         }
 
+        // Per-room failures are accumulated rather than propagated, so one bad
+        // room cannot drop the others (freenet/river#591). Still surfaced as an
+        // aggregate at the end, so a failure is not silent.
+        let mut errors: Vec<String> = Vec::new();
         for (vk, mut room_data) in other.map {
-            // Honour tombstones — never re-add a room the user has left.
+            // Honour tombstones — never re-add a room the user has left — UNLESS
+            // this observation comes from a strictly NEWER source than the one
+            // that tombstoned it (freenet/river#590). Probes are dispatched
+            // oldest-first, so without this a stale "you left" from the oldest
+            // generation suppresses the newest generation's `Present` and the
+            // re-save then tombstones the room on the current delegate.
             if self.removed_rooms.contains(&vk) {
-                continue;
+                if !ranks.presence_survives_tombstone(&vk.to_bytes(), incoming_rank) {
+                    continue;
+                }
+                // Strictly newer: the room is back. Record it so the SAVE path
+                // learns about the resurrection — it cannot work it out for
+                // itself, having no ranks (see `MergeRanks::resurrected`).
+                self.removed_rooms.remove(&vk);
+                ranks.tombstone.remove(&vk.to_bytes());
+                ranks.resurrected.insert(vk.to_bytes());
             }
 
             // Identity-conflict guard, BEFORE any contract-key bookkeeping: if
@@ -1900,7 +2087,8 @@ impl Rooms {
             if let Some(existing) = self.map.get(&vk) {
                 if existing.self_sk != room_data.self_sk {
                     use dioxus::logger::tracing::warn;
-                    let local_rank = identity_ranks
+                    let local_rank = ranks
+                        .identity
                         .get(&vk.to_bytes())
                         .copied()
                         .unwrap_or(SOURCE_RANK_AUTHORITATIVE);
@@ -1963,11 +2151,22 @@ impl Rooms {
                         )
                     })
                     .expect("AdoptIncoming implies the room is present");
-                room_data.room_state.merge(
+                // freenet/river#591: isolate the failure to THIS room. A bare
+                // `?` here returned from the whole function, so every room later
+                // in `other.map`'s (arbitrary, unstable) iteration order was
+                // silently never inserted — and a room absent from the map is
+                // exactly where the freenet/river#527 rank check does not run, so
+                // the next legacy generation's copy would be adopted unranked.
+                // Same shape as `do_save_rooms_to_delegate`, which accumulates
+                // per-key errors and keeps going for the same reason.
+                if let Err(e) = room_data.room_state.merge(
                     &room_data.room_state.clone(),
                     &ChatRoomParametersV1 { owner: vk },
                     &existing_state.0,
-                )?;
+                ) {
+                    errors.push(format!("merge adopted room {vk:?}: {e}"));
+                    continue;
+                }
                 // Union the invitation-carried secrets, same rule as the save-side
                 // reconcile (`chat_delegate::reconcile_room_present`): these are
                 // DECRYPTED per-version room secrets, so they are identity-
@@ -1993,7 +2192,7 @@ impl Rooms {
                 // Only now is the map mutated; `insert` replaces the old entry.
                 self.map.insert(vk, room_data);
                 record_identity_source(
-                    identity_ranks,
+                    &mut ranks.identity,
                     &vk,
                     source_rank,
                     /* was_vacant */ true,
@@ -2008,7 +2207,7 @@ impl Rooms {
             // its identity — the very rollback this ordering exists to stop.
             let already_present = self.map.contains_key(&vk);
             if already_present {
-                record_identity_source(identity_ranks, &vk, source_rank, false);
+                record_identity_source(&mut ranks.identity, &vk, source_rank, false);
             }
 
             // If not already in the map, add the room
@@ -2020,14 +2219,53 @@ impl Rooms {
                     // Already present with a matching `self_sk` (the conflict
                     // case was resolved above) — merge in the new state.
                     let self_room_data = self.map.get_mut(&vk).unwrap();
-                    self_room_data.room_state.merge(
+                    // freenet/river#591: per-room isolation, as above.
+                    if let Err(e) = self_room_data.room_state.merge(
                         &self_room_data.room_state.clone(),
                         &ChatRoomParametersV1 { owner: vk },
                         &room_data.room_state,
-                    )?;
+                    ) {
+                        errors.push(format!("merge room {vk:?}: {e}"));
+                        continue;
+                    }
+                    // freenet/river#590: merging ONLY `room_state` made every other
+                    // field first-writer-wins regardless of rank — and probes are
+                    // dispatched oldest-generation-first, so the systematic winner
+                    // was the OLDEST copy. This is the most-travelled of the three
+                    // merge paths (identities usually agree), and it was the only
+                    // one of the three not unioning the secrets: the adopt branch
+                    // above does, and so does the save-side
+                    // `reconcile_room_present`, both calling them
+                    // identity-INDEPENDENT recovery state.
+                    //
+                    // `invitation_secrets` is the one that loses DATA. It is the
+                    // fallback for exactly the case where the owner-signed
+                    // `encrypted_secrets` blob is unavailable — a private-room
+                    // invitee reading history before the owner delegate back-fills
+                    // — so dropping a version leaves those messages undecryptable
+                    // for good. `repopulate_secrets_from_state` cannot recover it:
+                    // it reads the contract blob, which is what is missing.
+                    // Local wins collisions, matching both sibling paths.
+                    for (version, secret) in room_data.invitation_secrets {
+                        self_room_data
+                            .invitation_secrets
+                            .entry(version)
+                            .or_insert(secret);
+                    }
+                    // Same rule as the adopt branch: a nickname the local copy
+                    // lacks is worth taking, or the member-info heal falls back to
+                    // a generated handle.
+                    if self_room_data.self_nickname.is_none() {
+                        self_room_data.self_nickname = room_data.self_nickname;
+                    }
+                    // Deliberately NOT merged: `notification_modes` and
+                    // `room_order` are handled outside this loop as local user
+                    // preferences ("this device wins"), and `last_read_message_id`
+                    // is cosmetic (the unread badge). Those are first-writer-wins
+                    // by design, not by omission.
                     false
                 };
-            record_identity_source(identity_ranks, &vk, source_rank, was_vacant);
+            record_identity_source(&mut ranks.identity, &vk, source_rank, was_vacant);
         }
 
         // Room display order: this device's order is authoritative (a local
@@ -2041,7 +2279,14 @@ impl Rooms {
         }
         self.room_order.retain(|vk| self.map.contains_key(vk));
 
-        Ok(())
+        // Surface accumulated per-room failures as one aggregate: every OTHER
+        // room has still been merged, but the caller must not be told this went
+        // cleanly (freenet/river#591).
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors.join("; "))
+        }
     }
 
     /// Mark a room as explicitly left. Removes from `map`, drops any
@@ -2637,6 +2882,485 @@ mod tests {
         rooms
     }
 
+    /// freenet/river#591 — one room's merge failure must not drop the others.
+    ///
+    /// A bare `?` on the fallible per-room merge returned from the WHOLE
+    /// function, so every room later in `other.map`'s arbitrary, unstable
+    /// iteration order was silently never inserted. A room absent from the map is
+    /// precisely where the freenet/river#527 rank check does not run, so the next
+    /// legacy generation's copy would then be adopted unranked.
+    ///
+    /// This drives REAL merge failures rather than scanning the source: each
+    /// failing room carries a configuration signed by somebody who is not its
+    /// owner, so `ChatRoomStateV1::merge` rejects it.
+    ///
+    /// Two rooms fail deliberately, and the assertion is that BOTH are reported.
+    /// That is what makes this deterministic: `other.map` is a `HashMap`, so any
+    /// assertion of the form "a good room later in the order survived" is a coin
+    /// flip on iteration order. An abort can only ever report the FIRST failure,
+    /// whichever one that is, so counting them is order-independent.
+    #[test]
+    fn a_failing_room_does_not_prevent_the_others_from_merging() {
+        fn forged(owner: VerifyingKey, version: u32) -> RoomData {
+            let mut room = test_minimal_room_data(owner);
+            let mut config = river_core::room_state::configuration::Configuration::default();
+            config.configuration_version = version;
+            room.room_state.configuration =
+                river_core::room_state::configuration::AuthorizedConfigurationV1::new(
+                    config,
+                    &SigningKey::from_bytes(&[99u8; 32]),
+                );
+            room
+        }
+
+        let bad_a = SigningKey::from_bytes(&[21u8; 32]).verifying_key();
+        let bad_b = SigningKey::from_bytes(&[22u8; 32]).verifying_key();
+
+        // Present already, so the merge takes the fallible already-present branch
+        // rather than a vacant insert.
+        let mut live = empty_rooms_for_merge();
+        live.map.insert(bad_a, test_minimal_room_data(bad_a));
+        live.map.insert(bad_b, test_minimal_room_data(bad_b));
+
+        let mut incoming = empty_rooms_for_merge();
+        incoming.map.insert(bad_a, forged(bad_a, 98));
+        incoming.map.insert(bad_b, forged(bad_b, 99));
+
+        let mut ranks = MergeRanks::default();
+        let err = live
+            .merge_from_source(incoming, 5, MergeAuthority::OlderSnapshot, &mut ranks)
+            .expect_err("both rooms must fail to merge");
+
+        assert_eq!(
+            err.matches("merge room").count(),
+            2,
+            "the loop must continue past the first failure and report BOTH — an \
+             abort reports only the first and silently drops every room later in \
+             an arbitrary HashMap order (freenet/river#591). Got: {err}"
+        );
+        assert!(
+            live.map.contains_key(&bad_a) && live.map.contains_key(&bad_b),
+            "a room whose merge failed keeps its previous copy rather than vanishing"
+        );
+    }
+
+    /// freenet/river#590 — a matching-identity merge must not discard the
+    /// incoming copy's `invitation_secrets`.
+    ///
+    /// The non-adopt branch merged only `room_state`, so every other field was
+    /// first-writer-wins regardless of rank — and probes dispatch
+    /// oldest-generation-first, making the systematic winner the OLDEST copy.
+    /// `invitation_secrets` is the field that loses DATA: it is the fallback for
+    /// exactly the case where the owner-signed `encrypted_secrets` blob is
+    /// unavailable, so a dropped version leaves those messages undecryptable for
+    /// good, and `repopulate_secrets_from_state` cannot recover it (it reads the
+    /// contract blob, which is what is missing).
+    ///
+    /// This was the only one of the three merge paths not unioning them — the
+    /// adopt branch and the save-side `reconcile_room_present` both do, and both
+    /// call them identity-INDEPENDENT recovery state.
+    #[test]
+    fn a_matching_identity_merge_unions_invitation_secrets() {
+        let vk = SigningKey::from_bytes(&[41u8; 32]).verifying_key();
+
+        // Oldest generation answers first, carrying no secrets.
+        let mut live = rooms_holding(vk, test_minimal_room_data(vk));
+        let mut ranks = MergeRanks::default();
+        live.merge_from_source(
+            rooms_holding(vk, test_minimal_room_data(vk)),
+            5,
+            MergeAuthority::OlderSnapshot,
+            &mut ranks,
+        )
+        .expect("merge must succeed");
+        assert!(live.map[&vk].invitation_secrets.is_empty());
+
+        // A newer generation holds the invitation-carried secret for v3. Same
+        // `self_sk`, so this takes the non-adopt branch.
+        let mut newer = test_minimal_room_data(vk);
+        newer.invitation_secrets.insert(3, [7u8; 32]);
+        live.merge_from_source(
+            rooms_holding(vk, newer),
+            20,
+            MergeAuthority::OlderSnapshot,
+            &mut ranks,
+        )
+        .expect("merge must succeed");
+
+        assert_eq!(
+            live.map[&vk].invitation_secrets.get(&3),
+            Some(&[7u8; 32]),
+            "a secret version only the newer copy holds must survive — without it \
+             a private-room member cannot decrypt messages sealed under it, and no \
+             later path can recover it"
+        );
+    }
+
+    /// The `self_nickname` half of the same fix, in both directions.
+    ///
+    /// The inversion here is not merely a lost improvement, it is destructive:
+    /// `if room_data.self_nickname.is_none() { self_room_data.self_nickname =
+    /// room_data.self_nickname; }` fires exactly when the incoming copy has NO
+    /// nickname and assigns that `None` over the local one — so an older
+    /// generation answering without a nickname would wipe the user's chosen name
+    /// and drop them to a generated handle, which is the outcome the line exists
+    /// to prevent. And it is the plausible edit: it is what copying the adopt
+    /// branch's condition verbatim produces, nine lines up, reading almost
+    /// identically.
+    #[test]
+    fn a_matching_identity_merge_takes_a_nickname_only_when_local_lacks_one() {
+        let vk = SigningKey::from_bytes(&[43u8; 32]).verifying_key();
+
+        // Local HAS a nickname, incoming has none → local must survive.
+        let mut named = test_minimal_room_data(vk);
+        named.self_nickname = Some("mine".to_string());
+        let mut live = rooms_holding(vk, named);
+        let mut ranks = MergeRanks::default();
+        live.merge_from_source(
+            rooms_holding(vk, test_minimal_room_data(vk)),
+            5,
+            MergeAuthority::OlderSnapshot,
+            &mut ranks,
+        )
+        .expect("merge must succeed");
+        assert_eq!(
+            live.map[&vk].self_nickname.as_deref(),
+            Some("mine"),
+            "an incoming copy without a nickname must not wipe the local one"
+        );
+
+        // Local has NONE, incoming has one → take it.
+        let mut live2 = rooms_holding(vk, test_minimal_room_data(vk));
+        let mut theirs = test_minimal_room_data(vk);
+        theirs.self_nickname = Some("theirs".to_string());
+        let mut ranks2 = MergeRanks::default();
+        live2
+            .merge_from_source(
+                rooms_holding(vk, theirs),
+                5,
+                MergeAuthority::OlderSnapshot,
+                &mut ranks2,
+            )
+            .expect("merge must succeed");
+        assert_eq!(
+            live2.map[&vk].self_nickname.as_deref(),
+            Some("theirs"),
+            "a nickname the local copy lacks must be taken, or the member-info \
+             heal falls back to a generated handle"
+        );
+    }
+
+    /// The collision rule matches both sibling paths: the LOCAL copy wins, so an
+    /// older generation answering later cannot overwrite a secret already held.
+    #[test]
+    fn a_matching_identity_merge_keeps_the_local_secret_on_collision() {
+        let vk = SigningKey::from_bytes(&[42u8; 32]).verifying_key();
+        let mut held = test_minimal_room_data(vk);
+        held.invitation_secrets.insert(3, [1u8; 32]);
+        let mut live = rooms_holding(vk, held);
+
+        let mut other = test_minimal_room_data(vk);
+        other.invitation_secrets.insert(3, [2u8; 32]);
+
+        let mut ranks = MergeRanks::default();
+        live.merge_from_source(
+            rooms_holding(vk, other),
+            5,
+            MergeAuthority::OlderSnapshot,
+            &mut ranks,
+        )
+        .expect("merge must succeed");
+
+        assert_eq!(live.map[&vk].invitation_secrets.get(&3), Some(&[1u8; 32]));
+    }
+
+    /// freenet/river#590 — the merge must RECORD a resurrection, because the save
+    /// path cannot infer one.
+    ///
+    /// `MergeRanks` is never persisted and `RoomSlot::Tombstone` carries no rank,
+    /// so the ranked model stops at the session boundary. Without this record
+    /// `reconcile_room_present` sees a delegate tombstone, answers
+    /// `AbortAdoptLeave` and writes nothing — the room lives in memory for one
+    /// session and stays tombstoned on the delegate for good, which is #590's
+    /// symptom with an extra session in front of it.
+    #[test]
+    fn a_resurrection_is_recorded_for_the_save_path() {
+        let vk = SigningKey::from_bytes(&[51u8; 32]).verifying_key();
+        let mut live = empty_rooms_for_merge();
+        let mut ranks = MergeRanks::default();
+
+        // An older generation tombstones it while the map is empty.
+        let mut older = empty_rooms_for_merge();
+        older.removed_rooms.insert(vk);
+        live.merge_from_source(older, 3, MergeAuthority::OlderSnapshot, &mut ranks)
+            .expect("merge must succeed");
+        assert!(
+            ranks.resurrected.is_empty(),
+            "a plain tombstone is not a resurrection"
+        );
+
+        // A newer generation still holds it.
+        live.merge_from_source(
+            rooms_holding(vk, test_minimal_room_data(vk)),
+            20,
+            MergeAuthority::OlderSnapshot,
+            &mut ranks,
+        )
+        .expect("merge must succeed");
+
+        assert!(live.map.contains_key(&vk));
+        assert!(
+            ranks.resurrected.contains(&vk.to_bytes()),
+            "the merge must record the resurrection, or the save path aborts on \
+             the delegate's tombstone and the room is lost after this session"
+        );
+    }
+
+    /// A room that was never tombstoned is not a resurrection — the record must
+    /// not fire for an ordinary insert, or every load would mark every room
+    /// rejoined and defeat the round-9 remote-leave guard entirely.
+    #[test]
+    fn an_ordinary_insert_is_not_recorded_as_a_resurrection() {
+        let vk = SigningKey::from_bytes(&[52u8; 32]).verifying_key();
+        let mut live = empty_rooms_for_merge();
+        let mut ranks = MergeRanks::default();
+        live.merge_from_source(
+            rooms_holding(vk, test_minimal_room_data(vk)),
+            20,
+            MergeAuthority::OlderSnapshot,
+            &mut ranks,
+        )
+        .expect("merge must succeed");
+        assert!(live.map.contains_key(&vk));
+        assert!(ranks.resurrected.is_empty());
+    }
+
+    /// freenet/river#590 — the rank an authority carries.
+    ///
+    /// `Authoritative` must map to `SOURCE_RANK_AUTHORITATIVE`, NOT to the raw
+    /// `source_rank`. `rank_for`'s own doc warns against "tidying" the two scales
+    /// together; this is what makes that warning enforceable. Collapsing it is
+    /// observable — an authoritative tombstone at a low `source_rank` stops
+    /// evicting a live room whose identity rank is higher.
+    #[test]
+    fn an_authoritative_source_ranks_above_every_generation() {
+        assert_eq!(
+            MergeAuthority::Authoritative.rank_for(3),
+            SOURCE_RANK_AUTHORITATIVE,
+            "an authoritative source must not carry the raw generation number"
+        );
+        assert_eq!(
+            MergeAuthority::Authoritative.rank_for(SOURCE_RANK_AUTHORITATIVE),
+            SOURCE_RANK_AUTHORITATIVE
+        );
+        assert_eq!(
+            MergeAuthority::OlderSnapshot.rank_for(3),
+            3,
+            "an older snapshot carries its own generation number"
+        );
+        assert_eq!(MergeAuthority::OlderSnapshot.rank_for(0), 0);
+    }
+
+    /// freenet/river#590 — an in-session leave must not be DOWNGRADED by a
+    /// source that agrees with it.
+    ///
+    /// `leave_room` records a tombstone with no rank, which
+    /// `presence_survives_tombstone` reads as `SOURCE_RANK_AUTHORITATIVE`. If a
+    /// legacy generation then answers with a tombstone for the same room —
+    /// AGREEING with the leave — a naive `or_insert(incoming_rank)` stamps that
+    /// generation's number over the unranked entry, and a higher-ranked `Present`
+    /// from a later generation resurrects the room, which the re-save persists.
+    ///
+    /// The inversion is the point: it takes a source that CONFIRMS the leave to
+    /// unlock it.
+    #[test]
+    fn an_in_session_leave_is_not_downgraded_by_a_legacy_tombstone() {
+        let vk = SigningKey::from_bytes(&[31u8; 32]).verifying_key();
+        let mut live = rooms_holding(vk, test_minimal_room_data(vk));
+        let mut ranks = MergeRanks::default();
+
+        // The user leaves. No tombstone rank recorded — implicitly authoritative.
+        live.leave_room(vk);
+        assert!(live.removed_rooms.contains(&vk));
+        assert!(!ranks.tombstone.contains_key(&vk.to_bytes()));
+
+        // A legacy generation AGREES the room is gone.
+        let mut agreeing = empty_rooms_for_merge();
+        agreeing.removed_rooms.insert(vk);
+        live.merge_from_source(agreeing, 3, MergeAuthority::OlderSnapshot, &mut ranks)
+            .expect("merge must succeed");
+
+        // A newer generation still holds it. It must NOT come back.
+        live.merge_from_source(
+            rooms_holding(vk, test_minimal_room_data(vk)),
+            20,
+            MergeAuthority::OlderSnapshot,
+            &mut ranks,
+        )
+        .expect("merge must succeed");
+
+        assert!(
+            !live.map.contains_key(&vk),
+            "a leave the user just performed must survive the whole fan-out, even \
+             when an older generation confirms it first"
+        );
+        assert!(live.removed_rooms.contains(&vk));
+    }
+
+    /// freenet/river#590, PROBE-B — the interleaving that probe order makes the
+    /// LIKELY one, and that a "is it in the map right now" guard cannot see.
+    ///
+    /// `fire_legacy_migration_request` dispatches `LEGACY_DELEGATES.iter()` in
+    /// file order, oldest generation first, so the OLDEST generation usually
+    /// answers while the map is still empty. Its stale tombstone lands
+    /// unopposed; the newest generation's `Present` then arrives and is skipped
+    /// by the tombstone check; and the re-save writes `room:R = Tombstone` to the
+    /// current delegate, taking `self_sk` with it.
+    ///
+    /// Ranking the tombstone is what fixes it: a strictly newer generation's
+    /// `Present` overrides an older generation's absence.
+    #[test]
+    fn a_newer_generations_presence_overrides_an_older_generations_tombstone() {
+        let vk = SigningKey::from_bytes(&[11u8; 32]).verifying_key();
+        let mut live = empty_rooms_for_merge();
+        let mut ranks = MergeRanks::default();
+
+        // Oldest generation answers first, map still empty.
+        let mut oldest = empty_rooms_for_merge();
+        oldest.removed_rooms.insert(vk);
+        live.merge_from_source(oldest, 0, MergeAuthority::OlderSnapshot, &mut ranks)
+            .expect("merge must succeed");
+        assert!(
+            live.removed_rooms.contains(&vk),
+            "the stale leave is recorded"
+        );
+
+        // A strictly newer generation says the room is present.
+        live.merge_from_source(
+            rooms_holding(vk, test_minimal_room_data(vk)),
+            20,
+            MergeAuthority::OlderSnapshot,
+            &mut ranks,
+        )
+        .expect("merge must succeed");
+
+        assert!(
+            live.map.contains_key(&vk),
+            "a newer generation's Present must override an older one's tombstone"
+        );
+        assert!(
+            !live.removed_rooms.contains(&vk),
+            "and clear the tombstone, or the re-save writes it to the current delegate"
+        );
+    }
+
+    /// freenet/river#590, PROBE-A — the mirror image. An OLDER generation's
+    /// tombstone must not undo a room a NEWER generation already supplied.
+    ///
+    /// Both sources are legacy, so an authority check alone cannot separate
+    /// them; the ranks must.
+    #[test]
+    fn an_older_generations_tombstone_cannot_evict_a_newer_generations_room() {
+        let vk = SigningKey::from_bytes(&[12u8; 32]).verifying_key();
+        let mut live = empty_rooms_for_merge();
+        let mut ranks = MergeRanks::default();
+
+        live.merge_from_source(
+            rooms_holding(vk, test_minimal_room_data(vk)),
+            20,
+            MergeAuthority::OlderSnapshot,
+            &mut ranks,
+        )
+        .expect("merge must succeed");
+
+        let mut older = empty_rooms_for_merge();
+        older.removed_rooms.insert(vk);
+        live.merge_from_source(older, 5, MergeAuthority::OlderSnapshot, &mut ranks)
+            .expect("merge must succeed");
+
+        assert!(
+            live.map.contains_key(&vk),
+            "an older generation's tombstone must not evict a newer copy"
+        );
+        assert!(!live.removed_rooms.contains(&vk));
+    }
+
+    /// ...but a NEWER generation's tombstone still removes an older generation's
+    /// room. The ranking is symmetric; only the direction of time decides.
+    #[test]
+    fn a_newer_generations_tombstone_still_removes_an_older_generations_room() {
+        let vk = SigningKey::from_bytes(&[13u8; 32]).verifying_key();
+        let mut live = empty_rooms_for_merge();
+        let mut ranks = MergeRanks::default();
+
+        live.merge_from_source(
+            rooms_holding(vk, test_minimal_room_data(vk)),
+            5,
+            MergeAuthority::OlderSnapshot,
+            &mut ranks,
+        )
+        .expect("merge must succeed");
+
+        let mut newer = empty_rooms_for_merge();
+        newer.removed_rooms.insert(vk);
+        live.merge_from_source(newer, 20, MergeAuthority::OlderSnapshot, &mut ranks)
+            .expect("merge must succeed");
+
+        assert!(
+            !live.map.contains_key(&vk),
+            "a newer generation's leave must still take effect"
+        );
+        assert!(live.removed_rooms.contains(&vk));
+    }
+
+    /// The other half of #590: the guard is scoped to rooms the live set HOLDS.
+    /// A legacy tombstone for a room nobody has an opinion about is still
+    /// honoured, so "a room the user left stays left" survives.
+    #[test]
+    fn a_legacy_tombstone_still_applies_to_a_room_the_live_set_lacks() {
+        let vk = SigningKey::from_bytes(&[8u8; 32]).verifying_key();
+        let mut live = empty_rooms_for_merge();
+
+        let mut stale = empty_rooms_for_merge();
+        stale.removed_rooms.insert(vk);
+
+        let mut ranks = MergeRanks::default();
+        live.merge_from_source(stale, 3, MergeAuthority::OlderSnapshot, &mut ranks)
+            .expect("merge must succeed");
+
+        assert!(
+            live.removed_rooms.contains(&vk),
+            "with nothing live to protect, the leave is still recorded"
+        );
+    }
+
+    /// An AUTHORITATIVE source — the current delegate, or an explicit in-session
+    /// action — keeps its removal power. The fix is one-directional.
+    #[test]
+    fn an_authoritative_tombstone_still_removes_a_live_room() {
+        let vk = SigningKey::from_bytes(&[9u8; 32]).verifying_key();
+        let mut live = rooms_holding(vk, test_minimal_room_data(vk));
+
+        let mut current = empty_rooms_for_merge();
+        current.removed_rooms.insert(vk);
+
+        let mut ranks = MergeRanks::default();
+        // Seed an identity rank ABOVE the source_rank we pass. Without this the
+        // live room has no recorded rank, the comparison never happens, and the
+        // test cannot prove what it claims: that the AUTHORITY, not the number,
+        // grants removal power. With `ranks.identity[R] = 5` and `source_rank =
+        // 3`, a `rank_for` that returned the raw number would give `3 <= 5` and
+        // skip the tombstone.
+        ranks.identity.insert(vk.to_bytes(), 5);
+        live.merge_from_source(current, 3, MergeAuthority::Authoritative, &mut ranks)
+            .expect("merge must succeed");
+
+        assert!(
+            !live.map.contains_key(&vk),
+            "the current delegate's tombstone must still remove the room"
+        );
+    }
+
     #[test]
     fn resolve_identity_conflict_prefers_a_strictly_newer_source() {
         assert_eq!(
@@ -2676,13 +3400,14 @@ mod tests {
         assert_ne!(old_identity.to_bytes(), current_identity.to_bytes());
 
         let mut local = empty_rooms_for_merge();
-        let mut ranks = HashMap::new();
+        let mut ranks = MergeRanks::default();
 
         // The oldest generation (rank 3) answers first.
         local
             .merge_from_source(
                 rooms_holding(vk, make_rejoin_test_room(&owner, &old_identity, true)),
                 3,
+                MergeAuthority::OlderSnapshot,
                 &mut ranks,
             )
             .expect("first merge");
@@ -2697,6 +3422,7 @@ mod tests {
             .merge_from_source(
                 rooms_holding(vk, make_rejoin_test_room(&owner, &current_identity, true)),
                 30,
+                MergeAuthority::OlderSnapshot,
                 &mut ranks,
             )
             .expect("second merge");
@@ -2730,13 +3456,14 @@ mod tests {
         let current_identity = SigningKey::generate(&mut rng);
 
         let mut local = empty_rooms_for_merge();
-        let mut ranks = HashMap::new();
+        let mut ranks = MergeRanks::default();
 
         // Newest first this time.
         local
             .merge_from_source(
                 rooms_holding(vk, make_rejoin_test_room(&owner, &current_identity, true)),
                 30,
+                MergeAuthority::OlderSnapshot,
                 &mut ranks,
             )
             .expect("first merge");
@@ -2744,6 +3471,7 @@ mod tests {
             .merge_from_source(
                 rooms_holding(vk, make_rejoin_test_room(&owner, &old_identity, true)),
                 3,
+                MergeAuthority::OlderSnapshot,
                 &mut ranks,
             )
             .expect("second merge");
@@ -2768,13 +3496,16 @@ mod tests {
         let from_delegate = SigningKey::generate(&mut rng);
 
         let mut local = rooms_holding(vk, make_rejoin_test_room(&owner, &imported, true));
-        let mut ranks = HashMap::new();
-        ranks.insert(vk.to_bytes(), SOURCE_RANK_AUTHORITATIVE);
+        let mut ranks = MergeRanks::default();
+        ranks
+            .identity
+            .insert(vk.to_bytes(), SOURCE_RANK_AUTHORITATIVE);
 
         local
             .merge_from_source(
                 rooms_holding(vk, make_rejoin_test_room(&owner, &from_delegate, true)),
                 u32::MAX - 1,
+                MergeAuthority::Authoritative,
                 &mut ranks,
             )
             .expect("merge");
@@ -2800,12 +3531,13 @@ mod tests {
 
         let mut local = rooms_holding(vk, make_rejoin_test_room(&owner, &in_session, true));
         // Deliberately EMPTY: nothing recorded this room's source.
-        let mut ranks = HashMap::new();
+        let mut ranks = MergeRanks::default();
 
         local
             .merge_from_source(
                 rooms_holding(vk, make_rejoin_test_room(&owner, &from_delegate, true)),
                 30,
+                MergeAuthority::OlderSnapshot,
                 &mut ranks,
             )
             .expect("merge");
@@ -2816,7 +3548,7 @@ mod tests {
             "a room with no recorded source must not be overwritten by a load"
         );
         assert!(
-            !ranks.contains_key(&vk.to_bytes()),
+            !ranks.identity.contains_key(&vk.to_bytes()),
             "and it must not be stamped with the loading source's rank, which would \
              make it overwritable by the next response"
         );
@@ -2852,14 +3584,20 @@ mod tests {
         );
 
         let mut local = empty_rooms_for_merge();
-        let mut ranks = HashMap::new();
+        let mut ranks = MergeRanks::default();
         local
-            .merge_from_source(rooms_holding(vk, old_room), 3, &mut ranks)
+            .merge_from_source(
+                rooms_holding(vk, old_room),
+                3,
+                MergeAuthority::OlderSnapshot,
+                &mut ranks,
+            )
             .expect("old generation merge");
         local
             .merge_from_source(
                 rooms_holding(vk, make_rejoin_test_room(&owner, &current_identity, true)),
                 30,
+                MergeAuthority::OlderSnapshot,
                 &mut ranks,
             )
             .expect("newer generation merge");
@@ -2900,12 +3638,22 @@ mod tests {
         new_room.invitation_secrets.insert(2, [22u8; 32]);
 
         let mut local = empty_rooms_for_merge();
-        let mut ranks = HashMap::new();
+        let mut ranks = MergeRanks::default();
         local
-            .merge_from_source(rooms_holding(vk, old_room), 3, &mut ranks)
+            .merge_from_source(
+                rooms_holding(vk, old_room),
+                3,
+                MergeAuthority::OlderSnapshot,
+                &mut ranks,
+            )
             .expect("old generation merge");
         local
-            .merge_from_source(rooms_holding(vk, new_room), 30, &mut ranks)
+            .merge_from_source(
+                rooms_holding(vk, new_room),
+                30,
+                MergeAuthority::OlderSnapshot,
+                &mut ranks,
+            )
             .expect("newer generation merge");
 
         let merged = local.map.get(&vk).unwrap();
@@ -3016,9 +3764,14 @@ mod tests {
         old_room.room_state.recent_messages.messages.push(msg);
 
         let mut local = empty_rooms_for_merge();
-        let mut ranks = HashMap::new();
+        let mut ranks = MergeRanks::default();
         local
-            .merge_from_source(rooms_holding(vk, old_room), 3, &mut ranks)
+            .merge_from_source(
+                rooms_holding(vk, old_room),
+                3,
+                MergeAuthority::OlderSnapshot,
+                &mut ranks,
+            )
             .expect("seeding the local copy must succeed");
         assert!(local.map.contains_key(&vk), "precondition: room is present");
 
@@ -3039,7 +3792,12 @@ mod tests {
             },
             &owner,
         );
-        let result = local.merge_from_source(rooms_holding(vk, newer), 30, &mut ranks);
+        let result = local.merge_from_source(
+            rooms_holding(vk, newer),
+            30,
+            MergeAuthority::OlderSnapshot,
+            &mut ranks,
+        );
 
         // PREMISE CHECK: if this ever stops erroring the assertions below go
         // vacuous, so fail loudly rather than silently guarding nothing.
@@ -3077,12 +3835,13 @@ mod tests {
         let arrivals = [(12u32, &id_mid), (30u32, &id_new), (3u32, &id_old)];
 
         let mut local = empty_rooms_for_merge();
-        let mut ranks = HashMap::new();
+        let mut ranks = MergeRanks::default();
         for (rank, sk) in arrivals {
             local
                 .merge_from_source(
                     rooms_holding(vk, make_rejoin_test_room(&owner, sk, true)),
                     rank,
+                    MergeAuthority::Authoritative,
                     &mut ranks,
                 )
                 .expect("merge");
@@ -3094,7 +3853,7 @@ mod tests {
             "the newest generation must win across three sources in any order"
         );
         assert_eq!(
-            ranks.get(&vk.to_bytes()),
+            ranks.identity.get(&vk.to_bytes()),
             Some(&30),
             "and the recorded provenance must be the highest rank seen, so a \
              later older response still loses"
@@ -3125,12 +3884,22 @@ mod tests {
         newer.self_nickname = None;
 
         let mut local = empty_rooms_for_merge();
-        let mut ranks = HashMap::new();
+        let mut ranks = MergeRanks::default();
         local
-            .merge_from_source(rooms_holding(vk, old_room), 3, &mut ranks)
+            .merge_from_source(
+                rooms_holding(vk, old_room),
+                3,
+                MergeAuthority::OlderSnapshot,
+                &mut ranks,
+            )
             .expect("seed");
         local
-            .merge_from_source(rooms_holding(vk, newer), 30, &mut ranks)
+            .merge_from_source(
+                rooms_holding(vk, newer),
+                30,
+                MergeAuthority::OlderSnapshot,
+                &mut ranks,
+            )
             .expect("adopt");
         assert_eq!(
             local.map.get(&vk).unwrap().self_nickname.as_deref(),
@@ -3145,12 +3914,22 @@ mod tests {
         newer2.self_nickname = Some("Current".to_string());
 
         let mut local2 = empty_rooms_for_merge();
-        let mut ranks2 = HashMap::new();
+        let mut ranks2 = MergeRanks::default();
         local2
-            .merge_from_source(rooms_holding(vk, old_room2), 3, &mut ranks2)
+            .merge_from_source(
+                rooms_holding(vk, old_room2),
+                3,
+                MergeAuthority::OlderSnapshot,
+                &mut ranks2,
+            )
             .expect("seed");
         local2
-            .merge_from_source(rooms_holding(vk, newer2), 30, &mut ranks2)
+            .merge_from_source(
+                rooms_holding(vk, newer2),
+                30,
+                MergeAuthority::OlderSnapshot,
+                &mut ranks2,
+            )
             .expect("adopt");
         assert_eq!(
             local2.map.get(&vk).unwrap().self_nickname.as_deref(),
@@ -3189,20 +3968,20 @@ mod tests {
     #[test]
     fn record_identity_source_takes_the_highest_rank_seen() {
         let vk = vk_from_seed(1);
-        let mut ranks = HashMap::new();
+        let mut ranks = MergeRanks::default();
 
-        record_identity_source(&mut ranks, &vk, 5, true);
-        assert_eq!(ranks.get(&vk.to_bytes()), Some(&5));
+        record_identity_source(&mut ranks.identity, &vk, 5, true);
+        assert_eq!(ranks.identity.get(&vk.to_bytes()), Some(&5));
 
         // A newer source upgrades it.
-        record_identity_source(&mut ranks, &vk, 12, false);
-        assert_eq!(ranks.get(&vk.to_bytes()), Some(&12));
+        record_identity_source(&mut ranks.identity, &vk, 12, false);
+        assert_eq!(ranks.identity.get(&vk.to_bytes()), Some(&12));
 
         // An older source must NOT downgrade it — otherwise a late old-generation
         // response would re-open the room to being overwritten.
-        record_identity_source(&mut ranks, &vk, 2, false);
+        record_identity_source(&mut ranks.identity, &vk, 2, false);
         assert_eq!(
-            ranks.get(&vk.to_bytes()),
+            ranks.identity.get(&vk.to_bytes()),
             Some(&12),
             "an older source must never lower a room's recorded provenance"
         );


### PR DESCRIPTION
Two ways the legacy-migration merge loses rooms permanently. **Both are live on `main`.** Found reviewing #587, which would have widened the first.

## 1. A legacy generation's tombstone deletes a live room (#590)

`migrate_legacy_per_room` pushes whatever slot it parses into `slots`, including `RoomSlot::Tombstone`. `reconstruct_rooms` turns those into `removed_rooms`. `hydrate_loaded_rooms` passes the whole `Rooms` to `merge_from_source`, which unions the incoming tombstones and immediately evicts:

```rust
for vk in other.removed_rooms { self.removed_rooms.insert(vk); }
self.map.retain(|vk, _| !self.removed_rooms.contains(vk));
```

So an **older** generation's tombstone deletes a room the **current** delegate holds `Present`, and `do_save_rooms_to_delegate`'s tombstone pass then CAS-writes that tombstone over the current slot. `self_sk` cannot be re-derived from the network — the room is gone for good.

**No failure is required.** Leave a room under generation G; a WASM bump makes G legacy; rejoin the room under the new generation; any later load whose current-delegate index is empty fires the fan-out and destroys it.

### Root cause

The merge treated every responding generation as a **peer**. It isn't — a legacy generation is a strictly older snapshot. `source_rank` was already threaded through, but consulted *only* for `self_sk` conflicts, so nothing constrained what an old snapshot could delete.

`merge_from_source` now takes a `MergeAuthority`:

- `Authoritative` — the current delegate, or a deliberate in-session action. Unchanged: its tombstones remove rooms.
- `OlderSnapshot` — a legacy generation. **Additive only.** It may contribute a tombstone for a room the live set does *not* hold, so "a room the user left stays left" survives; never for one it does.

The asymmetry is deliberate and one-directional. Worst case a left room reappears and the user leaves it again; the alternative is unrecoverable.

The justification this replaces — the receiver's tombstone set is authoritative "because legacy delegates predate the tombstone field" (#247) — had outlived its premise. `legacy_delegates.toml` gains an entry on **every** WASM bump, so recent legacy generations carry per-room tombstones routinely. That comment was written when "legacy" meant only the pre-tombstone blob generations.

## 2. One room's merge failure drops all the rest (#591)

Two bare `?` on the fallible per-room `ChatRoomStateV1::merge` returned from the **whole function**, so every room later in `other.map`'s iteration order was never inserted. `other.map` is a `HashMap`, so which rooms are lost is arbitrary and unstable between runs, and the caller only logs.

Worse than the immediate loss: a room absent from the map is exactly where the #527 rank check does not run — `merge_from_source` compares ranks only when the room is already present — so the next legacy generation's copy is adopted **unranked**, and `reconcile_room_present`'s diverged-identity branch CAS-writes that older identity over the current one.

Now per-room isolated: failures accumulate, the loop continues, and an aggregate is returned so nothing is swallowed. Same shape as `do_save_rooms_to_delegate`, which accumulates per-key errors for exactly this reason.

## Testing

Three behavioural tests for #590 — a legacy tombstone cannot evict a room the live set holds; it still applies to a room the live set lacks; an authoritative tombstone still removes — plus a pin for #591's loop shape.

**Mutation-checked**, each turning a test red:
- the #590 guard disabled (the bug restored);
- the guard made **over-broad**, dropping *all* legacy tombstones — which would silently resurrect rooms the user left, the failure mode in the opposite direction;
- the authority hard-coded `Authoritative` at the hydrate call site;
- the per-room merge aborting the loop again;
- accumulated errors swallowed.

The #527 wiring pin is extended to require the authority be **derived** from `is_legacy_delegate`, never hard-coded.

824 river-ui tests, full workspace green.

## Scope

UI-only — no delegate/contract WASM, `Cargo.toml` or `Cargo.lock` change, so no migration entry is required.

This is the first of the root-cause fixes for the family in #586. It addresses the *destruction* class. Convergence (the unbounded hoard across delegate generations, which is what actually causes the "Migrating your rooms…" banner) is separate and follows.

Closes #590
Closes #591

[AI-assisted - Claude]