### PR TITLE
chore(cli): riverctl 0.2.11, and scope a test-only import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4782,7 +4782,7 @@ dependencies = [
 
 [[package]]
 name = "riverctl"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riverctl"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 authors = ["Freenet Project"]
 description = "Command-line interface for River decentralized chat on Freenet"

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -1,3 +1,6 @@
+// Test-only: the production paths here derive through the resolved anchor, so
+// this is unused outside `mod tests` and warns if imported unconditionally.
+#[cfg(test)]
 use crate::api::compute_contract_key;
 use crate::pointer::{floor_corruption_hint, FloorStore, StoredFloor};
 use anyhow::{anyhow, Context, Result};


### PR DESCRIPTION
## Problem

Two things, both consequences of #627.

**A release build warns.** #627 removed the production uses of `compute_contract_key` from `storage.rs` (network paths now derive through the resolved anchor) but left the top-level import, so `cargo build --release -p riverctl` emits `unused import: crate::api::compute_contract_key`.

**riverctl needs a version bump to release.** `cli/Cargo.toml` and crates.io are both at 0.2.10, so the work in #627 cannot ship.

## Approach

Bump to 0.2.11, and scope the import to `#[cfg(test)]` rather than deleting it.

Worth recording why it is scoped and not removed: I deleted it first, and the test build broke. The import is not dead, it is test-only. Those tests call `compute_contract_key` deliberately, each carrying a `// bundled-wasm-ok: <reason>` marker, because they never resolve a pointer and the bundled derivation is genuinely the one under test. A `#[cfg(test)] use` line also does not carry the `compute_contract_key(` token the anchor pin scrapes for, so it does not need a marker of its own.

## Testing

- `cargo build -p riverctl`: zero unused-import warnings.
- `cargo test -p riverctl --lib`: 337 passed, 0 failed.
- `room_keys_for_the_network_are_derived_only_through_the_anchor` still passes, so the guard added in #627 is still armed after the import change.
- `cargo fmt --check` clean.

Verified #627 end to end against a local node before cutting this, rather than only in tests: `riverctl debug contract-key` logged `Room-contract generation for this run: GaGgXBSL... (Bundled, Pointer)`, where `Pointer` means the generation came from a resolved record rather than a fallback. That base58 decodes to `e765339ba3039f93...`, exactly the code hash River's published pointer record names, and the derived key matched the known key for the Freenet Official room.

[AI-assisted - Claude]