### PR TITLE
fix(ui): move the ban-withheld explanation out of the button row

### DIFF
--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -686,18 +686,31 @@ pub fn MemberInfoModal() -> Element {
                             // contract-VALID and cascades to their whole invite
                             // subtree (freenet/river#478).
                             if member_id != self_member_id {
+                                // #478, transitive case: the Ban action is ALSO
+                                // withheld when the cascade would sweep the
+                                // viewer up — i.e. the target is one of the
+                                // viewer's own invite ancestors. Same damage as
+                                // a self-ban, different route, so it is the same
+                                // rule (`ban_gate`), not a second special case.
+                                // `ban_refusal` is `Some` only when the viewer
+                                // would OTHERWISE have had the action, which is
+                                // why it also carries the text: a moderator
+                                // whose Ban button vanished is owed a reason.
+                                //
+                                // Rendered as its own full-width block, NOT as a
+                                // flex sibling inside the button row below: it
+                                // is a sentence-length explanation, not a
+                                // button-sized label, and squeezing it into the
+                                // row alongside Deputize wrapped and clipped it.
+                                if let Some(reason) = ban_refusal {
+                                    div {
+                                        "data-testid": "ban-withheld-reason",
+                                        class: "mt-4 px-3 py-2 text-sm text-text-muted bg-surface border border-border rounded-lg",
+                                        "{reason}"
+                                    }
+                                }
+
                                 div { class: "mt-4 flex items-start gap-3",
-                                    // #478, transitive case: the Ban action is
-                                    // ALSO withheld when the cascade would sweep
-                                    // the viewer up — i.e. the target is one of
-                                    // the viewer's own invite ancestors. Same
-                                    // damage as a self-ban, different route, so
-                                    // it is the same rule (`ban_gate`), not a
-                                    // second special case. `ban_refusal` is
-                                    // `Some` only when the viewer would OTHERWISE
-                                    // have had the action, which is why it also
-                                    // carries the text: a moderator whose Ban
-                                    // button vanished is owed a reason.
                                     if ban_refusal.is_none() {
                                         BanButton {
                                             member_to_ban: member_id,
@@ -712,13 +725,6 @@ pub fn MemberInfoModal() -> Element {
                                             // showed "[Encrypted: N bytes, vN]" instead
                                             // of a name in private rooms.
                                             nickname: target_nickname.clone()
-                                        }
-                                    }
-                                    if let Some(reason) = ban_refusal {
-                                        div {
-                                            "data-testid": "ban-withheld-reason",
-                                            class: "flex-1 px-3 py-2 text-sm text-text-muted bg-surface border border-border rounded-lg",
-                                            "{reason}"
                                         }
                                     }
 


### PR DESCRIPTION
## Summary
- The refusal reason shown when the Ban action is withheld (freenet/river#478) was rendered as a flex sibling of the Deputize button, squeezed into the same button-sized row (`flex items-start gap-3`). A sentence-length explanation in that slot wrapped/clipped awkwardly.
- Moves the reason `div` to its own full-width block above the button row, inside the same `member_id != self_member_id` guard, leaving the Ban/Deputize row itself unchanged.

## Review
Independent Claude review (Light tier — small, self-contained UI change, no high-risk surface): one finding (a duplicated comment left over from the move), fixed. No correctness/gating issues — the `#478` self-removing-ban guard structure is untouched, only the reason text's position moved.

## Test plan
- [x] `cargo test -p river-ui --bins` — all 89 `components::members` tests pass, including the source-scrape pin `ban_action_is_not_rendered_when_the_rule_refuses`
- [x] `cargo build -p river-ui --bins` — clean (only pre-existing unrelated warnings)

[AI-assisted - Claude]