### PR TITLE
feat(cli): resolve River's room-contract pointer instead of trusting the bundled WASM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2327,6 +2327,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "freenet-migrate"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099e0ac5fed5bdd30f35d1d10a881b292ac221f2880debc470c299983f343075"
+dependencies = [
+ "blake3",
+ "bs58",
+ "ciborium",
+ "ed25519-dalek",
+ "freenet-scaffold",
+ "freenet-stdlib 0.8.5",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
 name = "freenet-migrate-build"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4741,7 +4757,7 @@ dependencies = [
  "dioxus",
  "dioxus-free-icons",
  "ed25519-dalek",
- "freenet-migrate",
+ "freenet-migrate 0.5.0",
  "freenet-migrate-build",
  "freenet-scaffold",
  "freenet-stdlib 0.8.5",
@@ -4781,7 +4797,7 @@ dependencies = [
  "dialoguer",
  "directories 5.0.1",
  "ed25519-dalek",
- "freenet-migrate",
+ "freenet-migrate 0.6.0",
  "freenet-scaffold",
  "freenet-stdlib 0.8.5",
  "freenet-test-network",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -55,9 +55,14 @@ freenet-stdlib = { workspace = true, features = ["net"] }
 freenet-scaffold = "0.2.2"
 # Sans-IO backward-probe decision driver (freenet/river#398 phase 2b): drives
 # the legacy-generation recovery search (newest-first, first real generation
-# wins). Its stdlib dep unifies with the workspace's 0.8.x. 0.5 is the same
-# contract-side API; the new surface is the delegate-secret walk the UI uses.
-freenet-migrate = "0.5"
+# wins). Its stdlib dep unifies with the workspace's 0.8.x.
+#
+# 0.6 is required, not merely newer: it is the first release to expose
+# `pub mod pointer` (the forward-discovery resolver riverctl uses to re-anchor
+# its room-contract key at runtime), and it is the release that stopped a probe
+# timeout reading as a definitive absence. That distinction is load-bearing
+# here, because absence is the ONLY answer that may unlock a baked-in key.
+freenet-migrate = "0.6"
 
 # Serialization (for contract state)
 ciborium = "0.2.2"

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -1,9 +1,14 @@
 use crate::config::Config;
 use crate::output::OutputFormat;
+use crate::pointer::{
+    anchor_from_report, floor_key, probe_plan, river_author_vk, KeyIntent, ProbePlan,
+    ResolveReport, RoomAnchor, StoredFloor, ROOM_CONTRACT_APP_ID,
+};
 use crate::storage::Storage;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Local, Utc};
 use ed25519_dalek::{SigningKey, VerifyingKey};
+use freenet_migrate::pointer::{resolve_app_pointer, PointerFetch, PointerFloor, PointerIo};
 use freenet_migrate::{NewestFirst, Outcome, ProbeDriver, ProbeStateOps, SelectionPolicy, Step};
 use freenet_scaffold::ComposableState;
 use freenet_stdlib::client_api::{
@@ -45,6 +50,97 @@ const UPGRADE_HOP_TIMEOUT: Duration = Duration::from_secs(15);
 /// Maximum upgrade-pointer hops to follow before giving up — guards against a
 /// cyclic or runaway chain.
 const MAX_UPGRADE_HOPS: usize = 32;
+/// Timeout for the single GET that resolves River's room-contract pointer.
+///
+/// Short on purpose. Every command that opens a node connection pays it once,
+/// and a node that cannot reach the pointer must not turn every riverctl
+/// invocation into a 30-second wait. The record is ~100 bytes and the GET does
+/// not request contract code, so a reachable pointer answers well inside this.
+const POINTER_GET_TIMEOUT: Duration = Duration::from_secs(10);
+/// Responses to step over while waiting for the pointer's `GetResponse`.
+///
+/// The node multiplexes every response onto one connection, so an
+/// `UpdateNotification` for an already-subscribed room can overtake the answer
+/// we asked for (freenet-core#4970 is the same race on the SUBSCRIBE
+/// acknowledgement). Bounded so a chatty subscription cannot starve the wait.
+const MAX_UNRELATED_RESPONSES_DURING_POINTER_GET: usize = 16;
+
+/// The BLAKE3 code hash of the room-contract WASM this binary bundles.
+///
+/// This is the anchor riverctl used to have as its ONLY anchor, and the thing
+/// the pointer record is compared against.
+pub fn bundled_room_code_hash() -> [u8; 32] {
+    *blake3::hash(ROOM_CONTRACT_WASM).as_bytes()
+}
+
+/// [`PointerIo`] over riverctl's existing node connection.
+///
+/// Deliberately not built on the crate's `ConservativeProbeIo` adapter: that
+/// routes through `ProbeIo::get`, which requests the contract code, and would
+/// pull the pointer contract's own ~130 KB WASM on every run to read a
+/// 100-byte record.
+struct NodePointerIo<'a> {
+    web_api: &'a Arc<Mutex<WebApi>>,
+}
+
+impl PointerIo for NodePointerIo<'_> {
+    /// Never returned: every transport condition is reported as
+    /// [`PointerFetch::Unreachable`] instead, so a resolution is never aborted
+    /// by one bad round trip. `Err` here would surface as
+    /// `ResolveError::Transport`, which says the same thing with less nuance.
+    type Error = std::convert::Infallible;
+
+    async fn get_pointer(&mut self, id: ContractInstanceId) -> Result<PointerFetch, Self::Error> {
+        let request = ContractRequest::Get {
+            key: id,
+            // The record IS the answer, and the pointer contract's own WASM is
+            // ~130 KB. Asking for the code would pay that on every riverctl run.
+            return_contract_code: false,
+            subscribe: false,
+            blocking_subscribe: false,
+        };
+        let mut web_api = self.web_api.lock().await;
+        if let Err(e) = web_api.send(ClientRequest::ContractOp(request)).await {
+            warn!("Could not send the pointer GET: {e}");
+            return Ok(PointerFetch::Unreachable);
+        }
+        let deadline = tokio::time::Instant::now() + POINTER_GET_TIMEOUT;
+        for _ in 0..MAX_UNRELATED_RESPONSES_DURING_POINTER_GET {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match tokio::time::timeout(remaining, web_api.recv()).await {
+                Ok(Ok(HostResponse::ContractResponse(ContractResponse::GetResponse {
+                    key,
+                    state,
+                    ..
+                }))) if *key.id() == id => return Ok(PointerFetch::State(state.to_vec())),
+                // Something else on the shared connection. Keep waiting.
+                Ok(Ok(_)) => continue,
+                Ok(Err(e)) => {
+                    debug!("Pointer GET failed: {e}");
+                    break;
+                }
+                Err(_) => {
+                    debug!("Pointer GET timed out after {POINTER_GET_TIMEOUT:?}");
+                    break;
+                }
+            }
+        }
+        // NEVER `PointerFetch::Absent`. `Absent` is the only answer that can
+        // unlock a baked-in build-time key, and this transport cannot produce a
+        // trustworthy one: the node reports a missing contract as a
+        // `ContractError::Get` whose cause is a free-text string, and on the
+        // live network a `NotFound` is overwhelmingly a routing dead-end for a
+        // contract that exists rather than a real absence. Reporting absence
+        // from that would be a downgrade primitive. The cost is that
+        // `PointerOutcome::NeverPublished` is unreachable through this adapter,
+        // which costs nothing: its arm falls back to the bundled hash, and so
+        // does `Unavailable`.
+        Ok(PointerFetch::Unreachable)
+    }
+}
 
 /// Optional fail-closed checks for non-interactive moderation callers. All
 /// predicates are evaluated against the fresh state fetched by the ban path.
@@ -418,6 +514,15 @@ fn migration_candidate_ids(
 ///   [`RiverCliMigrationProbeOps::merge_with_local`]).
 /// * `SeedLocal { local }` / `NoLegacy { local }` — every candidate missed (or
 ///   there were none): migrate the local cache forward.
+/// * `Indeterminate { local }`: at least one candidate never answered, so
+///   whether there is anything to recover is still unknown. freenet-migrate
+///   0.6 split this out of `SeedLocal`, and riverctl's I/O adapter cannot tell
+///   a real absence from a timeout (see `probe_legacy_bytes`), so in this
+///   integration every miss arrives here. Mapping it to the local cache is
+///   therefore exactly the pre-0.6 behaviour, deliberately preserved: the
+///   active-migration path has always fallen back to the local cache when
+///   nothing was reachable, and the migrating PUT is idempotent and retried on
+///   the next run.
 /// * `None` — defensive (an already-taken outcome): the local cache.
 fn resolve_migration_state_outcome(
     outcome: Option<Outcome<ChatRoomStateV1>>,
@@ -425,13 +530,90 @@ fn resolve_migration_state_outcome(
 ) -> ChatRoomStateV1 {
     match outcome {
         Some(Outcome::Recovered { merged, .. }) => merged,
-        Some(Outcome::SeedLocal { local }) | Some(Outcome::NoLegacy { local }) => local,
-        None => local_state.clone(),
+        Some(Outcome::SeedLocal { local })
+        | Some(Outcome::NoLegacy { local })
+        | Some(Outcome::Indeterminate { local, .. }) => local,
+        // `Outcome` is `#[non_exhaustive]`. A future arm has not been reasoned
+        // about here, so it must not silently adopt network state: the local
+        // cache is the conservative answer, exactly as for a taken outcome.
+        Some(_) | None => local_state.clone(),
     }
 }
 
-/// Compute the contract key for a room from its owner verifying key.
-/// This uses the current bundled WASM to ensure consistency.
+/// Build the backward-probe decision driver riverctl uses, in ONE place.
+///
+/// Both production paths (the read-path recovery search and the active
+/// migration search) and every test go through this. That is deliberate: the
+/// configuration below is not incidental, and a test that rebuilt a driver by
+/// hand would stop describing what riverctl actually does the moment the
+/// configuration changed, which is exactly what happened when freenet-migrate
+/// 0.6 changed the `NewestFirstWins` default for an unanswered candidate.
+///
+/// * `NewestFirstWins`: stop at the first generation with real state, so an
+///   older generation can never shadow a newer one.
+/// * `continue_past_unknown`: keep walking past a candidate that did not
+///   answer. See the long note at the call: riverctl cannot tell absence from
+///   silence, and almost every candidate is genuinely absent, so stopping at the
+///   first unknown would end the search at the first generation probed.
+/// * `with_max_hops` sized to the candidate list, because the pre-driver loop was
+///   unbounded, and the crate's default cap (64) would silently strand the
+///   oldest generations if the registry outgrew it.
+fn new_probe_driver<O: ProbeStateOps>(
+    ops: O,
+    local: O::State,
+    candidates_newest_first: Vec<ContractInstanceId>,
+) -> ProbeDriver<O> {
+    let count = candidates_newest_first.len();
+    ProbeDriver::new(
+        ops,
+        local,
+        // Candidates are newest-first BY CONSTRUCTION at every call site, so
+        // `assume_ordered` is sound.
+        NewestFirst::assume_ordered(candidates_newest_first),
+        SelectionPolicy::NewestFirstWins,
+    )
+    // Keep walking past an unanswered candidate. 0.6 made `NewestFirstWins`
+    // STOP at the first unknown, which is the right default for a driver that
+    // can tell absence from silence, since walking past a newer generation that
+    // merely failed to answer risks adopting an older one over it.
+    //
+    // riverctl cannot tell them apart. `try_get_state` collapses "the contract
+    // does not exist", "the GET timed out" and "the bytes did not decode" into
+    // one `None`, and the node offers no trustworthy absence signal to build on.
+    // Almost every candidate here is genuinely absent (a room lives on ONE
+    // generation out of the 31 in the registry), so stopping at the first
+    // unknown would end the search at the first generation probed and disable
+    // dormant-room recovery outright. That is not a safer probe, it is a probe
+    // that never runs.
+    //
+    // The rollback the token warns about is separately mitigated: the active
+    // path's candidate list deliberately re-lists the stored key so a transient
+    // miss on the newest generation is RETRIED before the probe advances (see
+    // `migration_candidate_ids`), and `NewestFirstWins` still stops at the first
+    // generation with real state.
+    .continue_past_unknown(
+        freenet_migrate::RollbackRiskAck::i_understand_continuing_past_silence_can_roll_back(),
+    )
+    .with_max_hops(count.max(freenet_migrate::DEFAULT_MAX_PROBE_HOPS))
+}
+
+/// Compute the contract key for a room from its owner verifying key, using the
+/// room-contract WASM **this binary bundles**.
+///
+/// This is a build-time answer, and it is only current for as long as River has
+/// not re-keyed since this binary was built. It remains correct for the offline
+/// local-cache path (a command that never opens a node connection has nothing
+/// better available) and as the comparison point for a resolved pointer record.
+///
+/// **Do not use it to address a contract on the network.** Use
+/// [`ApiClient::contract_key_for`], which derives from the generation River's
+/// pointer record names. See [`crate::pointer`] for why the difference matters:
+/// riverctl is installed from crates.io and kept, so "the WASM I was built
+/// with" and "the WASM River is running" drift apart, and a key derived from
+/// the former addresses a contract nobody is using. Pinned by
+/// `room_keys_for_the_network_are_derived_only_through_the_anchor`.
+// bundled-wasm-ok: this function IS the bundled derivation, kept for the offline
+// local-cache path and as the comparison point for a resolved pointer record.
 pub fn compute_contract_key(owner_vk: &VerifyingKey) -> ContractKey {
     let params = ChatRoomParametersV1 { owner: *owner_vk };
     let params_bytes = {
@@ -439,6 +621,7 @@ pub fn compute_contract_key(owner_vk: &VerifyingKey) -> ContractKey {
         ciborium::ser::into_writer(&params, &mut buf).expect("Failed to serialize parameters");
         buf
     };
+    // bundled-wasm-ok: see above.
     let contract_code = ContractCode::from(ROOM_CONTRACT_WASM);
     ContractKey::from_params_and_code(Parameters::from(params_bytes), &contract_code)
 }
@@ -1519,6 +1702,14 @@ pub struct ApiClient {
     #[allow(dead_code)]
     config: Config,
     storage: Storage,
+    /// River's room-contract generation for this run, resolved from the pointer
+    /// record on first use and reused thereafter.
+    ///
+    /// Lazy rather than resolved in [`ApiClient::new`] so a command that opens a
+    /// connection but never touches a room key pays nothing, and so the one GET
+    /// happens where its failure can be reported against the operation that
+    /// needed it.
+    room_anchor: tokio::sync::OnceCell<RoomAnchor>,
 }
 
 impl ApiClient {
@@ -1560,7 +1751,104 @@ impl ApiClient {
             web_api: Arc::new(Mutex::new(web_api)),
             config,
             storage,
+            room_anchor: tokio::sync::OnceCell::new(),
         })
+    }
+
+    /// River's room-contract generation for this run, resolved once.
+    ///
+    /// Resolution is one GET of a fixed address, so the cost is a single short
+    /// round trip per riverctl invocation that touches a room.
+    pub async fn room_anchor(&self) -> Result<&RoomAnchor> {
+        self.room_anchor
+            .get_or_try_init(|| self.resolve_room_anchor())
+            .await
+    }
+
+    /// Resolve River's room-contract pointer, persist the anti-rollback floor,
+    /// and announce anything the user needs to know.
+    async fn resolve_room_anchor(&self) -> Result<RoomAnchor> {
+        let bundled = bundled_room_code_hash();
+        let author_vk = river_author_vk()?;
+        let key = floor_key(&author_vk, ROOM_CONTRACT_APP_ID);
+
+        // A floor that will not rebuild is an ERROR, never a reset. See
+        // `StoredFloor::to_floor`: `never_resolved` is the one state that
+        // re-enables the build-time key, so "recovering" into it is the
+        // downgrade the floor exists to prevent.
+        let floor = match self.storage.load_pointer_floor(&key)? {
+            Some(stored) => stored.to_floor().with_context(|| {
+                crate::pointer::floor_corruption_hint(self.storage.pointer_floors_path())
+            })?,
+            None => PointerFloor::never_resolved(),
+        };
+
+        let mut io = NodePointerIo {
+            web_api: &self.web_api,
+        };
+        let report =
+            match resolve_app_pointer(&mut io, &author_vk, ROOM_CONTRACT_APP_ID, floor).await {
+                Ok(outcome) => ResolveReport::Outcome(outcome),
+                // `NodePointerIo` never returns `Err`, so only the pointer-side
+                // error (a malformed or unverifiable record) can land here.
+                Err(e) => ResolveReport::Failed(e.to_string()),
+            };
+
+        // Persist the floor BEFORE acting on the outcome, and specifically
+        // including a withdrawal: `anchor_from_report` refuses on a withdrawal,
+        // and returning early without persisting would leave the floor at the
+        // pre-withdrawal version, so any peer could then serve a genuine
+        // pre-withdrawal record and resurrect the retired code.
+        if let ResolveReport::Outcome(outcome) = &report {
+            if let Some(next) = outcome.next_floor() {
+                if let Err(e) = self
+                    .storage
+                    .save_pointer_floor(&key, StoredFloor::from_floor(&next))
+                {
+                    // Best-effort: failing to persist costs anti-rollback
+                    // protection on the NEXT run, but the record verified on
+                    // THIS one, so refusing the operation would be worse.
+                    warn!("Could not persist the pointer anti-rollback floor: {e}");
+                }
+            }
+        }
+
+        let anchor = anchor_from_report(&report, &floor, bundled)?;
+
+        // Once per run, on stderr, so it is visible in a pipeline whose stdout
+        // is being parsed. Repeating it per derived key would train users to
+        // ignore it.
+        if let Some(advisory) = anchor.advisory() {
+            eprintln!("{advisory}");
+        }
+        info!(
+            "Room-contract generation for this run: {} ({:?}, {:?})",
+            crate::pointer::code_hash_b58(anchor.code_hash()),
+            anchor.generation(),
+            anchor.source(),
+        );
+
+        // Let the local room cache regenerate its keys against the same
+        // generation the network paths use, instead of against the bundled WASM.
+        self.storage.set_room_code_hash(*anchor.code_hash());
+        Ok(anchor)
+    }
+
+    /// The room-contract key for `owner_vk` under this run's resolved
+    /// generation, refusing when `intent` is not something this binary can
+    /// honestly do against that generation.
+    ///
+    /// **This is the choke point.** Deriving a room key from
+    /// [`ROOM_CONTRACT_WASM`] anywhere else re-introduces the stale-anchor bug;
+    /// `room_keys_for_the_network_are_derived_only_through_the_anchor` pins that.
+    pub async fn contract_key_for(
+        &self,
+        owner_vk: &VerifyingKey,
+        intent: KeyIntent,
+    ) -> Result<ContractKey> {
+        let anchor = self.room_anchor().await?;
+        anchor.authorize(intent)?;
+        Ok(anchor.contract_key(owner_vk))
     }
 
     pub async fn create_room(
@@ -1574,6 +1862,12 @@ impl ApiClient {
             if private { "private" } else { "public" },
             name
         );
+        // Publishing the room contract means PUTting the bytes this binary
+        // bundles, which is only honest when River's pointer record agrees that
+        // those bytes are the current generation.
+        self.room_anchor()
+            .await?
+            .authorize(KeyIntent::PublishCode)?;
 
         // Generate signing key for the room owner
         let signing_key =
@@ -1603,6 +1897,10 @@ impl ApiClient {
             buf
         };
 
+        // bundled-wasm-ok: this path PUTs the contract's real bytes, and riverctl
+        // only has the ones it bundles. Gated above on `KeyIntent::PublishCode`,
+        // which refuses unless River's pointer record agrees these bytes are the
+        // current generation.
         let contract_code = ContractCode::from(ROOM_CONTRACT_WASM);
         // Use the full ContractKey constructor that includes the code hash
         let contract_key = ContractKey::from_params_and_code(
@@ -1737,6 +2035,12 @@ impl ApiClient {
             "Republishing room owned by: {}",
             bs58::encode(room_owner_key.as_bytes()).into_string()
         );
+        // Publishing the room contract means PUTting the bytes this binary
+        // bundles, which is only honest when River's pointer record agrees that
+        // those bytes are the current generation.
+        self.room_anchor()
+            .await?
+            .authorize(KeyIntent::PublishCode)?;
 
         // Get the room state from local storage
         let room_data = self.storage.get_room(room_owner_key)?.ok_or_else(|| {
@@ -1755,6 +2059,10 @@ impl ApiClient {
             buf
         };
 
+        // bundled-wasm-ok: this path PUTs the contract's real bytes, and riverctl
+        // only has the ones it bundles. Gated above on `KeyIntent::PublishCode`,
+        // which refuses unless River's pointer record agrees these bytes are the
+        // current generation.
         let contract_code = ContractCode::from(ROOM_CONTRACT_WASM);
         let contract_key = ContractKey::from_params_and_code(
             Parameters::from(params_bytes.clone()),
@@ -2084,13 +2392,23 @@ impl ApiClient {
         }
 
         // 2. Backward search across previous contract generations, driven by
-        //    freenet_migrate's sans-IO decision driver. Candidates are the
-        //    legacy keys, already newest-first BY CONSTRUCTION
-        //    (`legacy_contract_keys_for_owner` reverses the oldest-first
-        //    registry), so `assume_ordered` is sound; `NewestFirstWins` stops
-        //    at the first real generation — the anti-rollback guarantee.
-        let legacy_keys = river_core::migration::legacy_contract_keys_for_owner(room_owner_key);
-        let legacy_count = legacy_keys.len();
+        //    freenet_migrate's sans-IO decision driver. Candidates are newest
+        //    first BY CONSTRUCTION, so `assume_ordered` is sound;
+        //    `NewestFirstWins` stops at the first real generation, which is the
+        //    anti-rollback guarantee.
+        //
+        //    The candidate list is ANCHORED ON THE RESOLVED GENERATION, not on
+        //    the bundled one. That is the whole point of resolving: "older than
+        //    where the room is" is only meaningful relative to where the room
+        //    actually is. Anchored at the bundled generation instead, a riverctl
+        //    that River has moved past searches a set that cannot contain the
+        //    live room, and can surface an ancient copy and republish it onto a
+        //    retired key.
+        let candidate_ids = match probe_plan(room_owner_key, self.room_anchor().await?) {
+            ProbePlan::Probe(ids) => ids,
+            ProbePlan::Refuse(message) => return Err(anyhow!(message)),
+        };
+        let legacy_count = candidate_ids.len();
         info!(
             "Room not present on current contract {current_id}; probing {legacy_count} previous \
              contract generation(s)"
@@ -2102,25 +2420,17 @@ impl ApiClient {
         // `river_core::migration`, and feeding the raw driver avoids fabricating
         // lineage values just to satisfy that signature. The pump below is the
         // same trivial loop `migrate_contract` runs.
-        let candidate_ids: Vec<ContractInstanceId> = legacy_keys.iter().map(|k| *k.id()).collect();
-        let mut driver = ProbeDriver::new(
+        let mut driver = new_probe_driver(
             RiverCliProbeOps {
                 owner_vk: *room_owner_key,
             },
             // The CLI never merges device-local state and never seeds it, so the
             // local snapshot is an empty default: `merge_with_local` returns the
-            // recovered state verbatim, and exhaustion (SeedLocal) maps to the
-            // not-found error below rather than PUTting anything.
+            // recovered state verbatim, and exhaustion maps to the not-found
+            // error below rather than PUTting anything.
             ChatRoomStateV1::default(),
-            NewestFirst::assume_ordered(candidate_ids),
-            SelectionPolicy::NewestFirstWins,
-        )
-        // The pre-driver loop probed EVERY legacy key unbounded; the driver's
-        // default hop cap (64) would silently strand the oldest generations if
-        // the registry ever exceeded it (27 today). Size the cap to fit the whole
-        // registry so it only ever guards a runaway registry, never truncates a
-        // real one.
-        .with_max_hops(legacy_count.max(freenet_migrate::DEFAULT_MAX_PROBE_HOPS));
+            candidate_ids,
+        );
 
         // Trivial pump: one awaitable GET (with its forward chain-walk) per
         // candidate. `probe_legacy_bytes` is the I/O adapter — it returns the
@@ -2133,7 +2443,14 @@ impl ApiClient {
             probes_run += 1;
             match self.probe_legacy_bytes(room_owner_key, id).await {
                 Some(bytes) => driver.on_response(id, &bytes),
-                None => driver.on_timeout(id),
+                // `on_unknown`, never `on_absent`: this adapter cannot tell an
+                // answered "no state here" from a timeout, a send failure or an
+                // undecodable body. `try_get_state` collapses all of them to
+                // `None`. Absence is the only answer that may seal a generation
+                // as empty, so claiming it here would seal a predecessor that
+                // was merely slow. (freenet-migrate#19; `on_timeout` is its
+                // deprecated alias for exactly this call.)
+                None => driver.on_unknown(id),
             }
         }
 
@@ -2287,6 +2604,31 @@ impl ApiClient {
         // key plus every known legacy key. A pointer to any of these is
         // current-or-older and must not be followed (freenet/river#427).
         let mut known_keys: HashSet<ContractInstanceId> = HashSet::new();
+        // The generation resolved from River's pointer record AND the bundled
+        // one. Both are "current-or-older" for this owner: an upgrade pointer
+        // aimed at either is not a forward hop, and following it can only
+        // regress (freenet/river#427). When the two are the same key this is one
+        // insert, as before.
+        // Read the ALREADY-resolved anchor rather than re-resolving: every path
+        // that reaches here went through `room_anchor()` first, so the value is
+        // cached and this performs no I/O and can swallow no transport error.
+        match self.room_anchor.get() {
+            Some(anchor) => {
+                known_keys.insert(*anchor.contract_key(room_owner_key).id());
+            }
+            // Unreachable today. Loud rather than silent, because the effect is a
+            // SMALLER refuse-list, which means following an upgrade pointer we
+            // would otherwise refuse (freenet/river#427) rather than failing.
+            None => warn!(
+                "Upgrade-pointer guard is running before the room-contract anchor was \
+                 resolved; the resolved generation is missing from `known_keys`, so a \
+                 pointer aimed at it would be followed (freenet/river#427)"
+            ),
+        }
+        // bundled-wasm-ok: `known_keys` must recognise a pointer aimed at ANY
+        // generation this binary knows, bundled included, so a backward pointer
+        // planted by migration poisoning is never chased (freenet/river#427).
+        // This set is never used to ADDRESS a contract.
         known_keys.insert(*self.owner_vk_to_contract_key(room_owner_key).id());
         for legacy_key in river_core::migration::legacy_contract_keys_for_owner(room_owner_key) {
             known_keys.insert(*legacy_key.id());
@@ -2311,12 +2653,22 @@ impl ApiClient {
         room_owner_key: &VerifyingKey,
         room_state: &ChatRoomStateV1,
     ) -> Result<()> {
+        // Publishing the room contract means PUTting the bytes this binary
+        // bundles, which is only honest when River's pointer record agrees that
+        // those bytes are the current generation.
+        self.room_anchor()
+            .await?
+            .authorize(KeyIntent::PublishCode)?;
         let parameters = ChatRoomParametersV1 {
             owner: *room_owner_key,
         };
         let mut params_bytes = Vec::new();
         ciborium::ser::into_writer(&parameters, &mut params_bytes)
             .map_err(|e| anyhow!("Failed to serialize parameters: {e}"))?;
+        // bundled-wasm-ok: this path PUTs the contract's real bytes, and riverctl
+        // only has the ones it bundles. Gated above on `KeyIntent::PublishCode`,
+        // which refuses unless River's pointer record agrees these bytes are the
+        // current generation.
         let contract_code = ContractCode::from(ROOM_CONTRACT_WASM);
         let contract_container = ContractContainer::from(ContractWasmAPIVersion::V1(
             WrappedContract::new(Arc::new(contract_code), Parameters::from(params_bytes)),
@@ -2547,7 +2899,9 @@ impl ApiClient {
         info!("Accepting invitation with nickname: {}", nickname);
 
         let room_owner_vk = invitation.room;
-        let contract_key = self.owner_vk_to_contract_key(&room_owner_vk);
+        let contract_key = self
+            .contract_key_for(&room_owner_vk, KeyIntent::Write)
+            .await?;
 
         // Refuse to re-accept an invitation for a room we already have stored
         // credentials for (issue freenet/river#308). Re-accepting rebuilds the
@@ -2820,6 +3174,14 @@ impl ApiClient {
         }
     }
 
+    /// The room key this binary's bundled WASM derives.
+    ///
+    /// Kept for the one caller that legitimately needs the BUNDLED generation
+    /// rather than the resolved one: `follow_upgrade_chain`'s `known_keys`,
+    /// which must recognise a pointer aimed at any generation we know about.
+    /// Every other caller wants [`Self::contract_key_for`].
+    // bundled-wasm-ok: this method IS the bundled derivation; the doc above names
+    // its one legitimate caller.
     pub fn owner_vk_to_contract_key(&self, owner_vk: &VerifyingKey) -> ContractKey {
         let parameters = ChatRoomParametersV1 { owner: *owner_vk };
         let params_bytes = {
@@ -2828,6 +3190,7 @@ impl ApiClient {
                 .expect("Serialization should not fail");
             buf
         };
+        // bundled-wasm-ok: see above.
         let contract_code = ContractCode::from(ROOM_CONTRACT_WASM);
         // Use the full ContractKey constructor that includes the code hash
         ContractKey::from_params_and_code(Parameters::from(params_bytes), &contract_code)
@@ -2846,9 +3209,25 @@ impl ApiClient {
     ///
     /// Any member can perform this migration — not just the owner.
     ///
+    /// Migration only runs when River's pointer record agrees that the bundled
+    /// generation is the current one. Migrating means PUTting the bundled
+    /// contract code, so against any other generation the target would be a key
+    /// nobody uses: when the network is ahead, we cannot publish its code, and
+    /// when it is behind, publishing ours would move the room somewhere the rest
+    /// of River is not looking. In both cases the resolved key is already
+    /// correct and there is nothing to migrate TO.
+    ///
     /// Returns the current contract key (possibly updated).
     pub async fn ensure_room_migrated(&self, room_owner_key: &VerifyingKey) -> Result<ContractKey> {
-        let expected_key = self.owner_vk_to_contract_key(room_owner_key);
+        let anchor = self.room_anchor().await?;
+        let expected_key = anchor.contract_key(room_owner_key);
+        if anchor.authorize(KeyIntent::PublishCode).is_err() {
+            debug!(
+                "Skipping room migration: the resolved room-contract generation is not the one \
+                 this riverctl bundles, so there is nothing to migrate onto"
+            );
+            return Ok(expected_key);
+        }
 
         // Check if we have this room locally
         let storage = self.storage.load_rooms()?;
@@ -3088,23 +3467,15 @@ impl ApiClient {
         // and exhaustion falls back to the local cache rather than erroring.
         // `NewestFirstWins` stops at the first real generation — so the stored
         // key short-circuits the deep scan on a hit, preserving the fast path.
-        let mut driver = ProbeDriver::new(
+        let mut driver = new_probe_driver(
             RiverCliMigrationProbeOps {
                 inner: RiverCliProbeOps {
                     owner_vk: *room_owner_key,
                 },
             },
-            // Folded into a hit via `merge_with_local`, and handed back verbatim
-            // on exhaustion (SeedLocal / NoLegacy) — the pre-driver
-            // `Ok(local_state.clone())` fallback.
             local_state.clone(),
-            NewestFirst::assume_ordered(candidate_ids),
-            SelectionPolicy::NewestFirstWins,
-        )
-        // Size the hop cap to the candidate set so the driver's default 64-hop
-        // cap can never truncate a >64-generation registry (the pre-driver deep
-        // path was unbounded), mirroring the read path.
-        .with_max_hops(candidate_count.max(freenet_migrate::DEFAULT_MAX_PROBE_HOPS));
+            candidate_ids,
+        );
 
         // Trivial pump: one awaitable GET per candidate. `probe_migration_bytes`
         // is the I/O adapter (plain GET, no upgrade-chain walk — matching the
@@ -3112,7 +3483,14 @@ impl ApiClient {
         while let Step::Get(id) = driver.next_action() {
             match self.probe_migration_bytes(room_owner_key, id).await {
                 Some(bytes) => driver.on_response(id, &bytes),
-                None => driver.on_timeout(id),
+                // `on_unknown`, never `on_absent`: this adapter cannot tell an
+                // answered "no state here" from a timeout, a send failure or an
+                // undecodable body. `try_get_state` collapses all of them to
+                // `None`. Absence is the only answer that may seal a generation
+                // as empty, so claiming it here would seal a predecessor that
+                // was merely slow. (freenet-migrate#19; `on_timeout` is its
+                // deprecated alias for exactly this call.)
+                None => driver.on_unknown(id),
             }
         }
 
@@ -3189,6 +3567,12 @@ impl ApiClient {
         new_contract_key: ContractKey,
     ) -> Result<ContractKey> {
         info!("Migrating room to new contract: {}", new_contract_key.id());
+        // Publishing the room contract means PUTting the bytes this binary
+        // bundles, which is only honest when River's pointer record agrees that
+        // those bytes are the current generation.
+        self.room_anchor()
+            .await?
+            .authorize(KeyIntent::PublishCode)?;
 
         let parameters = ChatRoomParametersV1 {
             owner: *room_owner_key,
@@ -3200,6 +3584,10 @@ impl ApiClient {
             buf
         };
 
+        // bundled-wasm-ok: this path PUTs the contract's real bytes, and riverctl
+        // only has the ones it bundles. Gated above on `KeyIntent::PublishCode`,
+        // which refuses unless River's pointer record agrees these bytes are the
+        // current generation.
         let contract_code = ContractCode::from(ROOM_CONTRACT_WASM);
         let contract_container = ContractContainer::from(ContractWasmAPIVersion::V1(
             WrappedContract::new(Arc::new(contract_code), Parameters::from(params_bytes)),
@@ -3480,7 +3868,9 @@ impl ApiClient {
             .map_err(|e| anyhow!("Failed to apply message delta: {:?}", e))?;
 
         // Send the delta to the network
-        let contract_key = self.owner_vk_to_contract_key(room_owner_key);
+        let contract_key = self
+            .contract_key_for(room_owner_key, KeyIntent::Write)
+            .await?;
 
         let delta_bytes = {
             let mut buf = Vec::new();
@@ -3601,7 +3991,9 @@ impl ApiClient {
             .update_room_state(room_owner_key, room_state.clone())?;
 
         // Send the delta to the network
-        let contract_key = self.owner_vk_to_contract_key(room_owner_key);
+        let contract_key = self
+            .contract_key_for(room_owner_key, KeyIntent::Write)
+            .await?;
 
         // Serialize the delta
         let delta_bytes = {
@@ -3656,7 +4048,9 @@ impl ApiClient {
         room_owner_key: &VerifyingKey,
         delta: &ChatRoomStateV1Delta,
     ) -> Result<()> {
-        let contract_key = self.owner_vk_to_contract_key(room_owner_key);
+        let contract_key = self
+            .contract_key_for(room_owner_key, KeyIntent::Write)
+            .await?;
 
         let delta_bytes = {
             let mut buf = Vec::new();
@@ -4119,7 +4513,9 @@ impl ApiClient {
         room_owner_key: &VerifyingKey,
         delta: ChatRoomStateV1Delta,
     ) -> Result<()> {
-        let contract_key = self.owner_vk_to_contract_key(room_owner_key);
+        let contract_key = self
+            .contract_key_for(room_owner_key, KeyIntent::Write)
+            .await?;
 
         // Serialize the delta
         let delta_bytes = {
@@ -4836,7 +5232,9 @@ impl ApiClient {
         };
 
         // Get contract key and send the update
-        let contract_key = self.owner_vk_to_contract_key(room_owner_key);
+        let contract_key = self
+            .contract_key_for(room_owner_key, KeyIntent::Write)
+            .await?;
 
         let update_request = ContractRequest::Update {
             key: contract_key,
@@ -5030,7 +5428,9 @@ impl ApiClient {
         };
 
         // Get contract key and send the update
-        let contract_key = self.owner_vk_to_contract_key(room_owner_key);
+        let contract_key = self
+            .contract_key_for(room_owner_key, KeyIntent::Write)
+            .await?;
 
         let update_request = ContractRequest::Update {
             key: contract_key,
@@ -5239,7 +5639,9 @@ impl ApiClient {
             buf
         };
 
-        let contract_key = self.owner_vk_to_contract_key(room_owner_key);
+        let contract_key = self
+            .contract_key_for(room_owner_key, KeyIntent::Write)
+            .await?;
 
         let update_request = ContractRequest::Update {
             key: contract_key,
@@ -5322,7 +5724,9 @@ impl ApiClient {
 
         // Fetch current room state to pre-populate seen_messages and trigger
         // migration if needed (get_room calls ensure_room_migrated internally).
-        let contract_key = self.owner_vk_to_contract_key(room_owner_key);
+        let contract_key = self
+            .contract_key_for(room_owner_key, KeyIntent::Read)
+            .await?;
         let contract_instance_id = *contract_key.id();
         {
             let mut room_state = self.get_room(room_owner_key, false).await?;
@@ -6019,6 +6423,164 @@ mod invitation_tests {
 mod migration_recovery_tests {
     use super::*;
 
+    /// Every room key that reaches the NETWORK must come from the resolved
+    /// pointer anchor, never from the WASM this binary bundles.
+    ///
+    /// This is the actual regression guard for the stale-anchor bug this change
+    /// exists to fix. Re-introducing that bug is ONE edit: a send path that
+    /// derives its key from the bundled WASM compiles, passes every behavioural
+    /// test in this crate, and silently UPDATEs a retired key for every user on
+    /// that build. Nothing but a scrape catches it, because the wrong key is a
+    /// perfectly well-formed key.
+    ///
+    /// # How it works, and why it is shaped this way
+    ///
+    /// An earlier version of this pin scraped ONE literal
+    /// (`self.owner_vk_to_contract_key`) in ONE file (`api.rs`). That is worth
+    /// recording, because it looked like a guard and was not one: the free
+    /// function `compute_contract_key` reaches the same derivation, is already
+    /// imported by `storage.rs` and `commands/identity.rs`, and was not in the
+    /// needle set. Swapping the main message-send path to it left the suite at
+    /// 337 passed. A guard with one door is not a guard.
+    ///
+    /// So this pin closes all three doors and scans the whole crate:
+    ///
+    /// * `compute_contract_key` and `owner_vk_to_contract_key`, the two helpers
+    ///   that derive from the bundled WASM; and
+    /// * the `ContractCode::from` of the bundled WASM, the root both helpers
+    ///   use, which catches a fresh derivation calling neither.
+    ///
+    /// It walks `src/` rather than naming files, so a NEW file cannot be born
+    /// outside its scope. Legitimate uses carry an explicit `bundled-wasm-ok:`
+    /// marker with a reason, so the allowlist lives at the call site instead of
+    /// drifting from it, and every future use has to be argued in writing
+    /// rather than merely compile.
+    #[test]
+    fn room_keys_for_the_network_are_derived_only_through_the_anchor() {
+        // Marker a line must carry to use the bundled WASM deliberately.
+        const OK: &str = "bundled-wasm-ok:";
+        let needles = [
+            "compute_contract_key(",     // bundled-wasm-ok: the needle itself
+            "owner_vk_to_contract_key(", // bundled-wasm-ok: the needle itself
+            // bundled-wasm-ok: the needle itself
+            "ContractCode::from(ROOM_CONTRACT_WASM)",
+        ];
+
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut sources: Vec<std::path::PathBuf> = Vec::new();
+        let mut stack = vec![root.clone()];
+        while let Some(dir) = stack.pop() {
+            for entry in std::fs::read_dir(&dir)
+                .unwrap_or_else(|e| panic!("cannot read {}: {e}", dir.display()))
+            {
+                let path = entry.expect("readable dir entry").path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if path.extension().is_some_and(|e| e == "rs") {
+                    sources.push(path);
+                }
+            }
+        }
+
+        // Fail CLOSED. A walk that silently found nothing would leave this pin
+        // passing forever while checking nothing, which is the exact failure its
+        // own history above is about.
+        assert!(
+            sources.len() >= 8,
+            "the source walk found only {} files under {}; it is not scanning the crate",
+            sources.len(),
+            root.display()
+        );
+        for required in ["api.rs", "storage.rs", "identity.rs"] {
+            assert!(
+                sources.iter().any(|p| p.ends_with(required)),
+                "the source walk missed {required}, which imports a bundled-WASM derivation"
+            );
+        }
+
+        // A line is allowed if it carries the marker itself, or if the contiguous
+        // comment block directly above it does. Reasons worth reading rarely fit
+        // in a trailing comment, and requiring one would select for reasons too
+        // short to be worth writing. The block must be CONTIGUOUS, so a marker
+        // cannot drift upward and silently cover a whole function.
+        fn allowed(lines: &[&str], i: usize, ok: &str) -> bool {
+            if lines[i].contains(ok) {
+                return true;
+            }
+            let mut j = i;
+            while j > 0 {
+                let prev = lines[j - 1].trim_start();
+                if !prev.starts_with("//") {
+                    return false;
+                }
+                if prev.contains(ok) {
+                    return true;
+                }
+                j -= 1;
+            }
+            false
+        }
+
+        let mut offending = Vec::new();
+        for path in &sources {
+            let text = std::fs::read_to_string(path).expect("readable source file");
+            let lines: Vec<&str> = text.lines().collect();
+            for (i, line) in lines.iter().enumerate() {
+                if needles.iter().any(|n| line.contains(n)) && !allowed(&lines, i, OK) {
+                    offending.push(format!(
+                        "{}:{}: {}",
+                        path.strip_prefix(&root).unwrap_or(path).display(),
+                        i + 1,
+                        line.trim()
+                    ));
+                }
+            }
+        }
+        offending.sort();
+        assert!(
+            offending.is_empty(),
+            "these lines derive a room key from the WASM this binary bundles, which goes stale \
+             the moment River re-keys. Use `contract_key_for(owner_vk, KeyIntent::..)`, which \
+             derives from the generation River's pointer record names. If a line genuinely needs \
+             the bundled generation, mark it `// {OK} <reason>` and say why.\n  {}",
+            offending.join("\n  ")
+        );
+    }
+
+    /// The four operations that PUT the room contract's actual bytes must each
+    /// check that the bundled generation is the current one first. riverctl only
+    /// has the bytes it bundles, so publishing them against any other resolved
+    /// generation writes to a key nobody reads, silently, with a successful
+    /// PutResponse.
+    #[test]
+    fn every_room_contract_put_is_gated_on_publishing_the_bundled_generation() {
+        let src = include_str!("api.rs");
+        let gate = "authorize(KeyIntent::PublishCode)";
+        for (fn_name, next_marker) in [
+            ("pub async fn create_room(", "ContractRequest::Put"),
+            ("pub async fn republish_room(", "ContractRequest::Put"),
+            ("async fn put_room_state(", "ContractRequest::Put"),
+            (
+                "async fn migrate_room_to_new_contract(",
+                "ContractRequest::Put",
+            ),
+        ] {
+            let start = src
+                .find(fn_name)
+                .unwrap_or_else(|| panic!("`{fn_name}` must exist"));
+            let put_at = src[start..]
+                .find(next_marker)
+                .map(|off| start + off)
+                .unwrap_or_else(|| panic!("`{fn_name}` has no {next_marker}"));
+            assert!(
+                src[start..put_at].contains(gate),
+                "`{fn_name}` PUTs the room contract without first checking \
+                 `{gate}`; a stale riverctl would publish its own bundled code onto a \
+                 generation River has moved past"
+            );
+        }
+    }
+
     /// The legacy registry derives a contract key exactly as the live code path
     /// (`compute_contract_key` / `owner_vk_to_contract_key`) does. If this ever
     /// drifts, every backward probe would target the wrong contract instance
@@ -6031,6 +6593,8 @@ mod migration_recovery_tests {
         let current_code_hash: [u8; 32] = *blake3::hash(ROOM_CONTRACT_WASM).as_bytes();
         let via_registry =
             river_core::migration::contract_key_for_code_hash(&owner, &current_code_hash);
+        // bundled-wasm-ok: this test's whole point is that the registry's
+        // derivation matches the bundled one for the same code hash.
         let via_live = compute_contract_key(&owner);
         assert_eq!(
             via_registry.id(),
@@ -6506,11 +7070,10 @@ mod migration_recovery_tests {
     fn cli_driver_adopts_newest_real_generation() {
         let owner_sk = SigningKey::from_bytes(&[73u8; 32]);
         let owner_vk = owner_sk.verifying_key();
-        let mut driver = ProbeDriver::new(
+        let mut driver = new_probe_driver(
             RiverCliProbeOps { owner_vk },
             ChatRoomStateV1::default(),
-            NewestFirst::assume_ordered(vec![cli_id(9), cli_id(5)]),
-            SelectionPolicy::NewestFirstWins,
+            vec![cli_id(9), cli_id(5)],
         );
         let Step::Get(newest) = driver.next_action() else {
             panic!("expected a GET")
@@ -6532,20 +7095,69 @@ mod migration_recovery_tests {
         assert!(merged.configuration.verify_signature(&owner_vk).is_ok());
     }
 
-    /// End-to-end: every generation misses (a timeout then an undecodable
-    /// response), so the driver reports SeedLocal — which
-    /// `fetch_room_state_with_recovery` maps to the not-found error. The CLI
-    /// never seeds device-local state.
+    /// The shared driver constructor keeps the three settings riverctl's probe
+    /// depends on. They are easy to drop in a refactor and each failure is
+    /// silent:
+    ///
+    /// * without `NewestFirstWins`, an older generation can shadow a newer one;
+    /// * without `continue_past_unknown`, the search stops at the first
+    ///   generation that does not answer, and since riverctl reports every
+    ///   miss as "did not answer", that is the FIRST candidate, so recovery
+    ///   stops working entirely while every test still passes;
+    /// * without `with_max_hops`, the crate's default 64-hop cap silently
+    ///   strands the oldest generations once the registry outgrows it.
     #[test]
-    fn cli_driver_exhausts_to_seed_local() {
+    fn the_shared_probe_driver_keeps_its_configuration() {
+        let full = include_str!("api.rs");
+        let start = full
+            .find("fn new_probe_driver")
+            .expect("new_probe_driver must exist");
+        let end = full[start..]
+            .find("\n/// Compute the contract key for a room")
+            .map(|off| start + off)
+            .expect("new_probe_driver must be followed by compute_contract_key's doc comment");
+        let body = &full[start..end];
+        for (needle, why) in [
+            (
+                "NewestFirstWins",
+                "an older generation could shadow a newer one",
+            ),
+            (
+                "continue_past_unknown",
+                "the probe would stop at the first candidate that did not answer, and riverctl \
+                 reports every miss that way, so recovery would stop working silently",
+            ),
+            (
+                "with_max_hops",
+                "the crate's default hop cap would silently strand the oldest generations",
+            ),
+        ] {
+            assert!(
+                body.contains(needle),
+                "`new_probe_driver` no longer sets `{needle}`: {why}"
+            );
+        }
+    }
+
+    /// End-to-end: every generation misses (a silent one, then an undecodable
+    /// response), so the driver exhausts, and the read path maps that to the
+    /// not-found error. The CLI never seeds device-local state.
+    ///
+    /// The outcome is `Indeterminate` rather than `SeedLocal` because one
+    /// candidate never answered, and freenet-migrate 0.6 keeps those apart:
+    /// "asked everyone, found nothing" is a different fact from "somebody never
+    /// answered". riverctl's I/O adapter cannot tell absence from silence, so
+    /// every one of its misses is the latter. The mapping is what this test is
+    /// really about, and it is unchanged: neither one seeds.
+    #[test]
+    fn cli_driver_exhausts_to_the_not_found_error() {
         let owner_sk = SigningKey::from_bytes(&[74u8; 32]);
-        let mut driver = ProbeDriver::new(
+        let mut driver = new_probe_driver(
             RiverCliProbeOps {
                 owner_vk: owner_sk.verifying_key(),
             },
             ChatRoomStateV1::default(),
-            NewestFirst::assume_ordered(vec![cli_id(2), cli_id(1)]),
-            SelectionPolicy::NewestFirstWins,
+            vec![cli_id(2), cli_id(1)],
         );
         let Step::Get(a) = driver.next_action() else {
             panic!()
@@ -6556,9 +7168,19 @@ mod migration_recovery_tests {
         };
         driver.on_response(b, &[0xffu8; 8]); // undecodable → miss
         assert_eq!(driver.next_action(), Step::Done);
+        let outcome = driver.take_outcome();
         assert!(
-            matches!(driver.take_outcome(), Some(Outcome::SeedLocal { .. })),
-            "exhaustion must be SeedLocal — which the CLI maps to the not-found Err, never a seed"
+            matches!(outcome, Some(Outcome::Indeterminate { .. })),
+            "a candidate that never answered must exhaust to Indeterminate, not SeedLocal; \
+             got {outcome:?}"
+        );
+        // The load-bearing half: whatever the variant is called, the read path
+        // must map exhaustion to the not-found Err and PUT nothing.
+        let err = resolve_legacy_recovery_outcome(outcome, cli_id(2), 2)
+            .expect_err("the CLI never seeds device-local state");
+        assert!(
+            err.to_string().contains("Room not found"),
+            "exhaustion must surface the stable not-found message; got: {err}"
         );
     }
 
@@ -6581,19 +7203,24 @@ mod migration_recovery_tests {
             .expect("probe_legacy_bytes must follow fetch_room_state_with_recovery");
         let body = &rest[..body_end];
 
-        // Match "NewestFirstWins" bare so a `use` that drops the
-        // `SelectionPolicy::` prefix cannot false-fail this pin.
+        // The driver's configuration (newest-first, hop cap, continue-past-
+        // unknown) lives in `new_probe_driver` and is pinned by
+        // `the_shared_probe_driver_keeps_its_configuration`. What THIS pin
+        // guards is that the recovery search still goes through it, rather than
+        // re-rolling a driver with its own settings.
         assert!(
-            body.contains("NewestFirstWins"),
-            "the legacy recovery search must use the newest-first decision driver"
+            body.contains("new_probe_driver("),
+            "the legacy recovery search must build its driver through `new_probe_driver`, \
+             which is where the newest-first policy and the hop cap live"
         );
-        // The hop cap must be sized to the registry so the driver's default
-        // 64-hop cap never silently truncates a >64-generation registry (the old
-        // loop was unbounded).
+        // The candidate list must come from the pointer-anchored plan, never
+        // straight off the legacy registry. Anchored at the bundled generation
+        // instead, a riverctl River has moved past searches a set that cannot
+        // contain the live room (see `crate::pointer::probe_plan`).
         assert!(
-            body.contains("with_max_hops"),
-            "the driver must set with_max_hops (sized to the registry) so the default hop cap \
-             can never strand the oldest legacy generations"
+            body.contains("probe_plan("),
+            "the backward probe's candidates must come from `probe_plan`, so the search is \
+             anchored on the RESOLVED generation and not on the WASM this binary bundles"
         );
         assert!(
             body.contains("resolve_legacy_recovery_outcome"),
@@ -6813,11 +7440,10 @@ mod migration_recovery_tests {
         let owner_vk = owner_sk.verifying_key();
         let original = fully_populated_state(&owner_sk);
 
-        let mut driver = ProbeDriver::new(
+        let mut driver = new_probe_driver(
             RiverCliProbeOps { owner_vk },
             ChatRoomStateV1::default(),
-            NewestFirst::assume_ordered(vec![cli_id(3), cli_id(2)]),
-            SelectionPolicy::NewestFirstWins,
+            vec![cli_id(3), cli_id(2)],
         );
         let Step::Get(newest) = driver.next_action() else {
             panic!("expected a GET")
@@ -6847,6 +7473,9 @@ mod migration_recovery_tests {
 
         let (out_state, out_id, migrate_forward) = resolve_legacy_recovery_outcome(
             Some(Outcome::Recovered {
+                // 0.6 added `unresolved`: candidates that never answered.
+                // Empty here, because these fixtures model a clean hit.
+                unresolved: Vec::new(),
                 merged: state.clone(),
                 source: cli_id(9),
                 truncated_fold: false,
@@ -6867,6 +7496,9 @@ mod migration_recovery_tests {
 
         let (_, _, migrate_same) = resolve_legacy_recovery_outcome(
             Some(Outcome::Recovered {
+                // 0.6 added `unresolved`: candidates that never answered.
+                // Empty here, because these fixtures model a clean hit.
+                unresolved: Vec::new(),
                 merged: state,
                 source: current,
                 truncated_fold: false,
@@ -6935,6 +7567,9 @@ mod migration_recovery_tests {
 
         let out = resolve_migration_state_outcome(
             Some(Outcome::Recovered {
+                // 0.6 added `unresolved`: candidates that never answered.
+                // Empty here, because these fixtures model a clean hit.
+                unresolved: Vec::new(),
                 merged: merged.clone(),
                 source: cli_id(9),
                 truncated_fold: false,
@@ -7127,13 +7762,12 @@ mod migration_recovery_tests {
         let local = owner_state_with_messages(&owner_sk, &["local"]);
         // Candidates as migration_candidate_ids builds them when the stored key
         // is the newest registry generation: [stored, stored(retry), older].
-        let mut driver = ProbeDriver::new(
+        let mut driver = new_probe_driver(
             RiverCliMigrationProbeOps {
                 inner: RiverCliProbeOps { owner_vk },
             },
             local.clone(),
-            NewestFirst::assume_ordered(vec![cli_id(9), cli_id(9), cli_id(5)]),
-            SelectionPolicy::NewestFirstWins,
+            vec![cli_id(9), cli_id(9), cli_id(5)],
         );
         // Fast-path attempt on the newest generation transiently times out.
         let Step::Get(first) = driver.next_action() else {
@@ -7184,13 +7818,12 @@ mod migration_recovery_tests {
         let owner_sk = SigningKey::from_bytes(&[95u8; 32]);
         let owner_vk = owner_sk.verifying_key();
         let local = owner_state_with_messages(&owner_sk, &["local"]);
-        let mut driver = ProbeDriver::new(
+        let mut driver = new_probe_driver(
             RiverCliMigrationProbeOps {
                 inner: RiverCliProbeOps { owner_vk },
             },
             local.clone(),
-            NewestFirst::assume_ordered(vec![cli_id(9), cli_id(5)]),
-            SelectionPolicy::NewestFirstWins,
+            vec![cli_id(9), cli_id(5)],
         );
         let Step::Get(newest) = driver.next_action() else {
             panic!("expected a GET")
@@ -7229,15 +7862,14 @@ mod migration_recovery_tests {
     fn cli_migration_driver_exhausts_to_local_cache() {
         let owner_sk = SigningKey::from_bytes(&[96u8; 32]);
         let local = owner_state_with_messages(&owner_sk, &["only local"]);
-        let mut driver = ProbeDriver::new(
+        let mut driver = new_probe_driver(
             RiverCliMigrationProbeOps {
                 inner: RiverCliProbeOps {
                     owner_vk: owner_sk.verifying_key(),
                 },
             },
             local.clone(),
-            NewestFirst::assume_ordered(vec![cli_id(2), cli_id(1)]),
-            SelectionPolicy::NewestFirstWins,
+            vec![cli_id(2), cli_id(1)],
         );
         let Step::Get(a) = driver.next_action() else {
             panic!()
@@ -7274,20 +7906,15 @@ mod migration_recovery_tests {
             .expect("probe_migration_bytes must follow get_migration_state");
         let body = &rest[..body_end];
 
-        // Match "NewestFirstWins" bare so a `use` that drops the
-        // `SelectionPolicy::` prefix cannot false-fail this pin.
+        // As above: the configuration lives in `new_probe_driver`; this pin
+        // guards that the active path goes through it.
         assert!(
-            body.contains("NewestFirstWins"),
-            "the active-migration search must use the newest-first decision driver"
+            body.contains("new_probe_driver("),
+            "the active-migration search must build its driver through `new_probe_driver`"
         );
         assert!(
             body.contains("RiverCliMigrationProbeOps"),
             "the active path must use the merge-with-local ops, NOT the read path's pass-through"
-        );
-        assert!(
-            body.contains("with_max_hops"),
-            "the driver must size its hop cap to the candidate set (the pre-driver deep path \
-             was unbounded)"
         );
         assert!(
             body.contains("migration_candidate_ids"),

--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -448,7 +448,11 @@ pub async fn execute(command: DebugCommands, api: ApiClient, format: OutputForma
             let owner_vk = VerifyingKey::from_bytes(&key_bytes)
                 .map_err(|e| anyhow!("Invalid verifying key: {}", e))?;
 
-            let contract_key = api.owner_vk_to_contract_key(&owner_vk);
+            // Read: `debug contract get` only fetches, so it works even when
+            // River's room contract is newer than this riverctl.
+            let contract_key = api
+                .contract_key_for(&owner_vk, crate::pointer::KeyIntent::Read)
+                .await?;
 
             if !matches!(format, OutputFormat::Json) {
                 eprintln!(
@@ -556,7 +560,11 @@ pub async fn execute(command: DebugCommands, api: ApiClient, format: OutputForma
             let owner_vk = VerifyingKey::from_bytes(&key_bytes)
                 .map_err(|e| anyhow!("Invalid verifying key: {}", e))?;
 
-            let contract_key = api.owner_vk_to_contract_key(&owner_vk);
+            // Read: this command only prints the key it would use, which is
+            // exactly the value a user debugging a stale riverctl needs to see.
+            let contract_key = api
+                .contract_key_for(&owner_vk, crate::pointer::KeyIntent::Read)
+                .await?;
 
             match format {
                 OutputFormat::Human => {

--- a/cli/src/commands/identity.rs
+++ b/cli/src/commands/identity.rs
@@ -465,7 +465,11 @@ async fn import_identity(
     // the lock, so a concurrent import can't interleave. Seeds `invitation_secrets`
     // from the export so a non-owner of a private room keeps the secret across a
     // device migration (freenet/river#306).
-    let contract_key = api_client.owner_vk_to_contract_key(&export.room_owner);
+    // Read: the import itself is purely local (it writes `rooms.json`), and the
+    // key it records must be the generation the network paths will address.
+    let contract_key = api_client
+        .contract_key_for(&export.room_owner, crate::pointer::KeyIntent::Read)
+        .await?;
     let outcome = api_client.storage().import_room_atomic(
         &export.room_owner,
         &export.signing_key,
@@ -804,6 +808,8 @@ mod tests {
         // room from the decoded export, mirroring `import_identity`.
         let temp_dir = TempDir::new().unwrap();
         let storage = Storage::new(Some(temp_dir.path().to_str().unwrap())).unwrap();
+        // bundled-wasm-ok: a test seeding local storage directly, with no node
+        // connection and so no resolved generation to derive from.
         let contract_key = compute_contract_key(&decoded.room_owner);
         storage
             .add_room_with_invitation_secrets(
@@ -855,6 +861,8 @@ mod tests {
 
         let temp_dir = TempDir::new().unwrap();
         let storage = Storage::new(Some(temp_dir.path().to_str().unwrap())).unwrap();
+        // bundled-wasm-ok: a test seeding local storage directly, with no node
+        // connection and so no resolved generation to derive from.
         let contract_key = compute_contract_key(&decoded.room_owner);
         storage
             .add_room_with_invitation_secrets(
@@ -990,6 +998,8 @@ mod tests {
 
         let temp_dir = TempDir::new().unwrap();
         let storage = Storage::new(Some(temp_dir.path().to_str().unwrap())).unwrap();
+        // bundled-wasm-ok: a test seeding local storage directly, with no node
+        // connection and so no resolved generation to derive from.
         let contract_key = compute_contract_key(&owner_vk);
 
         // First import establishes the OLD identity.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod deputies;
 pub mod error;
 pub mod output;
+pub mod pointer;
 pub mod private_room;
 pub mod storage;
 pub mod version_check;

--- a/cli/src/pointer.rs
+++ b/cli/src/pointer.rs
@@ -1,0 +1,1010 @@
+//! Runtime resolution of River's room-contract pointer record.
+//!
+//! # Why riverctl cannot derive its room key from its own WASM alone
+//!
+//! A room's contract key is `BLAKE3(BLAKE3(room_contract.wasm) ‖ CBOR{owner})`,
+//! so every room-contract WASM change moves the key for every room at once.
+//! River has re-keyed the room contract 31 times.
+//!
+//! riverctl compiles the WASM in and derives keys from it. That is correct at
+//! build time and wrong three months later, because riverctl is installed from
+//! crates.io and then kept. When the compiled-in generation is older than the
+//! live one, riverctl derives the OLD key, finds nothing, and falls into its
+//! backward probe, which searches OLDER generations only. The live room is
+//! FORWARD of where the probe looks, so the probe can never reach it; worse, it
+//! can find an ancient copy and migrate that forward onto a retired key.
+//!
+//! River publishes a **pointer record** for exactly this: a signed record at a
+//! fixed address naming the room contract's current code hash. Resolving it
+//! re-anchors riverctl at runtime. See `FREENET.md` and freenet-core#5194.
+//!
+//! # What lives here
+//!
+//! Everything in this module is pure and node-free: constants, the
+//! classification of a resolved hash against what this binary knows, the
+//! mapping from a [`PointerOutcome`] to an anchor, the backward-probe plan, and
+//! the on-disk floor representation. The one network-bound piece, the
+//! [`freenet_migrate::pointer::PointerIo`] implementation over riverctl's
+//! existing node connection, lives in [`crate::api`] next to the connection it
+//! borrows.
+
+use anyhow::{anyhow, bail, Result};
+use ed25519_dalek::VerifyingKey;
+use freenet_migrate::pointer::{PointerFloor, PointerOutcome};
+use freenet_stdlib::prelude::{ContractInstanceId, ContractKey};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// The `app_id` River publishes the room-contract pointer under.
+pub const ROOM_CONTRACT_APP_ID: &[u8] = b"river.room-contract";
+
+/// River's author verifying key, as published in this repository's
+/// `FREENET.md`, in the same `river:v1:vk:` presentation form.
+///
+/// This constant is the entire trust anchor for pointer resolution: a pointer
+/// record is only ever accepted if it verifies against this key. It is
+/// deliberately spelled exactly as `FREENET.md` spells it so the two can be
+/// compared by eye, and pinned by
+/// [`tests::author_key_matches_the_documented_pointer_address`].
+pub const RIVER_AUTHOR_VK: &str = "river:v1:vk:9Ebskq4y7NvJpTQTrF1FAxU8g6bR4Rhe4TRikXba55EJ";
+
+/// The prefix `FREENET.md` wraps the base58 author key in. Not part of the key.
+const AUTHOR_VK_PREFIX: &str = "river:v1:vk:";
+
+/// The room-contract pointer's fixed address, as published in `FREENET.md`.
+///
+/// Never used to address anything: resolution derives the address from
+/// `(author_vk, app_id)`. It exists so a test can prove the derivation lands on
+/// the documented address, which is what makes the documented address checkable
+/// rather than merely asserted.
+pub const ROOM_CONTRACT_POINTER_KEY: &str = "Ai4VLoC2jGdhpcB2UU8VPo3efUoxjm1Ju9VKXqRC63Az";
+
+/// Decode [`RIVER_AUTHOR_VK`] into the 32-byte verifying key.
+///
+/// Fallible rather than a `LazyLock` panic so a typo in the constant surfaces
+/// as a message naming the constant, not as an abort inside an unrelated
+/// command.
+pub fn river_author_vk() -> Result<VerifyingKey> {
+    let b58 = RIVER_AUTHOR_VK
+        .strip_prefix(AUTHOR_VK_PREFIX)
+        .ok_or_else(|| anyhow!("RIVER_AUTHOR_VK must start with `{AUTHOR_VK_PREFIX}`"))?;
+    let bytes = decode_b58_32(b58)
+        .ok_or_else(|| anyhow!("RIVER_AUTHOR_VK is not 32 base58-encoded bytes"))?;
+    VerifyingKey::from_bytes(&bytes)
+        .map_err(|e| anyhow!("RIVER_AUTHOR_VK is not a valid ed25519 verifying key: {e}"))
+}
+
+/// Decode a base58 string that must be exactly 32 bytes. `None` otherwise.
+fn decode_b58_32(s: &str) -> Option<[u8; 32]> {
+    let v = bs58::decode(s)
+        .with_alphabet(bs58::Alphabet::BITCOIN)
+        .into_vec()
+        .ok()?;
+    <[u8; 32]>::try_from(v.as_slice()).ok()
+}
+
+/// Render a code hash the way Freenet renders hashes in text.
+pub fn code_hash_b58(hash: &[u8; 32]) -> String {
+    bs58::encode(hash)
+        .with_alphabet(bs58::Alphabet::BITCOIN)
+        .into_string()
+}
+
+/// Where a room-contract code hash sits relative to what THIS binary knows.
+///
+/// The three cases are the whole point of resolving: they are the difference
+/// between "carry on", "the network is behind us" and "we are behind the
+/// network", and only the last one is unrecoverable without an upgrade.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Generation {
+    /// The generation this binary bundles as `ROOM_CONTRACT_WASM`.
+    Bundled,
+    /// A generation this binary knows as a previous one. The index is into
+    /// `river_core::migration::LEGACY_ROOM_CONTRACT_CODE_HASHES`, which is
+    /// ordered oldest-first.
+    Legacy(usize),
+    /// Neither the bundled generation nor any this binary knows: River has
+    /// re-keyed since this riverctl was built.
+    Unknown,
+}
+
+/// Classify `code_hash` against the generations this binary knows.
+pub fn classify(code_hash: &[u8; 32], bundled: &[u8; 32]) -> Generation {
+    if code_hash == bundled {
+        return Generation::Bundled;
+    }
+    match river_core::migration::LEGACY_ROOM_CONTRACT_CODE_HASHES
+        .iter()
+        .position(|h| h == code_hash)
+    {
+        Some(i) => Generation::Legacy(i),
+        None => Generation::Unknown,
+    }
+}
+
+/// How a run learned the room-contract code hash it is using.
+///
+/// Kept separate from [`Generation`] because they answer different questions:
+/// `Generation` is "what is this hash", `AnchorSource` is "how much do we trust
+/// that it is current". A hash can be the bundled one for two very different
+/// reasons (the pointer said so, or nothing answered), and the warning the user
+/// deserves differs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AnchorSource {
+    /// A signature-verified pointer record named this hash.
+    Pointer,
+    /// No pointer has ever been published for this `(author, app_id)`, and none
+    /// has ever resolved on this install. The one arm in which falling back to
+    /// a build-time key is legitimate.
+    NeverPublished,
+    /// The pointer could not be consulted, or answered something that moves
+    /// nothing (unreachable, stale, a competing record at the floor version, a
+    /// transport abort). The hash is whatever was last resolved on this install,
+    /// or the bundled one if nothing ever was. Carries the reason, which the
+    /// caller must make visible: this is exactly today's un-anchored behaviour,
+    /// so it is not a regression, but it must not be silent either.
+    Unverified(String),
+}
+
+/// The room-contract code hash this run will derive keys from, and the
+/// provenance that decides what riverctl may do with it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoomAnchor {
+    code_hash: [u8; 32],
+    bundled: [u8; 32],
+    generation: Generation,
+    source: AnchorSource,
+}
+
+/// What a caller intends to do with a derived key.
+///
+/// The anchor gates operations by intent because the three intents fail
+/// differently when riverctl is behind the network:
+///
+/// * [`KeyIntent::Read`] needs only an address. A GET against a generation this
+///   binary does not know still returns the right bytes, and a decode failure
+///   is visible and harmless. So a stale riverctl can still read.
+/// * [`KeyIntent::Write`] sends a delta encoded by THIS binary's `river-core`.
+///   A re-key usually happens *because* the state or delta shape changed, so a
+///   delta from an older river-core is exactly what a newer contract's
+///   `update_state` was re-keyed away from. The failure would be silent and on
+///   the network rather than local, so writes refuse.
+///
+///   **Writes are refused only when the network is AHEAD, never when it is
+///   behind**, and the asymmetry is deliberate rather than an oversight. Two
+///   reasons:
+///
+///   The compatibility promise runs in one direction. River's rule is that
+///   `ChatRoomStateV1` and its sub-types stay backwards-compatible (new fields
+///   `#[serde(default)]`, and on an individually-signed sub-struct also
+///   `#[serde(skip_serializing_if)]` so an unset new field serializes
+///   byte-identically to the old record). That is a promise that a NEWER
+///   river-core can produce bytes an OLDER contract still validates, with the
+///   worst case being a field the old contract ignores. There is no promise in
+///   the other direction: a newer contract may validate something this binary
+///   does not know to send, and we cannot inspect it to find out.
+///
+///   And only one direction has a remedy. Against an unknown generation the
+///   user can upgrade riverctl and the problem is gone. Against an older one
+///   there is nothing they can do: they cannot make the network re-key, and
+///   telling them to install a riverctl matching a superseded generation is not
+///   advice. Refusing there would also break every freshly-released riverctl
+///   until the network finished adopting the matching contract, which is the
+///   normal state of affairs for a while after each release.
+/// * [`KeyIntent::PublishCode`] must PUT the contract's actual WASM bytes.
+///   riverctl only has the bytes it bundles, so this is impossible, not merely
+///   unwise, whenever the anchor is not the bundled generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyIntent {
+    /// GET or SUBSCRIBE: needs an address only.
+    Read,
+    /// UPDATE: sends a delta this binary encoded.
+    Write,
+    /// PUT: needs the contract's real WASM bytes.
+    PublishCode,
+}
+
+impl RoomAnchor {
+    /// Build an anchor for a hash that a verified pointer record named.
+    fn from_pointer(code_hash: [u8; 32], bundled: [u8; 32]) -> Self {
+        Self {
+            code_hash,
+            bundled,
+            generation: classify(&code_hash, &bundled),
+            source: AnchorSource::Pointer,
+        }
+    }
+
+    /// Build an anchor that no pointer vouched for.
+    fn unvouched(code_hash: [u8; 32], bundled: [u8; 32], source: AnchorSource) -> Self {
+        Self {
+            code_hash,
+            bundled,
+            generation: classify(&code_hash, &bundled),
+            source,
+        }
+    }
+
+    /// The code hash every key this run derives is built from.
+    pub fn code_hash(&self) -> &[u8; 32] {
+        &self.code_hash
+    }
+
+    pub fn generation(&self) -> Generation {
+        self.generation
+    }
+
+    pub fn source(&self) -> &AnchorSource {
+        &self.source
+    }
+
+    /// The room-contract key for `owner_vk` under this anchor.
+    ///
+    /// Derived from the code hash alone, so it works for a generation whose
+    /// WASM this binary does not have. That is what lets a stale riverctl still
+    /// address a live room.
+    pub fn contract_key(&self, owner_vk: &VerifyingKey) -> ContractKey {
+        river_core::migration::contract_key_for_code_hash(owner_vk, &self.code_hash)
+    }
+
+    /// The key this binary would have derived with no pointer at all: today's
+    /// behaviour, kept for the paths that legitimately need the bundled
+    /// generation (upgrade-pointer `known_keys`, the backward-probe candidate
+    /// list when the network is ahead of us).
+    pub fn bundled_contract_key(&self, owner_vk: &VerifyingKey) -> ContractKey {
+        river_core::migration::contract_key_for_code_hash(owner_vk, &self.bundled)
+    }
+
+    /// Whether `intent` is permitted under this anchor. `Err` carries the
+    /// message the user sees, which always names both hashes so a bug report is
+    /// actionable without asking for more.
+    pub fn authorize(&self, intent: KeyIntent) -> Result<()> {
+        match (self.generation, intent) {
+            (Generation::Bundled, _) => Ok(()),
+            (Generation::Legacy(_), KeyIntent::Read | KeyIntent::Write) => Ok(()),
+            (Generation::Legacy(_), KeyIntent::PublishCode) => bail!(
+                "This operation has to publish the room contract's code, and riverctl only \
+                 carries the bytes it was built with.\n  \
+                 riverctl bundles room-contract generation {}\n  \
+                 River's pointer record names generation  {}\n\
+                 The network is on an OLDER generation than this riverctl, so publishing the \
+                 bundled code would create a room at a key nobody is using. Read and message \
+                 operations still work.",
+                code_hash_b58(&self.bundled),
+                code_hash_b58(&self.code_hash),
+            ),
+            (Generation::Unknown, KeyIntent::Read) => Ok(()),
+            (Generation::Unknown, KeyIntent::Write | KeyIntent::PublishCode) => bail!(
+                "{}\nRefusing to write with a room-contract generation this riverctl does not \
+                 know. Reads still work; run `cargo install riverctl` (or update your package) \
+                 to write.",
+                self.behind_network_summary()
+            ),
+        }
+    }
+
+    /// The two-hash summary for the case this whole module exists for.
+    pub fn behind_network_summary(&self) -> String {
+        format!(
+            "River's room contract is NEWER than this riverctl.\n  \
+             riverctl bundles room-contract generation {}\n  \
+             River's pointer record names generation  {}\n\
+             This riverctl knows {} previous generation(s) and the resolved one is none of \
+             them, so it was published after this binary was built.",
+            code_hash_b58(&self.bundled),
+            code_hash_b58(&self.code_hash),
+            river_core::migration::LEGACY_ROOM_CONTRACT_CODE_HASHES.len(),
+        )
+    }
+
+    /// The line to put on stderr once, at resolution time, or `None` when there
+    /// is nothing worth saying.
+    ///
+    /// Emitted once per run rather than per derived key: the condition is a
+    /// property of the run, and repeating it per operation would train users to
+    /// ignore it.
+    pub fn advisory(&self) -> Option<String> {
+        match (&self.source, self.generation) {
+            (AnchorSource::Pointer, Generation::Bundled) => None,
+            (AnchorSource::Pointer, Generation::Legacy(_)) => Some(format!(
+                "note: River's pointer record names room-contract generation {}, which is OLDER \
+                 than the one this riverctl bundles ({}). Trusting the pointer, because it names \
+                 what is actually deployed.",
+                code_hash_b58(&self.code_hash),
+                code_hash_b58(&self.bundled),
+            )),
+            (AnchorSource::Pointer, Generation::Unknown) => Some(format!(
+                "warning: {}\nRead-only commands will work against the live generation. Writing \
+                 needs a newer riverctl: `cargo install riverctl`.",
+                self.behind_network_summary()
+            )),
+            (AnchorSource::NeverPublished, _) => None,
+            (AnchorSource::Unverified(reason), _) => Some(format!(
+                "warning: could not verify that riverctl's room-contract generation is current \
+                 ({reason}). Continuing with generation {}. If River has re-keyed since this \
+                 build, room operations will address the wrong contract.",
+                code_hash_b58(&self.code_hash),
+            )),
+        }
+    }
+}
+
+/// What a resolution attempt produced, flattened so the arm-by-arm mapping
+/// below is a pure function that needs no node and no generic error type.
+#[derive(Debug, Clone)]
+pub enum ResolveReport {
+    /// `resolve_app_pointer` returned an outcome.
+    Outcome(PointerOutcome),
+    /// `resolve_app_pointer` returned an error: a transport abort, or a
+    /// `PointerError` about what the network served. Neither permits the
+    /// baked-in fallback, and both are retryable.
+    Failed(String),
+}
+
+/// Map a resolution attempt to the anchor this run will use.
+///
+/// Pure, so every arm is unit-testable without a node. **Every**
+/// [`PointerOutcome`] arm is handled explicitly and on purpose: a bare
+/// `if let Some(r) = outcome.resolved()` silently does nothing on the arms that
+/// carry no record, which collapses a withdrawal, a refused rollback and a
+/// plain timeout into the same no-op.
+pub fn anchor_from_report(
+    report: &ResolveReport,
+    floor: &PointerFloor,
+    bundled: [u8; 32],
+) -> Result<RoomAnchor> {
+    // A withdrawal floor is checked before anything else. A tombstone sorts
+    // below every real code hash, so once the floor records a withdrawal, any
+    // genuine pre-withdrawal record replayed at that version loses the tiebreak
+    // and arrives as `CompetingRecord`, and resuming with the key that floor
+    // superseded would resurrect, out of our own memory, exactly the code the
+    // author retired.
+    if floor.is_withdrawn() {
+        bail!(withdrawn_message(floor.version()));
+    }
+
+    // What to use when nothing was learned: the last hash this install verified,
+    // or the bundled one if it has never verified any. Preferring the floor is
+    // strictly better than always falling back to the bundled hash, because it is
+    // the "keep what you last resolved" the resolver asks for, and it degrades to
+    // exactly today's behaviour on a first run.
+    let last_known = || floor.code_hash().unwrap_or(bundled);
+
+    let outcome = match report {
+        ResolveReport::Failed(reason) => {
+            return Ok(RoomAnchor::unvouched(
+                last_known(),
+                bundled,
+                AnchorSource::Unverified(reason.clone()),
+            ));
+        }
+        ResolveReport::Outcome(o) => o,
+    };
+
+    match outcome {
+        // A record strictly newer than the floor, or the byte-identical record
+        // the floor already holds. Both carry a signature-verified pointer.
+        PointerOutcome::Resolved(r) | PointerOutcome::Unchanged(r) => {
+            Ok(RoomAnchor::from_pointer(r.code_hash(), bundled))
+        }
+
+        // The author says there is no current code. Not "the old code is
+        // current again", so there is nothing to fall back to.
+        PointerOutcome::Withdrawn { version, .. } => bail!(withdrawn_message(*version)),
+
+        // The only arm in which a build-time key is legitimate.
+        PointerOutcome::NeverPublished => Ok(RoomAnchor::unvouched(
+            bundled,
+            bundled,
+            AnchorSource::NeverPublished,
+        )),
+
+        // A validly-signed record older than our floor, refused. Routine rather
+        // than an attack signal: a freshly-bootstrapped or recently-evicted node
+        // can transiently serve an older record.
+        PointerOutcome::Stale { served, floor: f } => Ok(RoomAnchor::unvouched(
+            last_known(),
+            bundled,
+            AnchorSource::Unverified(format!(
+                "a peer served pointer version {served}, older than the version {f} this install \
+                 already verified; the rollback was refused"
+            )),
+        )),
+
+        // Two valid records at one version; ours won the tiebreak. The resolver
+        // deliberately hands back no record, so we keep what we last resolved
+        // and do NOT pick between the competitors. Our floor is riverctl's own
+        // config directory, written only by our own verified resolutions, which
+        // is the provenance the resolver requires before a caller may keep using
+        // its floor's hash.
+        PointerOutcome::CompetingRecord { version, .. } => Ok(RoomAnchor::unvouched(
+            last_known(),
+            bundled,
+            AnchorSource::Unverified(format!(
+                "a second, different pointer record exists at version {version}; keeping the one \
+                 already verified here rather than choosing between them"
+            )),
+        )),
+
+        // Nothing could be learned. This is today's behaviour, so continuing is
+        // not a regression, but `advisory()` makes it visible rather than
+        // silent.
+        PointerOutcome::Unavailable => Ok(RoomAnchor::unvouched(
+            last_known(),
+            bundled,
+            AnchorSource::Unverified(
+                "the pointer record could not be fetched (timeout, or the node had no answer)"
+                    .to_string(),
+            ),
+        )),
+
+        // `PointerOutcome` is `#[non_exhaustive]`. A future arm is not something
+        // to guess at: treat it as "learned nothing", which is the resolver's
+        // own default for every arm that carries no record.
+        other => Ok(RoomAnchor::unvouched(
+            last_known(),
+            bundled,
+            AnchorSource::Unverified(format!(
+                "the pointer resolver returned an outcome this riverctl does not understand \
+                 ({other:?}); upgrade riverctl"
+            )),
+        )),
+    }
+}
+
+fn withdrawn_message(version: u32) -> String {
+    format!(
+        "River has WITHDRAWN its room-contract pointer record (version {version}): the author is \
+         saying there is no current room-contract code, not that an older generation is current \
+         again. Refusing to derive a room key. If you believe this is wrong, check \
+         https://github.com/freenet/river for an announcement."
+    )
+}
+
+/// What the backward probe should do, given the anchor.
+///
+/// The probe searches generations OLDER than where the room should be. Which
+/// generations those are depends entirely on where the room should be, which is
+/// the anchor. Leaving the probe anchored at the bundled generation is the
+/// actual bug being fixed, not a detail.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProbePlan {
+    /// Probe these generations, newest-first.
+    Probe(Vec<ContractInstanceId>),
+    /// Do not probe. Carries the message to fail with.
+    ///
+    /// Reached only when the anchor is a generation this binary does not know.
+    /// Every generation riverctl knows is then OLDER than the live one, so a
+    /// backward probe would search a set that cannot contain the live room,
+    /// could surface an ancient copy as if it were current, and would try to
+    /// migrate that copy forward onto a retired key. That is the failure this
+    /// change exists to remove, so it must not be reachable by falling through
+    /// to the old path.
+    Refuse(String),
+}
+
+/// Build the backward-probe plan for `owner_vk` under `anchor`.
+///
+/// Pure so the anchoring is unit-testable without a node.
+pub fn probe_plan(owner_vk: &VerifyingKey, anchor: &RoomAnchor) -> ProbePlan {
+    let key_for =
+        |h: &[u8; 32]| *river_core::migration::contract_key_for_code_hash(owner_vk, h).id();
+    match anchor.generation() {
+        // The room lives on the bundled generation, so everything in the
+        // registry is older: today's candidate list, unchanged.
+        Generation::Bundled => ProbePlan::Probe(
+            river_core::migration::legacy_contract_keys_for_owner(owner_vk)
+                .iter()
+                .map(|k| *k.id())
+                .collect(),
+        ),
+        // The room lives on registry entry `i`, so only entries BELOW `i` are
+        // older. The registry is oldest-first, so that is `[..i]` reversed.
+        // Probing above `i` would search generations forward of the live one,
+        // the mirror image of the bug, and a way to migrate live state onto a
+        // generation nobody uses.
+        Generation::Legacy(i) => ProbePlan::Probe(
+            river_core::migration::LEGACY_ROOM_CONTRACT_CODE_HASHES[..i]
+                .iter()
+                .rev()
+                .map(key_for)
+                .collect(),
+        ),
+        Generation::Unknown => ProbePlan::Refuse(format!(
+            "{}\nThe room was not found on the live generation. Not searching older generations: \
+             every generation this riverctl knows is older than the live one, so a search could \
+             only turn up a stale copy and would try to republish it onto a retired key. Run \
+             `cargo install riverctl` to pick up the current room contract.",
+            anchor.behind_network_summary()
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Floor persistence
+// ---------------------------------------------------------------------------
+
+/// The on-disk form of a [`PointerFloor`], keyed by `(author_vk, app_id)`.
+///
+/// All three columns are stored, and `withdrawn` is a column of its own rather
+/// than an inference from a zeroed hash. A defaulted or half-written hash column
+/// looks byte-identical to a tombstone, so inferring would let one bad row turn
+/// a healthy app into a permanent "the author withdrew this".
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StoredFloor {
+    pub version: u32,
+    /// Base58 of the 32-byte code hash. Absent for a withdrawal floor, whose
+    /// hash is the all-zero tombstone and is reconstructed from `withdrawn`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code_hash: Option<String>,
+    #[serde(default)]
+    pub withdrawn: bool,
+}
+
+/// Every pointer floor this install holds, keyed by `"{author_vk_b58}/{app_id}"`.
+///
+/// Keyed by the pair, never by app_id alone: a rotation to a new author key
+/// means a new pointer address and a fresh version space, so it needs a fresh
+/// floor rather than the old one.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FloorStore {
+    #[serde(default)]
+    pub floors: BTreeMap<String, StoredFloor>,
+}
+
+/// The storage key for a floor.
+pub fn floor_key(author_vk: &VerifyingKey, app_id: &[u8]) -> String {
+    format!(
+        "{}/{}",
+        code_hash_b58(author_vk.as_bytes()),
+        String::from_utf8_lossy(app_id)
+    )
+}
+
+impl StoredFloor {
+    pub fn from_floor(floor: &PointerFloor) -> Self {
+        if floor.is_withdrawn() {
+            return Self {
+                version: floor.version(),
+                code_hash: None,
+                withdrawn: true,
+            };
+        }
+        Self {
+            version: floor.version(),
+            code_hash: floor.code_hash().as_ref().map(code_hash_b58),
+            withdrawn: false,
+        }
+    }
+
+    /// Rebuild the [`PointerFloor`] this row records.
+    ///
+    /// **Every failure is an error, never a fallback.** The reflex fix is
+    /// `unwrap_or_else(|_| PointerFloor::never_resolved())`, and it is exactly
+    /// wrong: `never_resolved` is the one state that unlocks the baked-in
+    /// build-time key, so recovering that way converts a corrupt row into a
+    /// silent downgrade. Surfacing lets the user delete the file deliberately.
+    pub fn to_floor(&self) -> Result<PointerFloor> {
+        if self.withdrawn {
+            return PointerFloor::withdrawn_at(self.version).map_err(|e| {
+                anyhow!("stored pointer floor records a withdrawal that cannot be rebuilt: {e}")
+            });
+        }
+        let encoded = self.code_hash.as_deref().ok_or_else(|| {
+            anyhow!(
+                "stored pointer floor at version {} has no code hash, and is not marked as a \
+                 withdrawal; the file is corrupt",
+                self.version
+            )
+        })?;
+        let hash = decode_b58_32(encoded).ok_or_else(|| {
+            anyhow!("stored pointer floor code hash `{encoded}` is not 32 base58-encoded bytes")
+        })?;
+        PointerFloor::at(self.version, hash)
+            .map_err(|e| anyhow!("stored pointer floor cannot be rebuilt: {e}"))
+    }
+}
+
+/// The advice attached to any floor-store failure. Split out so the read path
+/// and the tests share one wording.
+pub fn floor_corruption_hint(path: &std::path::Path) -> String {
+    format!(
+        "riverctl will not treat an unreadable anti-rollback floor as \"never resolved\", because \
+         that is the one state in which it would trust its own build-time key again. Inspect or \
+         delete {} to continue.",
+        path.display()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+    use freenet_migrate::pointer::{
+        pointer_contract_id, pointer_params, pointer_signing_message, PointerRecord,
+        PointerResolver,
+    };
+    use freenet_migrate::Step;
+
+    fn bundled() -> [u8; 32] {
+        [0xAA; 32]
+    }
+
+    fn owner() -> VerifyingKey {
+        SigningKey::from_bytes(&[7u8; 32]).verifying_key()
+    }
+
+    /// Drive a real resolver against a canned record so the tests below act on
+    /// genuine `PointerOutcome` values rather than hand-built ones. Hand-built
+    /// outcomes would let a test pass against an outcome the resolver can never
+    /// actually produce, and `Withdrawn` / `CompetingRecord` cannot be built
+    /// by hand at all, being `#[non_exhaustive]` variants, which is exactly the
+    /// boundary this helper respects rather than works around.
+    fn outcome_for(
+        author: &SigningKey,
+        floor: PointerFloor,
+        version: u32,
+        code_hash: [u8; 32],
+    ) -> PointerOutcome {
+        let vk = author.verifying_key();
+        let params = pointer_params(&vk, ROOM_CONTRACT_APP_ID).unwrap();
+        let sig = author.sign(&pointer_signing_message(&params, version, &code_hash));
+        let state = PointerRecord {
+            version,
+            code_hash,
+            signature: sig.to_bytes(),
+        }
+        .encode()
+        .to_vec();
+        let mut r = PointerResolver::new(&vk, ROOM_CONTRACT_APP_ID, floor).unwrap();
+        let Step::Get(id) = r.next_action() else {
+            panic!("a fresh resolver asks for the pointer");
+        };
+        assert!(r.on_response(id, &state));
+        r.take_outcome().unwrap().unwrap()
+    }
+
+    /// The documented pointer address in `FREENET.md` must be exactly what the
+    /// documented author key and app_id derive to. If this fails, one of the two
+    /// constants was edited without the other and every resolution would GET the
+    /// wrong address, an error that is otherwise invisible, because a wrong
+    /// address simply never answers.
+    #[test]
+    fn author_key_matches_the_documented_pointer_address() {
+        let vk = river_author_vk().expect("RIVER_AUTHOR_VK must decode");
+        let derived = pointer_contract_id(&vk, ROOM_CONTRACT_APP_ID).unwrap();
+        assert_eq!(
+            derived.to_string(),
+            ROOM_CONTRACT_POINTER_KEY,
+            "the author key and app_id in this module no longer derive the pointer address \
+             published in FREENET.md"
+        );
+    }
+
+    #[test]
+    fn classify_recognises_bundled_legacy_and_unknown() {
+        let b = bundled();
+        assert_eq!(classify(&b, &b), Generation::Bundled);
+        let legacy = river_core::migration::LEGACY_ROOM_CONTRACT_CODE_HASHES[3];
+        assert_eq!(classify(&legacy, &b), Generation::Legacy(3));
+        assert_eq!(classify(&[0x11; 32], &b), Generation::Unknown);
+    }
+
+    /// The case the change exists for: a resolved hash this binary does not
+    /// know must produce the upgrade message, must refuse writes, and must NOT
+    /// hand the backward probe a candidate list.
+    #[test]
+    fn unknown_generation_refuses_writes_and_refuses_to_probe() {
+        let author = SigningKey::from_bytes(&[3u8; 32]);
+        let live = [0x11; 32];
+        let outcome = outcome_for(&author, PointerFloor::never_resolved(), 4, live);
+        let anchor = anchor_from_report(
+            &ResolveReport::Outcome(outcome),
+            &PointerFloor::never_resolved(),
+            bundled(),
+        )
+        .expect("an unknown generation is a usable anchor, not an error");
+
+        assert_eq!(anchor.generation(), Generation::Unknown);
+        // The key is derived from the LIVE hash, which is the whole win: a
+        // stale riverctl can still address the room it could not reach before.
+        assert_eq!(
+            anchor.contract_key(&owner()).id(),
+            river_core::migration::contract_key_for_code_hash(&owner(), &live).id()
+        );
+
+        anchor.authorize(KeyIntent::Read).expect("reads proceed");
+        let write_err = anchor.authorize(KeyIntent::Write).unwrap_err().to_string();
+        assert!(
+            write_err.contains("NEWER than this riverctl"),
+            "{write_err}"
+        );
+        assert!(write_err.contains(&code_hash_b58(&live)), "{write_err}");
+        assert!(
+            write_err.contains(&code_hash_b58(&bundled())),
+            "{write_err}"
+        );
+        assert!(write_err.contains("cargo install riverctl"), "{write_err}");
+        anchor
+            .authorize(KeyIntent::PublishCode)
+            .expect_err("publishing code needs bytes we do not have");
+
+        let advisory = anchor.advisory().expect("this must be announced");
+        assert!(advisory.contains("NEWER than this riverctl"), "{advisory}");
+
+        match probe_plan(&owner(), &anchor) {
+            ProbePlan::Refuse(msg) => {
+                assert!(msg.contains("Not searching older generations"), "{msg}");
+                assert!(msg.contains(&code_hash_b58(&live)), "{msg}");
+            }
+            ProbePlan::Probe(c) => panic!("must not probe from a stale anchor; got {c:?}"),
+        }
+    }
+
+    /// The normal case must be indistinguishable from today: same key, no
+    /// advisory, no gating, and the full legacy registry as probe candidates.
+    #[test]
+    fn resolved_equals_bundled_behaves_exactly_as_before() {
+        let author = SigningKey::from_bytes(&[3u8; 32]);
+        let outcome = outcome_for(&author, PointerFloor::never_resolved(), 1, bundled());
+        let anchor = anchor_from_report(
+            &ResolveReport::Outcome(outcome),
+            &PointerFloor::never_resolved(),
+            bundled(),
+        )
+        .unwrap();
+
+        assert_eq!(anchor.generation(), Generation::Bundled);
+        assert_eq!(anchor.advisory(), None);
+        for intent in [KeyIntent::Read, KeyIntent::Write, KeyIntent::PublishCode] {
+            anchor.authorize(intent).expect("nothing is gated");
+        }
+        assert_eq!(
+            anchor.contract_key(&owner()).id(),
+            anchor.bundled_contract_key(&owner()).id()
+        );
+        let expected: Vec<_> = river_core::migration::legacy_contract_keys_for_owner(&owner())
+            .iter()
+            .map(|k| *k.id())
+            .collect();
+        assert_eq!(probe_plan(&owner(), &anchor), ProbePlan::Probe(expected));
+    }
+
+    /// A pointer naming an older generation is trusted, because it names what
+    /// is actually deployed, but the probe must then search only generations
+    /// older than THAT, and code publishing must refuse.
+    #[test]
+    fn legacy_generation_is_trusted_and_reanchors_the_probe() {
+        let author = SigningKey::from_bytes(&[3u8; 32]);
+        let legacy = river_core::migration::LEGACY_ROOM_CONTRACT_CODE_HASHES[5];
+        let outcome = outcome_for(&author, PointerFloor::never_resolved(), 2, legacy);
+        let anchor = anchor_from_report(
+            &ResolveReport::Outcome(outcome),
+            &PointerFloor::never_resolved(),
+            bundled(),
+        )
+        .unwrap();
+
+        assert_eq!(anchor.generation(), Generation::Legacy(5));
+        anchor.authorize(KeyIntent::Read).unwrap();
+        anchor.authorize(KeyIntent::Write).unwrap();
+        anchor.authorize(KeyIntent::PublishCode).unwrap_err();
+        assert!(anchor.advisory().unwrap().contains("OLDER"));
+
+        let ProbePlan::Probe(candidates) = probe_plan(&owner(), &anchor) else {
+            panic!("a known generation is probeable");
+        };
+        // Strictly older only: five entries (indices 4..=0), newest-first.
+        assert_eq!(candidates.len(), 5);
+        let newest_older = river_core::migration::contract_key_for_code_hash(
+            &owner(),
+            &river_core::migration::LEGACY_ROOM_CONTRACT_CODE_HASHES[4],
+        );
+        assert_eq!(candidates[0], *newest_older.id());
+        let anchor_id = *anchor.contract_key(&owner()).id();
+        assert!(
+            !candidates.contains(&anchor_id),
+            "the probe must not re-probe the generation it is anchored on"
+        );
+    }
+
+    /// Unreachable must not change the derived key, and must not be silent.
+    #[test]
+    fn unavailable_falls_back_to_bundled_with_a_visible_warning() {
+        let anchor = anchor_from_report(
+            &ResolveReport::Outcome(PointerOutcome::Unavailable),
+            &PointerFloor::never_resolved(),
+            bundled(),
+        )
+        .unwrap();
+        assert_eq!(*anchor.code_hash(), bundled());
+        assert_eq!(anchor.generation(), Generation::Bundled);
+        // Not gated: this is exactly today's behaviour, so gating it would break
+        // every user whose node cannot reach the pointer.
+        anchor.authorize(KeyIntent::PublishCode).unwrap();
+        let advisory = anchor.advisory().expect("must warn");
+        assert!(advisory.starts_with("warning:"), "{advisory}");
+        assert!(advisory.contains("could not verify"), "{advisory}");
+    }
+
+    /// A transport abort is the same story as `Unavailable`, and must reach the
+    /// same place rather than aborting the command.
+    #[test]
+    fn transport_failure_falls_back_to_bundled_with_a_visible_warning() {
+        let anchor = anchor_from_report(
+            &ResolveReport::Failed("websocket send failed".to_string()),
+            &PointerFloor::never_resolved(),
+            bundled(),
+        )
+        .unwrap();
+        assert_eq!(*anchor.code_hash(), bundled());
+        assert!(anchor.advisory().unwrap().contains("websocket send failed"));
+    }
+
+    /// When something WAS resolved before, "keep what you last resolved" beats
+    /// falling back to the build-time key: falling back would be the downgrade
+    /// an attacker gets for free by making the pointer briefly unreachable.
+    #[test]
+    fn unavailable_keeps_the_last_resolved_hash_over_the_bundled_one() {
+        let live = [0x11; 32];
+        let floor = PointerFloor::at(9, live).unwrap();
+        let anchor = anchor_from_report(
+            &ResolveReport::Outcome(PointerOutcome::Unavailable),
+            &floor,
+            bundled(),
+        )
+        .unwrap();
+        assert_eq!(*anchor.code_hash(), live);
+        assert_eq!(anchor.generation(), Generation::Unknown);
+        anchor
+            .authorize(KeyIntent::Write)
+            .expect_err("still an unknown generation, so writes still refuse");
+    }
+
+    #[test]
+    fn stale_and_competing_record_keep_the_last_resolved_hash() {
+        let author = SigningKey::from_bytes(&[3u8; 32]);
+        let live = [0x11; 32];
+        let floor = PointerFloor::at(9, live).unwrap();
+        for outcome in [
+            // A peer serving an older-but-validly-signed record: refused as a
+            // rollback.
+            outcome_for(&author, floor, 3, [0x44; 32]),
+            // A second, different record at the floor's own version. The floor
+            // holds `live`, and `0xFF..` sorts above it, so the served record
+            // loses the tiebreak.
+            outcome_for(&author, floor, 9, [0xFF; 32]),
+        ] {
+            let anchor =
+                anchor_from_report(&ResolveReport::Outcome(outcome), &floor, bundled()).unwrap();
+            assert_eq!(*anchor.code_hash(), live);
+            assert!(anchor.advisory().is_some());
+        }
+    }
+
+    #[test]
+    fn never_published_falls_back_to_bundled_silently() {
+        let anchor = anchor_from_report(
+            &ResolveReport::Outcome(PointerOutcome::NeverPublished),
+            &PointerFloor::never_resolved(),
+            bundled(),
+        )
+        .unwrap();
+        assert_eq!(*anchor.code_hash(), bundled());
+        assert_eq!(anchor.source(), &AnchorSource::NeverPublished);
+        assert_eq!(
+            anchor.advisory(),
+            None,
+            "the one legitimate baked-in fallback needs no warning"
+        );
+    }
+
+    #[test]
+    fn withdrawn_refuses() {
+        let author = SigningKey::from_bytes(&[3u8; 32]);
+        // A withdrawal IS a signed record; its code hash is the all-zero
+        // tombstone. Built through the resolver, so the test acts on the same
+        // value production would see.
+        let withdrawn = outcome_for(&author, PointerFloor::never_resolved(), 12, [0u8; 32]);
+        assert!(matches!(withdrawn, PointerOutcome::Withdrawn { .. }));
+        let err = anchor_from_report(
+            &ResolveReport::Outcome(withdrawn),
+            &PointerFloor::never_resolved(),
+            bundled(),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("WITHDRAWN"), "{err}");
+        assert!(err.contains("version 12"), "{err}");
+    }
+
+    /// A withdrawal already recorded in the floor must refuse before any record
+    /// is consulted. Otherwise a peer replaying a genuine pre-withdrawal record
+    /// arrives as `CompetingRecord` and "keep your last key" resurrects exactly
+    /// the code the withdrawal retired.
+    #[test]
+    fn a_withdrawn_floor_refuses_every_arm() {
+        let author = SigningKey::from_bytes(&[3u8; 32]);
+        let floor = PointerFloor::withdrawn_at(12).unwrap();
+        // A genuine pre-withdrawal record replayed at the withdrawal's version:
+        // the tombstone sorts below every real hash, so it loses the tiebreak
+        // and arrives as `CompetingRecord`. This is the arm that would
+        // otherwise resurrect the retired code out of our own floor.
+        let replayed = outcome_for(&author, floor, 12, [0x44; 32]);
+        assert!(matches!(replayed, PointerOutcome::CompetingRecord { .. }));
+        for report in [
+            ResolveReport::Outcome(PointerOutcome::Unavailable),
+            ResolveReport::Outcome(replayed),
+            ResolveReport::Outcome(PointerOutcome::NeverPublished),
+            ResolveReport::Failed("boom".to_string()),
+        ] {
+            let err = anchor_from_report(&report, &floor, bundled())
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("WITHDRAWN"), "{err}");
+        }
+    }
+
+    #[test]
+    fn floor_round_trips_through_its_stored_form() {
+        let floor = PointerFloor::at(7, [0x22; 32]).unwrap();
+        let stored = StoredFloor::from_floor(&floor);
+        assert_eq!(stored.to_floor().unwrap(), floor);
+
+        let withdrawn = PointerFloor::withdrawn_at(8).unwrap();
+        let stored = StoredFloor::from_floor(&withdrawn);
+        assert!(stored.withdrawn);
+        assert_eq!(stored.to_floor().unwrap(), withdrawn);
+    }
+
+    /// A corrupt row must surface, never silently become `never_resolved`,
+    /// which is the one state that unlocks the build-time key again.
+    #[test]
+    fn a_corrupt_stored_floor_surfaces_rather_than_resetting() {
+        let cases = [
+            StoredFloor {
+                version: 0,
+                code_hash: Some(code_hash_b58(&[0x22; 32])),
+                withdrawn: false,
+            },
+            StoredFloor {
+                version: 3,
+                code_hash: Some("not base58!!".to_string()),
+                withdrawn: false,
+            },
+            StoredFloor {
+                version: 3,
+                code_hash: Some(code_hash_b58(&[0u8; 32])),
+                withdrawn: false,
+            },
+            StoredFloor {
+                version: 3,
+                code_hash: None,
+                withdrawn: false,
+            },
+            StoredFloor {
+                version: 0,
+                code_hash: None,
+                withdrawn: true,
+            },
+        ];
+        for case in cases {
+            assert!(
+                case.to_floor().is_err(),
+                "corrupt floor {case:?} must not rebuild"
+            );
+        }
+    }
+
+    #[test]
+    fn floor_keys_are_scoped_to_the_author_key() {
+        let a = SigningKey::from_bytes(&[1u8; 32]).verifying_key();
+        let b = SigningKey::from_bytes(&[2u8; 32]).verifying_key();
+        assert_ne!(
+            floor_key(&a, ROOM_CONTRACT_APP_ID),
+            floor_key(&b, ROOM_CONTRACT_APP_ID),
+            "rotating the author key must not inherit the old key's floor"
+        );
+        assert!(floor_key(&a, ROOM_CONTRACT_APP_ID).ends_with("/river.room-contract"));
+    }
+}

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -1,4 +1,5 @@
 use crate::api::compute_contract_key;
+use crate::pointer::{floor_corruption_hint, FloorStore, StoredFloor};
 use anyhow::{anyhow, Context, Result};
 use directories::ProjectDirs;
 use ed25519_dalek::{SigningKey, VerifyingKey};
@@ -11,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use tracing::info;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -300,6 +302,22 @@ pub struct Storage {
     /// nominate the right identity at command time without touching
     /// `rooms.json`. See discussion on river#281.
     signing_key_override: Option<SigningKey>,
+    /// The room-contract pointer's floor store (`pointer_floors.json`). A side
+    /// file, like `outbound_dms.json`, so the anti-rollback floor is never
+    /// entangled with the room blob's read-modify-write.
+    pointer_floors_path: PathBuf,
+    /// The room-contract code hash resolved from River's pointer record this
+    /// run, installed by [`crate::api::ApiClient`] once resolution completes.
+    ///
+    /// Unset for a command that never opens a node connection, in which case
+    /// key regeneration falls back to the bundled WASM, which is exactly the behaviour
+    /// riverctl has always had, and the only behaviour available offline.
+    ///
+    /// A `OnceLock` rather than a constructor argument because resolution needs
+    /// a live connection and must stay lazy: `Storage` is built before the
+    /// first GET, and offline commands must not pay for a resolution they will
+    /// never use.
+    room_code_hash: OnceLock<[u8; 32]>,
 }
 
 impl Storage {
@@ -330,12 +348,86 @@ impl Storage {
         let storage_path = data_dir.join("rooms.json");
         let outbound_dms_path = data_dir.join("outbound_dms.json");
         let lock_path = data_dir.join(".river.lock");
+        let pointer_floors_path = data_dir.join("pointer_floors.json");
 
         Ok(Self {
             storage_path,
             outbound_dms_path,
             lock_path,
             signing_key_override,
+            pointer_floors_path,
+            room_code_hash: OnceLock::new(),
+        })
+    }
+
+    /// Record the room-contract code hash resolved from River's pointer record,
+    /// so key regeneration in [`Self::load_rooms`] agrees with the keys the
+    /// network paths are deriving. Idempotent; a second call is ignored.
+    pub fn set_room_code_hash(&self, code_hash: [u8; 32]) {
+        let _ = self.room_code_hash.set(code_hash);
+    }
+
+    /// Where the anti-rollback floor store lives, so an error can name the file
+    /// the user has to inspect or delete.
+    pub fn pointer_floors_path(&self) -> &Path {
+        &self.pointer_floors_path
+    }
+
+    /// Load the anti-rollback floor stored under `key`.
+    ///
+    /// Three outcomes, and the difference between the second and third is the
+    /// whole point: `Ok(None)` means nothing has ever resolved here (the one
+    /// state that permits a build-time fallback), while `Err` means a floor
+    /// exists and could not be trusted. Returning `Ok(None)` for a corrupt or
+    /// unreadable file would convert corruption into "first run" and hand back
+    /// the baked-in key, which is precisely the downgrade the floor exists to
+    /// prevent.
+    pub fn load_pointer_floor(&self, key: &str) -> Result<Option<StoredFloor>> {
+        if !self.pointer_floors_path.exists() {
+            return Ok(None);
+        }
+        let contents = fs::read_to_string(&self.pointer_floors_path).with_context(|| {
+            format!(
+                "reading pointer floor store {}. {}",
+                self.pointer_floors_path.display(),
+                floor_corruption_hint(&self.pointer_floors_path)
+            )
+        })?;
+        let store: FloorStore = serde_json::from_str(&contents).with_context(|| {
+            format!(
+                "parsing pointer floor store {}. {}",
+                self.pointer_floors_path.display(),
+                floor_corruption_hint(&self.pointer_floors_path)
+            )
+        })?;
+        Ok(store.floors.get(key).cloned())
+    }
+
+    /// Persist the anti-rollback floor for `key`, merging into whatever other
+    /// `(author_vk, app_id)` pairs the file already holds.
+    ///
+    /// Under the same advisory lock and the same atomic temp-file rename as the
+    /// room blob, so a concurrent riverctl cannot interleave a read-modify-write
+    /// and lose the other pair's row.
+    pub fn save_pointer_floor(&self, key: &str, floor: StoredFloor) -> Result<()> {
+        self.with_lock(|| {
+            let mut store: FloorStore = if self.pointer_floors_path.exists() {
+                let contents = fs::read_to_string(&self.pointer_floors_path)?;
+                serde_json::from_str(&contents).with_context(|| {
+                    format!(
+                        "parsing pointer floor store {}. {}",
+                        self.pointer_floors_path.display(),
+                        floor_corruption_hint(&self.pointer_floors_path)
+                    )
+                })?
+            } else {
+                FloorStore::default()
+            };
+            store.floors.insert(key.to_string(), floor);
+            Self::atomic_write(
+                &self.pointer_floors_path,
+                &serde_json::to_string_pretty(&store)?,
+            )
         })
     }
 
@@ -465,7 +557,14 @@ impl Storage {
     }
 
     /// Load all stored rooms, regenerating each room's contract key to match the
-    /// currently-bundled WASM (and persisting the regeneration).
+    /// room-contract generation this run resolved (and persisting the
+    /// regeneration).
+    ///
+    /// The regeneration runs only once [`Self::set_room_code_hash`] has recorded
+    /// what River's pointer record names. Until then the stored keys are returned
+    /// untouched, because rewriting them would be a migration decision taken from
+    /// this binary's build date rather than from what is deployed. See the body
+    /// for the full argument.
     ///
     /// Takes the advisory lock for the whole read-and-maybe-rewrite, so a
     /// concurrent mutating invocation can't interleave with the key-regeneration
@@ -486,8 +585,26 @@ impl Storage {
         let contents = fs::read_to_string(&self.storage_path)?;
         let mut storage: RoomStorage = serde_json::from_str(&contents)?;
 
-        // Regenerate contract keys to ensure they match the current bundled WASM
-        // This handles the case where rooms were stored with an older WASM version
+        // Regenerate each room's cached contract key to match the room-contract
+        // generation this run RESOLVED from River's pointer record.
+        //
+        // Skipped entirely when nothing has been resolved, and that is the point.
+        // This loop rewrites `contract_key` and demotes the old value into
+        // `previous_contract_key`, which is the input to the migration probe: it
+        // is a migration decision, not a display detail. A command that has not
+        // consulted the pointer record has no business making that decision from
+        // its own build date, and doing so would redefine `previous_contract_key`
+        // from "the immediately-previous generation" to "whatever this binary was
+        // built with" (plus a rooms.json write on every command that only reads).
+        //
+        // Before the pointer record existed, riverctl had nothing better than its
+        // own build and did this unconditionally. It has something better now, so
+        // it waits for it. Every path that migrates or addresses a contract calls
+        // `room_anchor()` first, which sets the hash before touching storage, so
+        // nothing that needs the regeneration loses it.
+        let Some(code_hash) = self.room_code_hash.get() else {
+            return Ok(storage);
+        };
         let mut updated = false;
         for (owner_key_str, room_info) in storage.rooms.iter_mut() {
             let owner_key_bytes = match bs58::decode(owner_key_str).into_vec() {
@@ -502,7 +619,7 @@ impl Storage {
                 Ok(vk) => vk,
                 Err(_) => continue,
             };
-            let new_key = compute_contract_key(&owner_vk);
+            let new_key = river_core::migration::contract_key_for_code_hash(&owner_vk, code_hash);
             let new_key_str = new_key.id().to_string();
             if room_info.contract_key != new_key_str {
                 info!(
@@ -1188,8 +1305,10 @@ mod tests {
     }
 
     /// Compute the expected contract key for a given owner verifying key.
-    /// This matches what load_rooms will regenerate.
+    /// This matches what load_rooms regenerates when nothing has been resolved.
     fn expected_contract_key(owner_vk: &VerifyingKey) -> ContractKey {
+        // bundled-wasm-ok: these tests never resolve a pointer, so the bundled
+        // derivation is the one `load_rooms` will use.
         compute_contract_key(owner_vk)
     }
 
@@ -1845,6 +1964,9 @@ mod tests {
     #[test]
     fn test_update_contract_key_success() {
         let (storage, _temp_dir) = create_test_storage();
+        // As above: regeneration needs a resolved generation, and the bundled
+        // hash keeps this test's expectations unchanged.
+        storage.set_room_code_hash(crate::api::bundled_room_code_hash());
         let owner_sk = create_test_signing_key();
         let owner_vk = owner_sk.verifying_key();
         let state = create_test_state(&owner_sk);
@@ -2180,6 +2302,10 @@ mod tests {
     #[test]
     fn test_load_rooms_sets_previous_contract_key_on_mismatch() {
         let (storage, _temp_dir) = create_test_storage();
+        // `load_rooms` regenerates only against a RESOLVED generation, so record
+        // one. The bundled hash keeps every expected key below identical to what
+        // this test asserted before pointer resolution existed.
+        storage.set_room_code_hash(crate::api::bundled_room_code_hash());
         let owner_sk = create_test_signing_key();
         let owner_vk = owner_sk.verifying_key();
         let state = create_test_state(&owner_sk);
@@ -3569,6 +3695,157 @@ mod tests {
                 && src.contains("fn load_rooms_unlocked("),
             "load_rooms must save via save_rooms_unlocked to avoid lock reentrancy \
              self-deadlock (issue #307)"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Pointer floor persistence + resolved-generation key regeneration
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn pointer_floor_round_trips_and_is_scoped_by_key() {
+        let (storage, _tmp) = create_test_storage();
+        assert!(
+            storage
+                .load_pointer_floor("nobody/river.room-contract")
+                .unwrap()
+                .is_none(),
+            "a fresh install has no floor, which is what permits a build-time fallback"
+        );
+
+        let room = StoredFloor {
+            version: 4,
+            code_hash: Some(crate::pointer::code_hash_b58(&[0x33; 32])),
+            withdrawn: false,
+        };
+        let delegate = StoredFloor {
+            version: 9,
+            code_hash: None,
+            withdrawn: true,
+        };
+        storage
+            .save_pointer_floor("author/river.room-contract", room.clone())
+            .unwrap();
+        storage
+            .save_pointer_floor("author/river.chat-delegate", delegate.clone())
+            .unwrap();
+
+        // Saving the second must not have dropped the first: the file holds one
+        // row per (author_vk, app_id) and a save is a read-merge-write.
+        assert_eq!(
+            storage
+                .load_pointer_floor("author/river.room-contract")
+                .unwrap(),
+            Some(room)
+        );
+        assert_eq!(
+            storage
+                .load_pointer_floor("author/river.chat-delegate")
+                .unwrap(),
+            Some(delegate)
+        );
+    }
+
+    /// A floor store that will not parse must be an ERROR, never `Ok(None)`.
+    ///
+    /// `Ok(None)` reads as "nothing has ever resolved here", which is the one
+    /// state that re-enables the baked-in build-time key. Turning corruption
+    /// into that is a silent downgrade, and it is exactly the reflex fix
+    /// (`unwrap_or_default`) this asserts against.
+    #[test]
+    fn a_corrupt_pointer_floor_store_surfaces_rather_than_reading_as_never_resolved() {
+        let (storage, _tmp) = create_test_storage();
+        fs::write(storage.pointer_floors_path(), "{ this is not json").unwrap();
+        let err = storage
+            .load_pointer_floor("author/river.room-contract")
+            .expect_err("a corrupt floor store must not read as `never resolved`");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("pointer floor store"), "{msg}");
+        assert!(
+            msg.contains("will not treat an unreadable anti-rollback floor"),
+            "the error must tell the user why it refuses to recover: {msg}"
+        );
+    }
+
+    /// `load_rooms` regenerates each room's cached contract key. Once a run has
+    /// resolved River's pointer record, that regeneration must target the
+    /// RESOLVED generation, not the WASM this binary bundles. Otherwise the
+    /// cache points at a contract none of the network paths address.
+    #[test]
+    fn load_rooms_regenerates_keys_against_the_resolved_generation() {
+        let (storage, _tmp) = create_test_storage();
+        let owner_sk = create_test_signing_key();
+        let owner_vk = owner_sk.verifying_key();
+        let state = create_test_state(&owner_sk);
+
+        // The room starts under a generation that is NEITHER the bundled one nor
+        // the one that will be resolved. That matters: if the fixture stored it
+        // under the bundled key, the unresolved assertions below would hold even
+        // if `load_rooms` DID regenerate against the bundled hash, because the
+        // recomputed key would equal the stored one and no write would happen.
+        // A first draft of this test made exactly that mistake and passed under
+        // the mutation it exists to catch.
+        let stored_gen = river_core::migration::LEGACY_ROOM_CONTRACT_CODE_HASHES[0];
+        let stored_key = river_core::migration::contract_key_for_code_hash(&owner_vk, &stored_gen)
+            .id()
+            .to_string();
+        // bundled-wasm-ok: named only to assert the regeneration never lands here.
+        let bundled_key = compute_contract_key(&owner_vk).id().to_string();
+        assert_ne!(
+            stored_key, bundled_key,
+            "the fixture must start on a generation the bundled derivation would change"
+        );
+        storage
+            .add_room(
+                &owner_vk,
+                &owner_sk,
+                state,
+                &river_core::migration::contract_key_for_code_hash(&owner_vk, &stored_gen),
+            )
+            .unwrap();
+
+        // With NOTHING resolved, `load_rooms` must leave the stored key alone:
+        // no rewrite, no demotion into `previous_contract_key`, no write to disk.
+        // Rewriting here would redefine `previous_contract_key` as "the bundled
+        // key" rather than "the immediately-previous generation", and it would do
+        // so from a command that never consulted River's pointer record.
+        let before = std::fs::read_to_string(&storage.storage_path).unwrap();
+        let unresolved = storage.load_rooms().unwrap();
+        let unresolved_info = &unresolved.rooms[&bs58::encode(owner_vk.as_bytes()).into_string()];
+        assert_eq!(
+            unresolved_info.contract_key, stored_key,
+            "an unresolved run must not regenerate the cached key against its own build"
+        );
+        assert_ne!(
+            unresolved_info.contract_key, bundled_key,
+            "an unresolved run must not rewrite the cached key to the bundled generation"
+        );
+        assert_eq!(
+            unresolved_info.previous_contract_key, None,
+            "an unresolved run must not demote anything into previous_contract_key"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&storage.storage_path).unwrap(),
+            before,
+            "an unresolved run must not rewrite rooms.json"
+        );
+
+        // Now a run resolves a generation from the pointer record.
+        let resolved = [0x5Au8; 32];
+        storage.set_room_code_hash(resolved);
+        let rooms = storage.load_rooms().unwrap();
+        let info = &rooms.rooms[&bs58::encode(owner_vk.as_bytes()).into_string()];
+        assert_eq!(
+            info.contract_key,
+            river_core::migration::contract_key_for_code_hash(&owner_vk, &resolved)
+                .id()
+                .to_string(),
+            "the cached key must follow the resolved generation"
+        );
+        assert_eq!(
+            info.previous_contract_key.as_deref(),
+            Some(stored_key.as_str()),
+            "the superseded key must be kept as the migration fallback"
         );
     }
 }


### PR DESCRIPTION
## Problem

A room's contract key is `BLAKE3(BLAKE3(room_contract.wasm) ‖ CBOR{owner})`, so any room-contract WASM change moves the key for every room at once. River has re-keyed the room contract 31 times.

riverctl compiled the WASM in and derived every key from it (`compute_contract_key`). That is correct at build time and wrong three months later, because riverctl is installed from crates.io and then kept.

The failure was specific and bad. When riverctl's compiled-in generation is older than the live one, it derives the OLD key, finds nothing, and falls into its backward probe, which searches OLDER generations only. The live room is FORWARD of where the probe is looking, so the probe can never reach it. Worse, it can find an ancient copy and migrate that forward onto a retired key. The existing `current_wasm_is_not_in_legacy_registry` test guards the binary at build time and does nothing for one already installed.

River publishes a pointer record precisely for this: a signed record at a fixed address naming the room contract's current code hash.

## Approach

riverctl resolves `river.room-contract` once per run, lazily, and derives room keys from the code hash the record names.

**Resolution.** `freenet-migrate` 0.5 to 0.6 (0.6 is the first release exposing `pub mod pointer`, and the release where a probe timeout stopped reading as a definitive absence). `PointerIo` is implemented over riverctl's existing node connection, so no new transport, and the GET does not request contract code: the ~100 byte record is the whole answer and the pointer's own WASM is ~130 KB.

**Classification.** The resolved hash is classified against what the binary knows, and that classification decides what riverctl may do:

| Resolved hash | Meaning | Read | Write (UPDATE) | Publish code (PUT) |
|---|---|---|---|---|
| == compiled-in | normal | yes | yes | yes |
| in the legacy registry | network is behind us | yes | yes | **refuse** |
| unknown | **River is newer than this riverctl** | yes, with a loud warning | **refuse** | **refuse** |

**Every `PointerOutcome` arm is handled explicitly.** `Withdrawn` refuses. `NeverPublished` falls back to the bundled hash silently, the one legitimate baked-in fallback. `Unavailable`, a transport error, `Stale` and `CompetingRecord` keep whatever was last resolved (the floor's hash, or the bundled one on a first run) and print a visible warning. A bare `if let Some(..) = outcome.resolved()` would have collapsed a withdrawal, a refused rollback and a plain timeout into the same no-op.

**Anti-rollback floor.** Persisted in `pointer_floors.json` in riverctl's data dir, keyed by `(author_vk, app_id)`, storing version, code hash and `is_withdrawn` as separate columns. A floor that will not rebuild is an error, never a reset: `never_resolved` is the one state that re-enables the build-time key, so `unwrap_or_else(|_| never_resolved())` would turn corruption into a silent downgrade.

**`load_rooms` no longer regenerates cached keys from this binary's build.** That loop rewrites `contract_key` and demotes the old value into `previous_contract_key`, which is the input to the migration probe: a migration decision, not a display detail. It now runs only once the pointer record has been consulted. Before the pointer existed riverctl had nothing better than its own build and did this unconditionally; it has something better now, so it waits for it. Every path that migrates or addresses a contract calls `room_anchor()` before touching storage, so nothing that needs the regeneration loses it, and a read-only command stops writing `rooms.json` on every invocation.

**The backward probe is re-anchored on the resolved hash.** This is the part that actually fixes the bug; left anchored at the compiled-in generation, the change would look complete and accomplish nothing. `pointer::probe_plan` returns the generations strictly older than the anchor: the whole registry when the anchor is the bundled generation (today's behaviour), `LEGACY[..i]` reversed when the anchor is registry entry `i`, and a refusal when the anchor is unknown.

## Design decisions worth arguing about

**Refuse writes, warn on reads.** Not "writes are scarier". A read needs only an address, so a GET against an unknown generation returns the right bytes and a decode failure is local and visible. A write sends a delta encoded by THIS binary's `river-core`, and a re-key usually happens *because* the state or delta shape changed, so a delta from an older `river-core` is exactly what a newer contract's `update_state` was re-keyed away from. That failure is silent and on the network. Publishing code is a third case and is not a judgement call at all: riverctl only has the bytes it bundles, so PUTting them against any other generation writes to a key nobody reads, with a successful `PutResponse`.

**Writes are refused when the network is ahead, but allowed when it is behind.** The delta-shape risk above is symmetric in principle, so the asymmetry needs an argument. Two. First, the compatibility promise runs one way: River's rule is that `ChatRoomStateV1` and its sub-types stay backwards-compatible (new fields `#[serde(default)]`, and on an individually-signed sub-struct also `skip_serializing_if` so an unset field serializes byte-identically), which is a promise that a newer `river-core` produces bytes an older contract still validates, worst case a field the old contract ignores. There is no promise in the other direction, and we cannot inspect a newer contract to find out what it now requires. Second, only one direction has a remedy: against an unknown generation the user upgrades riverctl and is done, while against an older one they can neither make the network re-key nor sensibly install a riverctl matching a superseded generation. Refusing there would also break every freshly-released riverctl until the network finished adopting the matching contract, which is the normal state for a while after each release.

**Refuse to backward-probe under an unknown anchor, rather than probing anyway.** Every generation riverctl knows is then older than the live one, so the search cannot contain the live room. It can only surface a stale copy, and the migrate-forward step would then republish that copy onto a retired key. That is the original bug, reached from the other side.

**A definitive absence is never reported to the resolver.** `PointerFetch::Absent` is the only answer that can unlock a baked-in key, and this transport cannot produce a trustworthy one: the node reports a missing contract as a `ContractError::Get` carrying a free-text cause, and on the live network a `NotFound` is overwhelmingly a routing dead-end for a contract that exists. So every non-`GetResponse` maps to `Unreachable`. The cost is that `NeverPublished` is unreachable through this adapter, which costs nothing, because its arm and `Unavailable`'s arm both fall back to the bundled hash.

**No build-time seeded floor.** `PointerFloor::at` recommends seeding from build-time constants, and it would genuinely bound what a first resolve can adopt. It is declined because the seeded version would have to be bumped in lockstep with every WASM re-key, and a wrong seed wedges resolution permanently (`Stale` or `CompetingRecord` forever, with no advancing floor). The classification step is a second, independent check that does not need a release-process ritual to stay correct.

**Not bumping `ui/`'s `freenet-migrate`.** The UI stays on 0.5. Both resolve in the lock file and they are separate binaries, so nothing links twice. Bumping it is a separate change with its own delegate-migration considerations.

## A behavioural change the dependency bump forced

0.6 made `SelectionPolicy::NewestFirstWins` **stop** at the first candidate that does not answer, rather than walking past it. That is the right default for a caller that can tell absence from silence.

riverctl cannot. `try_get_state` collapses "the contract does not exist", "the GET timed out" and "the bytes did not decode" into one `None`. Almost every candidate in a backward probe is genuinely absent, since a room lives on one generation out of 31, so keeping the new default would have ended the search at the first candidate and disabled dormant-room recovery outright, while every existing test still passed. This opts in to `continue_past_unknown` with the acknowledgement token, preserving 0.5 behaviour. The rollback the token warns about is separately mitigated: the candidate list already re-lists the stored key so a transient miss is retried before advancing, and `NewestFirstWins` still stops at the first generation with real state.

Three existing tests failed on the bump and were fixed rather than adjusted away. They had built their own `ProbeDriver` by hand, so they described a configuration production no longer used. Driver construction is now one `new_probe_driver` helper that production and tests share, with a source pin (`the_shared_probe_driver_keeps_its_configuration`) on the three settings, each of whose loss is silent.

## Testing

`cargo test -p riverctl`: 337 lib + 15 integration, all green, including the pre-existing `current_wasm_is_not_in_legacy_registry`. `cargo fmt --check` clean. `cargo clippy -p riverctl --all-targets -- -D warnings` adds no findings under `cli/src` (see Notes).

Every new mechanism was mutation-tested: the mechanism was removed and the suite re-run to confirm it goes red.

**Two rows in the first version of this table were false, and review caught both.** Both are corrected below, and the story is in "The guard that was not a guard" further down. Reviewers should read the guard rows as the load-bearing ones.

| Mutation | Test that caught it |
|---|---|
| Unknown hash classified as bundled | `unknown_generation_refuses_writes_and_refuses_to_probe`, `classify_recognises_bundled_legacy_and_unknown` |
| Unknown anchor falls through to probing the stale set | `unknown_generation_refuses_writes_and_refuses_to_probe` |
| Write gate removed | `unknown_generation_refuses_writes_and_refuses_to_probe` |
| Unverified fallback made silent | `unavailable_falls_back_to_bundled_with_a_visible_warning`, `transport_failure_...`, `stale_and_competing_record_...` |
| `Withdrawn` treated as a fallback | `withdrawn_refuses`, `a_withdrawn_floor_refuses_every_arm` |
| Corrupt floor reset to `never_resolved` | `a_corrupt_stored_floor_surfaces_rather_than_resetting`, `a_corrupt_pointer_floor_store_surfaces_...` |
| Probe re-anchored back onto the full registry | `legacy_recovery_routes_through_decision_driver` |
| A PUT gate dropped | `every_room_contract_put_is_gated_on_publishing_the_bundled_generation` |
| A network key re-derived from the bundled WASM, via `compute_contract_key` in a send path (the reviewer's exact edit) | `room_keys_for_the_network_are_derived_only_through_the_anchor` |
| The same, via `owner_vk_to_contract_key` in a *different file* (`storage.rs`) | same |
| The same, hand-rolled from `ContractCode::from(ROOM_CONTRACT_WASM)`, calling neither helper | same |
| The guard's own source walk narrowed so it scans almost nothing | same (it fails closed) |
| `load_rooms` restored to rewriting the cached key before the anchor resolves | `load_rooms_regenerates_keys_against_the_resolved_generation` |

### The guard that was not a guard

Adversarial review found the central pin in this PR did not pin. It scraped exactly one literal, `self.owner_vk_to_contract_key(`, in exactly one file, `api.rs`. The free function `compute_contract_key` reaches the same bundled derivation, was already imported by `storage.rs` and `commands/identity.rs`, and was not in the needle set. Changing the main message-send path (`send_message_with_key`) to it reintroduced the stale-anchor bug AND removed the unknown-generation write refusal in one edit, and the suite reported:

```
test result: ok. 337 passed; 0 failed
```

The table above asserted that row as covered. It was not. Every call site in the diff was correct then and is correct now, so nothing shipped wrong, but the guard in a PR whose whole purpose is stopping silent drift of exactly this kind was decorative.

The pin now closes all three doors and scans the whole crate:

* `compute_contract_key(` and `owner_vk_to_contract_key(`, the two helpers that derive from the bundled WASM; and
* `ContractCode::from(ROOM_CONTRACT_WASM)`, the root both use, which catches a fresh derivation calling neither.

It walks `src/` at test time rather than naming files, so a new file cannot be born outside its scope, and it asserts the walk found the crate before trusting an empty result. Legitimate uses carry an explicit `// bundled-wasm-ok: <reason>` marker on the line or in the comment block directly above, so the allowlist lives at the call site instead of drifting from it, and any future use has to be argued in writing rather than merely compile. There are eleven such markers, each naming its reason.

Re-running the reviewer's exact edit against the fixed guard:

```
---- room_keys_for_the_network_are_derived_only_through_the_anchor stdout ----
these lines derive a room key from the WASM this binary bundles, which goes stale the moment
River re-keys. Use `contract_key_for(owner_vk, KeyIntent::..)`, which derives from the generation
River's pointer record names. If a line genuinely needs the bundled generation, mark it
`// bundled-wasm-ok: <reason>` and say why.
  api.rs:3871: let contract_key = compute_contract_key(room_owner_key);

test result: FAILED. 336 passed; 1 failed
```

The other two doors and the fail-closed check were mutated the same way and all go red (rows in the table).

**A second vacuous test, found while fixing the first.** `load_rooms_regenerates_keys_against_the_resolved_generation` grew an assertion for the newly-gated unresolved direction, and that assertion was itself vacuous: the fixture stored the room under the *bundled* key, so a `load_rooms` that regenerated against the bundled hash would recompute the identical key, write nothing, and satisfy every assertion. It passed under the mutation it existed to catch. The fixture now starts the room on a legacy generation, which is neither the bundled nor the resolved one, and asserts the stored key is left alone and `rooms.json` is byte-identical. It now fails under that mutation.

`Withdrawn` and `CompetingRecord` are `#[non_exhaustive]` variants and cannot be built by hand; the tests drive a real `PointerResolver` to produce them, which is the boundary respected rather than worked around.

`author_key_matches_the_documented_pointer_address` derives the pointer address from the author key and app_id in this module and asserts it equals `Ai4VLoC2jGdhpcB2UU8VPo3efUoxjm1Ju9VKXqRC63Az` from `FREENET.md`, so the two constants cannot drift apart silently (a wrong address simply never answers).

### Verified against a live node

Read-only GETs against a local node on `127.0.0.1:7561`. Nothing was published.

Normal case, resolving River's real record:

```
INFO riverctl::api: Room-contract generation for this run: GaGgXBSL1z31dkt9ojRjpi7FerXiPqmmk4QLkuCKqARr (Bundled, Pointer)
Contract key: ESWoDUd9s43fT5hoRGcgRK6HuyiktXecz6EzAvLomzye
```

That hash is `e765339ba3039f937256f4b6f7e8683d43f90e158f5d80f0dd45afdca69911e5`, which is exactly `b3sum ui/public/contracts/room_contract.wasm`. No advisory on stderr, since there is nothing to say. The floor persisted:

```json
{ "floors": { "9Ebskq4y7NvJpTQTrF1FAxU8g6bR4Rhe4TRikXba55EJ/river.room-contract":
  { "version": 1, "code_hash": "GaGgXBSL1z31dkt9ojRjpi7FerXiPqmmk4QLkuCKqARr", "withdrawn": false } } }
```

A second run reused that floor and resolved `Unchanged`, same key, still silent.

Corrupting the floor store surfaces rather than resetting:

```
Error: parsing pointer floor store .../pointer_floors.json. riverctl will not treat an
unreadable anti-rollback floor as "never resolved", because that is the one state in which
it would trust its own build-time key again. Inspect or delete .../pointer_floors.json to continue.
```

An offline command (`riverctl room list`) still works and pays no resolution cost.

The unknown-generation case was reproduced honestly rather than by editing the registry: a scratch build resolving `river.chat-delegate` instead, which is a genuinely signed record from the same author whose code hash is legitimately not a room-contract generation. Reverted afterwards, and not part of this diff.

```
warning: River's room contract is NEWER than this riverctl.
  riverctl bundles room-contract generation GaGgXBSL1z31dkt9ojRjpi7FerXiPqmmk4QLkuCKqARr
  River's pointer record names generation  C4MRWz6XoG1es65ax9qaajaSmUK11yhU8fMGhUqgz2vZ
This riverctl knows 31 previous generation(s) and the resolved one is none of them, so it was
published after this binary was built.
Read-only commands will work against the live generation. Writing needs a newer riverctl.
INFO riverctl::api: Room-contract generation for this run: C4MRWz6...z2vZ (Unknown, Pointer)
Contract key: 5kZz16p7QXpLgPfbsLRhHmEFmvTEDARJgz4tpa6jjjZ3
```

The read resolved and addressed the live generation, which is the whole point: the old code would have derived the retired key and then searched backwards, away from the room. `riverctl room create` under the same anchor refused with the upgrade message.

## Notes

- No WASM changed, so this causes no re-key and needs no migration entry or pointer re-sign.
- `cargo clippy -- -D warnings` reports 6 pre-existing `doc_lazy_continuation` errors in `common/src/room_state/ban.rs` on `origin/main` (a newer clippy's lint on existing doc comments). Confirmed pre-existing by stashing this branch. Left alone to keep the diff focused; happy to fix separately.
- **User-visible change:** `riverctl debug contract-key` now costs one network round trip to print a value that used to be computed locally. That is the point, since the value it prints is now the key riverctl will actually use, but it is a behaviour change worth naming. Every other command that touches a room already opened a connection.
- `riverctl room create` prints its error twice (the command's error arm prints it and also returns it to `main`). Pre-existing, unrelated to this change, and left alone.

[AI-assisted - Claude]
