### PR TITLE
fix(delegate): a re-store of identical bytes must not arm the snapshot debounce

### DIFF
--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -1269,9 +1269,10 @@ mod tests {
     /// Re-storing the bytes the delegate ALREADY holds is reported as
     /// `Unchanged` and issues no store at all (freenet/river#629).
     ///
-    /// This is the load-time save: the UI hydrates a room from the delegate and
-    /// immediately re-serializes it, so `to_store` is byte-identical to
-    /// `current`. Before #629 that looked like a real write.
+    /// This covers the write-amplification saving only. Whether the load-time
+    /// save arms the debounce is decided by `first_write_of_session` in
+    /// [`slot_after_write`], not here — a byte comparison cannot be relied on
+    /// to fire, which is the whole reason the arming rule does not use one.
     #[test]
     fn cas_write_key_reports_unchanged_and_skips_identical_store() {
         let stores = std::cell::RefCell::new(0u32);
@@ -1306,21 +1307,18 @@ mod tests {
         assert_eq!(*stores.borrow(), 1);
     }
 
-    /// The #629 invariant itself, stated against the defer predicate rather
-    /// than the I/O: a slot recorded from an `Unchanged` write carries NO
-    /// timestamp, so the next cache-only change cannot be deferred against it.
-    ///
-    /// Pinned as a unit because the end-to-end sequence (hydrate -> self-save ->
-    /// network converges -> save) spans the synchronizer, the Dioxus effect in
-    /// `app.rs` and the websocket, and was therefore never covered by #534's
-    /// own tests — which is exactly why the regression shipped.
-    /// The freenet/river#629 invariant, against the real `slot_after_write`
-    /// mapping rather than a restatement of it.
+    /// The freenet/river#629 invariant, exercised against the real
+    /// [`slot_after_write`] mapping rather than restating it.
     ///
     /// The load-time save must NOT arm the snapshot debounce, whether or not
     /// the CAS happened to prove the bytes identical. Resting this on byte
     /// equality alone is what an earlier cut of the fix did, and it failed
     /// silently for rooms carrying a nondeterministically-encoded field.
+    ///
+    /// Pinned as a unit because the end-to-end sequence (hydrate -> self-save
+    /// -> network converges -> save) spans the synchronizer, the Dioxus effect
+    /// in `app.rs` and the websocket, and was therefore never covered by
+    /// #534's own tests — which is exactly why the regression shipped.
     #[test]
     fn the_first_write_of_a_session_never_arms_the_snapshot_debounce() {
         let present_without_timestamp = SavedSlot::Present {
@@ -5869,28 +5867,16 @@ fn content_hash(bytes: &[u8]) -> u64 {
     h.finish()
 }
 
-/// Generic read-merge-write CAS for a single delegate key (freenet/river#345).
-///
-/// `reconcile(current)` receives the delegate's current value (`None` if
-/// absent) and returns `Ok(Some(bytes))` to store, `Ok(None)` to abort the
-/// write as a no-op (e.g. adopt a remote tombstone), or `Err` to fail. On a CAS
-/// `Conflict` (another writer advanced the key between our read and store) it
-/// re-reads and re-reconciles. `get_versioned`/`cas_store` are injected so the
-/// loop is unit-testable without the websocket.
-///
-/// Reports what actually happened as a [`CasWriteOutcome`]. The caller needs
-/// the distinction to avoid recording a "we persisted Present" cache entry for
-/// a key the delegate still holds as a `Tombstone` (code-first review: abort
-/// poisoned `ROOM_SLOT_STATE` and could later skip a needed rejoin write).
 /// What a CAS write actually did.
 ///
 /// `Unchanged` is deliberately NOT folded into `Stored`: it means the delegate
 /// already held byte-for-byte what we reconciled, so no new state was
-/// persisted. Treating that as a write is precisely the freenet/river#629
-/// defect — the load-time save re-persists the snapshot it just hydrated,
-/// which armed the `ROOM_SNAPSHOT_MIN_INTERVAL_MS` debounce with data that was
-/// never new, so the genuinely fresh state arriving moments later was deferred
-/// and (for a session shorter than the interval) never written at all.
+/// persisted. The distinction buys two separate things — it lets the caller
+/// skip a pointless ~373 KiB rewrite (freenet/river#533), and it records a
+/// slot that carries no write timestamp. It is NOT what fixes
+/// freenet/river#629 on its own; see [`slot_after_write`], which refuses to
+/// arm the debounce on the first write of a session whether or not the bytes
+/// compared equal.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum CasWriteOutcome {
     /// New bytes were persisted.
@@ -5909,13 +5895,22 @@ enum CasWriteOutcome {
 /// regressed. Keep it testable.
 ///
 /// `first_write_of_session` is `true` when this room had no
-/// [`ROOM_SLOT_STATE`] entry before this save — which, because that map is a
-/// `thread_local` that starts empty on every page load, means this write is
-/// the load-time echo of the snapshot we just HYDRATED, not a response to new
-/// room state arriving. That write must not arm the debounce window: doing so
-/// is freenet/river#629, where the genuinely fresh state landing seconds later
+/// [`ROOM_SLOT_STATE`] entry before this save. Because that map is a
+/// `thread_local` starting empty on every page load, the case that matters is
+/// the load-time echo of the snapshot we just HYDRATED: a write carrying no
+/// room state we did not already have. Arming the window on it is
+/// freenet/river#629, where the genuinely fresh state landing seconds later
 /// was deferred and, for any session shorter than
 /// [`ROOM_SNAPSHOT_MIN_INTERVAL_MS`], never written at all.
+///
+/// It is deliberately not ONLY the hydration echo, and the flag is not a
+/// claim that it is (skeptical review). Two other writes have no prior slot:
+/// a room created this session, and an explicit rejoin, which
+/// [`mark_room_rejoined`] clears the slot for on purpose so the next save
+/// re-evaluates. Both are then allowed one un-debounced cache-only write
+/// before the window re-arms. That is bounded at one extra write per event
+/// and errs toward writing, so it cannot resurrect freenet/river#534's
+/// unbounded write amplification; erring the other way would resurrect #629.
 ///
 /// This deliberately does NOT depend on the bytes being equal. An earlier cut
 /// of the fix armed the clock unless the CAS proved the stored bytes identical,
@@ -5962,6 +5957,19 @@ fn slot_after_write(
     }
 }
 
+/// Generic read-merge-write CAS for a single delegate key (freenet/river#345).
+///
+/// `reconcile(current)` receives the delegate's current value (`None` if
+/// absent) and returns `Ok(Some(bytes))` to store, `Ok(None)` to abort the
+/// write as a no-op (e.g. adopt a remote tombstone), or `Err` to fail. On a CAS
+/// `Conflict` (another writer advanced the key between our read and store) it
+/// re-reads and re-reconciles. `get_versioned`/`cas_store` are injected so the
+/// loop is unit-testable without the websocket.
+///
+/// Reports what actually happened as a [`CasWriteOutcome`]. The caller needs
+/// the distinction to avoid recording a "we persisted Present" cache entry for
+/// a key the delegate still holds as a `Tombstone` (code-first review: abort
+/// poisoned `ROOM_SLOT_STATE` and could later skip a needed rejoin write).
 async fn cas_write_key<R, G, GFut, S, SFut>(
     mut reconcile: R,
     get_versioned: G,
@@ -5981,10 +5989,11 @@ where
             None => return Ok(CasWriteOutcome::Aborted),
         };
         // Storing X over X is a no-op that is not free: it rewrites the whole
-        // per-room blob (~373 KiB per member, freenet/river#533) and, far
-        // worse, it used to be indistinguishable from a real write and so
-        // armed the snapshot debounce (freenet/river#629). Both sides are in
-        // hand right here, which is the only place that can tell them apart.
+        // per-room blob (~373 KiB per member, freenet/river#533). Both sides
+        // are in hand right here, which is the only place that can tell them
+        // apart. This is purely that write-amplification saving — it does NOT
+        // decide whether the snapshot debounce is armed, because a byte
+        // comparison cannot be trusted to fire (see `slot_after_write`).
         if current.as_deref() == Some(to_store.as_slice()) {
             return Ok(CasWriteOutcome::Unchanged);
         }

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -1314,53 +1314,143 @@ mod tests {
     /// network converges -> save) spans the synchronizer, the Dioxus effect in
     /// `app.rs` and the websocket, and was therefore never covered by #534's
     /// own tests — which is exactly why the regression shipped.
+    /// The freenet/river#629 invariant, against the real `slot_after_write`
+    /// mapping rather than a restatement of it.
+    ///
+    /// The load-time save must NOT arm the snapshot debounce, whether or not
+    /// the CAS happened to prove the bytes identical. Resting this on byte
+    /// equality alone is what an earlier cut of the fix did, and it failed
+    /// silently for rooms carrying a nondeterministically-encoded field.
     #[test]
-    fn unchanged_write_does_not_arm_the_snapshot_debounce() {
-        // The load-time save: the delegate already held what we hydrated.
-        let after_hydrate = slot_after_write(CasWriteOutcome::Unchanged, 1, Some(2), 1_000.0);
+    fn the_first_write_of_a_session_never_arms_the_snapshot_debounce() {
+        let present_without_timestamp = SavedSlot::Present {
+            content: 1,
+            critical: Some(2),
+            written_at_ms: None,
+        };
+
+        // Bytes provably identical: nothing was persisted at all.
         assert_eq!(
-            after_hydrate,
-            SavedSlot::Present {
-                content: 1,
-                critical: Some(2),
-                written_at_ms: None,
-            },
-            "an Unchanged write must record NO write timestamp"
+            slot_after_write(CasWriteOutcome::Unchanged, true, 1, Some(2), 9_000.0),
+            present_without_timestamp,
+            "an Unchanged write persists nothing and must record no timestamp"
         );
-        // The defer branch matches only `written_at_ms: Some(_)`, so a slot
-        // recorded this way can never reach `should_defer_cache_only_save`.
-        assert!(
-            !matches!(
-                after_hydrate,
-                SavedSlot::Present {
-                    written_at_ms: Some(_),
-                    ..
-                }
-            ),
-            "a slot that persisted nothing new must not be deferrable against"
+        // The load-time echo, where the bytes did NOT compare equal (e.g. a
+        // map re-encoded in a different order, or hydration legitimately
+        // rewriting the room). Still the snapshot we just loaded, so still
+        // must not start the window. This is the case byte equality missed.
+        assert_eq!(
+            slot_after_write(CasWriteOutcome::Stored, true, 1, Some(2), 9_000.0),
+            present_without_timestamp,
+            "the first write of a session is the hydrated snapshot, not new state"
         );
 
-        // A real write still arms it, so #534's write-amplification fix stands.
-        let after_real = slot_after_write(CasWriteOutcome::Stored, 3, Some(2), 1_000.0);
+        // A later write IS new state, and arms the window — so #534's
+        // write-amplification fix is preserved, not weakened.
         assert_eq!(
-            after_real,
+            slot_after_write(CasWriteOutcome::Stored, false, 3, Some(2), 9_000.0),
             SavedSlot::Present {
                 content: 3,
                 critical: Some(2),
-                written_at_ms: Some(1_000.0),
+                written_at_ms: Some(9_000.0),
             },
-            "a Stored write must arm the debounce window"
+            "a subsequent real write must arm the debounce window"
         );
         assert!(
             should_defer_cache_only_save(0.0),
             "a cache-only change right after a real write is still deferred"
         );
 
-        // An abort still records the tombstone the delegate actually holds.
+        // An Unchanged write later in the session still persisted nothing.
         assert_eq!(
-            slot_after_write(CasWriteOutcome::Aborted, 4, Some(2), 1_000.0),
+            slot_after_write(CasWriteOutcome::Unchanged, false, 1, Some(2), 9_000.0),
+            present_without_timestamp
+        );
+
+        // An abort records the tombstone the delegate actually holds.
+        assert_eq!(
+            slot_after_write(CasWriteOutcome::Aborted, false, 4, Some(2), 9_000.0),
             SavedSlot::Tombstone
         );
+    }
+
+    /// The defer branch matches only `written_at_ms: Some(_)`, so a slot the
+    /// rule above recorded can never reach `should_defer_cache_only_save`.
+    /// Pins the coupling between the two halves of the fix.
+    #[test]
+    fn a_slot_with_no_write_timestamp_is_not_deferrable() {
+        for outcome in [CasWriteOutcome::Unchanged, CasWriteOutcome::Stored] {
+            let slot = slot_after_write(outcome, true, 1, Some(2), 9_000.0);
+            assert!(
+                !matches!(
+                    slot,
+                    SavedSlot::Present {
+                        written_at_ms: Some(_),
+                        ..
+                    }
+                ),
+                "{outcome:?} on the first write of a session must not be deferrable against"
+            );
+        }
+    }
+
+    /// `RoomData::invitation_secrets` must encode canonically, so that a
+    /// hydrate-then-re-serialize reproduces the on-disk bytes and the no-op
+    /// detection can actually fire. It was a `HashMap`, whose CBOR key order
+    /// follows each map's own random seed (freenet/river#629).
+    ///
+    /// Deliberately uses several entries and several independent round trips:
+    /// a single entry, or a single trip, would pass under the old type too.
+    #[test]
+    fn a_persisted_room_re_serializes_to_identical_bytes() {
+        let mut room = room_fixture();
+        for v in 0..8u32 {
+            room.invitation_secrets.insert(v, [v as u8; 32]);
+        }
+        // CONTROL: prove the hazard this test guards against is real, so the
+        // test cannot pass merely because CBOR happens to be deterministic for
+        // everything. A `HashMap` with the same contents must actually
+        // re-encode differently across round trips; if this control ever stops
+        // failing to match, the guard above has become vacuous and the whole
+        // rationale needs re-checking.
+        {
+            #[derive(serde::Serialize, serde::Deserialize)]
+            struct HashMapControl {
+                secrets: HashMap<u32, [u8; 32]>,
+            }
+            let control = HashMapControl {
+                secrets: (0..8u32).map(|v| (v, [v as u8; 32])).collect(),
+            };
+            let mut first = Vec::new();
+            ciborium::ser::into_writer(&control, &mut first).expect("serialize control");
+            let differed = (0..8).any(|_| {
+                let hydrated: HashMapControl =
+                    ciborium::de::from_reader(&first[..]).expect("deserialize control");
+                let mut again = Vec::new();
+                ciborium::ser::into_writer(&hydrated, &mut again).expect("re-serialize control");
+                again != first
+            });
+            assert!(
+                differed,
+                "control: a HashMap field was expected to re-encode differently \
+                 across round trips. If it no longer does, this test proves nothing."
+            );
+        }
+
+        let mut on_disk = Vec::new();
+        ciborium::ser::into_writer(&room, &mut on_disk).expect("serialize");
+
+        for trip in 0..8 {
+            let hydrated: crate::room_data::RoomData =
+                ciborium::de::from_reader(&on_disk[..]).expect("deserialize");
+            let mut again = Vec::new();
+            ciborium::ser::into_writer(&hydrated, &mut again).expect("re-serialize");
+            assert_eq!(
+                again, on_disk,
+                "round trip {trip} re-encoded the same room to different bytes; \
+                 a persisted field has a nondeterministic encoding"
+            );
+        }
     }
 
     /// Exhaustion after `ROOMS_CAS_MAX_ATTEMPTS` consecutive conflicts errors.
@@ -5685,6 +5775,13 @@ thread_local! {
     /// form (e.g. `regenerate_contract_key`, `remove_unverifiable_messages`), so
     /// seeding the baseline from the loaded bytes could wrongly skip a needed
     /// write. CAS reconcile makes the redundant same-content writes harmless.
+    ///
+    /// "Harmless" was FALSE between freenet/river#534 and #629: that redundant
+    /// first write stamped `written_at_ms`, arming the snapshot debounce with
+    /// data that was never new, so the state arriving from the network moments
+    /// later was deferred and usually never written. It is true again only
+    /// because [`slot_after_write`] now refuses to arm the window on the first
+    /// write of a session. Do not weaken that without re-reading #629.
     static ROOM_SLOT_STATE: std::cell::RefCell<HashMap<VerifyingKey, SavedSlot>> =
         std::cell::RefCell::new(HashMap::new());
     /// Last-persisted content hash of the `rooms_meta` value.
@@ -5781,11 +5878,10 @@ fn content_hash(bytes: &[u8]) -> u64 {
 /// re-reads and re-reconciles. `get_versioned`/`cas_store` are injected so the
 /// loop is unit-testable without the websocket.
 ///
-/// Returns `Ok(true)` if a value was actually stored, `Ok(false)` if the
-/// reconcile aborted the write (no store happened). The caller needs this to
-/// avoid recording a "we persisted Present" cache entry for a key the delegate
-/// still holds as a `Tombstone` (code-first review: abort poisoned
-/// `ROOM_SLOT_STATE` and could later skip a needed rejoin write).
+/// Reports what actually happened as a [`CasWriteOutcome`]. The caller needs
+/// the distinction to avoid recording a "we persisted Present" cache entry for
+/// a key the delegate still holds as a `Tombstone` (code-first review: abort
+/// poisoned `ROOM_SLOT_STATE` and could later skip a needed rejoin write).
 /// What a CAS write actually did.
 ///
 /// `Unchanged` is deliberately NOT folded into `Stored`: it means the delegate
@@ -5811,26 +5907,53 @@ enum CasWriteOutcome {
 /// freenet/river#629 fix, and inlined at the call site it sat behind a
 /// websocket and two Dioxus signals, so no test could have failed if it
 /// regressed. Keep it testable.
+///
+/// `first_write_of_session` is `true` when this room had no
+/// [`ROOM_SLOT_STATE`] entry before this save — which, because that map is a
+/// `thread_local` that starts empty on every page load, means this write is
+/// the load-time echo of the snapshot we just HYDRATED, not a response to new
+/// room state arriving. That write must not arm the debounce window: doing so
+/// is freenet/river#629, where the genuinely fresh state landing seconds later
+/// was deferred and, for any session shorter than
+/// [`ROOM_SNAPSHOT_MIN_INTERVAL_MS`], never written at all.
+///
+/// This deliberately does NOT depend on the bytes being equal. An earlier cut
+/// of the fix armed the clock unless the CAS proved the stored bytes identical,
+/// which quietly failed for the one persisted field with a nondeterministic
+/// encoding (`RoomData::invitation_secrets`, a `HashMap`): its CBOR key order
+/// follows each `HashMap`'s own random seed, so a re-serialized hydrate does
+/// not reproduce the on-disk byte order and the room silently kept the bug.
+/// That field is now a `BTreeMap` so the encoding is canonical, but the
+/// arming rule must not rest on that — serialization determinism is an easy
+/// property to lose again, and losing it here would fail silently.
 fn slot_after_write(
     outcome: CasWriteOutcome,
+    first_write_of_session: bool,
     content: u64,
     critical: Option<u64>,
     now_ms: f64,
 ) -> SavedSlot {
     match outcome {
-        // A real write: arm the debounce window (freenet/river#534).
-        CasWriteOutcome::Stored => SavedSlot::Present {
-            content,
-            critical,
-            written_at_ms: Some(now_ms),
-        },
-        // The delegate already held these bytes. It IS Present, but nothing
-        // new was persisted, so there is no write to defer against and the
-        // next cache-only change must go straight out (freenet/river#629).
+        // The delegate already held these exact bytes: nothing was persisted,
+        // so there is nothing to defer against.
         CasWriteOutcome::Unchanged => SavedSlot::Present {
             content,
             critical,
             written_at_ms: None,
+        },
+        // The load-time echo of the hydrated snapshot. It carries no room
+        // state we did not already have, so it must not start the window.
+        CasWriteOutcome::Stored if first_write_of_session => SavedSlot::Present {
+            content,
+            critical,
+            written_at_ms: None,
+        },
+        // A real write driven by new state: arm the window, which is what
+        // keeps freenet/river#534's write-amplification fix in force.
+        CasWriteOutcome::Stored => SavedSlot::Present {
+            content,
+            critical,
+            written_at_ms: Some(now_ms),
         },
         // The reconcile adopted a remote tombstone (freenet/river#345
         // round-9): record what the delegate actually holds, not a phantom
@@ -6243,8 +6366,10 @@ async fn do_save_rooms_to_delegate(force_flush: bool) -> Result<(), String> {
                 // persisted, so it must not start the debounce window
                 // (freenet/river#629).
                 ROOM_SLOT_STATE.with(|c| {
-                    c.borrow_mut()
-                        .insert(*vk, slot_after_write(outcome, h, crit, now_ms()));
+                    c.borrow_mut().insert(
+                        *vk,
+                        slot_after_write(outcome, prev.is_none(), h, crit, now_ms()),
+                    );
                 });
                 // Once a rejoin is persisted as Present, consume the rejoin
                 // intent: a LATER cross-tab leave + background update must then

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -1182,7 +1182,7 @@ mod tests {
     }
 
     /// `cas_write_key` stores the reconciled bytes at the generation just read,
-    /// and reports `Ok(true)` (a write happened).
+    /// and reports `Stored` (a write happened).
     #[test]
     fn cas_write_key_stores_reconciled_value() {
         let stored = std::cell::RefCell::new(None);
@@ -1196,12 +1196,12 @@ mod tests {
             },
         ))
         .unwrap_or_else(|e| panic!("cas_write_key failed: {e}"));
-        assert!(wrote, "a store must report wrote=true");
+        assert_eq!(wrote, CasWriteOutcome::Stored, "a store must report Stored");
         assert_eq!(*stored.borrow(), Some(b"v1".to_vec()));
     }
 
     /// `reconcile` returning `None` aborts the write — nothing is stored, and
-    /// the call reports `Ok(false)` so the caller records the delegate's actual
+    /// the call reports `Aborted` so the caller records the delegate's actual
     /// (un-overwritten) state rather than a phantom `Present` (code-first review).
     #[test]
     fn cas_write_key_abort_does_not_store() {
@@ -1215,7 +1215,11 @@ mod tests {
             },
         ))
         .unwrap_or_else(|e| panic!("cas_write_key failed: {e}"));
-        assert!(!wrote, "abort (None) must report wrote=false");
+        assert_eq!(
+            wrote,
+            CasWriteOutcome::Aborted,
+            "abort (None) must report Aborted"
+        );
         assert_eq!(*stores.borrow(), 0, "abort (None) must not store");
     }
 
@@ -1259,6 +1263,103 @@ mod tests {
             *store_expected.borrow(),
             vec![0, 7],
             "the retry stores at the re-read generation"
+        );
+    }
+
+    /// Re-storing the bytes the delegate ALREADY holds is reported as
+    /// `Unchanged` and issues no store at all (freenet/river#629).
+    ///
+    /// This is the load-time save: the UI hydrates a room from the delegate and
+    /// immediately re-serializes it, so `to_store` is byte-identical to
+    /// `current`. Before #629 that looked like a real write.
+    #[test]
+    fn cas_write_key_reports_unchanged_and_skips_identical_store() {
+        let stores = std::cell::RefCell::new(0u32);
+        let outcome = futures::executor::block_on(cas_write_key(
+            |_current| Ok(Some(b"same".to_vec())),
+            || async { Ok::<_, String>((Some(b"same".to_vec()), 3u64)) },
+            |_value, _expected| {
+                *stores.borrow_mut() += 1;
+                async move { Ok(CasStoreResult::Stored { generation: 4 }) }
+            },
+        ))
+        .unwrap_or_else(|e| panic!("cas_write_key failed: {e}"));
+        assert_eq!(outcome, CasWriteOutcome::Unchanged);
+        assert_eq!(*stores.borrow(), 0, "identical bytes must not be re-stored");
+    }
+
+    /// A byte DIFFERENCE against the stored value is still a real write, so the
+    /// no-op detection above cannot swallow a genuine change.
+    #[test]
+    fn cas_write_key_stores_when_bytes_differ() {
+        let stores = std::cell::RefCell::new(0u32);
+        let outcome = futures::executor::block_on(cas_write_key(
+            |_current| Ok(Some(b"new".to_vec())),
+            || async { Ok::<_, String>((Some(b"old".to_vec()), 3u64)) },
+            |_value, _expected| {
+                *stores.borrow_mut() += 1;
+                async move { Ok(CasStoreResult::Stored { generation: 4 }) }
+            },
+        ))
+        .unwrap_or_else(|e| panic!("cas_write_key failed: {e}"));
+        assert_eq!(outcome, CasWriteOutcome::Stored);
+        assert_eq!(*stores.borrow(), 1);
+    }
+
+    /// The #629 invariant itself, stated against the defer predicate rather
+    /// than the I/O: a slot recorded from an `Unchanged` write carries NO
+    /// timestamp, so the next cache-only change cannot be deferred against it.
+    ///
+    /// Pinned as a unit because the end-to-end sequence (hydrate -> self-save ->
+    /// network converges -> save) spans the synchronizer, the Dioxus effect in
+    /// `app.rs` and the websocket, and was therefore never covered by #534's
+    /// own tests — which is exactly why the regression shipped.
+    #[test]
+    fn unchanged_write_does_not_arm_the_snapshot_debounce() {
+        // The load-time save: the delegate already held what we hydrated.
+        let after_hydrate = slot_after_write(CasWriteOutcome::Unchanged, 1, Some(2), 1_000.0);
+        assert_eq!(
+            after_hydrate,
+            SavedSlot::Present {
+                content: 1,
+                critical: Some(2),
+                written_at_ms: None,
+            },
+            "an Unchanged write must record NO write timestamp"
+        );
+        // The defer branch matches only `written_at_ms: Some(_)`, so a slot
+        // recorded this way can never reach `should_defer_cache_only_save`.
+        assert!(
+            !matches!(
+                after_hydrate,
+                SavedSlot::Present {
+                    written_at_ms: Some(_),
+                    ..
+                }
+            ),
+            "a slot that persisted nothing new must not be deferrable against"
+        );
+
+        // A real write still arms it, so #534's write-amplification fix stands.
+        let after_real = slot_after_write(CasWriteOutcome::Stored, 3, Some(2), 1_000.0);
+        assert_eq!(
+            after_real,
+            SavedSlot::Present {
+                content: 3,
+                critical: Some(2),
+                written_at_ms: Some(1_000.0),
+            },
+            "a Stored write must arm the debounce window"
+        );
+        assert!(
+            should_defer_cache_only_save(0.0),
+            "a cache-only change right after a real write is still deferred"
+        );
+
+        // An abort still records the tombstone the delegate actually holds.
+        assert_eq!(
+            slot_after_write(CasWriteOutcome::Aborted, 4, Some(2), 1_000.0),
+            SavedSlot::Tombstone
         );
     }
 
@@ -5552,7 +5653,7 @@ fn critical_hash(room_data: &RoomData) -> Option<u64> {
 /// What we last persisted for a room key, so a save only writes the rooms that
 /// actually changed. Per-room isolation: a change to room X never rewrites room
 /// R's key, so it can't resurrect R's tombstone (freenet/river#345 round-9).
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 enum SavedSlot {
     /// Last-saved content hash of the room's serialized `RoomData`, plus the
     /// hash of just its critical fields and when we last wrote it, so a
@@ -5563,8 +5664,12 @@ enum SavedSlot {
         /// Hash of the unrecoverable subset. `None` if the critical projection
         /// failed to serialize, which forces the write (fail-safe).
         critical: Option<u64>,
-        /// `now_ms()` at the last successful write of this room's key.
-        written_at_ms: f64,
+        /// `now_ms()` at the last write of this room's key that actually
+        /// persisted NEW bytes this session, or `None` if no such write has
+        /// happened yet — in which case there is nothing to defer against and
+        /// the next cache-only change must be written immediately
+        /// (freenet/river#629).
+        written_at_ms: Option<f64>,
     },
     /// We've persisted this room as a tombstone (the user left it).
     Tombstone,
@@ -5681,11 +5786,64 @@ fn content_hash(bytes: &[u8]) -> u64 {
 /// avoid recording a "we persisted Present" cache entry for a key the delegate
 /// still holds as a `Tombstone` (code-first review: abort poisoned
 /// `ROOM_SLOT_STATE` and could later skip a needed rejoin write).
+/// What a CAS write actually did.
+///
+/// `Unchanged` is deliberately NOT folded into `Stored`: it means the delegate
+/// already held byte-for-byte what we reconciled, so no new state was
+/// persisted. Treating that as a write is precisely the freenet/river#629
+/// defect — the load-time save re-persists the snapshot it just hydrated,
+/// which armed the `ROOM_SNAPSHOT_MIN_INTERVAL_MS` debounce with data that was
+/// never new, so the genuinely fresh state arriving moments later was deferred
+/// and (for a session shorter than the interval) never written at all.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum CasWriteOutcome {
+    /// New bytes were persisted.
+    Stored,
+    /// The delegate already held these exact bytes; no store was issued.
+    Unchanged,
+    /// The reconcile declined to write (e.g. adopting a remote tombstone).
+    Aborted,
+}
+
+/// What to record in [`ROOM_SLOT_STATE`] after a per-room CAS write.
+///
+/// Pulled out as a pure function on purpose: this mapping IS the
+/// freenet/river#629 fix, and inlined at the call site it sat behind a
+/// websocket and two Dioxus signals, so no test could have failed if it
+/// regressed. Keep it testable.
+fn slot_after_write(
+    outcome: CasWriteOutcome,
+    content: u64,
+    critical: Option<u64>,
+    now_ms: f64,
+) -> SavedSlot {
+    match outcome {
+        // A real write: arm the debounce window (freenet/river#534).
+        CasWriteOutcome::Stored => SavedSlot::Present {
+            content,
+            critical,
+            written_at_ms: Some(now_ms),
+        },
+        // The delegate already held these bytes. It IS Present, but nothing
+        // new was persisted, so there is no write to defer against and the
+        // next cache-only change must go straight out (freenet/river#629).
+        CasWriteOutcome::Unchanged => SavedSlot::Present {
+            content,
+            critical,
+            written_at_ms: None,
+        },
+        // The reconcile adopted a remote tombstone (freenet/river#345
+        // round-9): record what the delegate actually holds, not a phantom
+        // Present that could later content-hash-skip a genuine rejoin.
+        CasWriteOutcome::Aborted => SavedSlot::Tombstone,
+    }
+}
+
 async fn cas_write_key<R, G, GFut, S, SFut>(
     mut reconcile: R,
     get_versioned: G,
     mut cas_store: S,
-) -> Result<bool, String>
+) -> Result<CasWriteOutcome, String>
 where
     R: FnMut(Option<&[u8]>) -> Result<Option<Vec<u8>>, String>,
     G: Fn() -> GFut,
@@ -5697,10 +5855,18 @@ where
         let (current, generation) = get_versioned().await?;
         let to_store = match reconcile(current.as_deref())? {
             Some(bytes) => bytes,
-            None => return Ok(false),
+            None => return Ok(CasWriteOutcome::Aborted),
         };
+        // Storing X over X is a no-op that is not free: it rewrites the whole
+        // per-room blob (~373 KiB per member, freenet/river#533) and, far
+        // worse, it used to be indistinguishable from a real write and so
+        // armed the snapshot debounce (freenet/river#629). Both sides are in
+        // hand right here, which is the only place that can tell them apart.
+        if current.as_deref() == Some(to_store.as_slice()) {
+            return Ok(CasWriteOutcome::Unchanged);
+        }
         match cas_store(to_store, generation).await? {
-            CasStoreResult::Stored { .. } => return Ok(true),
+            CasStoreResult::Stored { .. } => return Ok(CasWriteOutcome::Stored),
             CasStoreResult::Conflict { .. } => continue,
             CasStoreResult::Failed(e) => return Err(e),
         }
@@ -5710,9 +5876,9 @@ where
     ))
 }
 
-/// [`cas_write_key`] bound to a real delegate key over the websocket. Returns
-/// `Ok(true)` if a value was stored, `Ok(false)` if the reconcile aborted.
-async fn cas_write_delegate_key<R>(key: Vec<u8>, reconcile: R) -> Result<bool, String>
+/// [`cas_write_key`] bound to a real delegate key over the websocket. See
+/// [`CasWriteOutcome`] for what the three results mean.
+async fn cas_write_delegate_key<R>(key: Vec<u8>, reconcile: R) -> Result<CasWriteOutcome, String>
 where
     R: FnMut(Option<&[u8]>) -> Result<Option<Vec<u8>>, String>,
 {
@@ -6042,7 +6208,7 @@ async fn do_save_rooms_to_delegate(force_flush: bool) -> Result<(), String> {
         if !force_flush {
             if let Some(SavedSlot::Present {
                 critical,
-                written_at_ms,
+                written_at_ms: Some(written_at_ms),
                 ..
             }) = prev
             {
@@ -6065,31 +6231,30 @@ async fn do_save_rooms_to_delegate(force_flush: bool) -> Result<(), String> {
         })
         .await
         {
-            Ok(wrote) => {
-                // `wrote == false` means the reconcile aborted to adopt a remote
-                // Tombstone (round-9). The delegate then still holds a Tombstone,
-                // so record THAT — recording `Present(h)` would be a lie that
+            Ok(outcome) => {
+                // `Aborted` means the reconcile adopted a remote Tombstone
+                // (round-9). The delegate then still holds a Tombstone, so
+                // record THAT — recording `Present(h)` would be a lie that
                 // could later content-hash-skip a genuine rejoin write
                 // (code-first review).
+                //
+                // `Unchanged` records `Present` (the delegate does hold these
+                // bytes) but with NO write timestamp: nothing new was
+                // persisted, so it must not start the debounce window
+                // (freenet/river#629).
                 ROOM_SLOT_STATE.with(|c| {
-                    c.borrow_mut().insert(
-                        *vk,
-                        if wrote {
-                            SavedSlot::Present {
-                                content: h,
-                                critical: crit,
-                                written_at_ms: now_ms(),
-                            }
-                        } else {
-                            SavedSlot::Tombstone
-                        },
-                    );
+                    c.borrow_mut()
+                        .insert(*vk, slot_after_write(outcome, h, crit, now_ms()));
                 });
-                // Once a rejoin has actually been persisted as Present, consume
-                // the rejoin intent: a LATER cross-tab leave + background update
-                // must then adopt the leave, not resurrect on a stale flag
-                // (skeptical/big-picture review).
-                if wrote {
+                // Once a rejoin is persisted as Present, consume the rejoin
+                // intent: a LATER cross-tab leave + background update must then
+                // adopt the leave, not resurrect on a stale flag
+                // (skeptical/big-picture review). `Unchanged` counts — the
+                // delegate holds our Present bytes either way.
+                if matches!(
+                    outcome,
+                    CasWriteOutcome::Stored | CasWriteOutcome::Unchanged
+                ) {
                     REJOINED_THIS_SESSION.with(|s| {
                         s.borrow_mut().remove(vk);
                     });

--- a/ui/src/components/app/document_title.rs
+++ b/ui/src/components/app/document_title.rs
@@ -1023,7 +1023,7 @@ mod tests {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
-            invitation_secrets: HashMap::new(),
+            invitation_secrets: std::collections::BTreeMap::new(),
         }
     }
 

--- a/ui/src/components/app/freenet_api/response_handler/get_response.rs
+++ b/ui/src/components/app/freenet_api/response_handler/get_response.rs
@@ -473,7 +473,7 @@ pub async fn handle_get_response(
                             self_member_info: None,
                             self_nickname: None,
                             previous_contract_key: None,
-                            invitation_secrets: std::collections::HashMap::new(),
+                            invitation_secrets: std::collections::BTreeMap::new(),
                         }
                     });
 

--- a/ui/src/components/direct_messages.rs
+++ b/ui/src/components/direct_messages.rs
@@ -1124,7 +1124,7 @@ mod tests {
                 self_member_info: None,
                 self_nickname: None,
                 previous_contract_key: None,
-                invitation_secrets: std::collections::HashMap::new(),
+                invitation_secrets: std::collections::BTreeMap::new(),
             },
         );
         rooms

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1810,7 +1810,14 @@ fn ExportIdentityModal(is_active: Signal<bool>) -> Element {
                             // useful `room_secrets` via new invitations
                             // (freenet/river#306). Empty for public rooms and
                             // for owners.
-                            invitation_secrets: room_data.invitation_secrets.clone(),
+                            // `IdentityExport` keeps a `HashMap` (it lives in river-core, which is
+                            // published — bumping it would force a contract migration), so
+                            // convert at the boundary rather than changing the shared type.
+                            invitation_secrets: room_data
+                                .invitation_secrets
+                                .iter()
+                                .map(|(k, v)| (*k, *v))
+                                .collect(),
                         };
                         token_text.set(export.to_armored_string());
                     } else {
@@ -1952,7 +1959,7 @@ fn build_imported_room_data(export: IdentityExport) -> crate::room_data::RoomDat
         // (freenet/river#306). Folded into the `#[serde(skip)]` `secrets` map
         // by `repopulate_secrets_from_state` on the next sync. Empty for
         // public rooms, owners, and pre-#306 exports.
-        invitation_secrets: export.invitation_secrets,
+        invitation_secrets: export.invitation_secrets.into_iter().collect(),
     }
 }
 
@@ -2090,7 +2097,7 @@ fn swap_room_identity_in_place(
         existing.secrets.clear();
         existing.current_secret_version = None;
         existing.last_secret_rotation = None;
-        existing.invitation_secrets = export.invitation_secrets;
+        existing.invitation_secrets = export.invitation_secrets.into_iter().collect();
     } else {
         // SAME identity re-import (the user re-importing their OWN token, e.g. a
         // legacy/stale one). A backward-compat decode of an old token yields

--- a/ui/src/example_data.rs
+++ b/ui/src/example_data.rs
@@ -440,7 +440,7 @@ fn create_room(
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
-            invitation_secrets: std::collections::HashMap::new(),
+            invitation_secrets: std::collections::BTreeMap::new(),
         },
     }
 }

--- a/ui/src/room_data.rs
+++ b/ui/src/room_data.rs
@@ -24,7 +24,7 @@ use river_core::room_state::secret::{
 use river_core::room_state::ChatRoomParametersV1;
 use river_core::ChatRoomStateV1;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 #[derive(Debug, PartialEq)]
 pub enum SendMessageError {
@@ -363,8 +363,16 @@ pub struct RoomData {
     /// [`RoomData::repopulate_secrets_from_state`]. Empty for public
     /// rooms, for the room owner, and for rooms joined before this field
     /// existed.
+    ///
+    /// A `BTreeMap`, not a `HashMap`, so the persisted CBOR is CANONICAL.
+    /// A `HashMap`'s iteration order follows its own random seed, so a
+    /// hydrate-then-re-serialize would not reproduce the on-disk byte order
+    /// and every same-content save would look like a change
+    /// (freenet/river#629). Ordering is not load-bearing for correctness —
+    /// `slot_after_write` does not rest on byte equality — but a canonical
+    /// encoding is what lets the no-op detection actually fire.
     #[serde(default)]
-    pub invitation_secrets: HashMap<u32, [u8; 32]>,
+    pub invitation_secrets: BTreeMap<u32, [u8; 32]>,
 }
 
 /// Compute the `SealedBytes` for an invitee's chosen nickname at join time.
@@ -1942,7 +1950,7 @@ pub(crate) fn test_minimal_room_data(owner_vk: VerifyingKey) -> RoomData {
         self_member_info: None,
         self_nickname: None,
         previous_contract_key: None,
-        invitation_secrets: HashMap::new(),
+        invitation_secrets: BTreeMap::new(),
     }
 }
 
@@ -2098,7 +2106,7 @@ impl Rooms {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
-            invitation_secrets: HashMap::new(),
+            invitation_secrets: BTreeMap::new(),
         };
 
         info!("🟢 Inserting room into map...");
@@ -2768,7 +2776,7 @@ mod tests {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
-            invitation_secrets: HashMap::new(),
+            invitation_secrets: BTreeMap::new(),
         };
 
         // With stale key, user should NOT be recognized as a member
@@ -2843,7 +2851,7 @@ mod tests {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
-            invitation_secrets: HashMap::new(),
+            invitation_secrets: BTreeMap::new(),
         };
 
         // Before capture, self_member_info should be None
@@ -2914,7 +2922,7 @@ mod tests {
                 self_member_info: None,
                 self_nickname: None,
                 previous_contract_key: None,
-                invitation_secrets: HashMap::new(),
+                invitation_secrets: BTreeMap::new(),
             }
         };
 
@@ -2984,7 +2992,7 @@ mod tests {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
-            invitation_secrets: HashMap::new(),
+            invitation_secrets: BTreeMap::new(),
         }
     }
 
@@ -5250,7 +5258,7 @@ mod tests {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
-            invitation_secrets: HashMap::new(),
+            invitation_secrets: BTreeMap::new(),
         }
     }
 
@@ -5557,7 +5565,7 @@ mod tests {
                 self_member_info: None,
                 self_nickname: None,
                 previous_contract_key: None,
-                invitation_secrets: HashMap::new(),
+                invitation_secrets: BTreeMap::new(),
             }
         };
 
@@ -6007,7 +6015,7 @@ mod tests {
                 self_member_info: None,
                 self_nickname: None,
                 previous_contract_key: None,
-                invitation_secrets: HashMap::new(),
+                invitation_secrets: BTreeMap::new(),
             }
         };
 
@@ -6078,7 +6086,7 @@ mod tests {
                 self_member_info: None,
                 self_nickname: None,
                 previous_contract_key: None,
-                invitation_secrets: HashMap::new(),
+                invitation_secrets: BTreeMap::new(),
             }
         };
 
@@ -6310,7 +6318,7 @@ mod tests {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
-            invitation_secrets: HashMap::new(),
+            invitation_secrets: BTreeMap::new(),
         };
 
         (v0_secret, room)
@@ -6646,7 +6654,7 @@ mod tests {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
-            invitation_secrets: HashMap::new(),
+            invitation_secrets: BTreeMap::new(),
         };
 
         let decrypted = room.repopulate_secrets_from_state();
@@ -7198,7 +7206,17 @@ mod tests {
             decoded.self_verifying_key(),
             Some(invitee_sk.verifying_key())
         );
-        assert_eq!(decoded.invitation_secrets, invitation_secrets);
+        // The emulated writer above deliberately still uses a `HashMap` (that
+        // is what every blob stored today was written by), so convert for the
+        // comparison — proving a HashMap-written blob decodes into the
+        // `BTreeMap` field this build reads (freenet/river#629).
+        assert_eq!(
+            decoded.invitation_secrets,
+            invitation_secrets
+                .iter()
+                .map(|(k, v)| (*k, *v))
+                .collect::<BTreeMap<u32, [u8; 32]>>()
+        );
         assert_eq!(decoded.owner_vk, room.owner_vk);
         assert_eq!(decoded.contract_key, room.contract_key);
     }
@@ -7675,7 +7693,7 @@ mod tests {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
-            invitation_secrets: HashMap::new(),
+            invitation_secrets: BTreeMap::new(),
         }
     }
 
@@ -7894,7 +7912,7 @@ mod tests {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
-            invitation_secrets: HashMap::new(),
+            invitation_secrets: BTreeMap::new(),
         };
 
         // Sanity check pinning the bug: the raw live-members-only view
@@ -8113,7 +8131,7 @@ mod tests {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
-            invitation_secrets: HashMap::new(),
+            invitation_secrets: BTreeMap::new(),
         };
 
         // Deputize T. Since the CANONICAL base (clean) does not yet list T,
@@ -8228,7 +8246,7 @@ mod tests {
             self_member_info: Some(authorized_v5),
             self_nickname: None,
             previous_contract_key: None,
-            invitation_secrets: HashMap::new(),
+            invitation_secrets: BTreeMap::new(),
         };
 
         assert!(room.apply_deputy_change(t_id, true));
@@ -8345,7 +8363,7 @@ mod tests {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
-            invitation_secrets: HashMap::new(),
+            invitation_secrets: BTreeMap::new(),
         };
 
         // Sanity: the raw live-members view can't see S's ancestry at all —

--- a/ui/src/util.rs
+++ b/ui/src/util.rs
@@ -1025,7 +1025,7 @@ mod tests {
             self_member_info: None,
             self_nickname: None,
             previous_contract_key: None,
-            invitation_secrets: HashMap::new(),
+            invitation_secrets: std::collections::BTreeMap::new(),
         };
         room_data.regenerate_contract_key();
 


### PR DESCRIPTION
## Problem

The room snapshot River caches in the chat delegate was frozen at whenever the user last had a session long enough to write it. Every page load painted stale messages, converged a few seconds later, and then persisted nothing — so the next load was identically stale. Reported from try.freenet.org showing messages ~6 hours old on every load and every refresh.

The sequence is deterministic, not a race:

1. `hydrate_loaded_rooms_with_authority` calls `mark_needs_sync` per room (`response_handler.rs:1913`), firing the `NEEDS_SYNC` effect at `app.rs:441`. That effect starts the network sync **and** spawns `save_rooms_to_delegate()` (`app.rs:478`) in the same tick.
2. `ROOM_SLOT_STATE` is a `thread_local` that starts empty on each page load, so that save has no prior slot, cannot be deferred, and writes — re-persisting the snapshot it just hydrated and stamping `written_at_ms = now`.
3. The real state arrives moments later. Only `room_state` changed, which `critical_hash` blanks, so it is a cache-only change and the `ROOM_SNAPSHOT_MIN_INTERVAL_MS` debounce (#534) defers it with a bare `continue`. No timer, no retry.
4. `coalesce_save` does not rescue it: each iteration re-derives elapsed from the `written_at_ms` the previous iteration just stamped, so the second iteration still sees ~0ms.
5. The only bypass, `flush_rooms_to_delegate()`, is reachable only from `visibilitychange`, and is `safe_spawn_local` (`setTimeout(0)`) work doing a multi-round-trip CAS. A `setTimeout` continuation does not run during page teardown, so **a reload never flushes**. It is additionally skipped by `mark_all_rooms_as_read`'s `updates.is_empty()` early return when everything is already read. There is no `pagehide`/`beforeunload` path.

### Production measurement

On the try.freenet.org node, for the 962 users holding a slot for the same room, snapshot age tracked time-since-last-visit almost exactly:

| last seen | n | snapshot age (median) | over 1h stale |
|---|---|---|---|
| under 1h ago | 27 | 0.4 h | 0% |
| 1-6h ago | 49 | 3.6 h | 95.9% |
| 6-24h ago | 100 | 12.7 h | 100% |
| over 24h ago | 786 | 142.8 h | 100% |

Against a five-minute debounce, that is the signature of a cache written on arrival and never again. Median across the whole set: 101.6 hours.

## Approach

`slot_after_write()` decides what goes into `ROOM_SLOT_STATE` after a per-room CAS write, and it now takes `first_write_of_session` (passed as `prev.is_none()`). Because `ROOM_SLOT_STATE` starts empty on every page load, that flag identifies the load-time echo of the snapshot we just hydrated — a write carrying no room state we did not already have. It records `written_at_ms: None`, which the defer branch cannot match, so the first genuinely new state after a load is written immediately.

A later write still stamps the clock, so #534's intended cadence is preserved rather than weakened: ongoing cache-only changes are still debounced.

The mapping is a pure function rather than inlined at the call site. Inlined it sat behind a websocket and two Dioxus signals, so no test could have failed if it regressed — which is why this shipped in the first place.

### Why the arming rule does not use byte equality

The first cut of this PR armed the debounce unless the CAS proved the stored bytes byte-identical. Review (Codex, and an independent skeptical pass) found that rests correctness on serialization determinism, and `RoomData::invitation_secrets` was a `HashMap` — its CBOR key order follows each map's own random seed, so a hydrate-then-re-serialize does not reproduce the on-disk byte order. An invitee of a private room holding two or more invitation secrets would have kept the bug with no signal at all.

That objection is addressed at the root: the arming rule no longer consults the bytes. `CasWriteOutcome::Unchanged` survives only as a write-amplification saving (skipping a pointless ~373 KiB rewrite, the same amplification #534 set out to reduce).

Separately, `RoomData::invitation_secrets` becomes a `BTreeMap` so the persisted encoding is canonical and that saving can actually fire. This is defence in depth, deliberately **not** the correctness mechanism. `IdentityExport` keeps its `HashMap` and is converted at the boundary in `members.rs`: it lives in river-core, which is published, and bumping it would force a contract migration. Neither the delegate nor the room-contract WASM depends on `river-ui`, so no re-key — the CI migration checks confirm it.

### Scope note

`first_write_of_session` is broader than "the hydration echo": a room created this session, and an explicit rejoin (which `mark_room_rejoined` clears the slot for on purpose), also have no prior slot, and each gets one un-debounced cache-only write before the window re-arms. Bounded at one extra write per event, and it errs toward writing — erring the other way is #629. Documented on `slot_after_write` rather than special-cased.

## Testing

Five new tests in `ui/src/components/app/chat_delegate.rs`:

- `the_first_write_of_a_session_never_arms_the_snapshot_debounce` — the invariant, against the real `slot_after_write` mapping. Covers all four outcome/flag combinations plus `Aborted`.
- `a_slot_with_no_write_timestamp_is_not_deferrable` — pins the coupling to the defer branch's `written_at_ms: Some(_)` pattern.
- `a_persisted_room_re_serializes_to_identical_bytes` — a real `RoomData` with 8 invitation secrets round-trips to identical bytes across 8 trips. Carries a **`HashMap` control** that asserts such a field really does re-encode differently, so the test cannot pass merely because CBOR happens to be deterministic. The control fires: the hazard is measured, not assumed.
- `cas_write_key_reports_unchanged_and_skips_identical_store` and `cas_write_key_stores_when_bytes_differ` — the write-amplification saving.

Mutation-tested (each fails without the fix, passes with it):

| mutation | test that caught it |
|---|---|
| remove the `first_write_of_session` arm exemption (restores the bug) | `the_first_write_of_a_session_never_arms_the_snapshot_debounce`, `a_slot_with_no_write_timestamp_is_not_deferrable` |
| make `Unchanged` stamp `Some(now_ms)` | `unchanged_write_does_not_arm_the_snapshot_debounce` (that cut's test) |
| remove the no-op detection | `cas_write_key_reports_unchanged_and_skips_identical_store` |

Full suite: 930 passed, 0 failed. `cargo fmt --check` clean. The existing backward-compat test still emulates a `HashMap` writer, proving blobs stored today decode into the `BTreeMap` field.

#534's own tests covered the debounce predicate in isolation and never the hydrate-then-self-save-then-defer sequence, which is the CI gap this closes.

## Follow-ups not in this PR

- The flush path is weak on its own terms: no `pagehide`/`beforeunload` listener, and the `updates.is_empty()` early return sits above the flush call. This PR makes the flush non-load-bearing for the reported symptom but does not fix it.
- No test covers `do_save_rooms_to_delegate` end to end. The `TestNode`/`pump` harness already in this file could drive it; the `app.rs:478` trigger itself is a Dioxus effect and out of reach without a browser-level test.

Refs #622

[AI-assisted - Claude]
