### PR TITLE
chore: bump freenet-test-network to 0.1.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2449,9 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-test-network"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19879a189ec66a3f559882e200077e101d90861ae6151c9fb63dbd5eda65bdfe"
+checksum = "738747137ffe70134077a0737e09ad90673d5fc3f64c2733dcf80feee7091e16"
 dependencies = [
  "anyhow",
  "bollard",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -92,6 +92,6 @@ fs2 = "0.4"
 ureq = { version = "2", default-features = false, features = ["tls"] }
 
 [dev-dependencies]
-freenet-test-network = "0.1.23"
+freenet-test-network = "0.1.24"
 tempfile = "3"
 assert_cmd = "2"


### PR DESCRIPTION
Picks up freenet/freenet-test-network#5: Docker NAT test peers were silently reporting telemetry to the production collector (nova.locut.us:4318) instead of staying silent like the Local backend already does. This is a version bump only — no code changes here.

[AI-assisted - Claude]