### PR TITLE
fix(build): stale LEGACY_DELEGATES from undeclared registry input; missing registry now fatal

### DIFF
--- a/common/build.rs
+++ b/common/build.rs
@@ -11,20 +11,45 @@
 //! time, and emits the same `&[[u8; 32]]` const this script used to hand-roll.
 //! The TOML lives inside this crate (not at the repo root) so it is published
 //! with `river-core` and riverctl built from crates.io keeps the full
-//! registry; `allow_missing_registry` preserves the empty-list fallback for
-//! docs.rs and other non-workspace builds.
+//! registry. Because it ships with the package, a missing registry is a hard
+//! build failure everywhere except docs.rs — a blanket
+//! `allow_missing_registry(true)` would let any other missing-file case
+//! silently disable the dormant-room recovery via an empty table.
 
 use freenet_migrate_build::Component;
+
+/// A docs.rs build — the one environment granted the empty-registry fallback.
+fn docs_rs_build() -> bool {
+    std::env::var_os("DOCS_RS").is_some()
+}
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     // The crate emits cargo:rerun-if-changed for the TOML itself.
-    freenet_migrate_build::codegen()
+    let dest = freenet_migrate_build::codegen()
         .entry_registry("legacy_room_contracts.toml", Component::Contract)
         .canonical_consts(false)
         .contract_hash_view("LEGACY_ROOM_CONTRACT_CODE_HASHES")
         .out_file("legacy_room_contracts.rs")
-        .allow_missing_registry(true)
+        .allow_missing_registry(docs_rs_build())
         .emit()
         .expect("freenet-migrate-build: generate legacy room-contract hashes");
+
+    // Append-only registry; it can never legitimately be empty. An empty
+    // const silently disables the multi-hop dormant-room recovery (#292), so
+    // fail the build rather than ship it. Asserted on the GENERATED output —
+    // what actually ships — not on the input file.
+    if !docs_rs_build() {
+        let generated = std::fs::read_to_string(&dest)
+            .expect("read generated legacy_room_contracts.rs for the emptiness gate");
+        let rows = generated.matches("\n    [").count();
+        assert!(
+            rows > 0,
+            "generated LEGACY_ROOM_CONTRACT_CODE_HASHES has ZERO entries. The \
+             room-contract migration table would ship EMPTY and older \
+             generations of room state would silently stop being found. Check \
+             legacy_room_contracts.toml — this registry is append-only and \
+             must never be empty."
+        );
+    }
 }

--- a/common/tests/migration_test.rs
+++ b/common/tests/migration_test.rs
@@ -154,3 +154,43 @@ fn no_duplicate_delegate_keys() {
         );
     }
 }
+
+/// `common/build.rs` bakes `LEGACY_ROOM_CONTRACT_CODE_HASHES` from
+/// `legacy_room_contracts.toml`. The freenet-migrate-build crate declares the
+/// registry as a `rerun-if-changed` input by default; pin that nothing opts
+/// out, and that a missing registry fails a normal build instead of silently
+/// shipping an empty table (which disables the dormant-room recovery,
+/// freenet/river#292). Only non-comment lines count, so a commented-out call
+/// cannot satisfy the pin.
+#[test]
+fn build_script_keeps_registry_fresh_and_missing_registry_fatal() {
+    let src = include_str!("../build.rs");
+    let active: Vec<&str> = src
+        .lines()
+        .map(str::trim_start)
+        .filter(|l| !l.starts_with("//"))
+        .collect();
+    let has = |needle: &str| active.iter().any(|l| l.contains(needle));
+    let line_starts = |prefix: &str| active.iter().any(|l| l.starts_with(prefix));
+
+    assert!(
+        !has(".rerun_if_changed(false)"),
+        "common/build.rs must not disable the crate's registry \
+         rerun-if-changed directive — a stale build script ships a stale \
+         LEGACY_ROOM_CONTRACT_CODE_HASHES table"
+    );
+    assert!(
+        line_starts(r#"println!("cargo:rerun-if-changed=build.rs")"#),
+        "common/build.rs must declare itself as an input (emitting any \
+         directive disables Cargo's default re-run heuristic)"
+    );
+    assert!(
+        has(".allow_missing_registry(docs_rs_build())"),
+        "common/build.rs must gate the missing-registry leniency on docs.rs"
+    );
+    assert!(
+        !has(".allow_missing_registry(true)"),
+        "common/build.rs must not blanket-allow a missing registry — an empty \
+         table silently disables dormant-room recovery (freenet/river#292)"
+    );
+}

--- a/ui/build.rs
+++ b/ui/build.rs
@@ -1,13 +1,36 @@
 use chrono::Utc;
 use freenet_migrate_build::Component;
+use std::path::Path;
 use std::process::Command;
 
 fn main() {
+    // This script emits explicit `cargo:rerun-if-changed` directives, which
+    // disables Cargo's default re-run-on-any-package-change heuristic — so
+    // EVERY input the script reads must be declared, here or in
+    // `generate_legacy_delegates`. The previous revision instead emitted NO
+    // directives and relied on the default heuristic, but that heuristic only
+    // watches files inside this package: `../legacy_delegates.toml` lives at
+    // the workspace root, so editing it (exactly what `scripts/add-migration.sh`
+    // does) did NOT re-run this script, and a rebuild could ship a bundle whose
+    // baked `LEGACY_DELEGATES` omitted the outgoing delegate. The startup sweep
+    // then probes nobody and every returning user loses their rooms, silently —
+    // the delta#52 failure mode. See freenet/delta's `ui/build.rs` for the
+    // original of this shape.
+    println!("cargo:rerun-if-changed=build.rs");
     generate_build_info();
     generate_legacy_delegates();
 }
 
 fn generate_build_info() {
+    // `GIT_COMMIT_HASH` depends on git state, so declare the two files that
+    // decide it. `BUILD_TIMESTAMP_ISO` refreshes whenever this script re-runs
+    // (any declared input changed) and on demand via FORCE_REBUILD_TIMESTAMP —
+    // it is no longer stamped on literally every compile, but every publish
+    // follows a commit (HEAD moves), so a published build is always freshly
+    // stamped.
+    emit_git_ref_rerun_paths();
+    println!("cargo:rerun-if-env-changed=FORCE_REBUILD_TIMESTAMP");
+
     // Get the current UTC date and time
     let now = Utc::now();
     // Use ISO 8601 format (UTC) e.g., "2023-10-27T10:30:00Z"
@@ -20,16 +43,68 @@ fn generate_build_info() {
         build_timestamp_iso
     );
 
-    // Get git commit hash (short)
+    // Get git commit hash (short). Check the exit status, not just that the
+    // process spawned: git can spawn fine, exit non-zero, and write nothing,
+    // which would bake an empty string rather than "unknown".
     let git_hash = Command::new("git")
         .args(["rev-parse", "--short", "HEAD"])
         .output()
         .ok()
+        .filter(|o| o.status.success())
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "unknown".to_string());
 
     println!("cargo:rustc-env=GIT_COMMIT_HASH={}", git_hash);
+}
+
+/// Emit `rerun-if-changed` for the two git files that decide `GIT_COMMIT_HASH`:
+/// `HEAD` (which commit / branch) and `index` (staging, which moves on commit).
+///
+/// Do NOT hardcode `../.git/HEAD`: **in a git worktree `.git` is a FILE**
+/// holding `gitdir: …/.git/worktrees/<name>`, so a literal path does not
+/// resolve — and Cargo treats an unresolvable `rerun-if-changed` target as
+/// permanently dirty, re-running the script on every build. `git rev-parse
+/// --git-path` resolves correctly in both layouts.
+fn emit_git_ref_rerun_paths() {
+    for spec in ["HEAD", "index"] {
+        if let Some(path) = git_ref_path(spec) {
+            println!("cargo:rerun-if-changed={path}");
+        }
+    }
+}
+
+/// Resolve a git metadata file, or `None` if it cannot be resolved.
+///
+/// Returning `None` (no directive) is deliberate for the no-git case, e.g.
+/// building from a source tarball: emitting a nonexistent path would make the
+/// script permanently dirty, and `GIT_COMMIT_HASH` is already `"unknown"`
+/// whenever git cannot resolve HEAD, so there is nothing for a stale
+/// fingerprint to misreport.
+fn git_ref_path(spec: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--git-path", spec])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    // The existence check is the actual guard: `--git-path` returns a path
+    // whether or not the file is present, and a nonexistent path would
+    // re-introduce the always-dirty behaviour this function exists to avoid.
+    if path.is_empty() || !Path::new(&path).exists() {
+        return None;
+    }
+    Some(path)
+}
+
+/// A docs.rs build, the one environment where the registry legitimately does
+/// not exist (docs.rs builds the packaged crate, and the TOML lives at the
+/// workspace root, outside this package).
+fn docs_rs_build() -> bool {
+    std::env::var_os("DOCS_RS").is_some()
 }
 
 /// Generate the `LEGACY_DELEGATES` const from `../legacy_delegates.toml` via
@@ -38,21 +113,43 @@ fn generate_build_info() {
 /// with every hash — and each row's `delegate_key` derivation — validated at
 /// build time.
 ///
-/// * `.rerun_if_changed(false)`: we intentionally emit NO `cargo:rerun-if-changed`
-///   anywhere in this script — Cargo's default re-run heuristic is what keeps
-///   `BUILD_TIMESTAMP_ISO` fresh, and printing ANY such directive would disable
-///   it. We always regenerate; the crate only rewrites the file when content
-///   changed, so no spurious recompilation.
-/// * `.allow_missing_registry(true)`: the TOML lives at the repo root (outside
-///   this crate), so docs.rs / non-workspace builds fall back to an empty list.
+/// * `.rerun_if_changed(true)`: the crate declares the registry itself as an
+///   input, so `scripts/add-migration.sh` editing it invalidates the cached
+///   build script. This is load-bearing — see the comment in `main`.
+/// * `.allow_missing_registry(docs_rs_build())`: a missing registry is a HARD
+///   BUILD FAILURE except on docs.rs. The blanket `true` this replaces meant a
+///   missing file yielded an empty table with at most a `cargo:warning` — the
+///   same silent-total-migration-failure outcome as the staleness bug, by
+///   another route.
 fn generate_legacy_delegates() {
-    freenet_migrate_build::codegen()
+    let dest = freenet_migrate_build::codegen()
         .entry_registry("../legacy_delegates.toml", Component::Delegate)
         .canonical_consts(false)
         .delegate_pair_view("LEGACY_DELEGATES")
         .out_file("legacy_delegates.rs")
-        .rerun_if_changed(false)
-        .allow_missing_registry(true)
+        .rerun_if_changed(true)
+        .allow_missing_registry(docs_rs_build())
         .emit()
         .expect("freenet-migrate-build: generate legacy delegates");
+
+    // This registry is append-only and can never legitimately be empty: River
+    // re-keys its delegate regularly, so predecessors always exist and must be
+    // retained. An empty `LEGACY_DELEGATES` is silent total migration failure —
+    // the startup sweep asks no legacy delegate at all — so fail the build
+    // rather than ship it, whatever produced it (`freenet-migrate-build`
+    // accepts an entry-less TOML as a valid empty registry). Asserted on the
+    // GENERATED output, i.e. what actually ships, not on the input file.
+    if !docs_rs_build() {
+        let generated = std::fs::read_to_string(&dest)
+            .expect("read generated legacy_delegates.rs for the emptiness gate");
+        let rows = generated.matches("\n    (").count();
+        assert!(
+            rows > 0,
+            "generated LEGACY_DELEGATES has ZERO entries. The migration table \
+             would ship EMPTY, the startup sweep would ask no legacy delegate, \
+             and every returning user's rooms would be unrecoverable. Check \
+             ../legacy_delegates.toml — this registry is append-only and must \
+             never be empty."
+        );
+    }
 }

--- a/ui/src/util.rs
+++ b/ui/src/util.rs
@@ -1076,4 +1076,85 @@ mod tests {
              LEGACY_ROOM_CONTRACT_CODE_HASHES (freenet/river#292)"
         );
     }
+
+    /// `ui/build.rs` bakes `LEGACY_DELEGATES` from `../legacy_delegates.toml`,
+    /// which lives OUTSIDE this package — so Cargo's default re-run heuristic
+    /// (files in the package) never covers it, and only an explicit
+    /// `rerun-if-changed` keeps the baked table fresh. Without it,
+    /// `scripts/add-migration.sh` records a migration entry and the next build
+    /// ships a bundle whose table omits the outgoing delegate: the startup
+    /// sweep asks nobody and every returning user silently loses their rooms
+    /// (the delta#52 failure mode; reproduced in this repo 2026-08-11).
+    ///
+    /// Source scan, not a behavioural test: both shapes build identically —
+    /// the difference only shows up as a stale artifact in a NON-worktree
+    /// checkout, which no test harness here runs under. Only non-comment lines
+    /// count, so a commented-out directive cannot satisfy the pin (Delta's
+    /// first version of this pin had exactly that hole).
+    #[test]
+    fn build_script_declares_registry_and_timestamp_inputs() {
+        let src = include_str!("../build.rs");
+        let active: Vec<&str> = src
+            .lines()
+            .map(str::trim_start)
+            .filter(|l| !l.starts_with("//"))
+            .collect();
+        let has = |needle: &str| active.iter().any(|l| l.contains(needle));
+        let line_starts = |prefix: &str| active.iter().any(|l| l.starts_with(prefix));
+
+        // The registry directive itself is emitted by freenet-migrate-build;
+        // pin that build.rs explicitly opts IN and that nothing opts back out.
+        assert!(
+            has(".rerun_if_changed(true)"),
+            "ui/build.rs must keep .rerun_if_changed(true) on the codegen \
+             builder — the registry lives outside the package, so this \
+             directive is the ONLY thing keeping the baked LEGACY_DELEGATES \
+             fresh after scripts/add-migration.sh edits it"
+        );
+        assert!(
+            !has(".rerun_if_changed(false)"),
+            "ui/build.rs must not disable the registry rerun-if-changed \
+             directive — that re-opens the stale-migration-table bug (delta#52)"
+        );
+
+        // Emitting ANY rerun-if-changed disables Cargo's default heuristic,
+        // so the script's other inputs must be declared explicitly.
+        assert!(
+            line_starts(r#"println!("cargo:rerun-if-changed=build.rs")"#),
+            "ui/build.rs must declare itself as an input (the default \
+             heuristic is disabled once any directive is emitted)"
+        );
+        assert!(
+            has("rerun-if-env-changed=FORCE_REBUILD_TIMESTAMP"),
+            "ui/build.rs must keep the FORCE_REBUILD_TIMESTAMP escape hatch \
+             so BUILD_TIMESTAMP_ISO can be refreshed on demand"
+        );
+
+        // Git paths must be resolved via `git rev-parse --git-path`: a literal
+        // ../.git/HEAD does not resolve in a worktree (where .git is a file),
+        // and Cargo treats an unresolvable path as permanently dirty.
+        assert!(
+            has(r#""--git-path""#),
+            "ui/build.rs must resolve git metadata paths via \
+             `git rev-parse --git-path` so they work in both a worktree and a \
+             normal checkout"
+        );
+        assert!(
+            !has("../.git/"),
+            "ui/build.rs must not hardcode ../.git/ paths — they do not \
+             resolve in a worktree and make the script permanently dirty there"
+        );
+
+        // A missing registry must FAIL a normal build; the empty-table
+        // fallback is scoped to docs.rs only.
+        assert!(
+            has(".allow_missing_registry(docs_rs_build())"),
+            "ui/build.rs must gate the missing-registry leniency on docs.rs"
+        );
+        assert!(
+            !has(".allow_missing_registry(true)"),
+            "ui/build.rs must not blanket-allow a missing registry — an empty \
+             LEGACY_DELEGATES is silent total migration failure"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

`ui/build.rs` bakes `LEGACY_DELEGATES` — the delegate migration table — from `../legacy_delegates.toml`, but deliberately emitted **no** `cargo:rerun-if-changed` directives (`.rerun_if_changed(false)`), on the theory that Cargo's default heuristic "always regenerates". That theory is false: the default heuristic re-runs a build script when files **inside the package** change, and the registry lives at the **workspace root, outside the `ui` package**. So editing the registry does not invalidate the cached build script.

Reproduced in the main (non-worktree) checkout on this repo, before the fix:

```
$ cargo build -p river-ui          # baseline: Finished in 0.28s
$ echo "# repro: stale-registry probe" >> legacy_delegates.toml
$ cargo build -p river-ui
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.26s
# generated legacy_delegates.rs mtimes UNCHANGED across all build dirs
# (newest stayed 1785892298) — the build script never re-ran
```

`scripts/add-migration.sh` edits exactly that file. So the normal migration ritual — record the outgoing delegate's hash, rebuild, publish — can ship a bundle whose baked `LEGACY_DELEGATES` **omits the outgoing delegate**. The startup sweep then probes nobody and every returning user loses their rooms, with no error anywhere. This is the freenet/delta#52 failure mode (which stranded Delta users), reproduced in the app with the most users.

A worktree cannot reproduce this: there `.git` is a file, git-derived paths don't resolve, and Cargo treats the script as always-dirty — everything looks correct from exactly the vantage point the repo's own conventions mandate. That is why it survived this long.

Second route to the same outcome: `.allow_missing_registry(true)` meant a **missing** registry file yielded an empty table with at most a `cargo:warning` (which scrolls past unread in a release build). Same silent total-migration-failure, different trigger.

## Approach

Copied the shape Delta landed for this exact problem (`delta/ui/build.rs` on main), rather than inventing a new one:

- `ui/build.rs` now declares **every input it reads**: `build.rs` itself, the registry (via the crate's directive, `.rerun_if_changed(true)`), and the git `HEAD`/`index` files that decide `GIT_COMMIT_HASH` — resolved via `git rev-parse --git-path`, which works in both a normal checkout and a worktree (a literal `../.git/HEAD` doesn't resolve in a worktree and makes the script permanently dirty there).
- `.allow_missing_registry(docs_rs_build())` in both `ui/build.rs` and `common/build.rs`: a missing registry is now a **hard build failure** everywhere except docs.rs (the one environment where `../legacy_delegates.toml` legitimately isn't shipped; `common`'s TOML ships inside the `river-core` package, so its leniency is even narrower in practice).
- An emptiness gate on the **generated output** in both scripts: a registry that parses to zero entries fails the build. Both registries are append-only and can never legitimately be empty; the codegen crate accepts an entry-less TOML as valid, so this closes the renamed-section/truncated-file route to an empty table.
- `common/build.rs` was already fresh (the crate emits the registry directive by default) — it only gains the missing/empty gates.

### Behaviour change: `BUILD_TIMESTAMP_ISO` freshness

Reviewers should see this rather than discover it. Emitting any `rerun-if-changed` disables Cargo's default heuristic, so the timestamp is no longer stamped on literally every compile. The new guarantee is: **fresh whenever any declared input changes (build.rs, the registry, git HEAD/index — i.e. every commit or checkout), plus on demand via `FORCE_REBUILD_TIMESTAMP`**. Publishes follow a commit, so a published build is always freshly stamped. This is the same trade Delta made.

## Testing

Verified in a **fresh clone** (real `.git` directory — the layout where the bug lives and where `cargo make publish-river` runs; a worktree structurally cannot show it):

1. **Registry content change → rebuild + changed const**: edit a description in `legacy_delegates.toml` → build re-runs (4.85s), generated `legacy_delegates.rs` mtime advances, const content changes (`// V1: VERIFY-REBUILD probe` in the diff), `BUILD_TIMESTAMP_ISO` refreshes.
2. **No change → cheap no-op**: 0.29s, build-script output mtime and timestamp byte-identical — the fix does not make the script always-dirty (which would re-mask this bug class).
3. **Timestamp rule**: unchanged across a no-op build; refreshed by `FORCE_REBUILD_TIMESTAMP=1` (`21:50:46Z → 21:50:51Z`).
4. **Missing registry fails**: `mv legacy_delegates.toml` → exit 101 with `reading ../legacy_delegates.toml: No such file or directory`; `DOCS_RS=1` builds (empty-table fallback, docs.rs only); same hard failure for `common/legacy_room_contracts.toml` (exit 101).
5. **Worktree layout now caches too**: `--git-path` resolves the per-worktree paths, no-op build is 0.30s with the script not re-running — both layouts behave identically now.

Pin tests (source scans — both build shapes compile identically, so only a pin can hold this):

- `ui/src/util.rs::build_script_declares_registry_and_timestamp_inputs` — pins `.rerun_if_changed(true)`, the `build.rs` self-declaration, `FORCE_REBUILD_TIMESTAMP`, `--git-path` (and no literal `../.git/`), and the docs.rs-gated leniency. Anchored to **non-comment lines only**, so a commented-out directive does not satisfy it (Delta's first pin had exactly that hole).
- `common/tests/migration_test.rs::build_script_keeps_registry_fresh_and_missing_registry_fatal` — same pins for `common/build.rs`.

All four meaningful mutations were applied and observed to turn the pins red (`.rerun_if_changed(false)`, commenting out the self-declaration, `.allow_missing_registry(true)` in each file), then reverted.

Suites: `cargo test -p river-ui --bins` 895 passed; `river-core` `migration_test` 5 passed, `room_contract_migration_test` 4 passed. fmt/clippy clean.

**No WASM changes**: no delegate/contract/common source is touched; `ui/public/contracts/chat_delegate.wasm` is byte-identical (b3 `a44c64014d60fd245fe8fb5172f8fd7397039b248b3b6a8e95e89a0bb539fb5e`), so no migration entry is needed for this PR.

Scope note: this is a precursor to the freenet-migrate delegate-half adoption; it deliberately does not touch the sweep, the registry contents, or any delegate/contract source.

Risk tier: **Full** by surface — build/publish configuration on the data-loss-critical migration path.

[AI-assisted - Claude]
