### PR TITLE
docs: room state is idempotent commutative monoid, not just commutative

### DIFF
--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -12,15 +12,16 @@ River is a decentralized chat application built on Freenet with the following ke
 ## Key Components
 
 1. **FreenetApiSynchronizer** – Manages WebSocket communication with Freenet
-2. **Room State Management** – Implements a commutative monoid pattern for order-agnostic state
-   updates
+2. **Room State Management** – Implements an idempotent commutative monoid pattern for
+   order-agnostic, duplicate-safe state updates
 3. **Invitation System** – Allows users to invite others to chat rooms
 4. **Cryptographic Security** – Uses ed25519 for signatures and authentication
 
 ## Implementation Details
 
 - Uses a comprehensive logging system for debugging WebSocket interactions
-- State updates are designed to be commutative (order-independent)
+- State updates are designed to be commutative (order-independent) and idempotent
+  (safe to apply more than once)
 - Handles both full state updates and delta updates
 - Implements proper error handling and status reporting
 


### PR DESCRIPTION
## Problem
DEVNOTES.md described room state merge as commutative-only. The actual requirement (matching freenet-stdlib and the whitepaper) is that merge is associative, commutative, AND idempotent.

## Approach
Align wording with the ecosystem-wide terminology.

## Testing
Doc-only change.

[AI-assisted - Claude]