### PR TITLE
ci: move river off GitHub larger runners to Ubicloud

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,17 @@ on:
       - develop
       - 'releases/**'
 
+# Least-privilege floor for the whole workflow: these jobs need to read the
+# repo and nothing else. Without this block they inherit the org default,
+# which is `write` (see /orgs/freenet/actions/permissions/workflow), so every
+# job gets a GITHUB_TOKEN able to push contents, packages and deployments.
+# That blast radius is worth closing now the jobs run on a third-party runner.
+# Same idiom as release-riverctl.yml: set a read-only floor here and elevate
+# per-job where a job genuinely needs more (see `claude-ci-analysis` below,
+# which declares its own block and is unaffected by this floor).
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,16 @@ env:
 
 jobs:
   build:
-    runs-on: freenet-default-runner
+    # Ubicloud, NOT a GitHub-hosted larger runner. GitHub bills larger
+    # runners (`freenet-default-runner`, an 8-core/32GB org runner) at
+    # $0.022/min even on PUBLIC repos -- the free-minutes discount that zeroes
+    # every other line on our bill never applies to them. In July 2026 that one
+    # label was the ONLY billed item on the whole org invoice: $221.25 of a
+    # $1,767.51 gross usage figure, all of it from this repo, while
+    # freenet-core's $1,525.77 of gross usage billed $0 because it runs on
+    # Ubicloud. Same 8-core class of machine, off GitHub's meter.
+    # Do not move these jobs back to a larger-runner label.
+    runs-on: ubicloud-standard-8
 
     steps:
     - uses: actions/checkout@v3
@@ -62,11 +71,16 @@ jobs:
         key: ${{ runner.os }}-dioxus-cli-${{ hashFiles('ui/Cargo.toml') }}
 
     - name: Install Dioxus CLI
-      # Gate on the cache *result*, not on whether the file exists:
-      # freenet-default-runner is self-hosted, so a stale ~/.cargo/bin/dx can
-      # persist from an earlier job even when this key misses (e.g. after a
-      # dioxus bump). A file-existence check would then skip the install and
-      # use the stale CLI; a cache-key miss must always (re)install.
+      # Gate on the cache *result*, not on whether the file exists: a
+      # `dx` on disk is not evidence that it matches THIS key. It may have
+      # been restored by another cache step, shipped in the runner image, or
+      # left by an earlier step, so after a dioxus bump a file-existence check
+      # would skip the install and use the stale CLI. A cache-key miss must
+      # always (re)install. This held on `freenet-default-runner` and still
+      # holds on Ubicloud; it was never a consequence of the runner being
+      # self-hosted. `freenet-default-runner` was a GitHub-HOSTED larger
+      # runner, and believing otherwise is what let a billed 8-core machine
+      # sit in this file unnoticed. See the runs-on comment above.
       #
       # Pass GITHUB_TOKEN so binstall makes authenticated GitHub API requests
       # (5000/hr) instead of unauthenticated ones (60/hr). The unauthenticated
@@ -254,7 +268,8 @@ jobs:
       run: cargo test -p web-container-contract -p web-container-tool
 
   ui-playwright-tests:
-    runs-on: freenet-default-runner
+    # Ubicloud, NOT a GitHub-hosted larger runner -- see the `build` job above.
+    runs-on: ubicloud-standard-8
 
     steps:
     - uses: actions/checkout@v3
@@ -302,11 +317,16 @@ jobs:
         key: ${{ runner.os }}-dioxus-cli-${{ hashFiles('ui/Cargo.toml') }}
 
     - name: Install Dioxus CLI
-      # Gate on the cache *result*, not on whether the file exists:
-      # freenet-default-runner is self-hosted, so a stale ~/.cargo/bin/dx can
-      # persist from an earlier job even when this key misses (e.g. after a
-      # dioxus bump). A file-existence check would then skip the install and
-      # use the stale CLI; a cache-key miss must always (re)install.
+      # Gate on the cache *result*, not on whether the file exists: a
+      # `dx` on disk is not evidence that it matches THIS key. It may have
+      # been restored by another cache step, shipped in the runner image, or
+      # left by an earlier step, so after a dioxus bump a file-existence check
+      # would skip the install and use the stale CLI. A cache-key miss must
+      # always (re)install. This held on `freenet-default-runner` and still
+      # holds on Ubicloud; it was never a consequence of the runner being
+      # self-hosted. `freenet-default-runner` was a GitHub-HOSTED larger
+      # runner, and believing otherwise is what let a billed 8-core machine
+      # sit in this file unnoticed. See the runs-on comment above.
       #
       # Pass GITHUB_TOKEN so binstall makes authenticated GitHub API requests
       # (5000/hr) instead of unauthenticated ones (60/hr). The unauthenticated

--- a/.github/workflows/check-delegate-migration.yml
+++ b/.github/workflows/check-delegate-migration.yml
@@ -3,6 +3,13 @@ name: Check Delegate Migration
 on:
   pull_request:
 
+# Least-privilege floor: this gate only reads the repo. Without this block it
+# inherits the org default of `write`, handing a third-party runner a
+# GITHUB_TOKEN that can push contents and packages. See release-riverctl.yml
+# for the same idiom.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/check-delegate-migration.yml
+++ b/.github/workflows/check-delegate-migration.yml
@@ -8,7 +8,9 @@ env:
 
 jobs:
   check-delegate-migration:
-    runs-on: freenet-default-runner
+    # Ubicloud, NOT a GitHub-hosted larger runner: larger runners are billed
+    # at $0.022/min even on public repos. See .github/workflows/build.yml.
+    runs-on: ubicloud-standard-8
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/check-pointer-freshness.yml
+++ b/.github/workflows/check-pointer-freshness.yml
@@ -18,7 +18,9 @@ env:
 
 jobs:
   check-pointer-freshness:
-    runs-on: freenet-default-runner
+    # Ubicloud, NOT a GitHub-hosted larger runner: larger runners are billed
+    # at $0.022/min even on public repos. See .github/workflows/build.yml.
+    runs-on: ubicloud-standard-8
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/check-pointer-freshness.yml
+++ b/.github/workflows/check-pointer-freshness.yml
@@ -13,6 +13,13 @@ name: Check Pointer Freshness
 on:
   pull_request:
 
+# Least-privilege floor: this gate only reads the repo. Without this block it
+# inherits the org default of `write`, handing a third-party runner a
+# GITHUB_TOKEN that can push contents and packages. See release-riverctl.yml
+# for the same idiom.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/check-room-contract-migration.yml
+++ b/.github/workflows/check-room-contract-migration.yml
@@ -3,6 +3,13 @@ name: Check Room-Contract Migration
 on:
   pull_request:
 
+# Least-privilege floor: this gate only reads the repo. Without this block it
+# inherits the org default of `write`, handing a third-party runner a
+# GITHUB_TOKEN that can push contents and packages. See release-riverctl.yml
+# for the same idiom.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/check-room-contract-migration.yml
+++ b/.github/workflows/check-room-contract-migration.yml
@@ -8,7 +8,9 @@ env:
 
 jobs:
   check-room-contract-migration:
-    runs-on: freenet-default-runner
+    # Ubicloud, NOT a GitHub-hosted larger runner: larger runners are billed
+    # at $0.022/min even on public repos. See .github/workflows/build.yml.
+    runs-on: ubicloud-standard-8
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/clippy.yml.disabled
+++ b/.github/workflows/clippy.yml.disabled
@@ -14,7 +14,9 @@ env:
 
 jobs:
   clippy:
-    runs-on: freenet-default-runner
+    # Ubicloud, NOT a GitHub-hosted larger runner: larger runners are billed
+    # at $0.022/min even on public repos. See .github/workflows/build.yml.
+    runs-on: ubicloud-standard-8
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/clippy.yml.disabled
+++ b/.github/workflows/clippy.yml.disabled
@@ -9,6 +9,13 @@ on:
       - develop
       - 'releases/**'
 
+# Least-privilege floor: this gate only reads the repo. Without this block it
+# inherits the org default of `write`, handing a third-party runner a
+# GITHUB_TOKEN that can push contents and packages. See release-riverctl.yml
+# for the same idiom.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## Problem

The freenet org was billed **$221.26 for GitHub Actions in July 2026** (invoice 2026-08-20, txn 11K540743N620641F). Every cent of it came from this repo.

`runs-on: freenet-default-runner` is **not** a third-party runner despite the name. It is a **GitHub-hosted larger runner** configured on the org — linux-x64, 8-core / 32 GB / 300 GB, GitHub-owned Ubuntu 24.04 image. Verified directly:

```
$ gh api /orgs/freenet/actions/hosted-runners
{"name":"freenet-default-runner","platform":"linux-x64","image":{"source":"github"},
 "machine_size_details":{"cpu_cores":8,"memory_gb":32,"storage_gb":300}}
```

The org has **zero** self-hosted runners (`/orgs/freenet/actions/runners` and `/repos/freenet/river/actions/runners` both return empty).

GitHub bills larger runners at **$0.022/min even on public repos** — the free-minutes discount that zeroes every other line on our bill never applies to them. That made this one label the only billed item on the entire org invoice. Figures below are from `gh api /orgs/freenet/settings/billing/usage`:

| SKU | Minutes | Gross | **Net (billed)** |
|---|---|---|---|
| **Actions Linux 8-core** | **10,057** | **$221.25** | **$221.25** |
| Actions macOS 3-core | 20,898 | $1,295.68 | $0 |
| Actions Windows | 11,871 | $118.71 | $0 |
| Actions Linux | 14,627 | $87.76 | $0 |
| Actions Linux ARM | 1,566 | $7.83 | $0 |
| Actions storage | — | $36.28 | $0 |

(The invoice line reads $221.26 and the SKU row $221.254 — a rounding cent apart, same charge.) Org-wide July gross across all SKUs sums to $1,767.51, of which $1,546.25 was discounted away. The 8-core row is attributed to `repositoryName: river` and is the only row with a nonzero net.

freenet-core, by contrast, was billed **$0** despite being by far the heavier consumer of CI, because it runs on `ubicloud-standard-*`. (Its gross usage is roughly $1.5k; the exact per-repo figure is not cleanly reproducible from the billing API, which attributes each SKU-month to a single repo and rotates the storage row between repos, so treat that one number as approximate.)

This has been the configuration since river's build.yml first gained the label on 2025-01-19 (`git log -S`); July was simply river's busiest month (124 commits). August was tracking identically: 3,748 8-core minutes = $82.46 net by the 20th, again the only nonzero line.

## Approach

Point the six jobs that used `freenet-default-runner` at **`ubicloud-standard-8`** — the same class of machine, and the same provider freenet-core already uses, which moves them off GitHub's meter entirely.

- `build.yml` → `build`, `ui-playwright-tests`
- `check-delegate-migration.yml`
- `check-room-contract-migration.yml`
- `check-pointer-freshness.yml`
- `clippy.yml.disabled` (disabled today, changed so re-enabling it does not quietly reintroduce the cost)

**Why `ubicloud-standard-8` rather than `ubuntu-latest`.** `ubuntu-latest` is genuinely free for public repos, but it is 2 cores. These jobs do full Rust + WASM builds and a three-browser Playwright suite; the migration gates additionally `cargo install` b3sum and (for pointer freshness) build `freenet-pointer-contract` from git with no cache. Dropping to 2 cores would slow PR feedback materially on every one of them. `ubicloud-standard-8` keeps the current 8-core class at a small fraction of GitHub's larger-runner rate. The `ubicloud-managed-runners` GitHub App is installed org-wide (`repository_selection: all`), so the label resolves here.

Job names are unchanged, so no status-check names move. `main` is not a protected branch, so there are no required-check contexts to update either way.

### Second commit: least-privilege `GITHUB_TOKEN`

Both the org and the repo set `default_workflow_permissions: "write"`, and none of these five workflows declared a `permissions:` block — so every migrated job ran with a token scoped to write Contents, PullRequests, Actions, Packages and Deployments. That was already true on GitHub's own runners, but carrying it across a trust boundary onto a third-party managed runner is worth avoiding, so the second commit sets a workflow-level `contents: read` floor on all five.

Nothing in these jobs needs more: checkout reads; `actions/cache` uses its own service; `upload-artifact@v4` authenticates with `ACTIONS_RUNTIME_TOKEN` rather than the job token; `cargo binstall` only reads public release metadata; `freenet-migrate` is cloned over unauthenticated https. `claude-ci-analysis` declares its own job-level block and is unaffected — job scope replaces workflow scope outright, so it keeps `pull-requests: write`. This is the same idiom `release-riverctl.yml` already uses (read-only floor at line 32, `github-release` elevated to `contents: write` at line 201).

Also corrects the two `# freenet-default-runner is self-hosted` comments on the Dioxus CLI cache gate. That belief is precisely what let a billed larger runner sit in this file for 19 months without anyone looking at it. **The gate itself is unchanged** — `if: steps.cache-dioxus-cli.outputs.cache-hit != 'true'` is byte-identical, and now rests on a reason that does not depend on who provisioned the machine: a `dx` on disk is not evidence that it matches *this* cache key.

## Testing

`build.yml` and all three migration gates run on `pull_request`, so **this PR's own CI is the test** — it executes every changed job on Ubicloud. On the first commit all five went green: `check-delegate-migration` and `check-room-contract-migration` in 25s, plus `check-pointer-freshness`, `build`, and `ui-playwright-tests`.

That settles two things empirically rather than by assumption:

1. **`npx playwright install --with-deps chromium firefox webkit`**, which needs passwordless sudo + apt. `ui-playwright-tests` passing proves it directly. There was already a precedent in the org too: freenet-core's `playwright-shell.yml:49` runs on `ubicloud-standard-8` and line 129 runs the byte-identical install command, with `sudo apt-get install -y mold` at lines 68-69, green on 2026-08-22 in 7m9s.
2. **Cross-image cache restore.** Every cache key is `${{ runner.os }}`-based, which evaluates to `Linux` on both the old GitHub image and Ubicloud's, so this PR's first run restored `~/.cargo/bin/dx` and `target/` artifacts *cached by the old GitHub-hosted runner* onto an Ubicloud machine. `build` passing means those restored binaries executed and linked fine; an ABI mismatch would have surfaced as an exec-format or link failure.

Locally verified before pushing: every touched workflow still parses as YAML (checked with a parser, not by eye), and each job resolves to the intended label.

```
build.yml                          build=ubicloud-standard-8, ui-playwright-tests=ubicloud-standard-8, claude-ci-analysis=ubuntu-latest
check-delegate-migration.yml       check-delegate-migration=ubicloud-standard-8
check-pointer-freshness.yml        check-pointer-freshness=ubicloud-standard-8
check-room-contract-migration.yml  check-room-contract-migration=ubicloud-standard-8
clippy.yml.disabled                clippy=ubicloud-standard-8
```

## Not covered by this PR (org settings, needs a human)

Two of the three recommendations are GitHub org settings and cannot be made in a repo PR:

1. **Delete or restrict the `freenet-128gb` larger runner.** It is defined on the org at 32-core / 128 GB / 1200 GB. An org-wide code search across all 34 freenet repos finds **zero** references to it — it is unused, but any PR can start using it by typing the label. Same for `ubuntu-latest-m` (4-core) and `windows-latest-l` (8-core Windows), also defined, also referenced nowhere. Settings → Actions → Runners.
2. **Set an Actions budget alert on the org** so this surfaces before the invoice does. Billing → Manage budgets. A budget with a $0 threshold on "Actions" would have caught this in the first week of 2025.

After this merges, the expected billed Actions line for the org is **$0** — an org-wide search confirms no repo (freenet-core, freenet-stdlib, or any of the other 30-odd) references any larger-runner label, and every remaining runner label in river is `ubuntu-latest`, a standard macOS/Windows runner, or Ubicloud, all fully discounted on public repos.

## Review

Full-tier per the multi-model-review rule (CI configuration is a high-risk surface): three independent blind Claude lenses (code-first, adversarial, cost-completeness) plus an external Codex pass.

- The three Claude lenses returned no blocking findings. Between them they validated the YAML with a parser, confirmed the `if:` gate on the Dioxus install is byte-identical, and searched all 34 org repos to confirm no remaining larger-runner reference anywhere.
- The **cost lens re-verified the billing figures against the live `/orgs/freenet/settings/billing/usage` API** rather than accepting the invoice summary, which is what produced the two caveats noted inline above (the $221.25/$221.26 rounding, and the freenet-core gross figure that the API does not cleanly reproduce).
- **Codex raised one P1 the Claude lenses all missed**: the write-scoped `GITHUB_TOKEN`. Confirmed against the org and repo settings and fixed in the second commit rather than deferred.

[AI-assisted - Claude]

https://claude.ai/code/session_01XtqckXUGVzypeWr6tTBDkw
