### PR TITLE
fix(ci): the pointer-rev guard accepted anything after a 7-hex prefix

### DIFF
--- a/.github/workflows/check-pointer-freshness.yml
+++ b/.github/workflows/check-pointer-freshness.yml
@@ -42,9 +42,17 @@ jobs:
         # non-empty, so a bare `test -n` would accept it and then hand cargo a
         # garbage rev. A guard that cannot fail is the thing this whole gate
         # exists to avoid.
+        #
+        # It must reject ANY non-hex character, not merely require a hex PREFIX.
+        # The first version of this check was
+        # `[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*`, whose
+        # trailing `*` matches anything at all — so `abcdef1zzzz`,
+        # `abcdef1;rm -rf /` and `abcdef1 --features evil` all passed it, and
+        # the `-ge 7` length test below did not help, because the problem was
+        # never length. A guard whose comment says "validates the SHAPE" has to
+        # actually do that.
         case "$REV" in
-          [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*) ;;
-          *) echo "POINTER_TOOL_REV is not a hex SHA: '$REV'"; exit 1 ;;
+          ""|*[!0-9a-f]*) echo "POINTER_TOOL_REV is not lowercase hex: '$REV'"; exit 1 ;;
         esac
         test "${#REV}" -ge 7 || { echo "POINTER_TOOL_REV too short: '$REV'"; exit 1; }
         echo "pinned freenet-migrate rev: $REV"

--- a/scripts/publish-pointer-records.sh
+++ b/scripts/publish-pointer-records.sh
@@ -75,9 +75,28 @@ echo "=============================================================="
 # ---------------------------------------------------------------- PROVENANCE
 echo ""
 echo "[provenance] clean tree, on main, at origin/main, CI green"
-if [ -n "$(git status --porcelain)" ]; then
-    git status --short | sed 's/^/    /'
-    die "working tree is not clean. Publish only from a clean checkout of main."
+# TRACKED modifications only. An untracked file cannot change what is
+# published: every path this script reads is tracked, and the records are
+# separately checked against the committed blob, the derived key and the
+# artifact live on the network. Refusing on untracked files blocked every
+# publish in the Atlas port (freenet/atlas#47), whose checkout normally carries
+# build artifacts; River's happened to be clean, which is the only reason this
+# copy has not hit it.
+#
+# They are still PRINTED rather than ignored silently — if one of them is a
+# surprise, the operator should see it before writing to the network.
+#
+# A modified TRACKED file remains a hard refusal, deliberately: it means this
+# checkout differs from the commit whose CI was verified above, which is exactly
+# the provenance claim being made.
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+    git status --short --untracked-files=no | sed 's/^/    /'
+    die "tracked files are modified. Publish only from a clean checkout of main."
+fi
+UNTRACKED="$(git status --porcelain | grep '^??' || true)"
+if [ -n "$UNTRACKED" ]; then
+    say "note: untracked files present (they cannot affect what is published):"
+    printf '%s\n' "$UNTRACKED" | sed 's/^/      /'
 fi
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 [ "$BRANCH" = "main" ] || die "on branch '$BRANCH'. Publish only from main (see ~/.claude/rules/publish-from-main.md)."

--- a/scripts/publish-pointer-records.sh
+++ b/scripts/publish-pointer-records.sh
@@ -33,6 +33,14 @@ PORT=""
 DRY_RUN=0
 ASSUME_YES=0
 POINTER_WASM="${POINTER_WASM:-}"
+# Initialised here, not only where it is computed in the provenance section,
+# because it is read again in the Result summary AFTER the network write. Under
+# `set -u` an unset read there would kill the script at the one point where
+# dying is most expensive: records are already live and the summary saying
+# which ones is what the operator has left. The assignment below always runs
+# today, so this costs nothing; it stops a future edit that guards or moves
+# that assignment from turning a note into a post-publish abort.
+UNTRACKED=""
 while [ $# -gt 0 ]; do
     case "$1" in
         --node-port) PORT="${2:?--node-port needs a value}"; shift 2 ;;
@@ -84,7 +92,12 @@ echo "[provenance] clean tree, on main, at origin/main, CI green"
 # copy has not hit it.
 #
 # They are still PRINTED rather than ignored silently — if one of them is a
-# surprise, the operator should see it before writing to the network.
+# surprise, the operator should see it. An interactive run sees it here, before
+# the confirmation prompt. An unattended run (--yes) has nobody watching stdout
+# at this point, so the same list is REPEATED in the Result summary at the end:
+# that is the part of the output a later reader actually reads, and it is what
+# makes this note a durable record rather than a line that scrolled past. It
+# stays a note either way — untracked files never block a publish.
 #
 # A modified TRACKED file remains a hard refusal, deliberately: it means this
 # checkout differs from the commit whose CI was verified above, which is exactly
@@ -461,6 +474,18 @@ echo "=============================================================="
 [ -n "$PUBLISHED" ]     && { echo " published AND verified:"; for a in $PUBLISHED; do echo "   $a"; done; }
 [ -n "$FAILED_PUB" ]    && { echo " NOT published (the write failed):"; for a in $FAILED_PUB; do echo "   $a"; done; }
 [ -n "$FAILED_VERIFY" ] && { echo " WROTE but did NOT verify — treat as UNKNOWN state on the network:"; for a in $FAILED_VERIFY; do echo "   $a"; done; }
+
+# Repeated from the provenance section on purpose. Under --yes nobody is
+# watching stdout when that first note prints, so this is the copy an operator
+# (or an incident review) actually reads. `if` rather than the `&&` form above
+# because this is the last statement before the exit-1 branch, and a failing
+# `[` there is exactly where `set -e` semantics get argued about. Not a gate:
+# an untracked file cannot change what was published, and the run has already
+# finished by the time this prints.
+if [ -n "$UNTRACKED" ]; then
+    echo " untracked files present at publish time (they cannot affect what was published):"
+    printf '%s\n' "$UNTRACKED" | sed 's/^/   /'
+fi
 
 if [ -n "$FAILED_PUB" ] || [ -n "$FAILED_VERIFY" ]; then
     echo ""


### PR DESCRIPTION
Two independent defects in the pointer-record machinery, both in code whose job is to be a gate. Neither was caught by CI, because in both cases the gate's failure mode is to be *too permissive* — and nothing had ever driven either one with an input that should fail.

## Problem

### 1. The `POINTER_TOOL_REV` guard accepted anything after a 7-hex prefix

The shape check in `check-pointer-freshness.yml` was:

```sh
case "$REV" in
  [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*) ;;
  *) echo "not a hex SHA"; exit 1 ;;
esac
test "${#REV}" -ge 7 || exit 1
```

The trailing `*` matches **anything**, so the check only ever required a 7-character hex *prefix*:

| input | old guard |
|---|---|
| `abcdef1zzzz` | **accepted** |
| `abcdef1;rm -rf /` | **accepted** |
| `abcdef1 --features evil` | **accepted** |
| `ABCDEF1` | rejected |
| `abcdef` | rejected |

The `-ge 7` length test does not help, because the problem was never length.

Its own comment claimed it *"validates the SHAPE, not just non-emptiness"* — and it did not. That is the same defect this gate exists to prevent, sitting inside the gate.

### 2. The publish script's clean-tree check could never pass

`publish-pointer-records.sh` refused to publish unless `git status --porcelain` was empty. With no flags that command **counts untracked files**, and every real checkout carries untracked build artifacts — so the check did not guard the publish, it blocked it unconditionally. It refused every publish attempt in the Atlas port ([freenet/atlas#47](https://github.com/freenet/atlas/pull/47)); River's checkout happened to be clean, which is the only reason this copy had not hit it yet.

This is the mirror image of defect 1. One gate was too permissive to ever fail; the other was too strict to ever pass. Both are guards that had never been observed doing their job.

## Approach

**Guard.** Reject empty, **any** character that is not lowercase hex, and anything shorter than a short SHA:

```sh
case "$REV" in
  ""|*[!0-9a-f]*) echo "POINTER_TOOL_REV is not lowercase hex: '$REV'"; exit 1 ;;
esac
test "${#REV}" -ge 7 || { echo "POINTER_TOOL_REV too short: '$REV'"; exit 1; }
```

**Clean tree.** Check `--untracked-files=no`, so only *tracked* modifications refuse. A modified tracked file remains a hard refusal, deliberately: it means the checkout differs from the commit whose CI was just verified, which is exactly the provenance claim being made.

Relaxing this is safe because **an untracked file cannot change what gets published.** Every input to the publish is checked against something other than the local working tree: the records come from the committed `pointer-records.toml`, the pointer WASM is verified by code hash against the value in that file, each record's key is re-derived and cross-checked against `fdev`, each code hash is compared against the artifact **live on the network**, and every signature is verified before the PUT. There is no path by which an untracked local file reaches the network. That tracing was done as a separate review pass specifically to justify this relaxation, rather than assumed.

Untracked files are still **reported** — they are not silently ignored. If one is a surprise, the operator should see it.

**Making that report true under `--yes`.** The report is printed in the provenance section, near the start of the run. Under `--yes` (unattended) nobody is watching stdout at that point, so the note scrolls past unread and the run leaves no durable record of what was untracked at publish time — the comment claiming the operator "should see it before writing to the network" overclaimed. The same list is now **repeated in the Result summary at the end**, which is the part of the output an operator or an incident review actually reads. It stays a note, not a gate: untracked files never block a publish, and no confirmation prompt was added.

`UNTRACKED` is also now initialised at the top of the script. It is read after the network write, and under `set -u` an unset read there would abort at the most expensive possible moment — records already live, and the summary saying *which* ones is precisely what the operator would lose. The provenance assignment always runs today, so this costs nothing; it stops a future edit that moves or guards that assignment from turning a note into a post-publish abort.

## Testing

**Guard**, driven with 25 inputs, old and new side by side. The new guard rejected every hostile input; the old one accepted 12 of them. Rejected by the new guard: `abcdef1zzzz`, `abcdef1;rm -rf /`, `abcdef1 --features evil`, `abcdef1$(id)`, ``abcdef1`id` ``, `abcdef1&&id`, `abcdef1|id`, embedded newline, tab suffix, control character `\x01`, single and double quote, `abcdef1*`, `abcdef1/../../etc`, surrounding whitespace, `--features`, `-abcdef1`, uppercase, empty string, and the sed-passthrough case (`POINTER_TOOL_REV="${POINTER_TOOL_REV:-...}"`, what the extraction yields if that line ever stops matching). Accepted: the real pinned rev `5e1759c39f98ec54f51c84d632e28fc33578b48d` and a 7-character short SHA. Length boundary confirmed at 6 rejected / 7 accepted.

Also confirmed **locale-independent** (`LC_ALL=C` and `en_US.UTF-8` both reject uppercase, so the `a-f` range is not collation-sensitive here) and **POSIX-portable** (identical results under `dash`).

**Clean tree**, in a throwaway repo across 9 scenarios. The new check still refuses on every form of tracked divergence — modified, staged-modified, deleted-from-worktree, staged-delete, and newly-staged-add — and relaxes only for genuinely untracked files. The untracked-capture line was confirmed to survive `set -euo pipefail` both when untracked files exist and when none do.

**Result summary**, exercised under the script's own `set -euo pipefail` across success and partial-failure, with and without untracked files. Confirmed it prints in both outcomes, is absent when there is nothing untracked, does not abort the run, and preserves the exit code (0 on success, 1 on partial publish).

`bash -n` and `shellcheck -S warning` are clean on all four pointer scripts.

## Severity, stated honestly

**Defect 1: low, and not exploitable.** `POINTER_TOOL_REV` comes from a committed, reviewed script in this repo, so injecting a value requires commit access — at which point the workflow can be edited directly. The value is also quoted at the `cargo install --rev "$REV"` call site, so a hostile value produces a bad rev rather than a shell injection. Nothing was ever mis-installed: the real rev has always been a clean 40-char SHA.

**Defect 2: no security impact, but it broke the tool.** A publish gate that cannot pass is not a safety property, it is an outage of the publish path — and the natural workaround is for an operator to start deleting or bypassing the check, which costs the real protection along with the false one.

What makes both worth a PR rather than a shrug is that they are **guards whose comments overclaimed what they did**. The whole point of this machinery is that a check nobody has watched fail is not evidence.

## How it was found

An adversarial review of the Atlas port ([freenet/atlas#46](https://github.com/freenet/atlas/pull/46)) flagged what looked like a *dropped length guard* relative to this original. That specific reading was wrong — the pattern rejects 6 characters and accepts 7, so the length test was redundant — but checking it turned up the real hole, which is **larger than reported and present here too**, in the copy the reviewer was treating as correct. The clean-tree defect surfaced separately, when the Atlas port could not complete a publish.

Fixed in all three copies: this one, atlas#46 and delta#78. Three copies of one snippet each carrying the same bug is its own argument for consolidating the gate into the `pointer-record` tool, which I'd suggest as a follow-up rather than widening this PR.

[AI-assisted - Claude]
