### PR TITLE
feat(ui): adopt freenet-migrate 0.5 for the delegate-secret walk

### DIFF
--- a/.claude/rules/direct-messages.md
+++ b/.claude/rules/direct-messages.md
@@ -108,7 +108,14 @@ plaintext in the chat delegate.
   round-trip tests pin both shapes.
 - **UI in-memory cache**: `OUTBOUND_DMS: GlobalSignal<OutboundDmsCache>`
   keyed by `(VerifyingKey, MemberId, PurgeToken)`. Hydrated by
-  `fire_load_outbound_dms_request`.
+  `fire_load_outbound_dms_request`, and also by the crate walk's
+  `LiveImportSeam::merge_outbound_dms`. The hydrate helpers come in two
+  forms: the public `hydrate_*` wrappers defer their signal writes through
+  `util::defer`, while the `hydrate_*_now` cores do NOT and must therefore
+  only ever be called from inside a `defer` closure. The walk needs the
+  `_now` form because it has to know when the write has landed before it
+  flushes and seals a migration marker — deferring made `flush` snapshot
+  the pre-merge cache and seal `Done` over DM data that was never saved.
 - **Render path**: both `DmThreadModalBody` and `riverctl dm list` go
   through the shared pure helper
   `lookup_outbound_plaintext(cache, room, recipient, token)`. Cache
@@ -138,8 +145,9 @@ plaintext in the chat delegate.
 - **Legacy migration**: see `.claude/rules/river-publish.md` "How
   Delegate Migration Works". `outbound_dms` is a FIXED single key, so it
   must stay in the `storage_keys` probe array in
-  `fire_legacy_migration_request` AND keep its routing in
-  `response_handler.rs`. (Dynamic key families like `room:<vk>` are
+  `fire_legacy_migration_request`, keep its routing in
+  `response_handler.rs`, AND stay in the crate walk's own fixed-probe list
+  in `delegate_migration.rs` (three sites, not two). (Dynamic key families like `room:<vk>` are
   instead discovered via the legacy `ListRequest` path — see river-publish.md
   for that carve-out. `outbound_dms` is NOT dynamic, so the fixed probe
   is the right mechanism for it.)

--- a/.claude/rules/river-publish.md
+++ b/.claude/rules/river-publish.md
@@ -217,18 +217,57 @@ rooms on the current delegate but outbound DM plaintext only on a legacy
 delegate will not have those plaintexts migrated.
 
 **Adding new storage keys**: how to make a new top-level key survive a delegate
-rebuild depends on the key's shape:
+rebuild depends on the key's shape. Note there are now **three** sites, not two —
+the crate walk (below) carries its own fixed-probe list:
 - **Fixed, single-key** (like `outbound_dms`): add it to the `storage_keys`
-  array in `fire_legacy_migration_request` AND route its `GetResponse` in
-  `response_handler.rs` next to the existing `OUTBOUND_DMS_STORAGE_KEY` arm.
+  array in `fire_legacy_migration_request`, route its `GetResponse` in
+  `response_handler.rs` next to the existing `OUTBOUND_DMS_STORAGE_KEY` arm,
+  AND add it to the crate walk's fixed-probe list in
+  `ui/src/components/app/freenet_api/delegate_migration.rs` (the
+  `for fixed in [ROOMS_STORAGE_KEY, OUTBOUND_DMS_STORAGE_KEY]` loop, which is
+  asked even when unlisted because a frozen legacy WASM reports a corrupt index
+  as empty).
 - **Dynamic / open-ended key families** (like `room:<vk>`): a fixed probe can't
   enumerate them. They are discovered via the legacy `ListRequest` →
   `migrate_legacy_per_room` path instead. A new dynamic family needs its own
   branch there (and in the current-delegate `load_rooms_per_room`).
 
-Missing the relevant side leaves the new key orphaned across delegate rebuilds —
+Missing any of these leaves the new key orphaned across delegate rebuilds —
 exactly the bug the per-room `ListRequest` legacy probe (freenet/river#345) was
 added to prevent.
+
+## The crate walk (freenet-migrate) — the second, parallel recovery path
+
+Since freenet/river#398 phase 3 there are **two** migration mechanisms running
+side by side, and this file historically described only the first:
+
+1. the hand-rolled sweep documented above, which stays authoritative for the
+   user-facing load states; and
+2. the shared `freenet-migrate` crate's **walk**, which adds durable
+   per-predecessor markers and the library's classification.
+
+The walk is armed once per page load from the end of
+`fire_legacy_migration_request`, after the `any_dispatched` determination and
+gated on it (arming it when every send failed would burn the once-per-load
+latch on a dead transport). It waits for the sweep's load workers to settle
+before its first round-trip.
+
+Its durable markers live in the CURRENT delegate's KV store under
+`__migrate_pred_done__:<hex>` and `__migrate_pred_wip__:<hex>`, hex-encoded
+because the delegate's own key handling is `String::from_utf8_lossy`, which
+would alias two predecessors whose raw keys differ only in invalid UTF-8. These
+markers are what make the walk idempotent across page loads: a predecessor with
+a Done marker is never re-fetched.
+
+Because both mechanisms probe the same legacy delegates with the same
+correlation keys, a legacy `ListResponse` is routed to `migrate_legacy_per_room`
+only when no waiter consumed it (`!completed`) — otherwise the walk is already
+importing that delegate and a second concurrent migration would displace its
+reads in the single-waiter registry. See the comment at that call site for the
+counting argument and its two exceptions.
+
+Release 2 retires the sweep; until then, treat the sweep as authoritative and
+the walk as additive.
 
 ## Migration Limitations
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2312,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "freenet-migrate"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80de2864555343441300c6fa1aced20f989ec16657d651be3bb30bff1d1224c8"
+checksum = "866b434a07257c5bcda3b4e2a64c2c51e584ac7bc8664b91c0429352fb23e4fb"
 dependencies = [
  "blake3",
  "bs58",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -55,8 +55,9 @@ freenet-stdlib = { workspace = true, features = ["net"] }
 freenet-scaffold = "0.2.2"
 # Sans-IO backward-probe decision driver (freenet/river#398 phase 2b): drives
 # the legacy-generation recovery search (newest-first, first real generation
-# wins). Its stdlib dep unifies with the workspace's 0.8.x.
-freenet-migrate = "0.3"
+# wins). Its stdlib dep unifies with the workspace's 0.8.x. 0.5 is the same
+# contract-side API; the new surface is the delegate-secret walk the UI uses.
+freenet-migrate = "0.5"
 
 # Serialization (for contract state)
 ciborium = "0.2.2"

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -91,10 +91,11 @@ river-core = { workspace = true, features = ["ecies", "ecies-randomized", "migra
 # Freenet dependencies
 freenet-scaffold.workspace = true
 freenet-stdlib = { workspace = true, features = ["net"] }
-# Sans-IO backward-probe decision driver (freenet/river#398 phase 2). The `ui`
+# Sans-IO backward-probe decision driver (freenet/river#398 phase 2), plus the
+# 0.5 delegate-secret migration walk (freenet/river#398 phase 3). The `ui`
 # default profile exposes the probe/driver surface; its stdlib dep unifies with
 # the workspace's 0.8.x.
-freenet-migrate = "0.3"
+freenet-migrate = "0.5"
 
 futures = "0.3.30"
 futures-timer = "3.0.3"

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -255,6 +255,32 @@ pub fn is_legacy_delegate_key(key_bytes: &[u8]) -> bool {
         .any(|(dk, _)| dk.as_slice() == key_bytes)
 }
 
+/// The generated legacy registry, `(delegate_key, code_hash)` oldest-first.
+/// Exposed for the crate-migration walk (`delegate_migration.rs`), which
+/// builds its lineage from the SAME table the sweep probes so the two paths
+/// can never disagree about which generations exist.
+pub(crate) fn legacy_delegate_pairs() -> &'static [([u8; 32], [u8; 32])] {
+    LEGACY_DELEGATES
+}
+
+/// The current chat delegate's key (session-cached; see [`CHAT_DELEGATE_KEY`]).
+pub(crate) fn current_delegate_key() -> DelegateKey {
+    CHAT_DELEGATE_KEY.clone()
+}
+
+/// Whether `key` is the CURRENT chat delegate. Decides bare vs.
+/// delegate-scoped correlation in the crate-migration transport.
+pub(crate) fn is_current_delegate_key(key: &DelegateKey) -> bool {
+    *key == *CHAT_DELEGATE_KEY
+}
+
+/// Number of active awaited load workers (see [`PENDING_LOADS`]). The
+/// crate-migration walk polls this to let the initial load settle before
+/// starting its own round-trips.
+pub(crate) fn pending_load_workers() -> u32 {
+    PENDING_LOADS.load(Ordering::Relaxed)
+}
+
 // =============================================================================
 // DELEGATE-GENERATION AUTHORITY (freenet/river#527)
 // =============================================================================
@@ -6294,6 +6320,19 @@ pub(crate) async fn enqueue_delegate_request(
     enqueue_delegate_request_inner(CHAT_DELEGATE_KEY.clone(), request, key_bytes).await
 }
 
+/// Enqueue a request to a SPECIFIC (legacy) delegate, correlation scoped by the
+/// target delegate (see [`legacy_scoped_correlation`]) — the send/await split of
+/// [`send_delegate_request_to`]. Used by the crate-migration walk's pre-warm,
+/// which fires many probes concurrently; the per-delegate scoping is what makes
+/// that safe in the single-waiter `PENDING_REQUESTS` map.
+pub(crate) async fn enqueue_delegate_request_to(
+    delegate_key: DelegateKey,
+    request: ChatDelegateRequestMsg,
+) -> Result<PendingDelegateRequest, String> {
+    let key_bytes = legacy_scoped_correlation(&delegate_key, &get_request_key(&request));
+    enqueue_delegate_request_inner(delegate_key, request, key_bytes).await
+}
+
 /// Register the response waiter and SEND the request, WITHOUT awaiting the
 /// response. Returns a [`PendingDelegateRequest`] the caller awaits (once, or
 /// many concurrently via [`await_delegate_response`]).
@@ -6365,12 +6404,40 @@ async fn enqueue_delegate_request_inner(
     })
 }
 
+/// The typed outcome of awaiting a delegate response. The crate-migration
+/// walk needs the three cases kept apart: a timeout is SILENCE (never
+/// "absent"), and a cancellation is a displaced waiter (never an answer at
+/// all). String-matching the legacy error messages would make that mapping
+/// rot silently, hence the enum.
+pub(crate) enum DelegateAwaitOutcome {
+    /// The delegate executed and replied.
+    Response(ChatDelegateResponseMsg),
+    /// No response within the 10 s bound; the waiter was evicted.
+    TimedOut,
+    /// The waiter's sender was dropped without a response — another request
+    /// re-registered the same correlation key in the single-waiter
+    /// `PENDING_REQUESTS` map.
+    Cancelled,
+}
+
 /// Await the response for a request already sent via `enqueue_delegate_request*`.
 /// Many of these can be awaited concurrently (e.g. `join_all`) because each holds
 /// no `WEB_API` borrow — only its own oneshot receiver and timeout.
 pub(crate) async fn await_delegate_response(
     pending: PendingDelegateRequest,
 ) -> Result<ChatDelegateResponseMsg, String> {
+    match await_delegate_response_outcome(pending).await {
+        DelegateAwaitOutcome::Response(resp) => Ok(resp),
+        DelegateAwaitOutcome::Cancelled => Err("Response channel was cancelled".to_string()),
+        DelegateAwaitOutcome::TimedOut => Err("Timeout waiting for delegate response".to_string()),
+    }
+}
+
+/// [`await_delegate_response`] with the outcome kept as a typed
+/// [`DelegateAwaitOutcome`] instead of stringified errors.
+pub(crate) async fn await_delegate_response_outcome(
+    pending: PendingDelegateRequest,
+) -> DelegateAwaitOutcome {
     let PendingDelegateRequest {
         receiver,
         key_bytes,
@@ -6387,16 +6454,16 @@ pub(crate) async fn await_delegate_response(
         Either::Left((response, _)) => match response {
             Ok(resp) => {
                 debug!("Received delegate response: {:?}", resp);
-                Ok(resp)
+                DelegateAwaitOutcome::Response(resp)
             }
-            Err(_) => Err("Response channel was cancelled".to_string()),
+            Err(_) => DelegateAwaitOutcome::Cancelled,
         },
         Either::Right((_, _)) => {
             // Timeout occurred - remove the pending request
             if let Ok(mut pending) = PENDING_REQUESTS.lock() {
                 pending.remove(&key_bytes);
             }
-            Err("Timeout waiting for delegate response".to_string())
+            DelegateAwaitOutcome::TimedOut
         }
     }
 }

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -7657,22 +7657,6 @@ pub(crate) async fn fire_legacy_migration_request() -> bool {
         return false;
     }
 
-    // freenet/river#398 phase 3: run the shared `freenet-migrate` walk ALONGSIDE
-    // this hand-rolled sweep (release 1 — the sweep stays authoritative for the
-    // user-facing load states; the walk adds durable per-predecessor markers and
-    // the library's classification). Spawning HERE — after the #253-inherited
-    // done-gate and the per-session guard above — is what scopes the walk to
-    // "current delegate observed empty, or interrupted migration recovery", the
-    // same conditions this probe fires under. The latch is once-per-page-load;
-    // the walk itself waits for the sweep's load workers to settle before its
-    // first round-trip (the quiescence loop in `delegate_migration.rs`).
-    if super::freenet_api::delegate_migration::arm_crate_walk_once() {
-        crate::util::safe_spawn_local(async {
-            let _report =
-                super::freenet_api::delegate_migration::run_crate_delegate_migration().await;
-        });
-    }
-
     info!(
         "Attempting to migrate data from {} legacy delegate(s)",
         LEGACY_DELEGATES.len()
@@ -7820,6 +7804,32 @@ pub(crate) async fn fire_legacy_migration_request() -> bool {
     // the new attempt (whose own probe already ran / set it).
     if !any_dispatched && load_attempt_is_current(attempt) {
         LEGACY_MIGRATION_ATTEMPTED.store(false, Ordering::Relaxed);
+    }
+
+    // freenet/river#398 phase 3: run the shared `freenet-migrate` walk ALONGSIDE
+    // this hand-rolled sweep (release 1 — the sweep stays authoritative for the
+    // user-facing load states; the walk adds durable per-predecessor markers and
+    // the library's classification). Reaching HERE means we are past the
+    // #253-inherited done-gate and the per-session guard, which is what scopes
+    // the walk to "current delegate observed empty, or interrupted migration
+    // recovery" — the same conditions this probe fires under.
+    //
+    // Gated on `any_dispatched` for the same reason the guard reset above is:
+    // if EVERY send failed the connection is down, and arming the walk would
+    // burn its once-per-page-load shot on a dead transport. The sweep resets
+    // its own guard so a reconnect re-probes; without this gate the reconnect's
+    // re-probe would find the walk latch already armed and never run the walk
+    // at all for the rest of the page load.
+    //
+    // Still armed at most once per page load, so a reconnect can never stack a
+    // second concurrent walk — the property the latch exists for. The walk
+    // itself then waits for the sweep's load workers to settle before its first
+    // round-trip (the quiescence loop in `delegate_migration.rs`).
+    if any_dispatched && super::freenet_api::delegate_migration::arm_crate_walk_once() {
+        crate::util::safe_spawn_local(async {
+            let _report =
+                super::freenet_api::delegate_migration::run_crate_delegate_migration().await;
+        });
     }
     true
 }

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -4173,6 +4173,26 @@ mod tests {
             "cached CHAT_DELEGATE_KEY drifted from per-call construction"
         );
     }
+
+    /// The freenet-migrate adoption (freenet/river#398 phase 3) is UI-side
+    /// ONLY: the committed delegate WASM must be byte-identical to the one
+    /// shipping before it. A changed delegate WASM re-keys the delegate —
+    /// creating exactly the data-loss event `delegate_migration.rs` exists to
+    /// prevent — and requires the full migration ritual
+    /// (`.claude/rules/delegate-migration.md`) INCLUDING a new
+    /// `legacy_delegates.toml` entry, at which point this hash must be updated
+    /// alongside that entry, never alone.
+    #[test]
+    fn chat_delegate_wasm_is_byte_identical() {
+        let bytes = include_bytes!("../../../public/contracts/chat_delegate.wasm");
+        assert_eq!(
+            blake3::hash(bytes).to_hex().as_str(),
+            "a44c64014d60fd245fe8fb5172f8fd7397039b248b3b6a8e95e89a0bb539fb5e",
+            "chat_delegate.wasm changed — this branch must not alter the delegate WASM; \
+             if the change is intentional, follow .claude/rules/delegate-migration.md \
+             (add-migration BEFORE rebuilding) and update this pin in the same commit"
+        );
+    }
 }
 
 /// Remove a `room_owner_vk` from the per-session ensure-subscription dedup
@@ -7375,6 +7395,22 @@ pub(crate) async fn fire_legacy_migration_request() -> bool {
     if LEGACY_MIGRATION_ATTEMPTED.swap(true, Ordering::Relaxed) {
         info!("Legacy migration already attempted this session, skipping");
         return false;
+    }
+
+    // freenet/river#398 phase 3: run the shared `freenet-migrate` walk ALONGSIDE
+    // this hand-rolled sweep (release 1 — the sweep stays authoritative for the
+    // user-facing load states; the walk adds durable per-predecessor markers and
+    // the library's classification). Spawning HERE — after the #253-inherited
+    // done-gate and the per-session guard above — is what scopes the walk to
+    // "current delegate observed empty, or interrupted migration recovery", the
+    // same conditions this probe fires under. The latch is once-per-page-load;
+    // the walk itself waits for the sweep's load workers to settle before its
+    // first round-trip (the quiescence loop in `delegate_migration.rs`).
+    if super::freenet_api::delegate_migration::arm_crate_walk_once() {
+        crate::util::safe_spawn_local(async {
+            let _report =
+                super::freenet_api::delegate_migration::run_crate_delegate_migration().await;
+        });
     }
 
     info!(

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -5511,6 +5511,11 @@ pub fn hydrate_outbound_dms_cache(entries: Vec<OutboundDmEntry>) -> usize {
 /// See [`hydrate_hidden_dm_threads_now`] for why a caller would want this.
 pub(crate) fn hydrate_outbound_dms_cache_now(entries: Vec<OutboundDmEntry>) {
     use crate::components::direct_messages::OUTBOUND_DMS;
+    // Symmetric with `hydrate_hidden_dm_threads_now`: skip the GlobalSignal
+    // write entirely when there is nothing to merge.
+    if entries.is_empty() {
+        return;
+    }
     {
         let mut suppressed_any = false;
         OUTBOUND_DMS.with_mut(|cache| {

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -7900,7 +7900,14 @@ pub(crate) async fn fire_legacy_migration_request() -> bool {
     // at all for the rest of the page load.
     //
     // Still armed at most once per page load, so a reconnect can never stack a
-    // second concurrent walk — the property the latch exists for. The walk
+    // second concurrent walk — the property the latch exists for.
+    //
+    // Residual, deliberate: if every send failed AND a reconnect already bumped
+    // the attempt, neither the guard reset above (gated on still-current) nor
+    // this arming fires, so nothing retries for the rest of the page load. Not
+    // arming on a dead transport is the correct half — that is the whole point
+    // of the gate — and the durable markers make the next load retry. The
+    // guard-reset half is pre-existing behaviour, unchanged here. The walk
     // itself then waits for the sweep's load workers to settle before its first
     // round-trip (the quiescence loop in `delegate_migration.rs`).
     if any_dispatched && super::freenet_api::delegate_migration::arm_crate_walk_once() {

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -1921,6 +1921,190 @@ mod tests {
         assert_eq!(s1, legacy_scoped_correlation(&d1, &base));
     }
 
+    /// **Both sides of the correlation seam, for every variant that uses it.**
+    ///
+    /// The request side (`get_request_key`) and the response side
+    /// (`response_correlation_base`) are two independent derivations that MUST
+    /// agree, or the waiter registered by the request can never be completed by
+    /// the response. They disagreed for `ListResponse`, and the pre-existing
+    /// pin (`legacy_scoped_correlation_is_per_delegate`) could not see it: it
+    /// checked only that the request side produced distinct keys per delegate,
+    /// against a base (`b"list"`) that was not even the real one, and asserted
+    /// nothing about the response side. A mismatch across the seam was the only
+    /// interesting failure and the only one it could not detect.
+    ///
+    /// This drives the REAL functions on both sides, over matched
+    /// request/response pairs, so the seam is checked as a round trip.
+    #[test]
+    fn request_and_response_correlation_keys_round_trip() {
+        use river_core::chat_delegate::CasStoreResult;
+
+        let skey = ChatDelegateKey::new(b"room:some-owner-vk".to_vec());
+        let pairs: Vec<(&str, ChatDelegateRequestMsg, ChatDelegateResponseMsg)> = vec![
+            (
+                "Get",
+                ChatDelegateRequestMsg::GetRequest { key: skey.clone() },
+                ChatDelegateResponseMsg::GetResponse {
+                    key: skey.clone(),
+                    value: None,
+                },
+            ),
+            (
+                "Store",
+                ChatDelegateRequestMsg::StoreRequest {
+                    key: skey.clone(),
+                    value: vec![1, 2, 3],
+                },
+                ChatDelegateResponseMsg::StoreResponse {
+                    key: skey.clone(),
+                    value_size: 3,
+                    result: Ok(()),
+                },
+            ),
+            (
+                "Delete",
+                ChatDelegateRequestMsg::DeleteRequest { key: skey.clone() },
+                ChatDelegateResponseMsg::DeleteResponse {
+                    key: skey.clone(),
+                    result: Ok(()),
+                },
+            ),
+            (
+                "GetVersioned",
+                ChatDelegateRequestMsg::GetVersionedRequest { key: skey.clone() },
+                ChatDelegateResponseMsg::GetVersionedResponse {
+                    key: skey.clone(),
+                    value: None,
+                    generation: 0,
+                },
+            ),
+            (
+                "CasStore",
+                ChatDelegateRequestMsg::CasStoreRequest {
+                    key: skey.clone(),
+                    value: vec![4, 5],
+                    expected_generation: 0,
+                },
+                ChatDelegateResponseMsg::CasStoreResponse {
+                    key: skey.clone(),
+                    result: CasStoreResult::Stored { generation: 1 },
+                },
+            ),
+            (
+                // The variant that was broken. `ListRequest` carries no key, so
+                // there is nothing in the response to rebuild the base FROM —
+                // which is exactly why it is the one that drifted.
+                "List",
+                ChatDelegateRequestMsg::ListRequest,
+                ChatDelegateResponseMsg::ListResponse { keys: vec![] },
+            ),
+        ];
+
+        let legacy = DelegateKey::new([9u8; 32], freenet_stdlib::prelude::CodeHash::new([9u8; 32]));
+
+        for (name, request, response) in pairs {
+            let request_side = get_request_key(&request);
+            let response_side = response_correlation_base(&response).unwrap_or_else(|| {
+                panic!("{name}: response must correlate through PENDING_REQUESTS")
+            });
+            assert_eq!(
+                request_side, response_side,
+                "{name}: the request registers its waiter under one key and the \
+                 response completes under another — the waiter can never fire"
+            );
+
+            // ...and the delegate-scoped composition (the legacy-probe path,
+            // which is what the crate walk uses) must agree too. This is the
+            // half B1 actually broke: the bases matched, the SCOPING did not.
+            assert_eq!(
+                legacy_scoped_correlation(&legacy, &request_side),
+                legacy_scoped_correlation(&legacy, &response_side),
+                "{name}: scoped correlation must agree across the seam"
+            );
+            assert_ne!(
+                legacy_scoped_correlation(&legacy, &request_side),
+                request_side,
+                "{name}: a legacy-scoped key must differ from the bare one, or \
+                 scoping is a no-op and legacy/current reads can collide"
+            );
+        }
+    }
+
+    /// The response side must apply the legacy scoping in ONE place, over a
+    /// base it gets from the shared `response_correlation_base`.
+    ///
+    /// B1 existed because the scoping was applied per-variant, by hand, six
+    /// times — and one of the six forgot. The round-trip test above proves the
+    /// two derivations agree; this proves `response_handler.rs` actually routes
+    /// through them rather than reconstructing a key inline, which is the shape
+    /// that let a variant skip `scoped()` in the first place.
+    #[test]
+    fn response_handler_derives_correlation_keys_from_one_place() {
+        let rh_src = include_str!("freenet_api/response_handler.rs");
+        let production = rh_src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+
+        assert!(
+            production.contains("response_correlation_base(&response)"),
+            "response_handler.rs must derive storage-response correlation keys \
+             from the shared response_correlation_base()"
+        );
+        // No variant may rebuild the list base inline again — that literal
+        // living at the response side is precisely what drifted.
+        assert!(
+            !production.contains("b\"__list_request__\""),
+            "response_handler.rs must not hand-build the list correlation base; \
+             use list_request_correlation_key() via response_correlation_base()"
+        );
+        // Exactly one scoping site for the whole storage-response family.
+        assert_eq!(
+            production.matches("complete_pending_request(").count(),
+            1,
+            "there must be exactly ONE complete_pending_request call for storage \
+             responses, so no variant can be left unscoped (B1). Adding a second \
+             re-opens the per-variant shape that broke ListResponse."
+        );
+    }
+
+    /// A legacy `ListResponse` that a waiter already consumed must NOT also
+    /// spawn `migrate_legacy_per_room`.
+    ///
+    /// The sweep fires its ListRequest fire-and-forget (no waiter), so it still
+    /// drives the migration. The crate walk AWAITS its probes, so once B1's
+    /// routing fix lands its response is consumed — and spawning here as well
+    /// would run a second concurrent migration against the same legacy
+    /// delegate, whose per-key reads share the walk's scoped correlation keys.
+    /// Single-waiter displacement, `Cancelled` reads, and a possible false
+    /// `LoadFailed` for a user whose migration actually SUCCEEDED.
+    #[test]
+    fn consumed_legacy_list_response_does_not_double_spawn_migration() {
+        let rh_src = include_str!("freenet_api/response_handler.rs");
+        let production = rh_src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+
+        // Find the legacy branch of the ListResponse processing arm.
+        let arm = production
+            .split("ChatDelegateResponseMsg::ListResponse { keys }")
+            .nth(1)
+            .expect("the ListResponse processing arm must exist");
+        let spawn_at = arm
+            .find("migrate_legacy_per_room(")
+            .expect("the legacy branch must still spawn the sweep's migration");
+        let guard_at = arm.find("if !completed {").expect(
+            "the migrate_legacy_per_room spawn must be gated on !completed, \
+                 or a walk-consumed ListResponse spawns a duplicate concurrent \
+                 migration (B1)",
+        );
+        assert!(
+            guard_at < spawn_at,
+            "the !completed guard must precede the migrate_legacy_per_room spawn"
+        );
+    }
+
     /// `mark_room_rejoined` (set) / `clear_room_rejoined` (consume on leave) are
     /// the inputs to `present_action`'s rejoin override. A rejoin then a leave
     /// must NOT leave the flag set, or a later background update would resurrect
@@ -5271,9 +5455,18 @@ pub(crate) fn reset_dm_prune_tombstones() {
 }
 
 pub fn hydrate_outbound_dms_cache(entries: Vec<OutboundDmEntry>) -> usize {
-    use crate::components::direct_messages::OUTBOUND_DMS;
     let count = entries.len();
     crate::util::defer(move || {
+        hydrate_outbound_dms_cache_now(entries);
+    });
+    count
+}
+
+/// The body of [`hydrate_outbound_dms_cache`] WITHOUT the `defer` wrapper.
+/// See [`hydrate_hidden_dm_threads_now`] for why a caller would want this.
+pub(crate) fn hydrate_outbound_dms_cache_now(entries: Vec<OutboundDmEntry>) {
+    use crate::components::direct_messages::OUTBOUND_DMS;
+    {
         let mut suppressed_any = false;
         OUTBOUND_DMS.with_mut(|cache| {
             for entry in entries {
@@ -5320,8 +5513,7 @@ pub fn hydrate_outbound_dms_cache(entries: Vec<OutboundDmEntry>) -> usize {
         if suppressed_any {
             persist_sanitized_dm_store_after_tombstone_filter();
         }
-    });
-    count
+    }
 }
 
 /// Persist the sanitized outbound-DM store after a tombstone filter dropped a
@@ -5473,12 +5665,29 @@ pub(crate) fn resolve_hidden_thread_hydration(
 }
 
 pub fn hydrate_hidden_dm_threads(entries: Vec<HiddenDmThreadEntry>) -> usize {
-    use crate::components::direct_messages::HIDDEN_DM_THREADS;
     let count = entries.len();
     if count == 0 {
         return 0;
     }
     crate::util::defer(move || {
+        hydrate_hidden_dm_threads_now(entries);
+    });
+    count
+}
+
+/// The body of [`hydrate_hidden_dm_threads`] WITHOUT the `defer` wrapper, for a
+/// caller that must know when the write has actually landed.
+///
+/// The deferring wrapper is the right default for UI call sites (see the
+/// `defer()` rule in `.claude/rules/dioxus-signal-safety.md`), but it makes the
+/// write a MACROTASK: the caller returns before the signal is touched. A
+/// migration seam that merges and then flushes runs on microtasks, which drain
+/// first, so through the wrapper it would serialise the PRE-merge cache and
+/// then seal the predecessor as imported. Callers that need the write to have
+/// happened run this inside their own single `defer` and signal from there.
+pub(crate) fn hydrate_hidden_dm_threads_now(entries: Vec<HiddenDmThreadEntry>) {
+    use crate::components::direct_messages::HIDDEN_DM_THREADS;
+    {
         // Drop hidden-thread (archive) entries for a room that was overwritten
         // (freenet/river#414 P2-3, identity-based since round-9): they belong to
         // the replaced identity. Hidden entries carry no local-identity field, so
@@ -5524,8 +5733,7 @@ pub fn hydrate_hidden_dm_threads(entries: Vec<HiddenDmThreadEntry>) -> usize {
         if suppressed_any {
             persist_sanitized_dm_store_after_tombstone_filter();
         }
-    });
-    count
+    }
 }
 
 /// Outcome of [`decide_hide_action`]: should the caller (un)write the
@@ -6182,13 +6390,65 @@ pub(crate) fn get_versioned_correlation_key(key: &ChatDelegateKey) -> Vec<u8> {
     k
 }
 
+/// The correlation base for `ListRequest`/`ListResponse`.
+///
+/// `ListRequest` carries no key, so unlike every other KV op there is nothing in
+/// the response to rebuild a correlation key FROM — both sides must construct it
+/// from the same literal. When that literal was written out by hand at each side
+/// they drifted: the request side scoped it by target delegate
+/// (`legacy_scoped_correlation`) while the response side rebuilt it bare, so a
+/// legacy `ListRequest`'s waiter could never be completed. Both sides now call
+/// this, so the base cannot drift again; the delegate-scoping half is pinned
+/// separately by `legacy_list_request_round_trips_through_scoped_correlation`.
+pub(crate) fn list_request_correlation_key() -> Vec<u8> {
+    b"__list_request__".to_vec()
+}
+
+/// The response-side mirror of [`get_request_key`] for the storage ops that
+/// correlate through `PENDING_REQUESTS`.
+///
+/// `Some(base)` is the UNSCOPED correlation base; the caller applies
+/// `legacy_scoped_correlation` when the responding delegate is a legacy one,
+/// in exactly ONE place, so no individual variant can be left unscoped.
+/// `None` means the response correlates through a different registry
+/// (signing-key, public-key, sign, room-subscription) and this map is not
+/// involved.
+///
+/// This exists because the two sides of the seam were previously written out
+/// by hand, per variant, at two call sites — and drifted. `ListResponse` was
+/// rebuilt bare while its request had registered under a delegate-scoped key,
+/// so every legacy `ListRequest` waiter was uncompletable and the crate walk
+/// timed out on all 27 generations. Keeping the derivation here, paired with
+/// `get_request_key`, is what makes
+/// `request_and_response_correlation_keys_round_trip` able to check BOTH sides
+/// of the seam instead of one.
+pub(crate) fn response_correlation_base(response: &ChatDelegateResponseMsg) -> Option<Vec<u8>> {
+    match response {
+        ChatDelegateResponseMsg::GetResponse { key, .. }
+        | ChatDelegateResponseMsg::StoreResponse { key, .. }
+        | ChatDelegateResponseMsg::DeleteResponse { key, .. } => Some(key.as_bytes().to_vec()),
+        // CAS storage responses (freenet/river#345) correlate on DISTINCT keys
+        // (prefix + storage key) so they can't be confused with a concurrent
+        // plain Get/Store for the same storage key.
+        ChatDelegateResponseMsg::GetVersionedResponse { key, .. } => {
+            Some(get_versioned_correlation_key(key))
+        }
+        ChatDelegateResponseMsg::CasStoreResponse { key, .. } => {
+            Some(cas_store_correlation_key(key))
+        }
+        // `ListResponse` carries no key: the base is the shared literal.
+        ChatDelegateResponseMsg::ListResponse { .. } => Some(list_request_correlation_key()),
+        _ => None,
+    }
+}
+
 fn get_request_key(request: &ChatDelegateRequestMsg) -> Vec<u8> {
     match request {
         // Key-value storage operations
         ChatDelegateRequestMsg::StoreRequest { key, .. } => key.as_bytes().to_vec(),
         ChatDelegateRequestMsg::GetRequest { key } => key.as_bytes().to_vec(),
         ChatDelegateRequestMsg::DeleteRequest { key } => key.as_bytes().to_vec(),
-        ChatDelegateRequestMsg::ListRequest => b"__list_request__".to_vec(),
+        ChatDelegateRequestMsg::ListRequest => list_request_correlation_key(),
         // CAS storage ops use DISTINCT correlation keys (freenet/river#345)
         // so a concurrent plain Get/Store response for the same storage key
         // can't steal the awaiting save's slot. See the helper doc-comments.

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -1926,12 +1926,14 @@ mod tests {
     /// The request side (`get_request_key`) and the response side
     /// (`response_correlation_base`) are two independent derivations that MUST
     /// agree, or the waiter registered by the request can never be completed by
-    /// the response. They disagreed for `ListResponse`, and the pre-existing
-    /// pin (`legacy_scoped_correlation_is_per_delegate`) could not see it: it
-    /// checked only that the request side produced distinct keys per delegate,
-    /// against a base (`b"list"`) that was not even the real one, and asserted
-    /// nothing about the response side. A mismatch across the seam was the only
-    /// interesting failure and the only one it could not detect.
+    /// the response. They disagreed for `ListResponse`, and no pre-existing pin
+    /// could see it. `legacy_scoped_correlation_is_per_delegate` checks only
+    /// that the REQUEST side produces distinct keys per delegate;
+    /// `walk_is_sequential_and_prewarm_keys_are_distinct` (a different test, in
+    /// `delegate_migration.rs`) did the same against a stand-in base literal.
+    /// Neither asserted anything about the RESPONSE side, so a mismatch across
+    /// the seam was the only interesting failure and the only one neither
+    /// could detect.
     ///
     /// This drives the REAL functions on both sides, over matched
     /// request/response pairs, so the seam is checked as a round trip.
@@ -2013,19 +2015,37 @@ mod tests {
                  response completes under another — the waiter can never fire"
             );
 
-            // ...and the delegate-scoped composition (the legacy-probe path,
-            // which is what the crate walk uses) must agree too. This is the
-            // half B1 actually broke: the bases matched, the SCOPING did not.
-            assert_eq!(
-                legacy_scoped_correlation(&legacy, &request_side),
-                legacy_scoped_correlation(&legacy, &response_side),
-                "{name}: scoped correlation must agree across the seam"
+            // Round-trip through the REGISTRY, not just the two derivations:
+            // register a waiter exactly as `enqueue_delegate_request_to` does
+            // for a legacy target, then complete it exactly as the response
+            // handler does. This is the half B1 actually broke — the bases
+            // matched, the SCOPING did not — and comparing the two pure
+            // functions cannot observe it, because the scoping DECISION lives
+            // in `response_handler.rs` rather than in either function.
+            //
+            // A bare-key completion must NOT satisfy a scoped waiter, and the
+            // scoped one must.
+            let scoped_key = legacy_scoped_correlation(&legacy, &request_side);
+            let reply = response.clone();
+
+            let (tx, _rx) = futures::channel::oneshot::channel();
+            PENDING_REQUESTS
+                .lock()
+                .expect("pending requests lock")
+                .insert(scoped_key.clone(), tx);
+
+            assert!(
+                !complete_pending_request(
+                    &ChatDelegateKey::new(response_side.clone()),
+                    reply.clone()
+                ),
+                "{name}: completing under the BARE base must not satisfy a \
+                 legacy waiter — that is exactly B1"
             );
-            assert_ne!(
-                legacy_scoped_correlation(&legacy, &request_side),
-                request_side,
-                "{name}: a legacy-scoped key must differ from the bare one, or \
-                 scoping is a no-op and legacy/current reads can collide"
+            assert!(
+                complete_pending_request(&ChatDelegateKey::new(scoped_key), reply),
+                "{name}: completing under the scoped base must satisfy the \
+                 waiter the request registered"
             );
         }
     }
@@ -2057,6 +2077,22 @@ mod tests {
             !production.contains("b\"__list_request__\""),
             "response_handler.rs must not hand-build the list correlation base; \
              use list_request_correlation_key() via response_correlation_base()"
+        );
+        // The single site must actually APPLY the legacy scoping. Without this
+        // assertion the "one place" is only a tidier way to be wrong
+        // everywhere at once: dropping `scoped` here reproduces B1 for every
+        // storage variant, and now also kills the hand-rolled sweep's own
+        // per-room recovery (`migrate_legacy_per_room` reads through
+        // `send_delegate_request_to`, which is legacy-scoped) — a strictly
+        // wider blast radius than the bug this consolidation fixed.
+        assert!(
+            production.contains("&scoped(base)"),
+            "the single correlation site must scope the base by the responding \
+             delegate (scoped(base)); completing under the bare base is B1"
+        );
+        assert!(
+            production.contains("legacy_scoped_correlation("),
+            "the scoping helper must still be applied in production"
         );
         // Exactly one scoping site for the whole storage-response family.
         assert_eq!(
@@ -2102,6 +2138,15 @@ mod tests {
         assert!(
             guard_at < spawn_at,
             "the !completed guard must precede the migrate_legacy_per_room spawn"
+        );
+        // Ordering alone would also pass for `if !completed { debug!(..); }`
+        // followed by an UNGATED spawn, so require the spawn to be the guarded
+        // block's own first statement.
+        let guarded = &arm[guard_at + "if !completed {".len()..];
+        assert!(
+            guarded.trim_start().starts_with("let legacy_key"),
+            "the migrate_legacy_per_room spawn must be INSIDE the !completed \
+             block, not merely after it"
         );
     }
 
@@ -5687,6 +5732,15 @@ pub fn hydrate_hidden_dm_threads(entries: Vec<HiddenDmThreadEntry>) -> usize {
 /// happened run this inside their own single `defer` and signal from there.
 pub(crate) fn hydrate_hidden_dm_threads_now(entries: Vec<HiddenDmThreadEntry>) {
     use crate::components::direct_messages::HIDDEN_DM_THREADS;
+    // Shared with the wrapper rather than left there: `merge_outbound_dms`
+    // calls this directly, and `hidden_threads` is `#[serde(default)]`, so
+    // every predecessor whose store predates the archive feature would
+    // otherwise perform a no-op WRITE to a GlobalSignal — marking it dirty and
+    // notifying subscribers once per predecessor during migration. Given the
+    // #499/#555 contention family, gratuitous global-signal writes are not free.
+    if entries.is_empty() {
+        return;
+    }
     {
         // Drop hidden-thread (archive) entries for a room that was overwritten
         // (freenet/river#414 P2-3, identity-based since round-9): they belong to
@@ -6398,8 +6452,10 @@ pub(crate) fn get_versioned_correlation_key(key: &ChatDelegateKey) -> Vec<u8> {
 /// they drifted: the request side scoped it by target delegate
 /// (`legacy_scoped_correlation`) while the response side rebuilt it bare, so a
 /// legacy `ListRequest`'s waiter could never be completed. Both sides now call
-/// this, so the base cannot drift again; the delegate-scoping half is pinned
-/// separately by `legacy_list_request_round_trips_through_scoped_correlation`.
+/// this, so the base cannot drift again. The delegate-scoping half — the half
+/// B1 actually broke — is pinned by
+/// `request_and_response_correlation_keys_round_trip`, which round-trips
+/// through the real `PENDING_REQUESTS` registry.
 pub(crate) fn list_request_correlation_key() -> Vec<u8> {
     b"__list_request__".to_vec()
 }
@@ -6409,10 +6465,17 @@ pub(crate) fn list_request_correlation_key() -> Vec<u8> {
 ///
 /// `Some(base)` is the UNSCOPED correlation base; the caller applies
 /// `legacy_scoped_correlation` when the responding delegate is a legacy one,
-/// in exactly ONE place, so no individual variant can be left unscoped.
-/// `None` means the response correlates through a different registry
-/// (signing-key, public-key, sign, room-subscription) and this map is not
-/// involved.
+/// in exactly ONE place, so no individual variant of the STORAGE family can be
+/// left unscoped. (The four non-storage responses are not scoped at all; see
+/// the note on `None` below.)
+/// `None` means the response is correlated by one of the `complete_pending_*`
+/// helpers instead (signing-key, public-key, sign, room-subscription). Those
+/// use the SAME `PENDING_REQUESTS` map under their own prefixed keys — there
+/// is only one map. That matters: the request side scopes EVERY variant for a
+/// legacy target, while the response side scopes only the storage family, so
+/// if one of those four were ever sent to a legacy delegate it would be B1
+/// again, one layer over. Today none is (only `GetRequest` and `ListRequest`
+/// go to legacy delegates), which is what makes this safe.
 ///
 /// This exists because the two sides of the seam were previously written out
 /// by hand, per variant, at two call sites — and drifted. `ListResponse` was
@@ -6438,7 +6501,17 @@ pub(crate) fn response_correlation_base(response: &ChatDelegateResponseMsg) -> O
         }
         // `ListResponse` carries no key: the base is the shared literal.
         ChatDelegateResponseMsg::ListResponse { .. } => Some(list_request_correlation_key()),
-        _ => None,
+        // Enumerated, NOT a `_ =>` catch-all, deliberately. This function
+        // exists to stop per-variant correlation drift, and a catch-all would
+        // re-open exactly the class of bug B1 was: a newly added storage
+        // variant would silently correlate to nothing (`completed` stays
+        // false, the waiter never fires) instead of failing to compile. These
+        // four correlate through their own registries and never touch
+        // `PENDING_REQUESTS`.
+        ChatDelegateResponseMsg::StoreSigningKeyResponse { .. }
+        | ChatDelegateResponseMsg::GetPublicKeyResponse { .. }
+        | ChatDelegateResponseMsg::SignResponse { .. }
+        | ChatDelegateResponseMsg::EnsureRoomSubscriptionResponse { .. } => None,
     }
 }
 

--- a/ui/src/components/app/freenet_api.rs
+++ b/ui/src/components/app/freenet_api.rs
@@ -7,6 +7,7 @@ pub mod backward_probe;
 pub mod connection_manager;
 pub mod connection_watchdog;
 pub mod constants;
+pub mod delegate_migration;
 pub mod error;
 pub mod freenet_synchronizer;
 pub mod response_handler;

--- a/ui/src/components/app/freenet_api/delegate_migration.rs
+++ b/ui/src/components/app/freenet_api/delegate_migration.rs
@@ -83,6 +83,7 @@
 
 use std::collections::HashMap;
 use std::future::Future;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use dioxus::logger::tracing::{info, warn};
 use freenet_migrate::{
@@ -99,7 +100,7 @@ use crate::components::app::chat_delegate::{
     self, parse_room_storage_key, DelegateAwaitOutcome, OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY,
     ROOMS_STORAGE_KEY,
 };
-use crate::room_data::{MergeAuthority, MergeRanks, Rooms, RoomSlot, RoomsMeta};
+use crate::room_data::{MergeAuthority, MergeRanks, RoomSlot, Rooms, RoomsMeta};
 
 // ---------------------------------------------------------------------------
 // Marker keys (current delegate's KV store)
@@ -248,17 +249,19 @@ pub(crate) fn river_delegate_lineage(table: &[([u8; 32], [u8; 32])]) -> Vec<Dele
     table
         .iter()
         .enumerate()
-        .map(|(generation, (delegate_key, code_hash))| DelegateLineageEntry {
-            generation: generation as u32,
-            code_hash: *code_hash,
-            delegate_key: *delegate_key,
-            // True for rows whose recorded key does not derive from the code
-            // hash (River's V1). The walk never re-derives keys, so this is
-            // metadata — but `predecessor_delegate_keys_checked` would assert
-            // on it, so record it truthfully rather than hardcoding false.
-            irregular_key: blake3::hash(code_hash).as_bytes() != delegate_key,
-            note: "river legacy delegate",
-        })
+        .map(
+            |(generation, (delegate_key, code_hash))| DelegateLineageEntry {
+                generation: generation as u32,
+                code_hash: *code_hash,
+                delegate_key: *delegate_key,
+                // True for rows whose recorded key does not derive from the code
+                // hash (River's V1). The walk never re-derives keys, so this is
+                // metadata — but `predecessor_delegate_keys_checked` would assert
+                // on it, so record it truthfully rather than hardcoding false.
+                irregular_key: blake3::hash(code_hash).as_bytes() != delegate_key,
+                note: "river legacy delegate",
+            },
+        )
         .collect()
 }
 
@@ -335,11 +338,13 @@ impl<'a, C: RiverDelegateChannel> RiverPredecessorIo<'a, C> {
     /// single-waiter `PENDING_REQUESTS` map cannot drop one probe's waiter for
     /// another's.
     pub(crate) async fn prewarm(&mut self, predecessors: &[DelegateLineageEntry]) {
+        // A shared `&C` is what each concurrent probe captures — `self` stays
+        // free for the cache inserts after the join.
+        let channel = self.channel;
         let probes = predecessors.iter().map(|entry| {
             let key = DelegateKey::new(entry.delegate_key, CodeHash::new(entry.code_hash));
             async move {
-                let outcome = self
-                    .channel
+                let outcome = channel
                     .request(&key, ChatDelegateRequestMsg::ListRequest)
                     .await;
                 (key.bytes().to_vec(), outcome)
@@ -362,7 +367,10 @@ impl<'a, C: RiverDelegateChannel> RiverPredecessorIo<'a, C> {
     /// by the trait contract this runs only after `probe_executable` returned
     /// `Ok(true)`, so an index that cannot be read now is a fault to retry,
     /// NEVER an empty index.
-    async fn key_index(&mut self, predecessor: &DelegateKey) -> Result<Vec<ChatDelegateKey>, String> {
+    async fn key_index(
+        &mut self,
+        predecessor: &DelegateKey,
+    ) -> Result<Vec<ChatDelegateKey>, String> {
         if let Some(Prewarmed::Listed(keys)) = self.prewarmed.get(predecessor.bytes()) {
             return Ok(keys.clone());
         }
@@ -465,15 +473,12 @@ impl<C: RiverDelegateChannel> PredecessorSecretsIo for RiverPredecessorIo<'_, C>
                     .request(predecessor, ChatDelegateRequestMsg::ListRequest)
                     .await?;
                 let learned = match outcome {
-                    Some(ChatDelegateResponseMsg::ListResponse { keys }) => {
-                        Prewarmed::Listed(keys)
-                    }
+                    Some(ChatDelegateResponseMsg::ListResponse { keys }) => Prewarmed::Listed(keys),
                     Some(_) => Prewarmed::Executed,
                     None => Prewarmed::Silent,
                 };
                 let executable = learned != Prewarmed::Silent;
-                self.prewarmed
-                    .insert(predecessor.bytes().to_vec(), learned);
+                self.prewarmed.insert(predecessor.bytes().to_vec(), learned);
                 Ok(executable)
             }
         }
@@ -490,12 +495,12 @@ impl<C: RiverDelegateChannel> PredecessorSecretsIo for RiverPredecessorIo<'_, C>
         let listed = self.key_index(predecessor).await?;
         let mut pairs: Vec<SecretPair> = Vec::new();
         for storage_key in candidate_keys(&listed) {
-            match self.get_key(predecessor, &storage_key).await? {
-                Some(value) => pairs.push((storage_key, value)),
-                // Definitive absence — the delegate executed and said "no
-                // value". A legitimate skip, mirroring the sweep's
-                // `GetResponse { value: None }` arm.
-                None => {}
+            // A `None` here is definitive absence — the delegate executed and
+            // said "no value" — a legitimate skip, mirroring the sweep's
+            // `GetResponse { value: None }` arm. Anything unknown already
+            // aborted via the `?`.
+            if let Some(value) = self.get_key(predecessor, &storage_key).await? {
+                pairs.push((storage_key, value));
             }
         }
         Ok(pairs)
@@ -507,8 +512,9 @@ impl<C: RiverDelegateChannel> PredecessorSecretsIo for RiverPredecessorIo<'_, C>
 // ---------------------------------------------------------------------------
 
 /// What one recovered pair decodes to. Pure classification, split from the
-/// I/O so the mapping is unit-testable.
-#[derive(Debug)]
+/// I/O so the mapping is unit-testable. (No `Debug` derive: the payload types
+/// deliberately don't implement it — a `RoomData` debug-print would put
+/// private keys in logs.)
 pub(crate) enum RecoveredItem {
     /// A legacy single-blob `rooms_data` snapshot.
     RoomsBlob(Box<Rooms>),
@@ -693,10 +699,9 @@ impl RiverImportSeam for LiveImportSeam {
             // as in the sweep's hydrate: without `mark_room_rejoined` the
             // per-room CAS reconcile sees the delegate's tombstone, answers
             // AbortAdoptLeave, and the restored room stays tombstoned durably.
-            let resurrected: Vec<[u8; 32]> =
-                chat_delegate::with_identity_source_ranks(|ranks| {
-                    ranks.resurrected.drain().collect()
-                });
+            let resurrected: Vec<[u8; 32]> = chat_delegate::with_identity_source_ranks(|ranks| {
+                ranks.resurrected.drain().collect()
+            });
             for room_key in resurrected {
                 if let Ok(vk) = ed25519_dalek::VerifyingKey::from_bytes(&room_key) {
                     chat_delegate::mark_room_rejoined(vk);
@@ -791,7 +796,9 @@ impl<'a, C: RiverDelegateChannel, S: RiverImportSeam> RiverSuccessorIo<'a, C, S>
             Some(ChatDelegateResponseMsg::StoreResponse { result, .. }) => {
                 result.map_err(|e| format!("delegate refused marker store: {e}"))
             }
-            Some(other) => Err(format!("unexpected reply to marker StoreRequest: {other:?}")),
+            Some(other) => Err(format!(
+                "unexpected reply to marker StoreRequest: {other:?}"
+            )),
             None => Err("marker StoreRequest timed out".to_string()),
         }
     }
@@ -808,12 +815,18 @@ impl<C: RiverDelegateChannel, S: RiverImportSeam> SuccessorSecretsIo
     ) -> Result<Option<MigrationMarker>, Self::Error> {
         // `query.legacy_bridge` is ignored: River never used the crate's older
         // generation-keyed `import_secrets_once` markers (module docs).
-        if let Some(value) = self.get_marker(pred_done_marker_key(query.predecessor)).await? {
+        if let Some(value) = self
+            .get_marker(pred_done_marker_key(query.predecessor))
+            .await?
+        {
             return Ok(Some(MigrationMarker::Done {
                 had_data: value != PRED_DONE_MARKER_VALUE_EMPTY,
             }));
         }
-        match self.get_marker(pred_wip_marker_key(query.predecessor)).await? {
+        match self
+            .get_marker(pred_wip_marker_key(query.predecessor))
+            .await?
+        {
             Some(value) => Ok(Some(MigrationMarker::InProgress {
                 saw_data: value != PRED_DONE_MARKER_VALUE_EMPTY,
             })),
@@ -827,7 +840,9 @@ impl<C: RiverDelegateChannel, S: RiverImportSeam> SuccessorSecretsIo
         marker: MigrationMarker,
     ) -> Result<(), Self::Error> {
         let (key, data) = match marker {
-            MigrationMarker::InProgress { saw_data } => (pred_wip_marker_key(predecessor), saw_data),
+            MigrationMarker::InProgress { saw_data } => {
+                (pred_wip_marker_key(predecessor), saw_data)
+            }
             MigrationMarker::Done { had_data } => (pred_done_marker_key(predecessor), had_data),
         };
         let value = if data {
@@ -877,6 +892,28 @@ impl<C: RiverDelegateChannel, S: RiverImportSeam> SuccessorSecretsIo
 // Entry point
 // ---------------------------------------------------------------------------
 
+/// Page-load-scoped latch for the crate walk. A `static` is per-WASM-instance
+/// state, and a WASM instance lives exactly one page load — so "once per
+/// `static`" IS "once per page load". Deliberately NOT persisted anywhere:
+/// cross-load once-ness comes from the durable per-predecessor markers, and
+/// this latch only stops WebSocket reconnects within one load from stacking
+/// concurrent walks (Delta ships the same latch, untested; this one is
+/// exercised by `arm_walk_latch_fires_exactly_once`).
+static CRATE_WALK_ARMED: AtomicBool = AtomicBool::new(false);
+
+/// Arm the once-per-page-load crate walk. `true` exactly once per page load;
+/// every later call (reconnects, retry paths) gets `false` and must not spawn
+/// a second walk.
+pub(crate) fn arm_crate_walk_once() -> bool {
+    arm_walk_latch(&CRATE_WALK_ARMED)
+}
+
+/// Testable core of [`arm_crate_walk_once`] (the production latch is a global
+/// `static`, which a test cannot reset).
+fn arm_walk_latch(latch: &AtomicBool) -> bool {
+    !latch.swap(true, Ordering::Relaxed)
+}
+
 /// How long the walk will wait for the initial load (the hand-rolled sweep
 /// included) to settle before starting, so its round-trips don't contend with
 /// the sweep's single-waiter correlation slots. Bounded: after this it starts
@@ -904,24 +941,42 @@ pub(crate) async fn run_crate_delegate_migration() -> DelegateMigrationReport {
 
     let lineage = river_delegate_lineage(chat_delegate::legacy_delegate_pairs());
     let channel = NodeDelegateChannel;
-    let mut reader = RiverPredecessorIo::new(&channel);
-    reader.prewarm(&lineage).await;
-    let mut writer = RiverSuccessorIo::new(
+    let (report, _seam) = walk_with(
         &channel,
         LiveImportSeam::new(),
         chat_delegate::current_delegate_key(),
-    );
-    let report = freenet_migrate::migrate_delegate_secrets(
-        &mut writer,
-        &mut reader,
         &lineage,
-        MigrationAuthorization::app_author_ack(),
-        river_secret_policy(),
     )
     .await;
 
     log_migration_report(&report);
     report
+}
+
+/// The transport/seam-generic core of [`run_crate_delegate_migration`]:
+/// pre-warm the predecessors, then drive the crate's walk with River's reader
+/// and writer adapters. Production supplies [`NodeDelegateChannel`] +
+/// [`LiveImportSeam`]; the tests below supply mocks — everything in between
+/// (probe semantics, the union fetch, classification, ranked merge routing,
+/// marker bookkeeping) is EXACTLY the code production runs.
+pub(crate) async fn walk_with<C: RiverDelegateChannel, S: RiverImportSeam>(
+    channel: &C,
+    seam: S,
+    successor: DelegateKey,
+    lineage: &[DelegateLineageEntry],
+) -> (DelegateMigrationReport, S) {
+    let mut reader = RiverPredecessorIo::new(channel);
+    reader.prewarm(lineage).await;
+    let mut writer = RiverSuccessorIo::new(channel, seam, successor);
+    let report = freenet_migrate::migrate_delegate_secrets(
+        &mut writer,
+        &mut reader,
+        lineage,
+        MigrationAuthorization::app_author_ack(),
+        river_secret_policy(),
+    )
+    .await;
+    (report, writer.seam)
 }
 
 /// Log the walk's outcome. The report is METADATA ONLY and is never rendered
@@ -951,5 +1006,1064 @@ fn log_migration_report(report: &DelegateMigrationReport) {
         info!("crate-migration: walk incomplete; a later run may make progress");
     } else {
         warn!("crate-migration: walk incomplete with non-retryable rejections");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests (native). The scenario tests drive the REAL `freenet_migrate` driver
+// through `walk_with` with a scripted transport and an in-memory seam, so
+// everything between the transport and the signals — probe semantics, the
+// union fetch, classification, ranked-merge routing, marker bookkeeping — is
+// exactly the code production runs.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{SigningKey, VerifyingKey};
+    use freenet_migrate::{PredecessorMigration, WriterFailure, WriterStage};
+    use futures::executor::block_on;
+    use std::cell::{Cell, RefCell};
+    use std::collections::BTreeMap;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    // ---------------- fixtures ----------------
+
+    fn vk(seed: u8) -> VerifyingKey {
+        SigningKey::from_bytes(&[seed; 32]).verifying_key()
+    }
+
+    fn cbor<T: serde::Serialize>(v: &T) -> Vec<u8> {
+        let mut out = Vec::new();
+        ciborium::ser::into_writer(v, &mut out).expect("serialize fixture");
+        out
+    }
+
+    fn room_with_identity(owner: VerifyingKey, sk_seed: u8) -> crate::room_data::RoomData {
+        let mut rd = crate::room_data::test_minimal_room_data(owner);
+        rd.self_sk = Some(SigningKey::from_bytes(&[sk_seed; 32]));
+        rd
+    }
+
+    fn rooms_blob_with(owner: VerifyingKey, sk_seed: u8) -> Vec<u8> {
+        let mut rooms = empty_rooms();
+        rooms.map.insert(owner, room_with_identity(owner, sk_seed));
+        cbor(&rooms)
+    }
+
+    /// A 3-generation lineage over a synthetic registry. Delegate key bytes
+    /// `[10;32]`/`[11;32]`/`[12;32]` are generations 0/1/2.
+    fn table3() -> [([u8; 32], [u8; 32]); 3] {
+        [
+            ([10u8; 32], [110u8; 32]),
+            ([11u8; 32], [111u8; 32]),
+            ([12u8; 32], [112u8; 32]),
+        ]
+    }
+
+    fn lineage3() -> Vec<DelegateLineageEntry> {
+        river_delegate_lineage(&table3())
+    }
+
+    fn pred_key(gen_index: usize) -> DelegateKey {
+        let (k, ch) = table3()[gen_index];
+        DelegateKey::new(k, CodeHash::new(ch))
+    }
+
+    fn successor_key() -> DelegateKey {
+        DelegateKey::new([0xAA; 32], CodeHash::new([0xAB; 32]))
+    }
+
+    // ---------------- scripted transport ----------------
+
+    /// Yields once (waking itself) so concurrent mock requests genuinely
+    /// overlap under `join_all`, making `max_in_flight` a real measurement.
+    struct YieldOnce(bool);
+    impl std::future::Future for YieldOnce {
+        type Output = ();
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            if self.0 {
+                Poll::Ready(())
+            } else {
+                self.0 = true;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+    }
+
+    /// Scripted behaviour of one delegate on the mock node.
+    #[derive(Default)]
+    struct DelegateSim {
+        /// KV store; GETs answer from it, Stores land in it.
+        store: BTreeMap<Vec<u8>, Vec<u8>>,
+        /// Override what `ListRequest` reports (None = the store's keys).
+        /// `Some(vec![])` models the frozen legacy WASM's corrupt-index
+        /// behaviour: an empty list even though the store holds data.
+        listed: Option<Vec<Vec<u8>>>,
+        /// The whole delegate never answers (not installed / cannot execute).
+        silent: bool,
+        /// GETs for these keys never answer (per-key silence).
+        silent_get_keys: Vec<Vec<u8>>,
+        /// When a GET asks for `.0`, reply names key `.1` with value `.2` —
+        /// a mis-correlated answer.
+        wrong_key_reply: Option<(Vec<u8>, Vec<u8>, Vec<u8>)>,
+    }
+
+    #[derive(Default)]
+    struct MockChannel {
+        delegates: RefCell<HashMap<Vec<u8>, DelegateSim>>,
+        in_flight: Cell<usize>,
+        max_in_flight: Cell<usize>,
+        /// `(target delegate key bytes, "list" | "get:<key>" | "store:<key>")`
+        log: RefCell<Vec<(Vec<u8>, String)>>,
+    }
+
+    impl MockChannel {
+        fn with_delegate(self, key: &DelegateKey, sim: DelegateSim) -> Self {
+            self.delegates
+                .borrow_mut()
+                .insert(key.bytes().to_vec(), sim);
+            self
+        }
+        fn reset_counters(&self) {
+            self.in_flight.set(0);
+            self.max_in_flight.set(0);
+            self.log.borrow_mut().clear();
+        }
+        fn stored(&self, delegate: &DelegateKey, key: &[u8]) -> Option<Vec<u8>> {
+            self.delegates
+                .borrow()
+                .get(delegate.bytes())
+                .and_then(|sim| sim.store.get(key).cloned())
+        }
+        fn requests_to_predecessors(&self, kind: &str) -> usize {
+            let succ = successor_key().bytes().to_vec();
+            self.log
+                .borrow()
+                .iter()
+                .filter(|(target, what)| *target != succ && what.starts_with(kind))
+                .count()
+        }
+        fn answer(
+            &self,
+            target: &DelegateKey,
+            request: ChatDelegateRequestMsg,
+        ) -> Result<Option<ChatDelegateResponseMsg>, String> {
+            let mut delegates = self.delegates.borrow_mut();
+            let Some(sim) = delegates.get_mut(target.bytes()) else {
+                // Unknown delegate: the node has nothing registered — silence.
+                self.log
+                    .borrow_mut()
+                    .push((target.bytes().to_vec(), "unknown".into()));
+                return Ok(None);
+            };
+            match request {
+                ChatDelegateRequestMsg::ListRequest => {
+                    self.log
+                        .borrow_mut()
+                        .push((target.bytes().to_vec(), "list".into()));
+                    if sim.silent {
+                        return Ok(None);
+                    }
+                    let keys = sim
+                        .listed
+                        .clone()
+                        .unwrap_or_else(|| sim.store.keys().cloned().collect());
+                    Ok(Some(ChatDelegateResponseMsg::ListResponse {
+                        keys: keys.into_iter().map(ChatDelegateKey::new).collect(),
+                    }))
+                }
+                ChatDelegateRequestMsg::GetRequest { key } => {
+                    let kb = key.as_bytes().to_vec();
+                    self.log.borrow_mut().push((
+                        target.bytes().to_vec(),
+                        format!("get:{}", String::from_utf8_lossy(&kb)),
+                    ));
+                    if sim.silent || sim.silent_get_keys.iter().any(|k| *k == kb) {
+                        return Ok(None);
+                    }
+                    if let Some((asked, reply_key, reply_value)) = &sim.wrong_key_reply {
+                        if *asked == kb {
+                            return Ok(Some(ChatDelegateResponseMsg::GetResponse {
+                                key: ChatDelegateKey::new(reply_key.clone()),
+                                value: Some(reply_value.clone()),
+                            }));
+                        }
+                    }
+                    Ok(Some(ChatDelegateResponseMsg::GetResponse {
+                        key,
+                        value: sim.store.get(&kb).cloned(),
+                    }))
+                }
+                ChatDelegateRequestMsg::StoreRequest { key, value } => {
+                    let kb = key.as_bytes().to_vec();
+                    self.log.borrow_mut().push((
+                        target.bytes().to_vec(),
+                        format!("store:{}", String::from_utf8_lossy(&kb)),
+                    ));
+                    if sim.silent {
+                        return Ok(None);
+                    }
+                    let value_size = value.len();
+                    sim.store.insert(kb, value);
+                    Ok(Some(ChatDelegateResponseMsg::StoreResponse {
+                        key,
+                        value_size,
+                        result: Ok(()),
+                    }))
+                }
+                other => Err(format!("mock: unsupported request {other:?}")),
+            }
+        }
+    }
+
+    impl RiverDelegateChannel for MockChannel {
+        async fn request(
+            &self,
+            target: &DelegateKey,
+            request: ChatDelegateRequestMsg,
+        ) -> Result<Option<ChatDelegateResponseMsg>, String> {
+            self.in_flight.set(self.in_flight.get() + 1);
+            self.max_in_flight
+                .set(self.max_in_flight.get().max(self.in_flight.get()));
+            YieldOnce(false).await;
+            let out = self.answer(target, request);
+            self.in_flight.set(self.in_flight.get() - 1);
+            out
+        }
+    }
+
+    // ---------------- in-memory seam ----------------
+
+    /// In-memory [`RiverImportSeam`] holding a REAL `Rooms` + `MergeRanks`, so
+    /// merges route through the production `Rooms::merge_from_source` — the
+    /// #590/#527 machinery itself, not a reimplementation.
+    struct MemorySeam {
+        rooms: Rooms,
+        ranks: MergeRanks,
+        dm_merges: Vec<OutboundDmStore>,
+        flushes: usize,
+        fail_flush: bool,
+    }
+
+    impl MemorySeam {
+        fn new() -> Self {
+            Self {
+                rooms: empty_rooms(),
+                ranks: MergeRanks::default(),
+                dm_merges: Vec::new(),
+                flushes: 0,
+                fail_flush: false,
+            }
+        }
+    }
+
+    impl RiverImportSeam for MemorySeam {
+        async fn merge_rooms(&mut self, rooms: Rooms, source_rank: u32) -> Result<(), String> {
+            apply_recovered_rooms(&mut self.rooms, rooms, source_rank, &mut self.ranks)
+        }
+        async fn merge_outbound_dms(&mut self, store: OutboundDmStore) -> Result<(), String> {
+            self.dm_merges.push(store);
+            Ok(())
+        }
+        async fn flush(&mut self) -> Result<(), String> {
+            self.flushes += 1;
+            if self.fail_flush {
+                Err("coalesced save failed".to_string())
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    fn walk(channel: &MockChannel, seam: MemorySeam) -> (DelegateMigrationReport, MemorySeam) {
+        block_on(walk_with(channel, seam, successor_key(), &lineage3()))
+    }
+
+    // ---------------- the once-per-page-load latch ----------------
+
+    /// The latch arms exactly once. Mutating `arm_walk_latch` to always
+    /// return `true` (removing the latch) makes every reconnect spawn a
+    /// concurrent walk — this is the test that goes red.
+    #[test]
+    fn arm_walk_latch_fires_exactly_once() {
+        let latch = AtomicBool::new(false);
+        assert!(arm_walk_latch(&latch), "first arm must fire");
+        assert!(!arm_walk_latch(&latch), "second arm must NOT fire");
+        assert!(!arm_walk_latch(&latch), "later arms must NOT fire");
+    }
+
+    /// Source pin: the production spawn is gated on the latch, inside
+    /// `fire_legacy_migration_request` AFTER its #253-inherited done-gate and
+    /// per-session guard — deleting the latch call or hoisting the spawn above
+    /// the guards fails here.
+    #[test]
+    fn crate_walk_is_wired_behind_the_latch_and_the_253_gate() {
+        let src = include_str!("../chat_delegate.rs");
+        assert_eq!(
+            src.matches("run_crate_delegate_migration").count(),
+            1,
+            "exactly one call site for the walk in chat_delegate.rs"
+        );
+        // rfind: the signature also appears as a string literal inside
+        // chat_delegate.rs's own mid-file test module; the real definition is
+        // the last fn in that file.
+        let fn_start = src
+            .rfind("pub(crate) async fn fire_legacy_migration_request() -> bool {")
+            .expect("fire_legacy_migration_request must exist");
+        let body = &src[fn_start..];
+        let done_gate = body
+            .find("is_legacy_migration_done()")
+            .expect("the #253-inherited done-gate must exist");
+        let session_guard = body
+            .find("LEGACY_MIGRATION_ATTEMPTED.swap(true")
+            .expect("the per-session guard must exist");
+        let latch = body
+            .find("if super::freenet_api::delegate_migration::arm_crate_walk_once() {")
+            .expect("the spawn must be gated on arm_crate_walk_once()");
+        let spawn = body
+            .find("run_crate_delegate_migration")
+            .expect("the walk must be spawned in this function");
+        assert!(
+            done_gate < latch && session_guard < latch,
+            "the latch check must come after BOTH guards (inheriting the #253 gate)"
+        );
+        assert!(
+            latch < spawn,
+            "the spawn must be inside the latch-gated block"
+        );
+    }
+
+    // ---------------- marker keys ----------------
+
+    /// Marker keys must hex-encode the predecessor key. The delegate's
+    /// `create_origin_key` is `String::from_utf8_lossy`, which maps EVERY
+    /// invalid byte to U+FFFD — so two predecessors whose raw keys differ only
+    /// in invalid-UTF-8 bytes would alias onto ONE marker slot if the raw
+    /// bytes were embedded. Hex is pure ASCII: the lossy pass is the identity.
+    #[test]
+    fn marker_keys_hex_encode_the_predecessor_and_survive_utf8_lossy() {
+        let a = DelegateKey::new([0xFF; 32], CodeHash::new([1; 32]));
+        let mut b_bytes = [0xFF; 32];
+        b_bytes[0] = 0xFE; // still invalid UTF-8; lossy maps both to U+FFFD
+        let b = DelegateKey::new(b_bytes, CodeHash::new([1; 32]));
+
+        let ka = pred_done_marker_key(&a);
+        let kb = pred_done_marker_key(&b);
+        assert_ne!(ka, kb);
+        // The delegate-side aliasing check: after the lossy pass the two
+        // markers must STILL be distinct. Raw predecessor bytes fail this.
+        assert_ne!(
+            String::from_utf8_lossy(&ka),
+            String::from_utf8_lossy(&kb),
+            "marker keys must survive create_origin_key's utf8-lossy pass distinct"
+        );
+        assert!(ka.is_ascii(), "hex marker keys are pure ASCII");
+
+        let expected: String = [0xFFu8; 32].iter().map(|b| format!("{b:02x}")).collect();
+        assert_eq!(
+            ka,
+            [MIGRATE_PRED_DONE_PREFIX, expected.as_bytes()].concat(),
+            "done-marker key = prefix + lowercase hex of the predecessor key"
+        );
+        assert_eq!(
+            pred_wip_marker_key(&a),
+            [MIGRATE_PRED_WIP_PREFIX, expected.as_bytes()].concat(),
+            "wip-marker key = wip prefix + same hex"
+        );
+        assert!(is_migration_marker_key(&ka));
+        assert!(is_migration_marker_key(&pred_wip_marker_key(&a)));
+        assert!(!is_migration_marker_key(ROOMS_STORAGE_KEY));
+        assert!(!is_migration_marker_key(b"room:abc"));
+    }
+
+    // ---------------- candidate keys (the union rule) ----------------
+
+    /// The fixed probes are asked even when the (corruptible) legacy index
+    /// lists nothing; markers are excluded; `rooms_meta` goes last (its
+    /// `room_order` merge only keeps rooms already present).
+    #[test]
+    fn candidate_keys_union_fixed_probes_exclude_markers_meta_last() {
+        // Empty index still probes the single-blob era's keys.
+        assert_eq!(
+            candidate_keys(&[]),
+            vec![
+                ROOMS_STORAGE_KEY.to_vec(),
+                OUTBOUND_DMS_STORAGE_KEY.to_vec()
+            ],
+            "an empty legacy index must STILL probe rooms_data + outbound_dms"
+        );
+
+        let listed = vec![
+            ChatDelegateKey::new(b"room:abc".to_vec()),
+            ChatDelegateKey::new(ROOMS_META_KEY.to_vec()),
+            ChatDelegateKey::new(ROOMS_STORAGE_KEY.to_vec()),
+            ChatDelegateKey::new(pred_done_marker_key(&pred_key(0))),
+            ChatDelegateKey::new(pred_wip_marker_key(&pred_key(0))),
+            ChatDelegateKey::new(b"room:abc".to_vec()), // duplicate
+        ];
+        let keys = candidate_keys(&listed);
+        assert_eq!(
+            keys,
+            vec![
+                b"room:abc".to_vec(),
+                ROOMS_STORAGE_KEY.to_vec(),
+                OUTBOUND_DMS_STORAGE_KEY.to_vec(),
+                ROOMS_META_KEY.to_vec(),
+            ],
+            "dedup, no markers, fixed probes unioned, rooms_meta last"
+        );
+    }
+
+    // ---------------- classification ----------------
+
+    #[test]
+    fn classify_recovered_maps_each_key_family() {
+        let owner = vk(1);
+        let blob = rooms_blob_with(owner, 2);
+        assert!(matches!(
+            classify_recovered(ROOMS_STORAGE_KEY, &blob),
+            RecoveredItem::RoomsBlob(_)
+        ));
+        assert!(matches!(
+            classify_recovered(ROOMS_STORAGE_KEY, b"not cbor at all"),
+            RecoveredItem::Undecodable("rooms_data", _)
+        ));
+        let slot = cbor(&RoomSlot::Present(Box::new(room_with_identity(owner, 2))));
+        let room_key = chat_delegate::room_storage_key(&owner);
+        assert!(matches!(
+            classify_recovered(&room_key, &slot),
+            RecoveredItem::Room(k, RoomSlot::Present(_)) if k == owner
+        ));
+        let tomb = cbor(&RoomSlot::Tombstone);
+        assert!(matches!(
+            classify_recovered(&room_key, &tomb),
+            RecoveredItem::Room(_, RoomSlot::Tombstone)
+        ));
+        assert!(matches!(
+            classify_recovered(ROOMS_META_KEY, &cbor(&RoomsMeta::default())),
+            RecoveredItem::Meta(_)
+        ));
+        assert!(matches!(
+            classify_recovered(OUTBOUND_DMS_STORAGE_KEY, &cbor(&OutboundDmStore::default())),
+            RecoveredItem::OutboundDms(_)
+        ));
+        assert!(matches!(
+            classify_recovered(&pred_done_marker_key(&pred_key(0)), b"1"),
+            RecoveredItem::MigrationMarker
+        ));
+        assert!(matches!(
+            classify_recovered(b"some_future_key", b"whatever"),
+            RecoveredItem::Unrecognized
+        ));
+    }
+
+    /// A legacy blob's `current_room_key` is years-stale by construction and
+    /// must never dictate selection (freenet/river#255) — stripped for the
+    /// blob AND dropped from `rooms_meta`.
+    #[test]
+    fn rooms_to_merge_strips_the_legacy_cursor() {
+        let owner = vk(1);
+        let mut rooms = empty_rooms();
+        rooms.map.insert(owner, room_with_identity(owner, 2));
+        rooms.current_room_key = Some(owner);
+        let item = RecoveredItem::RoomsBlob(Box::new(rooms));
+        let merged = rooms_to_merge(&item).expect("blob converts");
+        assert_eq!(
+            merged.current_room_key, None,
+            "legacy cursor must be stripped"
+        );
+        assert!(merged.map.contains_key(&owner));
+
+        let meta = RecoveredItem::Meta(RoomsMeta {
+            current_room_key: Some(owner),
+            notification_modes: HashMap::new(),
+            room_order: vec![owner],
+        });
+        let merged = rooms_to_merge(&meta).expect("meta converts");
+        assert_eq!(merged.current_room_key, None, "meta cursor must be dropped");
+        assert_eq!(merged.room_order, vec![owner]);
+
+        let tomb = RecoveredItem::Room(owner, RoomSlot::Tombstone);
+        let merged = rooms_to_merge(&tomb).expect("tombstone converts");
+        assert!(merged.removed_rooms.contains(&owner));
+        assert!(merged.map.is_empty());
+    }
+
+    // ---------------- lineage ----------------
+
+    /// The lineage is the registry, one entry per generation, in order — a
+    /// mutation that DROPS or reorders a generation fails here.
+    #[test]
+    fn lineage_covers_every_registry_row_in_order() {
+        let table = table3();
+        let lineage = river_delegate_lineage(&table);
+        assert_eq!(
+            lineage.len(),
+            table.len(),
+            "every generation must be walked"
+        );
+        for (i, entry) in lineage.iter().enumerate() {
+            assert_eq!(entry.generation, i as u32);
+            assert_eq!(entry.delegate_key, table[i].0);
+            assert_eq!(entry.code_hash, table[i].1);
+        }
+        // irregular_key is truthful: a derivable row reads false, a
+        // non-derivable one (River's V1) reads true.
+        let derived = *blake3::hash(&[7u8; 32]).as_bytes();
+        let regular = river_delegate_lineage(&[([0u8; 32], [7u8; 32]), (derived, [7u8; 32])]);
+        assert!(
+            regular[0].irregular_key,
+            "non-derivable key must be flagged"
+        );
+        assert!(
+            !regular[1].irregular_key,
+            "derivable key must not be flagged"
+        );
+    }
+
+    /// THE RANK-SCALE AGREEMENT PIN: `RecoveredSecret::generation` is used
+    /// directly as the merge's `source_rank`, which is only sound because the
+    /// lineage generation and the sweep's `source_rank_for_delegate_key` are
+    /// the SAME scale (the `LEGACY_DELEGATES` index). Run against the REAL
+    /// registry: if either side reorders, this fails.
+    #[test]
+    fn lineage_generation_matches_the_sweep_merge_rank_scale() {
+        let pairs = chat_delegate::legacy_delegate_pairs();
+        assert!(
+            pairs.len() >= 20,
+            "the real registry has 20+ generations; got {} — wrong table?",
+            pairs.len()
+        );
+        let lineage = river_delegate_lineage(pairs);
+        for (entry, (dk, _)) in lineage.iter().zip(pairs.iter()) {
+            assert_eq!(
+                entry.generation,
+                chat_delegate::source_rank_for_delegate_key(dk.as_slice()),
+                "lineage generation and sweep merge rank diverged for a registry row"
+            );
+        }
+    }
+
+    // ---------------- scenarios through the real driver ----------------
+
+    /// The recovery walk end-to-end: a single-blob-era generation, a
+    /// per-room-era generation, and an empty newest generation. Everything is
+    /// recovered, every predecessor is sealed with a DURABLE marker on the
+    /// successor, and the marker value distinguishes data from empty.
+    #[test]
+    fn full_walk_recovers_all_generations_and_seals_durable_markers() {
+        let room_a = vk(1);
+        let room_b = vk(2);
+        let mut gen0 = DelegateSim::default();
+        gen0.store
+            .insert(ROOMS_STORAGE_KEY.to_vec(), rooms_blob_with(room_a, 3));
+        gen0.store.insert(
+            OUTBOUND_DMS_STORAGE_KEY.to_vec(),
+            cbor(&OutboundDmStore::default()),
+        );
+        let mut gen1 = DelegateSim::default();
+        gen1.store.insert(
+            chat_delegate::room_storage_key(&room_b),
+            cbor(&RoomSlot::Present(Box::new(room_with_identity(room_b, 4)))),
+        );
+        gen1.store.insert(
+            ROOMS_META_KEY.to_vec(),
+            cbor(&RoomsMeta {
+                current_room_key: Some(room_b),
+                notification_modes: HashMap::new(),
+                room_order: vec![room_b],
+            }),
+        );
+        let channel = MockChannel::default()
+            .with_delegate(&pred_key(0), gen0)
+            .with_delegate(&pred_key(1), gen1)
+            .with_delegate(&pred_key(2), DelegateSim::default()) // executes, no data
+            .with_delegate(&successor_key(), DelegateSim::default());
+
+        let (report, seam) = walk(&channel, MemorySeam::new());
+
+        assert!(
+            report.is_complete(),
+            "clean walk must be complete: {report:?}"
+        );
+        assert!(!report.any_unresponsive());
+        assert!(
+            seam.rooms.map.contains_key(&room_a),
+            "single-blob era recovered"
+        );
+        assert!(
+            seam.rooms.map.contains_key(&room_b),
+            "per-room era recovered"
+        );
+        assert_eq!(
+            seam.rooms.current_room_key, None,
+            "legacy cursor never adopted"
+        );
+        assert_eq!(
+            seam.rooms.room_order,
+            vec![room_b],
+            "meta view prefs recovered"
+        );
+        assert_eq!(seam.dm_merges.len(), 1, "outbound-DM store recovered");
+        assert!(seam.flushes >= 2, "each data-bearing predecessor flushes");
+
+        // Durable markers on the SUCCESSOR, value distinguishing data/empty.
+        assert_eq!(
+            channel.stored(&successor_key(), &pred_done_marker_key(&pred_key(0))),
+            Some(PRED_DONE_MARKER_VALUE_DATA.to_vec())
+        );
+        assert_eq!(
+            channel.stored(&successor_key(), &pred_done_marker_key(&pred_key(1))),
+            Some(PRED_DONE_MARKER_VALUE_DATA.to_vec())
+        );
+        assert_eq!(
+            channel.stored(&successor_key(), &pred_done_marker_key(&pred_key(2))),
+            Some(PRED_DONE_MARKER_VALUE_EMPTY.to_vec()),
+            "an executed-but-empty predecessor seals with the EMPTY value"
+        );
+    }
+
+    /// The durable-marker payoff: a second page load's walk short-circuits on
+    /// the sealed markers — no predecessor is re-fetched (this is what fixes
+    /// the gateway-iframe re-probe waste, where localStorage cannot persist
+    /// the sweep's own done flag).
+    #[test]
+    fn a_second_walk_short_circuits_on_the_durable_markers() {
+        let room_a = vk(1);
+        let mut gen0 = DelegateSim::default();
+        gen0.store
+            .insert(ROOMS_STORAGE_KEY.to_vec(), rooms_blob_with(room_a, 3));
+        let channel = MockChannel::default()
+            .with_delegate(&pred_key(0), gen0)
+            .with_delegate(&pred_key(1), DelegateSim::default())
+            .with_delegate(&pred_key(2), DelegateSim::default())
+            .with_delegate(&successor_key(), DelegateSim::default());
+
+        let (first, _) = walk(&channel, MemorySeam::new());
+        assert!(first.is_complete());
+
+        channel.reset_counters();
+        let (second, seam) = walk(&channel, MemorySeam::new());
+        assert!(
+            second
+                .predecessors
+                .iter()
+                .all(|p| matches!(p, PredecessorMigration::AlreadyMigrated { .. })),
+            "sealed predecessors must short-circuit: {second:?}"
+        );
+        assert_eq!(
+            channel.requests_to_predecessors("get:"),
+            0,
+            "a sealed predecessor must never be re-fetched"
+        );
+        assert!(
+            seam.rooms.map.is_empty(),
+            "nothing re-imported on a sealed walk"
+        );
+    }
+
+    /// **Timeout is not absence** (the freenet-migrate#19 override). A
+    /// predecessor that proves executable but goes silent on a GET must be
+    /// `Unresponsive` — never `NoData`, never sealed. Collapsing the silent
+    /// GET into "absent" seals the predecessor EMPTY and strands its data
+    /// forever; that mutation turns all three assertions red.
+    #[test]
+    fn a_silent_get_is_unresponsive_never_absent_never_sealed() {
+        let room_a = vk(1);
+        let mut gen0 = DelegateSim::default();
+        gen0.store
+            .insert(ROOMS_STORAGE_KEY.to_vec(), rooms_blob_with(room_a, 3));
+        gen0.silent_get_keys = vec![ROOMS_STORAGE_KEY.to_vec()];
+        let channel = MockChannel::default()
+            .with_delegate(&pred_key(0), gen0)
+            .with_delegate(&pred_key(1), DelegateSim::default())
+            .with_delegate(&pred_key(2), DelegateSim::default())
+            .with_delegate(&successor_key(), DelegateSim::default());
+
+        let (report, seam) = walk(&channel, MemorySeam::new());
+
+        assert!(
+            report.predecessors.iter().any(|p| matches!(
+                p,
+                PredecessorMigration::Unresponsive {
+                    generation: 0,
+                    error: Some(_),
+                    ..
+                }
+            )),
+            "a silent GET after a positive probe is a FAULT: {report:?}"
+        );
+        assert!(!report.is_complete());
+        assert!(report.retry_may_help(), "the walk must retry next load");
+        assert_eq!(
+            channel.stored(&successor_key(), &pred_done_marker_key(&pred_key(0))),
+            None,
+            "a predecessor that went silent must NOT be sealed"
+        );
+        assert!(seam.rooms.map.is_empty());
+    }
+
+    /// A predecessor whose probe gets silence (never installed, or broken) is
+    /// `Unresponsive` — and under River's Union policy the walk CONTINUES to
+    /// older generations instead of stranding them (freenet/river#204).
+    /// Switching the policy to `NewestSnapshotWins` supersedes gen 0 and
+    /// turns this red.
+    #[test]
+    fn a_silent_predecessor_does_not_halt_the_union_walk() {
+        let room_a = vk(1);
+        let mut gen0 = DelegateSim::default();
+        gen0.store
+            .insert(ROOMS_STORAGE_KEY.to_vec(), rooms_blob_with(room_a, 3));
+        let mut gen2 = DelegateSim::default();
+        gen2.silent = true;
+        let channel = MockChannel::default()
+            .with_delegate(&pred_key(0), gen0)
+            .with_delegate(&pred_key(1), DelegateSim::default())
+            .with_delegate(&pred_key(2), gen2)
+            .with_delegate(&successor_key(), DelegateSim::default());
+
+        let (report, seam) = walk(&channel, MemorySeam::new());
+
+        assert!(
+            report.predecessors.iter().any(|p| matches!(
+                p,
+                PredecessorMigration::Unresponsive {
+                    generation: 2,
+                    error: None,
+                    ..
+                }
+            )),
+            "clean silence is Unresponsive with error: None: {report:?}"
+        );
+        assert!(
+            seam.rooms.map.contains_key(&room_a),
+            "Union must keep walking past a silent newer generation (river#204)"
+        );
+        assert_eq!(
+            channel.stored(&successor_key(), &pred_done_marker_key(&pred_key(2))),
+            None,
+            "the silent generation is NOT sealed — a later load retries it"
+        );
+        assert!(!report.is_complete());
+    }
+
+    /// The corrupt-index floor: the frozen legacy WASM reports a decode
+    /// failure as an EMPTY list, so the fixed probes must fire even when the
+    /// index lists nothing. Removing the union in `candidate_keys` turns this
+    /// red.
+    #[test]
+    fn a_corrupt_empty_index_still_recovers_the_single_blob_era() {
+        let room_a = vk(1);
+        let mut gen0 = DelegateSim::default();
+        gen0.store
+            .insert(ROOMS_STORAGE_KEY.to_vec(), rooms_blob_with(room_a, 3));
+        gen0.listed = Some(vec![]); // corrupt index: data present, list empty
+        let channel = MockChannel::default()
+            .with_delegate(&pred_key(0), gen0)
+            .with_delegate(&pred_key(1), DelegateSim::default())
+            .with_delegate(&pred_key(2), DelegateSim::default())
+            .with_delegate(&successor_key(), DelegateSim::default());
+
+        let (report, seam) = walk(&channel, MemorySeam::new());
+        assert!(report.is_complete());
+        assert!(
+            seam.rooms.map.contains_key(&room_a),
+            "rooms_data must be recovered through a corrupt (empty) index"
+        );
+    }
+
+    /// A GET reply naming a DIFFERENT key is a mis-correlated answer; acting
+    /// on it would attribute one key's bytes to another. Removing the
+    /// key-mismatch check imports the smuggled room and turns this red.
+    #[test]
+    fn a_mismatched_get_reply_is_a_fault_not_data() {
+        let room_z = vk(9);
+        let mut gen0 = DelegateSim::default();
+        gen0.store
+            .insert(ROOMS_STORAGE_KEY.to_vec(), rooms_blob_with(vk(1), 3));
+        // Asking for rooms_data yields a reply that names outbound_dms but
+        // carries a decodable rooms blob with room Z.
+        gen0.wrong_key_reply = Some((
+            ROOMS_STORAGE_KEY.to_vec(),
+            OUTBOUND_DMS_STORAGE_KEY.to_vec(),
+            rooms_blob_with(room_z, 5),
+        ));
+        let channel = MockChannel::default()
+            .with_delegate(&pred_key(0), gen0)
+            .with_delegate(&pred_key(1), DelegateSim::default())
+            .with_delegate(&pred_key(2), DelegateSim::default())
+            .with_delegate(&successor_key(), DelegateSim::default());
+
+        let (report, seam) = walk(&channel, MemorySeam::new());
+
+        assert!(
+            !seam.rooms.map.contains_key(&room_z),
+            "a mis-correlated reply's bytes must never be imported"
+        );
+        assert!(
+            report.predecessors.iter().any(|p| matches!(
+                p,
+                PredecessorMigration::Unresponsive {
+                    generation: 0,
+                    error: Some(_),
+                    ..
+                }
+            )),
+            "the mismatch is a fault, not data: {report:?}"
+        );
+        assert_eq!(
+            channel.stored(&successor_key(), &pred_done_marker_key(&pred_key(0))),
+            None
+        );
+    }
+
+    /// An unreadable marker MUST stop the walk (`WriterUnavailable`) —
+    /// guessing "no marker" would re-import a possibly-done predecessor, and
+    /// guessing "done" would silently skip one. Mutating `get_marker`'s
+    /// timeout arm to `Ok(None)` imports everything (rooms non-empty → red);
+    /// mutating it to a fabricated `Done` completes the report (→ red).
+    #[test]
+    fn an_unreadable_marker_stops_the_walk_before_any_import() {
+        let mut gen0 = DelegateSim::default();
+        gen0.store
+            .insert(ROOMS_STORAGE_KEY.to_vec(), rooms_blob_with(vk(1), 3));
+        let mut successor = DelegateSim::default();
+        successor.silent = true; // marker reads time out
+        let channel = MockChannel::default()
+            .with_delegate(&pred_key(0), gen0)
+            .with_delegate(&pred_key(1), DelegateSim::default())
+            .with_delegate(&pred_key(2), DelegateSim::default())
+            .with_delegate(&successor_key(), successor);
+
+        let (report, seam) = walk(&channel, MemorySeam::new());
+
+        assert!(
+            matches!(
+                report.predecessors.first(),
+                Some(PredecessorMigration::WriterUnavailable { .. })
+            ),
+            "an unreadable marker is WriterUnavailable, never None/Done: {report:?}"
+        );
+        assert!(seam.rooms.map.is_empty(), "nothing may be imported blind");
+        assert_eq!(seam.flushes, 0);
+        assert!(!report.is_complete());
+        assert!(report.retry_may_help());
+        assert_eq!(
+            channel.requests_to_predecessors("get:"),
+            0,
+            "no predecessor fetch may run without marker bookkeeping"
+        );
+    }
+
+    /// A failed flush (the coalesced save reporting failure) withholds the
+    /// completion marker, so the next load re-walks the predecessor. No-op'ing
+    /// `flush_predecessor` while the save fails seals the predecessor with the
+    /// data unpersisted — every assertion here goes red under that mutation.
+    #[test]
+    fn a_failed_flush_withholds_the_completion_marker() {
+        let mut gen0 = DelegateSim::default();
+        gen0.store
+            .insert(ROOMS_STORAGE_KEY.to_vec(), rooms_blob_with(vk(1), 3));
+        let channel = MockChannel::default()
+            .with_delegate(&pred_key(0), gen0)
+            .with_delegate(&pred_key(1), DelegateSim::default())
+            .with_delegate(&pred_key(2), DelegateSim::default())
+            .with_delegate(&successor_key(), DelegateSim::default());
+        let mut seam = MemorySeam::new();
+        seam.fail_flush = true;
+
+        let (report, seam) = walk(&channel, seam);
+
+        assert!(seam.flushes >= 1, "the flush must actually be attempted");
+        assert!(
+            report.predecessors.iter().any(|p| matches!(
+                p,
+                PredecessorMigration::Incomplete {
+                    generation: 0,
+                    failure: Some(WriterFailure {
+                        stage: WriterStage::Flush,
+                        ..
+                    }),
+                    ..
+                }
+            )),
+            "a failed flush is an Incomplete predecessor: {report:?}"
+        );
+        assert_eq!(
+            channel.stored(&successor_key(), &pred_done_marker_key(&pred_key(0))),
+            None,
+            "the completion marker must be withheld when the save failed"
+        );
+        // The in-progress marker IS durable, so the interrupted run is
+        // re-walked next load.
+        assert!(
+            channel
+                .stored(&successor_key(), &pred_wip_marker_key(&pred_key(0)))
+                .is_some(),
+            "the in-progress marker must be recorded before items"
+        );
+        assert!(report.retry_may_help());
+    }
+
+    // ---------------- ranked merge (#590 / #527), through the walk ----------
+
+    /// #527: a room already held with a HIGHER-ranked identity keeps it when a
+    /// legacy generation offers a conflicting one; a room held from an OLDER
+    /// source adopts the identity a NEWER generation offers. Both directions
+    /// prove `RecoveredSecret::generation` is plumbed through as the merge's
+    /// source rank — a raw-slot-write mutation (or a constant rank) flips one
+    /// direction and turns this red.
+    #[test]
+    fn identity_conflicts_resolve_by_generation_rank_not_arrival() {
+        let room_x = vk(1);
+        let room_y = vk(2);
+        // gen2 (rank 2) offers X with identity 40 and Y with identity 41.
+        let mut gen2 = DelegateSim::default();
+        let mut blob = empty_rooms();
+        blob.map.insert(room_x, room_with_identity(room_x, 40));
+        blob.map.insert(room_y, room_with_identity(room_y, 41));
+        gen2.store.insert(ROOMS_STORAGE_KEY.to_vec(), cbor(&blob));
+        let channel = MockChannel::default()
+            .with_delegate(&pred_key(0), DelegateSim::default())
+            .with_delegate(&pred_key(1), DelegateSim::default())
+            .with_delegate(&pred_key(2), gen2)
+            .with_delegate(&successor_key(), DelegateSim::default());
+
+        // The successor already holds X (identity 50, rank 5 — newer than any
+        // generation) and Y (identity 51, rank 0 — an older-era load).
+        let mut seam = MemorySeam::new();
+        seam.rooms
+            .map
+            .insert(room_x, room_with_identity(room_x, 50));
+        seam.ranks.identity.insert(room_x.to_bytes(), 5);
+        seam.rooms
+            .map
+            .insert(room_y, room_with_identity(room_y, 51));
+        seam.ranks.identity.insert(room_y.to_bytes(), 0);
+
+        let (_report, seam) = walk(&channel, seam);
+
+        let x_identity = seam.rooms.map[&room_x].self_verifying_key().unwrap();
+        assert_eq!(
+            x_identity,
+            SigningKey::from_bytes(&[50; 32]).verifying_key(),
+            "a higher-ranked identity must survive a legacy offer (#527)"
+        );
+        let y_identity = seam.rooms.map[&room_y].self_verifying_key().unwrap();
+        assert_eq!(
+            y_identity,
+            SigningKey::from_bytes(&[41; 32]).verifying_key(),
+            "a strictly newer generation must correct an older-ranked identity (#527)"
+        );
+    }
+
+    /// #590: tombstones are RANKED observations. An older generation's
+    /// tombstone must not delete a room held from a newer source, and a newer
+    /// generation's `Present` must resurrect a room tombstoned by an older
+    /// one. A merge→overwrite mutation flattens both and turns this red.
+    #[test]
+    fn tombstones_are_ranked_observations_through_the_walk() {
+        let room_kept = vk(1);
+        let room_back = vk(2);
+        // gen2 (rank 2, walked FIRST) holds both rooms present.
+        let mut gen2 = DelegateSim::default();
+        let mut newer = empty_rooms();
+        newer
+            .map
+            .insert(room_kept, room_with_identity(room_kept, 30));
+        newer
+            .map
+            .insert(room_back, room_with_identity(room_back, 31));
+        gen2.store.insert(ROOMS_STORAGE_KEY.to_vec(), cbor(&newer));
+        // gen0 (rank 0, walked LAST) tombstones room_kept.
+        let mut gen0 = DelegateSim::default();
+        let mut older = empty_rooms();
+        older.removed_rooms.insert(room_kept);
+        gen0.store.insert(ROOMS_STORAGE_KEY.to_vec(), cbor(&older));
+        let channel = MockChannel::default()
+            .with_delegate(&pred_key(0), gen0)
+            .with_delegate(&pred_key(1), DelegateSim::default())
+            .with_delegate(&pred_key(2), gen2)
+            .with_delegate(&successor_key(), DelegateSim::default());
+
+        // The successor carries a rank-0 tombstone for room_back from an
+        // older-era load this session.
+        let mut seam = MemorySeam::new();
+        seam.rooms.removed_rooms.insert(room_back);
+        seam.ranks.tombstone.insert(room_back.to_bytes(), 0);
+
+        let (_report, seam) = walk(&channel, seam);
+
+        assert!(
+            seam.rooms.map.contains_key(&room_kept),
+            "an OLDER generation's tombstone must not delete a newer Present (#590)"
+        );
+        assert!(
+            !seam.rooms.removed_rooms.contains(&room_kept),
+            "the stale tombstone must not be recorded over the live room"
+        );
+        assert!(
+            seam.rooms.map.contains_key(&room_back),
+            "a NEWER generation's Present must resurrect an older tombstone (#590)"
+        );
+        assert!(
+            seam.ranks.resurrected.contains(&room_back.to_bytes()),
+            "the resurrection must be recorded for the save path (mark_room_rejoined)"
+        );
+    }
+
+    // ---------------- concurrency shape ----------------
+
+    /// The crate's walk is strictly sequential (one outstanding request), and
+    /// the pre-warm is the one deliberately concurrent phase — with every
+    /// request keyed by a DISTINCT target delegate, which is what makes the
+    /// burst safe in the single-waiter `PENDING_REQUESTS` map.
+    #[test]
+    fn walk_is_sequential_and_prewarm_keys_are_distinct() {
+        let channel = MockChannel::default()
+            .with_delegate(&pred_key(0), DelegateSim::default())
+            .with_delegate(&pred_key(1), DelegateSim::default())
+            .with_delegate(&pred_key(2), DelegateSim::default())
+            .with_delegate(&successor_key(), DelegateSim::default());
+
+        // Pre-warm: all probes in flight together.
+        let lineage = lineage3();
+        let mut reader = RiverPredecessorIo::new(&channel);
+        block_on(reader.prewarm(&lineage));
+        assert_eq!(
+            channel.max_in_flight.get(),
+            3,
+            "the pre-warm must probe every predecessor concurrently"
+        );
+
+        // The walk itself: never more than one outstanding request.
+        channel.reset_counters();
+        let mut writer = RiverSuccessorIo::new(&channel, MemorySeam::new(), successor_key());
+        let _report = block_on(freenet_migrate::migrate_delegate_secrets(
+            &mut writer,
+            &mut reader,
+            &lineage,
+            MigrationAuthorization::app_author_ack(),
+            river_secret_policy(),
+        ));
+        assert!(
+            !channel.log.borrow().is_empty(),
+            "the walk must actually issue requests"
+        );
+        assert_eq!(
+            channel.max_in_flight.get(),
+            1,
+            "the walk must hold at most ONE outstanding request — the \
+             single-waiter PENDING_REQUESTS safety argument rests on this"
+        );
+
+        // The pre-warm's correlation keys are DISTINCT per target delegate.
+        let base = b"list".to_vec();
+        let k0 = chat_delegate::legacy_scoped_correlation(&pred_key(0), &base);
+        let k1 = chat_delegate::legacy_scoped_correlation(&pred_key(1), &base);
+        let k2 = chat_delegate::legacy_scoped_correlation(&pred_key(2), &base);
+        assert!(k0 != k1 && k1 != k2 && k0 != k2);
     }
 }

--- a/ui/src/components/app/freenet_api/delegate_migration.rs
+++ b/ui/src/components/app/freenet_api/delegate_migration.rs
@@ -264,6 +264,13 @@ impl RiverDelegateChannel for NodeDelegateChannel {
     ///
     /// The wire behaviour is unchanged: every request is still in flight before
     /// any reply is awaited.
+    ///
+    /// Scope, stated honestly: this removes the overlap WITHIN the pre-warm.
+    /// It does NOT remove the cross-task case — while this is suspended inside
+    /// `send().await`, a `migrate_legacy_per_room` task spawned from the
+    /// message loop can call `send_delegate_request_to` and take the same
+    /// borrow. That case is still survived only by `WebApi::send` not yielding
+    /// for small payloads, exactly as before.
     async fn request_all(
         &self,
         requests: Vec<(DelegateKey, ChatDelegateRequestMsg)>,

--- a/ui/src/components/app/freenet_api/delegate_migration.rs
+++ b/ui/src/components/app/freenet_api/delegate_migration.rs
@@ -430,14 +430,25 @@ impl<'a, C: RiverDelegateChannel> RiverPredecessorIo<'a, C> {
             )
             .await;
         // `request_all`'s "one outcome per request, in order" contract is
-        // documentation only; a short vec would silently drop the tail
-        // predecessors from the cache and degrade them to full 10 s live probes
-        // rather than failing loudly.
-        assert_eq!(
-            outcomes.len(),
-            targets.len(),
-            "request_all must return exactly one outcome per request"
-        );
+        // documentation only. A short vec would silently drop the tail
+        // predecessors from the cache and degrade them to full 10 s live
+        // probes, so say so loudly.
+        //
+        // Deliberately a `warn!` and NOT an assert. `[profile.release]` sets
+        // `panic = 'abort'` and `safe_spawn_local` does not catch panics, so an
+        // assert here would kill the whole UI — on the one code path whose
+        // purpose is to not lose the user's rooms. What it would guard is
+        // benign by comparison: `zip` truncates safely and `key_index` falls
+        // back to a live probe, so a short vec is slower-but-correct. Trading
+        // that for total app death is the wrong way round.
+        if outcomes.len() != targets.len() {
+            warn!(
+                "request_all returned {} outcome(s) for {} request(s); tail \
+                 predecessors will fall back to live probes",
+                outcomes.len(),
+                targets.len()
+            );
+        }
         for (key, outcome) in targets.iter().zip(outcomes) {
             let key_bytes = key.bytes().to_vec();
             let learned = match outcome {
@@ -1473,8 +1484,12 @@ mod tests {
         // case so a reconnect re-probes; if the latch were already armed, that
         // re-probe would never run the walk for the rest of the page load.
         // Whitespace-stripped, per the repo's source-pin convention, so a
-        // rustfmt wrap or an added `use` does not fail this with a message
-        // about `any_dispatched` that misdescribes the real change. (The old
+        // rustfmt wrap does not fail this with a message about `any_dispatched`
+        // that misdescribes the real change. Note the limit: stripping
+        // whitespace does nothing for the fully-qualified path, so importing
+        // `arm_crate_walk_once` and calling it unqualified WOULD fail this with
+        // that same misdescribing message. Fix the pin, not the import, if that
+        // ever happens. (The old
         // `body[latch..].starts_with(..)` conjunct was true by construction of
         // `latch` and asserted nothing.)
         let before: String = body[..latch]
@@ -2248,8 +2263,26 @@ mod tests {
         // — which compiles (tx simply is not captured), satisfies every other
         // assertion here, and restores B2 exactly, because the await then
         // returns before the macrotask runs.
+        // Brace-matched from the `defer(` opening rather than `find("});")`.
+        // A first-match anchor breaks on any nested closure call inside the
+        // defer: `merge_rooms` right next door already has that shape
+        // (`ROOMS.with_mut(|current| { ... });` closes long before its
+        // `tx.send`), so the same pin applied there would fail on correct code
+        // while claiming B2 had been restored — the misdescribing failure this
+        // file has been bitten by before.
         let closure_end = body[defer_at..]
-            .find("});")
+            .char_indices()
+            .scan(0i32, |depth, (i, c)| {
+                match c {
+                    '{' => *depth += 1,
+                    '}' => *depth -= 1,
+                    _ => {}
+                }
+                Some((i, *depth))
+            })
+            .skip_while(|(_, d)| *d == 0)
+            .find(|(_, d)| *d == 0)
+            .map(|(i, _)| i)
             .map(|off| defer_at + off)
             .expect("the defer closure must be terminated");
         assert!(

--- a/ui/src/components/app/freenet_api/delegate_migration.rs
+++ b/ui/src/components/app/freenet_api/delegate_migration.rs
@@ -192,23 +192,17 @@ pub(crate) trait RiverDelegateChannel {
     /// small payloads — true of every delegate request, but a property of the
     /// transport rather than of this code, and free to stop being true.
     ///
-    /// The default is the naive fan-out, which is correct for test doubles:
-    /// they hold no shared borrow, and it keeps their observed concurrency
-    /// (and so the `max_in_flight` assertions) exactly as before.
-    /// [`NodeDelegateChannel`] overrides it with the safe shape.
+    /// **Deliberately has NO default.** The obvious default would be a
+    /// `join_all` over `request` — which is precisely the unsafe shape this
+    /// method exists to replace. With such a default, deleting
+    /// [`NodeDelegateChannel`]'s override (an entirely plausible "the default
+    /// already does this" cleanup) would silently return production to the
+    /// overlapping-borrow fan-out while every test stayed green. Requiring
+    /// each implementor to state its choice makes that a compile error.
     fn request_all(
         &self,
         requests: Vec<(DelegateKey, ChatDelegateRequestMsg)>,
-    ) -> impl Future<Output = Vec<Result<Option<ChatDelegateResponseMsg>, String>>> {
-        async move {
-            futures::future::join_all(
-                requests
-                    .iter()
-                    .map(|(target, request)| self.request(target, request.clone())),
-            )
-            .await
-        }
-    }
+    ) -> impl Future<Output = Vec<Result<Option<ChatDelegateResponseMsg>, String>>>;
 }
 
 /// The production transport: River's pending-request registry
@@ -1334,6 +1328,27 @@ mod tests {
             self.in_flight.set(self.in_flight.get() - 1);
             out
         }
+
+        /// The double fans out naively ON PURPOSE: it holds no shared
+        /// `WEB_API` borrow, so the hazard `NodeDelegateChannel::request_all`
+        /// guards against cannot exist here, and keeping the concurrency
+        /// observable is what lets `max_in_flight` assert the pre-warm really
+        /// does probe every predecessor at once.
+        ///
+        /// Note what this means: these assertions measure the DOUBLE's shape,
+        /// never production's. The production override is pinned separately,
+        /// by source scrape.
+        async fn request_all(
+            &self,
+            requests: Vec<(DelegateKey, ChatDelegateRequestMsg)>,
+        ) -> Vec<Result<Option<ChatDelegateResponseMsg>, String>> {
+            futures::future::join_all(
+                requests
+                    .iter()
+                    .map(|(target, request)| self.request(target, request.clone())),
+            )
+            .await
+        }
     }
 
     // ---------------- in-memory seam ----------------
@@ -1441,10 +1456,17 @@ mod tests {
         // dead transport. The sweep resets its own per-session guard in that
         // case so a reconnect re-probes; if the latch were already armed, that
         // re-probe would never run the walk for the rest of the page load.
+        // Whitespace-stripped, per the repo's source-pin convention, so a
+        // rustfmt wrap or an added `use` does not fail this with a message
+        // about `any_dispatched` that misdescribes the real change. (The old
+        // `body[latch..].starts_with(..)` conjunct was true by construction of
+        // `latch` and asserted nothing.)
+        let before: String = body[..latch]
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
         assert!(
-            body[latch..].starts_with("arm_crate_walk_once()")
-                && body[..latch]
-                    .ends_with("if any_dispatched && super::freenet_api::delegate_migration::"),
+            before.ends_with("if any_dispatched && super::freenet_api::delegate_migration::"),
             "the walk spawn must be gated on `any_dispatched &&` — arming it on a \
              page load where no probe dispatched wastes the latch on a dead transport"
         );
@@ -2195,6 +2217,75 @@ mod tests {
              helpers — they schedule a further macrotask, so the awaited signal \
              fires before the writes land"
         );
+        // The load-bearing ordering: the completion signal must be sent from
+        // INSIDE the defer closure, after the writes. Signalling before the
+        // defer satisfies every assertion above while restoring the bug
+        // exactly, because the await then returns before the writes land.
+        let defer_at = body
+            .find("defer(move ||")
+            .expect("the writes must run inside a defer closure");
+        let send_at = body
+            .find("tx.send(")
+            .expect("the oneshot must be signalled");
+        assert!(
+            defer_at < send_at,
+            "tx.send must happen INSIDE the defer closure, after the writes — \
+             signalling before it makes the await return pre-merge (B2)"
+        );
+        for helper in [
+            "hydrate_hidden_dm_threads_now(",
+            "hydrate_outbound_dms_cache_now(",
+        ] {
+            assert!(
+                body.find(helper).expect("helper call") < send_at,
+                "{helper} must run BEFORE the completion signal"
+            );
+        }
+    }
+
+    /// The PRODUCTION `request_all` must keep the safe shape.
+    ///
+    /// `MockChannel` deliberately fans out naively, so every `max_in_flight`
+    /// assertion measures the double rather than production. Nothing else
+    /// exercises `NodeDelegateChannel::request_all` — so without this, deleting
+    /// its override or rewriting it as a `join_all` over `request` would return
+    /// production to the overlapping-`WEB_API`-borrow shape with all tests green.
+    #[test]
+    fn production_request_all_enqueues_before_it_awaits() {
+        let src = include_str!("delegate_migration.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+        let body = production
+            .split("impl RiverDelegateChannel for NodeDelegateChannel {")
+            .nth(1)
+            .expect("the production channel impl must exist")
+            .split("\n}")
+            .next()
+            .expect("impl body");
+        let request_all = body.split("async fn request_all(").nth(1).expect(
+            "NodeDelegateChannel must define request_all — the trait has \
+                     no default, but a re-added default would make this silent",
+        );
+
+        let last_enqueue = request_all
+            .rfind("enqueue_delegate_request")
+            .expect("request_all must enqueue");
+        let first_await = request_all
+            .find("await_delegate_response_outcome")
+            .expect("request_all must await the replies");
+        assert!(
+            last_enqueue < first_await,
+            "every send must be enqueued BEFORE the first reply is awaited, so \
+             the WEB_API borrows never overlap and all requests are still in \
+             flight before any reply is awaited"
+        );
+        assert!(
+            request_all[..last_enqueue].contains("for "),
+            "the enqueue phase must be a sequential loop, not a concurrent \
+             combinator — concurrency here is the borrow hazard itself"
+        );
     }
 
     /// The pre-warm burst must fan out through `request_all`, never a
@@ -2282,10 +2373,11 @@ mod tests {
         );
 
         // The pre-warm's correlation keys are DISTINCT per target delegate.
-        // Use the REAL base the pre-warm's `ListRequest` registers under, not a
-        // stand-in: this assertion previously ran against `b"list"`, a literal
-        // that appears nowhere in the code, so it could not have noticed that
-        // the real base was being completed unscoped on the response side (B1).
+        // Use the REAL base the pre-warm's `ListRequest` registers under rather
+        // than the previous `b"list"` stand-in. This is a READABILITY fix and
+        // detects nothing new — the assertions below hold for any base at all.
+        // The response side is covered by
+        // `request_and_response_correlation_keys_round_trip`, not here.
         let base = chat_delegate::list_request_correlation_key();
         let k0 = chat_delegate::legacy_scoped_correlation(&pred_key(0), &base);
         let k1 = chat_delegate::legacy_scoped_correlation(&pred_key(1), &base);

--- a/ui/src/components/app/freenet_api/delegate_migration.rs
+++ b/ui/src/components/app/freenet_api/delegate_migration.rs
@@ -714,12 +714,35 @@ impl RiverImportSeam for LiveImportSeam {
     }
 
     async fn merge_outbound_dms(&mut self, store: OutboundDmStore) -> Result<(), String> {
-        // Same helpers the sweep's legacy DM arm uses; both defer their signal
-        // writes internally and are idempotent per entry.
-        chat_delegate::hydrate_hidden_dm_threads(store.hidden_threads);
-        chat_delegate::hydrate_outbound_dms_cache(store.entries);
         self.dms_dirty = true;
-        Ok(())
+        // Same helpers the sweep's legacy DM arm uses, and idempotent per entry
+        // — but the PUBLIC forms defer their signal writes through
+        // `util::defer` (`setTimeout(0)`, a MACROTASK) and return immediately.
+        //
+        // `flush` -> `save_outbound_dms_to_delegate` reads `OUTBOUND_DMS`
+        // SYNCHRONOUSLY, and the merge -> flush -> snapshot chain runs on
+        // microtasks, which drain before any macrotask. Returning `Ok` here
+        // without awaiting therefore let `flush` serialise the PRE-merge cache
+        // while the driver went on to seal `Done { had_data: true }` — and the
+        // marker guarantees the predecessor is never re-fetched, so the DMs
+        // were lost permanently. Deterministic for a DM-only predecessor (no
+        // rooms means no intervening network round-trip to let the timer fire),
+        // and worst in the gateway iframe, where no `localStorage` means the
+        // marker is the only authority.
+        //
+        // So run both writes inside ONE `defer` and await a oneshot signalled
+        // from within it, exactly as `merge_rooms` above already does. The
+        // `_now` helpers are the same bodies without their own `defer`, so this
+        // keeps the single-`setTimeout` execution context the signal-safety
+        // rules require rather than writing signals inline.
+        let (tx, rx) = futures::channel::oneshot::channel::<()>();
+        crate::util::defer(move || {
+            chat_delegate::hydrate_hidden_dm_threads_now(store.hidden_threads);
+            chat_delegate::hydrate_outbound_dms_cache_now(store.entries);
+            let _ = tx.send(());
+        });
+        rx.await
+            .map_err(|_| "outbound-DM merge was dropped before running".to_string())
     }
 
     async fn flush(&mut self) -> Result<(), String> {
@@ -2014,6 +2037,66 @@ mod tests {
         );
     }
 
+    /// **`LiveImportSeam::merge_outbound_dms` must not return until its writes
+    /// have landed.**
+    ///
+    /// This pin is a source scrape rather than a behavioural test, and that is
+    /// deliberate: nothing below it can see the bug. `util::defer` is
+    /// `setTimeout(0)` on wasm32 but a SYNCHRONOUS call natively (`util.rs`),
+    /// and `MemorySeam` merges synchronously too — so on every surface a test
+    /// can run, the deferred write has always landed by the time `flush` reads.
+    /// The ordering only exists in the browser. A behavioural test here would
+    /// pass identically with the bug present, which is worse than no test.
+    ///
+    /// The bug: the PUBLIC hydrate helpers defer their signal writes as a
+    /// macrotask and return immediately, while `flush` reads `OUTBOUND_DMS`
+    /// synchronously on a microtask chain that drains first. For a DM-only
+    /// predecessor the save serialised the PRE-merge cache, the driver sealed
+    /// `Done { had_data: true }`, and the marker guaranteed the predecessor was
+    /// never re-fetched — silent, permanent DM loss, worst in the gateway
+    /// iframe where the marker is the only authority.
+    #[test]
+    fn merge_outbound_dms_awaits_its_deferred_writes() {
+        let src = include_str!("delegate_migration.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+        let body = production
+            .split("async fn merge_outbound_dms(")
+            .nth(1)
+            .expect("LiveImportSeam::merge_outbound_dms must exist")
+            .split("\n    async fn ")
+            .next()
+            .expect("merge_outbound_dms body");
+
+        assert!(
+            body.contains("rx.await"),
+            "merge_outbound_dms must AWAIT its deferred writes before returning, \
+             as merge_rooms does — otherwise flush snapshots the pre-merge cache \
+             and the driver seals Done over DM data that was never saved"
+        );
+        // It must use the non-deferring cores inside its own single defer. The
+        // public helpers would re-defer, putting the writes back on a later
+        // macrotask and restoring the bug even with the await in place.
+        for helper in [
+            "hydrate_hidden_dm_threads_now(",
+            "hydrate_outbound_dms_cache_now(",
+        ] {
+            assert!(
+                body.contains(helper),
+                "merge_outbound_dms must call {helper} inside its own defer"
+            );
+        }
+        assert!(
+            !body.contains("hydrate_hidden_dm_threads(")
+                && !body.contains("hydrate_outbound_dms_cache("),
+            "merge_outbound_dms must NOT call the deferring public hydrate \
+             helpers — they schedule a further macrotask, so the awaited signal \
+             fires before the writes land"
+        );
+    }
+
     // ---------------- concurrency shape ----------------
 
     /// The crate's walk is strictly sequential (one outstanding request), and
@@ -2060,7 +2143,11 @@ mod tests {
         );
 
         // The pre-warm's correlation keys are DISTINCT per target delegate.
-        let base = b"list".to_vec();
+        // Use the REAL base the pre-warm's `ListRequest` registers under, not a
+        // stand-in: this assertion previously ran against `b"list"`, a literal
+        // that appears nowhere in the code, so it could not have noticed that
+        // the real base was being completed unscoped on the response side (B1).
+        let base = chat_delegate::list_request_correlation_key();
         let k0 = chat_delegate::legacy_scoped_correlation(&pred_key(0), &base);
         let k1 = chat_delegate::legacy_scoped_correlation(&pred_key(1), &base);
         let k2 = chat_delegate::legacy_scoped_correlation(&pred_key(2), &base);

--- a/ui/src/components/app/freenet_api/delegate_migration.rs
+++ b/ui/src/components/app/freenet_api/delegate_migration.rs
@@ -180,6 +180,35 @@ pub(crate) trait RiverDelegateChannel {
         target: &DelegateKey,
         request: ChatDelegateRequestMsg,
     ) -> impl Future<Output = Result<Option<ChatDelegateResponseMsg>, String>>;
+
+    /// Issue several requests concurrently, returning outcomes in input order.
+    ///
+    /// This exists because "concurrent" must NOT mean "concurrent sends" on the
+    /// production transport. A send takes the single `WEB_API` write borrow and
+    /// holds it across `api.send().await`; polling a second request into its
+    /// send while the first is suspended there is a `RefCell` double-borrow,
+    /// which in single-threaded WASM is a panic rather than contention. Today
+    /// that is survived only by `WebApi::send` happening not to yield for
+    /// small payloads — true of every delegate request, but a property of the
+    /// transport rather than of this code, and free to stop being true.
+    ///
+    /// The default is the naive fan-out, which is correct for test doubles:
+    /// they hold no shared borrow, and it keeps their observed concurrency
+    /// (and so the `max_in_flight` assertions) exactly as before.
+    /// [`NodeDelegateChannel`] overrides it with the safe shape.
+    fn request_all(
+        &self,
+        requests: Vec<(DelegateKey, ChatDelegateRequestMsg)>,
+    ) -> impl Future<Output = Vec<Result<Option<ChatDelegateResponseMsg>, String>>> {
+        async move {
+            futures::future::join_all(
+                requests
+                    .iter()
+                    .map(|(target, request)| self.request(target, request.clone())),
+            )
+            .await
+        }
+    }
 }
 
 /// The production transport: River's pending-request registry
@@ -229,6 +258,48 @@ impl RiverDelegateChannel for NodeDelegateChannel {
                 Err("delegate response waiter was displaced by a concurrent request".to_string())
             }
         }
+    }
+
+    /// Enqueue every request SEQUENTIALLY, then await the replies together.
+    ///
+    /// Each enqueue confines the `WEB_API` write borrow to its own synchronous
+    /// send and returns a `PendingDelegateRequest`, so no two borrows can
+    /// overlap however the sends are scheduled; the concurrency lives entirely
+    /// in the await phase, which holds no borrow. Same shape the startup
+    /// per-room fan-out uses (freenet/river#417).
+    ///
+    /// The wire behaviour is unchanged: every request is still in flight before
+    /// any reply is awaited.
+    async fn request_all(
+        &self,
+        requests: Vec<(DelegateKey, ChatDelegateRequestMsg)>,
+    ) -> Vec<Result<Option<ChatDelegateResponseMsg>, String>> {
+        let mut pending = Vec::with_capacity(requests.len());
+        for (target, request) in requests {
+            let enqueued = if chat_delegate::is_current_delegate_key(&target) {
+                chat_delegate::enqueue_delegate_request(request).await
+            } else {
+                chat_delegate::enqueue_delegate_request_to(target, request).await
+            };
+            pending.push(enqueued);
+        }
+
+        let mut out = Vec::with_capacity(pending.len());
+        let awaits = pending.into_iter().map(|enqueued| async move {
+            match enqueued {
+                Ok(p) => match chat_delegate::await_delegate_response_outcome(p).await {
+                    DelegateAwaitOutcome::Response(resp) => Ok(Some(resp)),
+                    DelegateAwaitOutcome::TimedOut => Ok(None),
+                    DelegateAwaitOutcome::Cancelled => Err(
+                        "delegate response waiter was displaced by a concurrent request"
+                            .to_string(),
+                    ),
+                },
+                Err(e) => Err(e),
+            }
+        });
+        out.extend(futures::future::join_all(awaits).await);
+        out
     }
 }
 
@@ -341,16 +412,24 @@ impl<'a, C: RiverDelegateChannel> RiverPredecessorIo<'a, C> {
         // A shared `&C` is what each concurrent probe captures — `self` stays
         // free for the cache inserts after the join.
         let channel = self.channel;
-        let probes = predecessors.iter().map(|entry| {
-            let key = DelegateKey::new(entry.delegate_key, CodeHash::new(entry.code_hash));
-            async move {
-                let outcome = channel
-                    .request(&key, ChatDelegateRequestMsg::ListRequest)
-                    .await;
-                (key.bytes().to_vec(), outcome)
-            }
-        });
-        for (key_bytes, outcome) in futures::future::join_all(probes).await {
+        let targets: Vec<DelegateKey> = predecessors
+            .iter()
+            .map(|entry| DelegateKey::new(entry.delegate_key, CodeHash::new(entry.code_hash)))
+            .collect();
+        // `request_all`, NOT a `join_all` of `request` — on the production
+        // transport the latter can poll a second probe into its send while the
+        // first still holds the `WEB_API` write borrow across `send().await`,
+        // which is a RefCell double-borrow panic in single-threaded WASM.
+        let outcomes = channel
+            .request_all(
+                targets
+                    .iter()
+                    .map(|key| (key.clone(), ChatDelegateRequestMsg::ListRequest))
+                    .collect(),
+            )
+            .await;
+        for (key, outcome) in targets.iter().zip(outcomes) {
+            let key_bytes = key.bytes().to_vec();
             let learned = match outcome {
                 Ok(Some(ChatDelegateResponseMsg::ListResponse { keys })) => Prewarmed::Listed(keys),
                 Ok(Some(_)) => Prewarmed::Executed,
@@ -1343,7 +1422,7 @@ mod tests {
             .find("LEGACY_MIGRATION_ATTEMPTED.swap(true")
             .expect("the per-session guard must exist");
         let latch = body
-            .find("if super::freenet_api::delegate_migration::arm_crate_walk_once() {")
+            .find("arm_crate_walk_once() {")
             .expect("the spawn must be gated on arm_crate_walk_once()");
         let spawn = body
             .find("run_crate_delegate_migration")
@@ -1355,6 +1434,27 @@ mod tests {
         assert!(
             latch < spawn,
             "the spawn must be inside the latch-gated block"
+        );
+
+        // ...and on `any_dispatched`, so a page load whose every send failed
+        // (connection down) does not burn the once-per-page-load latch on a
+        // dead transport. The sweep resets its own per-session guard in that
+        // case so a reconnect re-probes; if the latch were already armed, that
+        // re-probe would never run the walk for the rest of the page load.
+        assert!(
+            body[latch..].starts_with("arm_crate_walk_once()")
+                && body[..latch]
+                    .ends_with("if any_dispatched && super::freenet_api::delegate_migration::"),
+            "the walk spawn must be gated on `any_dispatched &&` — arming it on a \
+             page load where no probe dispatched wastes the latch on a dead transport"
+        );
+        let dispatch_reset = body
+            .find("if !any_dispatched && load_attempt_is_current(attempt)")
+            .expect("the sweep's transport-failure guard reset must exist");
+        assert!(
+            dispatch_reset < latch,
+            "the walk must be armed AFTER any_dispatched is final, or the gate \
+             reads a value that later sends can still change"
         );
     }
 
@@ -2094,6 +2194,45 @@ mod tests {
             "merge_outbound_dms must NOT call the deferring public hydrate \
              helpers — they schedule a further macrotask, so the awaited signal \
              fires before the writes land"
+        );
+    }
+
+    /// The pre-warm burst must fan out through `request_all`, never a
+    /// `join_all` of `request`.
+    ///
+    /// On the production transport `request` takes the single `WEB_API` write
+    /// borrow and holds it across `api.send().await`. Polling a second probe
+    /// into its send while the first is suspended there is a `RefCell`
+    /// double-borrow — a PANIC in single-threaded WASM, not contention. The
+    /// only thing standing between the old shape and that panic was
+    /// `WebApi::send` happening not to yield for small payloads.
+    ///
+    /// A mock cannot catch this (it holds no shared borrow), so this is a
+    /// source pin — the same reason the DM-merge pin above is one.
+    #[test]
+    fn prewarm_fans_out_through_the_borrow_safe_primitive() {
+        let src = include_str!("delegate_migration.rs");
+        let production = src
+            .split("mod tests {")
+            .next()
+            .expect("production code before `mod tests`");
+        let body = production
+            .split("pub(crate) async fn prewarm(")
+            .nth(1)
+            .expect("prewarm must exist")
+            .split("\n    async fn ")
+            .next()
+            .expect("prewarm body");
+
+        assert!(
+            body.contains("request_all("),
+            "prewarm must fan out via request_all(), which enqueues sequentially \
+             so the WEB_API borrows cannot overlap"
+        );
+        assert!(
+            !body.contains("join_all("),
+            "prewarm must not join_all over request() — that can overlap the \
+             WEB_API write borrow across send().await (RefCell panic in WASM)"
         );
     }
 

--- a/ui/src/components/app/freenet_api/delegate_migration.rs
+++ b/ui/src/components/app/freenet_api/delegate_migration.rs
@@ -422,6 +422,15 @@ impl<'a, C: RiverDelegateChannel> RiverPredecessorIo<'a, C> {
                     .collect(),
             )
             .await;
+        // `request_all`'s "one outcome per request, in order" contract is
+        // documentation only; a short vec would silently drop the tail
+        // predecessors from the cache and degrade them to full 10 s live probes
+        // rather than failing loudly.
+        assert_eq!(
+            outcomes.len(),
+            targets.len(),
+            "request_all must return exactly one outcome per request"
+        );
         for (key, outcome) in targets.iter().zip(outcomes) {
             let key_bytes = key.bytes().to_vec();
             let learned = match outcome {
@@ -2227,18 +2236,28 @@ mod tests {
         let send_at = body
             .find("tx.send(")
             .expect("the oneshot must be signalled");
+        // Bound by the closure's TERMINATOR, not just its opening. `defer_at <
+        // send_at` alone passes for a `tx.send` placed AFTER the whole closure
+        // — which compiles (tx simply is not captured), satisfies every other
+        // assertion here, and restores B2 exactly, because the await then
+        // returns before the macrotask runs.
+        let closure_end = body[defer_at..]
+            .find("});")
+            .map(|off| defer_at + off)
+            .expect("the defer closure must be terminated");
         assert!(
-            defer_at < send_at,
+            defer_at < send_at && send_at < closure_end,
             "tx.send must happen INSIDE the defer closure, after the writes — \
-             signalling before it makes the await return pre-merge (B2)"
+             signalling outside it makes the await return pre-merge (B2)"
         );
         for helper in [
             "hydrate_hidden_dm_threads_now(",
             "hydrate_outbound_dms_cache_now(",
         ] {
+            let at = body.find(helper).expect("helper call");
             assert!(
-                body.find(helper).expect("helper call") < send_at,
-                "{helper} must run BEFORE the completion signal"
+                at > defer_at && at < send_at,
+                "{helper} must run inside the defer, BEFORE the signal"
             );
         }
     }
@@ -2285,6 +2304,22 @@ mod tests {
             request_all[..last_enqueue].contains("for "),
             "the enqueue phase must be a sequential loop, not a concurrent \
              combinator — concurrency here is the borrow hazard itself"
+        );
+        // Text order alone is ALSO satisfied by a fully sequential rewrite that
+        // enqueues and awaits inside one loop. That stays borrow-safe but
+        // destroys the concurrency prewarm exists for: 27 predecessors would
+        // serialise into 27 x the 10 s timeout, the exact cost prewarm removes.
+        assert!(
+            request_all.contains("join_all"),
+            "the AWAIT phase must fan out (join_all) — enqueue-then-await in a \
+             single loop is borrow-safe but serialises the whole pre-warm"
+        );
+        let enqueue_loop_end = request_all[..first_await]
+            .rfind("\n        }")
+            .expect("the enqueue loop must close before the await phase");
+        assert!(
+            last_enqueue < enqueue_loop_end && enqueue_loop_end < first_await,
+            "the await phase must come after the enqueue loop CLOSES, not inside it"
         );
     }
 

--- a/ui/src/components/app/freenet_api/delegate_migration.rs
+++ b/ui/src/components/app/freenet_api/delegate_migration.rs
@@ -1,0 +1,955 @@
+//! Delegate secret migration on `freenet-migrate` 0.5 (freenet/river#398 phase 3).
+//!
+//! A delegate's address is `BLAKE3(BLAKE3(wasm) ‖ params)`, so any rebuild
+//! re-keys it and the successor starts with an EMPTY secret store. River's
+//! delegate holds each room's identity key (`RoomData::self_sk`), which cannot
+//! be re-derived from the network — losing it loses the user's identity in that
+//! room. River has hand-rolled the recovery sweep in `chat_delegate.rs` /
+//! `response_handler.rs` for 27 generations; this module runs the shared,
+//! reviewed library's walk ALONGSIDE that sweep (release 1, the shape Delta
+//! shipped), so the walk order, marker bookkeeping, withholding and
+//! per-predecessor classification come from one place. Retiring the hand-rolled
+//! sweep is release 2, after field validation — nothing here removes it.
+//!
+//! # This is a UI-side adoption — the delegate WASM does NOT change
+//!
+//! The delegate WASM is byte-identical before and after this module was added
+//! (pinned by `chat_delegate_wasm_is_byte_identical` in `chat_delegate.rs`), and
+//! that is load-bearing: changing it would re-key the delegate and create
+//! exactly the data-loss event the module exists to prevent. It is possible
+//! because River's delegate protocol already has both halves of the writer
+//! seam: `GetRequest`/`ListRequest` read a predecessor, and the current
+//! delegate's Store/CAS paths (via `save_rooms_to_delegate`'s per-room CAS
+//! `reconcile_room_present`) are the app's own import path.
+//!
+//! # The four constraints this adapter is built around
+//!
+//! 1. **A timeout is not an absence** (freenet-migrate#19 override — the
+//!    crate's recommended semantics treat silence as "the predecessor does not
+//!    have it"; we deliberately do not). Every channel round-trip is three-way:
+//!    a reply (present or definitively absent), silence
+//!    ([`RiverDelegateChannel`]'s `Ok(None)`), or transport failure. Silence
+//!    and failure NEVER classify a key as absent: a probe that gets silence is
+//!    `Unresponsive`, a fetch/marker round-trip that gets silence is an `Err`
+//!    that aborts the predecessor, and the walk retries next page load.
+//! 2. **Never trust the legacy List alone.** The legacy WASM's `get_key_index`
+//!    swallows decode errors into an empty list
+//!    (`delegates/chat-delegate/src/handlers.rs`, frozen — cannot be fixed), so
+//!    an empty/short index is not proof of absence. [`fetch_secrets`] unions
+//!    the listed keys with the FIXED probes `rooms_data` + `outbound_dms`, so
+//!    the single-blob era is recovered even through a corrupt index. (Per-room
+//!    `room:<vk>` keys are dynamic and unguessable, so a corrupt index still
+//!    strands those — the union is a floor, not a fix for the frozen WASM.)
+//! 3. **Never invent a second merge.** The writer routes every recovered room
+//!    through `Rooms::merge_from_source` at the generation's source rank with
+//!    the SHARED identity/tombstone rank registry — the same machinery the
+//!    sweep hydrates through — so ranked tombstones (freenet/river#590) and
+//!    identity conflicts (freenet/river#527) are handled identically, and the
+//!    flush persists through `save_rooms_to_delegate`'s per-room CAS
+//!    (`reconcile_room_present`). This is stronger than the never-clobber the
+//!    crate's Union policy rests on: precedence comes from generation RANK,
+//!    not arrival order.
+//! 4. **Markers are durable, in the CURRENT delegate's KV store.** ghostkeys
+//!    deliberately went the opposite way (in-memory, page-lifetime) because
+//!    sealing a predecessor there can strand late-arriving data. River's case
+//!    is different: a legacy delegate's data is FROZEN after the re-key (only
+//!    the current delegate is ever written), so sealing is safe — and durable
+//!    markers are what stop the walk re-running on every load in the gateway
+//!    iframe, where `localStorage` is unavailable and the sweep's own
+//!    `is_legacy_migration_done` flag cannot persist. Do not copy either
+//!    choice into another app without re-deriving which case applies.
+//!    Marker keys HEX-ENCODE the predecessor delegate key: the delegate's
+//!    `create_origin_key` runs the storage key through
+//!    `String::from_utf8_lossy`, which maps every invalid byte to U+FFFD, so
+//!    two raw 32-byte predecessor keys could alias to one marker slot.
+//!
+//! # Honest bounds
+//!
+//! * **Withholding is run-scoped** (freenet-migrate#15) and
+//!   **`imported_total()` under-reports** (freenet-migrate#16) — acknowledged,
+//!   not fixed here; the report is logged, never rendered as counts.
+//! * **Union resurrects delete-by-absence data** in general; for River this is
+//!   bounded because tombstones are RANKED observations (freenet/river#590): a
+//!   room left in a newer generation carries a tombstone that outranks an older
+//!   generation's `Present`, so the merge suppresses the resurrection.
+//! * A walk-recovered room is merged and persisted, and its secrets are
+//!   re-decrypted, but it is NOT run through the sweep's full hydrate
+//!   orchestration (subscriptions, actions_state rebuild) — those complete on
+//!   the next page load. Release 2 (sweep retirement) moves that orchestration
+//!   into the import seam.
+//! * `LegacyBridge` is ignored: River's successor store was never written by
+//!   the crate's older generation-keyed `import_secrets_once` API, so there are
+//!   no legacy generation-keyed markers to bridge.
+
+use std::collections::HashMap;
+use std::future::Future;
+
+use dioxus::logger::tracing::{info, warn};
+use freenet_migrate::{
+    DelegateLineageEntry, DelegateMigrationReport, ItemWrite, MarkerQuery, MigrationAuthorization,
+    MigrationMarker, PredecessorSecretsIo, RecoveredSecret, SecretPair, SecretSelectionPolicy,
+    SuccessorSecretsIo, UnionAck, PRED_DONE_MARKER_VALUE_DATA, PRED_DONE_MARKER_VALUE_EMPTY,
+};
+use freenet_stdlib::prelude::{CodeHash, DelegateKey};
+use river_core::chat_delegate::{
+    ChatDelegateKey, ChatDelegateRequestMsg, ChatDelegateResponseMsg, OutboundDmStore,
+};
+
+use crate::components::app::chat_delegate::{
+    self, parse_room_storage_key, DelegateAwaitOutcome, OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY,
+    ROOMS_STORAGE_KEY,
+};
+use crate::room_data::{MergeAuthority, MergeRanks, Rooms, RoomSlot, RoomsMeta};
+
+// ---------------------------------------------------------------------------
+// Marker keys (current delegate's KV store)
+// ---------------------------------------------------------------------------
+
+/// Storage-key prefix for a predecessor's COMPLETION marker in the current
+/// delegate's KV store. The suffix is the lowercase-hex predecessor delegate
+/// key (see [`pred_done_marker_key`] for why hex is load-bearing).
+pub(crate) const MIGRATE_PRED_DONE_PREFIX: &[u8] = b"__migrate_pred_done__:";
+/// Storage-key prefix for a predecessor's IN-PROGRESS marker. Written before
+/// the first item, upgraded to done only after every item and the flush landed,
+/// so an interrupted run is re-walked.
+pub(crate) const MIGRATE_PRED_WIP_PREFIX: &[u8] = b"__migrate_pred_wip__:";
+
+fn hex_lower(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn marker_key(prefix: &[u8], predecessor: &DelegateKey) -> Vec<u8> {
+    let mut k = prefix.to_vec();
+    k.extend_from_slice(hex_lower(predecessor.bytes()).as_bytes());
+    k
+}
+
+/// The completion-marker storage key for `predecessor`.
+///
+/// The predecessor key is HEX-ENCODED, never raw: the delegate's
+/// `create_origin_key` builds its secret key via `String::from_utf8_lossy`,
+/// which maps every invalid UTF-8 byte to U+FFFD — so two different raw
+/// predecessor keys could collide on ONE marker slot, sealing a predecessor
+/// that was never migrated. Hex is pure ASCII, so the lossy pass is the
+/// identity and every predecessor gets a distinct slot.
+pub(crate) fn pred_done_marker_key(predecessor: &DelegateKey) -> Vec<u8> {
+    marker_key(MIGRATE_PRED_DONE_PREFIX, predecessor)
+}
+
+/// The in-progress-marker storage key for `predecessor` (same encoding rules
+/// as [`pred_done_marker_key`]).
+pub(crate) fn pred_wip_marker_key(predecessor: &DelegateKey) -> Vec<u8> {
+    marker_key(MIGRATE_PRED_WIP_PREFIX, predecessor)
+}
+
+/// Whether `key` is one of THIS module's migration markers. Used to exclude
+/// markers from a predecessor's fetched pairs: when the current delegate later
+/// becomes a predecessor itself, its store contains these keys, and offering
+/// them to the writer (or re-copying them forward) would forge migration state.
+/// (The crate filters its OWN reserved `__fmigrate__` namespace; these keys are
+/// deliberately a different, app-chosen format — see the module docs — so the
+/// crate cannot know to filter them.)
+pub(crate) fn is_migration_marker_key(key: &[u8]) -> bool {
+    key.starts_with(MIGRATE_PRED_DONE_PREFIX) || key.starts_with(MIGRATE_PRED_WIP_PREFIX)
+}
+
+// ---------------------------------------------------------------------------
+// Transport seam
+// ---------------------------------------------------------------------------
+
+/// One request/response round-trip against a specific delegate (current or
+/// legacy).
+///
+/// # Contract
+///
+/// * `Ok(Some(response))` — the delegate EXECUTED and replied.
+/// * `Ok(None)` — no reply within the bound (10 s in production). The delegate
+///   could not execute, is not registered on this node, or the request was
+///   lost. **Silence, not absence** — see the module docs.
+/// * `Err(_)` — the transport is broken (send failed), or the awaiting slot was
+///   cancelled (another request re-registered the same correlation key).
+///
+/// Takes `&self` deliberately: `migrate_delegate_secrets` holds the
+/// predecessor reader and the successor writer as two simultaneous `&mut`
+/// borrows and BOTH need the transport, so a shared `&C` sits in both.
+pub(crate) trait RiverDelegateChannel {
+    /// Send `request` to `target` and await its reply.
+    fn request(
+        &self,
+        target: &DelegateKey,
+        request: ChatDelegateRequestMsg,
+    ) -> impl Future<Output = Result<Option<ChatDelegateResponseMsg>, String>>;
+}
+
+/// The production transport: River's pending-request registry
+/// (`PENDING_REQUESTS` oneshot side-table) over the node WebSocket.
+///
+/// Requests to the CURRENT delegate register under the bare correlation key
+/// (what the response handler rebuilds for a current-delegate response);
+/// requests to any other delegate register under the delegate-scoped key
+/// (`legacy_scoped_correlation`), which the response handler rebuilds from the
+/// RESPONDING delegate — so a reply from predecessor B can never resolve a
+/// request sent to predecessor A.
+///
+/// `PENDING_REQUESTS` is single-waiter-per-key: registering a request silently
+/// DROPS a prior waiter for the same correlation key. The crate's walk is
+/// strictly sequential (one outstanding request at a time), which makes that
+/// safe within the walk; the [`RiverPredecessorIo::prewarm`] burst is the one
+/// concurrent phase and every one of its requests has a DISTINCT key (scoped by
+/// target delegate). Both facts are pinned by
+/// `walk_is_sequential_and_prewarm_keys_are_distinct` below. The hand-rolled
+/// sweep can still collide with the walk on the same (delegate, key) — which is
+/// why [`run_crate_delegate_migration`] waits for the load to settle first —
+/// and a collision degrades safely: the dropped waiter resolves `Err`
+/// (cancelled), classifying the predecessor `Unresponsive`, and the durable
+/// markers make the next page load retry it.
+pub(crate) struct NodeDelegateChannel;
+
+impl RiverDelegateChannel for NodeDelegateChannel {
+    async fn request(
+        &self,
+        target: &DelegateKey,
+        request: ChatDelegateRequestMsg,
+    ) -> Result<Option<ChatDelegateResponseMsg>, String> {
+        let pending = if chat_delegate::is_current_delegate_key(target) {
+            chat_delegate::enqueue_delegate_request(request).await?
+        } else {
+            chat_delegate::enqueue_delegate_request_to(target.clone(), request).await?
+        };
+        match chat_delegate::await_delegate_response_outcome(pending).await {
+            DelegateAwaitOutcome::Response(resp) => Ok(Some(resp)),
+            // Timeout: the delegate never answered. Silence, NOT absence.
+            DelegateAwaitOutcome::TimedOut => Ok(None),
+            // Cancelled: our waiter was displaced by a concurrent request for
+            // the same correlation key (the hand-rolled sweep). Not an answer
+            // about the data at all — surface as a transport fault so the
+            // driver records Unresponsive and a later run retries.
+            DelegateAwaitOutcome::Cancelled => {
+                Err("delegate response waiter was displaced by a concurrent request".to_string())
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Lineage
+// ---------------------------------------------------------------------------
+
+/// Build the library's lineage from River's generated `LEGACY_DELEGATES` table.
+///
+/// The table is `(delegate_key, code_hash)` OLDEST-FIRST (the
+/// `legacy_delegates.toml` authoring order), so the slice index is the
+/// generation — the SAME scale `source_rank_for_delegate_key` uses for merge
+/// ranking, which is what makes [`RecoveredSecret::generation`] directly usable
+/// as the merge's `source_rank`. Keys are the STORED values, never re-derived:
+/// V1's recorded key predates the standard `BLAKE3(code_hash)` derivation and
+/// does not derive, which is exactly what `irregular_key` records.
+pub(crate) fn river_delegate_lineage(table: &[([u8; 32], [u8; 32])]) -> Vec<DelegateLineageEntry> {
+    table
+        .iter()
+        .enumerate()
+        .map(|(generation, (delegate_key, code_hash))| DelegateLineageEntry {
+            generation: generation as u32,
+            code_hash: *code_hash,
+            delegate_key: *delegate_key,
+            // True for rows whose recorded key does not derive from the code
+            // hash (River's V1). The walk never re-derives keys, so this is
+            // metadata — but `predecessor_delegate_keys_checked` would assert
+            // on it, so record it truthfully rather than hardcoding false.
+            irregular_key: blake3::hash(code_hash).as_bytes() != delegate_key,
+            note: "river legacy delegate",
+        })
+        .collect()
+}
+
+/// The policy River migrates under: [`SecretSelectionPolicy::UnionAllGenerations`].
+///
+/// `NewestSnapshotWins` halts the walk at the first silent predecessor, and
+/// silence is ORDINARY here — most of the 27 registered generations were never
+/// installed on any given node, and an uninstalled predecessor is
+/// indistinguishable from a broken one. Halting there would strand every older
+/// generation's rooms (the freenet/river#204 failure class). Union's
+/// delete-by-absence resurrection hazard is bounded for River by RANKED
+/// tombstones (freenet/river#590) — see the module docs — and the
+/// run-scoped-withholding hazard (freenet-migrate#15) is acknowledged by the
+/// `UnionAck`, not covered.
+pub(crate) fn river_secret_policy() -> SecretSelectionPolicy {
+    SecretSelectionPolicy::UnionAllGenerations(
+        UnionAck::i_understand_union_resurrects_deleted_by_absence_secrets(),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Predecessor side
+// ---------------------------------------------------------------------------
+
+/// What the concurrent pre-warm learned about one predecessor.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Prewarmed {
+    /// Replied to `ListRequest` with its key index.
+    Listed(Vec<ChatDelegateKey>),
+    /// Replied with something other than a `ListResponse` — proves execution,
+    /// but the index is unknown (fetch re-asks).
+    Executed,
+    /// No reply within the bound.
+    Silent,
+}
+
+/// Reads predecessors through River's own delegate protocol.
+///
+/// `probe_executable` is a `ListRequest`: any reply proves the old WASM
+/// executed on this node; 10 s of silence is `Ok(false)` (`Unresponsive`,
+/// never "no data"). `fetch_secrets` reconstructs the pair list from the
+/// requests the frozen legacy WASM already understands: the key index
+/// (dynamic `room:<vk>` slots + `rooms_meta`) UNIONED with the fixed probes
+/// `rooms_data` + `outbound_dms` — the union is load-bearing, see the module
+/// docs.
+///
+/// # Concurrent pre-warm
+///
+/// The crate walks predecessors sequentially, and an unregistered predecessor
+/// costs a full 10 s probe timeout — 27 generations would be ~4.5 minutes per
+/// load. [`Self::prewarm`] fires ALL the probes concurrently up front (~10 s
+/// wall-clock total), caches each predecessor's reachability (and its key
+/// index, so the common case needs no second `ListRequest`), and
+/// `probe_executable` answers from the cache.
+pub(crate) struct RiverPredecessorIo<'a, C: RiverDelegateChannel> {
+    channel: &'a C,
+    prewarmed: HashMap<Vec<u8>, Prewarmed>,
+}
+
+impl<'a, C: RiverDelegateChannel> RiverPredecessorIo<'a, C> {
+    pub(crate) fn new(channel: &'a C) -> Self {
+        Self {
+            channel,
+            prewarmed: HashMap::new(),
+        }
+    }
+
+    /// Probe every predecessor's executability concurrently and cache the
+    /// results. Transport errors are NOT cached — a later live probe surfaces
+    /// them to the driver as `Unresponsive { error }`.
+    ///
+    /// Safe to run concurrently because every request here has a DISTINCT
+    /// correlation key (each is scoped by its target delegate), so the
+    /// single-waiter `PENDING_REQUESTS` map cannot drop one probe's waiter for
+    /// another's.
+    pub(crate) async fn prewarm(&mut self, predecessors: &[DelegateLineageEntry]) {
+        let probes = predecessors.iter().map(|entry| {
+            let key = DelegateKey::new(entry.delegate_key, CodeHash::new(entry.code_hash));
+            async move {
+                let outcome = self
+                    .channel
+                    .request(&key, ChatDelegateRequestMsg::ListRequest)
+                    .await;
+                (key.bytes().to_vec(), outcome)
+            }
+        });
+        for (key_bytes, outcome) in futures::future::join_all(probes).await {
+            let learned = match outcome {
+                Ok(Some(ChatDelegateResponseMsg::ListResponse { keys })) => Prewarmed::Listed(keys),
+                Ok(Some(_)) => Prewarmed::Executed,
+                Ok(None) => Prewarmed::Silent,
+                // Not cached: the live probe retries and reports the error.
+                Err(_) => continue,
+            };
+            self.prewarmed.insert(key_bytes, learned);
+        }
+    }
+
+    /// The predecessor's key index: from the pre-warm cache when it answered
+    /// there, else a live `ListRequest`. `Err` on silence or a non-List reply —
+    /// by the trait contract this runs only after `probe_executable` returned
+    /// `Ok(true)`, so an index that cannot be read now is a fault to retry,
+    /// NEVER an empty index.
+    async fn key_index(&mut self, predecessor: &DelegateKey) -> Result<Vec<ChatDelegateKey>, String> {
+        if let Some(Prewarmed::Listed(keys)) = self.prewarmed.get(predecessor.bytes()) {
+            return Ok(keys.clone());
+        }
+        match self
+            .channel
+            .request(predecessor, ChatDelegateRequestMsg::ListRequest)
+            .await?
+        {
+            Some(ChatDelegateResponseMsg::ListResponse { keys }) => Ok(keys),
+            Some(other) => Err(format!("unexpected reply to legacy ListRequest: {other:?}")),
+            None => Err("legacy ListRequest timed out after a positive probe".to_string()),
+        }
+    }
+
+    /// GET one storage key from `predecessor`. Three-way:
+    /// `Ok(Some(bytes))` present, `Ok(None)` DEFINITIVELY absent (the delegate
+    /// executed and said so), `Err` unknown (silence, transport, or a
+    /// mismatched/unexpected reply) — unknown NEVER reads as absent.
+    async fn get_key(
+        &mut self,
+        predecessor: &DelegateKey,
+        storage_key: &[u8],
+    ) -> Result<Option<Vec<u8>>, String> {
+        let request = ChatDelegateRequestMsg::GetRequest {
+            key: ChatDelegateKey::new(storage_key.to_vec()),
+        };
+        match self.channel.request(predecessor, request).await? {
+            Some(ChatDelegateResponseMsg::GetResponse { key, value }) => {
+                if key.as_bytes() != storage_key {
+                    // A reply about a different key can only be a
+                    // mis-correlated answer to some other request; acting on
+                    // it would attribute one key's bytes to another.
+                    return Err(format!(
+                        "legacy GetResponse key mismatch: asked {:?}, got {:?}",
+                        String::from_utf8_lossy(storage_key),
+                        String::from_utf8_lossy(key.as_bytes())
+                    ));
+                }
+                Ok(value)
+            }
+            Some(other) => Err(format!("unexpected reply to legacy GetRequest: {other:?}")),
+            None => Err(format!(
+                "legacy GetRequest for {:?} timed out (silence is not absence)",
+                String::from_utf8_lossy(storage_key)
+            )),
+        }
+    }
+}
+
+/// The candidate storage keys to fetch from a predecessor, given its key
+/// index: the listed keys UNIONED with the fixed probes, minus this module's
+/// own markers, ordered so `rooms_meta` comes LAST (its `room_order` merge
+/// only retains rooms already present, so the rooms must merge first).
+///
+/// Pure, so the union rule — the "never trust List alone" constraint — is
+/// unit-testable and mutation-testable on its own.
+pub(crate) fn candidate_keys(listed: &[ChatDelegateKey]) -> Vec<Vec<u8>> {
+    let mut keys: Vec<Vec<u8>> = Vec::new();
+    let mut meta = false;
+    for k in listed {
+        let b = k.as_bytes();
+        if is_migration_marker_key(b) {
+            continue;
+        }
+        if b == ROOMS_META_KEY {
+            meta = true;
+            continue;
+        }
+        if !keys.iter().any(|existing| existing == b) {
+            keys.push(b.to_vec());
+        }
+    }
+    // Fixed probes: the single-blob era's keys, asked even when unlisted
+    // because the frozen legacy WASM reports a corrupt index as empty.
+    for fixed in [ROOMS_STORAGE_KEY, OUTBOUND_DMS_STORAGE_KEY] {
+        if !keys.iter().any(|existing| existing == fixed) {
+            keys.push(fixed.to_vec());
+        }
+    }
+    if meta {
+        keys.push(ROOMS_META_KEY.to_vec());
+    }
+    keys
+}
+
+impl<C: RiverDelegateChannel> PredecessorSecretsIo for RiverPredecessorIo<'_, C> {
+    type Error = String;
+
+    /// Executability preflight, answered from the pre-warm cache when
+    /// available. Any reply counts as executed; only silence is `Ok(false)`.
+    async fn probe_executable(&mut self, predecessor: &DelegateKey) -> Result<bool, Self::Error> {
+        match self.prewarmed.get(predecessor.bytes()) {
+            Some(Prewarmed::Listed(_)) | Some(Prewarmed::Executed) => Ok(true),
+            Some(Prewarmed::Silent) => Ok(false),
+            None => {
+                // Cache miss (not pre-warmed, or the pre-warm probe errored):
+                // live probe, so a transport error surfaces to the driver.
+                let outcome = self
+                    .channel
+                    .request(predecessor, ChatDelegateRequestMsg::ListRequest)
+                    .await?;
+                let learned = match outcome {
+                    Some(ChatDelegateResponseMsg::ListResponse { keys }) => {
+                        Prewarmed::Listed(keys)
+                    }
+                    Some(_) => Prewarmed::Executed,
+                    None => Prewarmed::Silent,
+                };
+                let executable = learned != Prewarmed::Silent;
+                self.prewarmed
+                    .insert(predecessor.bytes().to_vec(), learned);
+                Ok(executable)
+            }
+        }
+    }
+
+    /// Enumerate `predecessor`'s secrets: key index ∪ fixed probes, each key
+    /// GET'd individually. A key the delegate DEFINITIVELY reports absent
+    /// (`value: None`) is skipped; any unknown outcome aborts the predecessor
+    /// (`Err` → `Unresponsive`) rather than under-reporting its data.
+    async fn fetch_secrets(
+        &mut self,
+        predecessor: &DelegateKey,
+    ) -> Result<Vec<SecretPair>, Self::Error> {
+        let listed = self.key_index(predecessor).await?;
+        let mut pairs: Vec<SecretPair> = Vec::new();
+        for storage_key in candidate_keys(&listed) {
+            match self.get_key(predecessor, &storage_key).await? {
+                Some(value) => pairs.push((storage_key, value)),
+                // Definitive absence — the delegate executed and said "no
+                // value". A legitimate skip, mirroring the sweep's
+                // `GetResponse { value: None }` arm.
+                None => {}
+            }
+        }
+        Ok(pairs)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Successor side
+// ---------------------------------------------------------------------------
+
+/// What one recovered pair decodes to. Pure classification, split from the
+/// I/O so the mapping is unit-testable.
+#[derive(Debug)]
+pub(crate) enum RecoveredItem {
+    /// A legacy single-blob `rooms_data` snapshot.
+    RoomsBlob(Box<Rooms>),
+    /// A per-room `room:<vk>` slot.
+    Room(ed25519_dalek::VerifyingKey, RoomSlot),
+    /// The `rooms_meta` view preferences.
+    Meta(RoomsMeta),
+    /// The outbound-DM plaintext cache.
+    OutboundDms(Box<OutboundDmStore>),
+    /// One of this module's own migration markers (a future predecessor's
+    /// store carries them) — never imported, never a failure.
+    MigrationMarker,
+    /// A key this version of River does not understand — not ours to copy;
+    /// the successor's state stands.
+    Unrecognized,
+    /// A recognized key whose value failed to decode. Permanently rejected:
+    /// bytes that do not parse now will not parse later.
+    Undecodable(&'static str, String),
+}
+
+/// Decode one recovered `(key, value)` pair into a [`RecoveredItem`].
+pub(crate) fn classify_recovered(key: &[u8], value: &[u8]) -> RecoveredItem {
+    if is_migration_marker_key(key) {
+        return RecoveredItem::MigrationMarker;
+    }
+    if key == ROOMS_STORAGE_KEY {
+        return match ciborium::from_reader::<Rooms, _>(value) {
+            Ok(rooms) => RecoveredItem::RoomsBlob(Box::new(rooms)),
+            Err(e) => RecoveredItem::Undecodable("rooms_data", e.to_string()),
+        };
+    }
+    if key == OUTBOUND_DMS_STORAGE_KEY {
+        return match ciborium::from_reader::<OutboundDmStore, _>(value) {
+            Ok(store) => RecoveredItem::OutboundDms(Box::new(store)),
+            Err(e) => RecoveredItem::Undecodable("outbound_dms", e.to_string()),
+        };
+    }
+    if key == ROOMS_META_KEY {
+        return match ciborium::from_reader::<RoomsMeta, _>(value) {
+            Ok(meta) => RecoveredItem::Meta(meta),
+            Err(e) => RecoveredItem::Undecodable("rooms_meta", e.to_string()),
+        };
+    }
+    if let Some(vk) = parse_room_storage_key(key) {
+        return match ciborium::from_reader::<RoomSlot, _>(value) {
+            Ok(slot) => RecoveredItem::Room(vk, slot),
+            Err(e) => RecoveredItem::Undecodable("room slot", e.to_string()),
+        };
+    }
+    RecoveredItem::Unrecognized
+}
+
+/// Convert a decoded item into the single-source `Rooms` to merge, or `None`
+/// for items that do not merge through the rooms path.
+///
+/// The legacy blob's `current_room_key` is STRIPPED: a legacy cursor is
+/// years-stale by construction and must never dictate selection
+/// (freenet/river#255 — the same rule `decide_current_room_restore` applies on
+/// the sweep's path; `merge_from_source` does not touch the cursor, this makes
+/// the invariant hold even if a future merge change does).
+pub(crate) fn rooms_to_merge(item: &RecoveredItem) -> Option<Rooms> {
+    match item {
+        RecoveredItem::RoomsBlob(rooms) => {
+            let mut rooms = (**rooms).clone();
+            rooms.current_room_key = None;
+            Some(rooms)
+        }
+        RecoveredItem::Room(vk, slot) => {
+            let mut rooms = empty_rooms();
+            match slot {
+                RoomSlot::Present(room) => {
+                    rooms.map.insert(*vk, (**room).clone());
+                }
+                RoomSlot::Tombstone => {
+                    rooms.removed_rooms.insert(*vk);
+                }
+            }
+            Some(rooms)
+        }
+        RecoveredItem::Meta(meta) => {
+            let mut rooms = empty_rooms();
+            rooms.room_order = meta.room_order.clone();
+            rooms.notification_modes = meta.notification_modes.clone();
+            // meta.current_room_key deliberately dropped (see above).
+            Some(rooms)
+        }
+        _ => None,
+    }
+}
+
+fn empty_rooms() -> Rooms {
+    Rooms {
+        map: HashMap::new(),
+        current_room_key: None,
+        removed_rooms: std::collections::HashSet::new(),
+        notification_modes: HashMap::new(),
+        room_order: Vec::new(),
+        migrated_rooms: Vec::new(),
+    }
+}
+
+/// **The one merge** (constraint 3): fold a recovered single-source `Rooms`
+/// into the in-memory set via `Rooms::merge_from_source` at the generation's
+/// rank as an `OlderSnapshot` — the exact call the hand-rolled sweep's hydrate
+/// makes, sharing `ranks` so the two paths' decisions are mutually consistent.
+/// Ranked tombstones (freenet/river#590) and identity conflicts
+/// (freenet/river#527) are therefore handled here without any new logic.
+pub(crate) fn apply_recovered_rooms(
+    current: &mut Rooms,
+    incoming: Rooms,
+    source_rank: u32,
+    ranks: &mut MergeRanks,
+) -> Result<(), String> {
+    current.merge_from_source(incoming, source_rank, MergeAuthority::OlderSnapshot, ranks)
+}
+
+/// The successor-side import seam: what "apply this item" and "make it
+/// durable" mean in River. Split from [`RiverSuccessorIo`] so the
+/// classification/marker/tally behaviour is natively testable with a mock,
+/// while the production impl ([`LiveImportSeam`]) touches the Dioxus signals
+/// and the coalesced save.
+pub(crate) trait RiverImportSeam {
+    /// Merge a recovered single-source `Rooms` at `source_rank` (see
+    /// [`apply_recovered_rooms`]).
+    fn merge_rooms(
+        &mut self,
+        rooms: Rooms,
+        source_rank: u32,
+    ) -> impl Future<Output = Result<(), String>>;
+
+    /// Merge a recovered outbound-DM store into the local cache.
+    fn merge_outbound_dms(
+        &mut self,
+        store: OutboundDmStore,
+    ) -> impl Future<Output = Result<(), String>>;
+
+    /// Persist everything merged so far; `Ok` only when the save REALLY
+    /// landed. This is the durability boundary the crate's flush contract
+    /// exists for — a failure here re-counts this predecessor's optimistic
+    /// writes as failures and withholds its keys from older generations.
+    fn flush(&mut self) -> impl Future<Output = Result<(), String>>;
+}
+
+/// Production import seam: ranked merge into the `ROOMS` signal (inside
+/// `crate::util::defer`, per the signal-safety rules, with the result returned
+/// over a oneshot), DM hydrate via the same helpers the sweep uses, and flush
+/// through the coalesced `save_rooms_to_delegate` /
+/// `save_outbound_dms_to_delegate` — whose `CoalesceState::last_result`
+/// propagates a covering save's real failure to us even when our own loop runs
+/// zero iterations.
+pub(crate) struct LiveImportSeam {
+    rooms_dirty: bool,
+    dms_dirty: bool,
+}
+
+impl LiveImportSeam {
+    pub(crate) fn new() -> Self {
+        Self {
+            rooms_dirty: false,
+            dms_dirty: false,
+        }
+    }
+}
+
+impl RiverImportSeam for LiveImportSeam {
+    async fn merge_rooms(&mut self, rooms: Rooms, source_rank: u32) -> Result<(), String> {
+        self.rooms_dirty = true;
+        let (tx, rx) = futures::channel::oneshot::channel::<Result<(), String>>();
+        crate::util::defer(move || {
+            let result = crate::components::app::ROOMS.with_mut(|current| {
+                let merged = chat_delegate::with_identity_source_ranks(|ranks| {
+                    apply_recovered_rooms(current, rooms, source_rank, ranks)
+                });
+                // Re-decrypt secrets for merged rooms (they are #[serde(skip)]),
+                // as the sweep's hydrate does. Idempotent and cheap.
+                for room_data in current.map.values_mut() {
+                    room_data.repopulate_secrets_from_state();
+                }
+                merged
+            });
+            // A ranked resurrection must be visible to the SAVE path, exactly
+            // as in the sweep's hydrate: without `mark_room_rejoined` the
+            // per-room CAS reconcile sees the delegate's tombstone, answers
+            // AbortAdoptLeave, and the restored room stays tombstoned durably.
+            let resurrected: Vec<[u8; 32]> =
+                chat_delegate::with_identity_source_ranks(|ranks| {
+                    ranks.resurrected.drain().collect()
+                });
+            for room_key in resurrected {
+                if let Ok(vk) = ed25519_dalek::VerifyingKey::from_bytes(&room_key) {
+                    chat_delegate::mark_room_rejoined(vk);
+                }
+            }
+            let _ = tx.send(result);
+        });
+        rx.await
+            .map_err(|_| "rooms merge was dropped before running".to_string())?
+    }
+
+    async fn merge_outbound_dms(&mut self, store: OutboundDmStore) -> Result<(), String> {
+        // Same helpers the sweep's legacy DM arm uses; both defer their signal
+        // writes internally and are idempotent per entry.
+        chat_delegate::hydrate_hidden_dm_threads(store.hidden_threads);
+        chat_delegate::hydrate_outbound_dms_cache(store.entries);
+        self.dms_dirty = true;
+        Ok(())
+    }
+
+    async fn flush(&mut self) -> Result<(), String> {
+        if self.rooms_dirty {
+            // The coalesced save's per-room CAS (`reconcile_room_present`) is
+            // River's own import path to the delegate; its returned result is
+            // the real durability outcome (`CoalesceState::last_result`).
+            chat_delegate::save_rooms_to_delegate().await?;
+            self.rooms_dirty = false;
+        }
+        if self.dms_dirty {
+            chat_delegate::save_outbound_dms_to_delegate().await?;
+            self.dms_dirty = false;
+        }
+        Ok(())
+    }
+}
+
+/// River's own import path, as the library's successor writer.
+///
+/// Items are applied by MERGE at generation rank (see
+/// [`apply_recovered_rooms`]), which subsumes the never-clobber rule Union's
+/// newest-wins guarantee normally rests on: precedence comes from rank, not
+/// arrival order, so re-offering and re-walking are idempotent. Writes are
+/// BUFFERED (they land in the in-memory signals), so
+/// [`SuccessorSecretsIo::flush_predecessor`] is load-bearing: it awaits the
+/// coalesced delegate save and reports its real outcome.
+pub(crate) struct RiverSuccessorIo<'a, C: RiverDelegateChannel, S: RiverImportSeam> {
+    channel: &'a C,
+    seam: S,
+    /// The CURRENT delegate — where markers live.
+    successor: DelegateKey,
+}
+
+impl<'a, C: RiverDelegateChannel, S: RiverImportSeam> RiverSuccessorIo<'a, C, S> {
+    pub(crate) fn new(channel: &'a C, seam: S, successor: DelegateKey) -> Self {
+        Self {
+            channel,
+            seam,
+            successor,
+        }
+    }
+
+    /// GET a marker key from the CURRENT delegate. Three-way: value / definitive
+    /// absence / `Err` for silence, transport failure, or an unexpected reply.
+    /// An unreadable marker MUST be `Err` (→ `WriterUnavailable`, walk stops):
+    /// guessing `None` would re-import a possibly-done predecessor, and
+    /// guessing `Done` would silently skip one.
+    async fn get_marker(&mut self, storage_key: Vec<u8>) -> Result<Option<Vec<u8>>, String> {
+        let request = ChatDelegateRequestMsg::GetRequest {
+            key: ChatDelegateKey::new(storage_key.clone()),
+        };
+        match self.channel.request(&self.successor, request).await? {
+            Some(ChatDelegateResponseMsg::GetResponse { key, value }) => {
+                if key.as_bytes() != storage_key.as_slice() {
+                    return Err("marker GetResponse answered a different key".to_string());
+                }
+                Ok(value)
+            }
+            Some(other) => Err(format!("unexpected reply to marker GetRequest: {other:?}")),
+            None => Err("marker GetRequest timed out (silence is not absence)".to_string()),
+        }
+    }
+
+    /// Store a marker on the CURRENT delegate, awaiting the delegate's ack so
+    /// the marker is durable when this returns (the crate's record_marker
+    /// contract — markers are never batched with items).
+    async fn put_marker(&mut self, storage_key: Vec<u8>, value: &[u8]) -> Result<(), String> {
+        let request = ChatDelegateRequestMsg::StoreRequest {
+            key: ChatDelegateKey::new(storage_key),
+            value: value.to_vec(),
+        };
+        match self.channel.request(&self.successor, request).await? {
+            Some(ChatDelegateResponseMsg::StoreResponse { result, .. }) => {
+                result.map_err(|e| format!("delegate refused marker store: {e}"))
+            }
+            Some(other) => Err(format!("unexpected reply to marker StoreRequest: {other:?}")),
+            None => Err("marker StoreRequest timed out".to_string()),
+        }
+    }
+}
+
+impl<C: RiverDelegateChannel, S: RiverImportSeam> SuccessorSecretsIo
+    for RiverSuccessorIo<'_, C, S>
+{
+    type Error = String;
+
+    async fn migration_marker(
+        &mut self,
+        query: &MarkerQuery<'_>,
+    ) -> Result<Option<MigrationMarker>, Self::Error> {
+        // `query.legacy_bridge` is ignored: River never used the crate's older
+        // generation-keyed `import_secrets_once` markers (module docs).
+        if let Some(value) = self.get_marker(pred_done_marker_key(query.predecessor)).await? {
+            return Ok(Some(MigrationMarker::Done {
+                had_data: value != PRED_DONE_MARKER_VALUE_EMPTY,
+            }));
+        }
+        match self.get_marker(pred_wip_marker_key(query.predecessor)).await? {
+            Some(value) => Ok(Some(MigrationMarker::InProgress {
+                saw_data: value != PRED_DONE_MARKER_VALUE_EMPTY,
+            })),
+            None => Ok(None),
+        }
+    }
+
+    async fn record_marker(
+        &mut self,
+        predecessor: &DelegateKey,
+        marker: MigrationMarker,
+    ) -> Result<(), Self::Error> {
+        let (key, data) = match marker {
+            MigrationMarker::InProgress { saw_data } => (pred_wip_marker_key(predecessor), saw_data),
+            MigrationMarker::Done { had_data } => (pred_done_marker_key(predecessor), had_data),
+        };
+        let value = if data {
+            PRED_DONE_MARKER_VALUE_DATA
+        } else {
+            PRED_DONE_MARKER_VALUE_EMPTY
+        };
+        self.put_marker(key, value).await
+    }
+
+    async fn write_secret(&mut self, item: &RecoveredSecret<'_>) -> ItemWrite<Self::Error> {
+        match classify_recovered(item.key, item.value) {
+            decoded @ (RecoveredItem::RoomsBlob(_)
+            | RecoveredItem::Room(..)
+            | RecoveredItem::Meta(_)) => {
+                let rooms = rooms_to_merge(&decoded).expect("rooms variants always convert");
+                // `item.generation` is the lineage index, which is the SAME
+                // scale `source_rank_for_delegate_key` ranks the sweep's
+                // merges on (see `river_delegate_lineage`).
+                match self.seam.merge_rooms(rooms, item.generation).await {
+                    Ok(()) => ItemWrite::Written,
+                    Err(e) => ItemWrite::retryable(e),
+                }
+            }
+            RecoveredItem::OutboundDms(store) => match self.seam.merge_outbound_dms(*store).await {
+                Ok(()) => ItemWrite::Written,
+                Err(e) => ItemWrite::retryable(e),
+            },
+            // Never imported, never a failure: the successor's state stands.
+            RecoveredItem::MigrationMarker | RecoveredItem::Unrecognized => {
+                ItemWrite::AlreadyAuthoritative
+            }
+            // Bytes that do not decode now will not decode later. NOT
+            // withheld from older generations (an older copy may parse).
+            RecoveredItem::Undecodable(what, e) => {
+                ItemWrite::permanent(format!("undecodable {what}: {e}"))
+            }
+        }
+    }
+
+    async fn flush_predecessor(&mut self, _predecessor: &DelegateKey) -> Result<(), Self::Error> {
+        self.seam.flush().await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// How long the walk will wait for the initial load (the hand-rolled sweep
+/// included) to settle before starting, so its round-trips don't contend with
+/// the sweep's single-waiter correlation slots. Bounded: after this it starts
+/// anyway — a collision degrades to `Unresponsive` + retry-next-load, never to
+/// a wrong write.
+const WALK_QUIESCENCE_MAX_MS: u64 = 60_000;
+const WALK_QUIESCENCE_POLL_MS: u64 = 500;
+
+/// Run the crate's delegate-secret migration walk once.
+///
+/// Spawned from `fire_legacy_migration_request` behind the once-per-page-load
+/// latch (`arm_crate_walk_once`), so it inherits the freenet/river#253 gate:
+/// it only ever starts when the current delegate was observed empty or a prior
+/// migration was interrupted. Runs ALONGSIDE the hand-rolled sweep (release 1);
+/// its durable per-predecessor markers make subsequent page loads cheap
+/// (marker reads short-circuit to `AlreadyMigrated`) even in the gateway
+/// iframe, where the sweep's own localStorage latch cannot persist.
+pub(crate) async fn run_crate_delegate_migration() -> DelegateMigrationReport {
+    // Let the sweep's burst finish first (see `NodeDelegateChannel` on why).
+    let mut waited = 0u64;
+    while chat_delegate::pending_load_workers() != 0 && waited < WALK_QUIESCENCE_MAX_MS {
+        crate::util::sleep(std::time::Duration::from_millis(WALK_QUIESCENCE_POLL_MS)).await;
+        waited += WALK_QUIESCENCE_POLL_MS;
+    }
+
+    let lineage = river_delegate_lineage(chat_delegate::legacy_delegate_pairs());
+    let channel = NodeDelegateChannel;
+    let mut reader = RiverPredecessorIo::new(&channel);
+    reader.prewarm(&lineage).await;
+    let mut writer = RiverSuccessorIo::new(
+        &channel,
+        LiveImportSeam::new(),
+        chat_delegate::current_delegate_key(),
+    );
+    let report = freenet_migrate::migrate_delegate_secrets(
+        &mut writer,
+        &mut reader,
+        &lineage,
+        MigrationAuthorization::app_author_ack(),
+        river_secret_policy(),
+    )
+    .await;
+
+    log_migration_report(&report);
+    report
+}
+
+/// Log the walk's outcome. The report is METADATA ONLY and is never rendered
+/// to the user as counts (`imported_total` legitimately reads 0 for a fully
+/// successful recovery — freenet-migrate#16); the freenet/river#204 gate
+/// (`any_unresponsive`) is surfaced as a warning so a stranded generation is
+/// visible in diagnostics. The hand-rolled sweep owns the user-facing load
+/// states in release 1.
+fn log_migration_report(report: &DelegateMigrationReport) {
+    for p in &report.predecessors {
+        info!(
+            "crate-migration predecessor gen {}: {:?}",
+            p.generation(),
+            p
+        );
+    }
+    if report.any_unresponsive() {
+        warn!(
+            "crate-migration: {} predecessor generation(s) could not be confirmed executable — \
+             their data (if any) may exist but cannot auto-migrate; the walk retries next load",
+            report.unresponsive().count()
+        );
+    }
+    if report.is_complete() {
+        info!("crate-migration: walk complete");
+    } else if report.retry_may_help() {
+        info!("crate-migration: walk incomplete; a later run may make progress");
+    } else {
+        warn!("crate-migration: walk incomplete with non-retryable rejections");
+    }
+}

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -473,22 +473,39 @@ impl ResponseHandler {
                                         // GETs can be awaited without blocking the message
                                         // loop (the responses arrive through this loop).
                                         if is_legacy_delegate {
-                                            // Only the SWEEP's List drives this migration. The
-                                            // sweep fires its `ListRequest` fire-and-forget
-                                            // (`chat_delegate.rs`, legacy probe) so it registers
-                                            // no waiter and `completed` is false here.
+                                            // Suppresses the DUPLICATE migration when the crate
+                                            // walk is also probing this delegate. Two concurrent
+                                            // `migrate_legacy_per_room` runs share the walk's
+                                            // scoped correlation keys, so they displace each
+                                            // other in the single-waiter map — `Cancelled` reads,
+                                            // and a possible false `LoadFailed` for a user whose
+                                            // migration actually SUCCEEDED.
                                             //
-                                            // The crate WALK, by contrast, awaits its probes
-                                            // through the pending-request registry, so a
-                                            // completed response was consumed by the walk and is
-                                            // already being imported by the crate driver.
-                                            // Spawning here as well would run a second concurrent
-                                            // `migrate_legacy_per_room` against the same legacy
-                                            // delegate, whose per-key reads share the walk's
-                                            // scoped correlation keys — single-waiter
-                                            // displacement, `Cancelled` reads, and a possible
-                                            // false `LoadFailed` for a user whose migration
-                                            // actually SUCCEEDED. Deterministic, not a race.
+                                            // Be precise about WHY this is sufficient, because
+                                            // the obvious reason is the wrong one. Responses bind
+                                            // to waiters by CORRELATION KEY, not by which send
+                                            // produced them: the sweep's `ListRequest` and the
+                                            // walk's go to the same delegate under the same
+                                            // scoped key, so the sweep's response can perfectly
+                                            // well complete the WALK's waiter. Which response
+                                            // sees `completed == true` is interleaving-dependent.
+                                            //
+                                            // What makes it safe is a COUNTING argument: the
+                                            // sweep's probe registers no waiter (it is
+                                            // fire-and-forget), so N responses meet at most N-1
+                                            // walk waiters, and at least one response therefore
+                                            // falls through to spawn the migration exactly once.
+                                            //
+                                            // Two reachable exceptions, both fail-safe and both
+                                            // recovered by the durable markers on the next page
+                                            // load, neither losing data:
+                                            //  * a walk waiter times out (10 s) and is evicted
+                                            //    before its response lands — the late response
+                                            //    then spawns a migration that can overlap the
+                                            //    sweep-driven one;
+                                            //  * the sweep's send fails while the walk's
+                                            //    succeeds — the walk consumes the only response
+                                            //    and no sweep migration spawns this load.
                                             if !completed {
                                                 let legacy_key = key.clone();
                                                 crate::util::safe_spawn_local(async move {

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -11,16 +11,16 @@ mod update_response;
 use super::error::SynchronizerError;
 use super::room_synchronizer::RoomSynchronizer;
 use crate::components::app::chat_delegate::{
-    arm_legacy_migration_recovery, await_delegate_response, cas_store_correlation_key,
-    clear_legacy_migration_in_progress, complete_pending_public_key_request,
-    complete_pending_request, complete_pending_sign_request, complete_pending_signing_key_request,
-    current_delegate_source_rank, decide_legacy_migration_action, decide_per_room_load_action,
-    enqueue_delegate_request, fire_legacy_migration_request, get_versioned_correlation_key,
-    hydrate_hidden_dm_threads, hydrate_outbound_dms_cache, is_legacy_delegate_key,
-    is_legacy_migration_in_progress, legacy_scoped_correlation, load_state_after_probe_legacy,
-    mark_legacy_migration_done, mark_legacy_migration_in_progress, parse_room_storage_key,
-    per_room_terminal, prune_outbound_dms_for_purges, request_legacy_seal_on_quiescence,
-    room_storage_key, save_outbound_dms_to_delegate, save_rooms_to_delegate, send_delegate_request,
+    arm_legacy_migration_recovery, await_delegate_response, clear_legacy_migration_in_progress,
+    complete_pending_public_key_request, complete_pending_request, complete_pending_sign_request,
+    complete_pending_signing_key_request, current_delegate_source_rank,
+    decide_legacy_migration_action, decide_per_room_load_action, enqueue_delegate_request,
+    fire_legacy_migration_request, hydrate_hidden_dm_threads, hydrate_outbound_dms_cache,
+    is_legacy_delegate_key, is_legacy_migration_in_progress, legacy_scoped_correlation,
+    load_state_after_probe_legacy, mark_legacy_migration_done, mark_legacy_migration_in_progress,
+    parse_room_storage_key, per_room_terminal, prune_outbound_dms_for_purges,
+    request_legacy_seal_on_quiescence, response_correlation_base, room_storage_key,
+    save_outbound_dms_to_delegate, save_rooms_to_delegate, send_delegate_request,
     send_delegate_request_to, set_load_state_if_current, source_rank_for_delegate_key,
     LegacyMigrationAction, LoadWorkerGuard, PendingDelegateRequest, RoomsLoadState,
     OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY, ROOMS_STORAGE_KEY,
@@ -202,51 +202,30 @@ impl ResponseHandler {
                                         )
                                     };
 
-                                // Try to complete any pending request waiting for this response
+                                // Try to complete any pending request waiting for this response.
+                                //
+                                // Every storage response derives its correlation base from the
+                                // SINGLE shared `response_correlation_base` (the mirror of
+                                // `get_request_key`) and is scoped HERE, in one place. It used
+                                // to be six hand-written per-variant arms, and `ListResponse`
+                                // was the one that forgot `scoped()` — leaving every legacy
+                                // `ListRequest` waiter uncompletable and the crate walk dead.
+                                // Do NOT reintroduce per-variant key construction: a variant
+                                // that builds its own key can silently skip the scoping again.
                                 let completed = match &response {
-                                    // Key-value storage responses
-                                    ChatDelegateResponseMsg::GetResponse { key: skey, .. } => {
-                                        complete_pending_request(
-                                            &scoped(skey.as_bytes().to_vec()),
-                                            response.clone(),
-                                        )
-                                    }
-                                    ChatDelegateResponseMsg::StoreResponse { key: skey, .. } => {
-                                        complete_pending_request(
-                                            &scoped(skey.as_bytes().to_vec()),
-                                            response.clone(),
-                                        )
-                                    }
-                                    ChatDelegateResponseMsg::DeleteResponse { key: skey, .. } => {
-                                        complete_pending_request(
-                                            &scoped(skey.as_bytes().to_vec()),
-                                            response.clone(),
-                                        )
-                                    }
-                                    // CAS storage responses (freenet/river#345) correlate on
-                                    // DISTINCT keys (prefix + storage key) so they can't be
-                                    // confused with a concurrent plain Get/Store for the same
-                                    // storage key. Rebuild the same correlation key the request
-                                    // registered under (delegate-scoped too, for legacy).
-                                    ChatDelegateResponseMsg::GetVersionedResponse { key: skey, .. } => {
-                                        complete_pending_request(
-                                            &scoped(get_versioned_correlation_key(skey)),
-                                            response.clone(),
-                                        )
-                                    }
-                                    ChatDelegateResponseMsg::CasStoreResponse { key: skey, .. } => {
-                                        complete_pending_request(
-                                            &scoped(cas_store_correlation_key(skey)),
-                                            response.clone(),
-                                        )
-                                    }
-                                    ChatDelegateResponseMsg::ListResponse { .. } => {
-                                        // Use the special list request key
-                                        let list_key =
-                                            river_core::chat_delegate::ChatDelegateKey::new(
-                                                b"__list_request__".to_vec(),
-                                            );
-                                        complete_pending_request(&list_key, response.clone())
+                                    ChatDelegateResponseMsg::GetResponse { .. }
+                                    | ChatDelegateResponseMsg::StoreResponse { .. }
+                                    | ChatDelegateResponseMsg::DeleteResponse { .. }
+                                    | ChatDelegateResponseMsg::GetVersionedResponse { .. }
+                                    | ChatDelegateResponseMsg::CasStoreResponse { .. }
+                                    | ChatDelegateResponseMsg::ListResponse { .. } => {
+                                        match response_correlation_base(&response) {
+                                            Some(base) => complete_pending_request(
+                                                &scoped(base),
+                                                response.clone(),
+                                            ),
+                                            None => false,
+                                        }
                                     }
                                     // Signing key management responses
                                     ChatDelegateResponseMsg::StoreSigningKeyResponse {
@@ -483,10 +462,28 @@ impl ResponseHandler {
                                         // GETs can be awaited without blocking the message
                                         // loop (the responses arrive through this loop).
                                         if is_legacy_delegate {
-                                            let legacy_key = key.clone();
-                                            crate::util::safe_spawn_local(async move {
-                                                migrate_legacy_per_room(legacy_key, keys).await;
-                                            });
+                                            // Only the SWEEP's List drives this migration. The
+                                            // sweep fires its `ListRequest` fire-and-forget
+                                            // (`chat_delegate.rs`, legacy probe) so it registers
+                                            // no waiter and `completed` is false here.
+                                            //
+                                            // The crate WALK, by contrast, awaits its probes
+                                            // through the pending-request registry, so a
+                                            // completed response was consumed by the walk and is
+                                            // already being imported by the crate driver.
+                                            // Spawning here as well would run a second concurrent
+                                            // `migrate_legacy_per_room` against the same legacy
+                                            // delegate, whose per-key reads share the walk's
+                                            // scoped correlation keys — single-waiter
+                                            // displacement, `Cancelled` reads, and a possible
+                                            // false `LoadFailed` for a user whose migration
+                                            // actually SUCCEEDED. Deterministic, not a race.
+                                            if !completed {
+                                                let legacy_key = key.clone();
+                                                crate::util::safe_spawn_local(async move {
+                                                    migrate_legacy_per_room(legacy_key, keys).await;
+                                                });
+                                            }
                                         } else {
                                             crate::util::safe_spawn_local(async move {
                                                 load_rooms_per_room(keys).await;

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -442,6 +442,17 @@ impl ResponseHandler {
                                             // processing match still runs for every
                                             // response, so swallow these here rather
                                             // than warning "unexpected key".
+                                        } else if crate::components::app::freenet_api::delegate_migration::is_migration_marker_key(
+                                            key.as_bytes(),
+                                        ) {
+                                            // Crate-walk per-predecessor markers. Like the
+                                            // per-room keys above, these are consumed by the
+                                            // awaiting walk via the pending-request registry;
+                                            // the processing match still runs for every
+                                            // response. Without this branch a single walk
+                                            // logged ~54 "Unexpected key" warnings per page
+                                            // load — noise that trains the reader to ignore a
+                                            // warning that is meant to indicate a real gap.
                                         } else {
                                             warn!(
                                                 "Unexpected key in GetResponse: {:?}",


### PR DESCRIPTION
## Problem

River hand-rolls its delegate-secret recovery (the legacy sweep in `chat_delegate.rs` /
`response_handler.rs`, 27 registered generations). Four Freenet apps independently wrote the
same registry-and-probe loop; `freenet-migrate` exists to remove that duplication, and Delta
and ghostkeys have already adopted its 0.5 delegate walk. River was the largest remaining
hand-rolled delegate implementation (freenet/river#398 phase 3, freenet-core#2776 A3).

Separately, River has a concrete recurring cost the hand-rolled sweep cannot fix: in the
gateway iframe `localStorage` is unavailable, so the sweep's `is_legacy_migration_done` flag
never persists and every page load re-probes all 27 generations. Durable markers fix that.

## Approach

**Release 1 of 2: the crate's walk runs ALONGSIDE the existing sweep** (the shape Delta
shipped). Nothing is removed from the sweep; the walk adds the shared library's
classification, withholding, and durable per-predecessor markers. Retiring the sweep is
release 2, after field validation.

`ui/src/components/app/freenet_api/delegate_migration.rs` implements the two crate seams:

- **`RiverPredecessorIo`** reads predecessors through River's own delegate protocol
  (`ListRequest`/`GetRequest` over the pending-request oneshot side-table), with a
  **concurrent pre-warm** so 27 mostly-absent generations cost one 10s timeout window
  per load instead of ~4.5 minutes of sequential probes.
- **`RiverSuccessorIo`** writes the successor through River's own import path and keeps the
  marker bookkeeping in the CURRENT delegate's KV store.

Wired into `fire_legacy_migration_request` behind a **tested once-per-page-load latch**, so
the walk inherits the freenet/river#253 gate (it only starts when the current delegate was
observed empty, or an interrupted migration is being recovered).

### Deliberate divergences (each is load-bearing)

1. **freenet-migrate#19 override — a timeout is NOT an absence.** The crate's recommended
   semantics treat silence as "the predecessor does not have it"; that is a data-loss default
   and this adapter deliberately does not use it. Every round-trip is three-way: reply /
   silence / transport fault. Silence and faults classify the predecessor `Unresponsive`
   (retry next load) — they never read as "no data", never write, never seal a marker. A
   node-side `DelegateError` is uncorrelated with its request, so "delegate errored" and
   "no reply" are indistinguishable — both are UNKNOWN.

2. **Durable markers — the OPPOSITE of ghostkeys' choice, on purpose.** ghostkeys bans
   durable markers because its predecessor stores keep receiving writes after the re-key, so
   sealing there can strand late-arriving data. River's legacy delegates are FROZEN after a
   re-key (only the current delegate is ever written), so sealing is safe — and durability is
   what fixes the iframe re-probe waste above. Markers live in the current delegate's KV
   store under `__migrate_pred_done__:<hex>` / `__migrate_pred_wip__:<hex>`. The predecessor
   key is **hex-encoded, never raw**: the delegate's `create_origin_key` runs storage keys
   through `String::from_utf8_lossy`, which maps every invalid byte to U+FFFD, so two raw
   32-byte keys could alias onto one marker slot (sealing a predecessor that was never
   migrated).

3. **`fetch_secrets` UNIONS the legacy `ListRequest` with fixed `rooms_data` +
   `outbound_dms` probes.** The frozen legacy WASM swallows index decode errors into an
   empty list (`handlers.rs` — cannot be fixed), so List alone is not trustworthy. The union
   is a floor, not a full fix: dynamic `room:<vk>` keys are unguessable, so a corrupt index
   still strands those.

4. **One merge, ranked.** Every recovered room routes through `Rooms::merge_from_source`
   with `RecoveredSecret::generation` as the source rank — the SAME rank scale the sweep
   uses (`source_rank_for_delegate_key` = registry index; pinned by a test against the real
   registry). Ranked tombstones (#590) and identity conflicts (#527) are therefore handled
   identically to the sweep, with no second merge implementation. Persistence goes through
   the coalesced `save_rooms_to_delegate` per-room CAS, and `flush_predecessor` reports that
   save's REAL outcome — a failed flush withholds the completion marker.

5. **Policy = `UnionAllGenerations`** (the crate's loud opt-in): `NewestSnapshotWins` halts
   at the first silent predecessor, and silence is ordinary here (most of the 27 generations
   were never installed on a given node) — halting would strand every older generation
   (the #204 failure class). Union's resurrection hazard is bounded by River's ranked
   tombstones; the run-scoped-withholding hazard (freenet-migrate#15) is acknowledged, not
   fixed here.

### Delegate WASM is byte-identical

This is UI-side only. `ui/public/contracts/chat_delegate.wasm` is untouched:
`b3sum = a44c64014d60fd245fe8fb5172f8fd7397039b248b3b6a8e95e89a0bb539fb5e` (the required
pin), now enforced by the `chat_delegate_wasm_is_byte_identical` test.
`legacy_delegates.toml` is untouched (27 generations).

`freenet-migrate` 0.3 → 0.5 in `ui/` and `cli/`: the contract-side probe API
(`backward_probe.rs`, `cli/src/api.rs`) is source-compatible — both compile unchanged.

## Testing

17 new native tests in `delegate_migration.rs` + the WASM pin in `chat_delegate.rs`. The
scenario tests drive the REAL `freenet_migrate` driver through `walk_with` with a scripted
transport and an in-memory seam that holds a real `Rooms` + `MergeRanks`, so classification,
the union fetch, marker bookkeeping and the ranked merge are the production code paths.

Mutation evidence — every mutation applied, watched RED, then reverted (baseline 21/21
re-confirmed green after the final revert). Canary first: a `panic!` patched into the
crate's `migrate_delegate_secrets` via `[patch.crates-io]` failed exactly the 11 scenario
tests (10 unit/pin tests unaffected), proving the harness drives the real crate driver.
**No mutation survived.**

| # | Mutation | Killed by (count of failing tests) |
|---|---|---|
| M1 | predecessor GET timeout → "absent" | `a_silent_get_is_unresponsive_never_absent_never_sealed` (1) |
| M2 | probe silence → "executable" | `a_silent_predecessor_does_not_halt_the_union_walk` (1) |
| M3 | ranked merge → raw overwrite | the #527 + #590 fixtures (2) |
| M4 | oldest lineage generation dropped (`.skip(1)`) | 9 tests incl. both lineage pins + full walk |
| M5 | GET-reply key-mismatch check removed | `a_mismatched_get_reply_is_a_fault_not_data` (1) |
| M6 | latch always fires | `arm_walk_latch_fires_exactly_once` (1) |
| M7 | call-site latch gate removed | `crate_walk_is_wired_behind_the_latch_and_the_253_gate` (1) |
| M8 | marker read timeout → `Ok(None)` | `an_unreadable_marker_stops_the_walk_before_any_import` (1) — the fetch-count assert caught 2 predecessor GETs running without marker bookkeeping |
| M9 | marker read fault → fabricated `Done` | same test (1) |
| M10 | `flush_predecessor` no-op'd | `a_failed_flush_withholds_the_completion_marker` + full walk's flush-count assert (2) |
| M11 | marker keys carry raw predecessor bytes | `marker_keys_hex_encode_the_predecessor_and_survive_utf8_lossy` (1) |
| M12 | fixed probes removed (trust List alone) | unit rule + corrupt-index end-to-end (2) |
| M13 | policy weakened to `NewestSnapshotWins` | `a_silent_predecessor…` + full walk (2) |

Suite status on this branch: `cargo test -p river-ui --bins` **921 passed / 0 failed**;
`cargo make test` (web-container, room-contract, scaffold, common, chat-delegate +
integration) **354 passed / 0 failed**; `cargo make build-ui` succeeds; `cargo check -p
riverctl` and the wasm32 check pass; fmt applied; clippy clean for the new module.

## Review round 2 — two blocking bugs, both fixed

**All CI was green on this PR — including `check-delegate-migration`, `build`, and
Playwright — while the feature could not work at all in production.** It also had 19
tests and the 13-mutation campaign above, with predictions written first and all 13
killed. Both bugs survived every bit of that, because they live in layers that harness
structurally could not reach. Green CI on the earlier head said nothing about whether
the walk functioned.

The generalisable lesson: **mutation testing inherits the blind spot of its harness.**
Killing every mutation proves discrimination only over paths the harness reaches. Ask
what layer the test double stands in for, and whether the bug you care about is above or
below it.

### B1 — the walk's `ListRequest`s could never be answered (feature was dead code)

`enqueue_delegate_request_to` registered a legacy `ListRequest`'s waiter under
`legacy_scoped_correlation(delegate, base)`, but `response_handler.rs` completed
`ListResponse` under a freshly built **bare** `b"__list_request__"`. It was the only
storage variant that skipped the `scoped()` closure; Get/Store/Delete/GetVersioned/
CasStore all used it. `complete_pending_request` is an exact-key removal, so the waiter
was never completed: every prewarm probe and every `key_index` retry timed out after
10 s, leaving all 27 generations permanently `Unresponsive`. It fails SAFE (silence never
seals) but recovers nothing, at a cost of 10 s and 27 warnings per page load.

The blocking half: each prewarm `ListRequest` reaching an installed legacy delegate still
yielded a `ListResponse`, which was routed unconditionally into `migrate_legacy_per_room`
— a duplicate concurrent instance beside the one the sweep already spawned. Identical
scoped correlation keys, so single-waiter displacement produced `Cancelled` reads and a
possible false `LoadFailed` **for a user whose migration actually succeeded**.
Deterministic, not a race.

Fixed by root-causing the shape rather than the instance. The correlation base now comes
from one shared `list_request_correlation_key()`; the response side derives every storage
key through a single `response_correlation_base()` mirroring `get_request_key`; and the
legacy scoping is applied in exactly **one** place instead of six hand-written
per-variant arms, so no variant can be left unscoped again. The duplicate spawn is gated
on `!completed` — verified safe because both existing `ListRequest` senders (the
current-delegate load and the sweep) are fire-and-forget with no waiter, so they still
drive their migrations exactly as before.

### B2 — `flush` could seal `Done` over DM data that was never saved

`merge_outbound_dms` called hydrate helpers that defer their signal writes through
`util::defer` (`setTimeout(0)`, a **macrotask**) and returned `Ok` immediately, while
`flush` → `save_outbound_dms_to_delegate` reads `OUTBOUND_DMS` **synchronously**. The
merge→flush→snapshot chain runs on microtasks, which drain first. For a DM-only
predecessor (no rooms, so no intervening network round-trip) the save deterministically
serialised the PRE-merge cache, the driver sealed `Done { had_data: true }`, and the
marker guarantees the predecessor is never re-fetched. Silent, permanent loss.

Worst in the gateway iframe — no `localStorage`, so the sweep's flag never persists and
the marker is the only authority. That iframe case is the stated motivation for durable
markers, so the bug was worst exactly where the feature matters most. `outbound_dms` is
also a whole-blob replace-not-merge `StoreRequest`, the one store in River with Delta's
dangerous whole-list shape.

It now runs both writes inside one `defer` and awaits a oneshot signalled from within it,
exactly as `merge_rooms` already did correctly.

### Also in this round

- **S3** — the pre-warm's `join_all` could overlap the single `WEB_API` write borrow held
  across `api.send().await`: a `RefCell` double-borrow, which in single-threaded WASM is a
  panic. It was survived only by `WebApi::send` happening not to yield for small payloads,
  a property of the transport rather than of this code. The channel trait gains
  `request_all`, whose default is today's fan-out (correct for doubles, keeps their
  concurrency assertions unchanged) and whose `NodeDelegateChannel` override enqueues
  sequentially then awaits together — the shape the startup per-room fan-out already uses.
- **N1** — marker reads logged ~54 `Unexpected key in GetResponse` warnings per run; now
  swallowed like the per-room keys directly above them.
- **N2** — the walk was armed before its sends, so a load whose every send failed burned
  the once-per-page-load latch on a dead transport. Arming now happens after
  `any_dispatched` is final and is gated on it, matching the guard-reset precedent
  immediately above it. Still at most one arm per load, so a reconnect cannot stack a
  second concurrent walk.

### Reasoning that was load-bearing but undocumented

- **Check 7: sweep and walk are NOT independent, and that is what makes the data path
  safe.** They deliberately share the merge point, the save chokepoint and the correlation
  map: frozen predecessors, one ranked merge on a shared rank scale, CAS/coalesced saves,
  and a seal attesting only to the walk's own import. No interleaving can be constructed
  that loses a room or seals wrongly. The single exception was `outbound_dms` — B2.
- **Nothing writes a whole-list `rooms_data` any more.** Storage has been per-room CAS
  since #345; the legacy blob is read-only, kept purely as a rollback fallback.
- **The 60 s quiescence wait is load-shedding, not a safety mechanism.** `PENDING_LOADS`
  counts only response-processing workers, so it reads 0 between the sweep's sends and its
  responses. Correctness under overlap comes from the correlation scoping and the markers,
  not from this wait.
- **Inherited #253 coupling:** once the sweep marks done, `fire_legacy_migration_request`
  stops firing, so the walk stops retrying `Unresponsive` predecessors.

### Mutation campaign on the fixes

Re-run against the changed code, predictions written first; all killed, each verified
actually applied before running.

| # | Mutation | Test that caught it |
|---|----------|---------------------|
| M1 | `scoped()` dropped at the single correlation site | `response_handler_derives_correlation_keys_from_one_place` |
| M2 | List base drifts on the response side only | `request_and_response_correlation_keys_round_trip` |
| M3 | `!completed` gate removed (duplicate migration spawns) | `consumed_legacy_list_response_does_not_double_spawn_migration` |
| M4 | deferring hydrate helper restored inside the merge | `merge_outbound_dms_awaits_its_deferred_writes` |
| M5 | the DM-merge `await` dropped | same test |
| M6 | `any_dispatched` gate removed from the walk arming | `crate_walk_is_wired_behind_the_latch_and_the_253_gate` |
| M7 | `prewarm` reverted to `join_all` over `request` | `prewarm_fans_out_through_the_borrow_safe_primitive` |

Two of these pins are deliberately **source scrapes rather than behavioural tests**, and
that is the point rather than a shortcut. `util::defer` is `setTimeout(0)` on wasm32 but a
*synchronous call* natively, and `MemorySeam` merges synchronously — so on every surface a
test can actually run, the deferred write has always landed by the time `flush` reads. A
behavioural test for B2 would pass identically with the bug present, which is worse than
no test. The same applies to S3: a mock holds no shared `WEB_API` borrow, so it cannot
observe the double-borrow.

The previous correlation pin is also corrected. It checked only the *request* side, for
distinctness, against a base literal (`b"list"`) that appears nowhere in the code — so a
mismatch across the seam was the only interesting failure and the only one it could not
detect. **A guard at a seam must check both sides of the seam.**

### Withdrawn from the round-1 review

Two findings (revert `contract-version.txt`; split the `member_info_modal.rs` change) were
**false and have been withdrawn** — neither file is in this PR, which touches exactly six.
They came from a three-dot diff against a stale local `main`, which attributes main's own
newer commits to the branch. Called out here because the author pushed back with evidence
instead of complying, which is the only reason they were caught.


### Review round 3 — the round-2 pins were audited, and several were defeatable

Four independent lenses reviewed the round-2 fixes. They confirmed the two blocking
fixes are correct, and found that a number of the pins protecting them would pass with
their bug reintroduced. Those are fixed. Given this PR's own thesis, a pin that cannot
fail is worse than no pin, so these are reported rather than quietly corrected.

**The most serious was mine, and it is worth stating plainly.** The assertion that the
single correlation site applies `scoped()` was written and mutation-verified, then
destroyed by a `git checkout --` used to revert a mutation while it was still
uncommitted. Its loss went unnoticed because only two of the three affected edits were
re-checked afterwards. **Production was always correct; the pin protecting it was simply
absent from the pushed tree**, so the round-2 mutation table's "M1 killed" did not hold
for the committed code. Restored and re-verified. The general rule — commit before
mutating — was followed for the first campaign and not the second.

Fixed in round 3:

- The `scoped()` assertion is restored, and the blast radius is now recorded: an unscoped
  completion site also kills the hand-rolled **sweep's** per-room recovery, because
  `migrate_legacy_per_room` reads through the legacy-scoped `send_delegate_request_to`.
  Collapsing six arms into one made that single site wider than the bug it fixed.
- `request_and_response_correlation_keys_round_trip` now round-trips through the **real
  `PENDING_REQUESTS` registry**: it registers a waiter under the scoped key and asserts a
  bare-key completion does NOT satisfy it while the scoped one does. The previous scoping
  assertions were `f(a) == f(a)` on a pure function and could never fail, while the
  doc-comment advertised them as covering the half B1 broke.
- `request_all` loses its trait default. The obvious default is a `join_all` over
  `request` — exactly the unsafe shape — so deleting `NodeDelegateChannel`'s override
  would have silently returned production to the overlapping-borrow fan-out with every
  test green. `MockChannel` now states its naive fan-out explicitly, with a note that its
  `max_in_flight` assertions measure the double and never production.
- The B2 pin bounded `tx.send` only by the defer's *opening*. Placing the send after the
  whole closure compiles, satisfies every assertion, and restores B2 exactly. Now bounded
  by the closure's terminator.
- `production_request_all_enqueues_before_it_awaits` checked only text order, which a
  fully sequential enqueue-and-await-in-one-loop rewrite also satisfies — borrow-safe, but
  serialising the pre-warm into 27 x the 10 s timeout. Now also requires a real fan-out
  and requires the enqueue loop to close first.
- The duplicate-spawn pin required the guard to *precede* the spawn, which also passes for
  `if !completed { debug!(..); }` followed by an ungated spawn. Now requires containment.
- `response_correlation_base` enumerates the non-storage variants instead of `_ => None`,
  so a new storage variant is a compile error rather than a silently uncorrelated
  response — B1's exact failure mode.
- Both `_now` hydrate helpers regain the empty-input short-circuit, so a pre-archive
  predecessor no longer triggers a no-op `GlobalSignal` write per predecessor.
- `prewarm` asserts `request_all` returned one outcome per request; the length contract
  was documentation only, so a short vec would have silently dropped tail predecessors.

Comment corrections, each verified against source rather than assumed:

- **There is only ONE `PENDING_REQUESTS` map.** The non-storage responses use it under
  prefixed keys. The previous wording ("a different registry, this map is not involved")
  would leave a reader unaware that those four are unscoped for legacy targets.
- **The `!completed` guard's real invariant is a counting argument**, not the sender-based
  one previously given. Responses bind to waiters by correlation key, so the sweep's
  response can complete the walk's waiter; safety comes from N responses meeting at most
  N-1 waiters. Documented, with the two reachable exceptions (a timed-out waiter evicted
  before its response lands; the sweep's send failing while the walk's succeeds). Both
  fail-safe, both recovered next load.
- "No variant can be left unscoped" holds only within the storage family.
- Removed a reference to a pin that never existed, and corrected a stand-in-base
  attribution that named the wrong test in the wrong file.
- `request_all` removes the overlap *within* the pre-warm, not the cross-task case.
- The N2 gate's residual is stated rather than implied away.

The repo's own rules files were also stale in a way that matters: both told an author a
new fixed storage key needs **two** edits when it now needs **three** (the walk carries
its own fixed-probe list), and nothing under `.claude/` mentioned the walk or its durable
markers at all. Corrected in this PR, since that is the "next agent follows stale
instructions" failure the third site exists to prevent.

**Known remaining gap, stated rather than closed:** there is still no test that runs the
sweep and the walk concurrently against one mock delegate. `MockChannel` models per-delegate
KV stores and has no correlation map, no single-waiter slot and no displacement — so the
layer B1's blocking half lived in is still not exercised end to end. The round-trip test
now covers register-then-complete for a single driver, which is the part that was
achievable without new harness. A real two-driver test needs a registry double with
displacement semantics; that is the next piece of harness work, not something to fake.

### Round-3 mutation re-verification

| # | Mutation | Result |
|---|----------|--------|
| M1 | `scoped()` dropped at the single site (restored pin) | killed |
| M8 | `tx.send` moved outside the defer closure | killed |
| M9 | List base drifts on the response side | killed |

Each verified actually applied (non-empty diff) before running, and reverted after.
Suite: **921 passed / 0 failed** on `cargo test -p river-ui --bins`; full `cargo make test`
green; wasm32 and riverctl clean; no WASM binary touched.

## Deployment

No publish in this PR. The UI republish will be rehearsed against a throwaway container
key on a local-mode node before it goes to the production contract. Release 2 (retiring
the hand-rolled sweep) only happens after this release field-validates.

Part of freenet-core#2776 (A3) / freenet/river#398 phase 3. Follows PR #616.

Full-tier review requested (state migration surface).

[AI-assisted - Claude]


