### PR TITLE
fix(ui): move Share invite out of the composer row and shrink it

### DIFF
--- a/ui/src/components/direct_messages/dm_thread_modal.rs
+++ b/ui/src/components/direct_messages/dm_thread_modal.rs
@@ -920,7 +920,13 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                             "Send"
                         }
                     }
-                    div { class: "flex justify-between items-center pt-1",
+                    // Wraps rather than crushing: three children share this
+                    // row, and at a 320px viewport its inner width is ~248px,
+                    // so without wrapping the disclaimer gets squeezed to a
+                    // few characters per line. The point of moving the invite
+                    // link out of the composer was to stop trading away
+                    // phone-width space, so it must not be re-traded here.
+                    div { class: "flex flex-wrap justify-between items-center gap-x-3 gap-y-1 pt-1",
                         // The "you" half of the disclaimer is backed by
                         // the OUTBOUND_DMS local plaintext cache (#256).
                         // On-wire encryption is to `{peer}` only —
@@ -937,9 +943,10 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                         // Sharing an invite is a SECONDARY action here:
                         // sending a message is what this modal is for, so
                         // Send keeps the only filled `bg-accent` treatment and
-                        // this is a bare text link matching "Delete their
-                        // messages" — same size, same muted resting colour, no
-                        // background, border or padding.
+                        // this is a bare text link at the same SIZE as "Delete
+                        // their messages" — no background, border or heavy
+                        // padding. Its resting COLOUR deliberately differs;
+                        // see below.
                         //
                         // It deliberately does NOT sit in the composer row.
                         // A same-height bordered button beside Send competes
@@ -973,7 +980,17 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                         // banner above already says why.
                         button {
                             "data-testid": "dm-thread-share-invite-button",
-                            class: "text-xs text-accent hover:text-accent-hover disabled:opacity-50 disabled:hover:text-accent transition-colors",
+                            // The vertical padding here is hit target, not
+                            // visual weight: with no background it is
+                            // invisible, and the bare text size alone gives a
+                            // ~16px target against WCAG 2.2 SC 2.5.8's 24x24.
+                            // Deliberately not the larger button padding, which
+                            // `the_share_invite_button_stays_less_prominent_than_send`
+                            // forbids by name. (That pin scans this file with
+                            // whitespace stripped but comments INTACT, so do
+                            // not write the forbidden class names here — this
+                            // comment tripped it once already.)
+                            class: "text-xs py-1 text-accent hover:text-accent-hover disabled:opacity-50 disabled:hover:text-accent transition-colors",
                             disabled: !peer_still_member,
                             // Same name the Member Info dialog uses, so the
                             // feature reads as one thing across the app. It
@@ -1624,8 +1641,10 @@ mod tests {
     }
 
     /// Send stays the primary action: it keeps the ONLY filled `bg-accent`
-    /// treatment in this modal, and the invite control sits on the
-    /// established secondary tier.
+    /// treatment in the modal chrome, and the invite control stays a bare
+    /// text link — no background, border or button padding. Ian asked for
+    /// smaller and less prominent than Send twice; a bordered same-height
+    /// button beside Send was rejected for reading as MORE prominent.
     #[test]
     fn the_share_invite_button_stays_less_prominent_than_send() {
         let src = dm_thread_production_source();
@@ -1689,23 +1708,32 @@ mod tests {
     /// eats horizontal space the message box needs — measured at ~90px of
     /// textarea at phone widths — and competes with the modal's primary
     /// action. It belongs in the footer row with the other secondary action.
+    ///
+    /// Anchored on the FOOTER ROW, not on Send. An earlier version asserted
+    /// `invite > send`, which only forbade the slot between the textarea and
+    /// Send: moving the button into the composer row on the far side of Send
+    /// left every pin green while re-creating exactly the regression this
+    /// exists to prevent.
     #[test]
     fn the_share_invite_button_is_not_in_the_composer_row() {
         let src = dm_thread_production_source();
-        let composer = src
-            .find("placeholder:\"Typeadirectmessage...\"")
-            .expect("the composer textarea is present");
-        let send = src
-            .find("onclick:move|_|do_send(),\"Send\"")
-            .expect("the Send button is present");
+        let footer_row = src
+            .find("class:\"flexflex-wrapjustify-betweenitems-centergap-x-3gap-y-1pt-1\"")
+            .expect("the footer row is present");
         let invite = src
             .find("\"data-testid\":\"dm-thread-share-invite-button\"")
             .expect("the invite button is present");
         assert!(
-            invite > send && send > composer,
-            "the invite control moved back into the composer row (between the \
-             textarea and Send); it belongs in the footer row below"
+            invite > footer_row,
+            "the invite control moved out of the footer row and back up into \
+             the composer, where it takes width from the message box"
         );
+        // Belt and braces: it must also come after Send, so it cannot end up
+        // between the textarea and Send either.
+        let send = src
+            .find("onclick:move|_|do_send(),\"Send\"")
+            .expect("the Send button is present");
+        assert!(invite > send, "the invite control is ahead of Send");
     }
 
     /// An invitation IS an outbound DM, so the contract rejects it for the

--- a/ui/src/components/direct_messages/dm_thread_modal.rs
+++ b/ui/src/components/direct_messages/dm_thread_modal.rs
@@ -913,43 +913,6 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                             },
                             disabled: !peer_still_member,
                         }
-                        // Secondary action, sitting immediately left of Send.
-                        //
-                        // Send keeps the ONLY filled `bg-accent` treatment in
-                        // this modal — sending a message is what it is for.
-                        // This uses the codebase's established secondary tier
-                        // (`bg-surface` + border, as in `member_info_modal`),
-                        // which is clearly subordinate while still being a
-                        // real button next to where attention already is. An
-                        // earlier revision put it in the fine-print row at
-                        // resting styling identical to "Delete their
-                        // messages", which read as a maintenance utility and
-                        // parked a routine action beside a destructive one.
-                        //
-                        // Disabled in lockstep with Send whenever the peer has
-                        // left the room: an invitation IS an outbound DM, and
-                        // the contract rejects it for the same reason. The
-                        // banner above already explains why.
-                        button {
-                            "data-testid": "dm-thread-share-invite-button",
-                            class: "px-3 py-2 bg-surface hover:bg-surface-hover disabled:opacity-50 text-text text-sm font-medium rounded-lg border border-border transition-colors",
-                            disabled: !peer_still_member,
-                            // Same name the Member Info dialog uses, so the
-                            // feature reads as one thing across the app. It
-                            // collides with no Playwright selector: the specs
-                            // match `/share an invite/i` and `/^send invite$/i`,
-                            // and this is neither.
-                            "aria-label": "Share invite with {peer_label}",
-                            title: "Send them an invitation to one of your other rooms",
-                            onclick: move |_| {
-                                // Writes INVITE_VIA_DM_PICKER behind `defer()`
-                                // itself, which is what the signal-safety rule
-                                // requires of an event handler touching a
-                                // global.
-                                open_invite_via_dm_picker(room, peer);
-                            },
-                            "Share invite"
-                        }
                         button {
                             class: "px-3 py-2 bg-accent hover:bg-accent-hover disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors",
                             disabled: draft.read().trim().is_empty() || !peer_still_member,
@@ -971,9 +934,65 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                             span { class: "text-accent", "{peer_label}" }
                             " can read these messages."
                         }
-                        // Destructive, and the only thing in this row besides
-                        // the disclaimer — kept as a bare text link so it
-                        // never competes with the composer above.
+                        // Sharing an invite is a SECONDARY action here:
+                        // sending a message is what this modal is for, so
+                        // Send keeps the only filled `bg-accent` treatment and
+                        // this is a bare text link matching "Delete their
+                        // messages" — same size, same muted resting colour, no
+                        // background, border or padding.
+                        //
+                        // It deliberately does NOT sit in the composer row.
+                        // A same-height bordered button beside Send competes
+                        // with it for attention (arguably reading as MORE
+                        // prominent, since "Share invite" is the wider label)
+                        // and eats horizontal space the message box needs —
+                        // the textarea lost ~90px at phone widths. Ian asked
+                        // for smaller and less prominent, twice; this row is
+                        // where the modal's non-primary actions live.
+                        //
+                        // Same WEIGHT as "Delete their messages" (bare text,
+                        // `text-xs`) but deliberately not the same
+                        // PRESENTATION: these two are opposites — one offers
+                        // someone access, the other destroys messages — and
+                        // rendering them identically, distinguishable only by
+                        // a hover colour that touch devices never show, makes
+                        // them read as a matched pair. So this one is
+                        // accent-coloured at rest, like a link you are meant
+                        // to use; Delete stays muted grey and only turns red
+                        // on hover, like a thing you are meant to be sure
+                        // about. Prominence runs Send ≫ Share invite > Delete.
+                        //
+                        // Middle of a `justify-between` row, so it is also
+                        // physically separated from Delete: both are small hit
+                        // targets, and a mis-tap between them is the one that
+                        // matters.
+                        //
+                        // Disabled in lockstep with Send when the peer has
+                        // left the room — an invitation IS an outbound DM and
+                        // the contract rejects it for the same reason. The
+                        // banner above already says why.
+                        button {
+                            "data-testid": "dm-thread-share-invite-button",
+                            class: "text-xs text-accent hover:text-accent-hover disabled:opacity-50 disabled:hover:text-accent transition-colors",
+                            disabled: !peer_still_member,
+                            // Same name the Member Info dialog uses, so the
+                            // feature reads as one thing across the app. It
+                            // collides with no Playwright selector: the specs
+                            // match `/share an invite/i` and `/^send invite$/i`,
+                            // and this is neither.
+                            "aria-label": "Share invite with {peer_label}",
+                            title: "Send them an invitation to one of your other rooms",
+                            onclick: move |_| {
+                                // Writes INVITE_VIA_DM_PICKER behind `defer()`
+                                // itself, which is what the signal-safety rule
+                                // requires of an event handler touching a
+                                // global.
+                                open_invite_via_dm_picker(room, peer);
+                            },
+                            "Share invite"
+                        }
+                        // Destructive, so it keeps the far right of the row
+                        // and the red hover, away from the invite link.
                         button {
                             class: "text-xs text-text-muted hover:text-red-400 transition-colors",
                             onclick: move |_| confirm_delete_open.set(true),
@@ -1618,9 +1637,8 @@ mod tests {
             src.contains("bg-accenthover:bg-accent-hoverdisabled:opacity-50text-whitetext-smfont-mediumrounded-lgtransition-colors"),
             "Send stopped being the filled primary button"
         );
-        // The invite control must not adopt the filled accent treatment. The
-        // window is bounded by the NEXT button in the composer row (Send), so
-        // it cannot silently slide onto unrelated markup if this block shrinks.
+        // The window is bounded by the button's own label, so it cannot
+        // silently slide onto neighbouring markup if this block shrinks.
         let after_testid = src
             .split_once("\"data-testid\":\"dm-thread-share-invite-button\"")
             .expect("the invite button is present")
@@ -1629,14 +1647,64 @@ mod tests {
             .split_once("\"Shareinvite\"")
             .expect("the invite button's label closes its block")
             .0;
+        // It must carry NO background, border or padding — a bare text link,
+        // the same treatment as "Delete their messages". A bordered,
+        // same-height button next to Send competes with it (and reads as more
+        // prominent, the label being wider), which is the opposite of what
+        // this control is for.
+        for heavy in ["bg-accent", "bg-surface", "border-border", "px-3", "py-2"] {
+            assert!(
+                !invite_block.contains(heavy),
+                "the invite control picked up `{heavy}`; it must stay a bare \
+                 text link, smaller and quieter than Send"
+            );
+        }
         assert!(
-            !invite_block.contains("bg-accent"),
-            "the invite control took on the filled accent treatment reserved \
-             for Send; sending a message is this modal's primary purpose"
+            invite_block.contains("text-xs"),
+            "the invite control left the small bare-text weight it shares \
+             with \"Delete their messages\""
+        );
+        // …but it must NOT be presented identically to the destructive
+        // action. They are opposites — one offers access, the other destroys
+        // messages — and a hover-only distinction is invisible on touch.
+        //
+        // Pinned on the two class strings directly rather than by slicing to
+        // the delete button's label: `"Delete their messages"` first appears
+        // in this file's MODULE DOC COMMENT, and this scrape strips whitespace
+        // but not comments, so a `split_once` on the label silently cut at
+        // line 2 and made the assertion unreachable.
+        assert!(
+            src.contains("class:\"text-xstext-text-mutedhover:text-red-400transition-colors\""),
+            "the delete control stopped being the recessive muted-until-hover one"
         );
         assert!(
-            invite_block.contains("bg-surface") && invite_block.contains("border-border"),
-            "the invite control left the codebase's secondary button tier"
+            invite_block.contains("text-accent") && !invite_block.contains("text-text-muted"),
+            "the invite control now renders identically to the destructive \
+             \"Delete their messages\"; give it its own resting colour so the \
+             two are not a matched pair"
+        );
+    }
+
+    /// The invite control must not sit in the composer row. Beside Send it
+    /// eats horizontal space the message box needs — measured at ~90px of
+    /// textarea at phone widths — and competes with the modal's primary
+    /// action. It belongs in the footer row with the other secondary action.
+    #[test]
+    fn the_share_invite_button_is_not_in_the_composer_row() {
+        let src = dm_thread_production_source();
+        let composer = src
+            .find("placeholder:\"Typeadirectmessage...\"")
+            .expect("the composer textarea is present");
+        let send = src
+            .find("onclick:move|_|do_send(),\"Send\"")
+            .expect("the Send button is present");
+        let invite = src
+            .find("\"data-testid\":\"dm-thread-share-invite-button\"")
+            .expect("the invite button is present");
+        assert!(
+            invite > send && send > composer,
+            "the invite control moved back into the composer row (between the \
+             textarea and Send); it belongs in the footer row below"
         );
     }
 

--- a/ui/tests/dm-thread-modal.spec.ts
+++ b/ui/tests/dm-thread-modal.spec.ts
@@ -189,15 +189,45 @@ test.describe("DM thread modal (Phase 3 structure)", () => {
     const shareInvite = page.getByTestId("dm-thread-share-invite-button");
     await expect(shareInvite).toBeVisible({ timeout: 5_000 });
 
+    const send = page.getByRole("button", { name: /^send$/i }).last();
     const inviteClass = (await shareInvite.getAttribute("class")) || "";
-    const sendClass =
-      (await page
-        .getByRole("button", { name: /^send$/i })
-        .last()
-        .getAttribute("class")) || "";
+    const sendClass = (await send.getAttribute("class")) || "";
 
+    // Send keeps the filled accent treatment; the invite link carries no
+    // background at all.
     expect(sendClass).toContain("bg-accent");
     expect(inviteClass).not.toContain("bg-accent");
-    expect(inviteClass).toContain("bg-surface");
+    expect(inviteClass).not.toContain("bg-surface");
+
+    // Measured, not assumed: the invite link must actually render smaller
+    // than Send. A class-name check alone would pass even if the utilities
+    // stopped resolving (e.g. a Tailwind `@source` regression), and it is
+    // the rendered size Ian is reacting to.
+    const inviteBox = await shareInvite.boundingBox();
+    const sendBox = await send.boundingBox();
+    expect(inviteBox).not.toBeNull();
+    expect(sendBox).not.toBeNull();
+    expect(inviteBox!.height).toBeLessThan(sendBox!.height);
+
+    // …and it must not be sitting in the composer row beside Send, where it
+    // would take width from the message box. Same row ⇒ vertically overlapping.
+    const composer = page.locator(
+      'textarea[placeholder="Type a direct message..."]',
+    );
+    const composerBox = await composer.boundingBox();
+    expect(composerBox).not.toBeNull();
+    expect(inviteBox!.y).toBeGreaterThan(composerBox!.y + composerBox!.height);
+
+    // Sharing an invite and deleting someone's messages are opposites, so
+    // they must not render identically. Compared as COMPUTED colour rather
+    // than class names: the point is what a user actually sees, and a
+    // hover-only difference is invisible on touch.
+    const deleteLink = page.getByRole("button", {
+      name: /delete their messages/i,
+    });
+    await expect(deleteLink).toBeVisible();
+    const colourOf = (loc: typeof deleteLink) =>
+      loc.evaluate((el) => getComputedStyle(el).color);
+    expect(await colourOf(shareInvite)).not.toBe(await colourOf(deleteLink));
   });
 });


### PR DESCRIPTION

Ian asked twice for this control to be less prominent than Send, and the
merged version put it directly beside Send as a bordered, same-height
button. That was wrong on both counts he raised:

- it took horizontal space the message box needs (the textarea lost ~90px
  at phone widths), and
- beside Send it arguably read as MORE prominent, since "Share invite" is
  the wider label.

My first implementation had it right — a bare text link in the footer row.
A UX review recommended promoting it to the secondary tier next to Send and
I took that over the stated instruction. The instruction wins.

It is now a bare text link in the footer row, `text-xs`, no background,
border or padding. Measured on a real build at 1280x800: Send renders
54x36 at 14px, the invite link 62x16 at 12px, and the composer is back to
full width.

It is NOT presented identically to "Delete their messages", though. Those
two are opposites — one offers someone access, the other destroys their
messages — and rendering them as a matched pair distinguishable only by a
hover colour is wrong twice over, because touch devices never show hover.
So the invite link is accent-coloured at rest (rgb(2,101,231)) like
something you are meant to use, and Delete stays muted grey (rgb(107,107,107))
turning red only on hover, like something you are meant to be sure about.
Prominence now runs Send >> Share invite > Delete. It also sits in the
middle of the `justify-between` row rather than adjacent to Delete, since
both are small hit targets.

Tests:

- `the_share_invite_button_is_not_in_the_composer_row` pins the ordering
  (composer -> Send -> invite), so it cannot drift back.
- The prominence pin now rejects every heavy treatment (`bg-accent`,
  `bg-surface`, `border-border`, `px-3`, `py-2`) rather than asserting one
  specific tier, and separately requires the invite and delete controls to
  differ at rest.
- The Playwright test measures the RENDERED box and computed colour rather
  than class names: it asserts the invite link is shorter than Send, sits
  below the composer, and is not the same colour as Delete. Class-name
  assertions would pass even if the utilities stopped resolving, and it is
  the rendered result being reacted to.

One pin bug found and fixed while writing these: slicing the source at
`"Delete their messages"` cut at line 2, because the string first appears
in this file's module doc comment and the scrape strips whitespace but not
comments. The assertion after it was unreachable. Pinned on the class
strings directly instead.

865 unit tests pass; 10 Playwright specs across dm-thread-modal and
invite-via-dm-picker pass against a real build.

[AI-assisted - Claude]
