### PR TITLE
fix(ui): clarify invite-accept nickname field is the invitee's own name

### DIFF
--- a/ui/src/components/room_list/receive_invitation_modal.rs
+++ b/ui/src/components/room_list/receive_invitation_modal.rs
@@ -861,10 +861,11 @@ fn render_new_invitation(inv: Invitation, invitation: Signal<Option<Invitation>>
         p { class: "text-text-muted mb-4",
             "Choose "
             span { class: "text-text font-medium", "your own display name" }
-            " (not the room's name). It's what other members will see when you post:"
+            " (not the room's name). It's what other members will see when you send messages:"
         }
 
         div { class: "mb-4",
+            label { class: "block text-sm font-medium text-text mb-1", "Your display name" }
             input {
                 "data-testid": "receive-invitation-nickname-input",
                 class: if nickname_has_emoji {

--- a/ui/src/components/room_list/receive_invitation_modal.rs
+++ b/ui/src/components/room_list/receive_invitation_modal.rs
@@ -858,7 +858,11 @@ fn render_new_invitation(inv: Invitation, invitation: Signal<Option<Invitation>>
 
     rsx! {
         p { class: "text-text mb-2", "You have been invited to join a new room." }
-        p { class: "text-text-muted mb-4", "Choose a nickname to use in this room:" }
+        p { class: "text-text-muted mb-4",
+            "Choose "
+            span { class: "text-text font-medium", "your own display name" }
+            " (not the room's name). It's what other members will see when you post:"
+        }
 
         div { class: "mb-4",
             input {
@@ -884,7 +888,7 @@ fn render_new_invitation(inv: Invitation, invitation: Signal<Option<Invitation>>
                         accept_invitation(inv_for_enter.clone(), nickname.read().clone());
                     }
                 },
-                placeholder: "Your preferred nickname"
+                placeholder: "Your name (e.g. Alex)"
             }
             if nickname_has_emoji {
                 p {


### PR DESCRIPTION
## Problem
Multiple people joining River rooms have been setting their own username to the *room's* name (e.g. one user recently joined with the username "Freenet Official Room"). The invite-accept modal ("Invitation Received") asks the user to "Choose a nickname to use in this room:" but never shows the room's actual name anywhere in the modal for contrast, so the field reads ambiguously — it's easy to interpret it as "give this room a label in my UI" rather than "this is your own display name to other members."

## Approach
Reworded the label to be explicit and unambiguous:
- Old: "Choose a nickname to use in this room:"
- New: "Choose **your own display name** (not the room's name). It's what other members will see when you post:"

Also changed the input placeholder from the generic "Your preferred nickname" to "Your name (e.g. Alex)" for a clearer example.

Considered showing the actual room name in the modal for contrast, but the `Invitation` artifact (`ui/src/components/members.rs`) doesn't carry a room name — only the room owner's `VerifyingKey`, the invitee's credentials, and room secrets. Room `Configuration.display.name` only becomes available after accepting/subscribing. Surfacing it pre-accept would require prefetching room state before the modal renders, which is a larger architectural change out of scope for this copy fix.

Text-only change, no wire format, contract, or delegate WASM impact — no migration needed.

## Testing
- `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync` passes.
- Verified visually in a browser: built with `example-data`/`no-sync`, temporarily forced the "new invitation" branch to render (reverted before commit — not part of this diff), and screenshotted the modal to confirm the new copy displays correctly and reads clearly.
- Grepped `ui/tests/` and `e2e-test/` for the old copy string — no test asserts on this exact text, so nothing else needed updating.

[AI-assisted - Claude]