### PR TITLE
docs: codegen is delegated to freenet-migrate-build

### DIFF
--- a/.claude/rules/delegate-migration.md
+++ b/.claude/rules/delegate-migration.md
@@ -31,8 +31,10 @@ migration entry, **users lose all room data**.
 
 All legacy delegate entries are defined in `legacy_delegates.toml` at the
 repo root. This file is the **only** place migration entries are managed.
-The UI's `build.rs` generates Rust code from it at compile time. CI reads
-it directly for validation.
+`ui/build.rs` turns it into Rust at compile time by calling
+`freenet_migrate_build::codegen()`; the build script itself keeps only the
+local gate that fails the build when the generated table comes out empty.
+CI reads the TOML directly for validation.
 
 ## Single Source of Truth: `common/legacy_room_contracts.toml`
 
@@ -41,8 +43,9 @@ recording the BLAKE3 code hash of every previous room-contract WASM
 generation. A client re-derives the contract key any owner's room used
 under each generation and probes them newest-to-oldest to recover a room
 dormant across one or more WASM upgrades (freenet/river#292).
-`common/build.rs` generates `LEGACY_ROOM_CONTRACT_CODE_HASHES` from it;
-the `river-core` `migration` feature exposes the lookup. It lives inside
+`common/build.rs` generates `LEGACY_ROOM_CONTRACT_CODE_HASHES` from it via
+the same `freenet_migrate_build::codegen()` call; the `river-core`
+`migration` feature exposes the lookup. It lives inside
 the `common` crate (not the repo root) so it ships with the published
 `river-core` crate and riverctl keeps the full registry.
 
@@ -87,8 +90,8 @@ git commit -m "fix: update WASMs with delegate migration entry"
 |------|---------|
 | `legacy_delegates.toml` | Single source of truth for delegate migration entries |
 | `common/legacy_room_contracts.toml` | Single source of truth for room-contract generations (#292) |
-| `ui/build.rs` | Generates `LEGACY_DELEGATES` const from the delegate TOML |
-| `common/build.rs` | Generates `LEGACY_ROOM_CONTRACT_CODE_HASHES` from the room-contract TOML |
+| `ui/build.rs` | Calls `freenet_migrate_build::codegen()` to generate the `LEGACY_DELEGATES` const from the delegate TOML |
+| `common/build.rs` | Calls `freenet_migrate_build::codegen()` to generate `LEGACY_ROOM_CONTRACT_CODE_HASHES` from the room-contract TOML |
 | `common/src/migration.rs` | Re-derives legacy room-contract keys for backward recovery (#292) |
 | `ui/src/components/app/chat_delegate.rs` | Uses generated `LEGACY_DELEGATES` for runtime migration |
 | `scripts/check-migration.sh` / `scripts/add-migration.sh` | Delegate migration validation / entry |

--- a/.claude/rules/river-publish.md
+++ b/.claude/rules/river-publish.md
@@ -161,7 +161,8 @@ where stale legacy data overwrites newer state on the current delegate
    List-driven, not a `GetRequest{rooms_data}`, because the per-room keys are
    dynamic and must be discovered.)
 2. `LEGACY_DELEGATES` is generated at compile time from `legacy_delegates.toml`
-   by `ui/build.rs`.
+   by `ui/build.rs`, which delegates the codegen itself to
+   `freenet_migrate_build::codegen()`.
 3. The current delegate's `ListResponse` is classified by `plan_load_from_keys`:
    - **Has `room:<vk>` keys** → `load_rooms_per_room` plain-GETs each slot
      (+ `rooms_meta`), reconstructs `Rooms`, and hydrates. What it does about
@@ -267,7 +268,8 @@ reads in the single-waiter registry. See the comment at that call site for the
 counting argument and its two exceptions.
 
 Release 2 retires the sweep; until then, treat the sweep as authoritative and
-the walk as additive.
+the walk as additive. The `freenet-migrate-adoption` skill covers the
+call-site swap, the dual-running period and the parity test.
 
 ## Migration Limitations
 


### PR DESCRIPTION
## Problem

Two agent-facing rule files describe the legacy-delegate codegen as something River's own `build.rs` performs. That stopped being true when River adopted `freenet-migrate-build` (#398): the build script is now only the entry point, and the generation is done by the crate.

Stale statements:

- `.claude/rules/delegate-migration.md:34` "The UI's `build.rs` generates Rust code from it at compile time"
- `.claude/rules/delegate-migration.md:90` key-files row "`ui/build.rs` | Generates `LEGACY_DELEGATES` const from the delegate TOML"
- `.claude/rules/river-publish.md:163-164` "`LEGACY_DELEGATES` is generated at compile time from `legacy_delegates.toml` by `ui/build.rs`."

`common/build.rs` has the same shape for the room-contract registry and was described the same way at `delegate-migration.md:44`.

## Approach

Correct the attribution without inflating it. `ui/build.rs` is still the entry point, so the fix names the delegation rather than rewriting the surrounding procedure:

- `ui/build.rs:125` calls `freenet_migrate_build::codegen()` with `.entry_registry("../legacy_delegates.toml", Component::Delegate)` and `.delegate_pair_view("LEGACY_DELEGATES")`.
- `common/build.rs:29` calls the same `freenet_migrate_build::codegen()` with `Component::Contract` and `.contract_hash_view("LEGACY_ROOM_CONTRACT_CODE_HASHES")`.
- What each build script still owns locally is the append-only emptiness gate that asserts on the generated output (`ui/build.rs:143-158`, `common/build.rs:41-46`). The wording says so, since that is the part a reader would otherwise assume moved into the crate too.

`freenet-migrate-build` is pinned at `0.2` in `ui/Cargo.toml:108` and `common/Cargo.toml:77`. Note this is a separate crate from the runtime half `freenet-migrate`, which is at `0.5` (`ui/Cargo.toml:98`); the two are at different versions and the doc text does not cite a version for either.

`river-publish.md` already carries an accurate crate-walk section at `:239`, so that content is not duplicated. The only addition there is a pointer to the new `freenet-migrate-adoption` skill from the existing "Release 2 retires the sweep" line.

## Testing

Documentation only, no code paths touched. Every claim was read from `origin/main` source rather than the working tree.

[AI-assisted - Claude]
