### PR TITLE
ci: run chat-delegate and web-container tests, and guard the gap class

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,14 @@ jobs:
     - name: Build Project
       run: cargo make build
 
+    - name: Check every workspace member has a test step
+      # Guards the CLASS of gap that the per-crate steps below have each closed
+      # one instance of (freenet/river#614). A crate added to [workspace]
+      # members without a `cargo test -p <crate>` step here now fails CI,
+      # instead of shipping tests that quietly never execute — which is what
+      # the chat-delegate did for its entire existence.
+      run: ./scripts/check-ci-test-coverage.sh
+
     - name: Test room-contract
       env:
         RUST_MIN_STACK: 8388608
@@ -198,6 +206,43 @@ jobs:
       # them. Without this step a fixture regression that vacuates the
       # windowing Playwright specs would pass CI silently.
       run: cargo test -p river-ui --bins --features example-data,no-sync
+
+    - name: Test chat-delegate (delegate dispatch, CAS envelopes, room subscription)
+      env:
+        RUST_MIN_STACK: 8388608
+        CARGO_TARGET_DIR: ${{ github.workspace }}/target
+      # 40 unit tests that had never run in CI (freenet/river#614) — the
+      # `Makefile.toml` `test-chat-delegate` task existed, but no workflow
+      # invoked it, so they gated only a developer's local `cargo make test`.
+      # That mattered more here than for a normal crate: this is where River's
+      # secret storage and its delegate-re-key migration path live, and the
+      # delegate is re-keyed roughly weekly (see freenet/river#612).
+      #
+      # No `--target x86_64-unknown-linux-gnu` pin, unlike the Makefile task.
+      # The pin there pairs with `--target-dir target/native` to keep a local
+      # host build from clobbering the wasm artifacts that the UI pulls in via
+      # `include_bytes!`. CI has no such conflict — `cargo make build` has
+      # already produced the wasm, and every test step above likewise builds
+      # for the host into the same CARGO_TARGET_DIR. The crate's default
+      # target is only wasm by convention of how it is built, not by a
+      # `[build] target` setting, so a bare host `cargo test` is correct.
+      #
+      # Scope caveat, so this is not over-read: on native targets
+      # `DelegateCtx`'s `set_secret` is a no-op and `get_secret` always returns
+      # `None` (freenet-stdlib's stub — see the cfg at handlers.rs:190). These
+      # tests cover dispatch and pure-value logic, NOT storage round-trips.
+      run: cargo test -p chat-delegate
+
+    - name: Test web-container-contract + web-container-tool
+      env:
+        RUST_MIN_STACK: 8388608
+        CARGO_TARGET_DIR: ${{ github.workspace }}/target
+      # Same gap as the chat-delegate, found while fixing it: 9 tests
+      # (6 lib + 2 integration + 1 in the tool) that `Makefile.toml` knows how
+      # to run and no workflow ever did. Includes
+      # `test_tool_and_contract_compatibility`, which pins that the signing
+      # tool and the verifying contract agree on the parameter encoding.
+      run: cargo test -p web-container-contract -p web-container-tool
 
   ui-playwright-tests:
     runs-on: freenet-default-runner

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,8 +229,17 @@ jobs:
       #
       # Scope caveat, so this is not over-read: on native targets
       # `DelegateCtx`'s `set_secret` is a no-op and `get_secret` always returns
-      # `None` (freenet-stdlib's stub — see the cfg at handlers.rs:190). These
-      # tests cover dispatch and pure-value logic, NOT storage round-trips.
+      # `None` (freenet-stdlib's stub — see the `cfg(not(target_family =
+      # "wasm"))` arm at handlers.rs:191-198). These tests cover dispatch and
+      # pure-value logic, NOT storage round-trips. Measured, not assumed:
+      # deleting the `set_key_index(...)` call from `handle_store_request` — a
+      # regression that would stop every room migrating — leaves all 40 of
+      # these tests passing.
+      #
+      # The migration behaviour is gated elsewhere: the #613 source-scrape pin
+      # `only_the_indexed_delegate_paths_register_keys_for_migration`, which
+      # runs in the `cargo test -p river-ui --bins` step above and does catch
+      # that deletion. Trust that step, not this one, for freenet/river#612.
       run: cargo test -p chat-delegate
 
     - name: Test web-container-contract + web-container-tool

--- a/scripts/check-ci-test-coverage.sh
+++ b/scripts/check-ci-test-coverage.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Fail if any workspace member has no `cargo test` step in build.yml.
+#
+# Why this exists (freenet/river#614): a test that no CI job runs is
+# indistinguishable from a test that passes. This repo has hit that failure at
+# least five times — river-ui's unit tests, riverctl's unit tests, the bulk of
+# river-core's lib tests, the nine common/tests files that an allowlist of
+# `--test <name>` steps silently skipped, and finally the chat-delegate's 40
+# tests, which never ran from the crate's creation until #614. Each time the
+# fix was "add the missing step", which fixes the instance and not the class.
+#
+# The class fix is this script: adding a workspace member without wiring its
+# tests into CI now fails CI. See the long-form comments in
+# .github/workflows/build.yml for the individual incidents.
+#
+# A member with genuinely no tests still needs a step — `cargo test -p <name>`
+# on a testless crate is fast and passes, and it means the day someone adds the
+# first test to that crate, it runs.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+workflow="$repo_root/.github/workflows/build.yml"
+root_manifest="$repo_root/Cargo.toml"
+
+[[ -f "$workflow" ]] || { echo "ERROR: $workflow not found" >&2; exit 1; }
+[[ -f "$root_manifest" ]] || { echo "ERROR: $root_manifest not found" >&2; exit 1; }
+
+# `run:` lines that invoke cargo test. Restricting to these means a package
+# named only in a build step or a comment does not count as covered.
+test_invocations="$(grep -E '^\s*(run:|-)?\s*cargo test ' "$workflow" || true)"
+
+if [[ -z "$test_invocations" ]]; then
+  echo "ERROR: build.yml contains no 'cargo test' invocations at all." >&2
+  exit 1
+fi
+
+members="$(sed -n '/^members = \[/,/^]/p' "$root_manifest" \
+  | grep -oE '"[^"]+"' | tr -d '"')"
+
+if [[ -z "$members" ]]; then
+  echo "ERROR: could not parse [workspace] members from $root_manifest" >&2
+  exit 1
+fi
+
+missing=0
+for member in $members; do
+  manifest="$repo_root/$member/Cargo.toml"
+  if [[ ! -f "$manifest" ]]; then
+    echo "ERROR: workspace member '$member' has no Cargo.toml" >&2
+    missing=1
+    continue
+  fi
+
+  pkg="$(grep -m1 -E '^name\s*=' "$manifest" | sed -E 's/^name\s*=\s*"(.*)".*/\1/')"
+  if [[ -z "$pkg" ]]; then
+    echo "ERROR: could not read package name from $manifest" >&2
+    missing=1
+    continue
+  fi
+
+  # Match `-p <pkg>` or `--package <pkg>`, requiring a word boundary so
+  # `-p web-container-contract` does not satisfy `web-container-tool`.
+  if grep -qE "(-p|--package)[= ]$pkg([[:space:]]|$)" <<<"$test_invocations"; then
+    echo "ok:      $pkg ($member)"
+  else
+    echo "MISSING: $pkg ($member) has no 'cargo test -p $pkg' step in build.yml" >&2
+    missing=1
+  fi
+done
+
+if (( missing )); then
+  cat >&2 <<'EOF'
+
+Every workspace member must have a `cargo test` step in
+.github/workflows/build.yml. Add one next to the existing per-crate steps:
+
+    - name: Test <crate>
+      env:
+        RUST_MIN_STACK: 8388608
+        CARGO_TARGET_DIR: ${{ github.workspace }}/target
+      run: cargo test -p <crate>
+
+Do not silence this check by deleting the member from the list it reads —
+it reads [workspace] members directly, which is the point (freenet/river#614).
+EOF
+  exit 1
+fi
+
+echo "All workspace members have a cargo test step in build.yml."

--- a/scripts/check-ci-test-coverage.sh
+++ b/scripts/check-ci-test-coverage.sh
@@ -14,6 +14,18 @@
 # tests into CI now fails CI. See the long-form comments in
 # .github/workflows/build.yml for the individual incidents.
 #
+# SCOPE — this catches the ZERO-STEP class only, which is narrower than the
+# list above may suggest. Two of those five incidents (river-core's bulk lib
+# tests, the nine common/tests files behind a `--test <name>` allowlist)
+# happened while river-core DID have `cargo test -p river-core --test X` steps
+# — a configuration this script passes. It checks that a member has SOME test
+# step, not that the step is ADEQUATE: a partial `--test <name>` allowlist
+# still satisfies it, and a file missing from such an allowlist is neither run
+# nor even compiled. Guarding that class needs a catch-all step instead — see
+# the `cargo test -p river-core --tests` comment in build.yml. Stating this
+# plainly because a guard that overclaims its own coverage is precisely the
+# failure mode this PR is about.
+#
 # A member with genuinely no tests still needs a step — `cargo test -p <name>`
 # on a testless crate is fast and passes, and it means the day someone adds the
 # first test to that crate, it runs.
@@ -29,18 +41,35 @@ root_manifest="$repo_root/Cargo.toml"
 
 # `run:` lines that invoke cargo test. Restricting to these means a package
 # named only in a build step or a comment does not count as covered.
-test_invocations="$(grep -E '^\s*(run:|-)?\s*cargo test ' "$workflow" || true)"
+# POSIX classes, not `\s` — `\s` is a GNU extension, so a dev running this on
+# macOS/BSD would otherwise get a spurious parse failure. CI is Linux, but this
+# script is meant to be runnable locally.
+test_invocations="$(grep -E '^[[:space:]]*(run:|-)?[[:space:]]*cargo test ' "$workflow" || true)"
 
 if [[ -z "$test_invocations" ]]; then
   echo "ERROR: build.yml contains no 'cargo test' invocations at all." >&2
   exit 1
 fi
 
-members="$(sed -n '/^members = \[/,/^]/p' "$root_manifest" \
-  | grep -oE '"[^"]+"' | tr -d '"')"
+# Capture the `members = [ ... ]` array, stopping at the closing bracket.
+# Accumulating until `]` handles both the multi-line form and a single-line
+# reformat; an earlier line-range version ran to EOF on the single-line form
+# and swept up unrelated values (it reported "member '2' has no Cargo.toml",
+# having picked up `resolver = "2"`). It failed closed, but unreadably.
+members_block="$(awk '
+  /^members[[:space:]]*=[[:space:]]*\[/ { inblock = 1 }
+  inblock { buf = buf $0; if (index($0, "]") > 0) { print buf; exit } }
+' "$root_manifest")"
+
+if [[ -z "$members_block" ]]; then
+  echo "ERROR: could not locate a 'members = [ ... ]' array in $root_manifest" >&2
+  exit 1
+fi
+
+members="$(grep -oE '"[^"]+"' <<<"$members_block" | tr -d '"')"
 
 if [[ -z "$members" ]]; then
-  echo "ERROR: could not parse [workspace] members from $root_manifest" >&2
+  echo "ERROR: [workspace] members in $root_manifest parsed as empty" >&2
   exit 1
 fi
 
@@ -53,7 +82,8 @@ for member in $members; do
     continue
   fi
 
-  pkg="$(grep -m1 -E '^name\s*=' "$manifest" | sed -E 's/^name\s*=\s*"(.*)".*/\1/')"
+  pkg="$(grep -m1 -E '^name[[:space:]]*=' "$manifest" \
+    | sed -E 's/^name[[:space:]]*=[[:space:]]*"(.*)".*/\1/')"
   if [[ -z "$pkg" ]]; then
     echo "ERROR: could not read package name from $manifest" >&2
     missing=1


### PR DESCRIPTION
## Problem

The `chat-delegate` crate has **40 unit tests that have never executed in CI**
(the issue estimated ~39; the exact count is 40 — 13 in `handlers.rs`, 15 in
`subscription/tests.rs`, 12 in `versioning.rs`).

`Makefile.toml` defines `test-chat-delegate` and rolls it into `cargo make
test`, but no workflow ever invoked it. `build.yml` has explicit steps for
`room-contract`, `river-core`, `riverctl` and `river-ui`; the delegate was
simply never added. The only workflows mentioning `chat-delegate` are
`check-cli-wasm.yml` and `check-delegate-migration.yml`, and neither runs
`cargo test` — the latter only does a WASM byte-hash comparison.

A test that no CI job runs is indistinguishable from a test that passes. That
is bad anywhere, and worse here: this is the crate where River's secret storage
and its delegate-re-key migration path live, and the delegate is re-keyed
roughly weekly (#612). A silent regression there destroys user identity.

**Found while fixing it, same bug, different crate:** `web-container-contract`
(6 lib + 2 integration tests) and `web-container-tool` (1 test) were also
never run by any workflow. That includes
`test_tool_and_contract_compatibility`, which pins that the signing tool and
the verifying contract agree on the parameter encoding.

Verified before changing anything, per the issue's request: the premise held in
full. No subset of the delegate's tests was running.

## Approach

Three changes to `.github/workflows/build.yml`:

1. **`cargo test -p chat-delegate`** — a step alongside the existing per-crate
   ones.
2. **`cargo test -p web-container-contract -p web-container-tool`** — the same
   gap, found while fixing the first.
3. **`scripts/check-ci-test-coverage.sh`** — a guard that fails CI when any
   `[workspace]` member has no `cargo test -p <name>` step in `build.yml`.

On the toolchain question the issue raised: **no `--target
x86_64-unknown-linux-gnu` pin is needed**, unlike the `Makefile.toml` task. The
pin there pairs with `--target-dir target/native` so a developer's local host
build cannot clobber the wasm artifacts the UI pulls in via `include_bytes!`.
CI has no such conflict — `cargo make build` has already produced the wasm, and
every existing test step likewise builds for the host into the same
`CARGO_TARGET_DIR`. The crate's default target is wasm only by convention of
how it is built, not by a `[build] target` setting, so a bare host `cargo test`
is correct. `room-contract`, also a wasm cdylib, is already wired exactly this
way.

**On the guard (point 3), which is the part not strictly asked for.** The
per-crate steps in `build.yml` carry comments recording four previous instances
of this same gap: river-ui's unit tests, riverctl's unit tests, the bulk of
river-core's lib tests, and the nine `common/tests` files that an allowlist of
`--test <name>` steps silently skipped. This issue is the fifth and sixth. Each
previous fix added the missing step, which fixes the instance and not the
class. The script reads `[workspace] members` directly and resolves each
member's package name from its own `Cargo.toml`, so adding a crate without
wiring its tests now fails CI. It is plain bash with no `jq`/`python`
dependency. Happy to drop it if reviewers consider it out of scope.

## Testing

No test rot: all 40 delegate tests passed unmodified on first run, as did all
9 web-container tests. Nothing was deleted, skipped, or `#[ignore]`d — the
before/after count of passing tests is 40 → 40 and 9 → 9. What changed is that
they now gate merges.

### Mutation evidence — the new delegate step can actually fail

Expectation stated before running: inverting one assertion in each of the three
test modules should produce exactly three failures and a non-zero exit, proving
all three modules genuinely execute rather than just one.

Mutations applied (`handlers.rs:832` `assert_eq!(result.len(), 1)` → `99`;
`versioning.rs:164` `assert_eq!(gen, 13)` → `14`; `subscription/tests.rs:192`
`assert_eq!(m1, m2)` → `assert_ne!`), then the exact command CI runs:

```
$ cargo test -p chat-delegate
thread 'handlers::tests::test_list_request' panicked at delegates/chat-delegate/src/handlers.rs:832:9:
assertion `left == right` failed
  left: 1
 right: 99

thread 'subscription::tests::does_not_rotate_when_member_set_unchanged' panicked at delegates/chat-delegate/src/subscription/tests.rs:192:5:
assertion `left != right` failed
  left: {MemberId(CUS7CJMI), MemberId(4FVVXL7J)}
 right: {MemberId(CUS7CJMI), MemberId(4FVVXL7J)}

thread 'versioning::tests::encode_decode_round_trip' panicked at delegates/chat-delegate/src/versioning.rs:164:9:
assertion `left == right` failed
  left: 13
 right: 14

failures:
    handlers::tests::test_list_request
    subscription::tests::does_not_rotate_when_member_set_unchanged
    versioning::tests::encode_decode_round_trip

test result: FAILED. 37 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out
error: test failed, to rerun pass `-p chat-delegate --lib`
$ echo $?   # 101
```

All mutations reverted; the tree is clean against the baseline.

### Mutation evidence — the guard can actually fail

Removing the `cargo test -p chat-delegate` line from `build.yml`:

```
$ ./scripts/check-ci-test-coverage.sh
ok:      river-core (common)
ok:      river-ui (ui)
ok:      riverctl (cli)
ok:      room-contract (contracts/room-contract)
ok:      web-container-contract (contracts/web-container-contract)
ok:      web-container-tool (contracts/web-container-contract/web-container-tool)
MISSING: chat-delegate (delegates/chat-delegate) has no 'cargo test -p chat-delegate' step in build.yml
$ echo $?   # 1
```

Unmutated, it reports all 7 members ok and exits 0.

### Scope caveat — what these 40 tests do NOT cover

Worth recording so the new green checkmark is not over-read. On native targets
`DelegateCtx`'s `set_secret` is a no-op and `get_secret` always returns `None`
(freenet-stdlib's stub; see the `cfg` at `handlers.rs:190`). So these tests
cover dispatch and pure-value logic, not storage round-trips.

Measured, rather than assumed: I removed the `set_key_index(...)` call from
`handle_store_request` — a genuine #612-class regression that would stop every
room from migrating — and **all 40 delegate tests still passed.** The
source-scrape pin added by #613 caught it:

```
$ cargo test -p river-ui --bins only_the_indexed_delegate_paths
test components::app::chat_delegate::tests::only_the_indexed_delegate_paths_register_keys_for_migration ... FAILED
panicked at ui/src/components/app/chat_delegate.rs:1494:13:
fn handle_store_request( must add its key to the delegate's key_index — that index is what the
migration probe's ListRequest enumerates, so a write that skips it is a write that never migrates
(freenet/river#612)
test result: FAILED. 0 passed; 1 failed
```

**Follow-up, deliberately not done here (issue #614 point 6):** that pin's own
comment says to move it into the delegate crate "once they are [wired into
CI]". This PR makes that possible. But the evidence above shows it must stay a
**source-scrape** when it moves — the behavioral version is still not
expressible against a stub ctx that never stores anything. Moving it also needs
care about self-matching: as an in-file pin its needles would appear in its own
assertion strings, so the existing body-slicing helper has to stay. Clean
separate PR.

Closes #614
Refs #612, #613, freenet/freenet-core#2776

[AI-assisted - Claude]
