### PR TITLE
fix(ui): tolerate an absent self_sk, persist self_vk, stop persisting invite keys

### DIFF
--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -17,10 +17,11 @@ use crate::components::room_list::create_room_modal::CreateRoomModal;
 use crate::components::room_list::edit_room_modal::EditRoomModal;
 use crate::components::room_list::notification_modal::NotificationModal;
 use crate::components::room_list::receive_invitation_modal::{
-    accept_invitation, clear_invitation_from_storage, decide_recovered_invitation,
-    is_invitation_processed, load_invitation_from_storage, load_invitation_nickname_from_storage,
-    purge_legacy_persisted_invitation_once, save_invitation_to_storage, take_resume_once,
-    ReceiveInvitationModal, RecoveredInvitationAction, PRESENT_INVITATION_REQUEST,
+    accept_invitation, adopt_and_purge_legacy_persisted_invitation_once,
+    clear_invitation_from_storage, decide_recovered_invitation, is_invitation_processed,
+    load_invitation_from_storage, load_invitation_nickname_from_storage,
+    save_invitation_to_storage, take_resume_once, ReceiveInvitationModal,
+    RecoveredInvitationAction, PRESENT_INVITATION_REQUEST,
 };
 use crate::invites::PendingInvites;
 use crate::room_data::{CurrentRoom, Rooms};
@@ -325,13 +326,17 @@ pub fn App() -> Element {
         receive_invitation.set(Some(inv));
     });
 
-    // Retire any invitation an OLDER River persisted to localStorage. That
-    // blob carries a full ed25519 private key plus the room's plaintext
-    // secrets, and the old flow had no terminal state for an abandoned invite,
-    // so it could sit there indefinitely. River no longer writes it (the
-    // pending invitation is held in memory for the page's lifetime), but not
-    // writing it does nothing about what is already on disk — this does.
-    purge_legacy_persisted_invitation_once();
+    // Retire any invitation an OLDER River persisted to localStorage. That blob
+    // carries a full ed25519 private key plus the room's plaintext secrets, and
+    // the old flow had no terminal state for an abandoned invite, so it could
+    // sit there indefinitely. River no longer writes it (the pending invitation
+    // is held in memory for the page's lifetime), but not writing it does
+    // nothing about what is already on disk — this does.
+    //
+    // It ADOPTS the artifact into memory before erasing it, so an in-flight
+    // join left by the older build still completes on this one. Runs before the
+    // recovery block below, which is what consumes it.
+    adopt_and_purge_legacy_persisted_invitation_once();
 
     // Recover the pending invitation if it was not found in the URL. Note this
     // now only recovers WITHIN a page load, not across a reload: the artifact

--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -19,8 +19,8 @@ use crate::components::room_list::notification_modal::NotificationModal;
 use crate::components::room_list::receive_invitation_modal::{
     accept_invitation, clear_invitation_from_storage, decide_recovered_invitation,
     is_invitation_processed, load_invitation_from_storage, load_invitation_nickname_from_storage,
-    save_invitation_to_storage, take_resume_once, ReceiveInvitationModal,
-    RecoveredInvitationAction, PRESENT_INVITATION_REQUEST,
+    purge_legacy_persisted_invitation_once, save_invitation_to_storage, take_resume_once,
+    ReceiveInvitationModal, RecoveredInvitationAction, PRESENT_INVITATION_REQUEST,
 };
 use crate::invites::PendingInvites;
 use crate::room_data::{CurrentRoom, Rooms};
@@ -325,9 +325,21 @@ pub fn App() -> Element {
         receive_invitation.set(Some(inv));
     });
 
-    // Recover invitation from localStorage if not found in URL (e.g. after
-    // page reload before subscription completed). The invitation artifact
-    // stays in storage from the moment it is seen until the room is
+    // Retire any invitation an OLDER River persisted to localStorage. That
+    // blob carries a full ed25519 private key plus the room's plaintext
+    // secrets, and the old flow had no terminal state for an abandoned invite,
+    // so it could sit there indefinitely. River no longer writes it (the
+    // pending invitation is held in memory for the page's lifetime), but not
+    // writing it does nothing about what is already on disk — this does.
+    purge_legacy_persisted_invitation_once();
+
+    // Recover the pending invitation if it was not found in the URL. Note this
+    // now only recovers WITHIN a page load, not across a reload: the artifact
+    // is a bearer credential and is deliberately no longer persisted. See
+    // `PENDING_INVITATION`. The three cases below are unchanged in shape; case
+    // 1 (auto-resume) is reachable only when the invitation is still in memory.
+    //
+    // The artifact is held from the moment it is seen until the room is
     // subscribed OR the user dismisses it (`clear_invitation_from_storage`).
     //
     // Three cases, in priority order:

--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -194,6 +194,22 @@ pub fn App() -> Element {
         }
     });
 
+    // Retire any invitation an OLDER River persisted to localStorage, adopting
+    // it into memory first. That blob carries a full ed25519 private key plus
+    // the room's plaintext secrets, and the old flow had no terminal state for
+    // an abandoned invite, so it could sit there indefinitely. River no longer
+    // writes it (the pending invitation is held in memory for the page's
+    // lifetime), but not writing it does nothing about what is already on disk.
+    //
+    // MUST STAY ABOVE the URL-parse block below. That block calls
+    // `save_invitation_to_storage`, which itself purges the legacy artifact —
+    // so with the order reversed this hook would find nothing left to adopt,
+    // and an in-flight join left by the older build would be destroyed unread.
+    // Running first makes the ordering structural rather than a coincidence of
+    // which path happens to be taken; pinned by
+    // `the_startup_purge_is_wired_in_and_adopts_before_erasing`.
+    adopt_and_purge_legacy_persisted_invitation_once();
+
     // Get auth token from window global (injected by Freenet gateway)
     // This is synchronous - no network request needed
     get_auth_token_from_window();
@@ -325,18 +341,6 @@ pub fn App() -> Element {
         );
         receive_invitation.set(Some(inv));
     });
-
-    // Retire any invitation an OLDER River persisted to localStorage. That blob
-    // carries a full ed25519 private key plus the room's plaintext secrets, and
-    // the old flow had no terminal state for an abandoned invite, so it could
-    // sit there indefinitely. River no longer writes it (the pending invitation
-    // is held in memory for the page's lifetime), but not writing it does
-    // nothing about what is already on disk — this does.
-    //
-    // It ADOPTS the artifact into memory before erasing it, so an in-flight
-    // join left by the older build still completes on this one. Runs before the
-    // recovery block below, which is what consumes it.
-    adopt_and_purge_legacy_persisted_invitation_once();
 
     // Recover the pending invitation if it was not found in the URL. Note this
     // now only recovers WITHIN a page load, not across a reload: the artifact

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -1649,6 +1649,11 @@ mod tests {
     /// is how a future River will know who the local user is once `self_sk` is
     /// no longer in the blob, and it can only rely on that if today's build has
     /// been writing it all along.
+    ///
+    /// Writing it here does NOT make it durable — an older tab or build saving
+    /// the same room strips it again, and the backfill never runs on decode.
+    /// See the `RoomData::self_vk` field docs: the relocation writer must check
+    /// per-room that the STORED blob already carries it, not assume it.
     #[test]
     fn a_saved_slot_always_carries_self_vk() {
         let vk = SigningKey::from_bytes(&[31u8; 32]).verifying_key();
@@ -4567,6 +4572,13 @@ fn present_action(kind: SlotKind, explicitly_rejoined: bool) -> PresentAction {
 /// disagreement, it is a copy with nothing to say, and the callers' "diverged"
 /// branches are all lossy (they drop the other copy's state), so silence must
 /// not trigger them.
+///
+/// THE RULE, shared with the identity-conflict guard in `Rooms::merge`:
+/// a CONFLICT test treats an unknown identity as no-conflict. `members::
+/// swap_room_identity_in_place` deliberately takes the opposite view because it
+/// asks a different question — "is this import a CHANGE?" — to which an unknown
+/// identity is correctly "yes", since an import always supplies one. Conflict
+/// tests treat unknown as no-conflict; change tests treat unknown as changed.
 fn identities_diverged(a: &RoomData, b: &RoomData) -> bool {
     match (a.self_verifying_key(), b.self_verifying_key()) {
         (Some(x), Some(y)) => x != y,

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -1685,6 +1685,54 @@ mod tests {
         );
     }
 
+    /// LATENT, and it goes live exactly when the relocation lands.
+    ///
+    /// `reconcile_room_present` builds `merged` from `local.clone()` on every
+    /// branch, and `backfill_self_vk` can only derive `self_vk` from a held
+    /// `self_sk`. So a local copy carrying NEITHER half would serialize
+    /// `self_vk: None` over a stored `Some` and erase the only record of who
+    /// the user is in that room — orphaning it with no way to recover the
+    /// identity.
+    ///
+    /// Unreachable today: every production construction site writes
+    /// `self_sk: Some(..)`, which the paired-field pin in `room_data.rs`
+    /// enforces. The test exists because "unreachable" is a property of the
+    /// current writers, and the relocation changes exactly those writers —
+    /// at which point this becomes a live data-loss path. Cheap to pin now,
+    /// while someone still remembers why it matters.
+    #[test]
+    fn a_save_never_erases_a_stored_self_vk() {
+        let vk = SigningKey::from_bytes(&[41u8; 32]).verifying_key();
+
+        // What the delegate already holds: a full identity record.
+        let mut stored = crate::room_data::test_minimal_room_data(vk);
+        stored.backfill_self_vk();
+        let stored_identity = stored.self_vk.expect("fixture has an identity");
+
+        // A local copy that has lost BOTH halves — the shape the relocation
+        // makes reachable.
+        let mut local = stored.clone();
+        local.self_sk = None;
+        local.self_vk = None;
+
+        let out =
+            reconcile_room_present(Some(&present_slot_bytes(&stored)), &vk, &local, false).unwrap();
+
+        if let Some(bytes) = out {
+            let written = match ciborium::from_reader::<RoomSlot, _>(bytes.as_slice()).unwrap() {
+                RoomSlot::Present(r) => r,
+                RoomSlot::Tombstone => panic!("expected Present"),
+            };
+            assert_eq!(
+                written.self_vk,
+                Some(stored_identity),
+                "a save must never write self_vk: None over a stored identity — \
+                 once self_sk is no longer in the blob that erases the only \
+                 record of who the user is and orphans the room"
+            );
+        }
+    }
+
     /// A copy that merely LACKS the private key is not a different identity.
     /// Treating it as one would send every save down the diverged-identity
     /// branch, which discards the remote's state — so this is a data-loss
@@ -4604,6 +4652,11 @@ fn reconcile_room_present(
         },
     };
 
+    // The identity the delegate already has recorded for this room, captured
+    // before `remote` is consumed by the merge below. Used to stop a save from
+    // ERASING it — see the `self_vk` restore after the match.
+    let stored_self_vk: Option<VerifyingKey> = remote.as_ref().and_then(|r| r.self_verifying_key());
+
     let merged: RoomData = match present_action(kind, explicitly_rejoined) {
         PresentAction::AbortAdoptLeave => return Ok(None),
         PresentAction::StoreFresh => local.clone(),
@@ -4638,6 +4691,18 @@ fn reconcile_room_present(
                 // #420 and out of scope for the #414 escape hatch. Until then the
                 // overwrite-confirm dialog tells the user to close other sessions
                 // for the room first.
+                //
+                // `self_vk` rides along with this. The save chokepoint derives
+                // it from whichever `self_sk` this branch keeps, so a stale tab
+                // stamps its stale VERIFYING key too. No change in effect today
+                // — the stale private key was already being written beside it,
+                // and reads prefer the private key — but it matters for the
+                // relocation: after `self_sk` leaves the blob, `self_vk` is the
+                // only identity record, so this reversal stops being invisible
+                // and becomes the thing that decides who the user is. Deriving
+                // the pair together is what keeps them consistent through the
+                // reversal; #420's fix (an identity-generation counter) is what
+                // stops the reversal itself.
                 local.clone()
             } else {
                 let mut m = local.clone();
@@ -4669,6 +4734,25 @@ fn reconcile_room_present(
     // about the blob changes.
     let mut merged = merged;
     merged.backfill_self_vk();
+
+    // Identity must never REGRESS to unknown.
+    //
+    // Every branch above builds `merged` from `local.clone()`, and
+    // `backfill_self_vk` can only derive `self_vk` from a held `self_sk`. So a
+    // local copy carrying neither half would serialize `self_vk: None` over the
+    // delegate's stored `Some` and erase the only record of who the user is in
+    // this room — orphaning it, with nothing left to recover the identity from.
+    //
+    // Unreachable while every writer stores `self_sk`, which is why this is
+    // cheap now. It becomes live exactly when the relocation lands and
+    // `self_vk` is the only identity record there is, so the guard goes in
+    // before the change that needs it rather than after. Pinned by
+    // `a_save_never_erases_a_stored_self_vk`.
+    if merged.self_vk.is_none() {
+        if let Some(stored) = stored_self_vk {
+            merged.self_vk = Some(stored);
+        }
+    }
 
     let mut out = Vec::new();
     ciborium::ser::into_writer(&RoomSlot::Present(Box::new(merged)), &mut out)

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -1398,7 +1398,7 @@ mod tests {
     fn critical_hash_reacts_to_self_sk() {
         let base = room_fixture();
         let mut rotated = base.clone();
-        rotated.self_sk = SigningKey::from_bytes(&[42u8; 32]);
+        rotated.self_sk = Some(SigningKey::from_bytes(&[42u8; 32]));
 
         assert_ne!(
             critical_hash(&base),
@@ -1612,15 +1612,15 @@ mod tests {
         let vk = SigningKey::from_bytes(&[3u8; 32]).verifying_key();
         let local = crate::room_data::test_minimal_room_data(vk); // self_sk = [1u8;32]
         let mut remote = crate::room_data::test_minimal_room_data(vk);
-        remote.self_sk = SigningKey::from_bytes(&[2u8; 32]); // diverged identity
+        remote.self_sk = Some(SigningKey::from_bytes(&[2u8; 32])); // diverged identity
         let current = present_slot_bytes(&remote);
         let out = reconcile_room_present(Some(&current), &vk, &local, false)
             .unwrap()
             .expect("diverged identity keeps local, must still store");
         match ciborium::from_reader::<RoomSlot, _>(out.as_slice()).unwrap() {
             RoomSlot::Present(r) => assert_eq!(
-                r.self_sk.to_bytes(),
-                local.self_sk.to_bytes(),
+                r.self_sk.as_ref().map(|k| k.to_bytes()),
+                local.self_sk.as_ref().map(|k| k.to_bytes()),
                 "must keep local's identity, not adopt the remote's"
             ),
             RoomSlot::Tombstone => panic!("expected Present"),
@@ -1639,6 +1639,81 @@ mod tests {
     /// Matching-identity merge (the `MergeState` branch) UNIONS `invitation_secrets`:
     /// a version only the remote (delegate-stored) copy carries is preserved, and
     /// local wins on a version collision — so a concurrent tab's private-room
+    /// Every per-room save funnels through `reconcile_room_present`, so that is
+    /// where `self_vk` has to be stamped onto the blob — otherwise the field
+    /// depends on which of the many `RoomData` construction sites happened to
+    /// build the in-memory copy, and blobs written before the field existed
+    /// would never gain it.
+    ///
+    /// This matters for the eventual relocation of the private key: `self_vk`
+    /// is how a future River will know who the local user is once `self_sk` is
+    /// no longer in the blob, and it can only rely on that if today's build has
+    /// been writing it all along.
+    #[test]
+    fn a_saved_slot_always_carries_self_vk() {
+        let vk = SigningKey::from_bytes(&[31u8; 32]).verifying_key();
+        let mut local = crate::room_data::test_minimal_room_data(vk);
+        let expected = local
+            .self_sk
+            .as_ref()
+            .expect("fixture carries a key")
+            .verifying_key();
+        // Simulate a blob loaded from an older writer: key present, self_vk not.
+        local.self_vk = None;
+
+        let out = reconcile_room_present(None, &vk, &local, false)
+            .unwrap()
+            .expect("an absent slot stores fresh");
+        let stored = match ciborium::from_reader::<RoomSlot, _>(out.as_slice()).unwrap() {
+            RoomSlot::Present(r) => r,
+            RoomSlot::Tombstone => panic!("expected Present"),
+        };
+        assert_eq!(
+            stored.self_vk,
+            Some(expected),
+            "the save path must backfill self_vk from the private key"
+        );
+        assert_eq!(
+            stored.self_sk.as_ref().map(|k| k.to_bytes()),
+            local.self_sk.as_ref().map(|k| k.to_bytes()),
+            "and must not disturb the private key while doing it"
+        );
+    }
+
+    /// A copy that merely LACKS the private key is not a different identity.
+    /// Treating it as one would send every save down the diverged-identity
+    /// branch, which discards the remote's state — so this is a data-loss
+    /// guard, not a tidiness one.
+    #[test]
+    fn a_missing_private_key_is_not_a_diverged_identity() {
+        let vk = SigningKey::from_bytes(&[32u8; 32]).verifying_key();
+        let a = crate::room_data::test_minimal_room_data(vk);
+
+        let mut no_key = a.clone();
+        no_key.backfill_self_vk();
+        no_key.self_sk = None;
+        assert!(
+            !identities_diverged(&a, &no_key),
+            "same identity, one copy just does not hold the private half"
+        );
+
+        let mut nothing = a.clone();
+        nothing.self_sk = None;
+        nothing.self_vk = None;
+        assert!(
+            !identities_diverged(&a, &nothing),
+            "a copy that names no identity says nothing, so it cannot disagree"
+        );
+
+        let mut other = a.clone();
+        other.self_sk = Some(SigningKey::from_bytes(&[33u8; 32]));
+        other.self_vk = None;
+        assert!(
+            identities_diverged(&a, &other),
+            "two NAMED and different identities really do diverge"
+        );
+    }
+
     /// secret isn't dropped (skeptical review; this path was previously untested).
     #[test]
     fn reconcile_room_present_unions_invitation_secrets() {
@@ -4484,6 +4559,21 @@ fn present_action(kind: SlotKind, explicitly_rejoined: bool) -> PresentAction {
     }
 }
 
+/// Do two copies of the same room disagree about WHO the local user is?
+///
+/// Only `true` when both copies name an identity and the two names differ.
+/// A copy that carries no identity at all (`self_sk` absent and `self_vk`
+/// absent — possible once a future River stores the key elsewhere) is not a
+/// disagreement, it is a copy with nothing to say, and the callers' "diverged"
+/// branches are all lossy (they drop the other copy's state), so silence must
+/// not trigger them.
+fn identities_diverged(a: &RoomData, b: &RoomData) -> bool {
+    match (a.self_verifying_key(), b.self_verifying_key()) {
+        (Some(x), Some(y)) => x != y,
+        _ => false,
+    }
+}
+
 /// Reconcile a `Present` save for room `owner_vk` against the delegate's
 /// current slot. Returns the `RoomSlot` bytes to store, or `None` to abort
 /// (adopt a remote leave on a background update — the round-9 fix).
@@ -4507,7 +4597,14 @@ fn reconcile_room_present(
         PresentAction::StoreFresh => local.clone(),
         PresentAction::MergeState => {
             let remote = remote.expect("MergeState implies a Present remote slot");
-            if local.self_sk != remote.self_sk {
+            // Compared by IDENTITY, not by the raw `Option<SigningKey>`. A
+            // stored copy that merely lacks the private key (a blob written by
+            // a future River that keeps it elsewhere) is not a DIFFERENT
+            // identity, and treating it as one would throw away the remote's
+            // state on every save. Unknown on either side therefore means
+            // "same identity, merge normally" — the conservative choice, since
+            // the alternative discards a concurrent tab's messages.
+            if identities_diverged(local, &remote) {
                 // Diverged identity for the same room — keep local's
                 // (local-authoritative), don't merge the other identity's
                 // state, and don't fail the whole save (M1 fix: scoped to this
@@ -4552,6 +4649,14 @@ fn reconcile_room_present(
             }
         }
     };
+
+    // The single chokepoint every per-room save passes through, so this is
+    // where `self_vk` is guaranteed to reach storage regardless of which of the
+    // many `RoomData` construction sites produced the in-memory copy. Blobs
+    // written before the field existed gain it on their next save; nothing else
+    // about the blob changes.
+    let mut merged = merged;
+    merged.backfill_self_vk();
 
     let mut out = Vec::new();
     ciborium::ser::into_writer(&RoomSlot::Present(Box::new(merged)), &mut out)
@@ -4902,10 +5007,7 @@ fn dm_prune_suppresses_outbound(current: Option<MemberId>, entry_sender: MemberI
 fn current_room_identity_member_id(owner_vk: &VerifyingKey) -> Option<MemberId> {
     use dioxus::prelude::ReadableExt;
     let rooms = ROOMS.try_read().ok()?;
-    rooms
-        .map
-        .get(owner_vk)
-        .map(|rd| MemberId::from(&rd.self_sk.verifying_key()))
+    rooms.map.get(owner_vk).and_then(|rd| rd.self_member_id())
 }
 
 /// The identity a room's cached outbound DMs must match: the in-memory prune

--- a/ui/src/components/app/document_title.rs
+++ b/ui/src/components/app/document_title.rs
@@ -192,10 +192,22 @@ fn count_unread_in_room_data(room_data: &crate::room_data::RoomData) -> usize {
 fn unread_candidate_messages(
     room_data: &crate::room_data::RoomData,
 ) -> impl Iterator<Item = &river_core::room_state::message::AuthorizedMessageV1> {
-    // `None` when the stored room carries no locally-known identity. There is
-    // then no "own" author to exclude, so the tail keeps every message — the
-    // fail-safe direction for an unread count (an over-count is visible and
-    // clearable; a silent zero is the freenet/river#500 symptom).
+    // `None` when the stored room carries no locally-known identity.
+    //
+    // THE RULE for badge counts with an unknown identity, which is why this
+    // one keeps counting while `count_unread_dms_with` below returns zero:
+    // degrade toward the answer that stays approximately TRUE.
+    //
+    // Here the identity only REFINES the count — it excludes the user's own
+    // messages from their own unread badge. Dropping that refinement
+    // over-counts by however many of the recent messages are the user's, which
+    // is a small, visible, clearable error; a silent zero would be the
+    // freenet/river#500 symptom. So keep counting.
+    //
+    // In the DM case the identity is what makes the count MEAN anything —
+    // which threads are even the user's, and which way each message went — so
+    // a number computed without it would be about other people's
+    // conversations. There, zero is the honest answer.
     let self_member_id: Option<MemberId> = room_data.self_member_id();
     let recent = &room_data.room_state.recent_messages;
 
@@ -519,8 +531,12 @@ fn count_unread_dms_with(
 ) -> usize {
     let mut total = 0usize;
     for (owner_key, room_data) in map {
-        // Without a locally-known identity we cannot tell an inbound DM from
-        // an outbound one, so this room contributes no unread DMs.
+        // Without a locally-known identity we cannot tell which threads are the
+        // user's, nor which way any message went, so this room contributes no
+        // unread DMs. Deliberately the opposite direction from
+        // `unread_candidate_messages` above, which keeps counting — see the
+        // rule stated there: identity only REFINES the room count, but it is
+        // what makes the DM count mean anything at all.
         let Some(self_id) = room_data.self_member_id() else {
             continue;
         };

--- a/ui/src/components/app/document_title.rs
+++ b/ui/src/components/app/document_title.rs
@@ -192,7 +192,11 @@ fn count_unread_in_room_data(room_data: &crate::room_data::RoomData) -> usize {
 fn unread_candidate_messages(
     room_data: &crate::room_data::RoomData,
 ) -> impl Iterator<Item = &river_core::room_state::message::AuthorizedMessageV1> {
-    let self_member_id: MemberId = room_data.self_sk.verifying_key().into();
+    // `None` when the stored room carries no locally-known identity. There is
+    // then no "own" author to exclude, so the tail keeps every message — the
+    // fail-safe direction for an unread count (an over-count is visible and
+    // clearable; a silent zero is the freenet/river#500 symptom).
+    let self_member_id: Option<MemberId> = room_data.self_member_id();
     let recent = &room_data.room_state.recent_messages;
 
     // Index just past the last-read marker. No marker — or a marker that has
@@ -214,7 +218,7 @@ fn unread_candidate_messages(
                 && !m.message.content.is_event()
                 && !recent.actions_state.deleted.contains(&m.id())
         })
-        .filter(move |m| m.message.author != self_member_id)
+        .filter(move |m| self_member_id != Some(m.message.author))
 }
 
 /// Whether a body we could NOT read (`try_decrypt_message_content` returned
@@ -325,7 +329,12 @@ fn compute_mention_unread_count(room_data: &crate::room_data::RoomData) -> usize
         text_mentions_or_replies_to_self, SelfAuthoredIndex,
     };
 
-    let self_member_id: MemberId = room_data.self_sk.verifying_key().into();
+    // No locally-known identity: nothing can mention us and nothing can be a
+    // reply to a message we authored, so the count is genuinely 0 rather than
+    // a degraded guess.
+    let Some(self_member_id) = room_data.self_member_id() else {
+        return 0;
+    };
     let recent = &room_data.room_state.recent_messages.messages;
     // One lazily-built index of self-authored message ids for the whole
     // scan: the reply check would otherwise re-hash every message in the
@@ -404,7 +413,7 @@ fn mention_count_fingerprint(room_data: &crate::room_data::RoomData) -> u64 {
     secrets.sort_unstable_by_key(|(version, _)| **version);
     secrets.hash(&mut h);
     recent.actions_state.deleted.len().hash(&mut h);
-    MemberId::from(room_data.self_sk.verifying_key()).hash(&mut h);
+    room_data.self_member_id().hash(&mut h);
     h.finish()
 }
 
@@ -510,7 +519,11 @@ fn count_unread_dms_with(
 ) -> usize {
     let mut total = 0usize;
     for (owner_key, room_data) in map {
-        let self_id: MemberId = room_data.self_sk.verifying_key().into();
+        // Without a locally-known identity we cannot tell an inbound DM from
+        // an outbound one, so this room contributes no unread DMs.
+        let Some(self_id) = room_data.self_member_id() else {
+            continue;
+        };
 
         // Per-peer accumulation: unread inbound messages plus the newest
         // INBOUND timestamp (the revival clock — see the rail's
@@ -981,7 +994,8 @@ mod tests {
         RoomData {
             owner_vk,
             room_state,
-            self_sk,
+            self_sk: Some(self_sk),
+            self_vk: None,
             contract_key,
             last_read_message_id,
             secrets: HashMap::new(),

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -43,7 +43,6 @@ use river_core::chat_delegate::{
     CasStoreResult, ChatDelegateKey, ChatDelegateRequestMsg, ChatDelegateResponseMsg,
     OutboundDmStore,
 };
-use river_core::room_state::member::MemberId;
 use river_core::room_state::message::{MessageId, RoomMessageBody};
 use river_core::room_state::privacy::PrivacyMode;
 use std::collections::HashMap;
@@ -1573,7 +1572,7 @@ fn hydrate_loaded_rooms_with_authority(
                         info!(
                             "LoadRooms merge: decrypted {} room secret(s) for {:?}",
                             decrypted,
-                            MemberId::from(&room_data.self_sk.verifying_key())
+                            room_data.self_member_id()
                         );
                     }
                 }
@@ -1662,7 +1661,11 @@ fn hydrate_loaded_rooms_with_authority(
                     // identity conflict it resolved against this copy). Nothing
                     // to migrate; pushing a key for it is exactly the bug above.
                     let room_data = rooms.map.get(vk)?;
-                    let owns_room = room_data.owner_vk == room_data.self_sk.verifying_key();
+                    // No local private key => nothing to migrate INTO the
+                    // delegate; the whole point of this pass is to copy the
+                    // key we hold. Skip the room rather than push a `None`.
+                    let self_sk = room_data.signing_key()?.clone();
+                    let owns_room = room_data.is_self_owner();
                     // Derive the contract id from the CURRENT bundled
                     // room-contract WASM so an owner-mode subscription can't
                     // target a contract generation that no longer exists
@@ -1672,12 +1675,7 @@ fn hydrate_loaded_rooms_with_authority(
                     } else {
                         None
                     };
-                    Some((
-                        *vk,
-                        room_data.room_key(),
-                        room_data.self_sk.clone(),
-                        contract_id_for_owner,
-                    ))
+                    Some((*vk, room_data.room_key(), self_sk, contract_id_for_owner))
                 })
                 .collect()
         };
@@ -1718,7 +1716,13 @@ fn hydrate_loaded_rooms_with_authority(
                                     // while this migration ran, and marking the room
                                     // migrated for a superseded key would strand the new
                                     // identity (freenet/river#414).
-                                    if room_data.self_sk != migrated_key {
+                                    // Identity comparison, not raw-key: a copy
+                                    // with no local key is not the identity
+                                    // that completed this migration either, so
+                                    // it must not be marked migrated.
+                                    if room_data.self_verifying_key()
+                                        != Some(migrated_key.verifying_key())
+                                    {
                                         return;
                                     }
                                     room_data.key_migrated_to_delegate = true;

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -184,7 +184,7 @@ pub async fn handle_get_response(
                 rooms
                     .map
                     .get(&owner_vk)
-                    .map(|rd| rd.self_sk.verifying_key())
+                    .and_then(|rd| rd.self_verifying_key())
             });
             let already_member_under_held_key = held_self_vk.is_some_and(|self_vk| {
                 held_key_is_member(&owner_vk, &retrieved_state.members.members, &self_vk)
@@ -460,7 +460,8 @@ pub async fn handle_get_response(
                         RoomData {
                             owner_vk,
                             room_state: retrieved_state.clone(),
-                            self_sk: self_sk.clone(),
+                            self_sk: Some(self_sk.clone()),
+                            self_vk: None,
                             contract_key: key,
                             last_read_message_id: None,
                             secrets: std::collections::HashMap::new(),
@@ -527,16 +528,23 @@ pub async fn handle_get_response(
                         // records the fresh key's credentials would split the
                         // local identity (self_sk vs credentials at different
                         // keys). (Codex review of this PR.)
-                        let existing_vk = room_data.self_sk.verifying_key();
-                        let existing_is_member = existing_vk == owner_vk
-                            || room_data
-                                .room_state
-                                .members
-                                .members
-                                .iter()
-                                .any(|m| m.member.member_vk == existing_vk);
+                        // An identity we cannot name is not a member, so the
+                        // fresh invitation key is adopted — the same outcome as a
+                        // known-but-non-member key, and the only one that leaves
+                        // the room usable.
+                        let existing_is_member =
+                            room_data.self_verifying_key().is_some_and(|existing_vk| {
+                                existing_vk == owner_vk
+                                    || room_data
+                                        .room_state
+                                        .members
+                                        .members
+                                        .iter()
+                                        .any(|m| m.member.member_vk == existing_vk)
+                            });
                         if !existing_is_member {
-                            room_data.self_sk = self_sk.clone();
+                            room_data.self_sk = Some(self_sk.clone());
+                            room_data.self_vk = Some(self_sk.verifying_key());
                             // Reset migration flag so the new key gets migrated
                             room_data.key_migrated_to_delegate = false;
                         }
@@ -594,7 +602,12 @@ pub async fn handle_get_response(
                     // Apply membership immediately on invitation acceptance so
                     // that other room members see "X joined the room" right away
                     // (not deferred until the user's first message).
-                    let self_vk = room_data.self_sk.verifying_key();
+                    // Without a local identity there is no membership to
+                    // publish; treat it as "already handled" so the accept path
+                    // does not build an unsignable member record.
+                    let Some(self_vk) = room_data.self_verifying_key() else {
+                        return;
+                    };
                     let already_member = self_vk == owner_vk
                         || room_data
                             .room_state
@@ -791,7 +804,9 @@ pub async fn handle_get_response(
                                         // and marking the room migrated for a
                                         // superseded key would strand the new identity
                                         // (freenet/river#414).
-                                        if room_data.self_sk != signing_key_clone {
+                                        if room_data.self_verifying_key()
+                                            != Some(signing_key_clone.verifying_key())
+                                        {
                                             return;
                                         }
                                         room_data.key_migrated_to_delegate = true;
@@ -1126,7 +1141,7 @@ pub async fn handle_get_response(
                     // Trigger signing key migration now that we have valid state
                     let self_sk_opt: Option<ed25519_dalek::SigningKey> = {
                         let rooms = ROOMS.read();
-                        rooms.map.get(&owner_vk).map(|rd| rd.self_sk.clone())
+                        rooms.map.get(&owner_vk).and_then(|rd| rd.self_sk.clone())
                     };
                     if let Some(self_sk) = self_sk_opt {
                         wasm_bindgen_futures::spawn_local(async move {
@@ -1151,7 +1166,9 @@ pub async fn handle_get_response(
                                             // for a superseded key would strand the new
                                             // identity (freenet/river#414, round-10 P2 —
                                             // the guard the other 3 callbacks already have).
-                                            if room_data.self_sk != migrated_key {
+                                            if room_data.self_verifying_key()
+                                                != Some(migrated_key.verifying_key())
+                                            {
                                                 return;
                                             }
                                             room_data.key_migrated_to_delegate = true;
@@ -2191,11 +2208,16 @@ mod tests {
             .split("mod tests {")
             .next()
             .expect("get_response.rs must have production code before `mod tests`");
+        // Anchored on the API surface rather than the exact expression text:
+        // the guard now compares IDENTITIES (`self_verifying_key()`) rather than
+        // raw key bytes, because `self_sk` is optional and a copy that merely
+        // lacks the private key must not be mistaken for a different identity.
         assert!(
-            src.contains("if room_data.self_sk != migrated_key {"),
+            src.contains("room_data.self_verifying_key()")
+                && src.contains("migrated_key.verifying_key()"),
             "the post-GET migration completion callback must discard a stale-key \
-             result (room_data.self_sk != migrated_key) before marking migrated \
-             (freenet/river#414 round-10 P2)."
+             result (comparing room_data.self_verifying_key() against the migrated \
+             key's identity) before marking migrated (freenet/river#414 round-10 P2)."
         );
     }
 

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -602,19 +602,27 @@ pub async fn handle_get_response(
                     // Apply membership immediately on invitation acceptance so
                     // that other room members see "X joined the room" right away
                     // (not deferred until the user's first message).
-                    // Without a local identity there is no membership to
-                    // publish; treat it as "already handled" so the accept path
-                    // does not build an unsignable member record.
-                    let Some(self_vk) = room_data.self_verifying_key() else {
-                        return;
+                    //
+                    // With no locally-known identity there is no membership to
+                    // publish, so this is treated as "already a member" — it
+                    // SKIPS the membership block below and nothing else. Do not
+                    // early-return here: real work follows this block
+                    // (`rebuild_private_actions_state` and the rest of the
+                    // accept path) that has nothing to do with the identity.
+                    // Unreachable in practice on this path, which assigns
+                    // `self_sk` a few lines above.
+                    let already_member = match room_data.self_verifying_key() {
+                        None => true,
+                        Some(self_vk) => {
+                            self_vk == owner_vk
+                                || room_data
+                                    .room_state
+                                    .members
+                                    .members
+                                    .iter()
+                                    .any(|m| m.member.member_vk == self_vk)
+                        }
                     };
-                    let already_member = self_vk == owner_vk
-                        || room_data
-                            .room_state
-                            .members
-                            .members
-                            .iter()
-                            .any(|m| m.member.member_vk == self_vk);
 
                     if !already_member {
                         // Add member + any missing invite chain members

--- a/ui/src/components/app/freenet_api/room_synchronizer.rs
+++ b/ui/src/components/app/freenet_api/room_synchronizer.rs
@@ -403,7 +403,13 @@ impl RoomSynchronizer {
                 // back-filled secret AND new private messages would otherwise
                 // leave the notification path using the pre-merge (empty) map
                 // and rendering encrypted placeholders in the preview.
-                let self_member_id: MemberId = room_data.self_sk.verifying_key().into();
+                // `None` when this copy carries no local identity. The delta
+                // still applies in full — only the two self-relative
+                // side-effects below (inbound-DM unhide, and the new-message
+                // notification, which needs to know which messages are ours)
+                // are skipped, because neither can be decided without knowing
+                // who "self" is.
+                let self_member_id: Option<MemberId> = room_data.self_member_id();
 
                 // Issue freenet/river#267: snapshot pre-merge DM
                 // signatures so we can compute "what actually landed"
@@ -496,10 +502,10 @@ impl RoomSynchronizer {
                             if pre_merge_dm_sigs.contains(&sig_bytes) {
                                 continue;
                             }
-                            if msg.message.recipient != self_member_id {
+                            if Some(msg.message.recipient) != self_member_id {
                                 continue;
                             }
-                            if msg.message.sender == self_member_id {
+                            if Some(msg.message.sender) == self_member_id {
                                 // Self-DM is dropped by the contract,
                                 // but defence-in-depth.
                                 continue;
@@ -528,7 +534,9 @@ impl RoomSynchronizer {
                             // encrypted at a version that was back-filled in
                             // this same delta. See #251 / Codex P3.
                             let room_secrets = room_data.secrets.clone();
-                            pending_notification = Some((messages, self_member_id, updated_member_info, room_secrets));
+                            if let Some(self_member_id) = self_member_id {
+                                pending_notification = Some((messages, self_member_id, updated_member_info, room_secrets));
+                            }
                         }
 
                         // Persist to delegate so state survives refresh
@@ -926,7 +934,7 @@ impl RoomSynchronizer {
                 let (new_contract_key, is_owner) = {
                     let rooms = ROOMS.read();
                     if let Some(room_data) = rooms.map.get(owner_vk) {
-                        let is_owner = room_data.self_sk.verifying_key() == *owner_vk;
+                        let is_owner = room_data.self_verifying_key() == Some(*owner_vk);
                         (room_data.contract_key, is_owner)
                     } else {
                         continue;
@@ -979,9 +987,12 @@ impl RoomSynchronizer {
                 }
 
                 // Owner only: send upgrade pointer to old contract for old-client compat.
-                // `is_owner` guarantees `room_data.self_sk` is the owner key, so the
+                // `is_owner` guarantees the local identity IS the owner, so the
                 // `AuthorizedUpgradeV1` signature validates against the old contract's
-                // `parameters.owner`.
+                // `parameters.owner`. It does NOT guarantee the private key is held —
+                // `is_owner` is decided from the public half — so the signing step
+                // below still has to check (and skips the pointer if it can't sign;
+                // the pointer is a courtesy for stragglers, not correctness-critical).
                 if is_owner {
                     use river_core::room_state::upgrade::{AuthorizedUpgradeV1, UpgradeV1};
 
@@ -997,8 +1008,15 @@ impl RoomSynchronizer {
                                 version: 1,
                                 new_chatroom_address: new_address,
                             };
-                            let authorized_upgrade =
-                                AuthorizedUpgradeV1::new(upgrade, &room_data.self_sk);
+                            let Some(self_sk) = room_data.signing_key() else {
+                                warn!(
+                                    "Skipping upgrade pointer for room {:?}: no local \
+                                     signing key to sign it with",
+                                    MemberId::from(*owner_vk)
+                                );
+                                continue;
+                            };
+                            let authorized_upgrade = AuthorizedUpgradeV1::new(upgrade, self_sk);
 
                             // Send a minimal delta carrying ONLY the upgrade
                             // pointer — not a full `UpdateData::State`. A full
@@ -1245,7 +1263,10 @@ impl RoomSynchronizer {
                     old_ids.len(),
                     MemberId::from(room_owner_vk)
                 );
-                let self_id = MemberId::from(&room_data.self_sk.verifying_key());
+                // `None` propagates through the tuple: the consumers below all
+                // unpack it with `if let Some(self_id)`, so an unknown identity
+                // simply skips the self-relative notification work.
+                let self_id = room_data.self_member_id();
                 let member_info = room_data.room_state.member_info.clone();
                 let dm_sigs: std::collections::HashSet<[u8; 64]> = room_data
                     .room_state
@@ -1254,7 +1275,7 @@ impl RoomSynchronizer {
                     .iter()
                     .map(|m| m.sender_signature.to_bytes())
                     .collect();
-                (Some(old_ids), Some(self_id), Some(member_info), dm_sigs)
+                (Some(old_ids), self_id, Some(member_info), dm_sigs)
             } else {
                 debug!(
                     "update_room_state: Room {:?} not found in ROOMS when capturing old IDs",

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -2600,7 +2600,14 @@ pub fn Conversation() -> Element {
                     .next()
                     .is_some()
                 {
-                    let self_member_id = MemberId::from(&room_data.self_sk.verifying_key());
+                    // Only the PUBLIC half is needed here (own-reaction
+                    // highlighting, deputy badges). If the local identity is
+                    // unknown we fall back to the same `None` the contended
+                    // read below returns — the empty-history render — rather
+                    // than mis-attributing messages to a wrong member id.
+                    let Some(self_member_id) = room_data.self_member_id() else {
+                        return None;
+                    };
                     // Build member name lookup (reaction tooltips, @mention chips).
                     let member_names: HashMap<MemberId, String> = room_state
                         .member_info
@@ -3085,7 +3092,13 @@ pub fn Conversation() -> Element {
             if let (Some(current_room), Some(current_room_data)) =
                 (open_room, current_room_data_snapshot())
             {
-                let self_sk = current_room_data.self_sk.clone();
+                // Reactions are signed locally. Without the private key we
+                // cannot author one, so the toggle degrades to a no-op rather
+                // than sending an unsigned (contract-rejected) message.
+                let Some(self_sk) = current_room_data.signing_key().cloned() else {
+                    warn!("Cannot toggle reaction: local signing key unavailable for this room");
+                    return;
+                };
                 let room_state_clone = current_room_data.room_state.clone();
                 let is_private = current_room_data
                     .room_state
@@ -3279,7 +3292,12 @@ pub fn Conversation() -> Element {
             if let (Some(current_room), Some(current_room_data)) =
                 (open_room, current_room_data_snapshot())
             {
-                let self_sk = current_room_data.self_sk.clone();
+                // Deletes are signed locally; with no private key there is
+                // nothing valid to send, so the action is a no-op.
+                let Some(self_sk) = current_room_data.signing_key().cloned() else {
+                    warn!("Cannot delete message: local signing key unavailable for this room");
+                    return;
+                };
                 let room_state_clone = current_room_data.room_state.clone();
                 let is_private = current_room_data
                     .room_state
@@ -3387,7 +3405,12 @@ pub fn Conversation() -> Element {
             if let (Some(current_room), Some(current_room_data)) =
                 (open_room, current_room_data_snapshot())
             {
-                let self_sk = current_room_data.self_sk.clone();
+                // Edits are signed locally; with no private key there is
+                // nothing valid to send, so the action is a no-op.
+                let Some(self_sk) = current_room_data.signing_key().cloned() else {
+                    warn!("Cannot edit message: local signing key unavailable for this room");
+                    return;
+                };
                 let room_state_clone = current_room_data.room_state.clone();
                 let is_private = current_room_data
                     .room_state
@@ -3532,8 +3555,15 @@ pub fn Conversation() -> Element {
             if let (Some(current_room), Some(current_room_data)) =
                 (current_room_opt, fresh_room_data)
             {
-                // Clone what we need for the async block
-                let self_sk = current_room_data.self_sk.clone();
+                // Clone what we need for the async block.
+                // Sending signs locally: with no private key held for this
+                // room the send degrades to a logged no-op, the same shape as
+                // the "no room selected" / "room not loaded" bails above,
+                // rather than emitting an unsignable message.
+                let Some(self_sk) = current_room_data.signing_key().cloned() else {
+                    error!("Cannot send message: local signing key unavailable for this room");
+                    return;
+                };
                 let room_state_clone = current_room_data.room_state.clone();
                 let is_private = current_room_data.is_private();
                 // Copy the secret data (get_secret returns Option<(&[u8; 32], u32)>)
@@ -4424,13 +4454,17 @@ pub fn Conversation() -> Element {
                                 let room_is_private = room_data.is_private();
                                 // Mentionable members for the @ autocomplete: every member
                                 // with a (decrypted) nickname except self, sorted by name.
-                                let self_id = MemberId::from(&room_data.self_sk.verifying_key());
+                                // Public half only. `can_participate` already
+                                // returned Ok, so this is Some here; kept as an
+                                // Option so an absent key would merely leave
+                                // self in the mention list instead of panicking.
+                                let self_id = room_data.self_member_id();
                                 let mut mention_members: Vec<(MemberId, String)> = room_data
                                     .room_state
                                     .member_info
                                     .member_info
                                     .iter()
-                                    .filter(|ami| ami.member_info.member_id != self_id)
+                                    .filter(|ami| Some(ami.member_info.member_id) != self_id)
                                     .map(|ami| {
                                         (
                                             ami.member_info.member_id,
@@ -4462,16 +4496,32 @@ pub fn Conversation() -> Element {
                                 }
                             },
                             Err(SendMessageError::UserNotMember) => {
-                                let user_vk = room_data.self_sk.verifying_key();
-                                rsx! {
-                                    NotMemberNotification {
-                                        user_verifying_key: user_vk
-                                    }
+                                // `can_participate` reports IdentityUnavailable
+                                // (below), never UserNotMember, when the key is
+                                // absent — so this is Some. Matched rather than
+                                // unwrapped so an absent key renders nothing
+                                // instead of panicking the whole conversation.
+                                match room_data.self_verifying_key() {
+                                    Some(user_vk) => rsx! {
+                                        NotMemberNotification {
+                                            user_verifying_key: user_vk
+                                        }
+                                    },
+                                    None => rsx! {},
                                 }
                             },
                             Err(SendMessageError::UserBanned) => rsx! {
                                 div { class: "px-4 py-3 mx-4 mb-4 bg-error-bg text-red-700 dark:text-red-400 rounded-lg text-sm",
                                     "You have been banned from sending messages in this room."
+                                }
+                            },
+                            // Same shape as the banned notice above: the
+                            // composer is replaced by an explanation.
+                            // `NotMemberNotification` cannot be used here — it
+                            // needs the verifying key, which is what is missing.
+                            Err(SendMessageError::IdentityUnavailable) => rsx! {
+                                div { class: "px-4 py-3 mx-4 mb-4 bg-error-bg text-red-700 dark:text-red-400 rounded-lg text-sm",
+                                    "This device doesn't hold your key for this room, so you can't send messages here."
                                 }
                             },
                         }

--- a/ui/src/components/conversation.rs
+++ b/ui/src/components/conversation.rs
@@ -536,7 +536,12 @@ impl MessageClock<'_> {
 fn group_messages(
     messages_state: &MessagesV1,
     member_info: &MemberInfoV1,
-    self_member_id: MemberId,
+    // `None` when this build holds no locally-known identity for the room.
+    // Every message still renders; the identity-relative cosmetics (the
+    // `is_self` side of the bubble, the "mention of you" chip highlight)
+    // degrade to "not me". Never a mis-attribution: an unknown identity
+    // matches nobody.
+    self_member_id: Option<MemberId>,
     secrets: &HashMap<u32, [u8; 32]>,
     member_names: &HashMap<MemberId, String>,
     // Which members show a 🛡 shield in THIS viewer's conversation, built once
@@ -611,7 +616,9 @@ fn group_messages(
             members_fp,
             self_member_id,
         );
-        let is_self = author_id == self_member_id;
+        // With no locally-known identity nothing is "self", so every group
+        // renders on the other-party side rather than claiming an author.
+        let is_self = Some(author_id) == self_member_id;
 
         // Get edited status and reactions
         let edited = messages_state.is_edited(&message_id);
@@ -991,11 +998,12 @@ fn markdown_to_html(text: &str, behind_gateway: bool) -> String {
 ///
 /// `member_names` maps each member id to their decrypted current nickname (the
 /// `[name]` snapshot in the token is only used as a fallback when the id is not
-/// in the map). `self_member_id` gets a distinct highlight (a mention of you).
+/// in the map). `self_member_id` gets a distinct highlight (a mention of you);
+/// `None` (no locally-known identity) simply means no chip is self-highlighted.
 pub(crate) fn message_to_html_with_mentions(
     text: &str,
     member_names: &HashMap<MemberId, String>,
-    self_member_id: MemberId,
+    self_member_id: Option<MemberId>,
 ) -> String {
     use river_core::mention::{parse_segments, MentionSegment};
 
@@ -1040,7 +1048,11 @@ pub(crate) fn message_to_html_with_mentions(
                 chips.push(render_mention_chip_html(
                     resolved,
                     &name,
-                    resolved == Some(self_member_id),
+                    // `self_member_id.is_some_and(..)` rather than
+                    // `resolved == self_member_id`: the latter would call an
+                    // UNRESOLVED mention a mention of you when the local
+                    // identity is also unknown (`None == None`).
+                    self_member_id.is_some_and(|me| resolved == Some(me)),
                 ));
                 working.push(OPEN);
                 working.push_str(&idx.to_string());
@@ -1106,7 +1118,7 @@ fn member_names_fingerprint(member_names: &HashMap<MemberId, String>) -> u64 {
 /// part of the key. Gating the member inputs on the presence of a mention
 /// means an ordinary (mention-free) message survives member joins/renames in
 /// the cache, while a message that renders a chip is invalidated by them.
-fn message_html_fingerprint(text: &str, members_fp: u64, self_member_id: MemberId) -> u64 {
+fn message_html_fingerprint(text: &str, members_fp: u64, self_member_id: Option<MemberId>) -> u64 {
     let mut h = DefaultHasher::new();
     text.hash(&mut h);
     if text.contains(river_core::mention::REF_SCHEME) {
@@ -1125,7 +1137,7 @@ fn render_message_html_cached(
     text: &str,
     member_names: &HashMap<MemberId, String>,
     members_fp: u64,
-    self_member_id: MemberId,
+    self_member_id: Option<MemberId>,
 ) -> String {
     let fp = message_html_fingerprint(text, members_fp, self_member_id);
     MESSAGE_HTML_CACHE.with(|cache| {
@@ -2600,14 +2612,15 @@ pub fn Conversation() -> Element {
                     .next()
                     .is_some()
                 {
-                    // Only the PUBLIC half is needed here (own-reaction
-                    // highlighting, deputy badges). If the local identity is
-                    // unknown we fall back to the same `None` the contended
-                    // read below returns — the empty-history render — rather
-                    // than mis-attributing messages to a wrong member id.
-                    let Some(self_member_id) = room_data.self_member_id() else {
-                        return None;
-                    };
+                    // Only the PUBLIC half is needed here, and only for
+                    // cosmetics: own-reaction highlighting, `is_self` grouping,
+                    // deputy badges. `None` (no locally-known identity) is
+                    // carried through rather than returned: bailing here would
+                    // render "No messages yet. Start the conversation!" over a
+                    // room full of history, which is the exact wrong-render
+                    // freenet/river#555 was about. Nothing is mis-attributed —
+                    // an unknown identity matches no member.
+                    let self_member_id: Option<MemberId> = room_data.self_member_id();
                     // Build member name lookup (reaction tooltips, @mention chips).
                     let member_names: HashMap<MemberId, String> = room_state
                         .member_info
@@ -2626,13 +2639,23 @@ pub fn Conversation() -> Element {
                     // Which authors show a 🛡 shield in this viewer's view.
                     // Computed once here, not per message: the maps behind it
                     // are O(members) to build.
-                    let deputy_badges = deputy_badges_for_viewer(
-                        &room_state.members,
-                        &room_state.member_info,
-                        &room_data.secrets,
-                        MemberId::from(&key),
-                        self_member_id,
-                    );
+                    // The badge map is VIEWER-relative (which deputies could
+                    // ban *you*), so with no identity there is no viewer to be
+                    // relative to and the shields degrade to "no badge" — an
+                    // empty map, exactly what a room with no deputies produces.
+                    // The helper keeps its `MemberId` parameter: it has ~30
+                    // call sites, and a fabricated viewer id here would be
+                    // worse than none.
+                    let deputy_badges = match self_member_id {
+                        Some(self_member_id) => deputy_badges_for_viewer(
+                            &room_state.members,
+                            &room_state.member_info,
+                            &room_data.secrets,
+                            MemberId::from(&key),
+                            self_member_id,
+                        ),
+                        None => HashMap::new(),
+                    };
                     // The ⚠ impersonation checker, from the SAME badge map, so
                     // "who is a deputy" has one answer across the conversation
                     // and the member list. Built once here, like the badges.
@@ -4690,7 +4713,11 @@ pub fn Conversation() -> Element {
 #[component]
 fn MessageGroupComponent(
     group: MessageGroup,
-    self_member_id: MemberId,
+    /// `None` when this build holds no locally-known identity for the room.
+    /// Only cosmetics depend on it here (own-reaction highlight, excluding
+    /// yourself from the @mention list), and each degrades to the "not me"
+    /// answer.
+    self_member_id: Option<MemberId>,
     member_names: HashMap<MemberId, String>,
     /// Room max message size in ENCODED content bytes — bounds the edit
     /// action body (`RoomMessageBody::measure_edit`), not the raw text.
@@ -4769,7 +4796,10 @@ fn MessageGroupComponent(
     let edit_mention_members: Vec<(MemberId, String)> = {
         let mut v: Vec<(MemberId, String)> = member_names
             .iter()
-            .filter(|(id, _)| **id != self_member_id)
+            // With no known identity there is no "yourself" to exclude, so the
+            // list keeps every member. Over-inclusive, never wrong: excluding
+            // an arbitrary member would silently make them unmentionable.
+            .filter(|(id, _)| Some(**id) != self_member_id)
             // `display_nickname` never returns an empty string, so the old
             // is-empty filter became dead: the placeholder is what to exclude.
             .filter(|(_, name)| *name != crate::util::display_name::UNNAMED)
@@ -5552,8 +5582,12 @@ fn MessageGroupComponent(
                                     let is_inline_picker_open = open_emoji_picker.read().as_ref() == Some(&format!("inline-{}", msg_id_for_inline));
 
                                     // Find user's current reaction on this message (if any)
+                                    // No known identity ⇒ no reaction is ours,
+                                    // so nothing is highlighted and the picker
+                                    // offers a fresh reaction rather than a
+                                    // toggle of someone else's.
                                     let user_reaction: Option<String> = msg.reactions.iter().find_map(|(emoji, reactors)| {
-                                        if reactors.contains(&self_member_id) {
+                                        if self_member_id.is_some_and(|me| reactors.contains(&me)) {
                                             Some(emoji.clone())
                                         } else {
                                             None
@@ -5573,13 +5607,16 @@ fn MessageGroupComponent(
                                                 sorted_reactions.sort_by_key(|(emoji, _)| emoji.as_str());
                                                 sorted_reactions.into_iter().map(|(emoji, reactors)| {
                                                     let count = reactors.len();
-                                                    let is_user_reaction = reactors.contains(&self_member_id);
+                                                    let is_user_reaction = self_member_id.is_some_and(|me| reactors.contains(&me));
                                                     let emoji_for_click = emoji.clone();
                                                     let msg_id_for_click = msg_id_react.clone();
 
                                                     // Build list of reactor names for tooltip
                                                     let reactor_names: Vec<String> = reactors.iter().map(|reactor_id| {
-                                                        if *reactor_id == self_member_id {
+                                                        // Unknown identity ⇒ nobody is
+                                                        // labelled "You"; every reactor
+                                                        // falls through to their nickname.
+                                                        if Some(*reactor_id) == self_member_id {
                                                             "You".to_string()
                                                         } else {
                                                             member_names.get(reactor_id)
@@ -6521,7 +6558,7 @@ mod tests {
         let me = MemberId(freenet_scaffold::util::FastHash(1));
         let token = river_core::mention::encode_mention(unknown, "Admin 🛡");
 
-        let html = message_to_html_with_mentions(&token, &HashMap::new(), me);
+        let html = message_to_html_with_mentions(&token, &HashMap::new(), Some(me));
         assert!(
             !html.contains('\u{1F6E1}'),
             "an unresolved mention rendered a badge glyph from its snapshot: {html}"
@@ -7325,21 +7362,21 @@ mod tests {
 
         // Plain (mention-free) body: repeat call returns identical HTML.
         let text = "hello **world** https://freenet.org";
-        let first = render_message_html_cached(&id, text, &names, fp, me);
-        let second = render_message_html_cached(&id, text, &names, fp, me);
+        let first = render_message_html_cached(&id, text, &names, fp, Some(me));
+        let second = render_message_html_cached(&id, text, &names, fp, Some(me));
         assert_eq!(first, second, "cache hit is identical");
         assert_eq!(
             first,
-            message_to_html_with_mentions(text, &names, me),
+            message_to_html_with_mentions(text, &names, Some(me)),
             "cached output equals uncached"
         );
 
         // Editing the body (same id) invalidates and re-renders.
         let edited = "goodbye **world**";
-        let after_edit = render_message_html_cached(&id, edited, &names, fp, me);
+        let after_edit = render_message_html_cached(&id, edited, &names, fp, Some(me));
         assert_eq!(
             after_edit,
-            message_to_html_with_mentions(edited, &names, me),
+            message_to_html_with_mentions(edited, &names, Some(me)),
             "edited content re-rendered"
         );
         assert_ne!(after_edit, first, "edit changed the HTML");
@@ -7359,7 +7396,7 @@ mod tests {
         let mut names = HashMap::new();
         names.insert(alice, "Alice".to_string());
         let fp1 = member_names_fingerprint(&names);
-        let before = render_message_html_cached(&id, &text, &names, fp1, me);
+        let before = render_message_html_cached(&id, &text, &names, fp1, Some(me));
         assert!(
             before.contains("Alice"),
             "chip shows current name: {before}"
@@ -7370,10 +7407,10 @@ mod tests {
         names.insert(alice, "Roberta".to_string());
         let fp2 = member_names_fingerprint(&names);
         assert_ne!(fp1, fp2, "rename changes the member fingerprint");
-        let after = render_message_html_cached(&id, &text, &names, fp2, me);
+        let after = render_message_html_cached(&id, &text, &names, fp2, Some(me));
         assert_eq!(
             after,
-            message_to_html_with_mentions(&text, &names, me),
+            message_to_html_with_mentions(&text, &names, Some(me)),
             "rename invalidated the cached chip"
         );
         assert!(after.contains("Roberta"), "chip shows new name: {after}");
@@ -7388,8 +7425,8 @@ mod tests {
         let me = mid_from("00000000000000bb");
         let plain = "just a normal message, no mentions here";
         assert_eq!(
-            message_html_fingerprint(plain, 111, me),
-            message_html_fingerprint(plain, 222, me),
+            message_html_fingerprint(plain, 111, Some(me)),
+            message_html_fingerprint(plain, 222, Some(me)),
             "mention-free fingerprint ignores member fp"
         );
 
@@ -7397,8 +7434,8 @@ mod tests {
         let token = river_core::mention::encode_mention(alice, "Alice");
         let mentioned = format!("ping {token}");
         assert_ne!(
-            message_html_fingerprint(&mentioned, 111, me),
-            message_html_fingerprint(&mentioned, 222, me),
+            message_html_fingerprint(&mentioned, 111, Some(me)),
+            message_html_fingerprint(&mentioned, 222, Some(me)),
             "mention fingerprint depends on member fp"
         );
     }
@@ -7413,8 +7450,8 @@ mod tests {
         let fp = member_names_fingerprint(&names);
         let keep = msg_id(b"keep");
         let drop = msg_id(b"drop");
-        render_message_html_cached(&keep, "keep me", &names, fp, me);
-        render_message_html_cached(&drop, "drop me", &names, fp, me);
+        render_message_html_cached(&keep, "keep me", &names, fp, Some(me));
+        render_message_html_cached(&drop, "drop me", &names, fp, Some(me));
         assert_eq!(MESSAGE_HTML_CACHE.with(|c| c.borrow().len()), 2);
 
         let mut visible = std::collections::HashSet::new();
@@ -7474,7 +7511,7 @@ mod tests {
         let html = message_to_html_with_mentions(
             &format!("hi {token}!"),
             &names,
-            mid_from("00000000000000ff"),
+            Some(mid_from("00000000000000ff")),
         );
         assert!(
             html.contains("data-member-id=\"00000000000000aa\""),
@@ -7495,7 +7532,8 @@ mod tests {
         let id = mid_from("0000000000000abc");
         let names = HashMap::new(); // member not resolvable
         let token = river_core::mention::encode_mention(id, "Ghost");
-        let html = message_to_html_with_mentions(&token, &names, mid_from("0000000000000001"));
+        let html =
+            message_to_html_with_mentions(&token, &names, Some(mid_from("0000000000000001")));
         assert!(
             html.contains(">@Ghost</span>"),
             "unknown member falls back to the token's snapshot name: {html}"
@@ -7510,7 +7548,8 @@ mod tests {
         let mut names = HashMap::new();
         names.insert(id, "<img src=x onerror=alert(1)>".to_string());
         let token = river_core::mention::encode_mention(id, "snap");
-        let html = message_to_html_with_mentions(&token, &names, mid_from("0000000000000002"));
+        let html =
+            message_to_html_with_mentions(&token, &names, Some(mid_from("0000000000000002")));
         assert!(
             !html.contains("<img"),
             "raw markup must not survive: {html}"
@@ -7527,7 +7566,7 @@ mod tests {
         let mut names = HashMap::new();
         names.insert(me, "Me".to_string());
         let token = river_core::mention::encode_mention(me, "Me");
-        let html = message_to_html_with_mentions(&token, &names, me);
+        let html = message_to_html_with_mentions(&token, &names, Some(me));
         assert!(
             html.contains("river-mention-self"),
             "a mention of the local user must get the self class: {html}"
@@ -7540,7 +7579,7 @@ mod tests {
         let text = "a normal *markdown* msg with a https://example.com link";
         let any = mid_from("0000000000000001");
         assert_eq!(
-            message_to_html_with_mentions(text, &names, any),
+            message_to_html_with_mentions(text, &names, Some(any)),
             message_to_html(text),
             "the no-mention fast path must match the plain renderer byte-for-byte"
         );
@@ -7558,7 +7597,7 @@ mod tests {
             river_core::mention::encode_mention(a, "x"),
             river_core::mention::encode_mention(b, "y")
         );
-        let html = message_to_html_with_mentions(&text, &names, mid_from("00000000000000ff"));
+        let html = message_to_html_with_mentions(&text, &names, Some(mid_from("00000000000000ff")));
         assert!(html.contains(">@Ann</span>"), "{html}");
         assert!(html.contains(">@Bob</span>"), "{html}");
         assert!(
@@ -7587,7 +7626,8 @@ mod tests {
             )),
             "token uses the short base32 ref: {token}"
         );
-        let html = message_to_html_with_mentions(&token, &names, mid_from("00000000000000ff"));
+        let html =
+            message_to_html_with_mentions(&token, &names, Some(mid_from("00000000000000ff")));
         assert!(
             html.contains("data-member-id=\"00000000000000aa\""),
             "chip recovers the lossless id from the short ref: {html}"
@@ -7605,7 +7645,8 @@ mod tests {
             river_core::mention::REF_SCHEME,
             river_core::mention::member_id_to_hex(id)
         );
-        let html = message_to_html_with_mentions(&legacy, &names, mid_from("0000000000000001"));
+        let html =
+            message_to_html_with_mentions(&legacy, &names, Some(mid_from("0000000000000001")));
         assert!(
             html.contains("data-member-id=\"0000000000000abc\""),
             "legacy chip keeps the full id: {html}"
@@ -7621,7 +7662,8 @@ mod tests {
         let id = mid_from("0000000000000abc");
         let names = HashMap::new();
         let token = river_core::mention::encode_mention(id, "Ghost");
-        let html = message_to_html_with_mentions(&token, &names, mid_from("0000000000000001"));
+        let html =
+            message_to_html_with_mentions(&token, &names, Some(mid_from("0000000000000001")));
         assert!(
             html.contains(">@Ghost</span>"),
             "snapshot name shown: {html}"
@@ -7644,7 +7686,7 @@ mod tests {
             river_core::mention::REF_SCHEME,
             river_core::mention::member_id_to_hex(me)
         );
-        let html = message_to_html_with_mentions(&legacy, &names, me);
+        let html = message_to_html_with_mentions(&legacy, &names, Some(me));
         assert!(
             html.contains("river-mention-self"),
             "legacy self-mention must get the self class: {html}"
@@ -8567,7 +8609,7 @@ mod group_messages_clock_tests {
         group_messages(
             messages,
             member_info,
-            me,
+            Some(me),
             &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),
@@ -8580,6 +8622,88 @@ mod group_messages_clock_tests {
                 fallback_now,
             },
         )
+    }
+
+    /// A room whose local identity is unknown must still render its history.
+    ///
+    /// The regression this pins is user-visible and severe: `message_groups`
+    /// used to bail to `None` here, and the `None` arm renders
+    /// "No messages yet. Start the conversation!" — so a room full of history
+    /// would look empty. `signing_key()`'s own contract is to leave the rest of
+    /// the room readable (freenet/river#555 is the precedent for this exact
+    /// wrong render).
+    ///
+    /// The identity is needed here only for cosmetics, so it degrades to
+    /// "not me" rather than to nothing.
+    #[test]
+    fn messages_still_render_when_the_local_identity_is_unknown() {
+        let owner = signing_key(60);
+        let owner_id = member_id_of(&owner);
+        let a = signing_key(61);
+        let b = signing_key(62);
+        let now = Utc::now();
+        let messages = state(vec![
+            message_at(owner_id, &a, now),
+            message_at(owner_id, &b, now + chrono::Duration::minutes(1)),
+        ]);
+        let mut member_info = info(&a, "Alice");
+        member_info.member_info.extend(info(&b, "Bob").member_info);
+        let receive_times = ReceiveTimes::default();
+
+        let known = group_messages(
+            &messages,
+            &member_info,
+            Some(member_id_of(&a)),
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &ImpersonationChecker::default(),
+            owner_id,
+            MessageClock {
+                receive_times: &receive_times,
+                fallback_now: now,
+            },
+        );
+        let unknown = group_messages(
+            &messages,
+            &member_info,
+            None,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &ImpersonationChecker::default(),
+            owner_id,
+            MessageClock {
+                receive_times: &receive_times,
+                fallback_now: now,
+            },
+        );
+
+        // Precondition, so this cannot pass on an empty fixture.
+        assert!(
+            !known.is_empty(),
+            "fixture must produce groups with a known identity"
+        );
+        assert_eq!(
+            unknown.len(),
+            known.len(),
+            "every message must still render with no local identity — an empty \
+             result is what makes the UI claim the room has no messages"
+        );
+
+        // The only difference is the cosmetic: nothing is attributed to "me".
+        let self_flags: Vec<bool> = unknown
+            .iter()
+            .filter_map(|i| match i {
+                DisplayItem::Messages(g) => Some(g.is_self),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !self_flags.is_empty() && self_flags.iter().all(|f| !f),
+            "with an unknown identity nothing is 'mine' — but nothing is \
+             mis-attributed either"
+        );
     }
 
     fn only_group(items: &[DisplayItem]) -> &MessageGroup {

--- a/ui/src/components/direct_messages.rs
+++ b/ui/src/components/direct_messages.rs
@@ -251,8 +251,13 @@ pub fn open_invite_via_dm_picker(current_room: VerifyingKey, peer: MemberId) {
     let Ok(rooms) = crate::components::app::ROOMS.try_read() else {
         return;
     };
-    if let Some(room_data) = rooms.map.get(&current_room) {
-        let self_id: MemberId = room_data.self_sk.verifying_key().into();
+    // Public half only. With no local identity the self-as-peer check simply
+    // does not apply — the same fall-through as a room that isn't loaded.
+    if let Some(self_id) = rooms
+        .map
+        .get(&current_room)
+        .and_then(|room_data| room_data.self_member_id())
+    {
         if self_id == peer {
             dioxus::logger::tracing::warn!(
                 "open_invite_via_dm_picker: refusing to open for self-as-peer"
@@ -308,6 +313,10 @@ pub enum SendDmOutcome {
     /// recipient missing from members AND no rejoin bundle could fix
     /// it. See `ApplyOutcome::SilentDrop` in `dm_thread_modal.rs`.
     SilentDrop,
+    /// This device does not hold the local user's key for this room, so the
+    /// DM cannot be signed or sealed. Distinct from `SenderMissingRejoin`:
+    /// the user may well be a member, we just cannot author as them here.
+    IdentityUnavailable,
 }
 
 /// Compose, locally-apply, and queue for network sync a single direct
@@ -386,7 +395,11 @@ pub async fn send_structured_dm(
             else {
                 return PreflightOutcome::Reject(SendDmOutcome::RoomGone);
             };
-            let self_sk = room_data.self_sk.clone();
+            // A DM is signed AND sealed with the local key, so an absent one
+            // is a hard reject rather than a degraded send.
+            let Some(self_sk) = room_data.signing_key().cloned() else {
+                return PreflightOutcome::Reject(SendDmOutcome::IdentityUnavailable);
+            };
             let self_id: MemberId = (&self_sk.verifying_key()).into();
             let owner_id = MemberId::from(&room);
             if self_id == peer {
@@ -629,7 +642,11 @@ pub(crate) fn compute_dm_last_seen(
 ) -> HashMap<(VerifyingKey, MemberId), u64> {
     let mut updates: HashMap<(VerifyingKey, MemberId), u64> = HashMap::new();
     for (owner_vk, room_data) in &rooms.map {
-        let self_id: MemberId = room_data.self_sk.verifying_key().into();
+        // Without the local identity we cannot tell inbound DMs from outbound
+        // ones, so this room contributes no last-seen entries.
+        let Some(self_id) = room_data.self_member_id() else {
+            continue;
+        };
         for msg in &room_data.room_state.direct_messages.messages {
             if msg.message.recipient != self_id {
                 continue;
@@ -1094,7 +1111,8 @@ mod tests {
             RoomData {
                 owner_vk,
                 room_state: state,
-                self_sk: self_sk.clone(),
+                self_sk: Some(self_sk.clone()),
+                self_vk: None,
                 contract_key,
                 last_read_message_id: None,
                 secrets: std::collections::HashMap::new(),

--- a/ui/src/components/direct_messages/dm_thread_modal.rs
+++ b/ui/src/components/direct_messages/dm_thread_modal.rs
@@ -191,8 +191,13 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
             // involves `peer`, and picking a default would render some other
             // member's message as one the user sent. Constraint: never
             // mislabel. So the message loop is skipped entirely and the thread
-            // renders EMPTY (the peer's name, membership state and the
+            // renders with no bubbles (the peer's name, membership state and the
             // composer's own key check are unaffected) rather than wrong.
+            //
+            // That "no bubbles" state is NOT the same as an empty thread, and
+            // `identity_known` below carries the difference to the render: the
+            // empty-state copy must not claim a thread with real history is
+            // empty.
             let self_id: Option<MemberId> = room_data.self_member_id();
             let owner_id = MemberId::from(&room);
 
@@ -389,6 +394,8 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                 peer_still_member,
                 messages: rendered,
                 latest_inbound_ts,
+                identity_known: self_id.is_some(),
+                can_send: self_sk.is_some(),
             })
         }
     });
@@ -492,6 +499,8 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
 
     let peer_label = view_data.peer_nickname.clone();
     let peer_still_member = view_data.peer_still_member;
+    let identity_known = view_data.identity_known;
+    let can_send = view_data.can_send;
 
     let close = move |_| {
         crate::util::defer(move || {
@@ -908,7 +917,19 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                 div {
                     id: "dm-scroll-container",
                     class: "flex-1 overflow-y-auto px-5 py-4 space-y-2",
-                    if view_data.messages.is_empty() {
+                    if view_data.messages.is_empty() && !identity_known {
+                        // NOT "No messages yet". With no local identity every
+                        // DM in this thread was skipped rather than shown (see
+                        // the memo), so the history may be substantial — and
+                        // telling the reader it is empty is a claim about their
+                        // data that happens to be false. Same register as the
+                        // send path's refusal below.
+                        p {
+                            "data-testid": "dm-thread-identity-unavailable",
+                            class: "text-sm text-text-muted italic",
+                            "This device doesn't hold your key for this room, so this conversation can't be shown here."
+                        }
+                    } else if view_data.messages.is_empty() {
                         p { class: "text-sm text-text-muted italic",
                             "No messages yet. Say hello!"
                         }
@@ -944,6 +965,19 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                             "This member is not currently in the room — outbound DMs will be rejected by the contract."
                         }
                     }
+                    // Up front, not on Send. Composing a DM signs and seals with
+                    // the local private key, so without it the send can only
+                    // ever be refused; letting the user type a message first and
+                    // then fail is the worse of the two. Same wording as the
+                    // send path's refusal, which stays in place as the action
+                    // boundary. `edit_room_modal` warns the same way.
+                    if !can_send {
+                        div {
+                            "data-testid": "dm-thread-no-key-notice",
+                            class: "text-xs text-yellow-400",
+                            "This device doesn't hold your key for this room, so you can't send DMs here."
+                        }
+                    }
                     div { class: "flex items-end gap-2",
                         textarea {
                             class: "flex-1 px-3 py-2 bg-surface border border-border rounded-lg text-sm text-text resize-none min-h-[2.5rem] max-h-32",
@@ -957,16 +991,16 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                             onkeydown: move |e| {
                                 if e.key() == Key::Enter && !e.modifiers().shift() {
                                     e.prevent_default();
-                                    if !draft.read().trim().is_empty() && peer_still_member {
+                                    if !draft.read().trim().is_empty() && peer_still_member && can_send {
                                         do_send();
                                     }
                                 }
                             },
-                            disabled: !peer_still_member,
+                            disabled: !peer_still_member || !can_send,
                         }
                         button {
                             class: "px-3 py-2 bg-accent hover:bg-accent-hover disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors",
-                            disabled: draft.read().trim().is_empty() || !peer_still_member,
+                            disabled: draft.read().trim().is_empty() || !peer_still_member || !can_send,
                             onclick: move |_| do_send(),
                             "Send"
                         }
@@ -1042,7 +1076,10 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                             // not write the forbidden class names here — this
                             // comment tripped it once already.)
                             class: "text-xs py-1 text-accent hover:text-accent-hover disabled:opacity-50 disabled:hover:text-accent transition-colors",
-                            disabled: !peer_still_member,
+                            // Also disabled with no local private key, for the
+                            // same reason Send is: an invitation IS an outbound
+                            // DM, signed and sealed with that key.
+                            disabled: !peer_still_member || !can_send,
                             // Same name the Member Info dialog uses, so the
                             // feature reads as one thing across the app. It
                             // collides with no Playwright selector: the specs
@@ -1160,6 +1197,20 @@ struct ViewData {
     peer_still_member: bool,
     messages: Vec<RenderedDm>,
     latest_inbound_ts: u64,
+    /// Whether this build knows the local user's `MemberId` in this room.
+    ///
+    /// `false` means the message loop could not attribute a single DM, so
+    /// `messages` is empty for a reason that has nothing to do with the thread
+    /// being new. The empty state uses this to say "cannot be shown here"
+    /// instead of "no messages yet".
+    identity_known: bool,
+    /// Whether this build holds the local private key for this room.
+    ///
+    /// Composing a DM signs and seals with it, so `false` disables the composer
+    /// up front rather than letting the user write a message that only fails at
+    /// Send. Distinct from `identity_known`: an identity can be known (from the
+    /// persisted verifying key) while the private key is not held.
+    can_send: bool,
 }
 
 /// Inbound DM body presentation.

--- a/ui/src/components/direct_messages/dm_thread_modal.rs
+++ b/ui/src/components/direct_messages/dm_thread_modal.rs
@@ -178,11 +178,22 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
             };
             let room_data = rooms.map.get(&room)?;
 
-            // DM bodies are ECIES-sealed to us, so rendering the thread needs
-            // the private key. Without it there is nothing to show: fall back
-            // to the same `None` a contended ROOMS read returns.
-            let self_sk = room_data.signing_key().cloned()?;
-            let self_id = MemberId::from(&self_sk.verifying_key());
+            // INBOUND bodies are ECIES-sealed to us, so reading them needs the
+            // private key — but its absence must not blank the thread. Outbound
+            // bubbles come from the plaintext cache, and an unreadable inbound
+            // body degrades to the same placeholder a decrypt failure already
+            // renders. `None` here only costs the bodies.
+            let self_sk = room_data.signing_key().cloned();
+            // Direction (inbound vs outbound) is decided against the local
+            // member id, and the id survives without the private key
+            // (`self_verifying_key` falls back to the persisted `self_vk`).
+            // With NO identity at all, direction is undecidable: every DM here
+            // involves `peer`, and picking a default would render some other
+            // member's message as one the user sent. Constraint: never
+            // mislabel. So the message loop is skipped entirely and the thread
+            // renders EMPTY (the peer's name, membership state and the
+            // composer's own key check are unaffected) rather than wrong.
+            let self_id: Option<MemberId> = room_data.self_member_id();
             let owner_id = MemberId::from(&room);
 
             // Nickname / membership lookup.
@@ -241,8 +252,12 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
             let mut latest_inbound_ts: u64 = 0;
             let mut rendered: Vec<RenderedDm> = Vec::new();
             for msg in &room_data.room_state.direct_messages.messages {
-                let is_self_sender = msg.message.sender == self_id;
-                let is_self_recipient = msg.message.recipient == self_id;
+                // Both `false` when `self_id` is `None`, so `between_us` below
+                // is false for every message and the thread renders empty —
+                // the "never mislabel" degradation described above, with no
+                // special case needed here.
+                let is_self_sender = Some(msg.message.sender) == self_id;
+                let is_self_recipient = Some(msg.message.recipient) == self_id;
                 let between_us = (is_self_sender && msg.message.recipient == peer)
                     || (is_self_recipient && msg.message.sender == peer);
                 if !between_us {
@@ -254,8 +269,11 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                 }
 
                 let (body, kind) = if is_self_recipient {
-                    match open_direct_message(&self_sk, msg) {
-                        Ok(bytes) => match decode_body(&bytes) {
+                    // `None` = no private key held locally, so the ECIES
+                    // envelope cannot be opened at all. Rendered with the same
+                    // placeholder shape as a failed decrypt, below.
+                    match self_sk.as_ref().map(|sk| open_direct_message(sk, msg)) {
+                        Some(Ok(bytes)) => match decode_body(&bytes) {
                             Ok(DirectMessageBody::Text { text }) => (text, BodyKind::Plaintext),
                             Ok(DirectMessageBody::Invite(payload)) => {
                                 // Resolve a friendly room label and the
@@ -305,13 +323,22 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                                 BodyKind::Placeholder,
                             ),
                         },
-                        Err(err) => (
+                        Some(Err(err)) => (
                             // Skeptical reviewer caught: putting `<...>`
                             // through `message_to_html` produces mangled
                             // markup because `<unable:` looks like a
                             // markdown autolink scheme. Tag the kind so
                             // the renderer skips markdown for these.
                             format!("unable to decrypt: {}", err),
+                            BodyKind::Placeholder,
+                        ),
+                        None => (
+                            // No signing key for this room on this device.
+                            // Same placeholder shape (and the same
+                            // markdown-skipping `Placeholder` kind) as the
+                            // decrypt-failure branch above.
+                            "unable to decrypt: no signing key for this room on this device"
+                                .to_string(),
                             BodyKind::Placeholder,
                         ),
                     }

--- a/ui/src/components/direct_messages/dm_thread_modal.rs
+++ b/ui/src/components/direct_messages/dm_thread_modal.rs
@@ -178,7 +178,10 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
             };
             let room_data = rooms.map.get(&room)?;
 
-            let self_sk = room_data.self_sk.clone();
+            // DM bodies are ECIES-sealed to us, so rendering the thread needs
+            // the private key. Without it there is nothing to show: fall back
+            // to the same `None` a contended ROOMS read returns.
+            let self_sk = room_data.signing_key().cloned()?;
             let self_id = MemberId::from(&self_sk.verifying_key());
             let owner_id = MemberId::from(&room);
 
@@ -502,7 +505,17 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
             return;
         };
 
-        let self_sk = room_data.self_sk.clone();
+        // Composing a DM signs and seals with the local key. Without it the
+        // send is refused through the composer's existing error slot rather
+        // than attempted.
+        let Some(self_sk) = room_data.signing_key().cloned() else {
+            error!("DM send: no local signing key for this room");
+            send_error.set(Some(
+                "This device doesn't hold your key for this room, so you can't send DMs here."
+                    .into(),
+            ));
+            return;
+        };
         let self_id: MemberId = (&self_sk.verifying_key()).into();
         let peer_vk = match resolve_peer_vk(&room_data, room, peer) {
             Some(vk) => vk,
@@ -723,7 +736,18 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
                 error!("DM purge: room data missing");
                 return;
             };
-            let self_sk = room_data.self_sk.clone();
+            // The purge envelope is signed with the local key, so with no key
+            // there is nothing to publish: bail like the "room data missing"
+            // branch above (the confirm modal is already closed).
+            let Some(self_sk) = room_data.signing_key().cloned() else {
+                error!("DM purge: no local signing key for this room");
+                send_error.set(Some(
+                    "This device doesn't hold your key for this room, so their messages \
+                     can't be deleted from here."
+                        .into(),
+                ));
+                return;
+            };
             let self_id: MemberId = (&self_sk.verifying_key()).into();
 
             let tokens: Vec<PurgeToken> = room_data
@@ -1219,10 +1243,12 @@ fn classify_invite_card_state(
     match can_participate {
         Some(Ok(())) => InviteCardState::AlreadyMember,
         Some(Err(SendMessageError::UserBanned)) => InviteCardState::Banned,
-        // `UserNotMember` and "room not loaded" both fall through to
-        // joinable — the Accept flow itself handles "not yet a member"
-        // via the normal invitation path.
-        Some(Err(SendMessageError::UserNotMember)) | None => InviteCardState::Joinable,
+        // `UserNotMember`, "room not loaded", and "we hold no key for that
+        // room" all fall through to joinable — the Accept flow itself handles
+        // "not yet a member" via the normal invitation path, and accepting is
+        // precisely what would (re)establish a local identity there.
+        Some(Err(SendMessageError::UserNotMember | SendMessageError::IdentityUnavailable))
+        | None => InviteCardState::Joinable,
     }
 }
 

--- a/ui/src/components/direct_messages/invite_via_dm_picker_modal.rs
+++ b/ui/src/components/direct_messages/invite_via_dm_picker_modal.rs
@@ -312,7 +312,21 @@ pub fn InviteViaDmPickerModal() -> Element {
 
         let invitee_signing_key = SigningKey::generate(&mut rand::thread_rng());
         let invitee_vk = invitee_signing_key.verifying_key();
-        let invited_by: MemberId = candidate_data.self_sk.verifying_key().into();
+        // The invitation is signed with the local key for the CANDIDATE room,
+        // so hoist it here: with no key there is nothing to sign, and the pick
+        // is refused through the picker's existing error slot (same shape as
+        // the "candidate room data missing" bail above). `invited_by` is the
+        // public half of this same key.
+        let Some(inviter_sk) = candidate_data.signing_key().cloned() else {
+            error!("invite-via-DM: no local signing key for the candidate room");
+            send_error.set(Some(
+                "This device doesn't hold your key for the room you picked, so it can't \
+                 create an invitation there."
+                    .into(),
+            ));
+            return;
+        };
+        let invited_by: MemberId = inviter_sk.verifying_key().into();
         let owner_id: MemberId = candidate_data.owner_vk.into();
 
         let member = Member {
@@ -321,7 +335,6 @@ pub fn InviteViaDmPickerModal() -> Element {
             member_vk: invitee_vk,
         };
         let room_key = candidate_data.room_key();
-        let inviter_sk = candidate_data.self_sk.clone();
 
         let my_generation = PICK_GENERATION.fetch_add(1, Ordering::Relaxed) + 1;
 
@@ -691,6 +704,11 @@ async fn drive_send(
         SendDmOutcome::SilentDrop => Err(
             "Invite couldn't be added to the room (your member entry may be \
              missing). Try posting a message in the room first, then retry."
+                .into(),
+        ),
+        SendDmOutcome::IdentityUnavailable => Err(
+            "This device doesn't hold your key for the room you're DM'ing in, so the \
+             invite can't be sent from here."
                 .into(),
         ),
     }

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1413,7 +1413,12 @@ pub fn MemberList() -> Element {
         };
         let room_data = rooms_read.map.get(&room_owner)?;
         let room_state = room_data.room_state.clone();
-        let self_member_id: MemberId = room_data.self_sk.verifying_key().into();
+        // Every row's "relationship to me" flag (is_self, invited_you,
+        // sponsor, network) is derived from this id, so with no locally-known
+        // identity the list has nothing meaningful to render. Degrade exactly
+        // like the room-not-in-ROOMS case two lines above: bail out of the
+        // memo and let the panel show its empty state.
+        let self_member_id: MemberId = room_data.self_member_id()?;
         let owner_id: MemberId = room_owner.into();
 
         let member_info = &room_state.member_info;
@@ -1687,7 +1692,18 @@ fn ExportIdentityModal(is_active: Signal<bool>) -> Element {
                     return;
                 };
                 if let Some(room_data) = rooms_read.map.get(&owner_key) {
-                    let verifying_key = room_data.self_sk.verifying_key();
+                    // An identity export IS the private key, so a room whose
+                    // blob keeps the key elsewhere has nothing to export.
+                    // Reuse the modal's existing "cannot export" surface
+                    // rather than inventing a new UI state.
+                    let Some(self_sk) = room_data.signing_key().cloned() else {
+                        token_text.set(
+                            "Cannot export: the signing key for this room is not stored here."
+                                .to_string(),
+                        );
+                        return;
+                    };
+                    let verifying_key = self_sk.verifying_key();
 
                     // Resolve the AuthorizedMember and invite chain for export:
                     // 1. Use cached self_authorized_member if available
@@ -1702,7 +1718,7 @@ fn ExportIdentityModal(is_active: Signal<bool>) -> Element {
                             invited_by: owner_id,
                             member_vk: owner_key,
                         };
-                        Some((AuthorizedMember::new(member, &room_data.self_sk), vec![]))
+                        Some((AuthorizedMember::new(member, &self_sk), vec![]))
                     } else {
                         // Look up member and invite chain from current room state
                         let params = ChatRoomParametersV1 { owner: owner_key };
@@ -1752,7 +1768,7 @@ fn ExportIdentityModal(is_active: Signal<bool>) -> Element {
 
                         let export = IdentityExport {
                             room_owner: owner_key,
-                            signing_key: room_data.self_sk.clone(),
+                            signing_key: self_sk.clone(),
                             authorized_member,
                             invite_chain,
                             member_info,
@@ -1886,7 +1902,8 @@ fn build_imported_room_data(export: IdentityExport) -> crate::room_data::RoomDat
     crate::room_data::RoomData {
         owner_vk: owner_key,
         room_state: initial_state, // Will be fully populated on sync
-        self_sk: export.signing_key,
+        self_sk: Some(export.signing_key),
+        self_vk: None,
         contract_key,
         last_read_message_id: None,
         secrets: HashMap::new(),
@@ -1924,6 +1941,7 @@ fn build_imported_room_data(export: IdentityExport) -> crate::room_data::RoomDat
 /// owner_vk                KEEP (the room owner; identity-independent)
 /// room_state              KEEP (identity-independent shared contract state)
 /// self_sk                 REPLACE (the imported identity)
+/// self_vk                 REPLACE (derived from self_sk; paired with it)
 /// contract_key            KEEP (owner+WASM derived)
 /// last_read_message_id    KEEP (local read-tracking preference)
 /// secrets                 CLEAR+RECOMPUTE different-key (repopulate_secrets_from_state) / KEEP same-key
@@ -1943,6 +1961,7 @@ fn _room_data_swap_classification(rd: crate::room_data::RoomData) {
         owner_vk: _,
         room_state: _,
         self_sk: _,
+        self_vk: _,
         contract_key: _,
         last_read_message_id: _,
         secrets: _,
@@ -2010,8 +2029,26 @@ fn swap_room_identity_in_place(
     existing: &mut crate::room_data::RoomData,
     export: IdentityExport,
 ) -> bool {
-    let key_changed = existing.self_sk != export.signing_key;
-    existing.self_sk = export.signing_key;
+    // Compare IDENTITIES, not the stored `Option<SigningKey>`. `self_sk` may now
+    // be absent (a blob written by a River that keeps the private key
+    // elsewhere), and the two cases that absence covers must NOT be conflated:
+    //
+    // * `self_vk` still records WHICH identity this room is. Re-importing that
+    //   same identity is not a swap — the room's decrypt access is unchanged —
+    //   so the same-key merge branch is correct, and a naive
+    //   `Some(export.signing_key) != existing.self_sk` would have wrongly
+    //   cleared the kept secrets and clobbered richer local metadata.
+    // * Neither half stored means the identity was UNKNOWN, which the
+    //   comparison below correctly reports as a change: we are gaining an
+    //   identity we did not have.
+    //
+    // `self_vk` is REPLACE-paired-with-`self_sk` in the classification table
+    // above, so both halves are written together, unconditionally, and can
+    // never drift apart.
+    let imported_vk = export.signing_key.verifying_key();
+    let key_changed = existing.self_verifying_key() != Some(imported_vk);
+    existing.self_sk = Some(export.signing_key);
+    existing.self_vk = Some(imported_vk);
 
     if key_changed {
         // DIFFERENT identity (a genuine swap): REPLACE all identity metadata with
@@ -2272,7 +2309,14 @@ fn complete_identity_import(
                                 // its own migration owns `key_migrated_to_delegate`
                                 // — don't mark it for a superseded key
                                 // (freenet/river#414).
-                                if rd.self_sk != new_sk {
+                                // Compared by IDENTITY, not by the stored
+                                // `Option<SigningKey>`: a room that no longer
+                                // holds the private half is not the identity
+                                // we migrated, so the conservative answer
+                                // (bail, leave `key_migrated_to_delegate`
+                                // alone) is the same one this guard already
+                                // gives for a superseded key.
+                                if rd.self_verifying_key() != Some(new_sk.verifying_key()) {
                                     return;
                                 }
                                 rd.key_migrated_to_delegate = true;
@@ -2750,9 +2794,14 @@ mod tests {
 
         assert!(key_changed, "swapping to a different key reports a change");
         assert_eq!(
-            existing.self_sk.to_bytes(),
-            new_sk.to_bytes(),
+            existing.signing_key().map(|sk| sk.to_bytes()),
+            Some(new_sk.to_bytes()),
             "self_sk must become the imported identity"
+        );
+        assert_eq!(
+            existing.self_vk,
+            Some(new_sk.verifying_key()),
+            "self_vk must be written alongside self_sk so the two cannot drift"
         );
         assert_eq!(
             existing.room_state, kept_state,
@@ -2787,7 +2836,10 @@ mod tests {
 
         swap_room_identity_in_place(&mut existing, export);
 
-        assert_eq!(existing.self_sk.to_bytes(), new_sk.to_bytes());
+        assert_eq!(
+            existing.signing_key().map(|sk| sk.to_bytes()),
+            Some(new_sk.to_bytes())
+        );
         assert_eq!(
             existing.secrets.get(&0u32),
             Some(&[0xABu8; 32]),

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1413,12 +1413,13 @@ pub fn MemberList() -> Element {
         };
         let room_data = rooms_read.map.get(&room_owner)?;
         let room_state = room_data.room_state.clone();
-        // Every row's "relationship to me" flag (is_self, invited_you,
-        // sponsor, network) is derived from this id, so with no locally-known
-        // identity the list has nothing meaningful to render. Degrade exactly
-        // like the room-not-in-ROOMS case two lines above: bail out of the
-        // memo and let the panel show its empty state.
-        let self_member_id: MemberId = room_data.self_member_id()?;
+        // `None` when this build holds no locally-known identity for the room.
+        // The roster is public room state and stays fully readable; only the
+        // per-row "relationship to me" flags (is_self, invited_you, sponsor,
+        // network), the viewer-relative 🛡 badge and the self-pin depend on
+        // this id, and each degrades to its "not me" answer below. Bailing
+        // here instead would empty the whole member panel.
+        let self_member_id: Option<MemberId> = room_data.self_member_id();
         let owner_id: MemberId = room_owner.into();
 
         let member_info = &room_state.member_info;
@@ -1440,12 +1441,29 @@ pub fn MemberList() -> Element {
         // a strict ancestor of the viewer (their deputy could ban the viewer)
         // OR is the viewer themselves (the viewer appointed the deputy). Shared
         // with the modal legend via `viewer_relevant_deputizer_set` (#451).
-        let viewer_relevant = viewer_relevant_deputizer_set(members, owner_id, self_member_id);
+        // With no identity there is no viewer for these to be relative TO, so
+        // both degrade to empty: no shield shows, and the display order falls
+        // back to the plain tree. An arbitrary stand-in viewer id would instead
+        // assert a relevance that is not this reader's.
+        let viewer_relevant = match self_member_id {
+            Some(self_member_id) => {
+                viewer_relevant_deputizer_set(members, owner_id, self_member_id)
+            }
+            None => HashSet::new(),
+        };
 
         // The badge (visibility + tooltip) for every member, shared verbatim
         // with the conversation's author lines.
-        let deputy_badges =
-            deputy_badges_for_viewer(members, member_info, room_secrets, owner_id, self_member_id);
+        let deputy_badges = match self_member_id {
+            Some(self_member_id) => deputy_badges_for_viewer(
+                members,
+                member_info,
+                room_secrets,
+                owner_id,
+                self_member_id,
+            ),
+            None => HashMap::new(),
+        };
 
         // The ⚠ impersonation checker, built ONCE here from the badge map above
         // — never inside the per-member loop below, which would re-fold every
@@ -1492,22 +1510,27 @@ pub fn MemberList() -> Element {
                 nickname,
                 _member_id: member_id,
                 is_owner,
-                is_self: member_id == self_member_id,
-                invited_you: members.is_inviter_of(member_id, self_member_id, &params),
+                // Each of these is a statement ABOUT the local user, so with no
+                // known identity every one is `false` — the row renders with no
+                // relationship tags rather than claiming a wrong one.
+                is_self: Some(member_id) == self_member_id,
+                invited_you: self_member_id
+                    .is_some_and(|me| members.is_inviter_of(member_id, me, &params)),
                 sponsored_you: if is_owner {
                     false
                 } else {
-                    is_member_sponsor(member_id, members, self_member_id, &params)
+                    self_member_id
+                        .is_some_and(|me| is_member_sponsor(member_id, members, me, &params))
                 },
                 invited_by_you: if is_owner {
                     false
                 } else {
-                    did_you_invite_member(member_id, members, self_member_id)
+                    self_member_id.is_some_and(|me| did_you_invite_member(member_id, members, me))
                 },
                 in_your_network: if is_owner {
                     false
                 } else {
-                    is_in_your_network(member_id, members, self_member_id)
+                    self_member_id.is_some_and(|me| is_in_your_network(member_id, members, me))
                 },
                 // The 🛡 badge shows when a deputy is viewer-relevant (#410):
                 // a deputizer that is a strict ancestor of self (their deputy
@@ -1527,8 +1550,11 @@ pub fn MemberList() -> Element {
 
         // freenet/river#584: your own row goes to the top, so finding yourself
         // isn't a scroll-and-hunt in a large room. Everything below keeps its
-        // tree order.
-        pin_self_to_top(&mut all_members, self_member_id);
+        // tree order. With no known identity there is no own row to hoist, so
+        // the list keeps its tree order unchanged.
+        if let Some(self_member_id) = self_member_id {
+            pin_self_to_top(&mut all_members, self_member_id);
+        }
 
         Some(all_members)
     })()

--- a/ui/src/components/members/invite_member_modal.rs
+++ b/ui/src/components/members/invite_member_modal.rs
@@ -80,6 +80,16 @@ pub fn InviteMemberModal(is_active: Signal<bool>) -> Element {
             }
             let room_data = current_room_data_signal();
             if let Some(room_data) = room_data {
+                // Issuing an invitation signs the invitee's `Member` record
+                // with the inviter's key, so this whole path needs the
+                // private half. Surface it as a normal resource error (the
+                // modal already renders `Err(String)`) rather than panicking.
+                let Some(self_sk) = room_data.signing_key().cloned() else {
+                    return Err(
+                        "The local signing key for this room is unavailable, so an invitation cannot be created."
+                            .to_string(),
+                    );
+                };
                 // Generate new signing key for invitee
                 let invitee_signing_key = SigningKey::generate(&mut rand::thread_rng());
                 let invitee_verifying_key = invitee_signing_key.verifying_key();
@@ -87,7 +97,7 @@ pub fn InviteMemberModal(is_active: Signal<bool>) -> Element {
                 // Create member struct
                 let member = Member {
                     owner_member_id: room_data.owner_vk.into(),
-                    invited_by: room_data.self_sk.verifying_key().into(),
+                    invited_by: self_sk.verifying_key().into(),
                     member_vk: invitee_verifying_key,
                 };
 
@@ -100,7 +110,7 @@ pub fn InviteMemberModal(is_active: Signal<bool>) -> Element {
                 let signature = crate::signing::sign_member_with_fallback(
                     room_data.room_key(),
                     member_bytes,
-                    &room_data.self_sk,
+                    &self_sk,
                 )
                 .await;
 

--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -50,10 +50,7 @@ pub fn MemberInfoModal() -> Element {
             crate::util::signal_guard::schedule_nudge();
             return None;
         };
-        rooms
-            .map
-            .get(&key)
-            .map(|r| MemberId::from(&r.self_sk.verifying_key()))
+        rooms.map.get(&key).and_then(|r| r.self_member_id())
     });
 
     // Memoized values

--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -16,6 +16,30 @@ use dioxus::prelude::*;
 use river_core::room_state::member::MemberId;
 use river_core::room_state::ChatRoomParametersV1;
 
+/// The viewer's own [`MemberId`] in this room, or `None` when this build holds
+/// no local identity for it (see `RoomData::self_member_id`).
+///
+/// A newtype rather than a bare `Option<MemberId>` so that the `member_id ==
+/// self_member_id` sites below keep reading as the question they actually ask —
+/// "is this the viewer?" — and answer `false` for every member when there is no
+/// identity to compare against. Sites that genuinely need the id (the ban gate,
+/// the deputy helpers) match on the inner `Option` and degrade explicitly, so
+/// the two halves of the identity question cannot be conflated.
+#[derive(Clone, Copy, PartialEq)]
+struct SelfMemberId(Option<MemberId>);
+
+impl PartialEq<SelfMemberId> for MemberId {
+    fn eq(&self, other: &SelfMemberId) -> bool {
+        other.0 == Some(*self)
+    }
+}
+
+impl PartialEq<MemberId> for SelfMemberId {
+    fn eq(&self, other: &MemberId) -> bool {
+        self.0 == Some(*other)
+    }
+}
+
 #[component]
 pub fn MemberInfoModal() -> Element {
     // Memos
@@ -82,11 +106,22 @@ pub fn MemberInfoModal() -> Element {
     // `self_member_id` sites are panic-safe under a
     // concurrent ROOMS-write race (Skeptical M2 on PR #260). The
     // pre-existing code unwraps in three places; this single
-    // early-return covers all of them.
-    let self_member_id: MemberId = match self_member_id() {
-        Some(id) => id,
-        None => return rsx! {},
-    };
+    // resolution covers all of them.
+    //
+    // This used to early-return an EMPTY element when the id was unknown, which
+    // blanked the whole modal — and became newly reachable once the member list
+    // stopped blanking, so a reader could click a rendered row and get nothing.
+    // Everything the modal says about the TARGET is public room state that needs
+    // no local identity: the nickname, the member id, the invite chain, the 🛡
+    // appointer names, and the ⚠ impersonation sentence — which this is the ONLY
+    // surface to render as visible TEXT, and therefore the only explanation a
+    // touch user can reach at all (`title=` never fires on touch).
+    //
+    // Only the statements ABOUT THE VIEWER depend on the id — is-this-me, the
+    // "invited by you" / "invited you" tags, Ban, Deputize, and the
+    // viewer-relative 🛡 — and each degrades to its "not me" / unavailable
+    // answer below, the same way the member-list row does.
+    let self_member_id = SelfMemberId(self_member_id());
 
     // Count rooms other than the current one — used to gate the
     // "Share invite" button so it doesn't lead to an empty picker
@@ -149,8 +184,11 @@ pub fn MemberInfoModal() -> Element {
                     // Get the invite chain for this member
                     let invite_chain = room_state.room_state.members.get_invite_chain(m, &params);
 
-                    // `self_member_id` (a `MemberId`, resolved at modal-top
-                    // with an early-return) is captured by this closure.
+                    // `self_member_id` (a `SelfMemberId`, resolved at
+                    // modal-top) is captured by this closure. With no known
+                    // identity BOTH comparisons below are false, so the
+                    // "🔑 Invited by You" tag simply does not show — the
+                    // relationship is unknowable, not false-able.
                     // Member is downstream if:
                     // 1. Current user is owner (owner can ban anyone), or
                     // 2. Current user appears in their invite chain (upstream of target)
@@ -174,13 +212,20 @@ pub fn MemberInfoModal() -> Element {
         // action is taken away from someone who would otherwise have had it —
         // banning yourself, or banning an ancestor whose cascade sweeps you up —
         // gets a visible explanation instead of a mysteriously absent button.
+        //
+        // With no known identity there is no viewer for the rule to be about,
+        // so it degrades to `NoAuthority` — the same answer an unrelated member
+        // gets. That hides Ban (rather than offering an action whose ban
+        // envelope could not be signed) and leaves `ban_refusal` `None`, which
+        // is correct: nothing was taken away from anyone.
         let gate = owner_key_signal
             .as_ref()
-            .map(|owner| {
+            .zip(self_member_id.0)
+            .map(|(owner, me)| {
                 ban_gate(
                     &room_state.room_state.members,
                     &room_state.room_state.member_info,
-                    self_member_id,
+                    me,
                     member_id,
                     MemberId::from(&*owner),
                 )
@@ -219,6 +264,12 @@ pub fn MemberInfoModal() -> Element {
         // can be any member, so this shows in any member's modal (except self /
         // owner as targets); it is hidden entirely for a viewer with an empty
         // subtree to avoid advertising power they don't have.
+        //
+        // No code change was needed for the unknown-identity case: both branches
+        // compare a member id against `self_member_id`, which matches nobody when
+        // there is no identity, so this lands on `false` — the same "hide the
+        // action" answer a viewer with an empty subtree gets. Deputizing signs a
+        // `member_info` record, so an offered button would fail anyway.
         let viewer_has_authority = {
             let viewer_is_owner = owner_key_signal
                 .as_ref()
@@ -241,11 +292,16 @@ pub fn MemberInfoModal() -> Element {
             }
         };
         // Whether the target is currently one of the VIEWER's own deputies.
-        let target_is_my_deputy = room_state
-            .room_state
-            .member_info
-            .deputies_of(self_member_id)
-            .contains(&member_id);
+        // Unanswerable without a local identity, so it degrades to `false`
+        // (moot in practice — `viewer_has_authority` is also false there, which
+        // hides the button entirely).
+        let target_is_my_deputy = self_member_id.0.is_some_and(|me| {
+            room_state
+                .room_state
+                .member_info
+                .deputies_of(me)
+                .contains(&member_id)
+        });
 
         // The 🛡 legend chip below (freenet/river#451). Computed with the SAME
         // shared helper the member-list row and the conversation's author line
@@ -254,14 +310,22 @@ pub fn MemberInfoModal() -> Element {
         //
         // Single-target variant: this component is not memoised, and the sweep
         // decrypts every deputy's appointer nicknames.
-        let deputy_badge: Option<super::DeputyBadge> =
-            owner_key_signal.as_ref().and_then(|owner| {
+        //
+        // The shield is viewer-RELATIVE ("this member could ban me"), so with no
+        // known identity there is nobody for it to be relative to and it degrades
+        // to no shield — the same choice the member-list row makes. Standing in
+        // an arbitrary viewer id would assert a relevance that is not this
+        // reader's. The appointer names below hang off this, so they go with it.
+        let deputy_badge: Option<super::DeputyBadge> = owner_key_signal
+            .as_ref()
+            .zip(self_member_id.0)
+            .and_then(|(owner, me)| {
                 super::deputy_badge_for_viewer(
                     &room_state.room_state.members,
                     &room_state.room_state.member_info,
                     &room_state.secrets,
                     MemberId::from(&*owner),
-                    self_member_id,
+                    me,
                     member_id,
                 )
             });
@@ -301,13 +365,23 @@ pub fn MemberInfoModal() -> Element {
         // different code path for no gain.
         let impersonation = owner_key_signal.as_ref().and_then(|owner| {
             let owner_id = MemberId::from(&*owner);
-            let deputy_badges = super::deputy_badges_for_viewer(
-                &room_state.room_state.members,
-                &room_state.room_state.member_info,
-                &room_state.secrets,
-                owner_id,
-                self_member_id,
-            );
+            // Same viewer-relative degradation as the single-target shield
+            // above. Losing the map does NOT lose the warning: the protected
+            // set is "the owner, plus every member badged in this viewer's
+            // view", so it falls back to the owner alone — and someone imitating
+            // the room owner is exactly the case that needs no local identity to
+            // judge. That matters here more than anywhere: this modal is the
+            // only surface that spells the warning out as visible text.
+            let deputy_badges = match self_member_id.0 {
+                Some(me) => super::deputy_badges_for_viewer(
+                    &room_state.room_state.members,
+                    &room_state.room_state.member_info,
+                    &room_state.secrets,
+                    owner_id,
+                    me,
+                ),
+                None => std::collections::HashMap::new(),
+            };
             let checker = super::impersonation_checker_for_viewer(
                 &room_state.room_state.member_info,
                 &room_state.secrets,
@@ -535,6 +609,14 @@ pub fn MemberInfoModal() -> Element {
                         // accent border. Ban remains separate below
                         // because it's destructive — different styling
                         // is intentional there.
+                        //
+                        // With no known identity nobody matches, so this row
+                        // shows for every member including the viewer's own —
+                        // the "not me" degradation. Offering a DM the user
+                        // cannot send is the milder failure: the thread itself
+                        // now says why (see `dm_thread_modal`), whereas
+                        // suppressing the row would hide a working action from
+                        // everyone else in the same state.
                         if member_id != self_member_id {
                             {
                                 let dm_room = owner_key_signal.unwrap();

--- a/ui/src/components/members/member_info_modal/ban_button.rs
+++ b/ui/src/components/members/member_info_modal/ban_button.rs
@@ -36,7 +36,13 @@ pub fn BanButton(member_to_ban: MemberId, can_ban: bool, nickname: String) -> El
             current_room_data_signal.read().as_ref(),
         ) {
             let room_key = room_data.room_key();
-            let self_sk = room_data.self_sk.clone();
+            // Banning signs a `UserBan`, so it needs the private half. A room
+            // whose blob carries no local signing key simply cannot ban;
+            // refuse the action rather than panicking.
+            let Some(self_sk) = room_data.signing_key().cloned() else {
+                warn!("Cannot ban: no local signing key for this room");
+                return;
+            };
             let room_state_clone = room_data.room_state.clone();
             let banned_by = MemberId::from(&self_sk.verifying_key());
 

--- a/ui/src/components/members/member_info_modal/nickname_field.rs
+++ b/ui/src/components/members/member_info_modal/nickname_field.rs
@@ -28,7 +28,13 @@ pub fn NicknameField(member_info: AuthorizedMemberInfo) -> Element {
                 .ok()
                 .and_then(|rooms| {
                     rooms.map.get(key).map(|room_data| {
-                        (Some(room_data.self_sk.clone()), room_data.secrets.clone())
+                        // `self_sk` is itself an `Option` now: a blob written
+                        // by a River that keeps the key elsewhere has no
+                        // private half. Collapsing it here means "no key"
+                        // degrades exactly like "no room" already did — the
+                        // field renders read-only (`is_self` is false) and the
+                        // existing guard in `save_changes` never fires a save.
+                        (room_data.signing_key().cloned(), room_data.secrets.clone())
                     })
                 })
                 .unwrap_or((None, HashMap::new()))

--- a/ui/src/components/room_list/dm_rail_section.rs
+++ b/ui/src/components/room_list/dm_rail_section.rs
@@ -283,7 +283,7 @@ fn current_last_inbound_ts(room: &VerifyingKey, peer: MemberId) -> Option<u64> {
     use dioxus::prelude::ReadableExt;
     let rooms = ROOMS.try_read().ok()?;
     let room_data = rooms.map.get(room)?;
-    let self_id = MemberId::from(&room_data.self_sk.verifying_key());
+    let self_id = room_data.self_member_id()?;
     Some(max_inbound_ts_from_triples(
         dm_message_triples(room_data),
         self_id,
@@ -900,7 +900,12 @@ fn build_archived_view() -> Option<Vec<ArchivedEntry>> {
     let mut room_meta: HashMap<VerifyingKey, ArchivedRoomMeta> = HashMap::new();
     let mut last_inbound_ts: HashMap<(VerifyingKey, MemberId), u64> = HashMap::new();
     for (owner_vk, room_data) in &rooms.map {
-        let self_id: MemberId = room_data.self_sk.verifying_key().into();
+        // A room whose local identity is unknown contributes no DM rows:
+        // every row here is defined relative to "self", so there is nothing
+        // meaningful to compute for it.
+        let Some(self_id) = room_data.self_member_id() else {
+            continue;
+        };
         let sealed_name = &room_data
             .room_state
             .configuration
@@ -977,7 +982,12 @@ fn current_archived_count() -> usize {
     };
     let mut last_inbound_ts: HashMap<(VerifyingKey, MemberId), u64> = HashMap::new();
     for (owner_vk, room_data) in &rooms.map {
-        let self_id: MemberId = room_data.self_sk.verifying_key().into();
+        // A room whose local identity is unknown contributes no DM rows:
+        // every row here is defined relative to "self", so there is nothing
+        // meaningful to compute for it.
+        let Some(self_id) = room_data.self_member_id() else {
+            continue;
+        };
         for (peer, activity) in
             accumulate_peer_activity(owner_vk, self_id, dm_message_triples(room_data), None)
         {
@@ -1047,7 +1057,12 @@ fn build_view() -> Vec<DmRailEntry> {
 
     let mut entries: Vec<DmRailEntry> = Vec::new();
     for (owner_vk, room_data) in &rooms.map {
-        let self_id: MemberId = room_data.self_sk.verifying_key().into();
+        // A room whose local identity is unknown contributes no DM rows:
+        // every row here is defined relative to "self", so there is nothing
+        // meaningful to compute for it.
+        let Some(self_id) = room_data.self_member_id() else {
+            continue;
+        };
 
         // Decrypted room name for display.
         let sealed_name = &room_data

--- a/ui/src/components/room_list/edit_room_modal.rs
+++ b/ui/src/components/room_list/edit_room_modal.rs
@@ -52,9 +52,11 @@ pub fn EditRoomModal() -> Element {
     // Memoize if the current user is the owner of the room being edited
     let user_is_owner = use_memo(move || {
         editing_room.read().as_ref().is_some_and(|room_data| {
-            let user_vk = room_data.self_sk.verifying_key();
+            // Public half only: an unknown local identity is not the owner,
+            // which renders the modal read-only.
+            let user_vk = room_data.self_verifying_key();
             let room_vk = EDIT_ROOM_MODAL.read().room.unwrap();
-            user_vk == room_vk
+            user_vk == Some(room_vk)
         })
     });
 
@@ -210,7 +212,7 @@ pub fn EditRoomModal() -> Element {
                             // Secret Version (only for private rooms)
                             {
                                 let is_private = room_data.room_state.configuration.configuration.privacy_mode == PrivacyMode::Private;
-                                let is_owner = room_data.owner_vk == room_data.self_sk.verifying_key();
+                                let is_owner = room_data.is_self_owner();
                                 let secret_version = room_data.room_state.secrets.current_version;
                                 let owner_vk = room_data.owner_vk;
 
@@ -496,20 +498,27 @@ fn RoomDescriptionField(config: Configuration, is_owner: bool) -> Element {
 
         let owner_key = CURRENT_ROOM.read().owner_key.expect("No owner key");
 
+        // A configuration edit is signed, so it needs the private half. Fold
+        // the key into the same `Option` the "room not found" case already
+        // uses: a room whose blob carries no local signing key simply cannot
+        // publish a config change.
         let signing_data = ROOMS.with(|rooms| {
-            rooms.map.get(&owner_key).map(|room_data| {
-                (
-                    room_data.room_key(),
-                    room_data.self_sk.clone(),
-                    room_data.room_state.clone(),
-                    room_data.is_private(),
-                    room_data.get_secret().map(|(s, v)| (*s, v)),
-                )
+            rooms.map.get(&owner_key).and_then(|room_data| {
+                room_data.signing_key().cloned().map(|self_sk| {
+                    (
+                        room_data.room_key(),
+                        self_sk,
+                        room_data.room_state.clone(),
+                        room_data.is_private(),
+                        room_data.get_secret().map(|(s, v)| (*s, v)),
+                    )
+                })
             })
         });
 
         let Some((room_key, self_sk, room_state_clone, is_private, room_secret_opt)) = signing_data
         else {
+            warn!("Cannot update the room description: room or local signing key unavailable");
             return;
         };
 
@@ -706,17 +715,20 @@ fn NumericConfigField(
 
         let owner_key = CURRENT_ROOM.read().owner_key.expect("No owner key");
 
+        // Signed configuration edit: fold the private key into the same
+        // `Option` the "room not found" case already uses, so a blob without
+        // a local signing key degrades to "cannot edit" rather than panicking.
         let signing_data = ROOMS.with(|rooms| {
-            rooms.map.get(&owner_key).map(|room_data| {
-                (
-                    room_data.room_key(),
-                    room_data.self_sk.clone(),
-                    room_data.room_state.clone(),
-                )
+            rooms.map.get(&owner_key).and_then(|room_data| {
+                room_data
+                    .signing_key()
+                    .cloned()
+                    .map(|self_sk| (room_data.room_key(), self_sk, room_data.room_state.clone()))
             })
         });
 
         let Some((room_key, self_sk, room_state_clone)) = signing_data else {
+            warn!("Cannot update the room configuration: room or local signing key unavailable");
             return;
         };
 
@@ -826,17 +838,20 @@ fn MaxMembersField(
 
         let owner_key = CURRENT_ROOM.read().owner_key.expect("No owner key");
 
+        // Signed configuration edit: fold the private key into the same
+        // `Option` the "room not found" case already uses, so a blob without
+        // a local signing key degrades to "cannot edit" rather than panicking.
         let signing_data = ROOMS.with(|rooms| {
-            rooms.map.get(&owner_key).map(|room_data| {
-                (
-                    room_data.room_key(),
-                    room_data.self_sk.clone(),
-                    room_data.room_state.clone(),
-                )
+            rooms.map.get(&owner_key).and_then(|room_data| {
+                room_data
+                    .signing_key()
+                    .cloned()
+                    .map(|self_sk| (room_data.room_key(), self_sk, room_data.room_state.clone()))
             })
         });
 
         let Some((room_key, self_sk, room_state_clone)) = signing_data else {
+            warn!("Cannot update the room configuration: room or local signing key unavailable");
             return;
         };
 

--- a/ui/src/components/room_list/edit_room_modal.rs
+++ b/ui/src/components/room_list/edit_room_modal.rs
@@ -49,7 +49,12 @@ pub fn EditRoomModal() -> Element {
             .map(|room_data| room_data.room_state.configuration.configuration.clone())
     });
 
-    // Memoize if the current user is the owner of the room being edited
+    // Memoize if the current user is the owner of the room being edited.
+    //
+    // Public half only, deliberately: ownership IS a property of the public
+    // key. This drives the *informational* surfaces (the leave warning, and
+    // whether the owner-only secret row exists at all), never an editing
+    // affordance — see `user_can_edit` below.
     let user_is_owner = use_memo(move || {
         editing_room.read().as_ref().is_some_and(|room_data| {
             // Public half only: an unknown local identity is not the owner,
@@ -58,6 +63,21 @@ pub fn EditRoomModal() -> Element {
             let room_vk = EDIT_ROOM_MODAL.read().room.unwrap();
             user_vk == Some(room_vk)
         })
+    });
+
+    // Whether this device can actually PERFORM an owner edit. Every
+    // configuration change is signed, so it needs the private half as well as
+    // ownership. Gating the editable affordances on this rather than on
+    // `user_is_owner` is what stops a key-less owner being offered controls
+    // whose save would then bail with only a log line (review finding R4).
+    // Identical to `user_is_owner` whenever the key is held, which is every
+    // room written by a shipped River today.
+    let user_can_edit = use_memo(move || {
+        *user_is_owner.read()
+            && editing_room
+                .read()
+                .as_ref()
+                .is_some_and(|room_data| room_data.signing_key().is_some())
     });
 
     // Render the modal if room configuration is available
@@ -86,14 +106,26 @@ pub fn EditRoomModal() -> Element {
                         class: "p-6",
                         h1 { class: "text-xl font-semibold text-text mb-4", "Room Details" }
 
+                        // A key-less owner gets the read-only modal. Say why,
+                        // rather than leaving every control unexplainedly
+                        // disabled (review finding R4). Plain conditional
+                        // markup — no new signal, no new modal.
+                        if *user_is_owner.read() && !*user_can_edit.read() {
+                            p {
+                                "data-testid": "edit-room-no-key-notice",
+                                class: "mb-4 px-3 py-2 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-yellow-400 text-sm",
+                                "This device doesn't hold your key for this room, so you can't change its settings here."
+                            }
+                        }
+
                         RoomNameField {
                             config: config.clone(),
-                            is_owner: *user_is_owner.read()
+                            is_owner: *user_can_edit.read()
                         }
 
                         RoomDescriptionField {
                             config: config.clone(),
-                            is_owner: *user_is_owner.read()
+                            is_owner: *user_can_edit.read()
                         }
 
                         // Member capacity
@@ -107,15 +139,16 @@ pub fn EditRoomModal() -> Element {
                                         member_count: member_count,
                                         max_members: max_members,
                                         is_full: is_full,
-                                        is_owner: *user_is_owner.read(),
+                                        is_owner: *user_can_edit.read(),
                                         config: config.clone(),
                                     }
                                 }
                             }
                         }
 
-                        // Numeric configuration fields (owner-only)
-                        if *user_is_owner.read() {
+                        // Numeric configuration fields (owner-only, and only
+                        // when this device can sign the resulting config edit)
+                        if *user_can_edit.read() {
                             NumericConfigField {
                                 label: "Max Recent Messages",
                                 value: config.max_recent_messages,
@@ -213,6 +246,19 @@ pub fn EditRoomModal() -> Element {
                             {
                                 let is_private = room_data.room_state.configuration.configuration.privacy_mode == PrivacyMode::Private;
                                 let is_owner = room_data.is_self_owner();
+                                // Rotation derives AND signs the new secret, so
+                                // it needs the private half, not just ownership
+                                // (review finding R4). The button stays visible
+                                // for a key-less owner but is disabled with an
+                                // explanatory title — this row has no error
+                                // surface of its own, and silently offering a
+                                // control that only logs on failure is the bug.
+                                let can_rotate = is_owner && room_data.signing_key().is_some();
+                                let rotate_title = if can_rotate {
+                                    "Rotate room secret now (e.g., after suspecting a leak). The delegate also rotates automatically when the member set changes."
+                                } else {
+                                    "This device doesn't hold your key for this room, so it can't rotate the secret."
+                                };
                                 let secret_version = room_data.room_state.secrets.current_version;
                                 let owner_vk = room_data.owner_vk;
 
@@ -246,8 +292,9 @@ pub fn EditRoomModal() -> Element {
                                                     // converges via the contract's duplicate-version
                                                     // dedup.
                                                     button {
-                                                        class: "px-3 py-2 bg-accent hover:bg-accent-hover text-white text-sm rounded-lg transition-colors",
-                                                        title: "Rotate room secret now (e.g., after suspecting a leak). The delegate also rotates automatically when the member set changes.",
+                                                        class: "px-3 py-2 bg-accent hover:bg-accent-hover text-white text-sm rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed",
+                                                        title: "{rotate_title}",
+                                                        disabled: !can_rotate,
                                                         onclick: move |_| {
                                                             crate::util::defer(move || {
                                                                 let mut applied = false;
@@ -518,6 +565,9 @@ fn RoomDescriptionField(config: Configuration, is_owner: bool) -> Element {
 
         let Some((room_key, self_sk, room_state_clone, is_private, room_secret_opt)) = signing_data
         else {
+            // Backstop only. `is_owner` is now the key-gated `user_can_edit`,
+            // so a key-less owner never gets an enabled textarea to reach this
+            // from; the modal explains the refusal up front instead (R4).
             warn!("Cannot update the room description: room or local signing key unavailable");
             return;
         };
@@ -728,6 +778,8 @@ fn NumericConfigField(
         });
 
         let Some((room_key, self_sk, room_state_clone)) = signing_data else {
+            // Backstop only: this whole field is rendered behind the key-gated
+            // `user_can_edit`, so a key-less owner never sees it (R4).
             warn!("Cannot update the room configuration: room or local signing key unavailable");
             return;
         };
@@ -851,6 +903,8 @@ fn MaxMembersField(
         });
 
         let Some((room_key, self_sk, room_state_clone)) = signing_data else {
+            // Backstop only: the input is rendered behind the key-gated
+            // `user_can_edit`, so a key-less owner never sees it (R4).
             warn!("Cannot update the room configuration: room or local signing key unavailable");
             return;
         };

--- a/ui/src/components/room_list/edit_room_modal.rs
+++ b/ui/src/components/room_list/edit_room_modal.rs
@@ -1,17 +1,60 @@
 use super::room_name_field::RoomNameField;
 use crate::components::app::chat_delegate::save_rooms_to_delegate;
 use crate::components::app::{CURRENT_ROOM, EDIT_ROOM_MODAL, ROOMS};
+use crate::room_data::RoomData;
 use crate::util::ecies::{seal_for_room, unseal_bytes_with_secrets};
 use dioxus::logger::tracing::{error, info, warn};
 use dioxus::prelude::*;
 use dioxus_free_icons::icons::fa_solid_icons::FaCopy;
 use dioxus_free_icons::Icon;
+use ed25519_dalek::VerifyingKey;
 use freenet_scaffold::ComposableState;
 use river_core::room_state::configuration::{AuthorizedConfigurationV1, Configuration};
 use river_core::room_state::privacy::{PrivacyMode, RoomDisplayMetadata};
 use river_core::room_state::{ChatRoomParametersV1, ChatRoomStateV1Delta};
 use std::ops::Deref;
 use wasm_bindgen_futures::spawn_local;
+
+/// The two owner gates this modal applies, decided together.
+///
+/// They are bundled in one struct, and produced by one function, so they cannot
+/// drift apart: the whole point of review finding R4 is that they are NOT the
+/// same question. `is_owner` is a property of the PUBLIC key and drives only the
+/// *informational* surfaces (the leave warning, whether the owner-only secret
+/// row exists at all). `can_edit` additionally requires the PRIVATE half and
+/// drives every *editing* affordance — gating an editable control on `is_owner`
+/// alone offers a key-less owner a control whose save then bails with only a log
+/// line.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+struct OwnerEditGate {
+    is_owner: bool,
+    can_edit: bool,
+}
+
+impl OwnerEditGate {
+    /// Neither owner nor editor: the read-only answer for an unknown room or an
+    /// unknown local identity.
+    const DENIED: Self = Self {
+        is_owner: false,
+        can_edit: false,
+    };
+
+    /// Decide both gates for `room_data` viewed as the room owned by `room_vk`.
+    fn for_room(room_data: &RoomData, room_vk: &VerifyingKey) -> Self {
+        // Public half only: ownership IS a property of the public key, and an
+        // unknown local identity is not the owner (which renders the modal
+        // read-only).
+        let is_owner = room_data.self_verifying_key() == Some(*room_vk);
+        Self {
+            is_owner,
+            // Every configuration change is signed, so PERFORMING one needs the
+            // private half as well as ownership. Identical to `is_owner`
+            // whenever the key is held, which is every room written by a
+            // shipped River today.
+            can_edit: is_owner && room_data.signing_key().is_some(),
+        }
+    }
+}
 
 #[component]
 pub fn EditRoomModal() -> Element {
@@ -49,36 +92,26 @@ pub fn EditRoomModal() -> Element {
             .map(|room_data| room_data.room_state.configuration.configuration.clone())
     });
 
-    // Memoize if the current user is the owner of the room being edited.
-    //
-    // Public half only, deliberately: ownership IS a property of the public
-    // key. This drives the *informational* surfaces (the leave warning, and
-    // whether the owner-only secret row exists at all), never an editing
-    // affordance — see `user_can_edit` below.
-    let user_is_owner = use_memo(move || {
-        editing_room.read().as_ref().is_some_and(|room_data| {
-            // Public half only: an unknown local identity is not the owner,
-            // which renders the modal read-only.
-            let user_vk = room_data.self_verifying_key();
-            let room_vk = EDIT_ROOM_MODAL.read().room.unwrap();
-            user_vk == Some(room_vk)
-        })
+    // Memoize both owner gates for the room being edited. One decision site, so
+    // the informational gate and the editing gate cannot drift apart — see
+    // `OwnerEditGate`.
+    let edit_gate = use_memo(move || {
+        let room_vk = EDIT_ROOM_MODAL.read().room;
+        match (editing_room.read().as_ref(), room_vk) {
+            (Some(room_data), Some(room_vk)) => OwnerEditGate::for_room(room_data, &room_vk),
+            _ => OwnerEditGate::DENIED,
+        }
     });
 
-    // Whether this device can actually PERFORM an owner edit. Every
-    // configuration change is signed, so it needs the private half as well as
-    // ownership. Gating the editable affordances on this rather than on
-    // `user_is_owner` is what stops a key-less owner being offered controls
-    // whose save would then bail with only a log line (review finding R4).
-    // Identical to `user_is_owner` whenever the key is held, which is every
-    // room written by a shipped River today.
-    let user_can_edit = use_memo(move || {
-        *user_is_owner.read()
-            && editing_room
-                .read()
-                .as_ref()
-                .is_some_and(|room_data| room_data.signing_key().is_some())
-    });
+    // Informational only: the leave warning, and whether the owner-only secret
+    // row exists at all. Never an editing affordance — see `user_can_edit`.
+    let user_is_owner = use_memo(move || edit_gate.read().is_owner);
+
+    // Whether this device can actually PERFORM an owner edit. Gating the
+    // editable affordances on this rather than on `user_is_owner` is what stops
+    // a key-less owner being offered controls whose save would then bail with
+    // only a log line (review finding R4).
+    let user_can_edit = use_memo(move || edit_gate.read().can_edit);
 
     // Render the modal if room configuration is available
     if let Some(config) = room_config.clone().read().deref() {
@@ -245,7 +278,6 @@ pub fn EditRoomModal() -> Element {
                             // Secret Version (only for private rooms)
                             {
                                 let is_private = room_data.room_state.configuration.configuration.privacy_mode == PrivacyMode::Private;
-                                let is_owner = room_data.is_self_owner();
                                 // Rotation derives AND signs the new secret, so
                                 // it needs the private half, not just ownership
                                 // (review finding R4). The button stays visible
@@ -253,7 +285,12 @@ pub fn EditRoomModal() -> Element {
                                 // explanatory title — this row has no error
                                 // surface of its own, and silently offering a
                                 // control that only logs on failure is the bug.
-                                let can_rotate = is_owner && room_data.signing_key().is_some();
+                                // Same decision function as the modal-level
+                                // gates above: `is_owner` here is exactly
+                                // `room_data.is_self_owner()`.
+                                let gate = OwnerEditGate::for_room(room_data, &room_data.owner_vk);
+                                let is_owner = gate.is_owner;
+                                let can_rotate = gate.can_edit;
                                 let rotate_title = if can_rotate {
                                     "Rotate room secret now (e.g., after suspecting a leak). The delegate also rotates automatically when the member set changes."
                                 } else {
@@ -993,5 +1030,224 @@ fn MaxMembersField(
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::room_data::test_minimal_room_data;
+    use ed25519_dalek::SigningKey;
+
+    /// The local identity `test_minimal_room_data` installs.
+    fn local_sk() -> SigningKey {
+        SigningKey::from_bytes(&[1u8; 32])
+    }
+
+    /// The room owner AND holding the private half: every room a shipped River
+    /// has ever written.
+    fn owner_holding_key() -> (RoomData, VerifyingKey) {
+        let owner_vk = local_sk().verifying_key();
+        (test_minimal_room_data(owner_vk), owner_vk)
+    }
+
+    /// The room owner, but this device no longer holds the private half — the
+    /// tolerant-reader case the whole `Option<SigningKey>` change exists for.
+    fn owner_without_key() -> (RoomData, VerifyingKey) {
+        let (mut room, owner_vk) = owner_holding_key();
+        room.self_sk = None;
+        room.self_vk = Some(owner_vk);
+        (room, owner_vk)
+    }
+
+    /// An ordinary member, holding their own key, in someone else's room.
+    fn non_owner_holding_key() -> (RoomData, VerifyingKey) {
+        let owner_vk = SigningKey::from_bytes(&[7u8; 32]).verifying_key();
+        (test_minimal_room_data(owner_vk), owner_vk)
+    }
+
+    /// A room blob with no local identity at all.
+    fn unknown_identity() -> (RoomData, VerifyingKey) {
+        let (mut room, owner_vk) = owner_holding_key();
+        room.self_sk = None;
+        room.self_vk = None;
+        (room, owner_vk)
+    }
+
+    /// The property the R4 fix exists for: a key-less owner still OWNS the room
+    /// (so the leave warning and the secret row are correct) but must not be
+    /// offered any editing affordance, because every config edit is signed.
+    #[test]
+    fn a_key_less_owner_is_the_owner_but_cannot_edit() {
+        let (room, owner_vk) = owner_without_key();
+        let gate = OwnerEditGate::for_room(&room, &owner_vk);
+        assert!(
+            gate.is_owner,
+            "ownership is a property of the PUBLIC key, so a key-less owner is \
+             still the owner — the leave warning and the owner-only secret row \
+             depend on this"
+        );
+        assert!(
+            !gate.can_edit,
+            "a key-less owner MUST NOT be offered editing affordances: the save \
+             path cannot sign, so it would bail with only a log line (R4)"
+        );
+    }
+
+    /// The other half of the conjunction: holding a key is not ownership.
+    #[test]
+    fn a_non_owner_holding_a_key_cannot_edit() {
+        let (room, owner_vk) = non_owner_holding_key();
+        let gate = OwnerEditGate::for_room(&room, &owner_vk);
+        assert!(room.signing_key().is_some(), "fixture must hold a key");
+        assert!(!gate.is_owner);
+        assert!(
+            !gate.can_edit,
+            "holding a signing key for one's own membership is not ownership"
+        );
+    }
+
+    #[test]
+    fn an_owner_holding_the_key_can_edit() {
+        let (room, owner_vk) = owner_holding_key();
+        let gate = OwnerEditGate::for_room(&room, &owner_vk);
+        assert!(gate.is_owner);
+        assert!(gate.can_edit);
+    }
+
+    #[test]
+    fn an_unknown_local_identity_is_neither_owner_nor_editor() {
+        let (room, owner_vk) = unknown_identity();
+        let gate = OwnerEditGate::for_room(&room, &owner_vk);
+        assert_eq!(gate, OwnerEditGate::DENIED);
+    }
+
+    /// The "no behaviour change for existing users" property, and the one that
+    /// matters most: whenever the private half IS held, `can_edit` is exactly
+    /// `is_owner`. Every room written by a shipped River is in this case, so
+    /// splitting the gates changed nothing for anyone in the field.
+    #[test]
+    fn can_edit_equals_is_owner_whenever_the_key_is_held() {
+        for (label, (room, room_vk)) in [
+            ("owner", owner_holding_key()),
+            ("non-owner", non_owner_holding_key()),
+        ] {
+            assert!(
+                room.signing_key().is_some(),
+                "{label}: fixture must hold the private half"
+            );
+            let gate = OwnerEditGate::for_room(&room, &room_vk);
+            assert_eq!(
+                gate.can_edit, gate.is_owner,
+                "{label}: with the key held, the editing gate must be exactly \
+                 the ownership gate — otherwise the R4 split changed behaviour \
+                 for existing users"
+            );
+        }
+    }
+
+    /// `is_self_owner()` is what the secret row used before the split; the gate
+    /// must keep agreeing with it, or the row's visibility silently changes.
+    #[test]
+    fn is_owner_agrees_with_room_data_is_self_owner() {
+        for (room, _) in [
+            owner_holding_key(),
+            owner_without_key(),
+            non_owner_holding_key(),
+            unknown_identity(),
+        ] {
+            let gate = OwnerEditGate::for_room(&room, &room.owner_vk);
+            assert_eq!(gate.is_owner, room.is_self_owner());
+        }
+    }
+
+    /// The pure gate above cannot see whether the RENDER still consults it, so
+    /// pin the call sites and the two key-less-owner surfaces by source scrape.
+    /// Needles are assembled at runtime and the test module is sliced off, so
+    /// this test's own text cannot satisfy any of them.
+    #[test]
+    fn the_render_gates_editing_affordances_on_can_edit() {
+        let full = include_str!("edit_room_modal.rs");
+        let src = full
+            .split(&format!("{} {} {{", "mod", "tests"))
+            .next()
+            .expect("edit_room_modal.rs must have production code before its test module");
+        assert!(
+            src.len() < full.len(),
+            "positive control: the test module must have been sliced off — if \
+             the slice marker drifts, every needle below would be matchable by \
+             this test's own source"
+        );
+        // Whitespace-insensitive so rustfmt cannot disarm the pin.
+        let squashed: String = src.chars().filter(|c| !c.is_whitespace()).collect();
+
+        // Positive controls: the anchors these needles hang off must exist, so
+        // a rename/restructure fails loudly instead of matching nothing.
+        for control in [
+            format!("fn{}()", "EditRoomModal"),
+            format!("{}::{}", "OwnerEditGate", "for_room"),
+            format!("let{}=use_memo", "user_can_edit"),
+            format!("let{}=use_memo", "user_is_owner"),
+        ] {
+            assert!(
+                squashed.contains(&control),
+                "positive control {control:?} missing — this pin is scraping \
+                 something other than the code it means to pin"
+            );
+        }
+
+        // Both gates must come from the one decision function.
+        assert!(
+            squashed.contains(&format!("{}.read().{}", "edit_gate", "can_edit"))
+                && squashed.contains(&format!("{}.read().{}", "edit_gate", "is_owner")),
+            "`user_is_owner` and `user_can_edit` must both derive from the \
+             single `OwnerEditGate` decision, so they cannot drift apart"
+        );
+
+        // Every editing affordance is gated on the key-aware memo. There are
+        // five sites: the notice, the name field, the description field, the
+        // member-capacity field, and the numeric-config block.
+        let editing_needle = format!("*{}.read()", "user_can_edit");
+        assert!(
+            squashed.matches(&editing_needle).count() >= 5,
+            "every editing affordance must be gated on `user_can_edit`, not on \
+             `user_is_owner` (R4)"
+        );
+        let reverted = format!("{}:*{}.read()", "is_owner", "user_is_owner");
+        assert!(
+            !squashed.contains(&reverted),
+            "an editing affordance is gated on the PUBLIC half again — that is \
+             exactly the R4 regression (a key-less owner offered a control \
+             whose save bails with only a log line)"
+        );
+
+        // The key-less owner gets told why, rather than an unexplainedly
+        // read-only modal.
+        assert!(
+            squashed.contains(&format!("{}-{}-{}", "edit-room", "no-key", "notice")),
+            "the key-less-owner notice must exist"
+        );
+        assert!(
+            squashed.contains(&format!(
+                "*{}.read()&&!*{}.read()",
+                "user_is_owner", "user_can_edit"
+            )),
+            "the notice must render exactly for an owner who cannot edit"
+        );
+
+        // The Rotate button stays visible for a key-less owner (the row has no
+        // error surface of its own) but must be disabled and explain itself.
+        assert!(
+            squashed.contains(&format!("{}:!{}", "disabled", "can_rotate")),
+            "the Rotate button must be disabled when the key is not held"
+        );
+        assert!(
+            squashed.contains(&format!("let{}={}.{}", "can_rotate", "gate", "can_edit")),
+            "Rotate must use the same key-aware gate as the rest of the modal"
+        );
+        assert!(
+            squashed.contains(&format!("{}:\"{{{}}}\"", "title", "rotate_title")),
+            "the disabled Rotate button must carry the explanatory title"
+        );
     }
 }

--- a/ui/src/components/room_list/receive_invitation_modal.rs
+++ b/ui/src/components/room_list/receive_invitation_modal.rs
@@ -110,11 +110,19 @@ pub fn present_invitation(inv: Invitation) {
 // being reachable only in a browser. Behaviour on wasm is unchanged: the same
 // `window().local_storage()` call behind the same `Ok(Some(..))` gate.
 //
-// This is not a convenience. The one BLOCKING defect this file has had — a
-// purge that erased the nickname binding and silently turned the #218
-// auto-resume into a re-prompt — was invisible to a source-scrape test and
-// only falsifiable by driving the real sequence. See
+// This is not a convenience: a purge that erased the nickname binding, and so
+// silently turned the #218 auto-resume into a re-prompt, was invisible to a
+// source-scrape test and only falsifiable by driving the real sequence. See
 // `a_legacy_invite_with_its_nickname_still_auto_resumes`.
+//
+// REACHABILITY, so the coverage is not overstated: in the deployed gateway the
+// iframe has an opaque origin, `localStorage` throws, and all three of these
+// functions are no-ops. Every test that drives them therefore exercises a
+// branch that CANNOT occur there — as does the legacy artifact they read, which
+// no gateway user has. Real coverage is `dx serve` and non-sandboxed
+// deployments (self-hosted, or any future non-iframe embedding). The logic is
+// worth getting right for those, and worth having tested rather than scraped,
+// but this is not coverage of the production path.
 #[cfg(not(target_arch = "wasm32"))]
 thread_local! {
     static FAKE_STORAGE: RefCell<std::collections::HashMap<String, String>> =
@@ -291,6 +299,14 @@ fn clear_invitation_nickname_from_storage() {
 /// `invitation_encoded` is the canonical `Invitation::to_encoded_string()`;
 /// its fingerprint is stored too so the nickname is only ever applied back to
 /// the same invitation it was chosen for.
+/// The two writes are deliberately NOT guarded against a half-write, which the
+/// pre-kv version was: it bailed before writing the fingerprint if the nickname
+/// write failed. Losing that is benign, and the reason is worth recording
+/// rather than restoring the code. `load_invitation_nickname_from_storage`
+/// requires BOTH keys, so a nickname without a fingerprint reads as absent, and
+/// the cross-invitation leak #333 guarded against additionally needs a stale
+/// nickname that `save_invitation_to_storage` already clears at the single
+/// chokepoint every fresh invitation passes through.
 pub fn save_invitation_nickname_to_storage(invitation_encoded: &str, nickname: &str) {
     storage_set(INVITATION_NICKNAME_STORAGE_KEY, nickname);
     storage_set(
@@ -1222,13 +1238,16 @@ pub(crate) fn adopt_and_purge_legacy_persisted_invitation_once() {
 
     if let Some(invitation) = recovered {
         info!("Adopting a pending invitation persisted by an older River, then erasing it");
+        // Unconditional. This hook now runs BEFORE the URL-parse block (that
+        // ordering is what stops the artifact being purged unread, and is
+        // pinned), so the slot is always empty here on the path that matters.
+        // An earlier version guarded with `if slot.is_none()` and justified it
+        // as "the URL parse runs first" — true when the hook ran later, false
+        // once it moved, and dead either way. A live invitation still wins:
+        // the URL parse calls `save_invitation_to_storage` after this, which
+        // overwrites the slot outright.
         PENDING_INVITATION.with(|cell| {
-            // Never clobber an invitation this page load already holds (the URL
-            // parse runs first): the live one is strictly fresher.
-            let mut slot = cell.borrow_mut();
-            if slot.is_none() {
-                *slot = Some(invitation);
-            }
+            *cell.borrow_mut() = Some(invitation);
         });
     }
 
@@ -1446,13 +1465,26 @@ mod tests {
         );
         // The click-interceptor's `save_invitation_to_storage` sits textually
         // earlier but runs inside a `use_effect`, i.e. after the render body,
-        // so it is not a counterexample. Anchoring on the URL-parse block keeps
-        // this pin about the calls that actually run during the first render.
-        assert!(
-            app[..adopt_at].contains("use_effect"),
-            "expected the click-interceptor use_effect above the adopt call; if \
-             that moved, re-check which invitation-save paths now run before it"
-        );
+        // so it is not a counterexample. Assert that specifically — that EVERY
+        // save above the adopt call is inside an effect — rather than merely
+        // that the string "use_effect" appears somewhere above, which is true
+        // of almost any edit to this file and so proves nothing.
+        let saves_above: Vec<usize> = app[..adopt_at]
+            .match_indices("save_invitation_to_storage(&")
+            .map(|(i, _)| i)
+            .collect();
+        for at in saves_above {
+            let effect_at = app[..at]
+                .rfind("use_effect(")
+                .expect("a save above the adopt call must sit inside a use_effect");
+            let closes = app[effect_at..at].matches("});").count();
+            assert!(
+                closes == 0,
+                "app.rs has a save_invitation_to_storage at byte {at} that runs \
+                 during the render body, BEFORE the legacy adopt hook. It would \
+                 purge the legacy artifact before the hook can read it."
+            );
+        }
 
         let full = include_str!("receive_invitation_modal.rs");
         let src = full

--- a/ui/src/components/room_list/receive_invitation_modal.rs
+++ b/ui/src/components/room_list/receive_invitation_modal.rs
@@ -4,7 +4,9 @@ use crate::components::members::Invitation;
 use crate::invites::{PendingRoomJoin, PendingRoomStatus};
 use crate::room_data::Rooms;
 use crate::util::display_name::{contains_hidden_chars, EMOJI_REJECTION_MESSAGE};
-use dioxus::logger::tracing::{error, info, warn};
+#[cfg(target_arch = "wasm32")]
+use dioxus::logger::tracing::warn;
+use dioxus::logger::tracing::{error, info};
 use dioxus::prelude::*;
 use ed25519_dalek::VerifyingKey;
 use river_core::room_state::member::{AuthorizedMember, MemberId};
@@ -99,25 +101,72 @@ pub fn present_invitation(inv: Invitation) {
     });
 }
 
-/// This module's single door to `localStorage`.
-///
-/// `web_sys::window()` does not merely return `None` off-wasm — touching it
-/// panics ("cannot access imported statics on non-wasm targets"), which made
-/// every storage-touching function in this module untestable under
-/// `cargo test`. Routing through here makes them no-ops natively, so the
-/// invitation-handling logic can be unit-tested. Behaviour on wasm is
-/// unchanged: same `window().local_storage()` call, same `Ok(Some(..))` gate.
-fn with_local_storage<R>(f: impl FnOnce(web_sys::Storage) -> R) -> Option<R> {
+// This module's single door to `localStorage`.
+//
+// `web_sys::window()` does not merely return `None` off-wasm — touching it
+// panics ("cannot access imported statics on non-wasm targets"). Routing every
+// access through these three functions means the module's invitation logic is
+// exercisable under `cargo test`, backed by an in-process map, instead of
+// being reachable only in a browser. Behaviour on wasm is unchanged: the same
+// `window().local_storage()` call behind the same `Ok(Some(..))` gate.
+//
+// This is not a convenience. The one BLOCKING defect this file has had — a
+// purge that erased the nickname binding and silently turned the #218
+// auto-resume into a re-prompt — was invisible to a source-scrape test and
+// only falsifiable by driving the real sequence. See
+// `a_legacy_invite_with_its_nickname_still_auto_resumes`.
+#[cfg(not(target_arch = "wasm32"))]
+thread_local! {
+    static FAKE_STORAGE: RefCell<std::collections::HashMap<String, String>> =
+        RefCell::new(std::collections::HashMap::new());
+}
+
+fn storage_get(key: &str) -> Option<String> {
     #[cfg(target_arch = "wasm32")]
     {
         let window = web_sys::window()?;
         let storage = window.local_storage().ok()??;
-        Some(f(storage))
+        storage.get_item(key).ok()?
     }
     #[cfg(not(target_arch = "wasm32"))]
     {
-        let _ = f;
-        None
+        FAKE_STORAGE.with(|m| m.borrow().get(key).cloned())
+    }
+}
+
+fn storage_set(key: &str, value: &str) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        if let Some(window) = web_sys::window() {
+            if let Ok(Some(storage)) = window.local_storage() {
+                if let Err(e) = storage.set_item(key, value) {
+                    warn!("Failed to write {key} to localStorage: {e:?}");
+                }
+            }
+        }
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        FAKE_STORAGE.with(|m| {
+            m.borrow_mut().insert(key.to_string(), value.to_string());
+        });
+    }
+}
+
+fn storage_remove(key: &str) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        if let Some(window) = web_sys::window() {
+            if let Ok(Some(storage)) = window.local_storage() {
+                let _ = storage.remove_item(key);
+            }
+        }
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        FAKE_STORAGE.with(|m| {
+            m.borrow_mut().remove(key);
+        });
     }
 }
 
@@ -187,10 +236,8 @@ pub fn clear_invitation_from_storage() {
         *cell.borrow_mut() = None;
     });
     purge_persisted_invitation();
-    with_local_storage(|storage| {
-        let _ = storage.remove_item(INVITATION_NICKNAME_STORAGE_KEY);
-        let _ = storage.remove_item(INVITATION_NICKNAME_FP_STORAGE_KEY);
-    });
+    storage_remove(INVITATION_NICKNAME_STORAGE_KEY);
+    storage_remove(INVITATION_NICKNAME_FP_STORAGE_KEY);
 }
 
 /// Erase an invitation left in localStorage by an older River.
@@ -205,16 +252,28 @@ pub fn clear_invitation_from_storage() {
 /// ([`purge_legacy_persisted_invitation_once`]) as well as on the save and
 /// clear paths.
 pub(crate) fn purge_persisted_invitation() {
-    with_local_storage(|storage| {
-        let _ = storage.remove_item(INVITATION_STORAGE_KEY);
-        // Sweep the nickname binding too. It is not sensitive, but once the
-        // artifact it is fingerprint-bound to is gone there is nothing it can
-        // ever bind to again — `load_invitation_nickname_from_storage` only
-        // returns it on a fingerprint MATCH — so leaving it behind is dead
-        // state that outlives its guard.
-        let _ = storage.remove_item(INVITATION_NICKNAME_STORAGE_KEY);
-        let _ = storage.remove_item(INVITATION_NICKNAME_FP_STORAGE_KEY);
-    });
+    // ONLY the artifact. The nickname binding must survive.
+    //
+    // An earlier version of this swept the nickname and its fingerprint too,
+    // on the reasoning that once the artifact is gone the binding has nothing
+    // to bind to. That reasoning was wrong, and the bug it caused was the
+    // sharpest kind: the startup adopt hook calls this immediately after
+    // reading the artifact into memory, so the nickname was destroyed while
+    // the invitation it belonged to lived on. `decide_recovered_invitation`
+    // returns `Resume` only on `Some(nickname)`, and `accept_invitation` never
+    // marks the invite processed — so the user got the nickname prompt AGAIN
+    // for a join already in flight, and could re-accept under a different
+    // name. That is the exact freenet/river#218 symptom this hook exists to
+    // preserve against.
+    //
+    // The binding is not orphaned by the move to in-memory holding: it is
+    // fingerprint-bound to `Invitation::to_encoded_string()`, and that
+    // invitation is now held in `PENDING_INVITATION`, so it still resolves.
+    // The genuinely stale cases are already covered — `clear_invitation_from_storage`
+    // drops it at terminal success/dismiss, `save_invitation_to_storage` drops
+    // it when a different invitation replaces this one, and an unmatched
+    // fingerprint makes any leftover inert.
+    storage_remove(INVITATION_STORAGE_KEY);
 }
 
 /// Remove only the saved nickname binding, leaving the invitation artifact in
@@ -223,10 +282,8 @@ pub(crate) fn purge_persisted_invitation() {
 /// not-yet-accepted invitation that overwrote `INVITATION_STORAGE_KEY` (Codex
 /// review, PR #333).
 fn clear_invitation_nickname_from_storage() {
-    with_local_storage(|storage| {
-        let _ = storage.remove_item(INVITATION_NICKNAME_STORAGE_KEY);
-        let _ = storage.remove_item(INVITATION_NICKNAME_FP_STORAGE_KEY);
-    });
+    storage_remove(INVITATION_NICKNAME_STORAGE_KEY);
+    storage_remove(INVITATION_NICKNAME_FP_STORAGE_KEY);
 }
 
 /// Save the accepted nickname alongside the pending invitation so a reload
@@ -235,26 +292,11 @@ fn clear_invitation_nickname_from_storage() {
 /// its fingerprint is stored too so the nickname is only ever applied back to
 /// the same invitation it was chosen for.
 pub fn save_invitation_nickname_to_storage(invitation_encoded: &str, nickname: &str) {
-    with_local_storage(|storage| {
-        if let Err(e) = storage.set_item(INVITATION_NICKNAME_STORAGE_KEY, nickname) {
-            warn!(
-                "Failed to save invitation nickname to localStorage: {:?}",
-                e
-            );
-            return;
-        }
-        let fp = invitation_fingerprint(invitation_encoded);
-        if let Err(e) = storage.set_item(INVITATION_NICKNAME_FP_STORAGE_KEY, &fp) {
-            warn!(
-                "Failed to save invitation nickname fingerprint to localStorage: {:?}",
-                e
-            );
-            // Leave no half-written binding: drop the nickname too so the
-            // resume path falls back to prompting rather than applying an
-            // unbound nickname.
-            let _ = storage.remove_item(INVITATION_NICKNAME_STORAGE_KEY);
-        }
-    });
+    storage_set(INVITATION_NICKNAME_STORAGE_KEY, nickname);
+    storage_set(
+        INVITATION_NICKNAME_FP_STORAGE_KEY,
+        &invitation_fingerprint(invitation_encoded),
+    );
 }
 
 /// What the app should do with an invitation recovered from localStorage on
@@ -327,14 +369,8 @@ pub fn take_resume_once(fired: &std::cell::Cell<bool>) -> bool {
 /// invitation (a stale nickname from a different invitation; Codex review,
 /// PR #333).
 pub fn load_invitation_nickname_from_storage(invitation_encoded: &str) -> Option<String> {
-    let (nickname, stored_fp) = with_local_storage(|storage| {
-        let nickname = storage.get_item(INVITATION_NICKNAME_STORAGE_KEY).ok()??;
-        let stored_fp = storage
-            .get_item(INVITATION_NICKNAME_FP_STORAGE_KEY)
-            .ok()??;
-        Some((nickname, stored_fp))
-    })
-    .flatten()?;
+    let nickname = storage_get(INVITATION_NICKNAME_STORAGE_KEY)?;
+    let stored_fp = storage_get(INVITATION_NICKNAME_FP_STORAGE_KEY)?;
     // The nickname must belong to THIS invitation. Without the match, a
     // nickname saved for invitation A would be applied to a different
     // invitation B that overwrote the invitation key before A's join cleared
@@ -1181,8 +1217,7 @@ pub(crate) fn adopt_and_purge_legacy_persisted_invitation_once() {
     // nobody holding the key. Reading it into memory first costs nothing and
     // gives up none of the security win, because the artifact still leaves
     // durable storage in the same breath.
-    let recovered = with_local_storage(|storage| storage.get_item(INVITATION_STORAGE_KEY).ok()?)
-        .flatten()
+    let recovered = storage_get(INVITATION_STORAGE_KEY)
         .and_then(|encoded| Invitation::from_encoded_string(&encoded).ok());
 
     if let Some(invitation) = recovered {
@@ -1250,8 +1285,126 @@ mod tests {
         // to write it does nothing about copies already on users' disks.
         assert!(
             src.contains("fn purge_persisted_invitation")
-                && src.contains("remove_item(INVITATION_STORAGE_KEY)"),
+                && src.contains("storage_remove(INVITATION_STORAGE_KEY)"),
             "the legacy persisted invitation must still be erased on upgrade"
+        );
+    }
+
+    /// Reset the in-process storage fake so each test starts clean.
+    fn reset_storage() {
+        FAKE_STORAGE.with(|m| m.borrow_mut().clear());
+        PENDING_INVITATION.with(|c| *c.borrow_mut() = None);
+    }
+
+    fn an_invitation(seed: u8) -> Invitation {
+        let owner_sk = SigningKey::from_bytes(&[seed; 32]);
+        let invitee_sk = SigningKey::from_bytes(&[seed.wrapping_add(1); 32]);
+        Invitation {
+            room: owner_sk.verifying_key(),
+            invitee_signing_key: invitee_sk.clone(),
+            invitee: owner_invited_member(&owner_sk, invitee_sk.verifying_key()),
+            room_secrets: vec![(0u32, [9u8; 32])],
+        }
+    }
+
+    /// THE property the startup adopt hook exists for, driven end to end.
+    ///
+    /// An older River left BOTH an invitation artifact and the nickname the
+    /// user had already chosen when they clicked Accept. That pair is what
+    /// makes the join resumable: `decide_recovered_invitation` returns `Resume`
+    /// only on `Some(nickname)`, and `accept_invitation` deliberately does NOT
+    /// mark the invitation processed, so a mid-flight reload sees
+    /// `is_invitation_processed == false`. Adopt the artifact but drop the
+    /// nickname and the user is re-prompted for a name on a join that is
+    /// already in flight — free to answer differently — which is the exact
+    /// freenet/river#218 symptom.
+    ///
+    /// This is the regression test for a real defect: the purge used to sweep
+    /// the nickname binding alongside the artifact. The ordering pin below did
+    /// NOT catch it, because the ordering was still correct — the hook read
+    /// before it purged, and then purged the wrong thing. Ordering was only
+    /// ever a proxy; this asserts the outcome.
+    #[test]
+    fn a_legacy_invite_with_its_nickname_still_auto_resumes() {
+        reset_storage();
+        let invitation = an_invitation(71);
+        let encoded = invitation.to_encoded_string();
+
+        // What an older River left behind: the artifact, plus the accepted
+        // nickname bound to it by fingerprint.
+        storage_set(INVITATION_STORAGE_KEY, &encoded);
+        save_invitation_nickname_to_storage(&encoded, "Chosen Name");
+
+        adopt_and_purge_legacy_persisted_invitation_once();
+
+        // The artifact is adopted into memory and gone from durable storage.
+        let recovered = load_invitation_from_storage().expect("artifact must be adopted");
+        assert_eq!(recovered.to_encoded_string(), encoded);
+        assert_eq!(
+            storage_get(INVITATION_STORAGE_KEY),
+            None,
+            "and it must not remain on disk — that is the whole point"
+        );
+
+        // ...and the join is still RESUMABLE, which is the property that
+        // survived-the-upgrade actually means.
+        let action = decide_recovered_invitation(
+            load_invitation_nickname_from_storage(&recovered.to_encoded_string()),
+            false,
+        );
+        assert_eq!(
+            action,
+            RecoveredInvitationAction::Resume {
+                nickname: "Chosen Name".to_string()
+            },
+            "adopting the artifact but dropping its nickname re-prompts the user \
+             for a name on a join already in flight (freenet/river#218)"
+        );
+    }
+
+    /// The purge must not take the nickname binding with it. Stated separately
+    /// from the resume test so a failure says WHICH half broke.
+    #[test]
+    fn purging_the_legacy_artifact_keeps_the_nickname_binding() {
+        reset_storage();
+        let invitation = an_invitation(73);
+        let encoded = invitation.to_encoded_string();
+        storage_set(INVITATION_STORAGE_KEY, &encoded);
+        save_invitation_nickname_to_storage(&encoded, "Keep Me");
+
+        purge_persisted_invitation();
+
+        assert_eq!(storage_get(INVITATION_STORAGE_KEY), None, "artifact erased");
+        assert_eq!(
+            load_invitation_nickname_from_storage(&encoded),
+            Some("Keep Me".to_string()),
+            "the nickname binding is still live — it is fingerprint-bound to an \
+             invitation that now lives in memory, so it is not orphaned"
+        );
+    }
+
+    /// The terminal paths DO still drop the binding, so this fix did not just
+    /// leak the state the sweep was aiming at.
+    #[test]
+    fn terminal_and_replacement_paths_still_drop_the_nickname_binding() {
+        reset_storage();
+        let invitation = an_invitation(75);
+        let encoded = invitation.to_encoded_string();
+
+        save_invitation_nickname_to_storage(&encoded, "Gone Soon");
+        clear_invitation_from_storage();
+        assert_eq!(
+            load_invitation_nickname_from_storage(&encoded),
+            None,
+            "dismiss / terminal success clears the binding"
+        );
+
+        save_invitation_nickname_to_storage(&encoded, "Also Gone");
+        save_invitation_to_storage(&an_invitation(77));
+        assert_eq!(
+            load_invitation_nickname_from_storage(&encoded),
+            None,
+            "a replacing invitation clears the previous binding (#333)"
         );
     }
 
@@ -1269,10 +1422,36 @@ mod tests {
     #[test]
     fn the_startup_purge_is_wired_in_and_adopts_before_erasing() {
         let app = include_str!("../app.rs");
+        let adopt_at = app
+            .find("adopt_and_purge_legacy_persisted_invitation_once()")
+            .expect(
+                "App must run the legacy-invitation adopt+purge at startup, or an \
+                 older River's persisted private key is never erased",
+            );
+
+        // ACROSS call sites, not just inside the hook. `save_invitation_to_storage`
+        // purges the legacy artifact itself, so if the URL-parse block ran first
+        // the hook would find nothing to adopt and an in-flight join left by an
+        // older build would be destroyed unread. The in-function ordering pin
+        // below cannot see this; a property that depends on two calls a hundred
+        // lines apart not being reordered needs a pin that spans both.
+        let url_parse_at = app
+            .find(r#"params.get("invitation")"#)
+            .expect("App must still parse an invitation out of the URL query");
         assert!(
-            app.contains("adopt_and_purge_legacy_persisted_invitation_once()"),
-            "App must run the legacy-invitation adopt+purge at startup, or an \
-             older River's persisted private key is never erased"
+            adopt_at < url_parse_at,
+            "the legacy adopt+purge must run BEFORE the URL-parse block, which \
+             calls save_invitation_to_storage and so purges the legacy artifact \
+             as a side effect"
+        );
+        // The click-interceptor's `save_invitation_to_storage` sits textually
+        // earlier but runs inside a `use_effect`, i.e. after the render body,
+        // so it is not a counterexample. Anchoring on the URL-parse block keeps
+        // this pin about the calls that actually run during the first render.
+        assert!(
+            app[..adopt_at].contains("use_effect"),
+            "expected the click-interceptor use_effect above the adopt call; if \
+             that moved, re-check which invitation-save paths now run before it"
         );
 
         let full = include_str!("receive_invitation_modal.rs");
@@ -1285,7 +1464,7 @@ mod tests {
             .nth(1)
             .expect("the startup hook must exist");
         let read_at = body
-            .find("get_item(INVITATION_STORAGE_KEY)")
+            .find("storage_get(INVITATION_STORAGE_KEY)")
             .expect("the hook must READ the legacy artifact before erasing it");
         let purge_at = body
             .find("purge_persisted_invitation()")

--- a/ui/src/components/room_list/receive_invitation_modal.rs
+++ b/ui/src/components/room_list/receive_invitation_modal.rs
@@ -207,6 +207,13 @@ pub fn clear_invitation_from_storage() {
 pub(crate) fn purge_persisted_invitation() {
     with_local_storage(|storage| {
         let _ = storage.remove_item(INVITATION_STORAGE_KEY);
+        // Sweep the nickname binding too. It is not sensitive, but once the
+        // artifact it is fingerprint-bound to is gone there is nothing it can
+        // ever bind to again — `load_invitation_nickname_from_storage` only
+        // returns it on a fingerprint MATCH — so leaving it behind is dead
+        // state that outlives its guard.
+        let _ = storage.remove_item(INVITATION_NICKNAME_STORAGE_KEY);
+        let _ = storage.remove_item(INVITATION_NICKNAME_FP_STORAGE_KEY);
     });
 }
 
@@ -1150,6 +1157,49 @@ pub(crate) fn accept_invitation(inv: Invitation, nickname: String) {
     }
 }
 
+/// Startup hook: retire any invitation an older River left in localStorage.
+///
+/// Called from `App()`, which re-renders often, so the localStorage write is
+/// done at most once per page load. Idempotent either way; the flag only keeps
+/// it off the render hot path.
+pub(crate) fn adopt_and_purge_legacy_persisted_invitation_once() {
+    thread_local! {
+        static DONE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    }
+    if DONE.with(|d| d.replace(true)) {
+        return;
+    }
+
+    // ADOPT BEFORE PURGING. Destroying the stored artifact unread would lose a
+    // join that an older build had genuinely left in flight: the user clicks
+    // Accept, `accept_invitation` PUTs the invitee member, the room only enters
+    // `ROOMS` on the GET response, that stalls (see the auto-resume notes on
+    // the recovery block in `App` — freenet-core#4345 is cited there as a real
+    // occurrence), and the user reloads onto this build. The invitee private
+    // key would then be gone from BOTH memory and disk while the member entry
+    // may already exist in the room — the freenet/river#365 orphan shape, with
+    // nobody holding the key. Reading it into memory first costs nothing and
+    // gives up none of the security win, because the artifact still leaves
+    // durable storage in the same breath.
+    let recovered = with_local_storage(|storage| storage.get_item(INVITATION_STORAGE_KEY).ok()?)
+        .flatten()
+        .and_then(|encoded| Invitation::from_encoded_string(&encoded).ok());
+
+    if let Some(invitation) = recovered {
+        info!("Adopting a pending invitation persisted by an older River, then erasing it");
+        PENDING_INVITATION.with(|cell| {
+            // Never clobber an invitation this page load already holds (the URL
+            // parse runs first): the live one is strictly fresher.
+            let mut slot = cell.borrow_mut();
+            if slot.is_none() {
+                *slot = Some(invitation);
+            }
+        });
+    }
+
+    purge_persisted_invitation();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1202,6 +1252,48 @@ mod tests {
             src.contains("fn purge_persisted_invitation")
                 && src.contains("remove_item(INVITATION_STORAGE_KEY)"),
             "the legacy persisted invitation must still be erased on upgrade"
+        );
+    }
+
+    /// The startup hook must actually be wired into `App`, and must ADOPT
+    /// before it purges.
+    ///
+    /// A source scrape because the adopt/purge both go through `web_sys`,
+    /// which does not exist under `cargo test` — a behavioural test could not
+    /// fail here. What it guards is real: if the call were dropped from `App`,
+    /// an older River's stored artifact would simply sit on disk forever, which
+    /// is the exposure this change exists to retire; and if the purge ran
+    /// before the read, an in-flight join left by the older build would be
+    /// destroyed unread (the freenet/river#365 orphan shape, with nobody
+    /// holding the invitee key).
+    #[test]
+    fn the_startup_purge_is_wired_in_and_adopts_before_erasing() {
+        let app = include_str!("../app.rs");
+        assert!(
+            app.contains("adopt_and_purge_legacy_persisted_invitation_once()"),
+            "App must run the legacy-invitation adopt+purge at startup, or an \
+             older River's persisted private key is never erased"
+        );
+
+        let full = include_str!("receive_invitation_modal.rs");
+        let src = full
+            .split("mod tests {")
+            .next()
+            .expect("production code precedes `mod tests`");
+        let body = src
+            .split("fn adopt_and_purge_legacy_persisted_invitation_once")
+            .nth(1)
+            .expect("the startup hook must exist");
+        let read_at = body
+            .find("get_item(INVITATION_STORAGE_KEY)")
+            .expect("the hook must READ the legacy artifact before erasing it");
+        let purge_at = body
+            .find("purge_persisted_invitation()")
+            .expect("the hook must erase the legacy artifact");
+        assert!(
+            read_at < purge_at,
+            "the hook must adopt the stored invitation BEFORE purging it — \
+             purging first destroys an in-flight join unread"
         );
     }
 
@@ -1852,21 +1944,4 @@ mod tests {
              terminal success (the relocation target of the gravestone fix)."
         );
     }
-}
-
-/// Startup hook: retire any invitation an older River left in localStorage.
-///
-/// Called from `App()`, which re-renders often, so the localStorage write is
-/// done at most once per page load. Idempotent either way; the flag only keeps
-/// it off the render hot path.
-pub(crate) fn purge_legacy_persisted_invitation_once() {
-    thread_local! {
-        static PURGED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
-    }
-    PURGED.with(|done| {
-        if !done.get() {
-            done.set(true);
-            purge_persisted_invitation();
-        }
-    });
 }

--- a/ui/src/components/room_list/receive_invitation_modal.rs
+++ b/ui/src/components/room_list/receive_invitation_modal.rs
@@ -99,47 +99,115 @@ pub fn present_invitation(inv: Invitation) {
     });
 }
 
-/// Save invitation to localStorage so it survives page reloads.
+/// This module's single door to `localStorage`.
 ///
-/// Clears any previously-saved nickname binding first: this is the single
+/// `web_sys::window()` does not merely return `None` off-wasm — touching it
+/// panics ("cannot access imported statics on non-wasm targets"), which made
+/// every storage-touching function in this module untestable under
+/// `cargo test`. Routing through here makes them no-ops natively, so the
+/// invitation-handling logic can be unit-tested. Behaviour on wasm is
+/// unchanged: same `window().local_storage()` call, same `Ok(Some(..))` gate.
+fn with_local_storage<R>(f: impl FnOnce(web_sys::Storage) -> R) -> Option<R> {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let window = web_sys::window()?;
+        let storage = window.local_storage().ok()??;
+        Some(f(storage))
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let _ = f;
+        None
+    }
+}
+
+thread_local! {
+    /// The pending invitation, held in PROCESS MEMORY for the life of the page.
+    ///
+    /// It used to live in `localStorage[INVITATION_STORAGE_KEY]`, base58 of the
+    /// whole CBOR artifact. An `Invitation` carries `invitee_signing_key`, a
+    /// full ed25519 PRIVATE key, and `room_secrets`, the room's plaintext
+    /// symmetric secrets. localStorage is durable and readable by any script in
+    /// the origin, and — see `clear_invitation_from_storage` — the flow has no
+    /// terminal state for an abandoned invite, so an invitation merely OPENED
+    /// and never acted on parked that key material on disk indefinitely.
+    ///
+    /// A `thread_local!` is the right lifetime for it: the pending-invite window
+    /// runs from "invitation seen" to "subscribed or dismissed", which is
+    /// entirely within one page load. The same trade is already made for the
+    /// delegate cipher material in `chat_delegate::chat_delegate_cipher_material`.
+    ///
+    /// Cost, stated plainly: a mid-flow RELOAD no longer recovers the
+    /// invitation from storage. For the URL-bar entry path — the common one —
+    /// nothing changes in practice, because the `?invitation=` query parameter
+    /// survives the reload (the strip at `app.rs` is best-effort and fails in
+    /// the sandboxed gateway iframe) and `App` re-parses it BEFORE the recovery
+    /// block runs. For the DM-card, paste-a-code, and click-interceptor paths
+    /// there is no URL copy, so a reload drops the pending invite and the user
+    /// re-opens it. That is the deliberate trade: an invitation is a bearer
+    /// credential, and not writing bearer credentials to durable storage is
+    /// worth one re-click on a path that already fails this way in production
+    /// (localStorage is unavailable to an opaque-origin iframe, so the
+    /// reload-resume it backed has never worked in the deployed gateway —
+    /// freenet/river#219).
+    static PENDING_INVITATION: RefCell<Option<Invitation>> = const { RefCell::new(None) };
+}
+
+/// Hold the invitation for the pending-invite window.
+///
+/// Also clears any previously-saved nickname binding: this is the single
 /// chokepoint every fresh-invitation save path (URL bar, click interceptor,
 /// DM-card present, and `accept_invitation` itself) goes through, so a stale
 /// nickname from a previously-accepted invitation can never linger to be
-/// applied to a different invitation that overwrites the invitation key. The
+/// applied to a different invitation that replaces this one. The
 /// fingerprint binding in `load_invitation_nickname_from_storage` is the
 /// authoritative guard; this clear is defense-in-depth that keeps storage
 /// honest. `accept_invitation` re-saves the nickname immediately after, so its
 /// own binding survives. (Codex review, PR #333.)
+///
+/// The NICKNAME and its fingerprint stay in localStorage. Neither is a secret:
+/// a nickname is published into the room, and the fingerprint is a BLAKE3 hash.
 pub fn save_invitation_to_storage(invitation: &Invitation) {
     clear_invitation_nickname_from_storage();
-    if let Some(window) = web_sys::window() {
-        if let Ok(Some(storage)) = window.local_storage() {
-            let encoded = invitation.to_encoded_string();
-            if let Err(e) = storage.set_item(INVITATION_STORAGE_KEY, &encoded) {
-                warn!("Failed to save invitation to localStorage: {:?}", e);
-            }
-        }
-    }
+    purge_persisted_invitation();
+    PENDING_INVITATION.with(|cell| {
+        *cell.borrow_mut() = Some(invitation.clone());
+    });
 }
 
-/// Load invitation from localStorage (for recovery after page reload)
+/// Recover the pending invitation (after a re-render, not after a reload — see
+/// [`PENDING_INVITATION`]).
 pub fn load_invitation_from_storage() -> Option<Invitation> {
-    let window = web_sys::window()?;
-    let storage = window.local_storage().ok()??;
-    let encoded = storage.get_item(INVITATION_STORAGE_KEY).ok()??;
-    Invitation::from_encoded_string(&encoded).ok()
+    PENDING_INVITATION.with(|cell| cell.borrow().clone())
 }
 
-/// Clear saved invitation (and any saved nickname + its fingerprint binding)
-/// from localStorage.
+/// Drop the pending invitation and any saved nickname + fingerprint binding.
 pub fn clear_invitation_from_storage() {
-    if let Some(window) = web_sys::window() {
-        if let Ok(Some(storage)) = window.local_storage() {
-            let _ = storage.remove_item(INVITATION_STORAGE_KEY);
-            let _ = storage.remove_item(INVITATION_NICKNAME_STORAGE_KEY);
-            let _ = storage.remove_item(INVITATION_NICKNAME_FP_STORAGE_KEY);
-        }
-    }
+    PENDING_INVITATION.with(|cell| {
+        *cell.borrow_mut() = None;
+    });
+    purge_persisted_invitation();
+    with_local_storage(|storage| {
+        let _ = storage.remove_item(INVITATION_NICKNAME_STORAGE_KEY);
+        let _ = storage.remove_item(INVITATION_NICKNAME_FP_STORAGE_KEY);
+    });
+}
+
+/// Erase an invitation left in localStorage by an older River.
+///
+/// Not merely tidiness: because the old flow had no terminal state for an
+/// abandoned invite, an upgrading user can be carrying a private key and a set
+/// of plaintext room secrets under [`INVITATION_STORAGE_KEY`] from an invite
+/// they opened months ago. Removing the key is the only thing that actually
+/// retires that exposure — ceasing to WRITE it does nothing for data already
+/// written, and the users most exposed are exactly the ones who never touch an
+/// invitation again. So this runs unconditionally at startup
+/// ([`purge_legacy_persisted_invitation_once`]) as well as on the save and
+/// clear paths.
+pub(crate) fn purge_persisted_invitation() {
+    with_local_storage(|storage| {
+        let _ = storage.remove_item(INVITATION_STORAGE_KEY);
+    });
 }
 
 /// Remove only the saved nickname binding, leaving the invitation artifact in
@@ -148,12 +216,10 @@ pub fn clear_invitation_from_storage() {
 /// not-yet-accepted invitation that overwrote `INVITATION_STORAGE_KEY` (Codex
 /// review, PR #333).
 fn clear_invitation_nickname_from_storage() {
-    if let Some(window) = web_sys::window() {
-        if let Ok(Some(storage)) = window.local_storage() {
-            let _ = storage.remove_item(INVITATION_NICKNAME_STORAGE_KEY);
-            let _ = storage.remove_item(INVITATION_NICKNAME_FP_STORAGE_KEY);
-        }
-    }
+    with_local_storage(|storage| {
+        let _ = storage.remove_item(INVITATION_NICKNAME_STORAGE_KEY);
+        let _ = storage.remove_item(INVITATION_NICKNAME_FP_STORAGE_KEY);
+    });
 }
 
 /// Save the accepted nickname alongside the pending invitation so a reload
@@ -162,28 +228,26 @@ fn clear_invitation_nickname_from_storage() {
 /// its fingerprint is stored too so the nickname is only ever applied back to
 /// the same invitation it was chosen for.
 pub fn save_invitation_nickname_to_storage(invitation_encoded: &str, nickname: &str) {
-    if let Some(window) = web_sys::window() {
-        if let Ok(Some(storage)) = window.local_storage() {
-            if let Err(e) = storage.set_item(INVITATION_NICKNAME_STORAGE_KEY, nickname) {
-                warn!(
-                    "Failed to save invitation nickname to localStorage: {:?}",
-                    e
-                );
-                return;
-            }
-            let fp = invitation_fingerprint(invitation_encoded);
-            if let Err(e) = storage.set_item(INVITATION_NICKNAME_FP_STORAGE_KEY, &fp) {
-                warn!(
-                    "Failed to save invitation nickname fingerprint to localStorage: {:?}",
-                    e
-                );
-                // Leave no half-written binding: drop the nickname too so the
-                // resume path falls back to prompting rather than applying an
-                // unbound nickname.
-                let _ = storage.remove_item(INVITATION_NICKNAME_STORAGE_KEY);
-            }
+    with_local_storage(|storage| {
+        if let Err(e) = storage.set_item(INVITATION_NICKNAME_STORAGE_KEY, nickname) {
+            warn!(
+                "Failed to save invitation nickname to localStorage: {:?}",
+                e
+            );
+            return;
         }
-    }
+        let fp = invitation_fingerprint(invitation_encoded);
+        if let Err(e) = storage.set_item(INVITATION_NICKNAME_FP_STORAGE_KEY, &fp) {
+            warn!(
+                "Failed to save invitation nickname fingerprint to localStorage: {:?}",
+                e
+            );
+            // Leave no half-written binding: drop the nickname too so the
+            // resume path falls back to prompting rather than applying an
+            // unbound nickname.
+            let _ = storage.remove_item(INVITATION_NICKNAME_STORAGE_KEY);
+        }
+    });
 }
 
 /// What the app should do with an invitation recovered from localStorage on
@@ -256,12 +320,14 @@ pub fn take_resume_once(fired: &std::cell::Cell<bool>) -> bool {
 /// invitation (a stale nickname from a different invitation; Codex review,
 /// PR #333).
 pub fn load_invitation_nickname_from_storage(invitation_encoded: &str) -> Option<String> {
-    let window = web_sys::window()?;
-    let storage = window.local_storage().ok()??;
-    let nickname = storage.get_item(INVITATION_NICKNAME_STORAGE_KEY).ok()??;
-    let stored_fp = storage
-        .get_item(INVITATION_NICKNAME_FP_STORAGE_KEY)
-        .ok()??;
+    let (nickname, stored_fp) = with_local_storage(|storage| {
+        let nickname = storage.get_item(INVITATION_NICKNAME_STORAGE_KEY).ok()??;
+        let stored_fp = storage
+            .get_item(INVITATION_NICKNAME_FP_STORAGE_KEY)
+            .ok()??;
+        Some((nickname, stored_fp))
+    })
+    .flatten()?;
     // The nickname must belong to THIS invitation. Without the match, a
     // nickname saved for invitation A would be applied to a different
     // invitation B that overwrote the invitation key before A's join cleared
@@ -726,15 +792,21 @@ fn vk_is_room_member(
 /// restore-access branch still fires for the case it is meant for: a lost
 /// `self_vk` that is not itself a member (see
 /// `restore_access_invitation_still_detected`).
+///
+/// `self_vk` is `None` when the stored room carries no locally-known identity
+/// (a blob written by a River that keeps the key elsewhere). That drops only
+/// the `self_vk` disjunct below: the invitation's own key is still checked, so
+/// the routing degrades to "we cannot prove you are already a member", which is
+/// the same answer as for a room that is not stored locally at all.
 fn membership_status(
     owner_vk: &VerifyingKey,
     members: &[AuthorizedMember],
-    self_vk: &VerifyingKey,
+    self_vk: Option<&VerifyingKey>,
     invitation_key_vk: &VerifyingKey,
     invitation_invitee_vk: &VerifyingKey,
 ) -> (bool, bool) {
     let current_key_is_member = vk_is_room_member(owner_vk, members, invitation_key_vk)
-        || vk_is_room_member(owner_vk, members, self_vk);
+        || self_vk.is_some_and(|vk| vk_is_room_member(owner_vk, members, vk));
     let invited_member_exists = members
         .iter()
         .any(|m| &m.member.member_vk == invitation_invitee_vk);
@@ -747,7 +819,7 @@ fn check_membership_status(inv: &Invitation, current_rooms: &Rooms) -> (bool, bo
         membership_status(
             &room_data.owner_vk,
             &room_data.room_state.members.members,
-            &room_data.self_sk.verifying_key(),
+            room_data.self_verifying_key().as_ref(),
             &inv.invitee_signing_key.verifying_key(),
             &inv.invitee.member.member_vk,
         )
@@ -953,11 +1025,17 @@ pub(crate) fn accept_invitation(inv: Invitation, nickname: String) {
     // `self_sk` is no longer a member and this guard does not fire.
     if let Ok(rooms) = ROOMS.try_read() {
         if let Some(room_data) = rooms.map.get(&inv.room) {
-            let already_member = vk_is_room_member(
-                &room_data.owner_vk,
-                &room_data.room_state.members.members,
-                &room_data.self_sk.verifying_key(),
-            );
+            // With no locally-known identity there is nothing to compare, so
+            // the guard cannot fire. That is the same fall-through the
+            // best-effort contract documented above already allows for an
+            // unreadable/cold `ROOMS`.
+            let already_member = room_data.self_verifying_key().is_some_and(|self_vk| {
+                vk_is_room_member(
+                    &room_data.owner_vk,
+                    &room_data.room_state.members.members,
+                    &self_vk,
+                )
+            });
             if already_member {
                 drop(rooms);
                 info!(
@@ -1078,6 +1156,92 @@ mod tests {
     use ed25519_dalek::SigningKey;
     use river_core::room_state::member::Member;
 
+    /// The pending invitation must never be written to durable browser
+    /// storage. It carries `invitee_signing_key` — a full ed25519 PRIVATE key —
+    /// and `room_secrets`, the room's plaintext symmetric secrets, and the flow
+    /// has no terminal state for an abandoned invite, so anything persisted can
+    /// linger indefinitely where any script in the origin can read it.
+    ///
+    /// A source scrape rather than a behavioural test because the write would
+    /// go through `web_sys`, which does not exist under `cargo test`: a
+    /// behavioural test here would pass whether or not the write was
+    /// reintroduced, i.e. it could not fail. This can.
+    #[test]
+    fn the_pending_invitation_is_never_persisted() {
+        let full = include_str!("receive_invitation_modal.rs");
+        let src = full
+            .split("mod tests {")
+            .next()
+            .expect("production code precedes `mod tests`");
+
+        // Assembled at runtime so this test's own text cannot satisfy the scan.
+        let set_item = format!("{}{}", "set_i", "tem(");
+        for (i, line) in src.lines().enumerate() {
+            if line.contains(&set_item) && line.contains("INVITATION_STORAGE_KEY") {
+                panic!(
+                    "receive_invitation_modal.rs:{} writes the invitation artifact to \
+                     browser storage. It holds a private key and the room's plaintext \
+                     secrets; keep it in `PENDING_INVITATION` (process memory) for the \
+                     pending-invite window instead.",
+                    i + 1
+                );
+            }
+        }
+
+        // The nickname keys ARE still persisted, and deliberately so — neither a
+        // nickname nor a BLAKE3 fingerprint is a secret. Assert that, so this
+        // pin cannot be "satisfied" by deleting the storage code wholesale and
+        // silently dropping the #333 nickname binding with it.
+        assert!(
+            src.contains("INVITATION_NICKNAME_STORAGE_KEY"),
+            "the nickname binding must still be persisted (freenet/river#218/#333)"
+        );
+        // And the legacy artifact must still be actively REMOVED, since ceasing
+        // to write it does nothing about copies already on users' disks.
+        assert!(
+            src.contains("fn purge_persisted_invitation")
+                && src.contains("remove_item(INVITATION_STORAGE_KEY)"),
+            "the legacy persisted invitation must still be erased on upgrade"
+        );
+    }
+
+    /// The in-memory slot behaves like the storage it replaced for the only
+    /// lifetime that now matters: within one page load.
+    #[test]
+    fn pending_invitation_round_trips_in_memory_and_clears() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let invitation = Invitation {
+            room: owner_sk.verifying_key(),
+            invitee_signing_key: invitee_sk.clone(),
+            invitee: owner_invited_member(&owner_sk, invitee_sk.verifying_key()),
+            room_secrets: vec![(0u32, [7u8; 32])],
+        };
+
+        clear_invitation_from_storage();
+        assert!(
+            load_invitation_from_storage().is_none(),
+            "precondition: nothing held"
+        );
+
+        save_invitation_to_storage(&invitation);
+        let recovered = load_invitation_from_storage().expect("held for the pending window");
+        assert_eq!(
+            recovered.invitee_signing_key.to_bytes(),
+            invitee_sk.to_bytes(),
+            "the full artifact is recoverable in-process — the accept path needs \
+             the private key to complete the join"
+        );
+        assert_eq!(recovered.room_secrets, invitation.room_secrets);
+
+        clear_invitation_from_storage();
+        assert!(
+            load_invitation_from_storage().is_none(),
+            "dismiss/terminal-success drops the credential"
+        );
+    }
+
     /// Build an `AuthorizedMember` invited directly by the owner.
     fn owner_invited_member(owner_sk: &SigningKey, member_vk: VerifyingKey) -> AuthorizedMember {
         let owner_vk = owner_sk.verifying_key();
@@ -1134,7 +1298,7 @@ mod tests {
         let (current_key_is_member, invited_member_exists) = membership_status(
             &owner_vk,
             &members,
-            &self_sk.verifying_key(),
+            Some(&self_sk.verifying_key()),
             &fresh_invite_sk.verifying_key(),
             &invited_vk,
         );
@@ -1168,7 +1332,7 @@ mod tests {
         let (current_key_is_member, invited_member_exists) = membership_status(
             &owner_vk,
             &members,
-            &self_sk.verifying_key(),
+            Some(&self_sk.verifying_key()),
             &fresh_invite_sk.verifying_key(),
             &invited_vk,
         );
@@ -1205,7 +1369,7 @@ mod tests {
         let (current_key_is_member, invited_member_exists) = membership_status(
             &owner_vk,
             &members,
-            &lost_self_sk.verifying_key(),
+            Some(&lost_self_sk.verifying_key()),
             &invitation_key_sk.verifying_key(),
             &existing_member_sk.verifying_key(),
         );
@@ -1688,4 +1852,21 @@ mod tests {
              terminal success (the relocation target of the gravestone fix)."
         );
     }
+}
+
+/// Startup hook: retire any invitation an older River left in localStorage.
+///
+/// Called from `App()`, which re-renders often, so the localStorage write is
+/// done at most once per page load. Idempotent either way; the flag only keeps
+/// it off the render hot path.
+pub(crate) fn purge_legacy_persisted_invitation_once() {
+    thread_local! {
+        static PURGED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    }
+    PURGED.with(|done| {
+        if !done.get() {
+            done.set(true);
+            purge_persisted_invitation();
+        }
+    });
 }

--- a/ui/src/components/room_list/room_name_field.rs
+++ b/ui/src/components/room_list/room_name_field.rs
@@ -49,6 +49,9 @@ fn stored_room_name(config: &Configuration) -> String {
     }
 }
 
+/// `is_owner` means "may edit this room's name", which the caller
+/// (`EditRoomModal::user_can_edit`) computes as ownership AND holding the local
+/// signing key — the rename is signed, so the public half alone is not enough.
 #[component]
 pub fn RoomNameField(config: Configuration, is_owner: bool) -> Element {
     let seed_config = config.clone();
@@ -78,6 +81,10 @@ pub fn RoomNameField(config: Configuration, is_owner: bool) -> Element {
                     // The rename is signed, so the private half is required.
                     // A blob that keeps its key elsewhere degrades exactly
                     // like a missing room: the edit is dropped, with a log.
+                    // Backstop only. `is_owner` is the caller's key-gated
+                    // `user_can_edit`, so a key-less owner gets a disabled
+                    // input and the modal's own "this device doesn't hold your
+                    // key" notice instead of an edit that only logs (R4).
                     let Some(self_sk) = room_data.signing_key().cloned() else {
                         error!("No local signing key for the current room; room name edit dropped");
                         return None;

--- a/ui/src/components/room_list/room_name_field.rs
+++ b/ui/src/components/room_list/room_name_field.rs
@@ -75,9 +75,16 @@ pub fn RoomNameField(config: Configuration, is_owner: bool) -> Element {
             // Get signing data and encryption info from room
             let signing_data = ROOMS.with(|rooms| {
                 if let Some(room_data) = rooms.map.get(&owner_key) {
+                    // The rename is signed, so the private half is required.
+                    // A blob that keeps its key elsewhere degrades exactly
+                    // like a missing room: the edit is dropped, with a log.
+                    let Some(self_sk) = room_data.signing_key().cloned() else {
+                        error!("No local signing key for the current room; room name edit dropped");
+                        return None;
+                    };
                     Some((
                         room_data.room_key(),
-                        room_data.self_sk.clone(),
+                        self_sk,
                         room_data.room_state.clone(),
                         room_data.is_private(),
                         room_data.get_secret().map(|(s, v)| (*s, v)),

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -427,7 +427,8 @@ fn create_room(
         room_data: RoomData {
             owner_vk: owner_vk.clone(),
             room_state,
-            self_sk: self_sk.clone(),
+            self_sk: Some(self_sk.clone()),
+            self_vk: None,
             contract_key,
             last_read_message_id: None,
             secrets: std::collections::HashMap::new(),
@@ -1130,7 +1131,12 @@ mod tests {
 
         for (owner_vk, room_data) in create_example_rooms().map.iter() {
             let owner_id = MemberId::from(owner_vk);
-            let self_member_id = MemberId::from(&room_data.self_sk.verifying_key());
+            // Fixture invariant, asserted rather than unwrapped: an example
+            // room with no local identity would make every check below
+            // vacuous, so this is a fixture invariant and must fail loudly.
+            let self_member_id = room_data
+                .self_member_id()
+                .expect("every example room must carry a local identity");
             let state = &room_data.room_state;
 
             let deputy_badges = deputy_badges_for_viewer(
@@ -1221,8 +1227,11 @@ mod tests {
             "the muted room must have no read marker, or it has nothing unread \
              to suppress"
         );
-        let self_id: river_core::room_state::member::MemberId =
-            muted_room.self_sk.verifying_key().into();
+        // Fixture invariant: without a local identity the unread count below
+        // would be meaningless, so fail loudly rather than skip.
+        let self_id = muted_room
+            .self_member_id()
+            .expect("the muted example room must carry a local identity");
         let unread = muted_room
             .room_state
             .recent_messages

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -6877,9 +6877,12 @@ mod tests {
                 if !is_assignment && !is_literal_field {
                     continue;
                 }
-                if !in_test_helper[i] {
-                    checked += 1;
-                }
+                // Counted per-ARM below, not here: the literal arm has its own
+                // increment, so counting up front made every literal count
+                // TWICE. That inflated the tally past the floor and silently
+                // undid the point of tracking test helpers at all — a
+                // production site could be deleted and the floor would still
+                // hold on the double-counted remainder.
                 let window = lines[i.saturating_sub(3)..(i + 4).min(lines.len())].join("\n");
 
                 // For a LITERAL, naming the field is not enough — that is
@@ -6940,6 +6943,9 @@ mod tests {
                     continue;
                 }
 
+                if !in_test_helper[i] {
+                    checked += 1;
+                }
                 assert!(
                     window.contains(".self_vk ="),
                     "{}:{} assigns self_sk without assigning self_vk beside it. \

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -30,6 +30,11 @@ use std::collections::HashMap;
 pub enum SendMessageError {
     UserNotMember,
     UserBanned,
+    /// This device does not hold the local user's key for this room, so it
+    /// cannot sign anything here. Distinct from `UserNotMember` on purpose:
+    /// the user may well be a member, we just cannot prove it. Only reachable
+    /// from a `RoomData` whose `self_sk` is absent (see the field docs).
+    IdentityUnavailable,
 }
 
 /// Rank of an identity the user chose DELIBERATELY (identity import,
@@ -193,7 +198,43 @@ pub fn record_identity_source(
 pub struct RoomData {
     pub owner_vk: VerifyingKey,
     pub room_state: ChatRoomStateV1,
-    pub self_sk: SigningKey,
+    /// The local user's private signing key for this room.
+    ///
+    /// **Optional at the serde boundary on purpose — do NOT make this a
+    /// required field again.** It is `Option` so that a blob written by a
+    /// FUTURE River that no longer stores the private key here still decodes
+    /// in THIS build. A required CBOR field fails the whole
+    /// [`RoomSlot`] decode when absent, and a `RoomSlot` that fails to decode
+    /// does not degrade — the room *vanishes* from the user's list. Shipping
+    /// the tolerant reader well ahead of any writer change is what makes the
+    /// eventual relocation of the key survivable (see the "reader tolerance"
+    /// step in the key-storage staging plan).
+    ///
+    /// This build still ALWAYS writes `Some(..)`: the key has not moved, and
+    /// it must not move until a mechanism exists for private keys to survive
+    /// a delegate re-key. Secrets in the delegate's `signing_key:` namespace
+    /// do NOT survive one today, and River re-keys roughly weekly, so
+    /// relocating the key first would destroy every existing user's identity.
+    ///
+    /// Read it through [`RoomData::signing_key`] rather than matching on the
+    /// field, and prefer [`RoomData::self_verifying_key`] wherever only the
+    /// public half is needed.
+    #[serde(default)]
+    pub self_sk: Option<SigningKey>,
+    /// The local user's verifying key (the public half of [`Self::self_sk`]).
+    ///
+    /// Persisted so that the many `MemberId` / owner-check / "is this me"
+    /// sites can answer without reaching for the private key at all. Today it
+    /// is pure redundancy — `self_sk` is present and authoritative, and
+    /// [`RoomData::self_verifying_key`] derives from it in preference to this
+    /// field, so a stale or mismatched value here can never override the real
+    /// key. Once the private key moves out of this blob, this becomes the only
+    /// way the UI knows who the local user is in this room.
+    ///
+    /// `None` for blobs written before this field existed;
+    /// [`RoomData::backfill_self_vk`] populates it on load.
+    #[serde(default)]
+    pub self_vk: Option<VerifyingKey>,
     pub contract_key: ContractKey,
     /// The last message ID that was read by the user (for unread tracking).
     /// Messages after this ID from other users are considered unread when
@@ -348,6 +389,60 @@ pub(crate) fn current_secret_from_state(
 }
 
 impl RoomData {
+    /// The local user's private signing key for this room, if this build still
+    /// holds it locally.
+    ///
+    /// `None` means the blob was written by a River that keeps the key
+    /// elsewhere. No shipped writer does that yet, so in practice this is
+    /// always `Some` today — but every caller must still handle `None` without
+    /// panicking, because the whole point of the tolerant reader is that a
+    /// future writer CAN produce such a blob and this build must survive it.
+    /// The graceful behaviour is "this identity cannot act": skip the signing
+    /// or decryption, log, and leave the rest of the room readable.
+    pub fn signing_key(&self) -> Option<&SigningKey> {
+        self.self_sk.as_ref()
+    }
+
+    /// The local user's verifying key for this room, if known.
+    ///
+    /// Prefers deriving from the private key, which is authoritative whenever
+    /// it is present, and falls back to the persisted [`Self::self_vk`]. That
+    /// order matters: it makes a stale or tampered `self_vk` unable to change
+    /// who the UI thinks it is while the real key is in hand.
+    pub fn self_verifying_key(&self) -> Option<VerifyingKey> {
+        match &self.self_sk {
+            Some(sk) => Some(sk.verifying_key()),
+            None => self.self_vk,
+        }
+    }
+
+    /// The local user's [`MemberId`] in this room, if known.
+    pub fn self_member_id(&self) -> Option<MemberId> {
+        self.self_verifying_key().as_ref().map(MemberId::from)
+    }
+
+    /// True when the local user is this room's owner. `false` when the local
+    /// identity is unknown — an unknown identity is not the owner, and every
+    /// caller of this treats "not owner" as the safe, read-only answer.
+    pub fn is_self_owner(&self) -> bool {
+        self.self_verifying_key() == Some(self.owner_vk)
+    }
+
+    /// Populate [`Self::self_vk`] from the private key when it is missing.
+    ///
+    /// Called on every path that decodes a `RoomData` out of delegate storage,
+    /// so that a blob written before `self_vk` existed gains the field the next
+    /// time it is saved. Never overwrites an existing value with a different
+    /// one — see [`Self::self_verifying_key`] for why the private key stays
+    /// authoritative for *reads*.
+    pub fn backfill_self_vk(&mut self) {
+        if self.self_vk.is_none() {
+            if let Some(sk) = &self.self_sk {
+                self.self_vk = Some(sk.verifying_key());
+            }
+        }
+    }
+
     /// Regenerate the contract_key from the owner_vk using the current WASM.
     /// This ensures the contract_key always matches the bundled WASM, which may
     /// have been updated since the room was first created/stored.
@@ -523,7 +618,17 @@ impl RoomData {
         // (secret_version, ciphertext, nonce, sender_ephemeral_x25519_pk_bytes)
         type PendingBlob = (u32, Vec<u8>, [u8; 12], [u8; 32]);
 
-        let member_id = MemberId::from(&self.self_sk.verifying_key());
+        // Every blob below is ECIES-sealed to this member and can only be
+        // opened with the private key. Without it there is nothing to
+        // repopulate, so report zero rather than pretending to have tried.
+        let Some(self_sk) = self.signing_key().cloned() else {
+            warn!(
+                "repopulate_secrets_from_state: no local signing key for this room; \
+                 cannot decrypt owner-issued secrets"
+            );
+            return 0;
+        };
+        let member_id = MemberId::from(&self_sk.verifying_key());
 
         // Snapshot the member's encrypted_secrets blobs so we can release
         // the borrow on `room_state` before the `&mut self` calls below.
@@ -551,7 +656,6 @@ impl RoomData {
             })
             .collect();
 
-        let self_sk = self.self_sk.clone();
         let mut decrypted_count = 0usize;
         for (version, ciphertext, nonce, ephemeral_key_bytes) in pending {
             match decrypt_secret_from_member_blob_raw(
@@ -646,8 +750,9 @@ impl RoomData {
             return false;
         }
 
-        // Only the owner can rotate
-        if self.owner_vk != self.self_sk.verifying_key() {
+        // Only the owner can rotate. An unknown local identity is not the
+        // owner, so it never needs to rotate.
+        if !self.is_self_owner() {
             return false;
         }
 
@@ -717,7 +822,14 @@ impl RoomData {
     /// (every cached ancestor up to the owner) closes that gap (freenet/river
     /// #411 round 8).
     fn is_self_enforced_banned(&self) -> bool {
-        let self_id = MemberId::from(&self.self_sk.verifying_key());
+        // With no local identity there is nobody for a ban to name. Reporting
+        // "not banned" matches what every caller wants from an unknown
+        // identity: the ban check must not be the thing that decides the user
+        // can't act — `can_send_message` / `can_participate` refuse below on
+        // the identity itself, with an accurate reason.
+        let Some(self_id) = self.self_member_id() else {
+            return false;
+        };
         let mut members = self.room_state.members.clone();
         if !members.members.iter().any(|m| m.member.id() == self_id) {
             if let Some(self_member) = &self.self_authorized_member {
@@ -744,7 +856,16 @@ impl RoomData {
     /// A user is considered a member if they are the owner, are in the active
     /// members list, or have a stored invitation (self_authorized_member).
     pub fn can_send_message(&self) -> Result<(), SendMessageError> {
-        let verifying_key = self.self_sk.verifying_key();
+        // Sending means producing a SIGNED message, so this needs the private
+        // key — not merely a known identity. Gating on `self_verifying_key`
+        // alone would answer `Ok` for a copy that knows who it is but cannot
+        // sign, which shows the user a composer whose every send is silently
+        // rejected. Reported as its own reason rather than mislabelled
+        // "not a member": the user may well be a member.
+        let Some(self_sk) = self.signing_key() else {
+            return Err(SendMessageError::IdentityUnavailable);
+        };
+        let verifying_key = self_sk.verifying_key();
 
         // Check if banned first — using the ENFORCING banned set (deputy-aware),
         // not the raw bans list. An inert ban (revoked-deputy tombstone,
@@ -783,7 +904,13 @@ impl RoomData {
     /// Check if the user can participate in the room (send messages, edit profile).
     /// Returns Ok if user is not banned AND (is owner OR has self_authorized_member OR is in members list).
     pub fn can_participate(&self) -> Result<(), SendMessageError> {
-        let verifying_key = self.self_sk.verifying_key();
+        // Participating means publishing a signed record, so the same rule as
+        // `can_send_message` applies: the PRIVATE key is required, not just a
+        // known identity.
+        let Some(self_sk) = self.signing_key() else {
+            return Err(SendMessageError::IdentityUnavailable);
+        };
+        let verifying_key = self_sk.verifying_key();
 
         // Check if banned first — using the ENFORCING banned set (deputy-aware),
         // not the raw bans list; an inert ban removes nobody (freenet/river#411
@@ -822,7 +949,10 @@ impl RoomData {
     /// AuthorizedMember is only captured once (migration path for older rooms).
     /// MemberInfo is always updated to the latest version so nickname edits are preserved.
     pub fn capture_self_membership_data(&mut self, parameters: &ChatRoomParametersV1) {
-        let verifying_key = self.self_sk.verifying_key();
+        // Nothing to capture for an identity we cannot name.
+        let Some(verifying_key) = self.self_verifying_key() else {
+            return;
+        };
         if verifying_key == self.owner_vk {
             return; // Owner doesn't need this
         }
@@ -901,7 +1031,9 @@ impl RoomData {
         new_member_info: AuthorizedMemberInfo,
         nickname: String,
     ) {
-        if MemberId::from(&self.self_sk.verifying_key()) != edited_member {
+        // Only cache the edit when we can confirm it is OUR member_info.
+        // Without a local identity we cannot, so cache nothing.
+        if self.self_member_id() != Some(edited_member) {
             return;
         }
         self.self_member_info = Some(new_member_info);
@@ -931,7 +1063,14 @@ impl RoomData {
         use river_core::room_state::member_info::MAX_DEPUTIES;
         use river_core::room_state::ChatRoomStateV1Delta;
 
-        let self_id = MemberId::from(&self.self_sk.verifying_key());
+        // Granting or revoking a deputy republishes our OWN signed
+        // member_info, so it needs the private key. Refuse up front rather
+        // than build a delta we cannot sign.
+        let Some(self_sk) = self.signing_key().cloned() else {
+            error!("apply_deputy_change: no local signing key for this room");
+            return false;
+        };
+        let self_id = MemberId::from(&self_sk.verifying_key());
 
         // The viewer's CANONICAL signed member_info (highest member_info_rank:
         // version, then signature digest) — NOT a bare first-match. `verify`
@@ -982,7 +1121,6 @@ impl RoomData {
             preferred_nickname: current_self.member_info.preferred_nickname.clone(),
             deputies,
         };
-        let self_sk = self.self_sk.clone();
         let authorized = AuthorizedMemberInfo::new_with_member_key(new_info, &self_sk);
 
         // Re-add ourselves if we were pruned for inactivity — a
@@ -1032,7 +1170,13 @@ impl RoomData {
         Option<river_core::room_state::member::MembersDelta>,
         Option<Vec<AuthorizedMemberInfo>>,
     ) {
-        let self_vk = self.self_sk.verifying_key();
+        // The delta re-adds us AND re-signs our member_info, so both halves
+        // need the private key. With no identity there is nothing to rejoin
+        // as: return the same "nothing to do" pair the not-pruned case does.
+        let Some(self_sk) = self.signing_key() else {
+            return (None, None);
+        };
+        let self_vk = self_sk.verifying_key();
 
         // Owner is never pruned
         let is_in_members = self_vk == self.owner_vk
@@ -1117,7 +1261,7 @@ impl RoomData {
                             preferred_nickname,
                             deputies: Vec::new(),
                         },
-                        &self.self_sk,
+                        self_sk,
                     )
                 })
             };
@@ -1167,7 +1311,11 @@ impl RoomData {
     /// room secret is not yet present in `state` this returns `None`
     /// (deferring the heal) rather than publish a plaintext nickname.
     pub fn build_member_info_heal(&self, state: &ChatRoomStateV1) -> Option<AuthorizedMemberInfo> {
-        let self_vk = self.self_sk.verifying_key();
+        // A non-owner's member_info is only valid self-signed, so the heal is
+        // impossible without the private key. Defer exactly as it already does
+        // for a private room whose secret has not arrived.
+        let self_sk = self.signing_key()?;
+        let self_vk = self_sk.verifying_key();
         if self_vk == self.owner_vk {
             return None; // the owner's member_info is managed separately
         }
@@ -1216,7 +1364,7 @@ impl RoomData {
                     return Some(stored.clone());
                 }
             }
-            let (secret, version) = current_secret_from_state(state, &self.self_sk)?;
+            let (secret, version) = current_secret_from_state(state, self_sk)?;
             // The nickname the user picked at join time if we still have
             // it (the common case for a private-room join whose seal was
             // deferred — see `self_nickname`), else a generated default.
@@ -1234,10 +1382,7 @@ impl RoomData {
                 preferred_nickname: seal_bytes(nickname.as_bytes(), &secret, version),
                 deputies: Vec::new(),
             };
-            return Some(AuthorizedMemberInfo::new_with_member_key(
-                info,
-                &self.self_sk,
-            ));
+            return Some(AuthorizedMemberInfo::new_with_member_key(info, self_sk));
         }
 
         // Public room — a public nickname is not sensitive. Prefer an
@@ -1259,10 +1404,7 @@ impl RoomData {
             preferred_nickname: SealedBytes::public(nickname.into_bytes()),
             deputies: Vec::new(),
         };
-        Some(AuthorizedMemberInfo::new_with_member_key(
-            info,
-            &self.self_sk,
-        ))
+        Some(AuthorizedMemberInfo::new_with_member_key(info, self_sk))
     }
 
     pub fn owner_id(&self) -> MemberId {
@@ -1330,8 +1472,13 @@ impl RoomData {
             return Err("Cannot rotate secret for public room".to_string());
         }
 
-        // Only the room owner can rotate secrets
-        if self.owner_vk != self.self_sk.verifying_key() {
+        // Only the room owner can rotate secrets. Rotation also DERIVES the
+        // new secret from the owner's seed and signs the record, so the
+        // private key is required on top of the ownership check.
+        let Some(self_sk) = self.signing_key().cloned() else {
+            return Err("No local signing key for this room; cannot rotate the secret".to_string());
+        };
+        if self.owner_vk != self_sk.verifying_key() {
             return Err("Only room owner can rotate secrets".to_string());
         }
 
@@ -1355,7 +1502,7 @@ impl RoomData {
         // `derive_room_secret`) converges with this UI path via the
         // contract's CRDT dedup.
         let new_secret = river_core::key_derivation::derive_room_secret(
-            &self.self_sk.to_bytes(),
+            &self_sk.to_bytes(),
             &self.owner_vk,
             new_version,
         );
@@ -1367,7 +1514,7 @@ impl RoomData {
             created_at: get_current_system_time(),
         };
 
-        let authorized_version = AuthorizedSecretVersionRecord::new(secret_version, &self.self_sk);
+        let authorized_version = AuthorizedSecretVersionRecord::new(secret_version, &self_sk);
 
         // Get all current members, excluding banned members. We pair
         // each `MemberId` with their `VerifyingKey` so the shared
@@ -1413,7 +1560,7 @@ impl RoomData {
         // (Ivvor 2026-05-17).
         let new_encrypted_secrets =
             river_core::room_state::secret::build_rotation_encrypted_secrets(
-                &self.self_sk,
+                &self_sk,
                 &self.owner_vk,
                 owner_id,
                 new_version,
@@ -1445,6 +1592,9 @@ impl RoomData {
         if !self.is_private() {
             return None;
         }
+
+        // Every blob below is owner-signed, so the private key is required.
+        let self_sk = self.signing_key()?;
 
         let (room_secret, current_version) = self.get_secret()?;
 
@@ -1511,7 +1661,7 @@ impl RoomData {
                 };
 
                 let authorized_encrypted_secret =
-                    AuthorizedEncryptedSecretForMember::new(encrypted_secret, &self.self_sk);
+                    AuthorizedEncryptedSecretForMember::new(encrypted_secret, self_sk);
 
                 new_encrypted_secrets.push(authorized_encrypted_secret);
             }
@@ -1713,7 +1863,8 @@ pub(crate) fn test_minimal_room_data(owner_vk: VerifyingKey) -> RoomData {
     RoomData {
         owner_vk,
         room_state: ChatRoomStateV1::default(),
-        self_sk: SigningKey::from_bytes(&[1u8; 32]),
+        self_sk: Some(SigningKey::from_bytes(&[1u8; 32])),
+        self_vk: None,
         contract_key,
         last_read_message_id: None,
         secrets: HashMap::new(),
@@ -1864,7 +2015,8 @@ impl Rooms {
         let room_data = RoomData {
             owner_vk,
             room_state,
-            self_sk,
+            self_sk: Some(self_sk),
+            self_vk: None,
             contract_key,
             last_read_message_id: None,
             secrets,
@@ -2083,9 +2235,26 @@ impl Rooms {
             // Identity conflict: decide by SOURCE AUTHORITY, not arrival order
             // (freenet/river#527). A strictly newer delegate generation wins;
             // anything else keeps the local identity.
+            //
+            // Compared by IDENTITY (`self_verifying_key`), not by the raw
+            // private-key field. Two copies conflict when they disagree about
+            // WHO the user is, and a copy that simply does not carry the
+            // private key is not a disagreement — it is a copy with less to
+            // say. Comparing the raw `Option<SigningKey>` would report a
+            // conflict the moment either side omitted the key, and the
+            // `KeepLocal` arm `continue`s, i.e. drops that room's incoming
+            // state for the pass. An unknown identity on either side therefore
+            // means "no conflict".
             let mut adopt_incoming_identity = false;
             if let Some(existing) = self.map.get(&vk) {
-                if existing.self_sk != room_data.self_sk {
+                let identities_conflict = match (
+                    existing.self_verifying_key(),
+                    room_data.self_verifying_key(),
+                ) {
+                    (Some(local), Some(incoming)) => local != incoming,
+                    _ => false,
+                };
+                if identities_conflict {
                     use dioxus::logger::tracing::warn;
                     let local_rank = ranks
                         .identity
@@ -2505,7 +2674,8 @@ mod tests {
         let mut room_data = RoomData {
             owner_vk,
             room_state,
-            self_sk: stale_sk,
+            self_sk: Some(stale_sk),
+            self_vk: None,
             contract_key,
             last_read_message_id: None,
             secrets: HashMap::new(),
@@ -2527,7 +2697,7 @@ mod tests {
         );
 
         // After updating self_sk to the invitee's key, user should be a member
-        room_data.self_sk = invitee_sk;
+        room_data.self_sk = Some(invitee_sk);
         assert_eq!(room_data.can_send_message(), Ok(()));
     }
 
@@ -2579,7 +2749,8 @@ mod tests {
         let mut room_data = RoomData {
             owner_vk,
             room_state,
-            self_sk: invitee_sk.clone(),
+            self_sk: Some(invitee_sk.clone()),
+            self_vk: None,
             contract_key,
             last_read_message_id: None,
             secrets: HashMap::new(),
@@ -2649,7 +2820,8 @@ mod tests {
             RoomData {
                 owner_vk,
                 room_state,
-                self_sk: sk,
+                self_sk: Some(sk),
+                self_vk: None,
                 contract_key,
                 last_read_message_id: None,
                 secrets: HashMap::new(),
@@ -2718,7 +2890,8 @@ mod tests {
         RoomData {
             owner_vk,
             room_state,
-            self_sk: invitee_sk.clone(),
+            self_sk: Some(invitee_sk.clone()),
+            self_vk: None,
             contract_key,
             last_read_message_id: None,
             secrets: HashMap::new(),
@@ -2849,8 +3022,14 @@ mod tests {
         );
         // Room C kept the LOCAL (new) identity; the stale incoming one was skipped.
         assert_eq!(
-            local.map.get(&vk_c).unwrap().self_sk.to_bytes(),
-            new_sk_c.to_bytes(),
+            local
+                .map
+                .get(&vk_c)
+                .unwrap()
+                .self_sk
+                .as_ref()
+                .map(|k| k.to_bytes()),
+            Some(new_sk_c.to_bytes()),
             "the conflicting room must keep the local (current) identity"
         );
     }
@@ -3412,8 +3591,14 @@ mod tests {
             )
             .expect("first merge");
         assert_eq!(
-            local.map.get(&vk).unwrap().self_sk.to_bytes(),
-            old_identity.to_bytes(),
+            local
+                .map
+                .get(&vk)
+                .unwrap()
+                .self_sk
+                .as_ref()
+                .map(|k| k.to_bytes()),
+            Some(old_identity.to_bytes()),
             "precondition: the first responder seeds the room"
         );
 
@@ -3428,8 +3613,14 @@ mod tests {
             .expect("second merge");
 
         assert_eq!(
-            local.map.get(&vk).unwrap().self_sk.to_bytes(),
-            current_identity.to_bytes(),
+            local
+                .map
+                .get(&vk)
+                .unwrap()
+                .self_sk
+                .as_ref()
+                .map(|k| k.to_bytes()),
+            Some(current_identity.to_bytes()),
             "the newer delegate generation must correct the identity the older one \
              seeded — arrival order must not decide (freenet/river#527)"
         );
@@ -3477,8 +3668,14 @@ mod tests {
             .expect("second merge");
 
         assert_eq!(
-            local.map.get(&vk).unwrap().self_sk.to_bytes(),
-            current_identity.to_bytes(),
+            local
+                .map
+                .get(&vk)
+                .unwrap()
+                .self_sk
+                .as_ref()
+                .map(|k| k.to_bytes()),
+            Some(current_identity.to_bytes()),
             "an older generation arriving later must not overwrite a newer one"
         );
     }
@@ -3511,8 +3708,14 @@ mod tests {
             .expect("merge");
 
         assert_eq!(
-            local.map.get(&vk).unwrap().self_sk.to_bytes(),
-            imported.to_bytes(),
+            local
+                .map
+                .get(&vk)
+                .unwrap()
+                .self_sk
+                .as_ref()
+                .map(|k| k.to_bytes()),
+            Some(imported.to_bytes()),
             "an explicitly-chosen identity must outrank every delegate generation (#414)"
         );
     }
@@ -3543,8 +3746,14 @@ mod tests {
             .expect("merge");
 
         assert_eq!(
-            local.map.get(&vk).unwrap().self_sk.to_bytes(),
-            in_session.to_bytes(),
+            local
+                .map
+                .get(&vk)
+                .unwrap()
+                .self_sk
+                .as_ref()
+                .map(|k| k.to_bytes()),
+            Some(in_session.to_bytes()),
             "a room with no recorded source must not be overwritten by a load"
         );
         assert!(
@@ -3604,8 +3813,8 @@ mod tests {
 
         let merged = local.map.get(&vk).unwrap();
         assert_eq!(
-            merged.self_sk.to_bytes(),
-            current_identity.to_bytes(),
+            merged.self_sk.as_ref().map(|k| k.to_bytes()),
+            Some(current_identity.to_bytes()),
             "identity comes from the newer generation"
         );
         assert_eq!(
@@ -3698,6 +3907,7 @@ mod tests {
             // ADOPTED copy. Using the local values would defeat the adopt.
             owner_vk: _,
             self_sk: _,
+            self_vk: _,
             contract_key: _,
             self_authorized_member: _,
             invite_chain: _,
@@ -3814,8 +4024,14 @@ mod tests {
              and, if this pass is the one that re-saves, is stranded for good"
         );
         assert_eq!(
-            local.map.get(&vk).unwrap().self_sk.to_bytes(),
-            old_identity.to_bytes(),
+            local
+                .map
+                .get(&vk)
+                .unwrap()
+                .self_sk
+                .as_ref()
+                .map(|k| k.to_bytes()),
+            Some(old_identity.to_bytes()),
             "and it must still hold the identity it had before the failed adopt"
         );
     }
@@ -3848,8 +4064,14 @@ mod tests {
         }
 
         assert_eq!(
-            local.map.get(&vk).unwrap().self_sk.to_bytes(),
-            id_new.to_bytes(),
+            local
+                .map
+                .get(&vk)
+                .unwrap()
+                .self_sk
+                .as_ref()
+                .map(|k| k.to_bytes()),
+            Some(id_new.to_bytes()),
             "the newest generation must win across three sources in any order"
         );
         assert_eq!(
@@ -3959,8 +4181,14 @@ mod tests {
             .expect("merge");
 
         assert_eq!(
-            local.map.get(&vk).unwrap().self_sk.to_bytes(),
-            local_sk.to_bytes(),
+            local
+                .map
+                .get(&vk)
+                .unwrap()
+                .self_sk
+                .as_ref()
+                .map(|k| k.to_bytes()),
+            Some(local_sk.to_bytes()),
             "plain merge must be unchanged: local identity wins"
         );
     }
@@ -4077,7 +4305,7 @@ mod tests {
         let owner_id: MemberId = owner_sk.verifying_key().into();
 
         let mut room = make_private_owner_room(&owner_sk, &member_sk);
-        room.self_sk = member_sk.clone();
+        room.self_sk = Some(member_sk.clone());
         room.self_member_info = None;
         room.self_nickname = Some("UserPicked".to_string());
         let v0_secret = *room.secrets.get(&0).expect("v0 secret seeded");
@@ -4121,7 +4349,7 @@ mod tests {
         let owner_id: MemberId = owner_sk.verifying_key().into();
 
         let mut room = make_private_owner_room(&owner_sk, &member_sk);
-        room.self_sk = member_sk.clone();
+        room.self_sk = Some(member_sk.clone());
         room.self_member_info = None;
         room.self_nickname = Some("UserPicked".to_string());
         // No secret available to seal with.
@@ -4188,7 +4416,7 @@ mod tests {
         let owner_id: MemberId = owner_sk.verifying_key().into();
 
         let mut room = make_private_owner_room(&owner_sk, &member_sk);
-        room.self_sk = member_sk.clone();
+        room.self_sk = Some(member_sk.clone());
         room.self_nickname = Some("UserPicked".to_string());
         let v0_secret = *room.secrets.get(&0).expect("v0 secret seeded");
         let public_entry = MemberInfo {
@@ -4236,7 +4464,7 @@ mod tests {
         let owner_id: MemberId = owner_sk.verifying_key().into();
 
         let mut room = make_private_owner_room(&owner_sk, &member_sk);
-        room.self_sk = member_sk.clone();
+        room.self_sk = Some(member_sk.clone());
         let v0_secret = *room.secrets.get(&0).expect("v0 secret seeded");
         let private_entry = MemberInfo {
             member_id: MemberId::from(&member_sk.verifying_key()),
@@ -4478,7 +4706,7 @@ mod tests {
         // Private room; `member_sk` is in `members` with no member_info
         // (stranded). self is the member.
         let mut room = make_private_owner_room(&owner_sk, &member_sk);
-        room.self_sk = member_sk.clone();
+        room.self_sk = Some(member_sk.clone());
         // The heal reads the secret from the network `state` it is given,
         // so that state must carry an encrypted-secret blob for the
         // member (the heal does NOT trust `self.secrets`).
@@ -4518,7 +4746,7 @@ mod tests {
         // has not arrived yet). make_private_owner_room seeds only
         // `secrets.versions`, not `encrypted_secrets`.
         let mut room = make_private_owner_room(&owner_sk, &member_sk);
-        room.self_sk = member_sk.clone();
+        room.self_sk = Some(member_sk.clone());
 
         let network_state = room.room_state.clone();
         // No secret in `state` to seal the nickname → the heal must defer
@@ -4566,7 +4794,7 @@ mod tests {
         let member_sk = SigningKey::generate(&mut rng);
 
         let mut room = make_private_owner_room(&owner_sk, &member_sk);
-        room.self_sk = member_sk.clone();
+        room.self_sk = Some(member_sk.clone());
         let v0_secret = *room.secrets.get(&0).expect("v0 secret seeded");
         append_encrypted_secret_for(
             &mut room.room_state,
@@ -4626,7 +4854,7 @@ mod tests {
         let owner_sk = SigningKey::generate(&mut rng);
         let member_sk = SigningKey::generate(&mut rng);
         let mut room = make_private_owner_room(&owner_sk, &member_sk);
-        room.self_sk = member_sk.clone();
+        room.self_sk = Some(member_sk.clone());
         let v0_secret = *room.secrets.get(&0).expect("v0 secret seeded");
         append_encrypted_secret_for(
             &mut room.room_state,
@@ -4689,7 +4917,7 @@ mod tests {
         let member_sk = SigningKey::generate(&mut rng);
 
         let mut room = make_private_owner_room(&owner_sk, &member_sk);
-        room.self_sk = member_sk.clone();
+        room.self_sk = Some(member_sk.clone());
         room.self_member_info = None;
         room.self_nickname = Some("UserPicked".to_string());
         let v0_secret = *room.secrets.get(&0).expect("v0 secret seeded");
@@ -4793,7 +5021,7 @@ mod tests {
         let member_sk = SigningKey::generate(&mut rng);
 
         let mut room = make_private_owner_room(&owner_sk, &member_sk);
-        room.self_sk = member_sk.clone();
+        room.self_sk = Some(member_sk.clone());
         room.self_nickname = Some("JoinTimeName".to_string());
         let v0_secret = *room.secrets.get(&0).expect("v0 secret seeded");
         append_encrypted_secret_for(
@@ -4928,7 +5156,8 @@ mod tests {
         RoomData {
             owner_vk,
             room_state,
-            self_sk: owner_sk.clone(),
+            self_sk: Some(owner_sk.clone()),
+            self_vk: None,
             contract_key,
             last_read_message_id: None,
             secrets,
@@ -5234,7 +5463,8 @@ mod tests {
             RoomData {
                 owner_vk,
                 room_state: state,
-                self_sk: member_sk.clone(),
+                self_sk: Some(member_sk.clone()),
+                self_vk: None,
                 contract_key,
                 last_read_message_id: None,
                 secrets: HashMap::new(),
@@ -5683,7 +5913,8 @@ mod tests {
             RoomData {
                 owner_vk,
                 room_state: state,
-                self_sk: member_sk,
+                self_sk: Some(member_sk),
+                self_vk: None,
                 contract_key,
                 last_read_message_id: None,
                 secrets: HashMap::new(),
@@ -5753,7 +5984,8 @@ mod tests {
             RoomData {
                 owner_vk,
                 room_state: state,
-                self_sk: member_sk,
+                self_sk: Some(member_sk),
+                self_vk: None,
                 contract_key,
                 last_read_message_id: None,
                 secrets: HashMap::new(),
@@ -5984,7 +6216,8 @@ mod tests {
         let room = RoomData {
             owner_vk,
             room_state,
-            self_sk: invitee_sk.clone(),
+            self_sk: Some(invitee_sk.clone()),
+            self_vk: None,
             contract_key,
             last_read_message_id: None,
             secrets: HashMap::new(),
@@ -6319,7 +6552,8 @@ mod tests {
         let mut room = RoomData {
             owner_vk,
             room_state,
-            self_sk: member_sk,
+            self_sk: Some(member_sk),
+            self_vk: None,
             contract_key,
             last_read_message_id: None,
             secrets: HashMap::new(),
@@ -6499,6 +6733,431 @@ mod tests {
             ciborium::de::from_reader(buf.as_slice()).expect("legacy RoomData blob must decode");
         assert!(decoded.invitation_secrets.is_empty());
         assert!(decoded.previous_contract_key.is_none());
+        // The legacy blob's REQUIRED `self_sk` must still land in the now-
+        // optional field: this is the direction that protects every existing
+        // user, whose stored blobs all carry the key.
+        assert_eq!(
+            decoded.self_sk.as_ref().map(|k| k.to_bytes()),
+            Some(invitee_sk.to_bytes()),
+            "a pre-Option blob's self_sk must decode into Some(..)"
+        );
+        assert!(
+            decoded.self_vk.is_none(),
+            "a pre-self_vk blob has no self_vk on the wire"
+        );
+        assert_eq!(
+            decoded.self_verifying_key(),
+            Some(invitee_sk.verifying_key()),
+            "and the accessor still derives the public half from self_sk"
+        );
+    }
+
+    /// `self_sk` and `self_vk` are a paired unit: any production site that
+    /// ASSIGNS one must assign the other in the same breath, or the two drift.
+    ///
+    /// Drift is not load-bearing today — [`RoomData::self_verifying_key`]
+    /// prefers the private key whenever it is present, so a stale `self_vk`
+    /// cannot change who the UI thinks it is (pinned by
+    /// `self_sk_outranks_a_disagreeing_self_vk`). It becomes load-bearing the
+    /// moment the private key leaves the blob, because `self_vk` is then the
+    /// only record of the identity. This is the repo's "paired `Option` fields
+    /// that must co-occur" pattern; the type-system remedy (one sub-struct)
+    /// is not available here because both names are wire-format field names.
+    /// A scrape is the next best thing.
+    #[test]
+    fn self_sk_and_self_vk_are_assigned_together() {
+        let sources = [
+            ("room_data.rs", include_str!("room_data.rs")),
+            (
+                "get_response.rs",
+                include_str!("components/app/freenet_api/response_handler/get_response.rs"),
+            ),
+            ("members.rs", include_str!("components/members.rs")),
+        ];
+
+        let mut checked = 0usize;
+        for (name, full) in sources {
+            let src = full
+                .split("#[cfg(test)]")
+                .next()
+                .expect("production code precedes the first #[cfg(test)]");
+            let lines: Vec<&str> = src.lines().collect();
+            for (i, line) in lines.iter().enumerate() {
+                // An ASSIGNMENT, not a struct-literal field (`self_sk: ...`)
+                // and not a comparison.
+                if !line.contains(".self_sk =") || line.contains("==") {
+                    continue;
+                }
+                checked += 1;
+                let window = lines[i.saturating_sub(3)..(i + 4).min(lines.len())].join("\n");
+                assert!(
+                    window.contains(".self_vk ="),
+                    "{}:{} assigns self_sk without assigning self_vk beside it. \
+                     The two are a paired identity record; leaving self_vk stale \
+                     is harmless only while self_sk is still stored, which is \
+                     exactly the assumption this change exists to stop relying on.",
+                    name,
+                    i + 1
+                );
+            }
+        }
+
+        // Not vacuous: if the scan finds nothing, the needle has drifted away
+        // from how the code actually spells the assignment and the pin is dead.
+        assert!(
+            checked >= 2,
+            "expected to find the production self_sk assignments (identity import \
+             and invitation-accept adoption); found {checked}. The scan needle is \
+             stale, so this pin is no longer guarding anything."
+        );
+    }
+
+    /// FORWARD compatibility — the half that makes the eventual relocation of
+    /// the private key survivable.
+    ///
+    /// A `RoomSlot` blob written by a FUTURE River that no longer stores
+    /// `self_sk` must still DECODE here. Before `self_sk` became optional it
+    /// was a required CBOR field, so such a blob failed to deserialize, and a
+    /// `RoomSlot` that fails to deserialize does not degrade — the room
+    /// disappears from the user's list entirely. That is why the tolerant
+    /// reader has to ship well ahead of any writer change.
+    ///
+    /// The blob is built from a struct that OMITS `self_sk` rather than
+    /// writing it as `null`, because that is what a future writer that has
+    /// dropped the field would actually emit.
+    #[test]
+    fn roomdata_decodes_from_a_blob_with_no_self_sk() {
+        #[derive(Serialize)]
+        struct RelocatedRoomData {
+            owner_vk: VerifyingKey,
+            room_state: ChatRoomStateV1,
+            self_vk: VerifyingKey,
+            contract_key: ContractKey,
+        }
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let (_v0, room) = make_private_invitee_room(&owner_sk, &invitee_sk);
+
+        let relocated = RelocatedRoomData {
+            owner_vk: room.owner_vk,
+            room_state: room.room_state.clone(),
+            self_vk: invitee_sk.verifying_key(),
+            contract_key: room.contract_key,
+        };
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&relocated, &mut buf).unwrap();
+
+        // ORACLE, so this test cannot pass vacuously: decode the SAME bytes
+        // into the pre-change shape, where `self_sk` was a REQUIRED field.
+        // That must fail. Without this, a future refactor that made the field
+        // required again — or a serde/ciborium change that started tolerating
+        // missing required fields — would leave the assertions below passing
+        // while proving nothing.
+        #[derive(serde::Deserialize)]
+        #[allow(dead_code)]
+        struct PreChangeRoomData {
+            owner_vk: VerifyingKey,
+            room_state: ChatRoomStateV1,
+            self_sk: SigningKey,
+            contract_key: ContractKey,
+        }
+        assert!(
+            ciborium::de::from_reader::<PreChangeRoomData, _>(buf.as_slice()).is_err(),
+            "the pre-change shape (required self_sk) must REJECT these bytes — \
+             that rejection is exactly the room-vanishes failure this change \
+             exists to prevent, and it is what makes the assertion below \
+             meaningful"
+        );
+
+        let decoded: RoomData = ciborium::de::from_reader(buf.as_slice())
+            .expect("a blob without self_sk must still decode — the room must not vanish");
+
+        assert!(
+            decoded.self_sk.is_none(),
+            "the private key is genuinely absent"
+        );
+        assert!(
+            decoded.signing_key().is_none(),
+            "and the accessor reports it as absent rather than inventing one"
+        );
+        assert_eq!(
+            decoded.self_verifying_key(),
+            Some(invitee_sk.verifying_key()),
+            "but the identity is still known, from the persisted self_vk"
+        );
+        assert_eq!(
+            decoded.self_member_id(),
+            Some(MemberId::from(&invitee_sk.verifying_key())),
+            "so member-relative rendering still works with no private key"
+        );
+        assert_eq!(decoded.owner_vk, room.owner_vk);
+    }
+
+    /// The same forward-compat case one level up: the blob the delegate
+    /// actually stores is a `RoomSlot`, and it is `RoomSlot` decoding that a
+    /// missing required field would break. Decoding `RoomData` directly (the
+    /// test above) would not catch a regression in the enum wrapper.
+    #[test]
+    fn roomslot_decodes_from_a_blob_with_no_self_sk() {
+        #[derive(Serialize)]
+        struct RelocatedRoomData {
+            owner_vk: VerifyingKey,
+            room_state: ChatRoomStateV1,
+            self_vk: VerifyingKey,
+            contract_key: ContractKey,
+        }
+        #[derive(Serialize)]
+        enum RelocatedRoomSlot {
+            Present(Box<RelocatedRoomData>),
+            #[allow(dead_code)]
+            Tombstone,
+        }
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let (_v0, room) = make_private_invitee_room(&owner_sk, &invitee_sk);
+
+        let slot = RelocatedRoomSlot::Present(Box::new(RelocatedRoomData {
+            owner_vk: room.owner_vk,
+            room_state: room.room_state.clone(),
+            self_vk: invitee_sk.verifying_key(),
+            contract_key: room.contract_key,
+        }));
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&slot, &mut buf).unwrap();
+
+        match ciborium::de::from_reader::<RoomSlot, _>(buf.as_slice())
+            .expect("a RoomSlot without self_sk must decode — the room must not vanish")
+        {
+            RoomSlot::Present(rd) => {
+                assert!(rd.self_sk.is_none());
+                assert_eq!(rd.self_verifying_key(), Some(invitee_sk.verifying_key()));
+            }
+            RoomSlot::Tombstone => panic!("expected Present"),
+        }
+    }
+
+    /// BACKWARD compatibility at the `RoomSlot` level — the half that protects
+    /// every user who has a room stored TODAY. Their blobs all carry a required
+    /// `self_sk` and no `self_vk`; both must survive this build unchanged.
+    #[test]
+    fn roomslot_from_a_current_writer_still_round_trips() {
+        #[derive(Serialize)]
+        struct CurrentRoomData {
+            owner_vk: VerifyingKey,
+            room_state: ChatRoomStateV1,
+            self_sk: SigningKey,
+            contract_key: ContractKey,
+            invitation_secrets: HashMap<u32, [u8; 32]>,
+        }
+        #[derive(Serialize)]
+        enum CurrentRoomSlot {
+            Present(Box<CurrentRoomData>),
+            #[allow(dead_code)]
+            Tombstone,
+        }
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let (v0_secret, room) = make_private_invitee_room(&owner_sk, &invitee_sk);
+        let mut invitation_secrets = HashMap::new();
+        invitation_secrets.insert(0u32, v0_secret);
+
+        let slot = CurrentRoomSlot::Present(Box::new(CurrentRoomData {
+            owner_vk: room.owner_vk,
+            room_state: room.room_state.clone(),
+            self_sk: invitee_sk.clone(),
+            contract_key: room.contract_key,
+            invitation_secrets: invitation_secrets.clone(),
+        }));
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&slot, &mut buf).unwrap();
+
+        let decoded = match ciborium::de::from_reader::<RoomSlot, _>(buf.as_slice())
+            .expect("an existing user's stored RoomSlot must still decode")
+        {
+            RoomSlot::Present(rd) => *rd,
+            RoomSlot::Tombstone => panic!("expected Present"),
+        };
+
+        assert_eq!(
+            decoded.self_sk.as_ref().map(|k| k.to_bytes()),
+            Some(invitee_sk.to_bytes()),
+            "the stored private key must survive verbatim — this is the \
+             assertion that protects existing users"
+        );
+        assert_eq!(decoded.self_vk, None, "old blobs carry no self_vk");
+        assert_eq!(
+            decoded.self_verifying_key(),
+            Some(invitee_sk.verifying_key())
+        );
+        assert_eq!(decoded.invitation_secrets, invitation_secrets);
+        assert_eq!(decoded.owner_vk, room.owner_vk);
+        assert_eq!(decoded.contract_key, room.contract_key);
+    }
+
+    /// A blob this build writes must be re-readable by this build, `self_vk`
+    /// and all. Guards the round trip the two directional tests above do not:
+    /// that adding `self_vk` did not disturb the existing encoding.
+    #[test]
+    fn roomslot_written_now_round_trips_with_self_vk() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let (_v0, mut room) = make_private_invitee_room(&owner_sk, &invitee_sk);
+        room.backfill_self_vk();
+        assert_eq!(
+            room.self_vk,
+            Some(invitee_sk.verifying_key()),
+            "backfill populates the field from the private key"
+        );
+
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&RoomSlot::Present(Box::new(room.clone())), &mut buf).unwrap();
+        let decoded = match ciborium::de::from_reader::<RoomSlot, _>(buf.as_slice()).unwrap() {
+            RoomSlot::Present(rd) => *rd,
+            RoomSlot::Tombstone => panic!("expected Present"),
+        };
+        assert_eq!(decoded.self_vk, Some(invitee_sk.verifying_key()));
+        assert_eq!(
+            decoded.self_sk.as_ref().map(|k| k.to_bytes()),
+            Some(invitee_sk.to_bytes())
+        );
+    }
+
+    /// The private key stays authoritative for reads. A `self_vk` that
+    /// disagrees with the held private key must NOT change who the UI thinks
+    /// it is — otherwise a tampered or stale blob could redirect the local
+    /// identity while the real key sits right there.
+    #[test]
+    fn self_sk_outranks_a_disagreeing_self_vk() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let impostor = SigningKey::generate(&mut rng);
+        let (_v0, mut room) = make_private_invitee_room(&owner_sk, &invitee_sk);
+
+        room.self_vk = Some(impostor.verifying_key());
+        assert_eq!(
+            room.self_verifying_key(),
+            Some(invitee_sk.verifying_key()),
+            "the held private key wins over a disagreeing self_vk"
+        );
+
+        // And backfill must not silently "fix" the disagreement either way —
+        // it only ever fills an EMPTY slot.
+        room.backfill_self_vk();
+        assert_eq!(
+            room.self_vk,
+            Some(impostor.verifying_key()),
+            "backfill leaves an already-populated self_vk alone"
+        );
+    }
+
+    /// Every read path must survive an absent private key without panicking,
+    /// and must give the specific answer chosen for it. This is the
+    /// behavioural half of the forward-compat story: decoding is necessary but
+    /// not sufficient — the room also has to remain usable-as-far-as-possible
+    /// rather than crash on first render.
+    #[test]
+    fn read_paths_degrade_gracefully_with_no_private_key() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let (v0_secret, mut room) = make_private_invitee_room(&owner_sk, &invitee_sk);
+        room.invitation_secrets.insert(0, v0_secret);
+
+        // Precondition: with the key present this member CAN act. Without this
+        // the assertions below would pass on a room that was inert anyway.
+        assert!(room.can_send_message().is_ok());
+        assert!(room.can_participate().is_ok());
+
+        // Relocate: identity known, private key gone.
+        room.backfill_self_vk();
+        room.self_sk = None;
+
+        assert!(room.signing_key().is_none());
+        assert_eq!(
+            room.self_verifying_key(),
+            Some(invitee_sk.verifying_key()),
+            "identity survives via self_vk"
+        );
+        assert!(!room.is_self_owner());
+
+        // Signing/decrypting paths refuse, each in its own idiom.
+        assert_eq!(
+            room.can_send_message(),
+            Err(SendMessageError::IdentityUnavailable),
+            "refused with the accurate reason, NOT mislabelled UserNotMember"
+        );
+        assert_eq!(
+            room.can_participate(),
+            Err(SendMessageError::IdentityUnavailable)
+        );
+        assert_eq!(
+            room.repopulate_secrets_from_state(),
+            0,
+            "nothing can be decrypted without the key"
+        );
+        assert!(!room.needs_secret_rotation());
+        assert!(room.rotate_secret().is_err());
+        assert!(room
+            .build_member_info_heal(&room.room_state.clone())
+            .is_none());
+        assert!(room.generate_missing_member_secrets().is_none());
+        assert_eq!(room.build_rejoin_delta(), (None, None));
+        assert!(!room.apply_deputy_change(MemberId::from(&owner_sk.verifying_key()), true));
+
+        // Read-only bookkeeping is a no-op rather than a panic.
+        room.capture_self_membership_data(&room.parameters());
+        room.record_self_nickname_edit(
+            MemberId::from(&invitee_sk.verifying_key()),
+            AuthorizedMemberInfo::new_with_member_key(
+                MemberInfo {
+                    member_id: MemberId::from(&invitee_sk.verifying_key()),
+                    version: 1,
+                    preferred_nickname: SealedBytes::public(b"x".to_vec()),
+                    deputies: Vec::new(),
+                },
+                &invitee_sk,
+            ),
+            "x".to_string(),
+        );
+        assert!(
+            room.self_member_info.is_some(),
+            "the nickname edit IS still cached: confirming the edited member is \
+             us needs only the public half, which self_vk supplies. This is the \
+             point of persisting self_vk — public-half bookkeeping keeps working \
+             with no private key in hand."
+        );
+    }
+
+    /// An owner who has lost the private key is still recognised as the owner
+    /// (that is a property of the PUBLIC half), but still cannot rotate.
+    /// Separated from the member case above because `is_self_owner` and
+    /// `rotate_secret` disagree on purpose, and a future refactor that
+    /// collapsed the ownership check into the key check would be wrong.
+    #[test]
+    fn an_owner_without_a_private_key_is_still_the_owner_but_cannot_rotate() {
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let (_v0, mut room) = make_private_invitee_room(&owner_sk, &invitee_sk);
+        room.self_sk = Some(owner_sk.clone());
+        room.self_vk = Some(owner_sk.verifying_key());
+        assert!(room.is_self_owner());
+        assert!(room.rotate_secret().is_ok(), "precondition: rotation works");
+
+        room.self_sk = None;
+        assert!(
+            room.is_self_owner(),
+            "ownership is decided by the public half, which is still here"
+        );
+        assert!(
+            room.rotate_secret().is_err(),
+            "but rotation derives and signs, so it needs the private key"
+        );
     }
 
     /// Refresh durability: `invitation_secrets` is persisted while
@@ -6714,7 +7373,8 @@ mod tests {
         RoomData {
             owner_vk,
             room_state,
-            self_sk: owner_sk.clone(),
+            self_sk: Some(owner_sk.clone()),
+            self_vk: None,
             contract_key,
             last_read_message_id: None,
             secrets,
@@ -6774,7 +7434,7 @@ mod tests {
         );
 
         // As T, sending / participating must be allowed despite the stored ban.
-        room.self_sk = t_sk;
+        room.self_sk = Some(t_sk);
         assert_eq!(room.can_send_message(), Ok(()));
         assert_eq!(room.can_participate(), Ok(()));
     }
@@ -6799,7 +7459,7 @@ mod tests {
             "an owner ban must enforce"
         );
 
-        room.self_sk = t_sk;
+        room.self_sk = Some(t_sk);
         assert_eq!(room.can_send_message(), Err(SendMessageError::UserBanned));
         assert_eq!(room.can_participate(), Err(SendMessageError::UserBanned));
     }
@@ -6936,7 +7596,8 @@ mod tests {
         let room = RoomData {
             owner_vk,
             room_state,
-            self_sk: s_sk,
+            self_sk: Some(s_sk),
+            self_vk: None,
             contract_key,
             last_read_message_id: None,
             secrets: HashMap::new(),
@@ -6984,7 +7645,7 @@ mod tests {
         // private room so the owner-issued current-version secret keeps D and T
         // through `apply_delta`'s inactivity-prune (see `make_room_owner_d_t`).
         let mut room = make_room_owner_d_t(&owner_sk, &d_sk, &t_sk, true);
-        room.self_sk = d_sk;
+        room.self_sk = Some(d_sk);
         assert!(room.self_member_info.is_none());
 
         // Deputize T: the cached record must carry the new grant.
@@ -7152,7 +7813,8 @@ mod tests {
         let mut room = RoomData {
             owner_vk,
             room_state,
-            self_sk: d_sk,
+            self_sk: Some(d_sk),
+            self_vk: None,
             contract_key,
             last_read_message_id: None,
             secrets: HashMap::new(),
@@ -7268,7 +7930,8 @@ mod tests {
         let mut room = RoomData {
             owner_vk,
             room_state,
-            self_sk: d_sk,
+            self_sk: Some(d_sk),
+            self_vk: None,
             contract_key,
             last_read_message_id: None,
             secrets: HashMap::new(),
@@ -7382,7 +8045,8 @@ mod tests {
         let room = RoomData {
             owner_vk,
             room_state,
-            self_sk: s_sk,
+            self_sk: Some(s_sk),
+            self_vk: None,
             contract_key,
             last_read_message_id: None,
             secrets: HashMap::new(),

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -6960,6 +6960,23 @@ mod tests {
 
         // Not vacuous: if the scan finds nothing, the needle has drifted away
         // from how the code actually spells the assignment and the pin is dead.
+        //
+        // WHAT THIS FLOOR DOES AND DOES NOT CATCH — the two guards in this test
+        // divide the work, and neither covers the other:
+        //
+        // * This floor catches a site that leaves the scan's SHAPE. Refactor
+        //   `self_sk: Some(k)` into `let sk = Some(k); … self_sk: sk,` and the
+        //   line stops matching, the tally drops, and this fires. That is the
+        //   drift that would otherwise silently stop the pin checking a real
+        //   site while CI stayed green.
+        // * It does NOT catch a site that keeps the shape and changes the
+        //   VALUE. `self_sk: None` still starts with `self_sk: ` and still
+        //   counts, so the tally is unmoved. Catching that is the
+        //   value-agreement arm's job, above.
+        //
+        // Do not assume one subsumes the other: a shape-preserving value change
+        // is invisible to the tally, and a shape-breaking refactor is invisible
+        // to the value check because it never reaches it.
         assert!(
             checked >= 5,
             "expected to find the production self_sk sites (the identity-import \

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -231,8 +231,22 @@ pub struct RoomData {
     /// key. Once the private key moves out of this blob, this becomes the only
     /// way the UI knows who the local user is in this room.
     ///
-    /// `None` for blobs written before this field existed;
-    /// [`RoomData::backfill_self_vk`] populates it on load.
+    /// `None` for blobs written before this field existed.
+    /// [`RoomData::backfill_self_vk`] populates it at the per-room SAVE
+    /// chokepoint, so a blob gains the field the next time it is written.
+    ///
+    /// **It is not yet durable, and the relocation must not assume it is.**
+    /// Two holes remain, deliberately, because closing them needs the writer
+    /// change this PR is staged ahead of:
+    ///
+    /// * An OLDER River tab or build saving the same room re-serializes without
+    ///   the field and silently strips it again.
+    /// * The backfill runs only on the save path, never on decode, so a room
+    ///   that is loaded and never re-saved keeps `None` in memory.
+    ///
+    /// So the future writer that drops `self_sk` MUST verify `self_vk` is
+    /// already present in the STORED blob for a room before dropping the key
+    /// for that room — per-room, checked, never assumed fleet-wide.
     #[serde(default)]
     pub self_vk: Option<VerifyingKey>,
     pub contract_key: ContractKey,
@@ -428,18 +442,26 @@ impl RoomData {
         self.self_verifying_key() == Some(self.owner_vk)
     }
 
-    /// Populate [`Self::self_vk`] from the private key when it is missing.
+    /// Derive [`Self::self_vk`] from the private key whenever the key is held.
     ///
-    /// Called on every path that decodes a `RoomData` out of delegate storage,
-    /// so that a blob written before `self_vk` existed gains the field the next
-    /// time it is saved. Never overwrites an existing value with a different
-    /// one — see [`Self::self_verifying_key`] for why the private key stays
-    /// authoritative for *reads*.
+    /// Called from the per-room SAVE chokepoint
+    /// (`chat_delegate::reconcile_room_present`), so a blob written before the
+    /// field existed gains it on its next save.
+    ///
+    /// **Repairs, rather than merely fills.** A `self_vk` that disagrees with a
+    /// held `self_sk` is always wrong — the private key is the identity — so it
+    /// is overwritten, not preserved. Leaving the disagreement in place would
+    /// be harmless only for as long as `self_sk` is also stored, which is
+    /// exactly the assumption this whole change exists to stop relying on: once
+    /// the private key moves out of the blob, a stale `self_vk` silently BECOMES
+    /// the user's identity in that room, and they would render as a non-member,
+    /// see their own messages attributed to a stranger, and lose DM decryption.
+    ///
+    /// Reads are unaffected either way — [`Self::self_verifying_key`] prefers
+    /// the private key — so this only ever changes what is PERSISTED.
     pub fn backfill_self_vk(&mut self) {
-        if self.self_vk.is_none() {
-            if let Some(sk) = &self.self_sk {
-                self.self_vk = Some(sk.verifying_key());
-            }
+        if let Some(sk) = &self.self_sk {
+            self.self_vk = Some(sk.verifying_key());
         }
     }
 
@@ -618,73 +640,86 @@ impl RoomData {
         // (secret_version, ciphertext, nonce, sender_ephemeral_x25519_pk_bytes)
         type PendingBlob = (u32, Vec<u8>, [u8; 12], [u8; 32]);
 
-        // Every blob below is ECIES-sealed to this member and can only be
-        // opened with the private key. Without it there is nothing to
-        // repopulate, so report zero rather than pretending to have tried.
-        let Some(self_sk) = self.signing_key().cloned() else {
-            warn!(
-                "repopulate_secrets_from_state: no local signing key for this room; \
-                 cannot decrypt owner-issued secrets"
-            );
-            return 0;
-        };
-        let member_id = MemberId::from(&self_sk.verifying_key());
-
-        // Snapshot the member's encrypted_secrets blobs so we can release
-        // the borrow on `room_state` before the `&mut self` calls below.
-        //
-        // We deliberately do NOT filter out versions already in `secrets`:
-        // the owner-signed contract blob is authoritative and MUST be able
-        // to overwrite an (unauthenticated) value a prior `invitation_secrets`
-        // fold placed at the same version — otherwise a malicious or buggy
-        // inviter who supplied a wrong secret would permanently shadow the
-        // authentic blob for the rest of the session. Re-decrypting the
-        // handful of own-member blobs on each ingestion is negligible.
-        let pending: Vec<PendingBlob> = self
-            .room_state
-            .secrets
-            .encrypted_secrets
-            .iter()
-            .filter(|s| s.secret.member_id == member_id)
-            .map(|s| {
-                (
-                    s.secret.secret_version,
-                    s.secret.ciphertext.clone(),
-                    s.secret.nonce,
-                    s.secret.sender_ephemeral_public_key,
-                )
-            })
-            .collect();
-
         let mut decrypted_count = 0usize;
-        for (version, ciphertext, nonce, ephemeral_key_bytes) in pending {
-            match decrypt_secret_from_member_blob_raw(
-                &ciphertext,
-                &nonce,
-                &ephemeral_key_bytes,
-                &self_sk,
-            ) {
-                Ok(secret) => {
-                    let is_new = !self.secrets.contains_key(&version);
-                    // `set_secret` inserts/overwrites — the owner-signed
-                    // contract secret is authoritative.
-                    self.set_secret(secret, version);
-                    // It supersedes any invitation-carried copy at this
-                    // version: drop it so a stale/garbage invitation secret
-                    // cannot resurface and is not re-persisted in
-                    // `rooms_data`.
-                    self.invitation_secrets.remove(&version);
-                    if is_new {
-                        decrypted_count += 1;
+
+        // ONLY the owner-signed `encrypted_secrets` blobs need the private key
+        // — they are ECIES-sealed to this member. Everything after this block
+        // (the `invitation_secrets` fold and the `current_secret_version`
+        // alignment) works on plaintext already in hand and MUST still run
+        // without a key.
+        //
+        // Scope this guard tightly. Bailing out of the whole function instead
+        // would leave a private room joined by invitation showing
+        // "[Encrypted message - secret vN not available]" for its messages,
+        // name and description, even though the v0 secret is sitting
+        // decrypted in `invitation_secrets`: `secrets` is `#[serde(skip)]` so
+        // it is empty on every load, and without the alignment below
+        // `current_secret_version` is never set, so `get_secret()` returns
+        // `None`. That is the freenet/river#251 symptom, reintroduced.
+        if let Some(self_sk) = self.signing_key().cloned() {
+            let member_id = MemberId::from(&self_sk.verifying_key());
+
+            // Snapshot the member's encrypted_secrets blobs so we can release
+            // the borrow on `room_state` before the `&mut self` calls below.
+            //
+            // We deliberately do NOT filter out versions already in `secrets`:
+            // the owner-signed contract blob is authoritative and MUST be able
+            // to overwrite an (unauthenticated) value a prior `invitation_secrets`
+            // fold placed at the same version — otherwise a malicious or buggy
+            // inviter who supplied a wrong secret would permanently shadow the
+            // authentic blob for the rest of the session. Re-decrypting the
+            // handful of own-member blobs on each ingestion is negligible.
+            let pending: Vec<PendingBlob> = self
+                .room_state
+                .secrets
+                .encrypted_secrets
+                .iter()
+                .filter(|s| s.secret.member_id == member_id)
+                .map(|s| {
+                    (
+                        s.secret.secret_version,
+                        s.secret.ciphertext.clone(),
+                        s.secret.nonce,
+                        s.secret.sender_ephemeral_public_key,
+                    )
+                })
+                .collect();
+
+            for (version, ciphertext, nonce, ephemeral_key_bytes) in pending {
+                match decrypt_secret_from_member_blob_raw(
+                    &ciphertext,
+                    &nonce,
+                    &ephemeral_key_bytes,
+                    &self_sk,
+                ) {
+                    Ok(secret) => {
+                        let is_new = !self.secrets.contains_key(&version);
+                        // `set_secret` inserts/overwrites — the owner-signed
+                        // contract secret is authoritative.
+                        self.set_secret(secret, version);
+                        // It supersedes any invitation-carried copy at this
+                        // version: drop it so a stale/garbage invitation secret
+                        // cannot resurface and is not re-persisted in
+                        // `rooms_data`.
+                        self.invitation_secrets.remove(&version);
+                        if is_new {
+                            decrypted_count += 1;
+                        }
+                    }
+                    Err(e) => {
+                        warn!(
+                            "repopulate_secrets_from_state: failed to decrypt v{} for member {:?}: {}",
+                            version, member_id, e
+                        );
                     }
                 }
-                Err(e) => {
-                    warn!(
-                        "repopulate_secrets_from_state: failed to decrypt v{} for member {:?}: {}",
-                        version, member_id, e
-                    );
-                }
             }
+        } else {
+            warn!(
+                "repopulate_secrets_from_state: no local signing key for this room; \
+                 skipping the owner-signed blobs. Invitation-carried secrets are \
+                 still folded in below."
+            );
         }
 
         // Fold in any secrets recovered from the invitation artifact
@@ -2243,8 +2278,23 @@ impl Rooms {
             // say. Comparing the raw `Option<SigningKey>` would report a
             // conflict the moment either side omitted the key, and the
             // `KeepLocal` arm `continue`s, i.e. drops that room's incoming
-            // state for the pass. An unknown identity on either side therefore
-            // means "no conflict".
+            // state for the pass.
+            //
+            // THE RULE, which `chat_delegate::identities_diverged` states
+            // identically: for a CONFLICT test, an unknown identity on either
+            // side means "no conflict" — silence is not disagreement, and the
+            // branch it would trigger is lossy. This is deliberately the
+            // opposite of `members::swap_room_identity_in_place`, which asks a
+            // different question ("is this import a CHANGE?") and correctly
+            // answers "yes" for an unknown identity, since an import always
+            // supplies one. Conflict tests treat unknown as no-conflict;
+            // change tests treat unknown as changed.
+            //
+            // KNOWN GAP, harmless until the relocation: a local copy naming no
+            // identity takes the plain-merge branch, which keeps local's fields
+            // and so can never ACQUIRE an identity from an incoming copy that
+            // has one. Unreachable today (every stored copy carries `self_sk`);
+            // the relocation must add that acquisition.
             let mut adopt_incoming_identity = false;
             if let Some(existing) = self.map.get(&vk) {
                 let identities_conflict = match (
@@ -6777,21 +6827,37 @@ mod tests {
 
         let mut checked = 0usize;
         for (name, full) in sources {
-            let src = full
-                .split("#[cfg(test)]")
-                .next()
-                .expect("production code precedes the first #[cfg(test)]");
+            // Split at the big `mod tests` block, NOT at the first
+            // `#[cfg(test)]`: these files put cfg(test) HELPER functions above
+            // production code (`room_data::test_minimal_room_data` sits above
+            // `Rooms::create_new_room_with_name`), so splitting at the first
+            // attribute would drop real production sites from the scan.
+            let src = full.split("mod tests {").next().unwrap_or(full);
             let lines: Vec<&str> = src.lines().collect();
             for (i, line) in lines.iter().enumerate() {
                 // An ASSIGNMENT, not a struct-literal field (`self_sk: ...`)
                 // and not a comparison.
-                if !line.contains(".self_sk =") || line.contains("==") {
+                // Two shapes: an assignment (`x.self_sk = ..`) and a struct
+                // literal field (`self_sk: ..`). The exhaustive destructure pin
+                // in members.rs forces a new field to be NAMED, not to be named
+                // CORRECTLY, so the literal shape needs covering here too — a
+                // future literal pairing a mismatched `Some`/`Some` would
+                // otherwise sail through.
+                let trimmed = line.trim_start();
+                let is_assignment = line.contains(".self_sk =") && !line.contains("==");
+                // Only a literal FIELD, whose value must be `Some(..)`/`None`
+                // because the field is an `Option`. Anchoring on that excludes
+                // function parameters (`self_sk: &SigningKey,`) and struct
+                // definitions, which are not identity writes.
+                let is_literal_field =
+                    trimmed.starts_with("self_sk: Some(") || trimmed.starts_with("self_sk: None");
+                if !is_assignment && !is_literal_field {
                     continue;
                 }
                 checked += 1;
                 let window = lines[i.saturating_sub(3)..(i + 4).min(lines.len())].join("\n");
                 assert!(
-                    window.contains(".self_vk ="),
+                    window.contains(".self_vk =") || window.contains("self_vk:"),
                     "{}:{} assigns self_sk without assigning self_vk beside it. \
                      The two are a paired identity record; leaving self_vk stale \
                      is harmless only while self_sk is still stored, which is \
@@ -6805,10 +6871,11 @@ mod tests {
         // Not vacuous: if the scan finds nothing, the needle has drifted away
         // from how the code actually spells the assignment and the pin is dead.
         assert!(
-            checked >= 2,
-            "expected to find the production self_sk assignments (identity import \
-             and invitation-accept adoption); found {checked}. The scan needle is \
-             stale, so this pin is no longer guarding anything."
+            checked >= 5,
+            "expected to find the production self_sk sites (the identity-import \
+             and invitation-accept ASSIGNMENTS, plus the struct LITERALS that \
+             construct a RoomData); found {checked}. The scan needle is stale, so \
+             this pin is no longer guarding anything."
         );
     }
 
@@ -7026,6 +7093,54 @@ mod tests {
         );
     }
 
+    /// Documents a KNOWN GAP rather than a guarantee: `self_vk` is populated on
+    /// the SAVE path only, never on decode, so a room that is loaded and never
+    /// re-saved keeps whatever the blob carried — `None` for a pre-`self_vk`
+    /// blob.
+    ///
+    /// This is why the field docs tell the future relocation writer to verify
+    /// `self_vk` is present in the STORED blob per room before dropping
+    /// `self_sk`, instead of assuming this build has backfilled it everywhere.
+    /// If someone later adds a decode-time backfill, this test SHOULD fail —
+    /// and the field docs should be relaxed in the same commit.
+    #[test]
+    fn decoding_alone_does_not_backfill_self_vk() {
+        #[derive(Serialize)]
+        struct PreSelfVkRoomData {
+            owner_vk: VerifyingKey,
+            room_state: ChatRoomStateV1,
+            self_sk: SigningKey,
+            contract_key: ContractKey,
+        }
+        let mut rng = rand::thread_rng();
+        let owner_sk = SigningKey::generate(&mut rng);
+        let invitee_sk = SigningKey::generate(&mut rng);
+        let (_v0, room) = make_private_invitee_room(&owner_sk, &invitee_sk);
+
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(
+            &PreSelfVkRoomData {
+                owner_vk: room.owner_vk,
+                room_state: room.room_state.clone(),
+                self_sk: invitee_sk.clone(),
+                contract_key: room.contract_key,
+            },
+            &mut buf,
+        )
+        .unwrap();
+        let decoded: RoomData = ciborium::de::from_reader(buf.as_slice()).unwrap();
+
+        assert_eq!(
+            decoded.self_vk, None,
+            "decode does not backfill — only the save path does"
+        );
+        assert_eq!(
+            decoded.self_verifying_key(),
+            Some(invitee_sk.verifying_key()),
+            "which is harmless for READS while self_sk is present"
+        );
+    }
+
     /// The private key stays authoritative for reads. A `self_vk` that
     /// disagrees with the held private key must NOT change who the UI thinks
     /// it is — otherwise a tampered or stale blob could redirect the local
@@ -7045,13 +7160,28 @@ mod tests {
             "the held private key wins over a disagreeing self_vk"
         );
 
-        // And backfill must not silently "fix" the disagreement either way —
-        // it only ever fills an EMPTY slot.
+        // And the disagreement must be REPAIRED, not preserved. A self_vk that
+        // contradicts a held self_sk is always wrong, and persisting it is
+        // harmless only while self_sk is also stored — the moment the private
+        // key moves out of the blob, that stale value silently becomes the
+        // user's identity in this room.
         room.backfill_self_vk();
         assert_eq!(
             room.self_vk,
+            Some(invitee_sk.verifying_key()),
+            "backfill overwrites a self_vk that disagrees with the held key"
+        );
+
+        // With no private key there is nothing to derive from, so whatever the
+        // blob carried is left untouched — it is the only identity record left.
+        let mut relocated = room.clone();
+        relocated.self_sk = None;
+        relocated.self_vk = Some(impostor.verifying_key());
+        relocated.backfill_self_vk();
+        assert_eq!(
+            relocated.self_vk,
             Some(impostor.verifying_key()),
-            "backfill leaves an already-populated self_vk alone"
+            "with no private key, backfill has nothing to correct against"
         );
     }
 
@@ -7095,10 +7225,26 @@ mod tests {
             room.can_participate(),
             Err(SendMessageError::IdentityUnavailable)
         );
+        // The invitation-carried secret is PLAINTEXT and already in hand, so it
+        // must still be folded in and the version pointer still aligned. Only
+        // the owner-signed ECIES blobs need the key. Bailing out of the whole
+        // function would leave this room rendering
+        // "[Encrypted message - secret vN not available]" over content it can
+        // decrypt — the freenet/river#251 symptom.
         assert_eq!(
             room.repopulate_secrets_from_state(),
-            0,
-            "nothing can be decrypted without the key"
+            1,
+            "the plaintext invitation secret is still recovered without a key"
+        );
+        assert_eq!(
+            room.secrets.get(&0),
+            Some(&v0_secret),
+            "and it lands in the live secrets map"
+        );
+        assert!(
+            room.get_secret().is_some(),
+            "current_secret_version must still be aligned, or get_secret() \
+             returns None and every message renders as undecryptable"
         );
         assert!(!room.needs_secret_rotation());
         assert!(room.rotate_secret().is_err());

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -6834,6 +6834,29 @@ mod tests {
             // attribute would drop real production sites from the scan.
             let src = full.split("mod tests {").next().unwrap_or(full);
             let lines: Vec<&str> = src.lines().collect();
+
+            // Which of those lines sit inside a `#[cfg(test)]` HELPER block.
+            // They are still SCANNED — a fixture that pairs the fields wrongly
+            // is worth catching — but they must not count toward the
+            // positive control below, or a production site could be deleted
+            // while a test fixture holds the floor up.
+            let mut in_test_helper = vec![false; lines.len()];
+            let mut depth: i32 = -1;
+            let mut braces: i32 = 0;
+            for (n, line) in lines.iter().enumerate() {
+                if depth < 0 && line.trim_start().starts_with("#[cfg(test)]") {
+                    depth = 0;
+                    braces = 0;
+                }
+                if depth >= 0 {
+                    in_test_helper[n] = true;
+                    braces += line.matches('{').count() as i32;
+                    braces -= line.matches('}').count() as i32;
+                    if braces <= 0 && line.contains('}') {
+                        depth = -1;
+                    }
+                }
+            }
             for (i, line) in lines.iter().enumerate() {
                 // An ASSIGNMENT, not a struct-literal field (`self_sk: ...`)
                 // and not a comparison.
@@ -6854,10 +6877,71 @@ mod tests {
                 if !is_assignment && !is_literal_field {
                     continue;
                 }
-                checked += 1;
+                if !in_test_helper[i] {
+                    checked += 1;
+                }
                 let window = lines[i.saturating_sub(3)..(i + 4).min(lines.len())].join("\n");
+
+                // For a LITERAL, naming the field is not enough — that is
+                // verbatim the weakness that makes the exhaustive destructure
+                // pin in members.rs insufficient, so repeating it here would
+                // buy nothing. Require the two values to AGREE: either both
+                // absent, or `self_vk` derived from the same key `self_sk`
+                // takes. `self_sk: Some(k)` beside `self_vk: None` is allowed
+                // ONLY because the save chokepoint backfills it — recorded
+                // explicitly so the exception is a decision, not an oversight.
+                if is_literal_field {
+                    let sk_is_some = trimmed.starts_with("self_sk: Some(");
+                    let vk_line = lines[i + 1..(i + 4).min(lines.len())]
+                        .iter()
+                        .map(|l| l.trim_start())
+                        .find(|l| l.starts_with("self_vk:"));
+                    let vk = vk_line.unwrap_or_else(|| {
+                        panic!(
+                            "{}:{} constructs a RoomData without a self_vk field beside \
+                             self_sk — they are a paired identity record",
+                            name,
+                            i + 1
+                        )
+                    });
+                    let vk_is_none = vk.starts_with("self_vk: None");
+                    let vk_is_some = vk.starts_with("self_vk: Some(");
+                    assert!(
+                        vk_is_none || vk_is_some,
+                        "{}:{} writes an unrecognised self_vk value `{}`",
+                        name,
+                        i + 1,
+                        vk
+                    );
+                    if !sk_is_some {
+                        assert!(
+                            vk_is_none,
+                            "{}:{} has no self_sk but claims a self_vk — a literal \
+                             must not invent an identity",
+                            name,
+                            i + 1
+                        );
+                    } else if vk_is_some {
+                        // Both present: the values must be derived from the same
+                        // key, textually `self_vk: Some(<x>.verifying_key())`
+                        // against `self_sk: Some(<x>...)`.
+                        assert!(
+                            vk.contains("verifying_key()"),
+                            "{}:{} sets self_vk to something not derived from the \
+                             signing key beside it — that is exactly the drift this \
+                             pin exists to stop",
+                            name,
+                            i + 1
+                        );
+                    }
+                    if !in_test_helper[i] {
+                        checked += 1;
+                    }
+                    continue;
+                }
+
                 assert!(
-                    window.contains(".self_vk =") || window.contains("self_vk:"),
+                    window.contains(".self_vk ="),
                     "{}:{} assigns self_sk without assigning self_vk beside it. \
                      The two are a paired identity record; leaving self_vk stale \
                      is harmless only while self_sk is still stored, which is \
@@ -6874,7 +6958,8 @@ mod tests {
             checked >= 5,
             "expected to find the production self_sk sites (the identity-import \
              and invitation-accept ASSIGNMENTS, plus the struct LITERALS that \
-             construct a RoomData); found {checked}. The scan needle is stale, so \
+             construct a RoomData), EXCLUDING cfg(test) fixtures from the tally; \
+             found {checked}. The scan needle is stale, so \
              this pin is no longer guarding anything."
         );
     }

--- a/ui/src/signing.rs
+++ b/ui/src/signing.rs
@@ -743,17 +743,71 @@ mod tests {
         );
     }
 
-    /// freenet/river#512 rests on `RoomData::self_sk` being present and
-    /// authoritative — the send path signs with it and never consults the
-    /// delegate. If it ever becomes optional (delegate-only custody, a
-    /// hardware key), the message path needs rethinking rather than an
-    /// `unwrap`, and this is what says so at compile time.
+    /// freenet/river#512 rests on the send path signing LOCALLY and never
+    /// waiting on the delegate. It used to rest on a second thing as well —
+    /// `RoomData::self_sk` being infallibly present — and the previous version
+    /// of this test asserted exactly that at compile time, with the note that
+    /// "if it ever becomes optional (delegate-only custody, a hardware key),
+    /// the message path needs rethinking rather than an `unwrap`".
+    ///
+    /// That has now happened: `self_sk` is `Option<SigningKey>` so that a blob
+    /// written by a future River which keeps the key elsewhere still decodes
+    /// here (see the field docs). This build still always WRITES the key, so
+    /// #512's local-signing property is untouched in practice. What changed is
+    /// the obligation the old test named: the send path must degrade, not
+    /// `unwrap`.
+    ///
+    /// So this pins the successor invariant in both halves — the accessor is
+    /// fallible (compile time), and no signing path recovers the key by
+    /// unwrapping it (source scrape).
     #[test]
-    fn the_send_path_always_has_a_local_signing_key() {
-        fn assert_plain_signing_key(room: &crate::room_data::RoomData) -> &SigningKey {
-            &room.self_sk
+    fn the_send_path_handles_a_missing_local_signing_key() {
+        fn assert_fallible_signing_key(room: &crate::room_data::RoomData) -> Option<&SigningKey> {
+            room.signing_key()
         }
-        let _ = assert_plain_signing_key;
+        let _ = assert_fallible_signing_key;
+
+        // Needles are assembled at runtime so this test's own source cannot
+        // match them (the `include_str!` self-match trap).
+        let unwrap = format!("{}{}", ".unwra", "p()");
+        let expect = format!("{}{}", ".expec", "t(");
+        let accessor = "signing_key()";
+        let field = "self_sk";
+
+        for (name, src) in [
+            (
+                "conversation.rs",
+                include_str!("components/conversation.rs"),
+            ),
+            ("room_data.rs", include_str!("room_data.rs")),
+            (
+                "dm_thread_modal.rs",
+                include_str!("components/direct_messages/dm_thread_modal.rs"),
+            ),
+            (
+                "direct_messages.rs",
+                include_str!("components/direct_messages.rs"),
+            ),
+        ] {
+            // Strip the test module so a test's own deliberate unwrap of a
+            // fixture key does not trip the scan.
+            let prod = src.split("#[cfg(test)]").next().unwrap_or(src);
+            for needle in [
+                format!("{accessor}{unwrap}"),
+                format!("{accessor}{expect}"),
+                format!("{field}{unwrap}"),
+                format!("{field}{expect}"),
+            ] {
+                assert!(
+                    !prod.contains(&needle),
+                    "{name} recovers the local signing key with `{needle}`. \
+                     `self_sk` is deliberately optional so a future blob without \
+                     it still decodes; unwrapping it converts that tolerance back \
+                     into a panic. Degrade instead (return None/Err, or log and \
+                     skip)."
+                );
+            }
+        }
     }
 
     /// freenet/river#414 (Codex round-8): an AUTHORITATIVE identity choice records

--- a/ui/src/signing.rs
+++ b/ui/src/signing.rs
@@ -827,12 +827,18 @@ mod tests {
                     .unwrap_or(false)
             })
             .count();
+        // NB the tally includes signing.rs itself (this test's own text), so a
+        // floor of 5 is really four INDEPENDENT files. Deliberate: raising the
+        // floor to chase that off would just make it brittle against ordinary
+        // refactors, and the control only has to distinguish "the needle still
+        // matches something" from "the needle matches nothing".
         assert!(
             accessor_sites >= 5,
-            "expected the `signing_key()` accessor at several sites, found {accessor_sites}. \
-             Either it was renamed — in which case the needles below are searching \
-             for a string that no longer exists and this pin is dead — or the key \
-             stopped being read through the accessor at all."
+            "expected the `signing_key()` accessor at several sites, found {accessor_sites} \
+             (one of which is signing.rs itself). Either it was renamed — in which \
+             case the needles below are searching for a string that no longer \
+             exists and this pin is dead — or the key stopped being read through \
+             the accessor at all."
         );
 
         for path in files {

--- a/ui/src/signing.rs
+++ b/ui/src/signing.rs
@@ -473,8 +473,12 @@ async fn delegate_sign_or_fallback(
 ///
 /// 1. `delegate_sign_or_fallback` accepts the delegate's answer only when it
 ///    verifies under `self_sk` (see above); otherwise it signs locally anyway.
-/// 2. `RoomData::self_sk` is a plain, always-present field — the private key is
-///    already in the browser, so there is nothing to wait for.
+/// 2. Every writer stores `RoomData::self_sk`, so on the send path the private
+///    key is already in the browser and there is nothing to wait for. (The
+///    field is `Option` for reader tolerance — see its docs — and the send path
+///    refuses when it is absent rather than waiting on the delegate. Do NOT
+///    read this point as licence to make the field required again; it is a
+///    statement about where the key IS, not about the field's type.)
 /// 3. Ed25519 is deterministic (RFC 8032), and the delegate signs with
 ///    `SigningKey::from_bytes(sk).sign(data)` — the same operation. So whenever
 ///    the delegate's answer is *accepted*, it is byte-identical to this.
@@ -767,44 +771,70 @@ mod tests {
         }
         let _ = assert_fallible_signing_key;
 
+        // Walk the whole crate source tree rather than a hand-listed set of
+        // files. `signing_key()` is called in ~14 files; an allow-list pins
+        // only the ones someone remembered, so a future `.unwrap()` in an
+        // unlisted file would pass CI silently. `CARGO_MANIFEST_DIR` is
+        // resolved at COMPILE time, so this cannot be defeated by the working
+        // directory the test runs from.
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+
         // Needles are assembled at runtime so this test's own source cannot
         // match them (the `include_str!` self-match trap).
         let unwrap = format!("{}{}", ".unwra", "p()");
         let expect = format!("{}{}", ".expec", "t(");
-        let accessor = "signing_key()";
-        let field = "self_sk";
+        let needles = [
+            format!("signing_key(){unwrap}"),
+            format!("signing_key(){expect}"),
+            format!("self_sk{unwrap}"),
+            format!("self_sk{expect}"),
+        ];
 
-        for (name, src) in [
-            (
-                "conversation.rs",
-                include_str!("components/conversation.rs"),
-            ),
-            ("room_data.rs", include_str!("room_data.rs")),
-            (
-                "dm_thread_modal.rs",
-                include_str!("components/direct_messages/dm_thread_modal.rs"),
-            ),
-            (
-                "direct_messages.rs",
-                include_str!("components/direct_messages.rs"),
-            ),
-        ] {
-            // Strip the test module so a test's own deliberate unwrap of a
-            // fixture key does not trip the scan.
-            let prod = src.split("#[cfg(test)]").next().unwrap_or(src);
-            for needle in [
-                format!("{accessor}{unwrap}"),
-                format!("{accessor}{expect}"),
-                format!("{field}{unwrap}"),
-                format!("{field}{expect}"),
-            ] {
+        fn rust_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    rust_files(&path, out);
+                } else if path.extension().is_some_and(|e| e == "rs") {
+                    out.push(path);
+                }
+            }
+        }
+
+        let mut files = Vec::new();
+        rust_files(&root, &mut files);
+        assert!(
+            files.len() > 20,
+            "expected to walk the crate's sources, found {} files under {} — \
+             the walk is broken, so this pin is guarding nothing",
+            files.len(),
+            root.display()
+        );
+
+        for path in files {
+            let Ok(src) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            // Scan the WHOLE file, tests included. Splitting at the first
+            // `#[cfg(test)]` would silently truncate production code that
+            // follows a cfg(test) helper — `room_data.rs` has exactly that
+            // shape — so the split weakened the guard rather than refining it.
+            // Nothing in this crate unwraps the key even in tests, so there is
+            // no exemption to carve out; if a test ever needs to, it should
+            // reach for the fixture key it already holds.
+            for needle in &needles {
                 assert!(
-                    !prod.contains(&needle),
-                    "{name} recovers the local signing key with `{needle}`. \
+                    !src.contains(needle.as_str()),
+                    "{} recovers the local signing key with `{}`. \
                      `self_sk` is deliberately optional so a future blob without \
                      it still decodes; unwrapping it converts that tolerance back \
                      into a panic. Degrade instead (return None/Err, or log and \
-                     skip)."
+                     skip).",
+                    path.display(),
+                    needle
                 );
             }
         }

--- a/ui/src/signing.rs
+++ b/ui/src/signing.rs
@@ -814,6 +814,27 @@ mod tests {
             root.display()
         );
 
+        // POSITIVE CONTROL for the NEEDLE, not just the walk. `files.len()`
+        // proves we read the tree; it does not prove the strings we search for
+        // still correspond to anything. Rename `signing_key()` and every
+        // `!contains` assertion below becomes vacuously true while CI stays
+        // green. So require the accessor to actually appear somewhere.
+        let accessor_sites = files
+            .iter()
+            .filter(|p| {
+                std::fs::read_to_string(p)
+                    .map(|s| s.contains("signing_key()"))
+                    .unwrap_or(false)
+            })
+            .count();
+        assert!(
+            accessor_sites >= 5,
+            "expected the `signing_key()` accessor at several sites, found {accessor_sites}. \
+             Either it was renamed — in which case the needles below are searching \
+             for a string that no longer exists and this pin is dead — or the key \
+             stopped being read through the accessor at all."
+        );
+
         for path in files {
             let Ok(src) = std::fs::read_to_string(&path) else {
                 continue;

--- a/ui/src/util.rs
+++ b/ui/src/util.rs
@@ -1012,7 +1012,8 @@ mod tests {
         let mut room_data = RoomData {
             owner_vk,
             room_state: ChatRoomStateV1::default(),
-            self_sk: owner_sk,
+            self_sk: Some(owner_sk),
+            self_vk: None,
             contract_key: bogus_key,
             last_read_message_id: None,
             secrets: HashMap::new(),


### PR DESCRIPTION
## Problem

River persists each room's private signing key inside the `RoomSlot` blob it stores in the chat delegate (`RoomData.self_sk`, `ui/src/room_data.rs`). That blob is reachable from the app API, so it is the wrong place for key material — but it cannot simply be moved yet, and this PR does **not** move it. It removes the obstacles that make moving it later a data-loss event, and closes one exposure that is independent of the delegate entirely.

Three specific problems:

1. **`self_sk` was a REQUIRED CBOR field.** The moment any future River stops writing it, an older client reading that blob fails to deserialize `RoomSlot` *as a whole*. A `RoomSlot` that fails to decode does not degrade — the room **vanishes** from the user's list. Because River clients update at their own pace, the tolerant reader has to be in the field well before the writer changes, or the writer change strands whoever has not upgraded.

2. **Roughly 35 sites reached for the private key when they only needed the public half** — `MemberId` derivation, owner checks, "is this me" comparisons. Nothing could stop needing the private key while those sites existed.

3. **The pending invitation was written to `localStorage`.** An `Invitation` carries `invitee_signing_key` — a full ed25519 private key — and `room_secrets`, the room's plaintext symmetric secrets. It is a bearer credential, it was durable, it was readable by any script in the origin, and the flow has **no terminal state for an abandoned invite**: opening an invite link and never acting on it parked that key material on disk indefinitely, with no path that ever cleared it.

## Approach

Deliberately the subset that requires **no delegate change and therefore no delegate re-key**.

**1. Reader tolerance.** `self_sk` becomes `Option<SigningKey>`; the writer is unchanged and still always stores `Some(..)`. Reads go through four accessors — `signing_key()`, `self_verifying_key()`, `self_member_id()`, `is_self_owner()` — and every one of ~160 call sites was audited rather than unwrapped. There is no `unwrap`/`expect`/`panic!` on the key anywhere in production code, and a test pins that.

The degradation policy: a site needing only the public half uses `self_verifying_key()`; a site that genuinely signs or decrypts refuses through whatever failure channel it already has (`None`, `Err`, `false`, or a logged no-op). `SendMessageError` gains an `IdentityUnavailable` variant so "this device cannot sign here" is not mislabelled as "you are not a member".

**2. Persist `self_vk`.** Public-half work keeps functioning with no private key in hand. `self_verifying_key()` derives from `self_sk` **in preference to** the stored field, so a stale or tampered `self_vk` can never redirect the local identity while the real key is held. The field is stamped onto the blob at the single save chokepoint (`reconcile_room_present`), so it does not depend on which of the many `RoomData` construction sites built the in-memory copy.

Two identity comparisons that previously compared raw key bytes now compare *identities*, because a copy that merely lacks the private key is not a different identity — and both of those branches are lossy (they discard the other copy's state).

**3. Pending invitation.** Held in process memory (`PENDING_INVITATION`) for the pending-invite window, which is entirely within one page load. The nickname and its BLAKE3 fingerprint stay in `localStorage` — neither is a secret — so the #333 binding is intact. Any invitation an older River persisted is actively **erased** at startup: ceasing to write the key does nothing about copies already on users' disks, and the users most exposed are exactly the ones who never open another invite.

*Cost, stated plainly:* a mid-flow reload no longer recovers the invitation from storage. For the URL-bar path — the common one — nothing changes in practice, because the `?invitation=` parameter survives the reload and `App` re-parses it before the recovery block runs. For the DM-card, paste-a-code, and click-interceptor paths a reload drops the pending invite and the user re-opens it. In the deployed gateway this reload-resume has never worked anyway: the iframe runs on an opaque origin, where `localStorage` is unavailable (freenet/river#219).

### What is NOT in this PR, and why

**The relocation itself.** Secrets in the delegate's `signing_key:` namespace do **not** survive a delegate re-key — `fire_legacy_migration_request` recovers old generations via `GetRequest`/`ListRequest`, and that namespace is structurally unreachable by both. Signing keys survive a re-key today *only* because `self_sk` rides inside the migratable blob. River has re-keyed 28 recorded times since 2026-01-15, roughly one every 6-7 days. Shipping "stop writing `self_sk` to the blob" before a re-key-survival mechanism exists would lock every user out of every room at the next re-key. That mechanism is being designed separately, and the writer flip must not land before it.

**Two other findings, both delegate-side, both excluded:**

- The `String::from_utf8_lossy` key aliasing in `create_origin_key` (`delegates/chat-delegate/src/utils.rs`), where distinct non-UTF-8 keys collapse onto one slot.
- The cross-origin write primitive via `EnsureRoomSubscription` (`delegates/chat-delegate/src/handlers.rs` → `subscription.rs`), where the `room_sub:` namespaces are not origin-scoped.

Both live entirely inside the delegate. Neither has a UI-side mitigation — the UI cannot stop another origin calling the delegate, and it already base58-encodes its own keys, so it does not trigger the aliasing itself. Fixing either changes the delegate WASM and therefore forces a re-key, which is precisely what this PR is scoped to avoid. They should be batched into whatever release next re-keys the delegate.

## Testing

The change alters how data already sitting in every existing user's store is decoded, so the round-trip tests carry the weight. Each was written first and confirmed to fail (or be meaningfully exercised) before being confirmed to pass.

**Backward compatibility — protects current users:**
- `roomslot_from_a_current_writer_still_round_trips` — a `RoomSlot` in today's exact shape (required `self_sk`, no `self_vk`) decodes with the key intact byte-for-byte.
- `roomdata_decodes_from_minimal_legacy_blob` — extended to assert the legacy required field lands in `Some(..)` and the accessor still derives the public half from it.

**Forward compatibility — makes the later relocation safe:**
- `roomdata_decodes_from_a_blob_with_no_self_sk` and `roomslot_decodes_from_a_blob_with_no_self_sk` — a blob that OMITS the field (not one writing `null`, which is what a future writer would actually emit) decodes rather than erroring, at both the struct and the `RoomSlot` enum level.
- The first carries a **differential oracle**: the same bytes are decoded into the pre-change shape with a required `self_sk`, and that must fail. Without it the test could pass while proving nothing. Worth recording: `#[serde(default)]` turned out **not** to be the load-bearing part — removing it did not break the tests, because `Option` alone is what makes the field optional. The oracle is what establishes the property is real.

**Behaviour when the key is absent:**
- `read_paths_degrade_gracefully_with_no_private_key` — asserts a precondition (the member CAN act with the key present, so the test is not passing on an inert room), then removes the key and checks each path's specific answer. **This test found a real design error:** `can_send_message` was gated on the public half, so it returned `Ok` for a copy that could not sign — showing the user a composer whose every send would be silently rejected. Both it and `can_participate` now require the private key.
- `an_owner_without_a_private_key_is_still_the_owner_but_cannot_rotate` — ownership is a property of the public half and survives; rotation derives and signs, so it does not. Separated so a future refactor cannot collapse the two checks.
- `self_sk_outranks_a_disagreeing_self_vk` — the held private key wins over a disagreeing `self_vk`, and backfill only ever fills an empty slot.

**Wiring:**
- `a_saved_slot_always_carries_self_vk`, `a_missing_private_key_is_not_a_diverged_identity`, `self_sk_and_self_vk_are_assigned_together` (the repo's paired-`Option`-fields pattern; the type-system remedy is unavailable because both names are wire-format field names, so it is a scrape — with a non-vacuity floor on the number of sites found).
- `the_pending_invitation_is_never_persisted` — a source scrape, because the write goes through `web_sys`, which does not exist under `cargo test`; a behavioural test there could not fail. It also asserts the nickname binding is still persisted and the legacy purge still present, so the pin cannot be satisfied by deleting the storage code wholesale.
- `pending_invitation_round_trips_in_memory_and_clears`.
- `the_send_path_handles_a_missing_local_signing_key` replaces `the_send_path_always_has_a_local_signing_key`. That test was a deliberate canary whose comment said "if it ever becomes optional... the message path needs rethinking rather than an `unwrap`". This is that event, so the successor pins the obligation it named: the accessor is fallible (compile time) and no signing path unwraps it (source scrape).

**Mutation-verified.** Every new test was confirmed to fail under a targeted mutation before being trusted: preferring `self_vk` over `self_sk` in the accessor; deleting the save-path backfill; reverting the identity comparison to a raw `Option` compare; dropping or mis-deriving the paired `self_vk` write; reintroducing the `localStorage` persist; restoring the nickname sweep; reordering the startup adopt hook; re-introducing the conversation blank-render bail; planting an `unwrap` in a file the earlier allow-list pin did not scan; and refactoring a production literal out of the paired-field scan's needle.

Two guards were found to be weaker than they looked and were replaced rather than kept: an ordering pin that stayed green under the defect it was meant to catch (ordering was only ever a proxy for the outcome), and a `#[cfg(test)]` split that silently truncated production code following a test helper — so the scans were quietly narrowing rather than refining. Both now read whole files and assert outcomes.

### What the review rounds changed, and two things not to over-read

Three rounds of independent review followed. The substantive outcomes, with their reachability stated honestly:

- **A user-visible bug in the first cut.** The guard in `repopulate_secrets_from_state` was scoped too widely and skipped the `invitation_secrets` fold and the `current_secret_version` alignment, neither of which needs a key. That would have left a private room rendering "[Encrypted message — secret vN not available]" over content it could decrypt. Narrowed, and the test that had *ratified* the bug now pins the intended behaviour.
- **A regression I introduced while addressing review feedback.** A tidy-up swept the nickname binding inside the same purge that erases the legacy invitation artifact, which the startup adopt hook calls immediately after reading it — turning the #218 auto-resume into a re-prompt on a join already in flight. The purge now takes only the artifact.
- **`self_vk` erasure on save: LATENT, not live, and pre-empted.** `reconcile_room_present` builds from `local.clone()`, and the backfill can only derive `self_vk` from a held `self_sk`, so a copy carrying neither half would write `self_vk: None` over a stored identity. The test fails without the fix — but against a state the *test* constructs. Every production `self_sk` literal and assignment outside tests writes `Some`, so the precondition is unreachable in this build. The guard is in because the relocation is exactly what makes it reachable, and it is cheaper to add now than to remember later. It is not a bug being fixed in shipped behaviour.
- **The `localStorage` tests do not cover the deployed path.** Proving the invitation regression needed the storage layer to be drivable under `cargo test`, so access goes through three key/value functions backed by an in-process map off-wasm. In the production gateway the iframe has an opaque origin, `localStorage` throws, and all three are no-ops — so every one of those tests exercises a branch that cannot occur there, as does the legacy artifact they read. Their real coverage is `dx serve` and non-sandboxed deployments. The logic is worth getting right for those and worth testing rather than scraping, but this is not coverage of the gateway.

**Suite:** 891 `river-ui` unit tests pass (896 with `example-data,no-sync`), 252 `river-core` lib tests, plus the migration, room-contract-migration and delegate-key suites. `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync` is clean.

### No re-key — verified

Only `ui/src/` is touched; nothing under `delegates/`, `contracts/`, or `common/`, and no `.wasm` byte changed.

```
cargo make check-migration
  Committed WASM matches HEAD — no migration needed.
cargo make check-room-contract-migration
  Committed room-contract WASM matches HEAD — no migration entry needed.
```

Delegate WASM BLAKE3 is `a44c64014d60fd245fe8fb5172f8fd7397039b248b3b6a8e95e89a0bb539fb5e` before and after; the room-contract and web-container artifacts are likewise unchanged. No `legacy_delegates.toml` entry is required.

[AI-assisted - Claude]

