### PR TITLE
feat: publish pointer records so integrators stop pinning keys that move

### DIFF
--- a/.claude/rules/delegate-migration.md
+++ b/.claude/rules/delegate-migration.md
@@ -63,17 +63,28 @@ cargo make add-room-contract-migration
 # 2. Build new WASMs and copy to all committed locations
 cargo make sync-wasm
 
+# 2b. Re-sign the pointer records against the WASM you just built.
+#     Step 1 carries OUR users forward; this carries THIRD PARTIES forward
+#     (see "The other half of a re-key" below). Same trigger, and CI's
+#     check-pointer-freshness fails the PR if you skip it.
+cargo make sign-pointer-records
+
 # 3. Run migration tests
 cargo test -p river-core --test migration_test
 cargo test -p river-core --test room_contract_migration_test
+cargo make check-pointer-freshness
 
 # 4. Verify UI compiles with new generated code
 cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync
 
 # 5. Commit everything
 git add legacy_delegates.toml common/legacy_room_contracts.toml \
-    ui/public/contracts/ cli/contracts/
+    pointer-records.toml ui/public/contracts/ cli/contracts/
 git commit -m "fix: update WASMs with delegate migration entry"
+
+# 6. AFTER the PR merges, from main: publish the re-signed records.
+#    Signing is offline and belongs in the PR; the network write does not.
+#    See .claude/rules/river-publish.md Step 7.
 ```
 
 ## The other half of a re-key: pointer records

--- a/.claude/rules/delegate-migration.md
+++ b/.claude/rules/delegate-migration.md
@@ -76,6 +76,32 @@ git add legacy_delegates.toml common/legacy_room_contracts.toml \
 git commit -m "fix: update WASMs with delegate migration entry"
 ```
 
+## The other half of a re-key: pointer records
+
+The registries above carry **our own users'** data across a re-key. They do
+nothing for a **third party** integrating with River, whose reference to our
+contract or delegate key is a build-time constant that silently goes stale —
+every read comes back looking like "this user has nothing stored".
+
+That half is `pointer-records.toml`: a record at a FIXED address naming the
+artifact's current code hash, signed by River's author key, which integrators
+resolve instead of pinning. Same trigger as a migration entry, different
+beneficiary.
+
+```bash
+cargo make sign-pointer-records      # after sync-wasm, BEFORE committing
+cargo make check-pointer-freshness   # what CI runs
+# then, from main after the PR merges:
+cargo make publish-pointer-records
+```
+
+CI's `check-pointer-freshness` fails the PR if a pointed-at WASM changed and no
+new record was signed. So in practice: whenever you run `add-migration`, you
+also need `sign-pointer-records`. See FREENET.md for the integrator-facing side,
+including the scope boundary — **a pointer solves addressing only** and says
+nothing about whether secrets survived the re-key, which is exactly what the
+rest of this file is about.
+
 ## Validation
 
 - **`cargo make check-migration`** — local check: builds delegate WASM and verifies migration entry exists if hash changed
@@ -83,6 +109,7 @@ git commit -m "fix: update WASMs with delegate migration entry"
 - **CI `check-delegate-migration` workflow** — builds base and PR WASMs, verifies old hash is in `legacy_delegates.toml`
 - **CI `check-room-contract-migration` workflow** — verifies a changed room-contract WASM's old hash is in `common/legacy_room_contracts.toml`
 - **CI `check-cli-wasm` workflow** — verifies `ui/public/contracts/` and `cli/contracts/` WASMs are in sync
+- **CI `check-pointer-freshness` workflow** — verifies every record in `pointer-records.toml` still names the committed WASM and is signed by the author key published in `FREENET.md`
 
 ## Key Files
 
@@ -96,6 +123,8 @@ git commit -m "fix: update WASMs with delegate migration entry"
 | `ui/src/components/app/chat_delegate.rs` | Uses generated `LEGACY_DELEGATES` for runtime migration |
 | `scripts/check-migration.sh` / `scripts/add-migration.sh` | Delegate migration validation / entry |
 | `scripts/check-room-contract-migration.sh` / `scripts/add-room-contract-migration.sh` | Room-contract registry validation / entry |
+| `pointer-records.toml` | Signed pointer records — third-party stable identity (addressing only) |
+| `scripts/check-pointer-freshness.sh` / `scripts/sign-pointer-records.sh` / `scripts/publish-pointer-records.sh` | Pointer gate / re-sign / network publish |
 | `scripts/sync-wasm.sh` | Builds all WASMs and copies to committed locations |
 | `common/tests/migration_test.rs` / `common/tests/room_contract_migration_test.rs` | Validate TOML entries are well-formed |
 

--- a/.claude/rules/river-publish.md
+++ b/.claude/rules/river-publish.md
@@ -47,10 +47,30 @@ If changes are already in the tree, stash first: `git stash`, run add-migration,
 cargo make sync-wasm
 ```
 
+### Step 3b: Re-sign the pointer records
+
+The WASM you just rebuilt has a new code hash, so River's **pointer records**
+now name a key that no longer exists. Those records are what third parties
+resolve instead of pinning a key — see `pointer-records.toml` and FREENET.md.
+
+```bash
+cargo make sign-pointer-records   # re-signs against the WASM you just built
+```
+
+Step 2's migration entry carries **our own users'** data forward. This carries
+**everyone else** forward. Same trigger, different set of people who lose if it
+is skipped — and their failure is quieter, because a stale pointer answers
+confidently with a dead key rather than erroring.
+
+CI's `check-pointer-freshness` fails the PR if you skip this, so it is not
+possible to publish a stale pointer through the normal flow. That is the
+backstop, not the plan.
+
 ### Step 4: Validate and Test
 
 ```bash
 cargo make check-migration
+cargo make check-pointer-freshness
 cargo test -p river-core --test migration_test
 cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync
 cargo fmt
@@ -77,6 +97,24 @@ git commit -m "chore: bump web-container version after publish"
 curl -s http://127.0.0.1:7509/v1/contract/web/raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv/ | head -5
 git push origin main
 ```
+
+### Step 7: Publish the pointer records (only if step 3b re-signed any)
+
+Signing (3b) happens in the PR; publishing is the network half and runs from
+`main` after the merge, like every other publish here.
+
+```bash
+POINTER_NODE_PORT=<a network node of yours, NOT 7509> \
+POINTER_WASM=~/code/freenet/freenet-migrate/contracts/pointer-contract/pointer-v1.wasm \
+  cargo make publish-pointer-records
+```
+
+It runs its own pre-flight (clean tree, on main, CI green on this exact SHA,
+the record's hash matches the artifact **live on the network**, the version is
+exactly one above what the network holds) and then re-reads each record back
+and verifies it. Do not accept "the PUT returned OK": a publish at an
+already-used version is a no-op *success*, so the network will never tell you
+it was ignored.
 
 **Version policy:** the canonical source is `published-contract/contract-version.txt`, which `cargo make sign-webapp` increments and writes back each publish. NEVER base the version on wall-clock time (`date +%s / 60`) — the previous scheme bit us 2026-05-16 when the on-network version had drifted ahead of the timestamp-derived value. The counter file makes the version a strict monotonic local invariant; gaps are fine (the contract enforces monotonicity, not contiguity).
 

--- a/.claude/rules/wasm-safety.md
+++ b/.claude/rules/wasm-safety.md
@@ -24,7 +24,11 @@ If `git status` shows modified `.wasm` files in `ui/public/contracts/` or `cli/c
 **do not commit them** unless you have:
 1. Run `cargo make add-migration` to record the old delegate key
 2. Run `cargo make sync-wasm` to intentionally rebuild WASMs
-3. Run `cargo test -p river-core --test migration_test` to validate
+3. Run `cargo make sign-pointer-records` — a rebuilt WASM invalidates River's
+   published pointer records, which third parties resolve instead of pinning a
+   key (see `pointer-records.toml`). CI's `check-pointer-freshness` fails the PR
+   if you skip it.
+4. Run `cargo test -p river-core --test migration_test` to validate
 
 If you see modified WASMs and did NOT intentionally change them (e.g., `cargo make build`
 rebuilt them as a side effect), restore them:

--- a/.github/workflows/check-pointer-freshness.yml
+++ b/.github/workflows/check-pointer-freshness.yml
@@ -37,7 +37,16 @@ jobs:
       run: |
         REV="$(grep -m1 '^POINTER_TOOL_REV=' scripts/check-pointer-freshness.sh \
                | sed 's/.*:-\([0-9a-f]*\)}.*/\1/')"
-        test -n "$REV" || { echo "could not read POINTER_TOOL_REV from the script"; exit 1; }
+        # Validate the SHAPE, not just non-emptiness. If the line ever stops
+        # matching, sed passes the whole line through unchanged — which is
+        # non-empty, so a bare `test -n` would accept it and then hand cargo a
+        # garbage rev. A guard that cannot fail is the thing this whole gate
+        # exists to avoid.
+        case "$REV" in
+          [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*) ;;
+          *) echo "POINTER_TOOL_REV is not a hex SHA: '$REV'"; exit 1 ;;
+        esac
+        test "${#REV}" -ge 7 || { echo "POINTER_TOOL_REV too short: '$REV'"; exit 1; }
         echo "pinned freenet-migrate rev: $REV"
         cargo install --git https://github.com/freenet/freenet-migrate \
           --rev "$REV" --features publish --locked freenet-pointer-contract

--- a/.github/workflows/check-pointer-freshness.yml
+++ b/.github/workflows/check-pointer-freshness.yml
@@ -1,0 +1,49 @@
+name: Check Pointer Freshness
+
+# River publishes pointer records so third parties can resolve our artifacts'
+# current keys instead of pinning one that re-keys under them. This gate exists
+# because a STALE pointer is worse than no pointer: an integrator resolves it,
+# gets a confident answer, and derives a dead key.
+#
+# It fails the build when a pointed-at WASM changed and no new record was
+# signed. Sibling of check-delegate-migration, and the same shape — see
+# scripts/check-pointer-freshness.sh for why this asks a different question
+# ("does the record name THESE bytes?" rather than "does an entry exist?").
+
+on:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check-pointer-freshness:
+    runs-on: freenet-default-runner
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        # Full history: the gate compares the record against the PR's base
+        # commit to confirm the version moved when the record did.
+        fetch-depth: 0
+
+    - name: Install b3sum
+      run: command -v b3sum || cargo install b3sum --locked
+
+    # Pinned by revision, deliberately. This tool decides what a pointer
+    # record's bytes ARE; a gate whose oracle can change under it is not a
+    # gate. Bumping the rev is a reviewed act, not a silent floating upgrade.
+    - name: Install pointer-record
+      run: |
+        REV="$(grep -m1 '^POINTER_TOOL_REV=' scripts/check-pointer-freshness.sh \
+               | sed 's/.*:-\([0-9a-f]*\)}.*/\1/')"
+        test -n "$REV" || { echo "could not read POINTER_TOOL_REV from the script"; exit 1; }
+        echo "pinned freenet-migrate rev: $REV"
+        cargo install --git https://github.com/freenet/freenet-migrate \
+          --rev "$REV" --features publish --locked freenet-pointer-contract
+
+    - name: Verify every pointer record names the committed WASM and is signed
+      run: |
+        ./scripts/check-pointer-freshness.sh --ci \
+          "${{ github.event.pull_request.base.sha }}" \
+          "${{ github.event.pull_request.head.sha }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,6 +242,19 @@ lives in **`.claude/rules/delegate-migration.md`**. Read it before
 publishing any change that touches those paths. The publish-side
 counterpart is **`.claude/rules/river-publish.md`**.
 
+**The same change also invalidates River's pointer records.** A migration
+entry carries OUR users' data forward; a pointer record tells THIRD PARTIES
+where the artifact moved to, so they resolve instead of pinning a key that
+re-keys weekly. Run `cargo make sign-pointer-records` alongside
+`add-migration`, and `cargo make publish-pointer-records` from main after the
+merge. CI's `check-pointer-freshness` fails the PR if a pointed-at WASM changed
+and no new record was signed. See `pointer-records.toml` and `FREENET.md`.
+
+A pointer solves **addressing only** — it says nothing about whether state or
+secrets under the old key survived, which is what the migration registries are
+for. Do not let the two blur together; conflating them is the specific error
+this mechanism exists to prevent.
+
 ## Testing Notes
 - Run `cd common && cargo test private_room` when modifying encryption or secret distribution.
 - Use `cargo make test` before every PR to ensure all components still build and pass tests.

--- a/FREENET.md
+++ b/FREENET.md
@@ -35,4 +35,54 @@ This file enumerates the Freenet contracts and delegates published from this rep
 ## Notes for integrators
 
 - Depend on `river-core` for the wire types; you almost never need to compile or execute the contract/delegate WASM yourself to read or construct River-compatible data.
-- Every contract/delegate here can re-key on any release (see the Migration notes above) — a build-time-constant reference to a key will silently go stale. There is no stable-identity pointer published yet; track [freenet-core#5194](https://github.com/freenet/freenet-core/issues/5194) for when one lands.
+- Every contract/delegate here can re-key on any release (see the Migration notes above) — **a build-time-constant reference to a key will silently go stale.** Resolve a pointer instead; see below.
+
+## Stable identity: resolve a pointer, do not pin a key
+
+River publishes **pointer records** for the two artifacts that re-key. A pointer record is a contract at a **fixed address** whose state names the artifact's *current* code hash, signed by River's author key. You GET the pointer, read the code hash, and derive the key you actually wanted from that hash **plus your own params**. The address never changes, so your build-time constant never goes stale.
+
+This implements the convention in [freenet-core#5194](https://github.com/freenet/freenet-core/issues/5194).
+
+### The author verifying key — your trust anchor
+
+```
+river:v1:vk:9Ebskq4y7NvJpTQTrF1FAxU8g6bR4Rhe4TRikXba55EJ
+```
+
+Pin **this 32-byte value** as a constant in your build. It is the entire trust anchor: take it from anywhere else and you may resolve a validly-signed pointer belonging to somebody else. It is the same key that signs River's web container, which is why `raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv` derives from it.
+
+Two things we would rather you learned here than discovered later:
+
+- **River does not keep this key offline**, contrary to the pointer contract's own recommendation, because the same key signs every UI publish. We are telling you what we actually do rather than what the docs advise.
+- **Rotating it would move everything at once** — the web container's address and both pointer addresses. That would strand anyone who baked in the author vk, so it is a coordinated flag day, not routine key hygiene.
+
+### The pointers
+
+| `app_id` | Points at | Pointer key (fixed, GET this) |
+|---|---|---|
+| `river.room-contract` | [`contracts/room-contract/`](contracts/room-contract/) | `Ai4VLoC2jGdhpcB2UU8VPo3efUoxjm1Ju9VKXqRC63Az` |
+| `river.chat-delegate` | [`delegates/chat-delegate/`](delegates/chat-delegate/) | `6qF2H5JRPBxbKC45UtPnzdDzyfsejYFW1UwDLGDU66mu` |
+
+Both addresses are derivable offline from the pointer contract's frozen code hash `8wnAPaSRY1oYZCz723fdwK6BgzL6q8ozP3buVovXnt6v` and `(author_vk ‖ app_id)` — you do not have to trust the table.
+
+Current records are in [`pointer-records.toml`](pointer-records.toml), which CI checks on every PR (`scripts/check-pointer-freshness.sh`): if a pointed-at WASM changes and no new record is signed, the build fails. That gate is the reason resolving is safer than pinning.
+
+### How to resolve
+
+Rust integrators should use the resolver rather than hand-rolling it — it carries the anti-rollback floor and the absence-vs-unreachability distinction, neither of which you get from decoding the record yourself:
+
+```rust
+use freenet_migrate::pointer::{resolve_app_pointer, PointerFloor, PointerOutcome};
+
+let outcome = resolve_app_pointer(&mut io, &RIVER_AUTHOR_VK, b"river.chat-delegate", floor).await?;
+```
+
+Handle **every** arm. A bare `if let Some(r) = outcome.resolved()` silently does nothing on the outcomes that carry no record, which is how a withdrawal, a rollback attempt and a plain timeout all become "no output". Only `NeverPublished` permits falling back to a baked-in key. Persist `outcome.next_floor()`, keyed by `(author_vk, app_id)`.
+
+Non-Rust implementers: the wire format, the four resolution steps and hex test vectors are in the [pointer contract's README](https://github.com/freenet/freenet-migrate/tree/main/contracts/pointer-contract) and `TEST-VECTORS.md`.
+
+### What a pointer does NOT tell you
+
+**It solves addressing only.** It tells you which code hash is current. It says nothing about whether any state or any secret held under the previous key survived the re-key.
+
+This matters most for `river.chat-delegate`. Delegate secrets move only when River's own UI has run on that user's node, so you can resolve the pointer perfectly, derive the right key, and still find an **empty namespace** — which looks like "this user has no data" rather than like an error. That is the specific confusion the pointer exists to remove, so please do not let it back in one level up: treat data survival as a separate question, verify it per artifact, and assume it is unsolved until you have.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -354,6 +354,14 @@ echo "Please commit the changes to git"
 # migration entry. A local `sync-wasm` + `publish-river` that skips committing
 # the new WASM would silently re-key the on-network contract with NO CI
 # trip-wire and orphan every user's room data.
+#
+# The same republish also invalidates our POINTER RECORDS, which are what third
+# parties resolve instead of pinning a key (FREENET.md, pointer-records.toml).
+# Run `cargo make sign-pointer-records` in the same PR — CI's
+# check-pointer-freshness demands it — and `cargo make publish-pointer-records`
+# from main after the merge. Migration entries carry OUR users forward; the
+# pointer tells everyone ELSE where the artifact went. Same trigger, two
+# different sets of people who lose if it is skipped.
 description = "Publish River to Freenet using the committed contract version"
 dependencies = ["sign-webapp"]
 script = '''
@@ -696,6 +704,50 @@ echo "Don't forget to: git push origin main"
 [tasks.check-migration]
 description = "Check if delegate WASM changed and migration entry is needed"
 script = ["scripts/check-migration.sh"]
+
+# --- Pointer records (stable identity for third parties) ---------------------
+#
+# These are the OTHER half of a re-key. The migration registries above carry
+# OUR users' data forward across a re-key; a pointer record tells THIRD PARTIES
+# where the artifact moved to. Different problem, same trigger — so whenever you
+# run `add-migration`, you almost certainly also need `sign-pointer-records`.
+#
+# See FREENET.md and pointer-records.toml.
+
+[tasks.check-pointer-freshness]
+description = "Check every pointer record still names the committed WASM (CI runs this)"
+script = ["scripts/check-pointer-freshness.sh"]
+
+[tasks.sign-pointer-records]
+description = "Re-sign pointer records against the current WASM (needs the author key)"
+script = ["scripts/sign-pointer-records.sh"]
+
+[tasks.publish-pointer-records]
+description = "Publish signed pointer records to the network. FROM MAIN, AFTER MERGE."
+script = ['''
+#!/bin/bash
+# Deliberately not defaulted: the node to publish through and the committed
+# pointer WASM are both decisions, and a wrong default for either is a publish
+# that looks fine here and is invisible to everyone else.
+if [ -z "${POINTER_NODE_PORT:-}" ] || [ -z "${POINTER_WASM:-}" ]; then
+  cat <<'USAGE'
+Set both, then re-run:
+
+  POINTER_NODE_PORT   the ws-api port of a network-mode node to publish THROUGH.
+                      NOT 7509 (that is the production gateway).
+  POINTER_WASM        path to the COMMITTED contracts/pointer-contract/pointer-v1.wasm
+                      from a freenet-migrate checkout. Do NOT build it locally:
+                      a locally rebuilt WASM lands every record at an address
+                      nobody else derives.
+
+  POINTER_NODE_PORT=7599 \
+  POINTER_WASM=~/code/freenet/freenet-migrate/contracts/pointer-contract/pointer-v1.wasm \
+    cargo make publish-pointer-records
+USAGE
+  exit 2
+fi
+exec scripts/publish-pointer-records.sh --node-port "$POINTER_NODE_PORT" --pointer-wasm "$POINTER_WASM"
+''']
 
 [tasks.add-migration]
 description = "Add migration entry for currently committed delegate WASM"

--- a/pointer-records.toml
+++ b/pointer-records.toml
@@ -1,0 +1,89 @@
+# River's pointer records — stable identity for things that re-key.
+#
+# A pointer record is a tiny contract at a FIXED address whose state names the
+# CURRENT code hash of one of River's artifacts. Third parties resolve it
+# instead of pinning a key, so they survive our re-keys. See
+# freenet-core#5194 and the contract's README:
+# https://github.com/freenet/freenet-migrate/tree/main/contracts/pointer-contract
+#
+# This solves ADDRESSING ONLY. It says nothing about whether state or secrets
+# under the old key survived — see the note under [[record]] for the delegate.
+#
+# ## What this file is for
+#
+# It is BOTH the registry integrators read AND the thing CI checks. Every
+# record here carries its own signature, so `scripts/check-pointer-freshness.sh`
+# can prove, with no network and no key, that:
+#
+#   * the record is signed by the author key published in FREENET.md, AND
+#   * it names the BLAKE3 of the WASM committed at `wasm_path` right now.
+#
+# That second clause is the point. "Is there a record?" passes forever after
+# the first one is committed; "does the record name THESE bytes?" fails the
+# moment the WASM re-keys and nobody signed a new one. A pointer that has gone
+# stale is worse than no pointer at all, because an integrator resolves it,
+# gets a confident answer, and derives a dead key.
+#
+# ## Editing this file
+#
+#   Do not hand-edit `code_hash`, `version` or `state`. Run:
+#       cargo make sign-pointer-records      # re-signs against the committed WASM
+#   then commit the result. A hand-edited hash leaves the signature behind and
+#   CI fails, which is the intended outcome and not a bug in the gate.
+#
+#   `version` is a monotonic counter per record, gating the network update. It
+#   must strictly increase on every publish. Like
+#   `published-contract/contract-version.txt`, it is NOT safe under two parallel
+#   publishes on one workstation — wrap in `flock` if you need that.
+
+# The author identity. Also published in FREENET.md, and the gate checks the two
+# agree: an integrator takes this value from FREENET.md, so if the two ever
+# drift, the records we sign are ones nobody can verify.
+#
+# This is the SAME key that signs River's web container. Ian's decision,
+# 2026-08-18. It is safe against cross-app replay because the pointer contract
+# signs over the whole params blob (author_vk ‖ app_id), so a record for one
+# app_id cannot be replayed into another. Two consequences worth stating rather
+# than discovering:
+#
+#   * River does NOT keep this key offline, contrary to the pointer contract's
+#     own recommendation, because the same key is used on every UI publish.
+#   * Rotating it changes BOTH the web container's address AND both pointer
+#     addresses, stranding integrators who baked in the author vk. Acceptable,
+#     but it couples the flag days.
+author_verifying_key = "river:v1:vk:9Ebskq4y7NvJpTQTrF1FAxU8g6bR4Rhe4TRikXba55EJ"
+
+# The pointer contract's own frozen code hash. A CONSTANT, never recomputed:
+# every pointer address in the ecosystem is BLAKE3(this ‖ params), so a locally
+# rebuilt pointer WASM lands every record at an address nobody else derives —
+# invisible to every consumer while looking, from here, like a successful
+# publish. See contracts/pointer-contract/WASM-STABILITY.md upstream.
+pointer_code_hash = "8wnAPaSRY1oYZCz723fdwK6BgzL6q8ozP3buVovXnt6v"
+
+
+[[record]]
+app_id = "river.room-contract"
+wasm_path = "ui/public/contracts/room_contract.wasm"
+# The fixed address integrators GET. Derived from pointer_code_hash and
+# (author_verifying_key ‖ app_id); recorded here so a human can check it and
+# so the gate can catch a derivation that has drifted.
+pointer_key = "Ai4VLoC2jGdhpcB2UU8VPo3efUoxjm1Ju9VKXqRC63Az"
+version = 1
+code_hash = "e765339ba3039f937256f4b6f7e8683d43f90e158f5d80f0dd45afdca69911e5"
+state = "00000001e765339ba3039f937256f4b6f7e8683d43f90e158f5d80f0dd45afdca69911e5626b9b5565ee3f6c17d45f50fcc79f88a5b49233669fdd8bec396f89ee891dd88a2b083f6072fe1ab1ae0dc420ae4b0b2ed5f391f95d495e9d8ad0327f13280a"
+
+[[record]]
+app_id = "river.chat-delegate"
+wasm_path = "ui/public/contracts/chat_delegate.wasm"
+pointer_key = "6qF2H5JRPBxbKC45UtPnzdDzyfsejYFW1UwDLGDU66mu"
+version = 1
+code_hash = "a44c64014d60fd245fe8fb5172f8fd7397039b248b3b6a8e95e89a0bb539fb5e"
+state = "00000001a44c64014d60fd245fe8fb5172f8fd7397039b248b3b6a8e95e89a0bb539fb5e94857075de1c9d70377fd4929ba5eeedfb00685c11be3940fa9a16ba493f6deda2e6af94d787532332b0f00d30ac89415b822e6bef4e8259264bb51b862cbe0e"
+# SCOPE, and it matters most here. Resolving this pointer correctly tells you
+# the delegate's current key. It does NOT tell you that the user's secrets came
+# with it: delegate secrets only move when River's own UI has run on that user's
+# node, so an integrator can resolve this record perfectly and still find an
+# EMPTY namespace. That looks like "this user has no data" rather than like an
+# error, which is exactly the confusion this record exists to remove — so do not
+# let it re-introduce it one level up. Data survival is a separate, unsolved
+# problem; see legacy_delegates.toml and .claude/rules/delegate-migration.md.

--- a/scripts/check-pointer-freshness.sh
+++ b/scripts/check-pointer-freshness.sh
@@ -53,63 +53,17 @@ command -v pointer-record >/dev/null 2>&1 || die "pointer-record not found. Inst
 
 # --------------------------------------------------------------------- parsing
 #
-# Deliberately line-oriented rather than a TOML library: this has to run in a CI
-# job whose only job is to check, and adding a Python/Rust TOML dependency to do
-# it would make the gate itself something that can fail to install. The schema is
-# ours and is three scalar keys per [[record]] block.
-#
-# `field_of_record N KEY` prints the value of KEY in the Nth [[record]] block.
-field_of_record() {
-    local n="$1" key="$2" src="${3:-$TOML_PATH}"
-    awk -v want="$n" -v key="$key" '
-        /^\[\[record\]\]/ { i++; next }
-        i == want && $0 ~ "^"key"[ \t]*=" {
-            sub("^"key"[ \t]*=[ \t]*", "")
-            gsub(/^"|"$/, "")
-            print
-            exit
-        }
-    ' "$src"
-}
+# One shared reader, in scripts/pointer-toml-lib.sh, used by this gate AND by
+# sign-pointer-records.sh. There used to be two near-identical copies; the two
+# disagreeing about what a record says is the worst failure available here,
+# because the signer would write something the gate reads differently.
+. "$(dirname "$0")/pointer-toml-lib.sh"
 
-record_count() { grep -c '^\[\[record\]\]' "$TOML_PATH"; }
-
-# Every app_id in a file, one per line, anchored so a `[[record]]` mentioned in
-# a comment cannot contribute one.
-app_ids_in() {
-    awk '/^app_id[ \t]*=/ { sub("^app_id[ \t]*=[ \t]*", ""); gsub(/^"|"$/, ""); print }' "$1"
-}
-
-# The 1-based record index carrying APP_ID in a file, or empty.
-#
-# Records are matched BY app_id and never by position. Matching by position
-# means reordering two blocks makes each index compare two DIFFERENT apps, so
-# the version check below skips both — a free way to republish at an old
-# version, which is a silent no-op on the network.
-index_of_app() {
-    awk -v want="$2" '
-        /^\[\[record\]\]/ { i++; next }
-        /^app_id[ \t]*=/ {
-            v = $0
-            sub("^app_id[ \t]*=[ \t]*", "", v)
-            gsub(/^"|"$/, "", v)
-            if (v == want) { print i; exit }
-        }
-    ' "$1"
-}
-
-top_level_field() {
-    local key="$1" src="${2:-$TOML_PATH}"
-    awk -v key="$key" '
-        /^\[\[record\]\]/ { exit }
-        $0 ~ "^"key"[ \t]*=" {
-            sub("^"key"[ \t]*=[ \t]*", "")
-            gsub(/^"|"$/, "")
-            print
-            exit
-        }
-    ' "$src"
-}
+field_of_record() { pointer_field "${3:-$TOML_PATH}" "$1" "$2"; }
+top_level_field() { pointer_top_field "${2:-$TOML_PATH}" "$1"; }
+record_count()    { pointer_record_count "$TOML_PATH"; }
+app_ids_in()      { pointer_app_ids "$1"; }
+index_of_app()    { pointer_index_of_app "$1" "$2"; }
 
 wasm_hash_at_ref() {
     local ref="$1" path="$2"

--- a/scripts/check-pointer-freshness.sh
+++ b/scripts/check-pointer-freshness.sh
@@ -91,6 +91,32 @@ fi
 
 [ -f "$TOML_PATH" ] || die "$TOML_PATH not found"
 
+# ------------------------------------------------- read ONE tree, not two
+#
+# On `pull_request`, actions/checkout gives the synthetic MERGE commit, so the
+# working tree is base+head merged. The WASM is hashed from
+# `github.event.pull_request.head.sha`. Reading the registry from the working
+# tree while hashing the WASM from head.sha compares two different trees: if
+# the base branch lands a new WASM and its matching record after this branch
+# forked, the merged registry (correctly carrying base's new record) is checked
+# against head's OLD WASM and fails as stale, on a PR that is actually fine.
+#
+# So in CI mode every head-side file is materialized from $HEAD_SHA. Base-side
+# reads already used `git show`. This mirrors check-migration.sh, which reads
+# both sides through git and never touches the working tree.
+if [ "$MODE" = "ci" ]; then
+    HEAD_TREE="$(mktemp -d)"
+    trap 'rm -rf "$HEAD_TREE"' EXIT
+    for f in "$TOML_PATH" "$FREENET_MD"; do
+        git show "$HEAD_SHA:$f" > "$HEAD_TREE/$(basename "$f")" 2>/dev/null \
+            || die "$f does not exist at head ($HEAD_SHA)"
+    done
+    TOML_PATH="$HEAD_TREE/$(basename "$TOML_PATH")"
+    FREENET_MD="$HEAD_TREE/$(basename "$FREENET_MD")"
+    echo "== reading the registry and FREENET.md from head ($HEAD_SHA) =="
+    echo ""
+fi
+
 AUTHOR_VK="$(top_level_field author_verifying_key)"
 [ -n "$AUTHOR_VK" ] || die "no author_verifying_key in $TOML_PATH"
 

--- a/scripts/check-pointer-freshness.sh
+++ b/scripts/check-pointer-freshness.sh
@@ -140,6 +140,41 @@ N="$(record_count)"
 [ "$N" -gt 0 ] || die "no [[record]] blocks in $TOML_PATH"
 
 FAILED=0
+
+# ------------------------------------------------- no record may VANISH
+#
+# Every check below is per-record, so they all pass happily on a file that has
+# had a record DELETED from it — the gate dutifully verifies what remains and
+# reports success. That is the one way a pointer can go stale with CI green:
+# the record stops being maintained here while the address it published stays
+# live on the network forever, still answering with the last hash it was given.
+#
+# Adding a record is fine. Removing one is a deliberate act with consequences
+# for anyone already resolving it, so it must be visible in review rather than
+# silent.
+if [ "$MODE" = "ci" ]; then
+    BASE_TOML_ALL="$(mktemp)"
+    if git show "$BASE_SHA:$TOML_PATH" > "$BASE_TOML_ALL" 2>/dev/null; then
+        MISSING=""
+        while IFS= read -r base_app; do
+            [ -z "$base_app" ] && continue
+            grep -qE "^app_id[ \t]*=[ \t]*\"$base_app\"" "$TOML_PATH" || MISSING="$MISSING $base_app"
+        done < <(grep -E '^app_id[ \t]*=' "$BASE_TOML_ALL" | sed 's/.*= *"\([^"]*\)".*/\1/')
+        if [ -n "$MISSING" ]; then
+            echo "FAILED: a pointer record present at the base commit is GONE at head:"
+            for m in $MISSING; do echo "    $m"; done
+            echo ""
+            echo "The address that record published stays live on the network and keeps"
+            echo "answering with the last code hash it was given. Deleting the record here"
+            echo "only stops us maintaining it — it does not retract it."
+            echo ""
+            echo "If retiring a pointer is genuinely intended, that is a withdrawal and"
+            echo "needs doing on the network, not by deleting a line."
+            exit 1
+        fi
+    fi
+    rm -f "$BASE_TOML_ALL"
+fi
 for i in $(seq 1 "$N"); do
     APP_ID="$(field_of_record "$i" app_id)"
     WASM_PATH="$(field_of_record "$i" wasm_path)"

--- a/scripts/check-pointer-freshness.sh
+++ b/scripts/check-pointer-freshness.sh
@@ -1,0 +1,241 @@
+#!/bin/bash
+# Fail the build if a committed pointer record has gone stale.
+#
+# River publishes pointer records (see pointer-records.toml) so third parties
+# can resolve our artifacts' CURRENT keys instead of pinning one that re-keys
+# under them. Once a pointer exists, a STALE pointer is worse than none: before
+# it existed an integrator pinning our key knew they were pinning it; after, they
+# resolve, get a confident answer, and derive a dead key.
+#
+# So the rule this enforces is: whenever a pointed-at WASM changes, a new record
+# must be signed in the same PR.
+#
+# ## Why this is not a "does an entry exist" check
+#
+# check-migration.sh asks whether the OLD hash was recorded — a question that is
+# only meaningful when the WASM changed. This asks whether the record names the
+# CURRENT bytes, which is meaningful on every commit. That difference matters:
+# a presence check passes forever after the first record is committed, and would
+# sail through exactly the failure this script exists to catch.
+#
+# Three things are checked per record, and each can fail on its own:
+#
+#   1. code_hash == BLAKE3 of the committed WASM at wasm_path.  <- the real gate
+#   2. The 100-byte `state` VERIFIES under the author key in FREENET.md, and
+#      carries that same code_hash and version. Catches a hand-edited hash that
+#      left its signature behind, which check 1 alone would accept.
+#   3. version strictly increased if the record changed since the base commit.
+#      A repeat version is a silent no-op on the network: the contract treats a
+#      stale update as success on purpose, so nothing downstream would tell us.
+#
+# Usage:
+#   scripts/check-pointer-freshness.sh                         # HEAD vs working tree
+#   scripts/check-pointer-freshness.sh --ci BASE_SHA HEAD_SHA  # CI mode
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TOML_PATH="pointer-records.toml"
+FREENET_MD="FREENET.md"
+
+# The signing/verifying tool, pinned by revision. Pinned rather than floating for
+# the same reason integrators pin it: this tool decides what a record's bytes
+# ARE, and a gate whose oracle can change under it is not a gate.
+POINTER_TOOL_REPO="https://github.com/freenet/freenet-migrate"
+POINTER_TOOL_REV="${POINTER_TOOL_REV:-REPLACE_WITH_MERGE_SHA}"
+
+cd "$REPO_ROOT"
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+command -v b3sum >/dev/null 2>&1 || die "b3sum not found. Install with: cargo install b3sum"
+command -v pointer-record >/dev/null 2>&1 || die "pointer-record not found. Install with:
+  cargo install --git $POINTER_TOOL_REPO --rev $POINTER_TOOL_REV --features publish freenet-pointer-contract"
+
+# --------------------------------------------------------------------- parsing
+#
+# Deliberately line-oriented rather than a TOML library: this has to run in a CI
+# job whose only job is to check, and adding a Python/Rust TOML dependency to do
+# it would make the gate itself something that can fail to install. The schema is
+# ours and is three scalar keys per [[record]] block.
+#
+# `field_of_record N KEY` prints the value of KEY in the Nth [[record]] block.
+field_of_record() {
+    local n="$1" key="$2" src="${3:-$TOML_PATH}"
+    awk -v want="$n" -v key="$key" '
+        /^\[\[record\]\]/ { i++; next }
+        i == want && $0 ~ "^"key"[ \t]*=" {
+            sub("^"key"[ \t]*=[ \t]*", "")
+            gsub(/^"|"$/, "")
+            print
+            exit
+        }
+    ' "$src"
+}
+
+record_count() { grep -c '^\[\[record\]\]' "$TOML_PATH"; }
+
+top_level_field() {
+    local key="$1" src="${2:-$TOML_PATH}"
+    awk -v key="$key" '
+        /^\[\[record\]\]/ { exit }
+        $0 ~ "^"key"[ \t]*=" {
+            sub("^"key"[ \t]*=[ \t]*", "")
+            gsub(/^"|"$/, "")
+            print
+            exit
+        }
+    ' "$src"
+}
+
+wasm_hash_at_ref() {
+    local ref="$1" path="$2"
+    if git cat-file -e "$ref:$path" 2>/dev/null; then
+        git show "$ref:$path" | b3sum | cut -d' ' -f1
+    else
+        echo ""
+    fi
+}
+
+# ------------------------------------------------------------------- arguments
+
+MODE="local"
+BASE_SHA=""
+HEAD_SHA=""
+if [ "${1:-}" = "--ci" ]; then
+    MODE="ci"
+    BASE_SHA="${2:?Usage: check-pointer-freshness.sh --ci BASE_SHA HEAD_SHA}"
+    HEAD_SHA="${3:?Usage: check-pointer-freshness.sh --ci BASE_SHA HEAD_SHA}"
+elif [ -n "${1:-}" ]; then
+    # Strict on purpose. A typo'd flag that silently fell through to local mode
+    # would be a gate reporting success having compared the wrong things.
+    die "unknown argument '$1' (expected nothing, or --ci BASE_SHA HEAD_SHA)"
+fi
+
+[ -f "$TOML_PATH" ] || die "$TOML_PATH not found"
+
+AUTHOR_VK="$(top_level_field author_verifying_key)"
+[ -n "$AUTHOR_VK" ] || die "no author_verifying_key in $TOML_PATH"
+
+# ----------------------------------------------------- 0. the published anchor
+#
+# The author key is the ENTIRE trust anchor: an integrator takes it from
+# FREENET.md and verifies every record against it. If this file and that file
+# disagree, we sign records nobody can verify — and it fails silently, because
+# a record signed by the wrong key is perfectly well-formed.
+echo "== author key =="
+if ! grep -qF "$AUTHOR_VK" "$FREENET_MD"; then
+    echo "FAILED: $TOML_PATH publishes author_verifying_key"
+    echo "  $AUTHOR_VK"
+    echo "but $FREENET_MD does not contain that value."
+    echo ""
+    echo "Integrators take the author key from $FREENET_MD. If the two disagree,"
+    echo "every record we sign is one they will reject — and the record will look"
+    echo "perfectly valid from our side."
+    exit 1
+fi
+echo "  $AUTHOR_VK (present in $FREENET_MD)"
+echo ""
+
+N="$(record_count)"
+[ "$N" -gt 0 ] || die "no [[record]] blocks in $TOML_PATH"
+
+FAILED=0
+for i in $(seq 1 "$N"); do
+    APP_ID="$(field_of_record "$i" app_id)"
+    WASM_PATH="$(field_of_record "$i" wasm_path)"
+    VERSION="$(field_of_record "$i" version)"
+    CODE_HASH="$(field_of_record "$i" code_hash)"
+    STATE="$(field_of_record "$i" state)"
+    POINTER_KEY="$(field_of_record "$i" pointer_key)"
+
+    echo "== $APP_ID =="
+    for v in APP_ID WASM_PATH VERSION CODE_HASH STATE POINTER_KEY; do
+        [ -n "${!v}" ] || die "record $i is missing $(echo "$v" | tr 'A-Z_' 'a-z-')"
+    done
+
+    # --- 1. does the record name the bytes that are actually committed? -------
+    if [ "$MODE" = "ci" ]; then
+        ACTUAL="$(wasm_hash_at_ref "$HEAD_SHA" "$WASM_PATH")"
+        WHERE="committed at $HEAD_SHA"
+    else
+        [ -f "$WASM_PATH" ] || die "$WASM_PATH not found"
+        ACTUAL="$(b3sum "$WASM_PATH" | cut -d' ' -f1)"
+        WHERE="in the working tree"
+    fi
+    [ -n "$ACTUAL" ] || die "$WASM_PATH does not exist $WHERE"
+
+    if [ "$CODE_HASH" != "$ACTUAL" ]; then
+        echo "  FAILED: the record is STALE."
+        echo "    record names : $CODE_HASH"
+        echo "    $WASM_PATH ($WHERE): $ACTUAL"
+        echo ""
+        echo "  The WASM this pointer names has changed and no new record was signed."
+        echo "  Any integrator resolving $APP_ID would derive a DEAD key."
+        echo ""
+        echo "  To fix:  cargo make sign-pointer-records   (then commit $TOML_PATH)"
+        echo "  Or revert the WASM change."
+        FAILED=1
+        echo ""
+        continue
+    fi
+    echo "  code_hash matches $WASM_PATH ($WHERE): $ACTUAL"
+
+    # --- 2. is the record actually SIGNED for what it claims? ----------------
+    # Check 1 compares two strings in files we control, so on its own it would
+    # accept a hand-edited hash whose signature was left behind. This is the
+    # check that makes the file's contents mean something.
+    if ! pointer-record verify \
+            --author-vk "$AUTHOR_VK" \
+            --app-id "$APP_ID" \
+            --state "$STATE" \
+            --expect-version "$VERSION" \
+            --expect-code-hash "$CODE_HASH" \
+            --expect-key "$POINTER_KEY" >/dev/null; then
+        echo "  FAILED: the record's bytes do not verify (see the error above)."
+        echo ""
+        echo "  Do not hand-edit code_hash, version, state or pointer_key."
+        echo "  Run:  cargo make sign-pointer-records"
+        FAILED=1
+        echo ""
+        continue
+    fi
+    echo "  signature verifies under the author key, at version $VERSION"
+
+    # --- 3. did the version move when the record did? ------------------------
+    # A republish at an already-used version is a no-op SUCCESS on the network —
+    # the contract refuses to error on a stale update by design, so nothing
+    # downstream would ever tell us the release was ignored.
+    if [ "$MODE" = "ci" ]; then
+        BASE_TOML="$(mktemp)"
+        if git show "$BASE_SHA:$TOML_PATH" > "$BASE_TOML" 2>/dev/null; then
+            BASE_STATE="$(field_of_record "$i" state "$BASE_TOML")"
+            BASE_VERSION="$(field_of_record "$i" version "$BASE_TOML")"
+            BASE_APP="$(field_of_record "$i" app_id "$BASE_TOML")"
+            # Index-matched, so only compare when it is the same record. A
+            # reordered or inserted record would otherwise compare two different
+            # apps' versions and report nonsense.
+            if [ "$BASE_APP" = "$APP_ID" ] && [ -n "$BASE_STATE" ]; then
+                if [ "$BASE_STATE" != "$STATE" ] && [ "$VERSION" -le "$BASE_VERSION" ]; then
+                    echo "  FAILED: the record changed but version did not increase"
+                    echo "    base ($BASE_SHA): version $BASE_VERSION"
+                    echo "    head ($HEAD_SHA): version $VERSION"
+                    echo ""
+                    echo "  Publishing at an already-used version is a silent no-op:"
+                    echo "  the network accepts it and keeps the OLD record."
+                    FAILED=1
+                elif [ "$BASE_STATE" != "$STATE" ]; then
+                    echo "  version advanced $BASE_VERSION -> $VERSION"
+                fi
+            fi
+        fi
+        rm -f "$BASE_TOML"
+    fi
+    echo ""
+done
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "One or more pointer records are stale or unverifiable. See above."
+    exit 1
+fi
+
+echo "All $N pointer record(s) are fresh, signed, and name the committed WASM."

--- a/scripts/check-pointer-freshness.sh
+++ b/scripts/check-pointer-freshness.sh
@@ -49,7 +49,7 @@ die() { echo "ERROR: $*" >&2; exit 1; }
 
 command -v b3sum >/dev/null 2>&1 || die "b3sum not found. Install with: cargo install b3sum"
 command -v pointer-record >/dev/null 2>&1 || die "pointer-record not found. Install with:
-  cargo install --git $POINTER_TOOL_REPO --rev $POINTER_TOOL_REV --features publish freenet-pointer-contract"
+  cargo install --git $POINTER_TOOL_REPO --rev $POINTER_TOOL_REV --features publish --locked freenet-pointer-contract"
 
 # --------------------------------------------------------------------- parsing
 #

--- a/scripts/check-pointer-freshness.sh
+++ b/scripts/check-pointer-freshness.sh
@@ -74,6 +74,30 @@ field_of_record() {
 
 record_count() { grep -c '^\[\[record\]\]' "$TOML_PATH"; }
 
+# Every app_id in a file, one per line, anchored so a `[[record]]` mentioned in
+# a comment cannot contribute one.
+app_ids_in() {
+    awk '/^app_id[ \t]*=/ { sub("^app_id[ \t]*=[ \t]*", ""); gsub(/^"|"$/, ""); print }' "$1"
+}
+
+# The 1-based record index carrying APP_ID in a file, or empty.
+#
+# Records are matched BY app_id and never by position. Matching by position
+# means reordering two blocks makes each index compare two DIFFERENT apps, so
+# the version check below skips both — a free way to republish at an old
+# version, which is a silent no-op on the network.
+index_of_app() {
+    awk -v want="$2" '
+        /^\[\[record\]\]/ { i++; next }
+        /^app_id[ \t]*=/ {
+            v = $0
+            sub("^app_id[ \t]*=[ \t]*", "", v)
+            gsub(/^"|"$/, "", v)
+            if (v == want) { print i; exit }
+        }
+    ' "$1"
+}
+
 top_level_field() {
     local key="$1" src="${2:-$TOML_PATH}"
     awk -v key="$key" '
@@ -155,11 +179,21 @@ FAILED=0
 if [ "$MODE" = "ci" ]; then
     BASE_TOML_ALL="$(mktemp)"
     if git show "$BASE_SHA:$TOML_PATH" > "$BASE_TOML_ALL" 2>/dev/null; then
+        # Compared as exact STRINGS via `grep -qxF` against the head file's
+        # extracted app_id list — never by interpolating the app_id into a
+        # regex. Both real app_ids contain a `.`, which is a regex wildcard, so
+        # an `-E` match would have accepted `riverXroom-contract` as proof that
+        # `river.room-contract` is still present. A rename is exactly the
+        # deletion this check exists to catch, so that is the one input that
+        # must not slip through.
+        HEAD_APPS="$(mktemp)"
+        app_ids_in "$TOML_PATH" > "$HEAD_APPS"
         MISSING=""
         while IFS= read -r base_app; do
             [ -z "$base_app" ] && continue
-            grep -qE "^app_id[ \t]*=[ \t]*\"$base_app\"" "$TOML_PATH" || MISSING="$MISSING $base_app"
-        done < <(grep -E '^app_id[ \t]*=' "$BASE_TOML_ALL" | sed 's/.*= *"\([^"]*\)".*/\1/')
+            grep -qxF "$base_app" "$HEAD_APPS" || MISSING="$MISSING $base_app"
+        done < <(app_ids_in "$BASE_TOML_ALL")
+        rm -f "$HEAD_APPS"
         if [ -n "$MISSING" ]; then
             echo "FAILED: a pointer record present at the base commit is GONE at head:"
             for m in $MISSING; do echo "    $m"; done
@@ -243,13 +277,18 @@ for i in $(seq 1 "$N"); do
     if [ "$MODE" = "ci" ]; then
         BASE_TOML="$(mktemp)"
         if git show "$BASE_SHA:$TOML_PATH" > "$BASE_TOML" 2>/dev/null; then
-            BASE_STATE="$(field_of_record "$i" state "$BASE_TOML")"
-            BASE_VERSION="$(field_of_record "$i" version "$BASE_TOML")"
-            BASE_APP="$(field_of_record "$i" app_id "$BASE_TOML")"
-            # Index-matched, so only compare when it is the same record. A
-            # reordered or inserted record would otherwise compare two different
-            # apps' versions and report nonsense.
-            if [ "$BASE_APP" = "$APP_ID" ] && [ -n "$BASE_STATE" ]; then
+            # Looked up BY app_id. An index-matched lookup skips this check
+            # whenever the two blocks are reordered — for each index the base
+            # and head apps differ, so both records dodge the version gate at
+            # once, in a diff where nothing signals "skip me".
+            BASE_I="$(index_of_app "$BASE_TOML" "$APP_ID")"
+            BASE_STATE=""
+            BASE_VERSION=""
+            if [ -n "$BASE_I" ]; then
+                BASE_STATE="$(field_of_record "$BASE_I" state "$BASE_TOML")"
+                BASE_VERSION="$(field_of_record "$BASE_I" version "$BASE_TOML")"
+            fi
+            if [ -n "$BASE_STATE" ]; then
                 if [ "$BASE_STATE" != "$STATE" ] && [ "$VERSION" -le "$BASE_VERSION" ]; then
                     echo "  FAILED: the record changed but version did not increase"
                     echo "    base ($BASE_SHA): version $BASE_VERSION"

--- a/scripts/check-pointer-freshness.sh
+++ b/scripts/check-pointer-freshness.sh
@@ -41,7 +41,7 @@ FREENET_MD="FREENET.md"
 # the same reason integrators pin it: this tool decides what a record's bytes
 # ARE, and a gate whose oracle can change under it is not a gate.
 POINTER_TOOL_REPO="https://github.com/freenet/freenet-migrate"
-POINTER_TOOL_REV="${POINTER_TOOL_REV:-REPLACE_WITH_MERGE_SHA}"
+POINTER_TOOL_REV="${POINTER_TOOL_REV:-5e1759c39f98ec54f51c84d632e28fc33578b48d}"
 
 cd "$REPO_ROOT"
 

--- a/scripts/pointer-toml-lib.sh
+++ b/scripts/pointer-toml-lib.sh
@@ -1,0 +1,120 @@
+# Shared reader for pointer-records.toml. Source this; do not execute it.
+#
+# ## Why a hand-rolled reader rather than a TOML library
+#
+# The freshness gate is a CI job whose only purpose is to check. Giving it a
+# Python or Rust TOML dependency makes the gate itself something that can fail
+# to install, and a gate that cannot run is a gate that reports nothing. The
+# schema is ours and is a handful of scalar keys per `[[record]]` block.
+#
+# ## Why it is SHARED rather than copied
+#
+# There were two near-identical copies of these functions, in the gate and in
+# the signer. A parsing fix applied to one would not reach the other, and the
+# two disagreeing about what a record says is the worst failure available here:
+# the signer would write something the gate reads differently, or vice versa.
+# One copy, sourced by both.
+#
+# ## What the parsing handles, and what it deliberately does not
+#
+# Handled: whitespace around `=`, quoted and bare values, and a trailing
+# `# comment` after either. A `#` INSIDE a quoted value survives correctly,
+# because a quoted value is taken up to its closing quote.
+#
+# NOT handled: multi-line values, arrays, inline tables, and — deliberately —
+# a key INDENTED from the line start. Every pattern anchors `[[record]]` and
+# the key at column zero, which is what stops a mention of either inside a
+# comment or a prose block from contributing a phantom record or field. The
+# cost is that TOML's legal leading indentation is not read. That cost is paid
+# knowingly: an indented key fails CLOSED, with `record N is missing <field>`,
+# rather than being silently misread. Verified, not assumed — indenting
+# `app_id` produces exactly that error.
+#
+# If indentation is ever wanted, widen the anchor and re-check that a
+# `[[record]]` inside a comment still cannot create a phantom record. The
+# header of pointer-records.toml contains exactly such a mention.
+
+# Prints the value of KEY inside the Nth [[record]] block of FILE.
+#   pointer_field <file> <n> <key>
+pointer_field() {
+    awk -v want="$2" -v key="$3" '
+        function unquote(v) {
+            sub("^" key "[ \t]*=[ \t]*", "", v)
+            if (substr(v, 1, 1) == "\"") {
+                # Quoted: take up to the closing quote, so a trailing comment
+                # (or a "#" inside the value) cannot leak in.
+                v = substr(v, 2)
+                idx = index(v, "\"")
+                if (idx > 0) v = substr(v, 1, idx - 1)
+            } else {
+                sub(/[ \t]*#.*$/, "", v)   # bare value: drop a trailing comment
+                gsub(/^[ \t]+|[ \t]+$/, "", v)
+            }
+            return v
+        }
+        /^\[\[record\]\]/ { i++; next }
+        i == want && $0 ~ "^" key "[ \t]*=" { print unquote($0); exit }
+    ' "$1"
+}
+
+# Prints the value of a top-level KEY in FILE (anything before the first record).
+#   pointer_top_field <file> <key>
+pointer_top_field() {
+    awk -v key="$2" '
+        function unquote(v) {
+            sub("^" key "[ \t]*=[ \t]*", "", v)
+            if (substr(v, 1, 1) == "\"") {
+                v = substr(v, 2)
+                idx = index(v, "\"")
+                if (idx > 0) v = substr(v, 1, idx - 1)
+            } else {
+                sub(/[ \t]*#.*$/, "", v)
+                gsub(/^[ \t]+|[ \t]+$/, "", v)
+            }
+            return v
+        }
+        /^\[\[record\]\]/ { exit }
+        $0 ~ "^" key "[ \t]*=" { print unquote($0); exit }
+    ' "$1"
+}
+
+# Number of [[record]] blocks in FILE.
+pointer_record_count() { grep -c '^\[\[record\]\]' "$1"; }
+
+# Every app_id in FILE, one per line.
+pointer_app_ids() {
+    awk '
+        /^app_id[ \t]*=/ {
+            v = $0
+            sub("^app_id[ \t]*=[ \t]*", "", v)
+            if (substr(v, 1, 1) == "\"") {
+                v = substr(v, 2); idx = index(v, "\""); if (idx > 0) v = substr(v, 1, idx - 1)
+            } else {
+                sub(/[ \t]*#.*$/, "", v); gsub(/^[ \t]+|[ \t]+$/, "", v)
+            }
+            print v
+        }
+    ' "$1"
+}
+
+# The 1-based index of the record carrying APP_ID in FILE, or empty.
+#
+# Records are looked up BY app_id and never by position. Position-matching
+# means reordering two blocks makes each index compare two DIFFERENT apps, so
+# a version-regression check keyed on it skips every record at once — in a diff
+# where nothing signals "skip me".
+pointer_index_of_app() {
+    awk -v want="$2" '
+        /^\[\[record\]\]/ { i++; next }
+        /^app_id[ \t]*=/ {
+            v = $0
+            sub("^app_id[ \t]*=[ \t]*", "", v)
+            if (substr(v, 1, 1) == "\"") {
+                v = substr(v, 2); idx = index(v, "\""); if (idx > 0) v = substr(v, 1, idx - 1)
+            } else {
+                sub(/[ \t]*#.*$/, "", v); gsub(/^[ \t]+|[ \t]+$/, "", v)
+            }
+            if (v == want) { print i; exit }
+        }
+    ' "$1"
+}

--- a/scripts/pointer-toml-lib.sh
+++ b/scripts/pointer-toml-lib.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Shared reader for pointer-records.toml. Source this; do not execute it.
 #
 # ## Why a hand-rolled reader rather than a TOML library

--- a/scripts/pointer-toml-lib.sh
+++ b/scripts/pointer-toml-lib.sh
@@ -21,8 +21,11 @@
 # `# comment` after either. A `#` INSIDE a quoted value survives correctly,
 # because a quoted value is taken up to its closing quote.
 #
-# NOT handled: multi-line values, arrays, inline tables, and — deliberately —
-# a key INDENTED from the line start. Every pattern anchors `[[record]]` and
+# NOT handled: multi-line values, arrays, inline tables, a DUPLICATE key within
+# one block (the first occurrence wins and no error is raised, where real TOML
+# would reject the file — the signer writes this file so a duplicate means a bad
+# merge or a hand-edit), and — deliberately — a key INDENTED from the line
+# start. Every pattern anchors `[[record]]` and
 # the key at column zero, which is what stops a mention of either inside a
 # comment or a prose block from contributing a phantom record or field. The
 # cost is that TOML's legal leading indentation is not read. That cost is paid

--- a/scripts/publish-pointer-records.sh
+++ b/scripts/publish-pointer-records.sh
@@ -112,7 +112,13 @@ say "CI green on $HEAD_SHA ($TOTAL run(s), all successful)"
 # ------------------------------------------------------------------ THE NODE
 echo ""
 echo "[node] the target node is the intended one, and is on the network"
-PEERS="$(fdev -p "$PORT" query 2>/dev/null | grep -cE '^\| [1-9A-HJ-NP-Za-km-z]{17} ' || true)"
+# 16 OR 17 characters. A peer id is base58 of 12 bytes, and base58 of 12 random
+# bytes is 16 characters about 18% of the time (measured: 71 of 400). A `{17}`
+# pattern therefore undercounts always, and returns ZERO for a node whose peers
+# all happen to be short — which would abort every publish claiming the node has
+# no peers. Requiring the following column separator keeps the 46/47-character
+# contract keys in the same output from matching.
+PEERS="$(fdev -p "$PORT" query 2>/dev/null | grep -cE '^\| [1-9A-HJ-NP-Za-km-z]{16,17} +\|' || true)"
 [ "${PEERS:-0}" -gt 0 ] || die "node on port $PORT reports no connected peers. A PUT there reaches nobody."
 say "node on port $PORT has $PEERS connected peer(s)"
 
@@ -160,7 +166,10 @@ tar -xJf "$WORK/webapp.tar.xz" -C "$WORK/live" contracts/ 2>/dev/null \
 
 # --------------------------------------------------------------- PER-RECORD
 N="$(grep -c '^\[\[record\]\]' "$TOML_PATH")"
-declare -a PUB_APP PUB_KEY PUB_STATE PUB_VERSION PUB_HASH
+# No PUB_STATE array: the bytes live in $WORK/state_$i.bin, written below.
+# Keeping a second copy in a shell variable would be two things that can
+# disagree about what we are publishing.
+declare -a PUB_APP PUB_KEY PUB_VERSION PUB_HASH
 for i in $(seq 1 "$N"); do
     APP_ID="$(field_of_record "$i" app_id)"
     WASM_PATH="$(field_of_record "$i" wasm_path)"
@@ -212,8 +221,11 @@ Refusing to publish a record whose target could not be checked against the netwo
         || die "[5] the record for $APP_ID does not verify"
     say "[5] signature verifies against the key published in FREENET.md"
 
-    # 4. The version must be exactly one above what is ON THE NETWORK, read
-    #    from the network rather than assumed.
+    # The bytes we intend to publish, needed by the comparison below.
+    printf '%s' "$STATE" | xxd -r -p > "$WORK/state_$i.bin"
+
+    # 4. The version must be ABOVE what is ON THE NETWORK, read from the
+    #    network rather than assumed.
     #
     # ABSENCE MUST BE PROVEN, NOT INFERRED FROM A FAILED GET. A timeout and a
     # genuine "nothing there" both leave us without bytes, and treating them
@@ -249,19 +261,34 @@ Retry, or fix the node. Do not proceed on an ambiguous answer."
     elif [ -z "$ONNET_VERSION" ]; then
         die "[4] $APP_ID's pointer returned bytes that do not verify under our own author key.
 Refusing to publish over state whose provenance is unclear."
+    elif cmp -s "$WORK/cur_$i.bin" "$WORK/state_$i.bin"; then
+        # Already exactly what we were going to publish. This is the normal
+        # state when re-running after a PARTIAL publish, which the failure
+        # path explicitly tells the operator to do — so it must not be an
+        # error, or the documented recovery would abort on the record that
+        # already succeeded.
+        say "[4] already on the network at version $ONNET_VERSION, byte-identical — nothing to do"
+        PUB_OP="skip"
     else
-        EXPECT=$((ONNET_VERSION + 1))
-        [ "$VERSION" -eq "$EXPECT" ] || die "[4] on-network version is $ONNET_VERSION, so this publish must be
-version $EXPECT, but the record says $VERSION.
-A publish at an already-used version is a silent NO-OP: the network accepts it
-and keeps the OLD record. Re-sign with the right version."
+        # STRICTLY GREATER, not exactly one more. The contract's rule is
+        # monotonicity, not contiguity, and an exact `+1` breaks two ordinary
+        # situations: re-running after a partial publish, and two WASM changes
+        # merging before anyone runs the network publish (local v3, network v1).
+        # Both are legitimate; only going backwards or sideways is not.
+        [ "$VERSION" -gt "$ONNET_VERSION" ] || die "[4] the network holds version $ONNET_VERSION and this record says $VERSION.
+A publish at an already-used or older version is a silent NO-OP: the network
+accepts it and keeps the OLD record, and nothing downstream will tell you.
+Re-sign at a version above $ONNET_VERSION."
+        if [ "$VERSION" -ne $((ONNET_VERSION + 1)) ]; then
+            say "[4] note: skipping from $ONNET_VERSION to $VERSION (gaps are fine — the contract"
+            say "    enforces monotonicity, not contiguity)"
+        fi
         say "[4] on-network version $ONNET_VERSION -> publishing $VERSION (UPDATE)"
         PUB_OP="update"
     fi
 
-    PUB_APP[$i]="$APP_ID"; PUB_KEY[$i]="$POINTER_KEY"; PUB_STATE[$i]="$STATE"
-    PUB_VERSION[$i]="$VERSION"; PUB_HASH[$i]="$CODE_HASH"
-    printf '%s' "$STATE" | xxd -r -p > "$WORK/state_$i.bin"
+    PUB_APP[i]="$APP_ID"; PUB_KEY[i]="$POINTER_KEY"
+    PUB_VERSION[i]="$VERSION"; PUB_HASH[i]="$CODE_HASH"
     echo "$PUB_OP" > "$WORK/op_$i"
 done
 
@@ -270,7 +297,7 @@ echo "=============================================================="
 echo " All pre-flight checks PASSED."
 echo "=============================================================="
 for i in $(seq 1 "$N"); do
-    echo "  $(cat "$WORK/op_$i" | tr a-z A-Z) ${PUB_APP[$i]} v${PUB_VERSION[$i]} -> ${PUB_KEY[$i]}"
+    echo "  $(tr '[:lower:]' '[:upper:]' < "$WORK/op_$i") ${PUB_APP[$i]} v${PUB_VERSION[$i]} -> ${PUB_KEY[$i]}"
 done
 
 if [ "$DRY_RUN" -eq 1 ]; then
@@ -334,6 +361,17 @@ for i in $(seq 1 "$N"); do
     PARAMS="$WORK/params_$i.bin"
     pointer-record key --author-vk "$AUTHOR_VK" --app-id "${PUB_APP[$i]}" \
         | sed -n 's/^params=//p' | xxd -r -p > "$PARAMS"
+
+    if [ "$(cat "$WORK/op_$i")" = "skip" ]; then
+        say "already on the network and byte-identical; verifying only"
+        set +e
+        verify_one "$i"
+        V_RC=$?
+        set -e
+        if [ "$V_RC" -eq 0 ]; then PUBLISHED="$PUBLISHED ${PUB_APP[$i]}"
+        else FAILED_VERIFY="$FAILED_VERIFY ${PUB_APP[$i]}"; fi
+        continue
+    fi
 
     set +e
     if [ "$(cat "$WORK/op_$i")" = "put" ]; then

--- a/scripts/publish-pointer-records.sh
+++ b/scripts/publish-pointer-records.sh
@@ -172,6 +172,14 @@ for i in $(seq 1 "$N"); do
     echo ""
     echo "--- $APP_ID ---"
 
+    # Defence in depth: this script should only ever run against a main HEAD
+    # that already passed check-pointer-freshness in CI, but it can also be run
+    # by hand against a locally-edited file, and an empty field would otherwise
+    # reach fdev as an empty argument.
+    for v in APP_ID WASM_PATH VERSION CODE_HASH STATE POINTER_KEY; do
+        [ -n "${!v}" ] || die "record $i is missing $(echo "$v" | tr 'A-Z_' 'a-z-')"
+    done
+
     LIVE_WASM="$WORK/live/contracts/$(basename "$WASM_PATH")"
     if [ -f "$LIVE_WASM" ]; then
         LIVE_HASH="$(b3sum "$LIVE_WASM" | cut -d' ' -f1)"
@@ -206,15 +214,41 @@ Refusing to publish a record whose target could not be checked against the netwo
 
     # 4. The version must be exactly one above what is ON THE NETWORK, read
     #    from the network rather than assumed.
+    #
+    # ABSENCE MUST BE PROVEN, NOT INFERRED FROM A FAILED GET. A timeout and a
+    # genuine "nothing there" both leave us without bytes, and treating them
+    # alike takes the PUT branch — which SKIPS the version-monotonicity check
+    # below. So a transient hiccup against an already-published pointer would
+    # silently downgrade the one check that stops a no-op republish.
+    #
+    # fdev distinguishes them: a real negative prints
+    # `Error: Contract not found: <key>`. Anything else is "we did not learn",
+    # and this refuses rather than guessing.
     ONNET_VERSION=""
+    GET_OK=0
     if fdev -p "$PORT" execute get --timeout 120 -o "$WORK/cur_$i.bin" "$POINTER_KEY" >"$WORK/cur_$i.log" 2>&1 \
        && [ -s "$WORK/cur_$i.bin" ]; then
+        GET_OK=1
         ONNET_VERSION="$(pointer-record verify --author-vk "$AUTHOR_VK" --app-id "$APP_ID" \
                           --state "$WORK/cur_$i.bin" | sed -n 's/^version=//p')"
     fi
-    if [ -z "$ONNET_VERSION" ]; then
-        say "[4] nothing on the network yet — this is the FIRST publish (PUT), version $VERSION"
-        PUB_OP="put"
+    if [ "$GET_OK" -eq 0 ]; then
+        if grep -qF "Contract not found: $POINTER_KEY" "$WORK/cur_$i.log"; then
+            say "[4] the network reports NOT FOUND — this is the FIRST publish (PUT), version $VERSION"
+            PUB_OP="put"
+        else
+            tail -3 "$WORK/cur_$i.log" | sed 's/^/      /'
+            die "[4] could not read $APP_ID's pointer, and the node did NOT say 'not found'.
+
+That is 'we learned nothing', not 'nothing is there'. Publishing as a FIRST
+publish here would skip the version check that stops a silent no-op republish
+against a pointer that already exists.
+
+Retry, or fix the node. Do not proceed on an ambiguous answer."
+        fi
+    elif [ -z "$ONNET_VERSION" ]; then
+        die "[4] $APP_ID's pointer returned bytes that do not verify under our own author key.
+Refusing to publish over state whose provenance is unclear."
     else
         EXPECT=$((ONNET_VERSION + 1))
         [ "$VERSION" -eq "$EXPECT" ] || die "[4] on-network version is $ONNET_VERSION, so this publish must be
@@ -251,47 +285,35 @@ if [ "$ASSUME_YES" -eq 0 ]; then
     case "$REPLY" in y|Y|yes|YES) ;; *) echo "aborted."; exit 1 ;; esac
 fi
 
-# ------------------------------------------------------------------ PUBLISH
-for i in $(seq 1 "$N"); do
-    echo ""
-    echo "--- publishing ${PUB_APP[$i]} ---"
-    PARAMS="$WORK/params_$i.bin"
-    pointer-record key --author-vk "$AUTHOR_VK" --app-id "${PUB_APP[$i]}" \
-        | sed -n 's/^params=//p' | xxd -r -p > "$PARAMS"
-    if [ "$(cat "$WORK/op_$i")" = "put" ]; then
-        fdev -p "$PORT" execute put --timeout 180 \
-            --code "$POINTER_WASM" --parameters "$PARAMS" \
-            contract --state "$WORK/state_$i.bin" 2>&1 | tail -3 | sed 's/^/    /'
-    else
-        fdev -p "$PORT" execute update --timeout 180 \
-            "${PUB_KEY[$i]}" "$WORK/state_$i.bin" 2>&1 | tail -3 | sed 's/^/    /'
-    fi
-done
+# ------------------------------------------------------- PUBLISH, THEN VERIFY
+#
+# ONE loop, publishing and verifying each record before moving on.
+#
+# These used to be two loops. Under `set -e` a failed `fdev` on record 2 killed
+# the script before the verification loop ran at all — including for record 1,
+# which had already gone live. The header above argues that re-reading is the
+# only thing that proves a publish worked; running it in a second loop meant it
+# was skipped in exactly the partial-failure case where it matters most, and an
+# operator was left inferring what had landed from scrollback.
+#
+# `errexit` is suspended around each record so one failure cannot take the
+# summary down with it.
+PUBLISHED=""
+FAILED_PUB=""
+FAILED_VERIFY=""
 
-# --------------------------------------------------------------- VERIFY BACK
-# "The PUT returned OK" is not evidence. A stale publish is a no-op SUCCESS, so
-# the only check that proves an integrator gets the right answer is to read the
-# record back and resolve it end to end.
-echo ""
-echo "=============================================================="
-echo " Post-publish verification (the only check that proves anything)"
-echo "=============================================================="
-FAILED=0
-for i in $(seq 1 "$N"); do
-    echo ""
-    echo "--- ${PUB_APP[$i]} ---"
+verify_one() {
+    local i="$1"
     rm -f "$WORK/back_$i.bin"
     if ! fdev -p "$PORT" execute get --timeout 180 -o "$WORK/back_$i.bin" "${PUB_KEY[$i]}" \
          >"$WORK/back_$i.log" 2>&1 || [ ! -s "$WORK/back_$i.bin" ]; then
         echo "  FAILED: could not read the record back from ${PUB_KEY[$i]}"
-        FAILED=1
-        continue
+        return 1
     fi
     if ! cmp -s "$WORK/back_$i.bin" "$WORK/state_$i.bin"; then
         echo "  FAILED: the bytes on the network are not the bytes we published."
         echo "  This is what a silently-ignored stale publish looks like."
-        FAILED=1
-        continue
+        return 1
     fi
     say "byte-identical to what we published"
     if ! pointer-record verify --author-vk "$AUTHOR_VK" --app-id "${PUB_APP[$i]}" \
@@ -300,17 +322,69 @@ for i in $(seq 1 "$N"); do
             --expect-code-hash "${PUB_HASH[$i]}" \
             --expect-key "${PUB_KEY[$i]}" >/dev/null; then
         echo "  FAILED: the record read BACK from the network does not verify"
-        FAILED=1
-        continue
+        return 1
     fi
     say "verifies from the network at version ${PUB_VERSION[$i]}, code hash ${PUB_HASH[$i]}"
+    return 0
+}
+
+for i in $(seq 1 "$N"); do
+    echo ""
+    echo "--- ${PUB_APP[$i]} ---"
+    PARAMS="$WORK/params_$i.bin"
+    pointer-record key --author-vk "$AUTHOR_VK" --app-id "${PUB_APP[$i]}" \
+        | sed -n 's/^params=//p' | xxd -r -p > "$PARAMS"
+
+    set +e
+    if [ "$(cat "$WORK/op_$i")" = "put" ]; then
+        fdev -p "$PORT" execute put --timeout 180 \
+            --code "$POINTER_WASM" --parameters "$PARAMS" \
+            contract --state "$WORK/state_$i.bin" >"$WORK/pub_$i.log" 2>&1
+    else
+        fdev -p "$PORT" execute update --timeout 180 \
+            "${PUB_KEY[$i]}" "$WORK/state_$i.bin" >"$WORK/pub_$i.log" 2>&1
+    fi
+    PUB_RC=$?
+    set -e
+    tail -3 "$WORK/pub_$i.log" | sed 's/^/    /'
+
+    if [ "$PUB_RC" -ne 0 ]; then
+        echo "  FAILED: the $(cat "$WORK/op_$i") itself returned $PUB_RC"
+        FAILED_PUB="$FAILED_PUB ${PUB_APP[$i]}"
+        continue
+    fi
+
+    # Verify THIS record now, not after every publish. "The PUT returned OK" is
+    # not evidence: a publish at an already-used version is a no-op SUCCESS.
+    set +e
+    verify_one "$i"
+    V_RC=$?
+    set -e
+    if [ "$V_RC" -eq 0 ]; then
+        PUBLISHED="$PUBLISHED ${PUB_APP[$i]}"
+    else
+        FAILED_VERIFY="$FAILED_VERIFY ${PUB_APP[$i]}"
+    fi
 done
 
 echo ""
-if [ "$FAILED" -ne 0 ]; then
-    echo "PUBLISH DID NOT FULLY VERIFY. Do not announce these pointers."
+echo "=============================================================="
+echo " Result"
+echo "=============================================================="
+[ -n "$PUBLISHED" ]     && { echo " published AND verified:"; for a in $PUBLISHED; do echo "   $a"; done; }
+[ -n "$FAILED_PUB" ]    && { echo " NOT published (the write failed):"; for a in $FAILED_PUB; do echo "   $a"; done; }
+[ -n "$FAILED_VERIFY" ] && { echo " WROTE but did NOT verify — treat as UNKNOWN state on the network:"; for a in $FAILED_VERIFY; do echo "   $a"; done; }
+
+if [ -n "$FAILED_PUB" ] || [ -n "$FAILED_VERIFY" ]; then
+    echo ""
+    echo "PARTIAL PUBLISH. Some records may be live and some not — the lists above"
+    echo "say which. Do not announce these pointers. Re-run once the cause is fixed:"
+    echo "the version check reads the network, so a record that DID land will be"
+    echo "detected and its version requirement recomputed."
     exit 1
 fi
+
+echo ""
 echo "All $N record(s) published AND verified from the network."
 echo ""
 echo "An integrator resolving these now gets the code hash of the artifact"

--- a/scripts/publish-pointer-records.sh
+++ b/scripts/publish-pointer-records.sh
@@ -358,10 +358,6 @@ verify_one() {
 for i in $(seq 1 "$N"); do
     echo ""
     echo "--- ${PUB_APP[$i]} ---"
-    PARAMS="$WORK/params_$i.bin"
-    pointer-record key --author-vk "$AUTHOR_VK" --app-id "${PUB_APP[$i]}" \
-        | sed -n 's/^params=//p' | xxd -r -p > "$PARAMS"
-
     if [ "$(cat "$WORK/op_$i")" = "skip" ]; then
         say "already on the network and byte-identical; verifying only"
         set +e
@@ -370,6 +366,23 @@ for i in $(seq 1 "$N"); do
         set -e
         if [ "$V_RC" -eq 0 ]; then PUBLISHED="$PUBLISHED ${PUB_APP[$i]}"
         else FAILED_VERIFY="$FAILED_VERIFY ${PUB_APP[$i]}"; fi
+        continue
+    fi
+
+    # Inside the same errexit suspension as everything else in this loop. It is
+    # a local computation that already succeeded during preflight, so a failure
+    # here would be surprising — but an unguarded `set -e` abort at this point
+    # would kill the script before the Result summary prints, losing the record
+    # of which records DID publish. Consistency is cheaper than that risk.
+    PARAMS="$WORK/params_$i.bin"
+    set +e
+    pointer-record key --author-vk "$AUTHOR_VK" --app-id "${PUB_APP[$i]}" \
+        | sed -n 's/^params=//p' | xxd -r -p > "$PARAMS"
+    PARAMS_RC=$?
+    set -e
+    if [ "$PARAMS_RC" -ne 0 ] || [ ! -s "$PARAMS" ]; then
+        echo "  FAILED: could not derive params for ${PUB_APP[$i]}"
+        FAILED_PUB="$FAILED_PUB ${PUB_APP[$i]}"
         continue
     fi
 

--- a/scripts/publish-pointer-records.sh
+++ b/scripts/publish-pointer-records.sh
@@ -56,22 +56,12 @@ for tool in fdev b3sum xxd tar python3 jq gh pointer-record pointer-codehash; do
 done
 [ -f "$TOML_PATH" ] || die "$TOML_PATH not found"
 
-field_of_record() {
-    awk -v want="$1" -v key="$2" '
-        /^\[\[record\]\]/ { i++; next }
-        i == want && $0 ~ "^"key"[ \t]*=" {
-            sub("^"key"[ \t]*=[ \t]*", ""); gsub(/^"|"$/, ""); print; exit
-        }
-    ' "$TOML_PATH"
-}
-top_level_field() {
-    awk -v key="$1" '
-        /^\[\[record\]\]/ { exit }
-        $0 ~ "^"key"[ \t]*=" {
-            sub("^"key"[ \t]*=[ \t]*", ""); gsub(/^"|"$/, ""); print; exit
-        }
-    ' "$TOML_PATH"
-}
+# The same shared reader the gate and the signer use. All three MUST agree
+# about what a record says — see scripts/pointer-toml-lib.sh.
+. "$(dirname "$0")/pointer-toml-lib.sh"
+
+field_of_record() { pointer_field "$TOML_PATH" "$1" "$2"; }
+top_level_field() { pointer_top_field "$TOML_PATH" "$1"; }
 
 AUTHOR_VK="$(top_level_field author_verifying_key)"
 POINTER_CODE_HASH="$(top_level_field pointer_code_hash)"

--- a/scripts/publish-pointer-records.sh
+++ b/scripts/publish-pointer-records.sh
@@ -48,9 +48,12 @@ done
 # path and testing against it is explicitly out of bounds.
 [ "$PORT" != "7509" ] || die "port 7509 is the production gateway — publish through your own node"
 
-command -v fdev >/dev/null 2>&1 || die "fdev not found"
-command -v b3sum >/dev/null 2>&1 || die "b3sum not found"
-command -v pointer-record >/dev/null 2>&1 || die "pointer-record not found"
+# Every external tool this script calls, checked up front. A `command not
+# found` in the middle of the publish sequence is the worst place to discover
+# one, because some records may already be on the network by then.
+for tool in fdev b3sum xxd tar python3 jq gh pointer-record pointer-codehash; do
+    command -v "$tool" >/dev/null 2>&1 || die "$tool not found (needed by this script)"
+done
 [ -f "$TOML_PATH" ] || die "$TOML_PATH not found"
 
 field_of_record() {
@@ -94,23 +97,27 @@ ORIGIN_SHA="$(git rev-parse origin/main)"
 [ "$HEAD_SHA" = "$ORIGIN_SHA" ] || die "HEAD ($HEAD_SHA) != origin/main ($ORIGIN_SHA). Pull first."
 say "HEAD == origin/main == $HEAD_SHA"
 
-if command -v gh >/dev/null 2>&1; then
-    # Non-SUCCESS conclusions include failure, cancelled and timed_out; a
-    # still-running check is also not a green signal.
-    BAD="$(gh run list --repo freenet/river --commit "$HEAD_SHA" \
-             --json conclusion,status,name \
-             --jq '[.[] | select(.status != "completed" or (.conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral"))] | length' 2>/dev/null || echo "?")"
-    if [ "$BAD" = "?" ]; then
-        say "WARNING: could not read CI status for $HEAD_SHA — verify by hand"
-    elif [ "$BAD" != "0" ]; then
-        gh run list --repo freenet/river --commit "$HEAD_SHA" --limit 20 | sed 's/^/    /'
-        die "$BAD CI check(s) on $HEAD_SHA are not green. Never publish on red or pending CI."
-    else
-        say "CI green on $HEAD_SHA"
-    fi
-else
-    say "WARNING: gh not found — verify CI on $HEAD_SHA by hand"
+command -v gh >/dev/null 2>&1 || die "gh not found — cannot verify CI on $HEAD_SHA"
+RUNS="$(gh run list --repo freenet/river --commit "$HEAD_SHA" --json conclusion,status,name 2>/dev/null || echo "")"
+[ -n "$RUNS" ] || die "could not read CI status for $HEAD_SHA. Refusing to publish on an unknown signal."
+
+# COUNT THE RUNS, not only the bad ones. An empty list yields zero failures,
+# so a `length == 0` test on its own reports "green" for a commit CI never ran
+# on — a guard that cannot fail, which is worse than no guard because it is
+# reassuring. Ask for evidence of success, then for absence of failure.
+TOTAL="$(printf '%s' "$RUNS" | jq 'length')"
+[ "$TOTAL" -gt 0 ] || die "NO CI runs exist for $HEAD_SHA.
+That is not the same as green. Either CI has not started, or this commit is not
+what you think it is. Refusing to publish."
+
+# Non-SUCCESS conclusions include failure, cancelled and timed_out; a
+# still-running check is also not a green signal.
+BAD="$(printf '%s' "$RUNS" | jq '[.[] | select(.status != "completed" or (.conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral"))] | length')"
+if [ "$BAD" != "0" ]; then
+    gh run list --repo freenet/river --commit "$HEAD_SHA" --limit 20 | sed 's/^/    /'
+    die "$BAD of $TOTAL CI check(s) on $HEAD_SHA are not green. Never publish on red or pending CI."
 fi
+say "CI green on $HEAD_SHA ($TOTAL run(s), all successful)"
 
 # ------------------------------------------------------------------ THE NODE
 echo ""

--- a/scripts/publish-pointer-records.sh
+++ b/scripts/publish-pointer-records.sh
@@ -1,0 +1,320 @@
+#!/bin/bash
+# Publish River's signed pointer records to the Freenet network.
+#
+# Run this from `main`, after the PR carrying the signed records has merged and
+# CI is green on that exact SHA. Signing is offline and happens in the PR
+# (scripts/sign-pointer-records.sh); this step is the network half.
+#
+# ## The checks below are the point of this script
+#
+# Every one of them can fail, and each exists because of a specific way a
+# publish can look successful from here while being useless or invisible to
+# everyone else. In particular a PUT at an already-used version is a NO-OP
+# SUCCESS — the pointer contract deliberately does not error on a stale update,
+# because erroring would turn routine anti-entropy from a peer that is merely
+# behind into a merge failure. So the network will never tell you your publish
+# was ignored. That is why this script re-reads afterwards rather than trusting
+# "published successfully".
+#
+# Usage:
+#   scripts/publish-pointer-records.sh --node-port 7599 [--dry-run] [--yes]
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TOML_PATH="pointer-records.toml"
+WEB_CONTAINER_KEY="raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv"
+
+cd "$REPO_ROOT"
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+say() { echo "  $*"; }
+
+PORT=""
+DRY_RUN=0
+ASSUME_YES=0
+POINTER_WASM="${POINTER_WASM:-}"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --node-port) PORT="${2:?--node-port needs a value}"; shift 2 ;;
+        --pointer-wasm) POINTER_WASM="${2:?--pointer-wasm needs a value}"; shift 2 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --yes) ASSUME_YES=1; shift ;;
+        *) die "unknown argument '$1'" ;;
+    esac
+done
+[ -n "$PORT" ] || die "--node-port is required (the node to publish THROUGH)"
+
+# 7509 is the PRODUCTION gateway. Publishing through it is not the intended
+# path and testing against it is explicitly out of bounds.
+[ "$PORT" != "7509" ] || die "port 7509 is the production gateway — publish through your own node"
+
+command -v fdev >/dev/null 2>&1 || die "fdev not found"
+command -v b3sum >/dev/null 2>&1 || die "b3sum not found"
+command -v pointer-record >/dev/null 2>&1 || die "pointer-record not found"
+[ -f "$TOML_PATH" ] || die "$TOML_PATH not found"
+
+field_of_record() {
+    awk -v want="$1" -v key="$2" '
+        /^\[\[record\]\]/ { i++; next }
+        i == want && $0 ~ "^"key"[ \t]*=" {
+            sub("^"key"[ \t]*=[ \t]*", ""); gsub(/^"|"$/, ""); print; exit
+        }
+    ' "$TOML_PATH"
+}
+top_level_field() {
+    awk -v key="$1" '
+        /^\[\[record\]\]/ { exit }
+        $0 ~ "^"key"[ \t]*=" {
+            sub("^"key"[ \t]*=[ \t]*", ""); gsub(/^"|"$/, ""); print; exit
+        }
+    ' "$TOML_PATH"
+}
+
+AUTHOR_VK="$(top_level_field author_verifying_key)"
+POINTER_CODE_HASH="$(top_level_field pointer_code_hash)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "=============================================================="
+echo " Pointer record publish — pre-flight"
+echo "=============================================================="
+
+# ---------------------------------------------------------------- PROVENANCE
+echo ""
+echo "[provenance] clean tree, on main, at origin/main, CI green"
+if [ -n "$(git status --porcelain)" ]; then
+    git status --short | sed 's/^/    /'
+    die "working tree is not clean. Publish only from a clean checkout of main."
+fi
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+[ "$BRANCH" = "main" ] || die "on branch '$BRANCH'. Publish only from main (see ~/.claude/rules/publish-from-main.md)."
+git fetch origin main --quiet
+HEAD_SHA="$(git rev-parse HEAD)"
+ORIGIN_SHA="$(git rev-parse origin/main)"
+[ "$HEAD_SHA" = "$ORIGIN_SHA" ] || die "HEAD ($HEAD_SHA) != origin/main ($ORIGIN_SHA). Pull first."
+say "HEAD == origin/main == $HEAD_SHA"
+
+if command -v gh >/dev/null 2>&1; then
+    # Non-SUCCESS conclusions include failure, cancelled and timed_out; a
+    # still-running check is also not a green signal.
+    BAD="$(gh run list --repo freenet/river --commit "$HEAD_SHA" \
+             --json conclusion,status,name \
+             --jq '[.[] | select(.status != "completed" or (.conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral"))] | length' 2>/dev/null || echo "?")"
+    if [ "$BAD" = "?" ]; then
+        say "WARNING: could not read CI status for $HEAD_SHA — verify by hand"
+    elif [ "$BAD" != "0" ]; then
+        gh run list --repo freenet/river --commit "$HEAD_SHA" --limit 20 | sed 's/^/    /'
+        die "$BAD CI check(s) on $HEAD_SHA are not green. Never publish on red or pending CI."
+    else
+        say "CI green on $HEAD_SHA"
+    fi
+else
+    say "WARNING: gh not found — verify CI on $HEAD_SHA by hand"
+fi
+
+# ------------------------------------------------------------------ THE NODE
+echo ""
+echo "[node] the target node is the intended one, and is on the network"
+PEERS="$(fdev -p "$PORT" query 2>/dev/null | grep -cE '^\| [1-9A-HJ-NP-Za-km-z]{17} ' || true)"
+[ "${PEERS:-0}" -gt 0 ] || die "node on port $PORT reports no connected peers. A PUT there reaches nobody."
+say "node on port $PORT has $PEERS connected peer(s)"
+
+# ------------------------------------------------------- 1. WHICH BYTES ARE NAMED
+# The pointer WASM must be the COMMITTED artifact, never a local rebuild. A
+# locally rebuilt WASM lands every record at a key nobody else derives —
+# invisible to every consumer, and indistinguishable from success here.
+echo ""
+echo "[1] the pointer WASM we PUT hashes to the published pointer code hash"
+[ -n "$POINTER_WASM" ] || die "set --pointer-wasm (or \$POINTER_WASM) to the COMMITTED pointer-v1.wasm.
+Do NOT build it: see contracts/pointer-contract/WASM-STABILITY.md upstream."
+[ -f "$POINTER_WASM" ] || die "pointer WASM not found: $POINTER_WASM"
+ACTUAL_PCH="$(pointer-codehash "$POINTER_WASM" 2>/dev/null || true)"
+if [ -z "$ACTUAL_PCH" ]; then
+    die "could not compute the pointer WASM's code hash (is pointer-codehash installed?)"
+fi
+[ "$ACTUAL_PCH" = "$POINTER_CODE_HASH" ] || die "the pointer WASM at $POINTER_WASM hashes to
+  $ACTUAL_PCH
+but $TOML_PATH names
+  $POINTER_CODE_HASH
+Publishing this would put every River record at an address nobody derives.
+You have almost certainly rebuilt the WASM locally. Use the committed artifact."
+say "$POINTER_WASM -> $ACTUAL_PCH (matches)"
+
+# ----------------------------------------- 2. AGAINST WHAT IS ACTUALLY ON THE NETWORK
+# The record must name the hash of the artifact users are actually running, not
+# the one in this checkout. Those diverge in practice. River ships both WASMs
+# INSIDE the web container's webapp archive, so the live bytes are fetchable.
+echo ""
+echo "[2] the code hash in each record == the artifact LIVE ON THE NETWORK"
+say "fetching the live web container ($WEB_CONTAINER_KEY) ..."
+fdev -p "$PORT" execute get --timeout 180 -o "$WORK/wc.state" "$WEB_CONTAINER_KEY" >"$WORK/wc.log" 2>&1 \
+    || { tail -5 "$WORK/wc.log" | sed 's/^/    /'; die "could not GET the live web container"; }
+python3 - "$WORK/wc.state" "$WORK/webapp.tar.xz" <<'PY'
+import struct, sys
+d = open(sys.argv[1], 'rb').read()
+off = 0
+mlen = struct.unpack('>Q', d[off:off+8])[0]; off += 8 + mlen
+wlen = struct.unpack('>Q', d[off:off+8])[0]; off += 8
+open(sys.argv[2], 'wb').write(d[off:off+wlen])
+PY
+mkdir -p "$WORK/live"
+tar -xJf "$WORK/webapp.tar.xz" -C "$WORK/live" contracts/ 2>/dev/null \
+    || die "could not unpack contracts/ from the live webapp archive"
+
+# --------------------------------------------------------------- PER-RECORD
+N="$(grep -c '^\[\[record\]\]' "$TOML_PATH")"
+declare -a PUB_APP PUB_KEY PUB_STATE PUB_VERSION PUB_HASH
+for i in $(seq 1 "$N"); do
+    APP_ID="$(field_of_record "$i" app_id)"
+    WASM_PATH="$(field_of_record "$i" wasm_path)"
+    VERSION="$(field_of_record "$i" version)"
+    CODE_HASH="$(field_of_record "$i" code_hash)"
+    STATE="$(field_of_record "$i" state)"
+    POINTER_KEY="$(field_of_record "$i" pointer_key)"
+
+    echo ""
+    echo "--- $APP_ID ---"
+
+    LIVE_WASM="$WORK/live/contracts/$(basename "$WASM_PATH")"
+    if [ -f "$LIVE_WASM" ]; then
+        LIVE_HASH="$(b3sum "$LIVE_WASM" | cut -d' ' -f1)"
+        if [ "$LIVE_HASH" != "$CODE_HASH" ]; then
+            die "the record names $CODE_HASH
+but the artifact LIVE on the network hashes to $LIVE_HASH.
+
+This is the divergence that matters: publishing this record would point every
+integrator at code that is not what users are running. Republish the UI first
+(cargo make publish-river), or re-sign against the live bytes."
+        fi
+        say "[2] live network copy matches: $LIVE_HASH"
+    else
+        die "could not find $(basename "$WASM_PATH") in the live webapp archive.
+Refusing to publish a record whose target could not be checked against the network."
+    fi
+
+    # 3. app_id / derived key. A typo in app_id produces a perfectly valid
+    #    record at an address nobody ever queries.
+    DERIVED="$(pointer-record key --author-vk "$AUTHOR_VK" --app-id "$APP_ID" | sed -n 's/^key=//p')"
+    [ "$DERIVED" = "$POINTER_KEY" ] || die "[3] derived key $DERIVED != recorded $POINTER_KEY for $APP_ID"
+    say "[3] app_id '$APP_ID' derives to $DERIVED (matches)"
+
+    # 5. The signature verifies, under the key published in FREENET.md, BEFORE
+    #    the PUT. A key-file/doc mismatch must fail loudly rather than ship a
+    #    record integrators cannot verify.
+    grep -qF "$AUTHOR_VK" FREENET.md || die "[5] FREENET.md does not publish $AUTHOR_VK"
+    pointer-record verify --author-vk "$AUTHOR_VK" --app-id "$APP_ID" --state "$STATE" \
+        --expect-version "$VERSION" --expect-code-hash "$CODE_HASH" --expect-key "$POINTER_KEY" >/dev/null \
+        || die "[5] the record for $APP_ID does not verify"
+    say "[5] signature verifies against the key published in FREENET.md"
+
+    # 4. The version must be exactly one above what is ON THE NETWORK, read
+    #    from the network rather than assumed.
+    ONNET_VERSION=""
+    if fdev -p "$PORT" execute get --timeout 120 -o "$WORK/cur_$i.bin" "$POINTER_KEY" >"$WORK/cur_$i.log" 2>&1 \
+       && [ -s "$WORK/cur_$i.bin" ]; then
+        ONNET_VERSION="$(pointer-record verify --author-vk "$AUTHOR_VK" --app-id "$APP_ID" \
+                          --state "$WORK/cur_$i.bin" | sed -n 's/^version=//p')"
+    fi
+    if [ -z "$ONNET_VERSION" ]; then
+        say "[4] nothing on the network yet — this is the FIRST publish (PUT), version $VERSION"
+        PUB_OP="put"
+    else
+        EXPECT=$((ONNET_VERSION + 1))
+        [ "$VERSION" -eq "$EXPECT" ] || die "[4] on-network version is $ONNET_VERSION, so this publish must be
+version $EXPECT, but the record says $VERSION.
+A publish at an already-used version is a silent NO-OP: the network accepts it
+and keeps the OLD record. Re-sign with the right version."
+        say "[4] on-network version $ONNET_VERSION -> publishing $VERSION (UPDATE)"
+        PUB_OP="update"
+    fi
+
+    PUB_APP[$i]="$APP_ID"; PUB_KEY[$i]="$POINTER_KEY"; PUB_STATE[$i]="$STATE"
+    PUB_VERSION[$i]="$VERSION"; PUB_HASH[$i]="$CODE_HASH"
+    printf '%s' "$STATE" | xxd -r -p > "$WORK/state_$i.bin"
+    echo "$PUB_OP" > "$WORK/op_$i"
+done
+
+echo ""
+echo "=============================================================="
+echo " All pre-flight checks PASSED."
+echo "=============================================================="
+for i in $(seq 1 "$N"); do
+    echo "  $(cat "$WORK/op_$i" | tr a-z A-Z) ${PUB_APP[$i]} v${PUB_VERSION[$i]} -> ${PUB_KEY[$i]}"
+done
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo ""
+    echo "--dry-run: stopping before the network write."
+    exit 0
+fi
+
+if [ "$ASSUME_YES" -eq 0 ]; then
+    echo ""
+    read -r -p "Publish these records to the network? [y/N] " REPLY
+    case "$REPLY" in y|Y|yes|YES) ;; *) echo "aborted."; exit 1 ;; esac
+fi
+
+# ------------------------------------------------------------------ PUBLISH
+for i in $(seq 1 "$N"); do
+    echo ""
+    echo "--- publishing ${PUB_APP[$i]} ---"
+    PARAMS="$WORK/params_$i.bin"
+    pointer-record key --author-vk "$AUTHOR_VK" --app-id "${PUB_APP[$i]}" \
+        | sed -n 's/^params=//p' | xxd -r -p > "$PARAMS"
+    if [ "$(cat "$WORK/op_$i")" = "put" ]; then
+        fdev -p "$PORT" execute put --timeout 180 \
+            --code "$POINTER_WASM" --parameters "$PARAMS" \
+            contract --state "$WORK/state_$i.bin" 2>&1 | tail -3 | sed 's/^/    /'
+    else
+        fdev -p "$PORT" execute update --timeout 180 \
+            "${PUB_KEY[$i]}" "$WORK/state_$i.bin" 2>&1 | tail -3 | sed 's/^/    /'
+    fi
+done
+
+# --------------------------------------------------------------- VERIFY BACK
+# "The PUT returned OK" is not evidence. A stale publish is a no-op SUCCESS, so
+# the only check that proves an integrator gets the right answer is to read the
+# record back and resolve it end to end.
+echo ""
+echo "=============================================================="
+echo " Post-publish verification (the only check that proves anything)"
+echo "=============================================================="
+FAILED=0
+for i in $(seq 1 "$N"); do
+    echo ""
+    echo "--- ${PUB_APP[$i]} ---"
+    rm -f "$WORK/back_$i.bin"
+    if ! fdev -p "$PORT" execute get --timeout 180 -o "$WORK/back_$i.bin" "${PUB_KEY[$i]}" \
+         >"$WORK/back_$i.log" 2>&1 || [ ! -s "$WORK/back_$i.bin" ]; then
+        echo "  FAILED: could not read the record back from ${PUB_KEY[$i]}"
+        FAILED=1
+        continue
+    fi
+    if ! cmp -s "$WORK/back_$i.bin" "$WORK/state_$i.bin"; then
+        echo "  FAILED: the bytes on the network are not the bytes we published."
+        echo "  This is what a silently-ignored stale publish looks like."
+        FAILED=1
+        continue
+    fi
+    say "byte-identical to what we published"
+    if ! pointer-record verify --author-vk "$AUTHOR_VK" --app-id "${PUB_APP[$i]}" \
+            --state "$WORK/back_$i.bin" \
+            --expect-version "${PUB_VERSION[$i]}" \
+            --expect-code-hash "${PUB_HASH[$i]}" \
+            --expect-key "${PUB_KEY[$i]}" >/dev/null; then
+        echo "  FAILED: the record read BACK from the network does not verify"
+        FAILED=1
+        continue
+    fi
+    say "verifies from the network at version ${PUB_VERSION[$i]}, code hash ${PUB_HASH[$i]}"
+done
+
+echo ""
+if [ "$FAILED" -ne 0 ]; then
+    echo "PUBLISH DID NOT FULLY VERIFY. Do not announce these pointers."
+    exit 1
+fi
+echo "All $N record(s) published AND verified from the network."
+echo ""
+echo "An integrator resolving these now gets the code hash of the artifact"
+echo "that is actually live. Addressing only — say nothing about data survival."

--- a/scripts/publish-pointer-records.sh
+++ b/scripts/publish-pointer-records.sh
@@ -212,6 +212,23 @@ Refusing to publish a record whose target could not be checked against the netwo
     [ "$DERIVED" = "$POINTER_KEY" ] || die "[3] derived key $DERIVED != recorded $POINTER_KEY for $APP_ID"
     say "[3] app_id '$APP_ID' derives to $DERIVED (matches)"
 
+    # 3b. And the NODE agrees. Both values above come from this crate; if the
+    # crate and the node ever disagreed about how a key is derived, every check
+    # here would pass while the record landed somewhere nobody queries. So ask
+    # a second, independent implementation — fdev, from the raw wasm and params.
+    # This is the cross-check the pre-publish gate ran as its step 0, and it is
+    # the only one that involves an implementation we did not write.
+    printf '%s' "$(pointer-record key --author-vk "$AUTHOR_VK" --app-id "$APP_ID" \
+        | sed -n 's/^params=//p')" | xxd -r -p > "$WORK/pcheck_$i.bin"
+    FDEV_KEY="$(fdev get-contract-id --code "$POINTER_WASM" --parameters "$WORK/pcheck_$i.bin" 2>/dev/null | tail -1)"
+    [ "$FDEV_KEY" = "$POINTER_KEY" ] || die "[3b] DERIVATION FORK for $APP_ID.
+  this crate derives : $POINTER_KEY
+  fdev derives       : $FDEV_KEY
+The node and the signing tool disagree about where this record lives. Publishing
+would put it at an address no consumer derives, and every other check here would
+still pass."
+    say "[3b] fdev derives the same key from the raw wasm + params (no convention fork)"
+
     # 5. The signature verifies, under the key published in FREENET.md, BEFORE
     #    the PUT. A key-file/doc mismatch must fail loudly rather than ship a
     #    record integrators cannot verify.

--- a/scripts/sign-pointer-records.sh
+++ b/scripts/sign-pointer-records.sh
@@ -43,28 +43,25 @@ command -v pointer-record >/dev/null 2>&1 || die "pointer-record not found — s
 
 # Refuse to sign against a key file anyone else can read. The author key is the
 # whole trust anchor for every integrator resolving a River pointer.
+#
+# Deliberately NOT `stat -L`: on a symlinked key file this reports the link's
+# own mode (typically 777) and refuses, which is the safe direction. Following
+# the link would report the target's mode and accept, which is the direction
+# that hides a surprise. A narrow TOCTOU window remains between this check and
+# the read below; it is not worth closing for a script a human runs while
+# holding the key, and closing it badly would be worse than naming it.
 PERMS="$(stat -c '%a' "$KEY_FILE")"
 case "$PERMS" in
     600|400) ;;
     *) die "$KEY_FILE has mode $PERMS; expected 600. Fix with: chmod 600 '$KEY_FILE'" ;;
 esac
 
-field_of_record() {
-    awk -v want="$1" -v key="$2" '
-        /^\[\[record\]\]/ { i++; next }
-        i == want && $0 ~ "^"key"[ \t]*=" {
-            sub("^"key"[ \t]*=[ \t]*", ""); gsub(/^"|"$/, ""); print; exit
-        }
-    ' "$TOML_PATH"
-}
-top_level_field() {
-    awk -v key="$1" '
-        /^\[\[record\]\]/ { exit }
-        $0 ~ "^"key"[ \t]*=" {
-            sub("^"key"[ \t]*=[ \t]*", ""); gsub(/^"|"$/, ""); print; exit
-        }
-    ' "$TOML_PATH"
-}
+# The same shared reader the gate uses — see scripts/pointer-toml-lib.sh for
+# why it is shared rather than copied.
+. "$(dirname "$0")/pointer-toml-lib.sh"
+
+field_of_record() { pointer_field "$TOML_PATH" "$1" "$2"; }
+top_level_field() { pointer_top_field "$TOML_PATH" "$1"; }
 
 AUTHOR_VK="$(top_level_field author_verifying_key)"
 [ -n "$AUTHOR_VK" ] || die "no author_verifying_key in $TOML_PATH"
@@ -125,7 +122,28 @@ for b in blocks[1:]:
     out.append(b)
 if hits != 1:
     sys.exit("expected exactly one [[record]] with app_id=%s, found %d" % (app_id, hits))
-open(path, 'w', encoding='utf-8').write('[[record]]'.join(out))
+
+# Write to a temp file in the same directory, then rename. `open(path, 'w')`
+# truncates FIRST and writes second, so an interrupt in between leaves the
+# registry empty or half-written with no backup — and this file is the gate's
+# oracle and the record of what we signed. os.replace is atomic within a
+# filesystem, so a reader sees either the old file or the new one, never a
+# fragment.
+import os, tempfile
+d = os.path.dirname(os.path.abspath(path)) or '.'
+fd, tmp = tempfile.mkstemp(dir=d, prefix='.pointer-records.', suffix='.tmp')
+try:
+    with os.fdopen(fd, 'w', encoding='utf-8') as f:
+        f.write('[[record]]'.join(out))
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, path)
+except BaseException:
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    raise
 PY
     CHANGED=1
 done

--- a/scripts/sign-pointer-records.sh
+++ b/scripts/sign-pointer-records.sh
@@ -100,7 +100,13 @@ for i in $(seq 1 "$N"); do
 
     NEW_STATE="$(printf '%s\n' "$OUT" | sed -n 's/^state=//p')"
     NEW_KEY="$(printf '%s\n' "$OUT" | sed -n 's/^key=//p')"
-    [ -n "$NEW_STATE" ] && [ -n "$NEW_KEY" ] || die "signer produced no state/key for $APP_ID"
+    # Written as an explicit `if` rather than `A && B || die`: that form runs
+    # the `die` whenever the conjunction is false, which happens to be right
+    # here, but it reads as if-then-else and is not one. Not worth leaving a
+    # shape that invites a wrong edit later.
+    if [ -z "$NEW_STATE" ] || [ -z "$NEW_KEY" ]; then
+        die "signer produced no state/key for $APP_ID"
+    fi
 
     # Rewrite only this record's block, matched by app_id rather than by line
     # number: a line-addressed edit silently rewrites the wrong record the first

--- a/scripts/sign-pointer-records.sh
+++ b/scripts/sign-pointer-records.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# Re-sign every pointer record against the WASM currently in the working tree.
+#
+# Run this whenever a pointed-at WASM changes, BEFORE committing, then commit
+# pointer-records.toml alongside the new WASM. CI (check-pointer-freshness)
+# fails the PR if you forget.
+#
+# Signing is offline: it needs the author key but not the network. Publishing
+# the signed records is a separate step (scripts/publish-pointer-records.sh),
+# run from main after merge.
+#
+# Usage:
+#   scripts/sign-pointer-records.sh            # bump version, re-sign changed records
+#   scripts/sign-pointer-records.sh --force    # re-sign even records that did not change
+#
+# The key is read from ~/.config/river/web-container-keys.toml — the SAME key
+# that signs the web container (Ian's decision, 2026-08-18). It is piped
+# straight into the signer and never lands in a variable, a temp file, or argv.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TOML_PATH="pointer-records.toml"
+KEY_FILE="${RIVER_POINTER_KEY_FILE:-$HOME/.config/river/web-container-keys.toml}"
+
+cd "$REPO_ROOT"
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+FORCE=0
+for arg in "$@"; do
+    case "$arg" in
+        --force) FORCE=1 ;;
+        # Strict: a typo'd flag that fell through would produce records the
+        # caller did not ask for, signed with a production key.
+        *) die "unknown argument '$arg' (expected nothing, or --force)" ;;
+    esac
+done
+
+command -v b3sum >/dev/null 2>&1 || die "b3sum not found. Install with: cargo install b3sum"
+command -v pointer-record >/dev/null 2>&1 || die "pointer-record not found — see scripts/check-pointer-freshness.sh for the install line"
+[ -f "$KEY_FILE" ] || die "key file not found: $KEY_FILE"
+[ -f "$TOML_PATH" ] || die "$TOML_PATH not found"
+
+# Refuse to sign against a key file anyone else can read. The author key is the
+# whole trust anchor for every integrator resolving a River pointer.
+PERMS="$(stat -c '%a' "$KEY_FILE")"
+case "$PERMS" in
+    600|400) ;;
+    *) die "$KEY_FILE has mode $PERMS; expected 600. Fix with: chmod 600 '$KEY_FILE'" ;;
+esac
+
+field_of_record() {
+    awk -v want="$1" -v key="$2" '
+        /^\[\[record\]\]/ { i++; next }
+        i == want && $0 ~ "^"key"[ \t]*=" {
+            sub("^"key"[ \t]*=[ \t]*", ""); gsub(/^"|"$/, ""); print; exit
+        }
+    ' "$TOML_PATH"
+}
+top_level_field() {
+    awk -v key="$1" '
+        /^\[\[record\]\]/ { exit }
+        $0 ~ "^"key"[ \t]*=" {
+            sub("^"key"[ \t]*=[ \t]*", ""); gsub(/^"|"$/, ""); print; exit
+        }
+    ' "$TOML_PATH"
+}
+
+AUTHOR_VK="$(top_level_field author_verifying_key)"
+[ -n "$AUTHOR_VK" ] || die "no author_verifying_key in $TOML_PATH"
+
+N="$(grep -c '^\[\[record\]\]' "$TOML_PATH")"
+CHANGED=0
+
+for i in $(seq 1 "$N"); do
+    APP_ID="$(field_of_record "$i" app_id)"
+    WASM_PATH="$(field_of_record "$i" wasm_path)"
+    OLD_HASH="$(field_of_record "$i" code_hash)"
+    OLD_VERSION="$(field_of_record "$i" version)"
+
+    [ -f "$WASM_PATH" ] || die "$WASM_PATH not found (record $i, $APP_ID)"
+    NEW_HASH="$(b3sum "$WASM_PATH" | cut -d' ' -f1)"
+
+    if [ "$NEW_HASH" = "$OLD_HASH" ] && [ "$FORCE" -eq 0 ]; then
+        echo "$APP_ID: unchanged at $NEW_HASH (version $OLD_VERSION)"
+        continue
+    fi
+
+    # The version is a monotonic counter gating the network update. A republish
+    # at an already-used version is a silent NO-OP: the contract deliberately
+    # does not error on a stale update, so the network would never tell us the
+    # release was ignored.
+    NEW_VERSION=$((OLD_VERSION + 1))
+    echo "$APP_ID: $OLD_HASH -> $NEW_HASH  (version $OLD_VERSION -> $NEW_VERSION)"
+
+    # The key is piped straight in; --author-vk makes the signer REFUSE if the
+    # key file has drifted from the identity published in FREENET.md.
+    OUT="$(pointer-record sign \
+        --author-vk "$AUTHOR_VK" \
+        --app-id "$APP_ID" \
+        --version "$NEW_VERSION" \
+        --code-hash "$NEW_HASH" < "$KEY_FILE")" || die "signing $APP_ID failed"
+
+    NEW_STATE="$(printf '%s\n' "$OUT" | sed -n 's/^state=//p')"
+    NEW_KEY="$(printf '%s\n' "$OUT" | sed -n 's/^key=//p')"
+    [ -n "$NEW_STATE" ] && [ -n "$NEW_KEY" ] || die "signer produced no state/key for $APP_ID"
+
+    # Rewrite only this record's block, matched by app_id rather than by line
+    # number: a line-addressed edit silently rewrites the wrong record the first
+    # time somebody reorders the file.
+    python3 - "$TOML_PATH" "$APP_ID" "$NEW_VERSION" "$NEW_HASH" "$NEW_STATE" "$NEW_KEY" <<'PY'
+import re, sys
+path, app_id, version, code_hash, state, key = sys.argv[1:7]
+src = open(path, encoding='utf-8').read()
+blocks = src.split('[[record]]')
+out = [blocks[0]]
+hits = 0
+for b in blocks[1:]:
+    if re.search(r'^app_id\s*=\s*"%s"\s*$' % re.escape(app_id), b, re.M):
+        hits += 1
+        b = re.sub(r'^version\s*=.*$',    'version = %s' % version,     b, count=1, flags=re.M)
+        b = re.sub(r'^code_hash\s*=.*$',  'code_hash = "%s"' % code_hash, b, count=1, flags=re.M)
+        b = re.sub(r'^state\s*=.*$',      'state = "%s"' % state,       b, count=1, flags=re.M)
+        b = re.sub(r'^pointer_key\s*=.*$','pointer_key = "%s"' % key,   b, count=1, flags=re.M)
+    out.append(b)
+if hits != 1:
+    sys.exit("expected exactly one [[record]] with app_id=%s, found %d" % (app_id, hits))
+open(path, 'w', encoding='utf-8').write('[[record]]'.join(out))
+PY
+    CHANGED=1
+done
+
+if [ "$CHANGED" -eq 0 ]; then
+    echo ""
+    echo "Nothing to do — every record already names the WASM in the working tree."
+    exit 0
+fi
+
+echo ""
+echo "Re-verifying through the gate CI will run..."
+./scripts/check-pointer-freshness.sh
+
+cat <<'EOF'
+
+Next:
+  1. git add pointer-records.toml   (and the WASM change that caused this)
+  2. Open a PR. check-pointer-freshness will re-verify.
+  3. AFTER merge, from main: cargo make publish-pointer-records
+
+Signing does not publish. Until step 3 runs, integrators still resolve the
+PREVIOUS record — which is correct, because the new WASM is not on the network
+until the UI is republished either.
+EOF


### PR DESCRIPTION
## Problem

River's room contract and chat delegate **re-key on any WASM change** — the delegate roughly weekly, with 30 recorded generations in `legacy_delegates.toml`. Our own users are carried across that by the migration registries. A **third party** is not: their reference is a build-time constant, and after a re-key it silently addresses an empty namespace.

Every read then comes back looking like *"this user has nothing stored"*, which at the protocol level is indistinguishable from the truth. That is not hypothetical — it is [freenet/ghostkeys#21](https://github.com/freenet/ghostkeys/issues/21), where an integrating app told a user to buy a Ghost Key they already owned.

## Approach

Publish a **pointer record** for each artifact: a contract at a *fixed* address whose state names that artifact's current code hash, signed by River's author key. Integrators resolve it instead of pinning. The address never moves, so their constant never goes stale.

| `app_id` | Pointer key (fixed) |
|---|---|
| `river.room-contract` | `Ai4VLoC2jGdhpcB2UU8VPo3efUoxjm1Ju9VKXqRC63Az` |
| `river.chat-delegate` | `6qF2H5JRPBxbKC45UtPnzdDzyfsejYFW1UwDLGDU66mu` |

Implements the convention in [freenet-core#5194](https://github.com/freenet/freenet-core/issues/5194). River is the first publisher in the ecosystem. Signing and verification use the shared `pointer-record` tool from [freenet-migrate#26](https://github.com/freenet/freenet-migrate/pull/26), pinned by merge SHA — no signing code is added here.

## The CI gate matters more than the launch

**Once a pointer exists, a stale pointer is worse than no pointer.** Before one existed, an integrator pinning our key knew they were pinning it. After, they resolve, get a confident answer, and derive a dead key — the failure gets *quieter* exactly as more people depend on it.

So `check-pointer-freshness` runs on every PR and fails the build when a pointed-at WASM changed and no new record was signed. It deliberately asks a **different question** from `check-delegate-migration`: not *"does an entry exist?"* — which passes forever after the first record is committed — but *"does the record name **these** bytes?"*, which is meaningful on every commit.

Three checks per record, each able to fail alone:

1. `code_hash` == BLAKE3 of the committed WASM at `wasm_path`.
2. The 100-byte record **verifies** under the author key published in `FREENET.md`, and carries that same hash and version. Catches a hand-edited hash that left its signature behind, which check 1 alone would accept.
3. The version strictly increased if the record changed. A repeat version is a silent no-op on the network — the contract treats a stale update as success by design, so nothing downstream would tell us.

Plus a fourth, structural: **no record may vanish.** Deleting a record's block would otherwise pass, since every check is per-record and the gate happily verifies what remains.

### Every check was watched going red

A guard nobody has seen fail is not evidence it can.

| Fault injected | Result |
|---|---|
| append a byte to `chat_delegate.wasm`, sign nothing (**the real failure**) | RED — *"Any integrator resolving river.chat-delegate would derive a DEAD key"* |
| hand-edit `code_hash` | RED |
| hand-bump `version` without re-signing | RED |
| `FREENET.md` and the TOML disagree on the author key | RED |
| hand-edit `pointer_key` | RED |
| truncate a record | RED |
| mistyped flag falling through to local mode | RED |
| delete a whole record block (CI mode) | RED — names the missing `app_id` |
| zero records / missing WASM / empty TOML | RED |

## Verified against the live network, not just the repo

The record for each artifact was checked against the bytes **users are actually running**: the live web container was fetched from the network, its webapp archive unpacked, and the two WASMs inside hashed. Both match the committed copies.

```
LIVE (network)   e765339b…  room_contract.wasm      a44c6401…  chat_delegate.wasm
REPO (committed) e765339b…  room_contract.wasm      a44c6401…  chat_delegate.wasm
```

`publish-pointer-records.sh` repeats that check on every publish, because those two **do** diverge in practice — the live web container's version counter is currently two ahead of the committed `contract-version.txt`, which means at least one publish happened without the counter being committed. Worth a separate look; it does not affect the records here.

## The signing key

The same key that signs the web container, per Ian's decision of 2026-08-18. Safe against cross-app replay because the pointer contract signs over the **whole params blob** (`author_vk ‖ app_id`), so a record for one `app_id` cannot be replayed into another.

Two consequences are written down in `FREENET.md` and `pointer-records.toml` rather than left to be discovered: River does **not** keep this key offline, contrary to the pointer contract's own recommendation, because the same key signs every UI publish; and rotating it would move the web container's address **and** both pointer addresses at once, so it is a coordinated flag day rather than routine key hygiene.

## Scope, stated everywhere it could be misread

**A pointer solves addressing only.** It says nothing about whether state or secrets under the old key survived. This matters most for the delegate: secrets move only when River's own UI has run on that user's node, so an integrator can resolve `river.chat-delegate` perfectly and still find an **empty namespace** — which looks like *"this user has no data"* rather than like an error. That is precisely the confusion the pointer exists to remove, so conflating the two would reintroduce it one level up.

## Testing

Beyond the fault-injection table above: the gate was run in both local and CI mode, and the whole toolchain was exercised through the exact path CI takes — `cargo install --git … --rev 5e1759c --features publish --locked`, then the gate against that binary. Re-signing is deterministic (same inputs reproduce byte-identical records), verified by round-tripping the version counter.

No WASM was rebuilt (`.claude/rules/wasm-safety.md`) and **nothing is published to the network by this PR** — publishing is a separate step from `main` after merge.

## Follow-up

`cargo make publish-pointer-records` from `main` once this lands, which runs the five pre-flight gates and then re-reads each record back off the network and resolves it through the real resolver. "The PUT returned OK" is not evidence: a publish at an already-used version is a no-op *success*.

[AI-assisted - Claude]