### PR TITLE
fix(pointer): author-key check matched a substring, so a truncated key passed

### DIFF
--- a/scripts/check-pointer-freshness.sh
+++ b/scripts/check-pointer-freshness.sh
@@ -126,11 +126,23 @@ AUTHOR_VK="$(top_level_field author_verifying_key)"
 # FREENET.md and verifies every record against it. If this file and that file
 # disagree, we sign records nobody can verify — and it fails silently, because
 # a record signed by the wrong key is perfectly well-formed.
+#
+# Matched as a WHOLE LINE (`-qx`), never as a substring. The key is published in
+# FREENET.md alone on its own line, and a substring match accepts any value that
+# is merely a PREFIX or SUFFIX of it — a truncated key, or one that lost its
+# `river:v1:vk:` prefix — which is precisely the disagreement this check exists
+# to catch. It failed OPEN on exactly its own subject matter: with the prefix
+# stripped from this file only, the whole gate reported success while the two
+# files published textually different anchors.
 echo "== author key =="
-if ! grep -qF "$AUTHOR_VK" "$FREENET_MD"; then
+if ! grep -qxF "$AUTHOR_VK" "$FREENET_MD"; then
     echo "FAILED: $TOML_PATH publishes author_verifying_key"
     echo "  $AUTHOR_VK"
-    echo "but $FREENET_MD does not contain that value."
+    echo "but $FREENET_MD does not carry that value on a line of its own."
+    echo ""
+    echo "A near-miss counts as a mismatch: a truncated key, or one missing its"
+    echo "\`river:v1:vk:\` prefix, is a DIFFERENT published anchor even though it"
+    echo "reads almost the same."
     echo ""
     echo "Integrators take the author key from $FREENET_MD. If the two disagree,"
     echo "every record we sign is one they will reject — and the record will look"

--- a/scripts/pointer-toml-lib.sh
+++ b/scripts/pointer-toml-lib.sh
@@ -82,8 +82,34 @@ pointer_top_field() {
     ' "$1"
 }
 
-# Number of [[record]] blocks in FILE.
-pointer_record_count() { grep -c '^\[\[record\]\]' "$1"; }
+# Number of [[record]] blocks in FILE. Refuses to return zero.
+#
+# `grep -c` exits 1 when it matches nothing, so under `set -e` an empty registry
+# killed the caller with a bare exit code and NO message — swallowing the
+# caller's own "no [[record]] blocks" error in exactly the case that message
+# exists for. This says the same thing out loud and still fails.
+#
+# The `|| true` below suppresses grep's exit code ONLY so this function can
+# report the reason itself; it must never be relaxed into simply returning 0.
+# Every caller multiplies this number into a `seq 1 $N` loop, so a quiet 0 turns
+# each of them into a loop that runs zero times and then reports success over
+# nothing — a publish script printing "All 0 record(s) published AND verified
+# from the network" having published nothing at all. That is a fail-CLOSED bug
+# traded for a fail-OPEN one. Failing stays the point; the only thing fixed here
+# is that it now says why. Callers guard the result as well, so an empty
+# registry is still refused where `set -e` is off.
+pointer_record_count() {
+    local n
+    n="$(grep -c '^\[\[record\]\]' "$1" || true)"
+    if [ "${n:-0}" -eq 0 ]; then
+        echo "ERROR: no [[record]] blocks in $1 — the registry is empty, so there is" >&2
+        echo "       nothing to check, sign or publish. This is a hard failure: an empty" >&2
+        echo "       registry is not 'zero work to do', it is a registry that lost its" >&2
+        echo "       records." >&2
+        return 1
+    fi
+    printf '%s\n' "$n"
+}
 
 # Every app_id in FILE, one per line.
 pointer_app_ids() {

--- a/scripts/publish-pointer-records.sh
+++ b/scripts/publish-pointer-records.sh
@@ -197,7 +197,8 @@ tar -xJf "$WORK/webapp.tar.xz" -C "$WORK/live" contracts/ 2>/dev/null \
     || die "could not unpack contracts/ from the live webapp archive"
 
 # --------------------------------------------------------------- PER-RECORD
-N="$(grep -c '^\[\[record\]\]' "$TOML_PATH")"
+N="$(pointer_record_count "$TOML_PATH")"
+[ "${N:-0}" -gt 0 ] || die "no [[record]] blocks in $TOML_PATH"
 # No PUB_STATE array: the bytes live in $WORK/state_$i.bin, written below.
 # Keeping a second copy in a shell variable would be two things that can
 # disagree about what we are publishing.

--- a/scripts/sign-pointer-records.sh
+++ b/scripts/sign-pointer-records.sh
@@ -66,7 +66,8 @@ top_level_field() { pointer_top_field "$TOML_PATH" "$1"; }
 AUTHOR_VK="$(top_level_field author_verifying_key)"
 [ -n "$AUTHOR_VK" ] || die "no author_verifying_key in $TOML_PATH"
 
-N="$(grep -c '^\[\[record\]\]' "$TOML_PATH")"
+N="$(pointer_record_count "$TOML_PATH")"
+[ "${N:-0}" -gt 0 ] || die "no [[record]] blocks in $TOML_PATH"
 CHANGED=0
 
 for i in $(seq 1 "$N"); do


### PR DESCRIPTION
## Problem

`scripts/check-pointer-freshness.sh` starts by checking that the `author_verifying_key` in `pointer-records.toml` is the same value `FREENET.md` publishes. That check is load-bearing: FREENET.md is where an integrator takes their trust anchor from, so if the two files disagree we sign records nobody can verify, and it fails silently because a record signed by the wrong key is perfectly well-formed.

It used a **substring** match:

```bash
if ! grep -qF "$AUTHOR_VK" "$FREENET_MD"; then
```

So any value that is merely a **prefix or suffix** of the published line passes — a truncated key, or one written without its `river:v1:vk:` prefix in one file only. That is exactly the mismatch the check exists to catch, and it **fails open**: the gate prints "present in FREENET.md" and moves on.

Concretely, with the FREENET.md line carrying one extra trailing character (a stray edit, a reformat) and the registry left alone, the whole gate exits **0**:

```
== author key ==
  river:v1:vk:9Ebskq4y7NvJpTQTrF1FAxU8g6bR4Rhe4TRikXba55EJ (present in FREENET.md)
...
All 2 pointer record(s) are fresh, signed, and name the committed WASM.
EXIT=0        <- fail-OPEN, while the two files publish different anchors
```

## Approach

`grep -qxF` — whole-line match. Verified safe before changing anything: the key sits alone on its own line in FREENET.md (line 49), so a whole-line match still succeeds, and the gate still passes on the untouched repo.

The failure message now names the near-miss case, because "does not contain that value" reads as "the key is absent" when in fact it is present-but-different by one character.

### Also in this PR: an empty registry failed with no message

`scripts/pointer-toml-lib.sh` had:

```bash
pointer_record_count() { grep -c '^\[\[record\]\]' "$1"; }
```

`grep -c` exits 1 on zero matches, so under `set -e` a record-less registry killed the caller with a bare exit code and **no output** — swallowing the caller's own `no [[record]] blocks in pointer-records.toml` error in precisely the case that message exists for. It now reports the reason and still fails.

`sign-pointer-records.sh` and `publish-pointer-records.sh` each carried their own **inline** `grep -c` with no guard on the result. Both now use the shared counter and check it explicitly, so a zero count is refused loudly even where `set -e` is off.

This deliberately does **not** append `|| true` at the call sites. That trades a fail-closed defect for a fail-open one: `N=0` makes every `seq 1 $N` loop run zero times and the publish script then prints `All 0 record(s) published AND verified from the network` and exits 0 having published nothing. Failing is still the point; the only thing changed is that it now says why.

## Testing

Run by hand in a worktree, before and after, with the pre-change gate kept alongside for a genuine comparison.

**1. The gate still passes untouched** — `EXIT=0`, `All 2 pointer record(s) are fresh, signed, and name the committed WASM.`

**2. `author_verifying_key` truncated by one character** (`...Xba55EJ` -> `...Xba55E`):

```
--- BEFORE (origin/main gate) ---
== author key ==
  river:v1:vk:9Ebskq4y7NvJpTQTrF1FAxU8g6bR4Rhe4TRikXba55E (present in FREENET.md)   <- passed
--- AFTER (this branch) ---
== author key ==
FAILED: pointer-records.toml publishes author_verifying_key
  river:v1:vk:9Ebskq4y7NvJpTQTrF1FAxU8g6bR4Rhe4TRikXba55E
but FREENET.md does not carry that value on a line of its own.
```

Worth stating precisely: on *this* input the old script still exited 1 overall, because the truncated key decodes to a different key and the later signature check caught it — with a confusing "signature verification failed" message rather than "your two files disagree". The author-key check itself passed on a key it should have rejected.

**2b. The end-to-end fail-open**, FREENET.md's published line gaining one character while the registry is untouched: **before EXIT=0** (with `All 2 pointer record(s) are fresh...`), **after EXIT=1** with the author-key failure above.

**3. Registry emptied of `[[record]]` blocks:** before, `EXIT=1` with no message at all after the author-key block. After, `EXIT=1` with

```
ERROR: no [[record]] blocks in pointer-records.toml — the registry is empty, so there is
       nothing to check, sign or publish. This is a hard failure: an empty
       registry is not 'zero work to do', it is a registry that lost its
       records.
```

from `check-pointer-freshness.sh` and from `sign-pointer-records.sh`. The `publish-pointer-records.sh` call site was exercised directly (it exits earlier on missing `--node-port` before reaching the count): it refuses with the same message both under `set -euo pipefail` and with `set -e` off, and reaches the publish loop only with the real registry.

`bash -n` clean on all four scripts; `shellcheck -S warning` clean. `pointer-records.toml` and `FREENET.md` are unchanged in the committed result — every test edit was reverted.

[AI-assisted - Claude]
