### PR TITLE
fix(ui): stop the add-reaction button from growing the reaction row

### DIFF
--- a/ui/assets/main.css
+++ b/ui/assets/main.css
@@ -40,10 +40,11 @@
  * which reads as "the composer now takes up more room" — a real visible
  * regression, not just a WCAG nice-to-have. This button is also a
  * lower-stakes target than the DM-archive ✕ (a mis-tap just opens the
- * emoji picker, not a destructive action) and touch users have a second,
- * already-sized path to the same action via the message kebab menu's
- * "React" entry (`conversation.rs`, `.touch-actions`). So: fix visibility
- * only, leave sizing alone. */
+ * emoji picker, not a destructive action) and touch users have a second
+ * path to the same action via the message kebab menu's "React" entry
+ * (`conversation.rs`, `.touch-actions`) — a full menu row, comfortably
+ * above the WCAG 2.5.8 AA 24px floor though still short of the 44px AAA
+ * target itself. So: fix visibility only, leave sizing alone. */
 @media (hover: none), (any-pointer: coarse) {
     .add-reaction-btn {
         opacity: 0.4;

--- a/ui/assets/main.css
+++ b/ui/assets/main.css
@@ -34,18 +34,19 @@
  * (`any-pointer: coarse` also catches a touchscreen laptop, which reports
  * `hover: hover` while a finger is on the glass).
  *
- * Also widen the tap target to >=44px (WCAG 2.5.8 / Apple HIG), matching
- * #462's fix for the same bug class: at rest the button is just a bare "+"
- * glyph (`text-xl leading-none`, no padding), well under the minimum. Unlike
- * #462's absolutely-positioned archive ✕, this button sits inline in a
- * `flex flex-wrap` reaction row (`conversation.rs`), so growing it needs no
- * companion padding fix elsewhere — the row simply wraps if a message has
- * many reactions and the row is tight. */
+ * Deliberately does NOT widen the tap target the way #462 did: a min-size
+ * here (tried in #605, reverted after user feedback) grows the reaction
+ * row's line height on every message, even ones without reactions yet,
+ * which reads as "the composer now takes up more room" — a real visible
+ * regression, not just a WCAG nice-to-have. This button is also a
+ * lower-stakes target than the DM-archive ✕ (a mis-tap just opens the
+ * emoji picker, not a destructive action) and touch users have a second,
+ * already-sized path to the same action via the message kebab menu's
+ * "React" entry (`conversation.rs`, `.touch-actions`). So: fix visibility
+ * only, leave sizing alone. */
 @media (hover: none), (any-pointer: coarse) {
     .add-reaction-btn {
         opacity: 0.4;
-        min-width: 2.75rem;
-        min-height: 2.75rem;
     }
 
     .add-reaction-btn.has-reactions {

--- a/ui/tests/add-reaction-touch.spec.ts
+++ b/ui/tests/add-reaction-touch.spec.ts
@@ -11,6 +11,13 @@ import { test, expect } from "@playwright/test";
 // #462's pointer-capability media query. This probes the cascade directly
 // against the shipped stylesheets, since that's the layer where the bug
 // actually lived (Tailwind's utility layer vs. main.css's plain rules).
+//
+// Deliberately does NOT assert a minimum tap-target size: an earlier version
+// of this fix added `min-width`/`min-height: 2.75rem` (mirroring #462), but
+// that grew the reaction row's height on every message and read as a visible
+// regression (river chat feedback, 2026-08-07) — reverted. The size
+// assertion below pins that decision: it fails if `min-width`/`min-height`
+// gets re-added to `.add-reaction-btn` without deliberately revisiting this.
 
 const PROBE_ID = "add-reaction-cascade-probe";
 
@@ -64,13 +71,15 @@ test.describe("Add-reaction + button cascade", () => {
             "at rest — if this is 0 (or 0.2), main.css's touch rule regressed " +
             "and the + button is invisible again"
         ).toBeGreaterThanOrEqual(0.4);
-        // WCAG 2.5.8 asks for 24px; Apple HIG for 44. The rule sets 2.75rem,
-        // matching the #462 archive-button precedent for the same bug class.
+        // No min-width/min-height on touch — see the file header. A plain
+        // <button> with no explicit sizing renders well under 44px from UA
+        // default padding alone, so this catches a re-added min-size rule.
         expect(
           Math.min(m.width, m.height),
-          "the touch tap target must be at least 44px, or a finger can miss " +
-            "the now-visible + button"
-        ).toBeGreaterThanOrEqual(44);
+          "the button must NOT have a forced minimum tap-target size on " +
+            "touch — that was tried and reverted because it grew the " +
+            "reaction row's height on every message (visible regression)"
+        ).toBeLessThan(44);
       } else {
         // Mouse-only: the hover reveal must be preserved.
         const expected = hasReactions ? 0.2 : 0;


### PR DESCRIPTION
## Problem

Follow-up to #605. That PR fixed the reaction "+" button being
invisible-but-tappable on touch devices, and additionally widened its
tap target to 44px (mirroring the #462 archive-button fix), reasoning
it was under the WCAG 2.5.8 minimum.

User feedback in River chat afterward:

> Am i imagining it or did the react button not used to be below the
> message text. It feels like it's taking up more space than it used
> to. Also kinda redundant on touch devices as react is in the side
> menu anyway

Confirmed: an `opacity: 0` element still occupies its layout box, so
the button already had space reserved at its natural size
(`text-xl leading-none`, ~20px tall, no padding). Forcing
`min-width`/`min-height: 2.75rem` grew that to 44px on *every*
message's reaction row, not just ones with existing reactions —
a real, user-visible regression.

## Approach

Revert the tap-target sizing, keep the visibility fix (opacity via
the `(hover: none), (any-pointer: coarse)` media query — that part
of #605 is correct and unaffected).

Left the sizing out rather than shrinking it to something in between,
because:
- This button is lower-stakes than the DM-archive ✕ the sizing
  mirrored — a mis-tap just opens the emoji picker, not a destructive
  action.
- Touch users already have a second path to the same action: the
  message kebab menu's "React" entry (`.touch-actions` in
  `conversation.rs`) — a full menu row (~33-36px tall), comfortably
  above the WCAG 2.5.8 AA 24px floor though, like this button, short
  of the 44px AAA/HIG target. (Corrected after review — an earlier
  version of this description overstated this as "already >=44px".)

## Testing

- Extended `ui/tests/add-reaction-touch.spec.ts` to assert the button
  has **no** forced minimum size on a coarse pointer (previously it
  asserted `>= 44px`; now asserts `< 44px`) — this pins the decision,
  so a future re-add of `min-width`/`min-height` fails the test.
- Verified via mutation testing: reintroduced the min-size rule in the
  built CSS output, confirmed the test goes red; restored, confirmed
  green.
- Verified visually via a Playwright screenshot at a 375px viewport on
  a room with existing reactions — row spacing matches the original
  (pre-#605) compact layout.
- Full local Playwright suite (`npx playwright test`, all 5 browser
  projects): 787 passed, 23 pre-existing skips, no regressions.

No delegate/contract/common WASM touched — CSS-only change (plus the
test), no migration needed.

[AI-assisted - Claude]
