### PR TITLE
fix(ui): make the add-reaction + button visible on touch devices

### DIFF
--- a/ui/assets/main.css
+++ b/ui/assets/main.css
@@ -32,10 +32,20 @@
  * Gate on pointer CAPABILITY, not viewport width — see the #462 comment
  * above for why `(hover: none), (any-pointer: coarse)` is the correct query
  * (`any-pointer: coarse` also catches a touchscreen laptop, which reports
- * `hover: hover` while a finger is on the glass). */
+ * `hover: hover` while a finger is on the glass).
+ *
+ * Also widen the tap target to >=44px (WCAG 2.5.8 / Apple HIG), matching
+ * #462's fix for the same bug class: at rest the button is just a bare "+"
+ * glyph (`text-xl leading-none`, no padding), well under the minimum. Unlike
+ * #462's absolutely-positioned archive ✕, this button sits inline in a
+ * `flex flex-wrap` reaction row (`conversation.rs`), so growing it needs no
+ * companion padding fix elsewhere — the row simply wraps if a message has
+ * many reactions and the row is tight. */
 @media (hover: none), (any-pointer: coarse) {
     .add-reaction-btn {
         opacity: 0.4;
+        min-width: 2.75rem;
+        min-height: 2.75rem;
     }
 
     .add-reaction-btn.has-reactions {

--- a/ui/assets/main.css
+++ b/ui/assets/main.css
@@ -21,6 +21,28 @@
     opacity: 0.4;
 }
 
+/* Touch reveal for the inline add-reaction "+" button (same failure mode as
+ * #402/#462 above): `.add-reaction-btn` reveals via `.group:hover`, a real
+ * CSS `:hover`, which touch devices can't reliably trigger — so on a phone
+ * the button was invisible (opacity: 0) yet still tappable, unless the
+ * message already had reactions (`.has-reactions` gives it opacity: 0.2 at
+ * rest regardless of hover), which is why the bug only showed on
+ * reaction-less messages.
+ *
+ * Gate on pointer CAPABILITY, not viewport width — see the #462 comment
+ * above for why `(hover: none), (any-pointer: coarse)` is the correct query
+ * (`any-pointer: coarse` also catches a touchscreen laptop, which reports
+ * `hover: hover` while a finger is on the glass). */
+@media (hover: none), (any-pointer: coarse) {
+    .add-reaction-btn {
+        opacity: 0.4;
+    }
+
+    .add-reaction-btn.has-reactions {
+        opacity: 0.4;
+    }
+}
+
 /* @mention chips. Rendered as raw <span class="river-mention"> inside message
  * bodies (see conversation::message_to_html_with_mentions). Clickable via the
  * document-level mention click interceptor.

--- a/ui/tests/add-reaction-touch.spec.ts
+++ b/ui/tests/add-reaction-touch.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from "@playwright/test";
+
+// Regression coverage for the inline add-reaction "+" button being invisible
+// (but still tappable) on touch devices.
+//
+// `.add-reaction-btn` (ui/assets/main.css) reveals via `.group:hover`, a real
+// CSS `:hover`, which touch devices can't reliably trigger — so on a phone
+// the button rendered at `opacity: 0` yet still received taps (the reported
+// symptom: invisible, but tapping roughly where it should be opens the
+// picker). Same failure mode as freenet/river#402 and #462; the fix mirrors
+// #462's pointer-capability media query. This probes the cascade directly
+// against the shipped stylesheets, since that's the layer where the bug
+// actually lived (Tailwind's utility layer vs. main.css's plain rules).
+
+const PROBE_ID = "add-reaction-cascade-probe";
+
+async function measureProbe(page: import("@playwright/test").Page, hasReactions: boolean) {
+  return page.evaluate(
+    ({ id, hasReactions }) => {
+      // Mirrors the real markup in `conversation.rs`: an add-reaction button
+      // inside a `group` row, revealed by `.group:hover`.
+      const row = document.createElement("div");
+      row.className = "group relative";
+      const btn = document.createElement("button");
+      btn.id = id;
+      btn.className =
+        "add-reaction-btn" + (hasReactions ? " has-reactions" : "");
+      row.appendChild(btn);
+      document.body.appendChild(row);
+
+      const style = getComputedStyle(btn);
+      const result = {
+        coarse: window.matchMedia("(hover: none), (any-pointer: coarse)").matches,
+        opacity: style.opacity,
+      };
+      row.remove();
+      return result;
+    },
+    { id: PROBE_ID, hasReactions }
+  );
+}
+
+test.describe("Add-reaction + button cascade", () => {
+  for (const hasReactions of [false, true]) {
+    test(`touch reveal beats the hover-only rule, and only on a coarse pointer (has-reactions=${hasReactions})`, async ({
+      page,
+    }) => {
+      await page.goto("/");
+      await page.waitForSelector(".app-root", { timeout: 30_000 });
+
+      const m = await measureProbe(page, hasReactions);
+
+      if (m.coarse) {
+        // The bug: `.group:hover .add-reaction-btn` can never match without a
+        // hover pointer, so without the touch rule this stays at opacity 0
+        // (or 0.2 with existing reactions) — dim-to-invisible, but still
+        // tappable underneath.
+        expect(
+          parseFloat(m.opacity),
+          "on a coarse pointer `.add-reaction-btn` must be clearly visible " +
+            "at rest — if this is 0 (or 0.2), main.css's touch rule regressed " +
+            "and the + button is invisible again"
+        ).toBeGreaterThanOrEqual(0.4);
+      } else {
+        // Mouse-only: the hover reveal must be preserved.
+        const expected = hasReactions ? 0.2 : 0;
+        expect(
+          parseFloat(m.opacity),
+          "on a mouse-only pointer the button must stay at its hover-gated " +
+            "rest opacity"
+        ).toBeCloseTo(expected, 5);
+      }
+    });
+  }
+});

--- a/ui/tests/add-reaction-touch.spec.ts
+++ b/ui/tests/add-reaction-touch.spec.ts
@@ -29,9 +29,12 @@ async function measureProbe(page: import("@playwright/test").Page, hasReactions:
       document.body.appendChild(row);
 
       const style = getComputedStyle(btn);
+      const rect = btn.getBoundingClientRect();
       const result = {
         coarse: window.matchMedia("(hover: none), (any-pointer: coarse)").matches,
         opacity: style.opacity,
+        width: rect.width,
+        height: rect.height,
       };
       row.remove();
       return result;
@@ -61,6 +64,13 @@ test.describe("Add-reaction + button cascade", () => {
             "at rest — if this is 0 (or 0.2), main.css's touch rule regressed " +
             "and the + button is invisible again"
         ).toBeGreaterThanOrEqual(0.4);
+        // WCAG 2.5.8 asks for 24px; Apple HIG for 44. The rule sets 2.75rem,
+        // matching the #462 archive-button precedent for the same bug class.
+        expect(
+          Math.min(m.width, m.height),
+          "the touch tap target must be at least 44px, or a finger can miss " +
+            "the now-visible + button"
+        ).toBeGreaterThanOrEqual(44);
       } else {
         // Mouse-only: the hover reveal must be preserved.
         const expected = hasReactions ? 0.2 : 0;


### PR DESCRIPTION
## Problem

On mobile (Android reported), the inline add-reaction "+" button next
to a message is invisible — but tapping roughly where it should be
still opens the reaction picker. If a message already has reactions,
the "+" is (dimly) visible.

## Approach

`.add-reaction-btn` in `ui/assets/main.css` reveals via `.group:hover`,
a real CSS `:hover`, which touch devices can't reliably trigger:

```css
.add-reaction-btn { opacity: 0; }
.group:hover .add-reaction-btn { opacity: 0.4; }
.add-reaction-btn.has-reactions { opacity: 0.2; }
```

So on touch it stays at `opacity: 0` (or `0.2` once it has reactions,
matching the report), while the click handler still fires because an
`opacity: 0` element is still tappable.

This is the same failure mode already fixed twice in this file —
freenet/river#402 (the hover message-action bar) and #462 (the DM rail
archive ✕) — so the fix mirrors #462's pointer-capability media query,
gating on `(hover: none), (any-pointer: coarse)` rather than viewport
width (a touchscreen laptop reports `hover: hover` while a finger is on
the glass, which `any-pointer: coarse` still catches).

I checked for other instances of the same pattern
(`group-hover:opacity`/`.group:hover` reveal) in the UI: the hover
message-action bar and the DM archive button both already have their
touch-visible counterparts (#402/#462). `MessageActions` /
`QuickReactionButton` in `message_actions.rs` have the same
`opacity-0 group-hover:opacity-100` pattern but are dead code (not
referenced anywhere in the app), so left untouched.

## Testing

- Added `ui/tests/add-reaction-touch.spec.ts`, a cascade probe against
  the shipped stylesheet (mirrors `dm-archive-touch.spec.ts`).
  Verified it fails without the fix (checked via mutation: stripped
  the new CSS rule from the built output, reran on `mobile-chrome`,
  got the expected red) and passes with it.
- Ran the full Playwright suite (`npx playwright test`, all 5 browser
  projects): 787 passed, 23 pre-existing skips, no regressions.

No delegate/contract/common WASM touched — CSS-only change, no
migration needed.

[AI-assisted - Claude]