### PR TITLE
fix(cli): escape attacker-controlled nicknames before terminal output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4782,7 +4782,7 @@ dependencies = [
 
 [[package]]
 name = "riverctl"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4719,7 +4719,7 @@ dependencies = [
 
 [[package]]
 name = "river-core"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -4746,7 +4746,7 @@ dependencies = [
 
 [[package]]
 name = "river-ui"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "aes-gcm",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ freenet-scaffold-macro = "0.2.2"
 freenet-stdlib = { version = "0.8.5", features = ["contract"] }
 
 [workspace.package]
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 
 [profile.release]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -50,7 +50,7 @@ dialoguer = "0.11"
 atty = "0.2"
 
 # Internal dependencies
-river-core = { version = "=0.1.19", path = "../common", features = ["ecies", "ecies-randomized", "migration", "mentions"] }
+river-core = { version = "=0.1.20", path = "../common", features = ["ecies", "ecies-randomized", "migration", "mentions"] }
 freenet-stdlib = { workspace = true, features = ["net"] }
 freenet-scaffold = "0.2.2"
 # Sans-IO backward-probe decision driver (freenet/river#398 phase 2b): drives

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riverctl"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 authors = ["Freenet Project"]
 description = "Command-line interface for River decentralized chat on Freenet"

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -1225,7 +1225,15 @@ pub(crate) fn reply_prefix_display(ctx: &ReplyContextDisplay) -> String {
         ReplyContextDisplay::Quote {
             author, preview, ..
         } => {
-            format!("[reply to {}: {}] ", author, preview)
+            // `author` is attacker-controlled (any member sets their own
+            // nickname) and is the FAITHFUL decoded value shared with
+            // `reply_to_json` — escape only here, at the terminal print site,
+            // never at the shared source. See `display_nickname`.
+            format!(
+                "[reply to {}: {}] ",
+                crate::deputies::display_nickname(author),
+                preview
+            )
         }
         // The quoted message could not be read back — its author was banned and
         // their messages purged, it was deleted, it aged out, or (for a private
@@ -4424,6 +4432,9 @@ impl ApiClient {
         // `ReplyContentV1.target_author_name` and PERSISTS it to contract state.
         // Without decrypting here, the reply's quoted author would read
         // "[Encrypted: N bytes, vN]" to every reader (including the UI) forever.
+        // Deliberately NOT run through `display_nickname`: this value is
+        // persisted, not printed, and escaping it would corrupt the stored
+        // author name for every future reader.
         let target_author_name = room_state
             .member_info
             .canonical(target_msg.message.author)
@@ -4889,6 +4900,11 @@ impl ApiClient {
                 let display_name = nickname
                     .clone()
                     .unwrap_or_else(|| author_str.chars().take(8).collect());
+                // Escaped only for this terminal line — `nickname` itself
+                // stays raw below because the JSON branch below serializes it
+                // faithfully (attacker-controlled nickname; JSON escaping
+                // already makes it safe there).
+                let display_name = crate::deputies::display_nickname(&display_name);
                 let reactions_str = reactions
                     .map(|r| {
                         if r.is_empty() {
@@ -4972,6 +4988,9 @@ impl ApiClient {
                 let display_name = nickname
                     .clone()
                     .unwrap_or_else(|| author_str.chars().take(8).collect());
+                // Escaped only for this terminal line — see the identical
+                // comment in `output_reaction_change`.
+                let display_name = crate::deputies::display_nickname(&display_name);
                 println!(
                     "[deleted] [{} - {}]: (message deleted)",
                     local_time.format("%H:%M:%S"),
@@ -5030,12 +5049,19 @@ impl ApiClient {
                 let author_str = msg.message.author.to_string();
                 let author_short = author_str.chars().take(8).collect::<String>();
 
-                // Get nickname if available (decrypted for a private room)
+                // Get nickname if available (decrypted for a private room).
+                // Escaped for this HUMAN-only println — the JSON branch below
+                // makes its own separate `unseal_nickname_display` call and
+                // stays raw (attacker-controlled nickname; JSON escaping
+                // already makes it safe there).
                 let nickname = room_state
                     .member_info
                     .canonical(msg.message.author)
                     .map(|info| {
-                        unseal_nickname_display(&info.member_info.preferred_nickname, secrets)
+                        crate::deputies::display_nickname(&unseal_nickname_display(
+                            &info.member_info.preferred_nickname,
+                            secrets,
+                        ))
                     })
                     .unwrap_or(author_short);
 
@@ -9704,7 +9730,9 @@ mod mention_cli_tests {
             message_id: "42".to_string(),
             preview: "hello".to_string(),
         };
-        assert_eq!(reply_prefix_display(&quote), "[reply to Alice: hello] ");
+        // Escaped and quoted for the terminal (freenet/river#474) — see
+        // `display_nickname`. The JSON author below stays the bare string.
+        assert_eq!(reply_prefix_display(&quote), "[reply to \"Alice\": hello] ");
         assert_eq!(
             reply_to_json(&quote),
             Some(json!({
@@ -9724,6 +9752,45 @@ mod mention_cli_tests {
 
         assert_eq!(reply_prefix_display(&ReplyContextDisplay::NotAReply), "");
         assert_eq!(reply_to_json(&ReplyContextDisplay::NotAReply), None);
+    }
+
+    /// A member's nickname is attacker-controlled — any room member sets
+    /// their own — so a nickname carrying ANSI escapes, a bare CR, or a bell
+    /// must not reach the terminal unescaped (freenet/river#474): unescaped,
+    /// it can rewrite prior terminal output, hide/replace text via `\r`, or
+    /// beep. `reply_prefix_display` (the terminal path) must render it
+    /// escaped, while `reply_to_json` (the JSON/bridge path, and the same
+    /// value persisted into `ReplyContentV1`) must carry the BYTE-IDENTICAL
+    /// raw value: JSON's own string escaping already makes it safe there, and
+    /// escaping it a second time would corrupt the data for any consumer.
+    #[test]
+    fn reply_author_ansi_escapes_are_escaped_for_terminal_and_raw_in_json() {
+        let hostile = "\u{1b}[2J\rEve\u{7}";
+        let quote = ReplyContextDisplay::Quote {
+            author: hostile.to_string(),
+            author_id: "EVE123".to_string(),
+            message_id: "1".to_string(),
+            preview: "hi".to_string(),
+        };
+
+        let text = reply_prefix_display(&quote);
+        assert!(
+            !text.contains('\u{1b}') && !text.contains('\r') && !text.contains('\u{7}'),
+            "raw control bytes must not reach the terminal: {text:?}"
+        );
+        assert_eq!(
+            text,
+            format!(
+                "[reply to {}: hi] ",
+                crate::deputies::display_nickname(hostile)
+            )
+        );
+
+        let json = reply_to_json(&quote).unwrap();
+        assert_eq!(
+            json["author"], hostile,
+            "the JSON path must carry the raw nickname byte-for-byte"
+        );
     }
 }
 
@@ -10673,5 +10740,49 @@ pub(crate) fn unseal_nickname_display(",
     #[test]
     fn pin_accepts_the_unmutated_source() {
         assert!(membership_guard_violations(include_str!("api.rs")).is_empty());
+    }
+
+    /// `output_reaction_change`, `output_deletion`, and `output_message` each
+    /// resolve a member's nickname (attacker-controlled — any room member sets
+    /// their own, freenet/river#474) and print it to BOTH a human terminal
+    /// line and a JSON field. The human line must escape it via
+    /// `display_nickname`; the JSON field must stay raw (JSON's own string
+    /// escaping already makes it safe there, and escaping it again would
+    /// corrupt the value for a bridge/consumer). Reuses `production_source`
+    /// (defined above in this module) so `#[cfg(test)]` content — including
+    /// this test's own literals — cannot satisfy the counts.
+    #[test]
+    fn terminal_nickname_sites_escape_human_output_and_leave_json_raw() {
+        let p = production_source(include_str!("api.rs"));
+        assert!(p.problems.is_empty(), "{:?}", p.problems);
+        let src = &p.source;
+
+        // `output_reaction_change` and `output_deletion` share the same
+        // shape: escape a *derived* `display_name`, never the shared
+        // `nickname` variable the JSON arm also reads.
+        assert_eq!(
+            src.matches("let display_name = crate::deputies::display_nickname(&display_name);")
+                .count(),
+            2,
+            "expected exactly one escaped human display_name in each of \
+             output_reaction_change and output_deletion"
+        );
+        // `output_message`'s human branch makes its own separate
+        // `unseal_nickname_display` call (distinct from the JSON branch's),
+        // so it can be escaped inline.
+        assert_eq!(
+            src.matches("crate::deputies::display_nickname(&unseal_nickname_display(")
+                .count(),
+            1,
+            "expected output_message's human branch to escape its own nickname call"
+        );
+        // All three JSON arms must still emit the nickname UNescaped.
+        assert_eq!(
+            src.matches("\"nickname\": nickname,").count(),
+            3,
+            "expected output_reaction_change, output_deletion, and \
+             output_message to each emit the nickname raw in their JSON arm; \
+             the pin would pass vacuously if this drifted to 0"
+        );
     }
 }

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -710,7 +710,35 @@ pub(crate) fn message_display_text_with_secrets(
     msg: &river_core::room_state::message::AuthorizedMessageV1,
     secrets: &HashMap<u32, [u8; 32]>,
 ) -> String {
-    let raw = room_state
+    render_mentions_for_terminal(room_state, &raw_message_body_text(room_state, msg, secrets))
+}
+
+/// Like [`message_display_text_with_secrets`], but escapes every substituted
+/// `@mention` nickname for terminal output (freenet/river#474). ONLY for a
+/// human/terminal println — never for JSON or persistence, since a mentioned
+/// member's nickname is attacker-controlled and escaping it would corrupt the
+/// byte-for-byte contract those paths depend on.
+pub(crate) fn message_display_text_for_terminal(
+    room_state: &ChatRoomStateV1,
+    msg: &river_core::room_state::message::AuthorizedMessageV1,
+    secrets: &HashMap<u32, [u8; 32]>,
+) -> String {
+    render_mentions_for_terminal_escaped(
+        room_state,
+        &raw_message_body_text(room_state, msg, secrets),
+    )
+}
+
+/// Decrypt/decode a message's display body, WITHOUT yet resolving `@mention`
+/// tokens — shared by [`message_display_text_with_secrets`] and
+/// [`message_display_text_for_terminal`] so the two differ only in whether the
+/// substituted mention name gets escaped, never in body resolution.
+fn raw_message_body_text(
+    room_state: &ChatRoomStateV1,
+    msg: &river_core::room_state::message::AuthorizedMessageV1,
+    secrets: &HashMap<u32, [u8; 32]>,
+) -> String {
+    room_state
         .recent_messages
         .effective_text(msg)
         .or_else(|| decrypt_private_body_text(&msg.message.content, secrets))
@@ -720,8 +748,7 @@ pub(crate) fn message_display_text_with_secrets(
                 .decode_content()
                 .map(|decoded| decoded.to_display_string())
                 .unwrap_or_else(|| "<encrypted>".to_string())
-        });
-    render_mentions_for_terminal(room_state, &raw)
+        })
 }
 
 /// Decrypt a **private** message body to its display text, mirroring the UI's
@@ -766,28 +793,60 @@ fn decrypt_private_body_text(
     Some(String::from_utf8_lossy(&plaintext).to_string())
 }
 
+/// Resolve a mention token's member_id to its *current* public nickname, for
+/// [`render_mentions_for_terminal`] / [`render_mentions_for_terminal_escaped`].
+/// Shared so the two renderers cannot drift on WHICH name is substituted —
+/// only on whether it gets escaped afterward.
+fn resolve_mention_nickname(
+    room_state: &ChatRoomStateV1,
+    r: &river_core::mention::MemberRef,
+) -> Option<String> {
+    // Resolve the mention token to a member_id first (identity lookup,
+    // not a content read — safe to leave as a bare `.find()`), then fetch
+    // that member's CANONICAL record for the nickname. A bare `.find()`
+    // straight to the nickname could return a losing (e.g. stale) duplicate
+    // record if the state holds more than one (#411 round 8 item A).
+    room_state
+        .member_info
+        .member_info
+        .iter()
+        .find(|info| r.matches(info.member_info.member_id))
+        .map(|info| info.member_info.member_id)
+        .and_then(|id| room_state.member_info.canonical(id))
+        .and_then(|info| info.member_info.preferred_nickname.as_public_bytes())
+        .map(|bytes| String::from_utf8_lossy(bytes).to_string())
+}
+
 /// Replace `@[name](rv:id)` mention tokens with `@<name>` for terminal display.
 /// Prefers each member's *current* public nickname (so the rendered name
 /// follows renames); falls back to the token's snapshot name when the member is
 /// unknown or their nickname is encrypted (riverctl does not decrypt
 /// private-room nicknames). Plain text without tokens is returned unchanged.
+///
+/// The substituted name — resolved OR snapshot fallback — is NOT escaped here.
+/// This is shared with the JSON/persistence path (see
+/// [`message_display_text_with_secrets`]), so escaping it would corrupt that
+/// byte-for-byte contract. For a human/terminal-only println, use
+/// [`render_mentions_for_terminal_escaped`] instead.
 pub(crate) fn render_mentions_for_terminal(room_state: &ChatRoomStateV1, text: &str) -> String {
-    river_core::mention::render_plaintext(text, |r| {
-        // Resolve the mention token to a member_id first (identity lookup,
-        // not a content read — safe to leave as a bare `.find()`), then fetch
-        // that member's CANONICAL record for the nickname. A bare `.find()`
-        // straight to the nickname could return a losing (e.g. stale) duplicate
-        // record if the state holds more than one (#411 round 8 item A).
-        room_state
-            .member_info
-            .member_info
-            .iter()
-            .find(|info| r.matches(info.member_info.member_id))
-            .map(|info| info.member_info.member_id)
-            .and_then(|id| room_state.member_info.canonical(id))
-            .and_then(|info| info.member_info.preferred_nickname.as_public_bytes())
-            .map(|bytes| String::from_utf8_lossy(bytes).to_string())
-    })
+    river_core::mention::render_plaintext(text, |r| resolve_mention_nickname(room_state, r))
+}
+
+/// Like [`render_mentions_for_terminal`], but escapes the substituted name —
+/// resolved live nickname OR the token's snapshot fallback, both attacker-
+/// controlled — via [`crate::deputies::display_nickname`] before splicing it
+/// in (freenet/river#474). ONLY for a human/terminal println; never for
+/// output that also feeds JSON or persistence, since escaping would corrupt
+/// that byte-for-byte contract.
+pub(crate) fn render_mentions_for_terminal_escaped(
+    room_state: &ChatRoomStateV1,
+    text: &str,
+) -> String {
+    river_core::mention::render_plaintext_transformed(
+        text,
+        |r| resolve_mention_nickname(room_state, r),
+        |name| crate::deputies::display_nickname(&name),
+    )
 }
 
 /// Resolve a member's `preferred_nickname` [`SealedBytes`] to its display
@@ -1023,7 +1082,15 @@ pub(crate) enum ReplyContextDisplay {
         author: String,
         author_id: String,
         message_id: String,
+        /// Faithful, unescaped preview — for JSON/bridge consumers and
+        /// anything persisted. A quoted message can itself `@mention` someone,
+        /// and that mentioned member's nickname is attacker-controlled, so
+        /// this must stay byte-identical to what a bridge already sees.
         preview: String,
+        /// The SAME preview, but with every substituted `@mention` nickname
+        /// escaped for terminal output (freenet/river#474). Human/terminal
+        /// output only — see [`reply_prefix_display`].
+        preview_for_terminal: String,
     },
 }
 
@@ -1146,6 +1213,9 @@ pub(crate) fn reply_context_display_with_secrets(
         author_id: target.message.author.to_string(),
         message_id: target.id().0 .0.to_string(),
         preview: truncate_reply_preview(&render_mentions_for_terminal(room_state, &text)),
+        preview_for_terminal: truncate_reply_preview(&render_mentions_for_terminal_escaped(
+            room_state, &text,
+        )),
     }
 }
 
@@ -1223,16 +1293,23 @@ fn decrypt_private_quote_text(
 pub(crate) fn reply_prefix_display(ctx: &ReplyContextDisplay) -> String {
     match ctx {
         ReplyContextDisplay::Quote {
-            author, preview, ..
+            author,
+            preview_for_terminal,
+            ..
         } => {
             // `author` is attacker-controlled (any member sets their own
             // nickname) and is the FAITHFUL decoded value shared with
             // `reply_to_json` — escape only here, at the terminal print site,
             // never at the shared source. See `display_nickname`.
+            //
+            // `preview_for_terminal` (rather than `preview`) because a quoted
+            // message can itself `@mention` someone, and that mentioned
+            // member's nickname is just as attacker-controlled as `author` —
+            // see `render_mentions_for_terminal_escaped` (freenet/river#474).
             format!(
                 "[reply to {}: {}] ",
                 crate::deputies::display_nickname(author),
-                preview
+                preview_for_terminal
             )
         }
         // The quoted message could not be read back — its author was banned and
@@ -1258,6 +1335,7 @@ pub(crate) fn reply_to_json(ctx: &ReplyContextDisplay) -> Option<serde_json::Val
             author_id,
             message_id,
             preview,
+            ..
         } => Some(json!({
             "author": author,
             "author_id": author_id,
@@ -5087,13 +5165,21 @@ impl ApiClient {
                     })
                     .unwrap_or_default();
 
+                // A message can itself `@mention` someone, and that mentioned
+                // member's nickname is attacker-controlled — a SEPARATE call
+                // from the shared `content` above (which the JSON arm below
+                // still uses raw), escaping only the substituted mention name
+                // for this println (freenet/river#474).
+                let content_for_terminal =
+                    message_display_text_for_terminal(room_state, msg, secrets);
+
                 println!(
                     "{}[{} - {}]: {}{}{}{}",
                     edit_prefix,
                     local_time.format("%H:%M:%S"),
                     nickname,
                     reply_prefix,
-                    content,
+                    content_for_terminal,
                     edited_indicator,
                     reactions_str
                 );
@@ -9417,6 +9503,148 @@ mod mention_cli_tests {
         assert_eq!(message_display_text(&state, &msg), "hi @Alice");
     }
 
+    // --- render_mentions_for_terminal_escaped (freenet/river#474) ---
+    //
+    // A mentioned member's nickname is exactly as attacker-controlled as the
+    // message author's: any member can set it, and a message mentioning them
+    // splices it into terminal output the same way the author's name does.
+    // One attacker, no second party needed — set your own nickname to a
+    // hostile payload and mention yourself.
+
+    #[test]
+    fn render_escaped_escapes_the_resolved_live_nickname() {
+        let eve = SigningKey::from_bytes(&[3u8; 32]);
+        let hostile = "\u{1b}[2J\rEve\u{7}";
+        let state = state_with_members(&[(eve.clone(), SealedBytes::public(hostile.into()))]);
+        let text = format!("hey {}", encode_mention(member_id(&eve), "OldName"));
+
+        let unescaped = render_mentions_for_terminal(&state, &text);
+        assert_eq!(
+            unescaped,
+            format!("hey @{hostile}"),
+            "sanity: the raw (JSON/persistence) path is unaffected by this fix"
+        );
+
+        let escaped = render_mentions_for_terminal_escaped(&state, &text);
+        assert!(
+            !escaped.contains('\u{1b}') && !escaped.contains('\r') && !escaped.contains('\u{7}'),
+            "raw control bytes must not reach the terminal: {escaped:?}"
+        );
+        assert_eq!(
+            escaped,
+            format!("hey @{}", crate::deputies::display_nickname(hostile))
+        );
+    }
+
+    /// The snapshot-fallback branch (unknown member, or a private-room
+    /// nickname `render_mentions_for_terminal` never decrypts) is JUST AS
+    /// attacker-controlled as the resolved-live-nickname branch above: the
+    /// token's `display_name` is whatever bytes sit between `[` and `]` in
+    /// the wire token, which `try_parse_token_at` accepts with no charset
+    /// restriction. The token is built BY HAND here, not via `encode_mention`
+    /// — that helper's own `sanitize_name` strips control characters at
+    /// AUTHORING time, which is exactly the gap: a hostile client (or a
+    /// stdlib bump that changes the outgoing encoder) can put a raw token on
+    /// the wire directly, and the PARSER must not depend on the encoder
+    /// having been polite.
+    #[test]
+    fn render_escaped_escapes_the_snapshot_fallback_name_too() {
+        let ghost = SigningKey::from_bytes(&[9u8; 32]); // not in room state
+        let hostile = "\u{1b}[2J\rGhost\u{7}";
+        let state = state_with_members(&[]);
+        let text = format!(
+            "hey @[{hostile}]({}{})",
+            river_core::mention::REF_SCHEME,
+            river_core::mention::member_id_to_short(member_id(&ghost))
+        );
+
+        let escaped = render_mentions_for_terminal_escaped(&state, &text);
+        assert!(
+            !escaped.contains('\u{1b}') && !escaped.contains('\r') && !escaped.contains('\u{7}'),
+            "raw control bytes in the snapshot fallback must not reach the \
+             terminal: {escaped:?}"
+        );
+        assert_eq!(
+            escaped,
+            format!("hey @{}", crate::deputies::display_nickname(hostile))
+        );
+    }
+
+    /// End-to-end through the message-display helpers actually wired into
+    /// `output_message` / `message list`: a message mentioning a member whose
+    /// LIVE nickname is an ANSI/CR/bell payload must render escaped through
+    /// `message_display_text_for_terminal` (the human path), while
+    /// `message_display_text_with_secrets` (the JSON/persistence path) must
+    /// stay byte-identical to the raw mention substitution — mirroring the
+    /// author/JSON split this whole PR is built on.
+    #[test]
+    fn message_display_text_for_terminal_escapes_mentioned_nickname_json_stays_raw() {
+        let eve = SigningKey::from_bytes(&[3u8; 32]);
+        let hostile = "\u{1b}[2J\rEve\u{7}";
+        let state = state_with_members(&[(eve.clone(), SealedBytes::public(hostile.into()))]);
+        let msg = msg_with_text(format!("hi {}", encode_mention(member_id(&eve), "OldName")));
+
+        let terminal = message_display_text_for_terminal(&state, &msg, &HashMap::new());
+        assert!(
+            !terminal.contains('\u{1b}') && !terminal.contains('\r') && !terminal.contains('\u{7}'),
+            "raw control bytes must not reach the terminal: {terminal:?}"
+        );
+
+        let json_path = message_display_text_with_secrets(&state, &msg, &HashMap::new());
+        assert_eq!(
+            json_path,
+            format!("hi @{hostile}"),
+            "the JSON/persistence path must carry the raw mentioned nickname \
+             byte-for-byte"
+        );
+    }
+
+    /// A REPLY's preview goes through mention rendering too (it quotes
+    /// another message's text), so the third injection site — the quoted
+    /// message mentions the hostile-nicknamed member — must also be closed.
+    /// `reply_prefix_display` (terminal) must escape it via
+    /// `preview_for_terminal`; `reply_to_json` (JSON/bridge) must keep the
+    /// raw `preview` byte-identical.
+    #[test]
+    fn reply_preview_escapes_mentioned_nickname_for_terminal_json_stays_raw() {
+        let bob = SigningKey::from_bytes(&[4u8; 32]);
+        let eve = SigningKey::from_bytes(&[3u8; 32]);
+        let hostile = "\u{1b}[2J\rEve\u{7}";
+        let mut state = state_with_members(&[(eve.clone(), SealedBytes::public(hostile.into()))]);
+        let reply = reply_quoting(
+            &mut state,
+            &bob,
+            &format!("see {}", encode_mention(member_id(&eve), "OldName")),
+        );
+
+        let ctx = reply_context_display(&state, &reply);
+        let ReplyContextDisplay::Quote {
+            preview,
+            preview_for_terminal,
+            ..
+        } = &ctx
+        else {
+            panic!("expected a resolved quote, got {ctx:?}");
+        };
+        assert_eq!(
+            preview,
+            &format!("see @{hostile}"),
+            "the JSON/persistence preview must carry the raw mentioned \
+             nickname byte-for-byte"
+        );
+
+        let terminal = reply_prefix_display(&ctx);
+        assert!(
+            !terminal.contains('\u{1b}') && !terminal.contains('\r') && !terminal.contains('\u{7}'),
+            "raw control bytes in a reply preview's mention must not reach \
+             the terminal: {terminal:?}"
+        );
+        assert_eq!(
+            preview_for_terminal,
+            &format!("see @{}", crate::deputies::display_nickname(hostile))
+        );
+    }
+
     #[test]
     fn reply_context_display_renders_mention_in_preview() {
         let alice = SigningKey::from_bytes(&[1u8; 32]);
@@ -9729,6 +9957,7 @@ mod mention_cli_tests {
             author_id: "ALICE123".to_string(),
             message_id: "42".to_string(),
             preview: "hello".to_string(),
+            preview_for_terminal: "hello".to_string(),
         };
         // Escaped and quoted for the terminal (freenet/river#474) — see
         // `display_nickname`. The JSON author below stays the bare string.
@@ -9771,6 +10000,7 @@ mod mention_cli_tests {
             author_id: "EVE123".to_string(),
             message_id: "1".to_string(),
             preview: "hi".to_string(),
+            preview_for_terminal: "hi".to_string(),
         };
 
         let text = reply_prefix_display(&quote);

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -5167,8 +5167,8 @@ impl ApiClient {
 
                 // A message can itself `@mention` someone, and that mentioned
                 // member's nickname is attacker-controlled — a SEPARATE call
-                // from the shared `content` above (which the JSON arm below
-                // still uses raw), escaping only the substituted mention name
+                // from the JSON arm's own `content` below (which still uses
+                // the raw helper), escaping only the substituted mention name
                 // for this println (freenet/river#474).
                 let content_for_terminal =
                     message_display_text_for_terminal(room_state, msg, secrets);

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -710,7 +710,7 @@ pub(crate) fn message_display_text_with_secrets(
     msg: &river_core::room_state::message::AuthorizedMessageV1,
     secrets: &HashMap<u32, [u8; 32]>,
 ) -> String {
-    render_mentions_for_terminal(room_state, &raw_message_body_text(room_state, msg, secrets))
+    render_mentions_raw(room_state, &raw_message_body_text(room_state, msg, secrets))
 }
 
 /// Like [`message_display_text_with_secrets`], but escapes every substituted
@@ -794,7 +794,7 @@ fn decrypt_private_body_text(
 }
 
 /// Resolve a mention token's member_id to its *current* public nickname, for
-/// [`render_mentions_for_terminal`] / [`render_mentions_for_terminal_escaped`].
+/// [`render_mentions_raw`] / [`render_mentions_for_terminal_escaped`].
 /// Shared so the two renderers cannot drift on WHICH name is substituted —
 /// only on whether it gets escaped afterward.
 fn resolve_mention_nickname(
@@ -817,25 +817,30 @@ fn resolve_mention_nickname(
         .map(|bytes| String::from_utf8_lossy(bytes).to_string())
 }
 
-/// Replace `@[name](rv:id)` mention tokens with `@<name>` for terminal display.
-/// Prefers each member's *current* public nickname (so the rendered name
-/// follows renames); falls back to the token's snapshot name when the member is
+/// Replace `@[name](rv:id)` mention tokens with `@<name>`. Prefers each
+/// member's *current* public nickname (so the rendered name follows
+/// renames); falls back to the token's snapshot name when the member is
 /// unknown or their nickname is encrypted (riverctl does not decrypt
 /// private-room nicknames). Plain text without tokens is returned unchanged.
 ///
-/// The substituted name — resolved OR snapshot fallback — is NOT escaped here.
-/// This is shared with the JSON/persistence path (see
+/// RAW — the substituted name, resolved OR snapshot fallback, is NOT escaped
+/// here. This feeds the JSON/persistence path (see
 /// [`message_display_text_with_secrets`]), so escaping it would corrupt that
-/// byte-for-byte contract. For a human/terminal-only println, use
-/// [`render_mentions_for_terminal_escaped`] instead.
-pub(crate) fn render_mentions_for_terminal(room_state: &ChatRoomStateV1, text: &str) -> String {
+/// byte-for-byte contract. Despite the name resembling "for terminal
+/// display", this is NOT safe to print directly: for a human/terminal-only
+/// println, use [`render_mentions_for_terminal_escaped`] instead.
+pub(crate) fn render_mentions_raw(room_state: &ChatRoomStateV1, text: &str) -> String {
     river_core::mention::render_plaintext(text, |r| resolve_mention_nickname(room_state, r))
 }
 
-/// Like [`render_mentions_for_terminal`], but escapes the substituted name —
+/// Like [`render_mentions_raw`], but escapes the substituted name —
 /// resolved live nickname OR the token's snapshot fallback, both attacker-
-/// controlled — via [`crate::deputies::display_nickname`] before splicing it
-/// in (freenet/river#474). ONLY for a human/terminal println; never for
+/// controlled — via [`crate::deputies::escape_nickname_inline`] before
+/// splicing it in (freenet/river#474). The NON-quoting sibling of
+/// `display_nickname` is deliberate here: this name lands in the MIDDLE of
+/// other text (a message body, a reply preview), not a standalone column, so
+/// the quoting that defends a column/label site would only cost legibility
+/// on every ordinary mention. ONLY for a human/terminal println; never for
 /// output that also feeds JSON or persistence, since escaping would corrupt
 /// that byte-for-byte contract.
 pub(crate) fn render_mentions_for_terminal_escaped(
@@ -845,7 +850,7 @@ pub(crate) fn render_mentions_for_terminal_escaped(
     river_core::mention::render_plaintext_transformed(
         text,
         |r| resolve_mention_nickname(room_state, r),
-        |name| crate::deputies::display_nickname(&name),
+        |name| crate::deputies::escape_nickname_inline(&name),
     )
 }
 
@@ -1212,7 +1217,7 @@ pub(crate) fn reply_context_display_with_secrets(
         author,
         author_id: target.message.author.to_string(),
         message_id: target.id().0 .0.to_string(),
-        preview: truncate_reply_preview(&render_mentions_for_terminal(room_state, &text)),
+        preview: truncate_reply_preview(&render_mentions_raw(room_state, &text)),
         preview_for_terminal: truncate_reply_preview(&render_mentions_for_terminal_escaped(
             room_state, &text,
         )),
@@ -5111,11 +5116,6 @@ impl ApiClient {
         is_edit: bool,
         secrets: &HashMap<u32, [u8; 32]>,
     ) -> Result<()> {
-        // Get display content (handles edits and non-text public content like
-        // join events; `secrets` decrypts private-room bodies — only a body
-        // whose secret is unavailable renders as "<encrypted>")
-        let content = message_display_text_with_secrets(room_state, msg, secrets);
-
         // Get message ID for checking edited status and reactions
         let msg_id = msg.id();
         let edited = room_state.recent_messages.is_edited(&msg_id);
@@ -5195,6 +5195,15 @@ impl ApiClient {
                     });
 
                 let datetime: DateTime<Utc> = msg.message.time.into();
+
+                // Get display content (handles edits and non-text public
+                // content like join events; `secrets` decrypts private-room
+                // bodies — only a body whose secret is unavailable renders as
+                // "<encrypted>"). Computed here, not before the `match`: the
+                // Human arm above uses its own `content_for_terminal` and
+                // never reads this raw value, so hoisting it would decrypt
+                // and mention-render the body a second time for nothing.
+                let content = message_display_text_with_secrets(room_state, msg, secrets);
 
                 let reactions_map: std::collections::HashMap<String, usize> = reactions
                     .map(|r| r.iter().map(|(k, v)| (k.clone(), v.len())).collect())
@@ -9475,7 +9484,7 @@ mod mention_cli_tests {
         assert_eq!(resolve_outgoing_mentions(&state, &token), token);
     }
 
-    // --- render_mentions_for_terminal (display path) ---
+    // --- render_mentions_raw (display path) ---
 
     #[test]
     fn render_uses_current_nickname_over_snapshot() {
@@ -9483,7 +9492,7 @@ mod mention_cli_tests {
         let state =
             state_with_members(&[(alice.clone(), SealedBytes::public(b"NewName".to_vec()))]);
         let text = format!("hey {}", encode_mention(member_id(&alice), "OldName"));
-        assert_eq!(render_mentions_for_terminal(&state, &text), "hey @NewName");
+        assert_eq!(render_mentions_raw(&state, &text), "hey @NewName");
     }
 
     #[test]
@@ -9491,7 +9500,7 @@ mod mention_cli_tests {
         let ghost = SigningKey::from_bytes(&[9u8; 32]);
         let state = state_with_members(&[]); // ghost not present
         let text = format!("hey {}", encode_mention(member_id(&ghost), "Ghost"));
-        assert_eq!(render_mentions_for_terminal(&state, &text), "hey @Ghost");
+        assert_eq!(render_mentions_raw(&state, &text), "hey @Ghost");
     }
 
     #[test]
@@ -9499,7 +9508,7 @@ mod mention_cli_tests {
         let alice = SigningKey::from_bytes(&[1u8; 32]);
         let state = state_with_members(&[(alice.clone(), SealedBytes::public(b"Alice".to_vec()))]);
         let msg = msg_with_text(format!("hi {}", encode_mention(member_id(&alice), "Alice")));
-        // The full display path wraps render_mentions_for_terminal.
+        // The full display path wraps render_mentions_raw.
         assert_eq!(message_display_text(&state, &msg), "hi @Alice");
     }
 
@@ -9518,7 +9527,7 @@ mod mention_cli_tests {
         let state = state_with_members(&[(eve.clone(), SealedBytes::public(hostile.into()))]);
         let text = format!("hey {}", encode_mention(member_id(&eve), "OldName"));
 
-        let unescaped = render_mentions_for_terminal(&state, &text);
+        let unescaped = render_mentions_raw(&state, &text);
         assert_eq!(
             unescaped,
             format!("hey @{hostile}"),
@@ -9532,12 +9541,12 @@ mod mention_cli_tests {
         );
         assert_eq!(
             escaped,
-            format!("hey @{}", crate::deputies::display_nickname(hostile))
+            format!("hey @{}", crate::deputies::escape_nickname_inline(hostile))
         );
     }
 
     /// The snapshot-fallback branch (unknown member, or a private-room
-    /// nickname `render_mentions_for_terminal` never decrypts) is JUST AS
+    /// nickname `render_mentions_raw` never decrypts) is JUST AS
     /// attacker-controlled as the resolved-live-nickname branch above: the
     /// token's `display_name` is whatever bytes sit between `[` and `]` in
     /// the wire token, which `try_parse_token_at` accepts with no charset
@@ -9566,7 +9575,7 @@ mod mention_cli_tests {
         );
         assert_eq!(
             escaped,
-            format!("hey @{}", crate::deputies::display_nickname(hostile))
+            format!("hey @{}", crate::deputies::escape_nickname_inline(hostile))
         );
     }
 
@@ -9641,7 +9650,7 @@ mod mention_cli_tests {
         );
         assert_eq!(
             preview_for_terminal,
-            &format!("see @{}", crate::deputies::display_nickname(hostile))
+            &format!("see @{}", crate::deputies::escape_nickname_inline(hostile))
         );
     }
 
@@ -11013,6 +11022,53 @@ pub(crate) fn unseal_nickname_display(",
             "expected output_reaction_change, output_deletion, and \
              output_message to each emit the nickname raw in their JSON arm; \
              the pin would pass vacuously if this drifted to 0"
+        );
+    }
+
+    /// This PR (freenet/river#474) exists because a `println!` path was
+    /// missed reaching for a RAW (unescaped) content/nickname helper — TWICE:
+    /// once for the direct author/nickname case, once for the `@mention`
+    /// substitution case. Rather than trust that every future `Human` arm
+    /// remembers to pick the escaped sibling, scan every
+    /// `OutputFormat::Human => { ... }` arm in production `api.rs` (brace-
+    /// matched via `end_of_item`, so nested braces/strings/comments can't
+    /// desynchronize the scan) and assert NONE of them calls either RAW
+    /// helper directly.
+    #[test]
+    fn human_output_arms_never_call_a_raw_content_or_mention_helper() {
+        const ANCHOR: &str = "OutputFormat::Human => {";
+        const RAW_HELPERS: [&str; 2] =
+            ["render_mentions_raw(", "message_display_text_with_secrets("];
+
+        let p = production_source(include_str!("api.rs"));
+        assert!(p.problems.is_empty(), "{:?}", p.problems);
+        let src = &p.source;
+
+        let mut idx = 0usize;
+        let mut arms_checked = 0usize;
+        while let Some(rel) = src[idx..].find(ANCHOR) {
+            let open_brace = idx + rel + ANCHOR.len() - 1; // index of the `{`
+            let len = end_of_item(&src[open_brace..]).unwrap_or_else(|| {
+                panic!("unterminated `OutputFormat::Human` arm at byte {open_brace}; the pin cannot scan it")
+            });
+            let body = &src[open_brace..open_brace + len];
+            for helper in RAW_HELPERS {
+                assert!(
+                    !body.contains(helper),
+                    "a Human println arm calls the RAW helper `{helper}` \
+                     directly -- this exact miss is what freenet/river#474 \
+                     was about, twice. Arm body:\n{body}"
+                );
+            }
+            arms_checked += 1;
+            idx = open_brace + len;
+        }
+        assert!(
+            arms_checked >= 3,
+            "expected to find every `OutputFormat::Human` arm in api.rs \
+             (output_message, output_reaction_change, output_deletion); \
+             found {arms_checked} -- the pin may be scanning the wrong \
+             region and would pass vacuously"
         );
     }
 }

--- a/cli/src/commands/dm.rs
+++ b/cli/src/commands/dm.rs
@@ -728,9 +728,13 @@ async fn execute_list(
             let mut peers: Vec<_> = by_peer.keys().copied().collect();
             peers.sort();
             for peer in peers {
+                // `nicknames` is shared with the JSON branch below (and stays
+                // raw there — JSON escaping already makes it safe); escape
+                // only for this terminal line.
                 let nickname = nicknames
                     .get(&peer)
                     .cloned()
+                    .map(|n| crate::deputies::display_nickname(&n))
                     .unwrap_or_else(|| short_member_id(&peer));
                 println!("--- DM thread with {} ({}) ---", nickname, peer);
                 let mut idx = 1usize;
@@ -1422,6 +1426,54 @@ fn format_unix_local(unix_secs: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `dm list`'s counterparty nickname is attacker-controlled (any room
+    /// member sets their own) — freenet/river#474. The HUMAN thread-header
+    /// println must escape it via `display_nickname` (ANSI/CR/bell must not
+    /// reach the terminal), while the JSON arm's `counterparty_nickname` must
+    /// stay raw: escaping it there would corrupt the value for a bridge, since
+    /// JSON's own string escaping already makes it safe. Both read the same
+    /// shared `nicknames` lookup map, so the escaping has to happen at each
+    /// print site, not at the map's construction.
+    ///
+    /// Source-scrape rather than behavioural: this file has no stdout-capture
+    /// harness. Anchored on `for peer in peers {` (unique, the loop that
+    /// computes AND prints the escaped nickname in the human branch) so the
+    /// human/json regions cannot be confused with the unrelated Human/Json
+    /// arms of other `dm` subcommands elsewhere in this file.
+    #[test]
+    fn dm_list_escapes_nickname_for_human_and_keeps_json_raw() {
+        let src = include_str!("dm.rs");
+        let production = &src[..src.find("mod tests").unwrap_or(src.len())];
+        let after_anchor = production
+            .split_once("for peer in peers {")
+            .map(|(_, after)| after)
+            .expect("loop anchor not found; the pin would scan nothing");
+        assert_eq!(
+            after_anchor.matches("OutputFormat::Json => {").count(),
+            1,
+            "split anchor must be unique past this point or the pin scrapes \
+             the wrong region"
+        );
+        let (human_region, json_region) = after_anchor
+            .split_once("OutputFormat::Json => {")
+            .expect("anchor not found; the pin would scan nothing");
+
+        assert!(
+            human_region.contains("display_nickname("),
+            "the dm list HUMAN branch must escape the counterparty nickname"
+        );
+        assert!(
+            json_region.contains("counterparty_nickname"),
+            "the dm list JSON branch must still emit the nickname field; \
+             the pin would pass vacuously otherwise"
+        );
+        assert!(
+            !json_region.contains("display_nickname("),
+            "the dm list JSON branch's nickname must stay raw — escaping it \
+             here would corrupt the value for a bridge/consumer"
+        );
+    }
 
     /// The DM send path must NOT carry a client-side per-pair cap guard.
     ///

--- a/cli/src/commands/dm.rs
+++ b/cli/src/commands/dm.rs
@@ -1441,6 +1441,14 @@ mod tests {
     /// computes AND prints the escaped nickname in the human branch) so the
     /// human/json regions cannot be confused with the unrelated Human/Json
     /// arms of other `dm` subcommands elsewhere in this file.
+    ///
+    /// The plain `.find("mod tests")` cut below (rather than the
+    /// `production_source` brace-aware stripper used elsewhere in this repo)
+    /// is only equivalent to it because this file has exactly ONE
+    /// `#[cfg(test)] mod tests` block, at the very end, with no earlier
+    /// `#[cfg(test)]` item. If an earlier `#[cfg(test)]` item is ever added
+    /// above this point, this cut would stop excluding it and the pin could
+    /// silently start matching against test-only code.
     #[test]
     fn dm_list_escapes_nickname_for_human_and_keeps_json_raw() {
         let src = include_str!("dm.rs");

--- a/cli/src/commands/message.rs
+++ b/cli/src/commands/message.rs
@@ -642,6 +642,15 @@ mod tests {
             human_region.contains("display_nickname("),
             "the message list HUMAN branch must escape the nickname"
         );
+        // Same failure mode this whole PR is about, closed a second time:
+        // the human branch must reach for the escaped content helper, never
+        // the raw one directly.
+        assert!(
+            !human_region.contains("message_display_text_with_secrets(")
+                && !human_region.contains("render_mentions_raw("),
+            "the message list HUMAN branch must not call a raw content/\
+             mention helper directly; use `message_display_text_for_terminal`"
+        );
         assert!(
             json_and_after.contains("unseal_nickname_display("),
             "the message list JSON branch must still resolve a nickname; \

--- a/cli/src/commands/message.rs
+++ b/cli/src/commands/message.rs
@@ -614,6 +614,14 @@ mod tests {
     /// list` (verified unique in production) so the human/json regions can't
     /// be confused with each other or with the unrelated Human/Json arms of
     /// the other `message` subcommands later in this file.
+    ///
+    /// The plain `.split_once("mod tests")` cut below (rather than the
+    /// `production_source` brace-aware stripper used elsewhere in this repo)
+    /// is only equivalent to it because this file has exactly ONE
+    /// `#[cfg(test)] mod tests` block, at the very end, with no earlier
+    /// `#[cfg(test)]` item. If an earlier `#[cfg(test)]` item is ever added
+    /// above this point, this cut would stop excluding it and the pin could
+    /// silently start matching against test-only code.
     #[test]
     fn message_list_escapes_nickname_for_human_and_keeps_json_raw() {
         let source = include_str!("message.rs");

--- a/cli/src/commands/message.rs
+++ b/cli/src/commands/message.rs
@@ -242,13 +242,21 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
                             // `canonical`, not a bare `.find()` (#411 round 8 item A): a
                             // duplicate-holding state could otherwise display a stale
                             // (e.g. revoked) record's nickname.
+                            //
+                            // Escaped for this HUMAN-only println below — the
+                            // JSON branch further down makes its own separate
+                            // `unseal_nickname_display` call and stays raw
+                            // (attacker-controlled nickname; JSON escaping
+                            // already makes it safe there).
                             let nickname = room_state
                                 .member_info
                                 .canonical(msg.message.author)
                                 .map(|info| {
-                                    crate::api::unseal_nickname_display(
-                                        &info.member_info.preferred_nickname,
-                                        &secrets,
+                                    crate::deputies::display_nickname(
+                                        &crate::api::unseal_nickname_display(
+                                            &info.member_info.preferred_nickname,
+                                            &secrets,
+                                        ),
                                     )
                                 })
                                 .unwrap_or(author_short);
@@ -588,6 +596,50 @@ fn parse_message_id(message_id: &str) -> Result<MessageId> {
 
 #[cfg(test)]
 mod tests {
+    /// `message list`'s nickname is attacker-controlled (any room member sets
+    /// their own) — freenet/river#474. The HUMAN println must escape it via
+    /// `display_nickname` (ANSI/CR/bell must not reach the terminal), while
+    /// the JSON arm's separate `unseal_nickname_display` call must stay raw:
+    /// escaping it there would corrupt the value for a bridge/consumer, since
+    /// JSON's own string escaping already makes it safe.
+    ///
+    /// Source-scrape, not a live round trip: this file has no stdout-capture
+    /// harness. Split on the unique `OutputFormat::Json => {` for `message
+    /// list` (verified unique in production) so the human/json regions can't
+    /// be confused with each other or with the unrelated Human/Json arms of
+    /// the other `message` subcommands later in this file.
+    #[test]
+    fn message_list_escapes_nickname_for_human_and_keeps_json_raw() {
+        let source = include_str!("message.rs");
+        let production = source
+            .split_once("mod tests")
+            .map(|(before, _)| before)
+            .expect("test module marker missing; the cut would scan everything");
+        assert_eq!(
+            production.matches("OutputFormat::Json => {").count(),
+            1,
+            "split anchor must be unique or this pin scrapes the wrong region"
+        );
+        let (human_region, json_and_after) = production
+            .split_once("OutputFormat::Json => {")
+            .expect("anchor not found; the pin would scan nothing");
+
+        assert!(
+            human_region.contains("display_nickname("),
+            "the message list HUMAN branch must escape the nickname"
+        );
+        assert!(
+            json_and_after.contains("unseal_nickname_display("),
+            "the message list JSON branch must still resolve a nickname; \
+             the pin would pass vacuously otherwise"
+        );
+        assert!(
+            !json_and_after.contains("display_nickname("),
+            "the message list JSON branch's nickname must stay raw — \
+             escaping it here would corrupt the value for a bridge/consumer"
+        );
+    }
+
     /// `message reply --format json` must return the new message's ID, and in
     /// the SAME form `message list` prints and `message delete` accepts.
     ///

--- a/cli/src/commands/message.rs
+++ b/cli/src/commands/message.rs
@@ -268,8 +268,14 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
                             // public content like join events, and — via
                             // `secrets` — decrypted private-room bodies; only a
                             // body whose secret is unavailable renders as
-                            // "<encrypted>")
-                            let content = crate::api::message_display_text_with_secrets(
+                            // "<encrypted>"). The `_for_terminal` variant also
+                            // escapes any `@mention` nickname substituted into
+                            // the text — a mentioned member's nickname is
+                            // attacker-controlled just like the author's
+                            // (freenet/river#474). The JSON arm below keeps its
+                            // own separate `message_display_text_with_secrets`
+                            // call and stays raw.
+                            let content = crate::api::message_display_text_for_terminal(
                                 &room_state,
                                 msg,
                                 &secrets,

--- a/cli/src/deputies.rs
+++ b/cli/src/deputies.rs
@@ -562,6 +562,31 @@ pub fn display_nickname(nickname: &str) -> String {
     format!("{:?}", nickname)
 }
 
+/// Like [`display_nickname`], but WITHOUT the surrounding quote pair — for
+/// splicing an escaped name into the MIDDLE of other text (e.g. an
+/// `@mention` substituted inline into a message or reply preview,
+/// freenet/river#474), rather than presenting it as a standalone row/column.
+///
+/// The quoting `display_nickname` adds is there to defend a COLUMN or LABEL
+/// site: a nickname of purely printable characters can otherwise forge a
+/// plausible second output row (see its doc comment). That defense does not
+/// transfer inline — inside a message body the attacker already controls
+/// every surrounding byte and can type a fake row as plain prose with no
+/// mention at all — so quoting there buys no security and costs legibility
+/// on every ordinary, non-hostile mention (`hey @"Alice" can you review?`).
+///
+/// Reuses the EXACT SAME escape table as `display_nickname` (`str`'s
+/// `Debug`), so this is not a second, hand-maintained escaping scheme: it is
+/// `display_nickname`'s output with the outer quote character trimmed off
+/// each end. `{:?}` on a `&str` always emits exactly one ASCII `"` at each
+/// end (never doubled, never omitted), so trimming one byte from each side is
+/// exact — including on an empty name, where the two quote bytes are all
+/// there is.
+pub fn escape_nickname_inline(nickname: &str) -> String {
+    let quoted = display_nickname(nickname);
+    quoted[1..quoted.len() - 1].to_string()
+}
+
 /// Render a party as `"Nickname" (SHORTID)`, or `(unknown) (SHORTID)` when they
 /// have no `member_info` record in this room. The nickname is escaped and quoted
 /// by [`display_nickname`]; `(unknown)` is unquoted precisely so it cannot be
@@ -1313,6 +1338,52 @@ mod tests {
         assert_eq!(display_nickname("Ian Clarke"), "\"Ian Clarke\"");
         assert_eq!(display_nickname("O'Brien"), "\"O'Brien\"");
         assert_eq!(display_nickname("emoji \u{1f600}"), "\"emoji \u{1f600}\"");
+    }
+
+    /// `escape_nickname_inline` (freenet/river#474) must escape exactly the
+    /// same control/format/separator bytes as `display_nickname` — it is
+    /// `display_nickname`'s output with the outer quote pair trimmed, not a
+    /// second hand-maintained escaping scheme — but must NOT wrap the result
+    /// in quotes, since it is meant to sit inline inside other text (an
+    /// `@mention` substituted into a message or reply preview) rather than
+    /// stand as a labelled column.
+    #[test]
+    fn escape_nickname_inline_matches_display_nickname_minus_quotes() {
+        let hostile = "\u{1b}[2J\rEve\u{7}";
+        let quoted = display_nickname(hostile);
+        let inline = escape_nickname_inline(hostile);
+
+        assert!(
+            quoted.starts_with('"') && quoted.ends_with('"'),
+            "sanity: display_nickname always wraps in exactly one quote pair"
+        );
+        assert_eq!(
+            inline,
+            quoted[1..quoted.len() - 1],
+            "escape_nickname_inline must be display_nickname's escaping with \
+             only the surrounding quotes removed"
+        );
+        assert!(
+            !inline.starts_with('"') && !inline.ends_with('"'),
+            "escape_nickname_inline must not add its own quoting: {inline:?}"
+        );
+        for forbidden in ['\u{1b}', '\r', '\u{7}'] {
+            assert!(
+                !inline.contains(forbidden),
+                "{forbidden:?} must not survive into inline terminal output: {inline:?}"
+            );
+        }
+
+        // Ordinary names round-trip with no visible change at all — this is
+        // the property that makes it safe for EVERY ordinary @mention, not
+        // just hostile ones.
+        assert_eq!(escape_nickname_inline("Alice"), "Alice");
+
+        // The empty name is a genuine edge case (an empty nickname is a
+        // degenerate but not impossible resolved value): `display_nickname`
+        // produces exactly two quote characters and nothing else, so the
+        // inline form must be empty, not panic on an out-of-bounds slice.
+        assert_eq!(escape_nickname_inline(""), "");
     }
 
     #[test]

--- a/common/src/mention.rs
+++ b/common/src/mention.rs
@@ -295,9 +295,24 @@ pub fn contains_mention_of(text: &str, id: MemberId) -> bool {
 /// member's *current* display name (typically by scanning the room's members
 /// with [`MemberRef::matches`]); when it returns `None` the snapshot name in the
 /// token is used.
-pub fn render_plaintext<F>(text: &str, mut resolve: F) -> String
+pub fn render_plaintext<F>(text: &str, resolve: F) -> String
 where
     F: FnMut(&MemberRef) -> Option<String>,
+{
+    render_plaintext_transformed(text, resolve, |name| name)
+}
+
+/// Like [`render_plaintext`], but passes the CHOSEN name — the resolver's
+/// live-nickname result, OR (when it returns `None`) the token's own
+/// attacker-supplied snapshot `display_name` — through `transform` before
+/// splicing it into the output. Both sources are equally untrusted, so a
+/// caller that needs to sanitize a substituted name (e.g. escaping terminal
+/// control bytes, freenet/river#474) must transform AFTER the fallback, not
+/// inside `resolve`, or the snapshot-fallback branch stays unsanitized.
+pub fn render_plaintext_transformed<F, T>(text: &str, mut resolve: F, mut transform: T) -> String
+where
+    F: FnMut(&MemberRef) -> Option<String>,
+    T: FnMut(String) -> String,
 {
     let mut out = String::with_capacity(text.len());
     for seg in parse_segments(text) {
@@ -306,7 +321,7 @@ where
             MentionSegment::Mention(m) => {
                 let name = resolve(&m.member_ref).unwrap_or(m.display_name);
                 out.push('@');
-                out.push_str(&name);
+                out.push_str(&transform(name));
             }
         }
     }
@@ -731,5 +746,34 @@ mod tests {
         let text = format!("(see {}, thanks)", encode_mention(id, "Cat"));
         let rendered = render_plaintext(&text, |_| Some("Cat".to_string()));
         assert_eq!(rendered, "(see @Cat, thanks)");
+    }
+
+    /// `transform` must see the CHOSEN name — resolved OR the snapshot
+    /// fallback — not just the resolver's own `Some(...)` branch. A caller
+    /// (riverctl, freenet/river#474) uses this to sanitize a substituted name
+    /// for terminal output regardless of which branch produced it; a
+    /// transform wired only around `resolve` would silently skip the
+    /// fallback case.
+    #[test]
+    fn render_plaintext_transformed_applies_to_resolved_and_fallback_names_alike() {
+        let known = mid(1);
+        let unknown = mid(2);
+        let text = format!(
+            "hey {} and {}",
+            encode_mention(known, "OldName"),
+            encode_mention(unknown, "Ghost")
+        );
+        let rendered = render_plaintext_transformed(
+            &text,
+            |r| {
+                if r.matches(known) {
+                    Some("NewName".to_string())
+                } else {
+                    None
+                }
+            },
+            |name| format!("<{name}>"),
+        );
+        assert_eq!(rendered, "hey @<NewName> and @<Ghost>");
     }
 }


### PR DESCRIPTION
## Problem

`riverctl` prints member nicknames to the terminal unescaped at several sites outside the deputy commands. Nicknames are attacker-controlled — any room member sets their own — so an unescaped nickname can inject ANSI terminal escape sequences into an operator's terminal (e.g. to rewrite prior output, hide text via a bare `\r`, or sound a bell).

`unseal_nickname_display` (`cli/src/api.rs`) is a plain, unfiltered `String::from_utf8_lossy` with no escaping, and was called raw at the human-output sites in `api.rs` (reply quoting, reaction/deletion/message printing), `commands/message.rs` (`message list`), and `commands/dm.rs` (`dm list`).

A second injection path exists via `@mention` rendering: the mention-substitution renderer (`cli/src/api.rs`) substitutes a member's current nickname (or the wire token's own attacker-supplied snapshot name, when the member is unknown) into message/reply text with no escaping, and that text feeds the same human println sites. One attacker suffices — set your own nickname to a hostile payload and `@mention` yourself in a message or a reply.

An escape helper already existed and was already used correctly on the deputy surface: `display_nickname` (`cli/src/deputies.rs`), which quotes the nickname and escapes it via `{:?}` (covers control, format, and separator Unicode categories, not a hand-maintained range list).

**Scope statement:** this PR closes the nickname-injection surface (direct nickname printing and `@mention` substitution). Message bodies, DM bodies, reaction emoji, and room names/descriptions are ALSO attacker-controlled and printed raw, but that is a different vulnerability class — you can't `{:?}`-escape a message body without wrecking readability, so it needs a different fix shape. Deliberately not addressed here; Ian is deciding how that gets handled.

## Approach

Reuse `display_nickname`'s escape table at every identified terminal print site rather than inventing a second escaping scheme.

Went site by site because several sites share the *same* raw value with a JSON output field or a value persisted to contract state, and escaping those would corrupt the data:

**Escaped (terminal-only output) — direct nickname sites:**
- `api.rs::reply_prefix_display` — the `[reply to X: ...]` terminal quote prefix (a column/label site — kept quoted via `display_nickname`).
- `api.rs::output_reaction_change` / `output_deletion` — escape a *derived* `display_name` used only in the human `println!`; the shared `nickname` variable feeding the JSON `"nickname"` field is untouched.
- `api.rs::output_message` (human branch) — this branch makes its own separate `unseal_nickname_display` call distinct from the JSON branch's, so it's escaped inline.
- `commands/message.rs` (`message list`, human branch) — same shape as `output_message`.
- `commands/dm.rs` (`dm list`, human thread-header) — the shared `nicknames` lookup map is read by both the human and JSON branches; escaping happens at the print site, not at the map.

**Escaped (terminal-only output) — `@mention` rendering:**
- `common/src/mention.rs::render_plaintext` is split into a thin wrapper plus `render_plaintext_transformed`, which runs a `transform` closure over whichever name is substituted (resolved live nickname OR the token's own snapshot fallback) before splicing it in — the fallback matters because it's just as attacker-controlled, and the parser (unlike the outgoing encoder's `sanitize_name`) applies no charset restriction on read.
- `api.rs::render_mentions_for_terminal_escaped` is the terminal-only sibling of the raw renderer (renamed `render_mentions_raw` — see below), passing a NEW helper, `deputies::escape_nickname_inline`, as the transform.
- **`escape_nickname_inline` vs `display_nickname`:** an inline `@mention` sits in the MIDDLE of other text, not a standalone column, so the column-forgery argument that justifies `display_nickname`'s quoting doesn't transfer — inside a message body the attacker already controls every surrounding byte and can fake a row as plain prose with no mention at all. Quoting every ordinary mention (`hey @"Alice" can you review?`) would cost legibility for zero extra security. `escape_nickname_inline` reuses the exact same escape table (`display_nickname`'s `{:?}` output with the outer quote pair trimmed), so it isn't a second hand-maintained scheme.
- `api.rs::message_display_text_for_terminal` is the terminal-only sibling of `message_display_text_with_secrets`, sharing a common raw-body helper, that renders mentions through the escaped path. Wired into `output_message`'s human branch and `commands/message.rs`'s `message list` human branch.
- `ReplyContextDisplay::Quote` gained a `preview_for_terminal` field (mention-escaped) alongside the existing `preview` (raw, unchanged, used by `reply_to_json` and the persisted `ReplyContentV1`); `reply_prefix_display` now reads `preview_for_terminal`. **`preview_for_terminal` truncates AFTER escaping** — this is intentionally unchanged and safe: `truncate_reply_preview` takes 50 chars from text whose control bytes are already literal `\u{...}` sequences, so a mid-sequence cut yields harmless text like `...\u{1` and can never re-materialize a control byte. Accepted cosmetic residual, not something this PR fixes.

**Naming / robustness cleanup (from review):**
- The raw mention renderer was originally named `render_mentions_for_terminal` despite feeding JSON/persistence — actively misleading. Renamed to `render_mentions_raw`.
- Added a source-scrape pin, `human_output_arms_never_call_a_raw_content_or_mention_helper` (plus an extension of `message.rs`'s existing pin), asserting no `OutputFormat::Human` arm in `api.rs`/`message.rs` calls a raw helper (`render_mentions_raw` / `message_display_text_with_secrets`) directly. This PR exists because that exact mistake happened twice; the pin is there so a third miss fails CI instead of shipping.
- `output_message` computed the raw, unescaped `content` unconditionally before branching on format, but the Human arm only reads `content_for_terminal`. Moved the `content` binding into the `Json` arm, the only place that still reads it.

**Deliberately left raw:**
- `api.rs` (reply-send path) `target_author_name` — persisted into `ReplyContentV1.target_author_name` / contract state. Escaping here would corrupt the stored value for every future reader.
- `reply_to_json`'s `preview`/`author`, and the JSON arms of `output_reaction_change`, `output_deletion`, `output_message`, `message list`, and `dm list` — JSON's own string escaping already makes these safe, and a second escaping pass would corrupt the value for a bridge/consumer.
- `cli/src/deputies.rs` (deputy commands) and `commands/member.rs` (`member list`) were already correct before this PR and are unchanged.
- `commands/identity.rs` (`identity whoami`) prints a member's own `member_info` record read from network room state (`storage::self_identity_from` reads `room_info.state.member_info.canonical(member_id)`) — but the contract binds a non-owner's `member_info` to that member's own verifying key (`member_info.rs`, `verify_signature_with_key(&member.member.member_vk)`), so nobody else can author it. Out of scope for this attacker-controlled-*other-party* issue.

## Version bumps (required for this to actually ship)

- **`river-core` (workspace version) 0.1.19 → 0.1.20.** `render_plaintext_transformed` is new public API in `river-core`. `river-core` 0.1.19 is already published on crates.io; `cli/Cargo.toml` pins `river-core = { version = "=0.1.19", path = "../common", ... }`, and `cargo publish` strips the `path`, resolving against the published crate — which lacks the new function. Not caught by CI; only bites at publish time. Updated the `=0.1.19` pin to `=0.1.20` to match.
- **`riverctl` (`cli/Cargo.toml`) 0.2.11 → 0.2.12.** crates.io's max published riverctl version is also `0.2.11`, and the release workflow's `publish_if_needed` step skips an already-published version — so a `riverctl-v0.2.11` release tag would run fully green and publish nothing. This fix would never reach a user.
- **Deferred WASM re-key — no code change here, but flagging for whoever rebuilds next.** CI's `check-delegate-migration` / `check-room-contract-migration` pass on this PR, but only because they diff the COMMITTED `.wasm` files between base and head, and this PR touches no `.wasm` file — that is NOT evidence the version bump is WASM-neutral. It is not: rustc's `-C metadata` includes the crate version, and this repo has already measured that exact effect (`ui/src/components/app/chat_delegate.rs`, the V30/#571 `legacy_set_fingerprint_is_stable_across_codegen_changes` note: a river-core version bump alone re-keyed `chat_delegate.wasm` even though the functional change that motivated the bump was dead-code-eliminated from the delegate). Shipping a version-bump-only PR without an immediate WASM rebuild has precedent here (`b2654d1b`, `f3f6907e`, `f72b5a6c`), so this is not a blocker — but the next PR that legitimately rebuilds `chat_delegate.wasm` / `room_contract.wasm` inherits a re-key it did not cause, and will need a `legacy_delegates.toml` entry, a `common/legacy_room_contracts.toml` entry, and an updated `legacy_set_fingerprint` pin (currently `c43e66ee147e3739`).

## Testing

- `api.rs::reply_author_ansi_escapes_are_escaped_for_terminal_and_raw_in_json` — a nickname containing ANSI CSI (`\x1b[2J`), a bare CR, and a bell must render escaped (quoted) through `reply_prefix_display`, and remain byte-identical (raw) through `reply_to_json`.
- `api.rs::terminal_nickname_sites_escape_human_output_and_leave_json_raw`, `commands/message.rs::message_list_escapes_nickname_for_human_and_keeps_json_raw`, `commands/dm.rs::dm_list_escapes_nickname_for_human_and_keeps_json_raw` — source-scrape pins confirming each human branch escapes via `display_nickname` and each JSON branch stays raw.
- `api.rs::human_output_arms_never_call_a_raw_content_or_mention_helper` — brace-matched source-scrape (reusing the existing `production_source` / `end_of_item` infrastructure) asserting no `OutputFormat::Human` arm in `api.rs` calls a raw helper directly.
- `common/src/mention.rs::render_plaintext_transformed_applies_to_resolved_and_fallback_names_alike` — the transform hook fires for both the resolved and snapshot-fallback branches.
- `api.rs::render_escaped_escapes_the_resolved_live_nickname` / `render_escaped_escapes_the_snapshot_fallback_name_too` — both `render_mentions_for_terminal_escaped` branches escape (unquoted, inline form) a hostile payload; the fallback case is built by hand, not via `encode_mention`, since that helper's own `sanitize_name` would launder the payload before it reaches the parser.
- `api.rs::message_display_text_for_terminal_escapes_mentioned_nickname_json_stays_raw` and `reply_preview_escapes_mentioned_nickname_for_terminal_json_stays_raw` — end-to-end through the actual functions wired into `output_message` / `message list` / `reply_prefix_display`, confirming the human path escapes a mentioned member's hostile nickname while the JSON/persistence path stays byte-identical.
- `deputies.rs::escape_nickname_inline_matches_display_nickname_minus_quotes` — direct unit coverage: same escape table as `display_nickname`, no added quoting, ordinary names round-trip unchanged, empty-name edge case doesn't panic.
- Every behavioral test above was mutation-tested by hand (temporarily reverting the corresponding fix) to confirm it fails without the fix and passes with it, including the `human_output_arms_never_call_a_raw_content_or_mention_helper` pin and the un-quoting change.
- Updated the pre-existing `unverifiable_quotes_are_omitted_from_json_and_neutral_in_text` test, whose expected string pinned the old unescaped/unquoted terminal format.
- Full `cargo test -p riverctl --lib`: 347 passed, 0 failed. `cargo test -p river-core --features ecies,ecies-randomized,migration,mentions --lib`: 253 passed, 0 failed. `cargo fmt --check` clean on both crates.
- CI (this branch): `check-delegate-migration`, `check-room-contract-migration`, `check-pointer-freshness`, and `check-wasm-sync` all pass — see the "Version bumps" section above for why that's expected but not proof of WASM-neutrality.

Closes #474

[AI-assisted - Claude]
