### PR TITLE
fix(publish): read the network before signing the web container

### DIFF
--- a/.claude/rules/river-publish.md
+++ b/.claude/rules/river-publish.md
@@ -81,17 +81,21 @@ cargo fmt
 ```bash
 git add legacy_delegates.toml ui/public/contracts/ cli/contracts/
 git commit -m "fix: <description> with delegate migration"
-cargo make build
-cargo make compress-webapp
-cargo make publish-river  # bumps published-contract/contract-version.txt
+cargo make publish-river  # builds, signs, publishes, and verifies the result
 ```
+
+`publish-river` owns the whole sequence in one process, under one lock. Do NOT
+run `cargo make compress-webapp` or `cargo make sign-webapp` beforehand: each is
+a separate `cargo make` process, so `publish-river` re-runs them as
+dependencies — rebuilding the UI (which is not reproducible, so the archive
+changes) and advancing the version counter a second time for a single publish.
+That is where the gaps in the counter's history came from.
 
 ### Step 6: Commit the version bump, verify, and push
 
 ```bash
-# `cargo make sign-webapp` (run transitively by publish-river) incremented
-# the counter. Commit it together with whatever other changes the publish
-# included.
+# The publish advanced published-contract/contract-version.txt. Commit it
+# together with whatever other changes the publish included.
 git add published-contract/contract-version.txt
 git commit -m "chore: bump web-container version after publish"
 curl -s http://127.0.0.1:7509/v1/contract/web/raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv/ | head -5
@@ -116,7 +120,11 @@ and verifies it. Do not accept "the PUT returned OK": a publish at an
 already-used version is a no-op *success*, so the network will never tell you
 it was ignored.
 
-**Version policy:** the canonical source is `published-contract/contract-version.txt`, which `cargo make sign-webapp` increments and writes back each publish. NEVER base the version on wall-clock time (`date +%s / 60`) — the previous scheme bit us 2026-05-16 when the on-network version had drifted ahead of the timestamp-derived value. The counter file makes the version a strict monotonic local invariant; gaps are fine (the contract enforces monotonicity, not contiguity).
+**Version policy:** the counter at `published-contract/contract-version.txt` is local bookkeeping; the authority is the version **on the network**. `scripts/publish-web-container.sh` (which `cargo make publish-river` and `cargo make sign-webapp` both run) reads that version, verifies it under our own contract parameters, and signs at `max(counter, network) + 1`. NEVER base the version on wall-clock time (`date +%s / 60`) — that scheme bit us 2026-05-16 when the on-network version had drifted ahead of the timestamp-derived value. Gaps are fine (the contract enforces monotonicity, not contiguity).
+
+**Never reissue a version, and never roll the counter back.** 2026-08-04 (commit `1032d373`): a publish of version 30000377 reported `put timed out after 1 peer attempt(s)`, the counter was rolled back, and the retry rebuilt the UI — a *different* archive, because the build is not reproducible — signed it 30000377 again, and published it. The first PUT had landed. Two validly signed archives now existed at one version, and they do not converge: `update_state` rejects `version <= current` in **both** directions, and `summarize_state` emits only the u32 version, so anti-entropy between two split peers sees matching summaries and never heals. The second archive spreads because a peer new to the contract takes the initial-state bypass, which runs `validate_state` only. River self-heals at the next successful publish, so exposure is one release cycle — bounded, not harmless.
+
+The counter is therefore forward-only, and the publish script re-reads the state after publishing rather than trusting `fdev`'s exit code (a publish at an already-used version is a no-op *success*; a publish that reports a timeout may have landed). If a publish reports failure, **read the verdict block** — if it says PUBLISHED despite a non-zero fdev exit, do not retry.
 
 ## Two independent release surfaces
 

--- a/.claude/rules/river-publish.md
+++ b/.claude/rules/river-publish.md
@@ -76,11 +76,21 @@ cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync
 cargo fmt
 ```
 
-### Step 5: Commit, Build, and Publish
+### Step 5: Merge, then Build and Publish from main
+
+The web container is ONE contract key serving every River user, and there is no
+per-branch address to publish to instead — so the publish runs from a green
+`main`, never from the branch. `scripts/publish-web-container.sh` enforces this
+before it signs anything: clean tracked tree, on `main`, `HEAD == origin/main`,
+and CI green on that exact SHA (an empty list of runs is *not* green). It
+refuses otherwise. `RIVER_WC_ALLOW_UNPROVEN=1` skips the gate for one run; it
+is for an emergency you can justify, not for routine convenience.
 
 ```bash
 git add legacy_delegates.toml ui/public/contracts/ cli/contracts/
 git commit -m "fix: <description> with delegate migration"
+# open the PR, get it reviewed, wait for CI green, merge
+git checkout main && git pull
 cargo make publish-river  # builds, signs, publishes, and verifies the result
 ```
 
@@ -124,7 +134,9 @@ it was ignored.
 
 **Never reissue a version, and never roll the counter back.** 2026-08-04 (commit `1032d373`): a publish of version 30000377 reported `put timed out after 1 peer attempt(s)`, the counter was rolled back, and the retry rebuilt the UI — a *different* archive, because the build is not reproducible — signed it 30000377 again, and published it. The first PUT had landed. Two validly signed archives now existed at one version, and they do not converge: `update_state` rejects `version <= current` in **both** directions, and `summarize_state` emits only the u32 version, so anti-entropy between two split peers sees matching summaries and never heals. The second archive spreads because a peer new to the contract takes the initial-state bypass, which runs `validate_state` only. River self-heals at the next successful publish, so exposure is one release cycle — bounded, not harmless.
 
-The counter is therefore forward-only, and the publish script re-reads the state after publishing rather than trusting `fdev`'s exit code (a publish at an already-used version is a no-op *success*; a publish that reports a timeout may have landed). If a publish reports failure, **read the verdict block** — if it says PUBLISHED despite a non-zero fdev exit, do not retry.
+The counter is therefore forward-only, and the publish script re-reads the state after publishing rather than trusting `fdev`'s exit code. A zero exit says the node you published *through* accepted the PUT, not that the bytes users fetch are yours; and a publish that reports a timeout may have landed anyway, which is what 2026-08-04 actually was. If a publish reports failure, **read the verdict block** — if it says PUBLISHED despite a non-zero fdev exit, do not retry.
+
+Note the web container does **not** behave like the pointer contract here. An earlier version of this file said a web-container publish at an already-used version is a "no-op success"; that is wrong. `update_state` returns `InvalidUpdateWithInfo` for `version <= current` and freenet-core surfaces a failed PutResponse as an error to the publishing node — which is how the 2026-08-04 operator saw `New state version 30000377 must be higher than current version 30000377` at all. The silent-stale-update property belongs to the **pointer** contract (step 7 above), by design, and does not carry across.
 
 ## Two independent release surfaces
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,6 +278,30 @@ jobs:
       # tool and the verifying contract agree on the parameter encoding.
       run: cargo test -p web-container-contract -p web-container-tool
 
+    - name: Test web-container publish decisions
+      # The publish path cannot be rehearsed in CI — it needs a live network,
+      # and testing against the shared production contract is out of bounds. So
+      # the decisions it turns on (which version to sign at, whether an
+      # unreadable network may be published over, whether a publish actually
+      # landed) live in scripts/web-container-publish-lib.sh with no I/O in
+      # them, and this runs every branch with stubbed inputs. Without this step
+      # the file would be exactly the "tests nothing ever runs" shape the
+      # coverage guard above exists to prevent, just outside Cargo's reach.
+      run: ./scripts/tests/web-container-publish-lib-test.sh
+
+    - name: Rehearse the web-container publish against a stub node
+      env:
+        CARGO_TARGET_DIR: ${{ github.workspace }}/target
+      # Runs the REAL publish script and the REAL web-container-tool against a
+      # throwaway repo layout, a throwaway signing key and an `fdev` that is a
+      # shell script — including the 2026-08-04 shape (a publish that reports a
+      # timeout and lands anyway). This is the only coverage of the wiring:
+      # fdev argument order, the `Contract not found` string absence is keyed
+      # off, the `version=` line the script parses, and whether the verdict
+      # comes from the read-back rather than the exit code. It never touches
+      # the network or the production key.
+      run: ./scripts/tests/web-container-publish-rehearsal.sh
+
   ui-playwright-tests:
     # Ubicloud, NOT a GitHub-hosted larger runner -- see the `build` job above.
     runs-on: ubicloud-standard-8

--- a/.gitignore
+++ b/.gitignore
@@ -55,9 +55,10 @@ ui/tests/test-results/
 # an older checkout cannot be committed by accident.
 /published-contract/contract-version.txt.prev
 
-# Single-writer lock for the web-container publish. Two concurrent publishes
-# race the version counter.
-/published-contract/.publish.lock
+# (The single-writer lock for the web-container publish is deliberately NOT
+# here. It lives at $XDG_RUNTIME_DIR/river-web-container-<contract-id>.lock,
+# outside the checkout: a lock inside the repo gives two worktrees two
+# different lock files and serialises nothing.)
 
 # Syncthing in-flight transfer files (`.syncthing.<name>.tmp` are
 # created by the syncthing daemon while a file is being received).

--- a/.gitignore
+++ b/.gitignore
@@ -48,11 +48,16 @@ ui/tests/test-results/
 # Manual e2e test screenshots (see #244 review feedback)
 /dm-*.png
 
-# Web-container version-counter rollback snapshot. Created by
-# `cargo make sign-webapp` BEFORE bumping the counter; removed on
-# successful publish, or moved back over the counter on failure.
-# Should never appear in commits.
+# Web-container version-counter rollback snapshot. No longer written — the
+# counter is forward-only now, because rolling it back after a publish that had
+# actually landed is what forked the site on 2026-08-04 (see
+# scripts/publish-web-container.sh). Kept ignored so a stale one left over from
+# an older checkout cannot be committed by accident.
 /published-contract/contract-version.txt.prev
+
+# Single-writer lock for the web-container publish. Two concurrent publishes
+# race the version counter.
+/published-contract/.publish.lock
 
 # Syncthing in-flight transfer files (`.syncthing.<name>.tmp` are
 # created by the syncthing daemon while a file is being received).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,10 +188,15 @@ artifacts.
 
 Two things that follow from that, and matter if a publish goes wrong:
 
-- **`fdev`'s exit code decides nothing.** A publish at an already-used
-  version is a no-op *success*, and a publish that reports a timeout may
-  have landed anyway. Read the script's verdict block, not the exit status
-  of the publish inside it.
+- **`fdev`'s exit code decides nothing.** A zero exit says the node you
+  published *through* accepted the PUT, not that the bytes users fetch are
+  yours; and a publish that reports a timeout may have landed anyway, which
+  is what 2026-08-04 actually was. Read the script's verdict block, not the
+  exit status of the publish inside it. (The web container does **not**
+  silently accept a stale update: `update_state` returns
+  `InvalidUpdateWithInfo` for `version <= current`, which is how the
+  2026-08-04 operator saw the rejection message. That no-op-success property
+  belongs to the *pointer* contract, by design.)
 - **Never retry a publish by re-signing at the same version, and never roll
   the counter back.** The counter is forward-only on purpose; gaps are fine
   (the contract enforces monotonicity, not contiguity). Reissuing a version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,9 +179,25 @@ cargo make publish-river                    # Publish UI release build to Freene
 The web container contract requires signed metadata with a version
 number strictly higher than the current published version. The version
 is tracked by a committed counter at
-`published-contract/contract-version.txt`; `cargo make sign-webapp`
-increments it. Commit the bumped counter alongside other publish
+`published-contract/contract-version.txt`, but the counter is bookkeeping,
+not the authority: `scripts/publish-web-container.sh` READS the version on
+the network before signing and signs at `max(counter, network) + 1`, then
+re-reads after publishing and compares the archive byte for byte before
+declaring success. Commit the bumped counter alongside other publish
 artifacts.
+
+Two things that follow from that, and matter if a publish goes wrong:
+
+- **`fdev`'s exit code decides nothing.** A publish at an already-used
+  version is a no-op *success*, and a publish that reports a timeout may
+  have landed anyway. Read the script's verdict block, not the exit status
+  of the publish inside it.
+- **Never retry a publish by re-signing at the same version, and never roll
+  the counter back.** The counter is forward-only on purpose; gaps are fine
+  (the contract enforces monotonicity, not contiguity). Reissuing a version
+  that may already be in use forked the site on 2026-08-04 — two validly
+  signed archives at version 30000377, which the update gate cannot converge
+  and anti-entropy cannot even see.
 
 **Contract ID:** `raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv`
 

--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -27,9 +27,14 @@ River is a decentralized chat application built on Freenet with the following ke
 ## Deployment Process
 
 1. **Build the UI:** `cargo make build-ui`
-2. **Compress the webapp:** `cargo make compress-webapp`
-3. **Sign the webapp:** `cargo make sign-webapp`
-4. **Publish to Freenet:** `cargo make publish-river`
+2. **Publish to Freenet:** `cargo make publish-river`
+
+`publish-river` builds, compresses, signs and publishes in one process, then
+reads the state back off the network to check it actually landed. Do not run
+`cargo make sign-webapp` first: it is a separate `cargo make` process, so
+`publish-river` would build and sign a second time, and the version counter
+would advance twice for one publish. The full workflow, including the
+delegate-migration coupling, is in `.claude/rules/river-publish.md`.
 
 ## Testing Challenges
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -200,50 +200,29 @@ tar -cJf ../../../../../webapp/webapp.tar.xz *
 '''
 
 [tasks.sign-webapp]
-description = "Sign the compressed webapp"
+# The version counter committed at published-contract/contract-version.txt is
+# still the local bookkeeping (the previous `seconds/60` timestamp scheme was
+# abandoned after the 2026-05-16 incident: the on-network version had drifted
+# to 30000208 while the timestamp gave 29649402, so publishes were rejected
+# with no way to catch up). What changed is that the counter is no longer
+# TRUSTED. The version signed here is
+#
+#     max(local counter, version currently on the network) + 1
+#
+# with the on-network version READ from the network and verified under our own
+# contract parameters before signing. It is also forward-only — nothing rolls
+# the counter back any more, because the rollback is what caused the 2026-08-04
+# fork (River commit 1032d373): a timed-out publish that had actually landed
+# was rolled back, and the retry re-signed a DIFFERENT archive at the same
+# version. Two states at one version never converge.
+#
+# All of it, including the flock the old comment here asked for and nothing
+# ever added, lives in scripts/publish-web-container.sh. Read that file's
+# header before changing any of this.
+description = "Sign the compressed webapp at a version proven to be above the network's"
 dependencies = ["compress-webapp", "build-web-container-tool", "build-web-container"]
 script = '''
-# Bump the version counter committed at published-contract/contract-version.txt
-# and use that as the metadata version. The previous `seconds/60` timestamp
-# scheme was fragile — if any past publish ever ran with a clock skewed
-# ahead (or someone hand-bumped to a future round number), the on-network
-# version is stuck ahead and the timestamp-derived value can't catch up
-# without manual intervention. 2026-05-16 incident: the on-network version
-# was 30000208 while the timestamp gave 29649402, so the publish was
-# rejected.
-#
-# Counter lifecycle:
-# 1. `sign-webapp` here writes a `.prev-version` snapshot BEFORE bumping
-#    the counter file, so a downstream `publish-river` failure can roll
-#    back atomically (see [tasks.publish-river]'s `on-failure` arm).
-# 2. The counter file is bumped to `current+1` and the new metadata is
-#    signed with that value.
-# 3. After a successful `fdev publish`, the caller commits the bumped
-#    counter file (the snapshot is left for the publish task to clean
-#    up). Skeptical-review (#258) flagged that bumping before publish
-#    risks leaving the local file ahead of on-network if publish fails;
-#    the .prev-version snapshot + rollback closes that window.
-#
-# Locking: this script is NOT safe under two parallel `publish-river`
-# runs on the same workstation — they would race the read-modify-write.
-# Wrap in `flock` if you need that:
-#     flock published-contract/contract-version.txt cargo make publish-river
-version_file="published-contract/contract-version.txt"
-prev_snapshot="$version_file.prev"
-if [ ! -f "$version_file" ]; then
-    echo "ERROR: $version_file missing. Seed it with the current on-network version."
-    exit 1
-fi
-current=$(cat "$version_file" | tr -d '[:space:]')
-version=$((current + 1))
-cp "$version_file" "$prev_snapshot"
-echo "$version" > "$version_file"
-echo "Web-container version: $current -> $version (commit $version_file after a successful publish)"
-target/native/x86_64-unknown-linux-gnu/${BUILD_PROFILE}/web-container-tool sign \
-  --input target/webapp/webapp.tar.xz \
-  --output target/webapp/webapp.metadata \
-  --parameters target/webapp/webapp.parameters \
-  --version $version
+exec ./scripts/publish-web-container.sh --sign-only
 '''
 
 [tasks.build-ui-example]
@@ -328,9 +307,21 @@ cd ui/tests && npm install && npx playwright install --with-deps chromium firefo
 '''
 
 [tasks.update-published-contract]
-description = "Build, publish, and update the published contract files"
-dependencies = ["sign-webapp"]
+description = "Refresh published-contract/ (wasm, parameters, contract id)"
+# This needs the PARAMETERS (the 32-byte verifying key), not a signature, so it
+# uses `export-parameters` rather than depending on `sign-webapp`. It used to
+# depend on `sign-webapp`, which meant refreshing the committed contract files
+# silently burned a version counter value it never published — one of the
+# sources of the gaps visible in the counter's history. Since sign-webapp now
+# also reads the network before signing, that dependency would additionally
+# have made this task need a reachable node for no reason.
+dependencies = ["build-web-container", "build-web-container-tool"]
 script = '''
+set -e
+mkdir -p target/webapp
+target/native/x86_64-unknown-linux-gnu/${BUILD_PROFILE}/web-container-tool export-parameters \
+  --parameters target/webapp/webapp.parameters
+
 # Get the contract ID without publishing
 contract_id=$(fdev get-contract-id \
   --code target/wasm32-unknown-unknown/release/web_container_contract.wasm \
@@ -362,68 +353,25 @@ echo "Please commit the changes to git"
 # from main after the merge. Migration entries carry OUR users forward; the
 # pointer tells everyone ELSE where the artifact went. Same trigger, two
 # different sets of people who lose if it is skipped.
-description = "Publish River to Freenet using the committed contract version"
-dependencies = ["sign-webapp"]
+#
+# The sign-publish-verify sequence lives in scripts/publish-web-container.sh so
+# it can hold ONE lock across the whole thing and re-read the network after the
+# publish. `dependencies` deliberately no longer names `sign-webapp`: signing
+# happens inside that script, under the same lock as the publish, because the
+# gap between "sign at version N" and "publish version N" is where the
+# 2026-08-04 fork lived.
+description = "Publish River to Freenet, verifying the result against the network"
+dependencies = ["compress-webapp", "build-web-container-tool", "build-web-container"]
 script = '''
-if [ ! -f "published-contract/contract-id.txt" ]; then
-    echo "No published contract found"
-    exit 1
-fi
-contract_id=$(cat published-contract/contract-id.txt)
-echo "Publishing using committed contract: $contract_id"
-version_file="published-contract/contract-version.txt"
-prev_snapshot="$version_file.prev"
-if fdev network publish \
-  --code published-contract/web_container_contract.wasm \
-  --parameters published-contract/webapp.parameters \
-  contract \
-  --webapp-archive target/webapp/webapp.tar.xz \
-  --webapp-metadata target/webapp/webapp.metadata; then
-    # Publish succeeded — the bumped counter file is the new truth.
-    # Discard the snapshot. Caller must commit $version_file.
-    rm -f "$prev_snapshot"
-    echo "Publish OK. Remember to commit $version_file."
-else
-    rc=$?
-    # Publish failed — roll the counter back so subsequent retries
-    # don't accumulate a drift. The on-network version is unchanged,
-    # and our local counter is now matched to it again.
-    if [ -f "$prev_snapshot" ]; then
-        mv "$prev_snapshot" "$version_file"
-        echo "Publish failed (exit $rc); rolled $version_file back to its pre-publish value." >&2
-    fi
-    exit $rc
-fi
+exec ./scripts/publish-web-container.sh
 '''
 
 [tasks.publish-river-debug]
 description = "Publish River to Freenet in debug mode"
 env = { BUILD_PROFILE = "dev" }
-dependencies = ["sign-webapp"]
+dependencies = ["compress-webapp", "build-web-container-tool", "build-web-container"]
 script = '''
-if [ ! -f "published-contract/contract-id.txt" ]; then
-    echo "No published contract found"
-    exit 1
-fi
-contract_id=$(cat published-contract/contract-id.txt)
-echo "Publishing using committed contract in debug mode: $contract_id"
-version_file="published-contract/contract-version.txt"
-prev_snapshot="$version_file.prev"
-if fdev network publish \
-  --code published-contract/web_container_contract.wasm \
-  --parameters published-contract/webapp.parameters \
-  contract \
-  --webapp-archive target/webapp/webapp.tar.xz \
-  --webapp-metadata target/webapp/webapp.metadata; then
-    rm -f "$prev_snapshot"
-else
-    rc=$?
-    if [ -f "$prev_snapshot" ]; then
-        mv "$prev_snapshot" "$version_file"
-        echo "Publish failed (exit $rc); rolled $version_file back to its pre-publish value." >&2
-    fi
-    exit $rc
-fi
+exec ./scripts/publish-web-container.sh
 '''
 
 # Test publishing tasks - use separate keypair to avoid affecting production
@@ -550,6 +498,13 @@ fi
 # as the production publish (see [tasks.sign-webapp] for the 2026-05-16
 # incident). Test contract counter is NOT committed since the test
 # contract ID is regenerated freely.
+#
+# NOTE: this still uses the bump-then-roll-back scheme the PRODUCTION path
+# dropped, because rolling the counter back after a publish that had actually
+# landed is what forked the site on 2026-08-04. It is left here deliberately:
+# the test contract is throwaway, so a fork of it costs nothing, and nobody
+# reads it. Do NOT copy this pattern back to the production path — see
+# scripts/publish-web-container.sh.
 # .prev snapshot is captured here for the publish task to roll back on
 # failure — same pattern as the production sign/publish flow.
 version_file="test-contract/contract-version.txt"
@@ -659,30 +614,33 @@ echo "========================================="
 echo ""
 
 # Step 1: Build and publish River UI
-echo "▶ Step 1/5: Building River UI..."
-cargo make compress-webapp
-cargo make sign-webapp
-
-echo ""
-echo "▶ Step 2/5: Publishing River UI to Freenet..."
+#
+# One `cargo make publish-river`, not compress + sign + publish. Those two
+# extra lines used to be here and each ran in its OWN cargo-make process, so
+# `publish-river` re-ran them as dependencies: the UI was built twice and the
+# version counter was bumped TWICE for a single publish, while the rollback
+# snapshot was overwritten so a failure rolled back only one of the bumps.
+# That is where the gaps in the counter's history came from. `publish-river`
+# already depends on the build, and now does the signing itself.
+echo "▶ Step 1/4: Building and publishing River UI to Freenet..."
 cargo make publish-river
 
 # Step 2: Bump riverctl version
 echo ""
-echo "▶ Step 3/5: Bumping riverctl version..."
+echo "▶ Step 2/4: Bumping riverctl version..."
 cargo make bump-cli-version
 
 NEW_VERSION=$(grep '^version' cli/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
 
 # Step 3: Commit the version bump
 echo ""
-echo "▶ Step 4/5: Committing version bump..."
+echo "▶ Step 3/4: Committing version bump..."
 git add cli/Cargo.toml
 git commit -m "chore: bump riverctl to v${NEW_VERSION} (WASM sync)"
 
 # Step 4: Publish to crates.io
 echo ""
-echo "▶ Step 5/5: Publishing riverctl v${NEW_VERSION} to crates.io..."
+echo "▶ Step 4/4: Publishing riverctl v${NEW_VERSION} to crates.io..."
 cd cli
 cargo publish
 cd ..

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -219,11 +219,33 @@ tar -cJf ../../../../../webapp/webapp.tar.xz *
 # All of it, including the flock the old comment here asked for and nothing
 # ever added, lives in scripts/publish-web-container.sh. Read that file's
 # header before changing any of this.
+#
+# Signing is gated the same way publishing is (clean tree, on main, at
+# origin/main, CI green on that SHA): it burns a version and hands back an
+# artifact `fdev network publish` will take by hand, so it is a release step,
+# not a build step. RIVER_WC_ALLOW_UNPROVEN=1 skips that gate for one run.
 description = "Sign the compressed webapp at a version proven to be above the network's"
-dependencies = ["compress-webapp", "build-web-container-tool", "build-web-container"]
+# No `dependencies`. The script builds them itself via
+# [tasks.web-container-build-inputs], from INSIDE the publish lock — see that
+# task's comment.
 script = '''
-exec ./scripts/publish-web-container.sh --sign-only
+exec ./scripts/publish-web-container.sh --sign-only --build
 '''
+
+[tasks.web-container-build-inputs]
+# Deliberately a task with dependencies and NO script, invoked by
+# scripts/publish-web-container.sh once it holds the single-writer lock.
+#
+# These used to be `dependencies` of [tasks.publish-river] and
+# [tasks.sign-webapp]. cargo-make runs a task's dependencies to completion
+# BEFORE its script, so they ran before the script could take the lock: two
+# overlapping `cargo make publish-river` runs both executed `compress-webapp`
+# and both wrote the shared `target/webapp/webapp.tar.xz` with no lock held,
+# and the second could replace the archive while the first was signing,
+# publishing or byte-comparing it. The lock covered sign-to-verify but not the
+# artifact being verified. Do not move these back into a `dependencies` list.
+description = "Build the artifacts the web-container publish consumes"
+dependencies = ["compress-webapp", "build-web-container-tool", "build-web-container"]
 
 [tasks.build-ui-example]
 description = "Build the Dioxus UI with example data"
@@ -360,18 +382,26 @@ echo "Please commit the changes to git"
 # happens inside that script, under the same lock as the publish, because the
 # gap between "sign at version N" and "publish version N" is where the
 # 2026-08-04 fork lived.
+#
+# Run it from a green `main`, after the PR has merged. This contract key is
+# shared by every River user with no per-branch address to publish to instead,
+# so the script refuses a dirty tree, a branch that is not main, a HEAD that is
+# not origin/main, or CI that is not green on that exact SHA — the same
+# pre-flight scripts/publish-pointer-records.sh makes.
 description = "Publish River to Freenet, verifying the result against the network"
-dependencies = ["compress-webapp", "build-web-container-tool", "build-web-container"]
+# No `dependencies` — see [tasks.web-container-build-inputs].
 script = '''
-exec ./scripts/publish-web-container.sh
+exec ./scripts/publish-web-container.sh --build
 '''
 
 [tasks.publish-river-debug]
 description = "Publish River to Freenet in debug mode"
 env = { BUILD_PROFILE = "dev" }
-dependencies = ["compress-webapp", "build-web-container-tool", "build-web-container"]
+# No `dependencies` — see [tasks.web-container-build-inputs]. The script passes
+# BUILD_PROFILE through with `cargo make --env`, because a cargo-make [env]
+# block overrides an inherited variable of the same name.
 script = '''
-exec ./scripts/publish-web-container.sh
+exec ./scripts/publish-web-container.sh --build
 '''
 
 # Test publishing tasks - use separate keypair to avoid affecting production
@@ -635,7 +665,13 @@ NEW_VERSION=$(grep '^version' cli/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/
 # Step 3: Commit the version bump
 echo ""
 echo "▶ Step 3/4: Committing version bump..."
-git add cli/Cargo.toml
+# published-contract/contract-version.txt was advanced by step 1 and is
+# committed HERE. It used to be left dirty, which quietly undoes the reason the
+# counter is forward-only: a stray `git checkout`, `git stash` or discarded
+# working-tree change restores a version that has already been published, and
+# reissuing a used version is the 2026-08-04 fork. `git add` on it is a no-op
+# if step 1 refused before signing.
+git add cli/Cargo.toml published-contract/contract-version.txt
 git commit -m "chore: bump riverctl to v${NEW_VERSION} (WASM sync)"
 
 # Step 4: Publish to crates.io

--- a/contracts/web-container-contract/web-container-tool/src/main.rs
+++ b/contracts/web-container-contract/web-container-tool/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use ed25519_dalek::{Signer, SigningKey};
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
 use river_core::crypto_values::CryptoValue;
 use river_core::web_container::WebContainerMetadata;
 use std::fs;
@@ -58,6 +58,38 @@ enum Commands {
         /// Key file to use (default: ~/.config/river/web-container-keys.toml)
         #[arg(long, short)]
         key_file: Option<String>,
+    },
+    /// Read a PACKED web-container state (the bytes `fdev execute get` returns)
+    /// and print its version, so the publish path can compare its intended
+    /// version against the one the network actually holds.
+    ///
+    /// This exists because the publish path had no way to answer "what version
+    /// is live right now?". Without it, `sign-webapp` signed at
+    /// `local_counter + 1` and `publish-river` trusted `fdev`'s exit code —
+    /// and on 2026-08-04 (River commit 1032d373) that combination signed two
+    /// DIFFERENT archives at the same version 30000377 and put both on the
+    /// network. See scripts/publish-web-container.sh for the whole story.
+    ///
+    /// Prints `version=<n>` on stdout, in the same `key=value` shape
+    /// `pointer-record verify` uses, so callers can `sed -n 's/^version=//p'`.
+    Inspect {
+        /// Packed state file (`[u64 metadata_len][metadata][u64 web_len][web]`)
+        #[arg(long, short)]
+        state: String,
+        /// Contract parameters (the raw 32-byte verifying key). When given,
+        /// the embedded signature MUST verify under it or this fails.
+        ///
+        /// Pass it. A version read out of unverified bytes is not evidence of
+        /// anything: it is whatever the responder chose to say.
+        #[arg(long)]
+        parameters: Option<String>,
+        /// Write the embedded webapp archive here, so the caller can compare
+        /// it byte-for-byte against the archive it published.
+        #[arg(long)]
+        archive_out: Option<String>,
+        /// Fail unless the state's version is exactly this.
+        #[arg(long)]
+        expect_version: Option<u32>,
     },
 }
 
@@ -299,6 +331,129 @@ fn export_parameters(
     write_parameters(&signing_key, &parameters)
 }
 
+/// The parsed pieces of a packed web-container state.
+struct PackedWebApp {
+    version: u32,
+    signature: Signature,
+    archive: Vec<u8>,
+}
+
+impl PackedWebApp {
+    /// Parse the packed WebApp container:
+    /// `[metadata_len: u64 BE][metadata: CBOR][web_len: u64 BE][web]`.
+    ///
+    /// This layout is defined by `WebApp::pack` in freenet-core and read back
+    /// by the web-container contract's own `validate_state`. Those two are the
+    /// authority; `sign_output_parses_back_and_verifies` below pins that this
+    /// parser still agrees with what `sign` produces.
+    fn parse(bytes: &[u8]) -> Result<Self, String> {
+        fn take_u64(bytes: &[u8], off: &mut usize) -> Result<u64, String> {
+            let end = off
+                .checked_add(8)
+                .ok_or_else(|| "length field offset overflows".to_string())?;
+            let slice = bytes
+                .get(*off..end)
+                .ok_or_else(|| "state truncated: no room for a length field".to_string())?;
+            *off = end;
+            let mut buf = [0u8; 8];
+            buf.copy_from_slice(slice);
+            Ok(u64::from_be_bytes(buf))
+        }
+
+        fn take<'a>(bytes: &'a [u8], off: &mut usize, len: u64) -> Result<&'a [u8], String> {
+            let len =
+                usize::try_from(len).map_err(|_| "declared length exceeds usize".to_string())?;
+            let end = off
+                .checked_add(len)
+                .ok_or_else(|| "declared length overflows".to_string())?;
+            let slice = bytes.get(*off..end).ok_or_else(|| {
+                format!(
+                    "state truncated: declared {len} bytes, {} remain",
+                    bytes.len().saturating_sub(*off)
+                )
+            })?;
+            *off = end;
+            Ok(slice)
+        }
+
+        let mut off = 0usize;
+        let metadata_len = take_u64(bytes, &mut off)?;
+        let metadata_bytes = take(bytes, &mut off, metadata_len)?;
+        let metadata: WebContainerMetadata = ciborium::de::from_reader(metadata_bytes)
+            .map_err(|e| format!("metadata is not valid WebContainerMetadata CBOR: {e}"))?;
+        let web_len = take_u64(bytes, &mut off)?;
+        let archive = take(bytes, &mut off, web_len)?.to_vec();
+
+        Ok(Self {
+            version: metadata.version,
+            signature: metadata.signature,
+            archive,
+        })
+    }
+
+    /// Verify the state's signature against the contract parameters.
+    ///
+    /// The parameters file is exactly the 32-byte verifying key (see
+    /// `write_parameters`), and the contract ID is derived from
+    /// `(wasm, parameters)`. So "verifies under these parameters" means "this
+    /// state was signed by the key that owns this contract" — which is the
+    /// only reason to believe a version number that came off the network.
+    /// An unverified version is not evidence; it is whatever the responder
+    /// chose to say.
+    fn verify(&self, parameters: &[u8]) -> Result<(), String> {
+        let key_bytes: [u8; 32] = parameters
+            .try_into()
+            .map_err(|_| format!("parameters must be 32 bytes, got {}", parameters.len()))?;
+        let verifying_key = VerifyingKey::from_bytes(&key_bytes)
+            .map_err(|e| format!("parameters are not a valid verifying key: {e}"))?;
+
+        // The signed message is `version || archive`, exactly as `sign_webapp`
+        // builds it and `validate_state` re-builds it.
+        let mut message = self.version.to_be_bytes().to_vec();
+        message.extend_from_slice(&self.archive);
+
+        verifying_key
+            .verify_strict(&message, &self.signature)
+            .map_err(|e| format!("signature does not verify under the contract parameters: {e}"))
+    }
+}
+
+fn inspect_state(
+    state: String,
+    parameters: Option<String>,
+    archive_out: Option<String>,
+    expect_version: Option<u32>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let bytes = fs::read(&state).map_err(|e| format!("failed to read state '{state}': {e}"))?;
+    let parsed = PackedWebApp::parse(&bytes)?;
+
+    if let Some(parameters) = parameters.as_deref() {
+        let params = fs::read(parameters)
+            .map_err(|e| format!("failed to read parameters '{parameters}': {e}"))?;
+        parsed.verify(&params)?;
+    }
+
+    if let Some(expected) = expect_version {
+        if parsed.version != expected {
+            return Err(format!(
+                "state is at version {}, expected {}",
+                parsed.version, expected
+            )
+            .into());
+        }
+    }
+
+    // Written before the version is printed: a caller that trusts stdout must
+    // not be handed a version for a state whose archive it failed to receive.
+    if let Some(path) = archive_out.as_deref() {
+        fs::write(path, &parsed.archive)
+            .map_err(|e| format!("failed to write archive to '{path}': {e}"))?;
+    }
+
+    println!("version={}", parsed.version);
+    Ok(())
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
@@ -315,6 +470,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             parameters,
             key_file,
         } => export_parameters(parameters, key_file),
+        Commands::Inspect {
+            state,
+            parameters,
+            archive_out,
+            expect_version,
+        } => inspect_state(state, parameters, archive_out, expect_version),
     }
 }
 
@@ -397,5 +558,193 @@ mod tests {
         );
 
         fs::remove_dir_all(&dir).ok();
+    }
+
+    // ---------------------------------------------------------------- inspect
+    //
+    // `inspect` is what lets the publish path answer "what version is live
+    // right now?" — the question nobody could answer on 2026-08-04 (River
+    // commit 1032d373), when a timed-out publish was retried and a SECOND,
+    // differently-built archive was signed at the same version 30000377. Both
+    // ended up on the network. The container's `update_state` gate rejects
+    // `version <= current`, which converges DIFFERING versions and does
+    // nothing for two states at the SAME one.
+
+    /// Pack a state exactly as freenet-core's `WebApp::pack` does, which is
+    /// what `fdev publish --webapp-archive/--webapp-metadata` sends and what
+    /// `fdev execute get` hands back.
+    fn pack(metadata: &[u8], archive: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&(metadata.len() as u64).to_be_bytes());
+        out.extend_from_slice(metadata);
+        out.extend_from_slice(&(archive.len() as u64).to_be_bytes());
+        out.extend_from_slice(archive);
+        out
+    }
+
+    /// Sign `archive` at `version` and return the packed state, mirroring the
+    /// full sign -> publish path.
+    fn signed_state(signing_key: &SigningKey, version: u32, archive: &[u8]) -> Vec<u8> {
+        let mut message = version.to_be_bytes().to_vec();
+        message.extend_from_slice(archive);
+        let metadata = WebContainerMetadata {
+            version,
+            signature: signing_key.sign(&message),
+        };
+        let mut metadata_bytes = Vec::new();
+        ciborium::ser::into_writer(&metadata, &mut metadata_bytes).unwrap();
+        pack(&metadata_bytes, archive)
+    }
+
+    /// The round trip the publish pre-flight depends on: what `sign` writes,
+    /// packed the way the node packs it, must parse back to the same version
+    /// and the same archive bytes, and must verify under the parameters `sign`
+    /// wrote. If the packed layout ever changes in freenet-core, this fails
+    /// here rather than at 3am in the middle of a publish.
+    #[test]
+    fn sign_output_parses_back_and_verifies() {
+        let dir = tmpdir("inspect-roundtrip");
+        let signing_key = SigningKey::from_bytes(&[11u8; 32]);
+        let key_file = write_key_file(&dir, &signing_key);
+
+        let archive_bytes = b"pretend this is webapp.tar.xz".to_vec();
+        let archive = dir.join("webapp.tar.xz");
+        fs::write(&archive, &archive_bytes).unwrap();
+
+        let metadata_path = dir.join("webapp.metadata");
+        let params_path = dir.join("webapp.parameters");
+        sign_webapp(
+            archive.to_str().unwrap().to_string(),
+            metadata_path.to_str().unwrap().to_string(),
+            params_path.to_str().unwrap().to_string(),
+            30_000_377,
+            Some(key_file.to_str().unwrap().to_string()),
+        )
+        .unwrap();
+
+        let state = pack(&fs::read(&metadata_path).unwrap(), &archive_bytes);
+        let parsed = PackedWebApp::parse(&state).expect("packed state must parse");
+        assert_eq!(parsed.version, 30_000_377);
+        assert_eq!(parsed.archive, archive_bytes);
+        parsed
+            .verify(&fs::read(&params_path).unwrap())
+            .expect("must verify under the parameters `sign` wrote");
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A version read from bytes we did not verify is not evidence. Reject a
+    /// state signed by any other key, so a wrong-key or substituted response
+    /// can never be mistaken for "the network is at version N".
+    #[test]
+    fn verify_rejects_a_state_signed_by_another_key() {
+        let ours = SigningKey::from_bytes(&[1u8; 32]);
+        let theirs = SigningKey::from_bytes(&[2u8; 32]);
+        let state = signed_state(&theirs, 42, b"archive");
+        let parsed = PackedWebApp::parse(&state).unwrap();
+        let err = parsed
+            .verify(&ours.verifying_key().to_bytes())
+            .expect_err("a foreign signature must not verify");
+        assert!(err.contains("does not verify"), "unexpected error: {err}");
+    }
+
+    /// The signature covers `version || archive`, so swapping either half
+    /// invalidates it. This is why the pre-flight reads the version out of a
+    /// VERIFIED state rather than out of whatever came back.
+    #[test]
+    fn verify_rejects_a_state_whose_archive_was_swapped() {
+        let key = SigningKey::from_bytes(&[3u8; 32]);
+        let good = signed_state(&key, 7, b"the archive that was signed");
+        let parsed = PackedWebApp::parse(&good).unwrap();
+
+        // Re-pack the same metadata over a different archive.
+        let metadata_len = u64::from_be_bytes(good[..8].try_into().unwrap()) as usize;
+        let metadata = &good[8..8 + metadata_len];
+        let tampered = pack(metadata, b"a different archive entirely");
+
+        let tampered = PackedWebApp::parse(&tampered).unwrap();
+        assert_eq!(tampered.version, parsed.version);
+        assert!(tampered.verify(&key.verifying_key().to_bytes()).is_err());
+    }
+
+    /// Truncation must be an error, never a silently short read that yields a
+    /// plausible-looking version.
+    #[test]
+    fn parse_rejects_truncated_and_malformed_states() {
+        let key = SigningKey::from_bytes(&[4u8; 32]);
+        let full = signed_state(&key, 5, b"archive bytes");
+
+        assert!(PackedWebApp::parse(&[]).is_err(), "empty state");
+        assert!(PackedWebApp::parse(&full[..4]).is_err(), "half a length");
+        assert!(
+            PackedWebApp::parse(&full[..full.len() - 1]).is_err(),
+            "archive one byte short"
+        );
+
+        // A length field that claims far more than the buffer holds must be
+        // rejected on the declared length, not trusted into an allocation.
+        let mut lying = full.clone();
+        lying[..8].copy_from_slice(&u64::MAX.to_be_bytes());
+        assert!(PackedWebApp::parse(&lying).is_err(), "absurd metadata_len");
+    }
+
+    /// `--expect-version` is the caller's assertion that the state it just
+    /// read back is the one it published. It has to be able to fail.
+    #[test]
+    fn inspect_expect_version_rejects_a_mismatch_and_writes_no_archive() {
+        let dir = tmpdir("inspect-expect");
+        let key = SigningKey::from_bytes(&[5u8; 32]);
+        let state_path = dir.join("state.bin");
+        fs::write(&state_path, signed_state(&key, 100, b"archive")).unwrap();
+        let params_path = dir.join("params");
+        fs::write(&params_path, key.verifying_key().to_bytes()).unwrap();
+        let archive_out = dir.join("out.tar.xz");
+
+        let err = inspect_state(
+            state_path.to_str().unwrap().to_string(),
+            Some(params_path.to_str().unwrap().to_string()),
+            Some(archive_out.to_str().unwrap().to_string()),
+            Some(101),
+        )
+        .expect_err("a version mismatch must fail");
+        assert!(err.to_string().contains("expected 101"), "{err}");
+        assert!(
+            !archive_out.exists(),
+            "no archive should be written when the version assertion failed"
+        );
+
+        inspect_state(
+            state_path.to_str().unwrap().to_string(),
+            Some(params_path.to_str().unwrap().to_string()),
+            Some(archive_out.to_str().unwrap().to_string()),
+            Some(100),
+        )
+        .expect("the matching version must succeed");
+        assert_eq!(fs::read(&archive_out).unwrap(), b"archive".to_vec());
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The publish path compares the archive it read back against the archive
+    /// it published. That comparison is the ONLY thing that can distinguish
+    /// "my state is live" from "a state at my version is live" — the 2026-08-04
+    /// fork, where two different archives were both validly signed at 30000377.
+    #[test]
+    fn same_version_different_archives_both_verify() {
+        let key = SigningKey::from_bytes(&[6u8; 32]);
+        let first = signed_state(&key, 30_000_377, b"build A of the UI");
+        let second = signed_state(&key, 30_000_377, b"build B of the UI");
+        assert_ne!(first, second);
+
+        let params = key.verifying_key().to_bytes();
+        let a = PackedWebApp::parse(&first).unwrap();
+        let b = PackedWebApp::parse(&second).unwrap();
+        a.verify(&params).unwrap();
+        b.verify(&params).unwrap();
+        assert_eq!(a.version, b.version);
+        assert_ne!(
+            a.archive, b.archive,
+            "signature validity cannot separate these; only the byte comparison can"
+        );
     }
 }

--- a/pointer-records.toml
+++ b/pointer-records.toml
@@ -32,9 +32,10 @@
 #   CI fails, which is the intended outcome and not a bug in the gate.
 #
 #   `version` is a monotonic counter per record, gating the network update. It
-#   must strictly increase on every publish. Like
-#   `published-contract/contract-version.txt`, it is NOT safe under two parallel
-#   publishes on one workstation — wrap in `flock` if you need that.
+#   must strictly increase on every publish, and it is NOT safe under two
+#   parallel publishes on one workstation — wrap in `flock` if you need that.
+#   (`published-contract/contract-version.txt` used to carry the same caveat;
+#   scripts/publish-web-container.sh now takes that lock itself.)
 
 # The author identity. Also published in FREENET.md, and the gate checks the two
 # agree: an integrator takes this value from FREENET.md, so if the two ever

--- a/scripts/publish-web-container.sh
+++ b/scripts/publish-web-container.sh
@@ -1,0 +1,493 @@
+#!/usr/bin/env bash
+# Sign and publish River's web container, reading the network before signing
+# and again after publishing.
+#
+# Invoked by `cargo make publish-river` / `cargo make publish-river-debug`, and
+# in --sign-only form by `cargo make sign-webapp`. Not usually run by hand.
+#
+# ## Why this script exists
+#
+# 2026-08-04, River commit 1032d373. `cargo make publish-river` signed web
+# container version 30000377 and uploaded it. `fdev network publish` reported
+# `put timed out after 1 peer attempt(s)`, so the rollback arm in
+# [tasks.publish-river] restored the counter to 30000376 and the operator
+# retried. The retry re-ran `sign-webapp`, which REBUILT the UI — producing a
+# different archive, because the build is not reproducible — signed it as
+# 30000377 again, and published it. Only then did the network say
+# `New state version 30000377 must be higher than current version 30000377`:
+# the first PUT had landed after all.
+#
+# Two different archives, both validly signed at version 30000377, both on the
+# network.
+#
+# ## Why that forks the site rather than resolving
+#
+# The container IS correctly gated: `update_state` rejects
+# `version <= current_version`. That makes DIFFERING versions converge. It does
+# nothing for two states at the SAME version — it rejects in both directions,
+# so every peer keeps whichever it saw first. And `summarize_state` emits only
+# the u32 version, so anti-entropy between two split peers compares equal
+# summaries and never tries to heal. The split is silent.
+#
+# The second archive reaches peers at all because a peer NEW to the contract
+# takes the initial-state bypass, which runs `validate_state` only (signature,
+# and version != 0) and not the update gate.
+#
+# River self-heals at the next successful publish, since a strictly higher
+# version is accepted by both branches, so exposure is bounded at one release
+# cycle. Bounded, not harmless: for that window two populations of users are on
+# different builds of the site with no signal that they are.
+#
+# ## The three things that were missing
+#
+# 1. READ BEFORE SIGNING. The version to sign at is
+#    `max(local counter, on-network version) + 1`, where the on-network version
+#    is read from the network and verified under our own contract parameters —
+#    not assumed from a local file. A version we cannot prove is above the live
+#    one does not get signed.
+#
+# 2. ABSENCE MUST BE PROVEN. A failed GET means "we did not learn", not
+#    "nothing is there". This script separates known / absent / unknown and
+#    refuses on ambiguity. It goes one step further than
+#    scripts/publish-pointer-records.sh, which treats a `Contract not found` as
+#    proof of a first publish: for THIS contract that answer is not proof of
+#    anything, because a Freenet GET can dead-end and report NotFound for a
+#    contract that exists, and the web container is one we know is published.
+#
+# 3. RE-READ AFTER PUBLISHING. fdev's exit code is not evidence in either
+#    direction. A publish at an already-used version is a no-op SUCCESS, and a
+#    publish that reports a timeout may have landed anyway — 2026-08-04 was the
+#    second case. So the only thing that establishes "our state is live" is
+#    fetching it back and comparing the archive byte for byte. Signature
+#    validity cannot do it: both forked archives were validly signed.
+#
+# ## And one thing that was actively harmful
+#
+# The counter no longer rolls back. Rolling back on a failed publish is what
+# handed the retry a version that had, in fact, already been used. The counter
+# is now forward-only: gaps are fine (the contract enforces monotonicity, not
+# contiguity) and a bumped-but-unpublished counter costs nothing, because the
+# read-before-sign floor recomputes from the network anyway. A burned version
+# is never reissued.
+#
+# ## Usage
+#
+#   scripts/publish-web-container.sh              # sign, publish, verify
+#   scripts/publish-web-container.sh --sign-only  # sign only (cargo make sign-webapp)
+#   scripts/publish-web-container.sh --dry-run    # pre-flight only, sign nothing
+#
+# Environment:
+#   WS_API_PORT                     node the publish goes THROUGH (fdev's own
+#                                   variable; default 7509). The pre-flight read
+#                                   and the publish deliberately share it, so
+#                                   the version we check is the version the
+#                                   publish is measured against.
+#   RIVER_WC_ALLOW_UNVERIFIED=1     proceed even though the on-network version
+#                                   could not be determined (see below)
+#   RIVER_WC_ALLOW_FIRST_PUBLISH=1  accept "Contract not found" as a genuine
+#                                   first publish (for a NEW contract only)
+#   RIVER_WC_GET_TIMEOUT            seconds, default 180
+#   RIVER_WC_PUBLISH_TIMEOUT        seconds, default 300
+#   RIVER_WC_READBACK_ATTEMPTS      default 3
+#   RIVER_WC_READBACK_DELAY         seconds between read-back attempts, default 15
+#   RIVER_WC_KEY_FILE               signing key file (default:
+#                                   ~/.config/river/web-container-keys.toml).
+#                                   Exists so this script can be rehearsed
+#                                   against a throwaway key and a stub node
+#                                   without going anywhere near the production
+#                                   one; the parameters check below fails
+#                                   closed if the key is not this contract's.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Kept because the flock re-exec below has to hand this script its own
+# arguments, and by then the parse loop has consumed "$@".
+ORIGINAL_ARGS=("$@")
+
+# shellcheck source=scripts/web-container-publish-lib.sh
+. "$SCRIPT_DIR/web-container-publish-lib.sh"
+
+die() { echo "" >&2; echo "ERROR: $*" >&2; exit 1; }
+say() { echo "  $*"; }
+
+SIGN_ONLY=0
+DRY_RUN=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --sign-only) SIGN_ONLY=1; shift ;;
+        --dry-run)   DRY_RUN=1; shift ;;
+        *) die "unknown argument '$1'" ;;
+    esac
+done
+
+VERSION_FILE="published-contract/contract-version.txt"
+PARAMS_FILE="published-contract/webapp.parameters"
+WASM_FILE="published-contract/web_container_contract.wasm"
+CONTRACT_ID_FILE="published-contract/contract-id.txt"
+ARCHIVE="target/webapp/webapp.tar.xz"
+METADATA="target/webapp/webapp.metadata"
+SIGNED_PARAMS="target/webapp/webapp.parameters"
+TOOL="target/native/x86_64-unknown-linux-gnu/${BUILD_PROFILE:-release}/web-container-tool"
+LOCK_FILE="published-contract/.publish.lock"
+
+GET_TIMEOUT="${RIVER_WC_GET_TIMEOUT:-180}"
+PUBLISH_TIMEOUT="${RIVER_WC_PUBLISH_TIMEOUT:-300}"
+READBACK_ATTEMPTS="${RIVER_WC_READBACK_ATTEMPTS:-3}"
+READBACK_DELAY="${RIVER_WC_READBACK_DELAY:-15}"
+ALLOW_UNVERIFIED="${RIVER_WC_ALLOW_UNVERIFIED:-0}"
+ALLOW_FIRST_PUBLISH="${RIVER_WC_ALLOW_FIRST_PUBLISH:-0}"
+
+# --------------------------------------------------------------- SINGLE WRITER
+#
+# Two concurrent runs would race the read-modify-write on the counter and could
+# sign two archives at the same version — the fork, arrived at from a different
+# direction. [tasks.sign-webapp] has carried a comment saying "wrap in flock if
+# you need that" since the counter was introduced; nothing ever did.
+#
+# A missing flock WARNS rather than refusing. flock is Linux-only (these tasks
+# already build x86_64-unknown-linux-gnu, so that is the expected platform), and
+# blocking a release because a lock utility is absent is a worse failure than
+# the race it prevents — the race needs two simultaneous publishes by one
+# operator on one machine.
+if [ -z "${RIVER_WC_PUBLISH_LOCKED:-}" ]; then
+    if command -v flock >/dev/null 2>&1; then
+        mkdir -p "$(dirname "$LOCK_FILE")"
+        : > "$LOCK_FILE" 2>/dev/null || true
+        export RIVER_WC_PUBLISH_LOCKED=1
+        set +e
+        flock --nonblock --conflict-exit-code 75 "$LOCK_FILE" "$0" \
+            ${ORIGINAL_ARGS[@]+"${ORIGINAL_ARGS[@]}"}
+        rc=$?
+        set -e
+        if [ "$rc" -eq 75 ]; then
+            die "another web-container publish is already running (lock: $LOCK_FILE).
+Two concurrent runs race the version counter and can sign two different
+archives at the same version. Wait for the other one, or remove the lock file
+if you are certain nothing is running."
+        fi
+        exit "$rc"
+    fi
+    echo "WARNING: flock not found — running WITHOUT the single-writer lock." >&2
+    echo "         Do not run a second publish concurrently." >&2
+fi
+
+# ------------------------------------------------------------- PRECONDITIONS
+echo "=============================================================="
+echo " River web-container publish — pre-flight"
+echo "=============================================================="
+echo ""
+
+for tool in fdev cmp; do
+    command -v "$tool" >/dev/null 2>&1 || die "$tool not found (needed by this script)"
+done
+[ -x "$TOOL" ] || die "$TOOL not found. Run via cargo make so it gets built."
+for f in "$VERSION_FILE" "$PARAMS_FILE" "$WASM_FILE" "$CONTRACT_ID_FILE"; do
+    [ -f "$f" ] || die "$f missing."
+done
+[ -s "$ARCHIVE" ] || die "$ARCHIVE missing or empty. Run 'cargo make compress-webapp' first."
+
+CONTRACT_ID="$(tr -d '[:space:]' < "$CONTRACT_ID_FILE")"
+COUNTER="$(tr -d '[:space:]' < "$VERSION_FILE")"
+case "$COUNTER" in
+    ''|*[!0-9]*) die "$VERSION_FILE does not hold a number: '$COUNTER'" ;;
+esac
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --------------------------------------------- [1] READ THE NETWORK, BEFORE SIGNING
+echo "[1] reading the version currently on the network"
+say "contract $CONTRACT_ID (through the node at WS_API_PORT=${WS_API_PORT:-7509})"
+
+NET_STATUS="unknown"
+NET_VERSION=""
+# `read_network_version <state-out> <log-out>` sets NET_STATUS / NET_VERSION.
+read_network_version() {
+    local out="$1" log="$2" inspect_out
+    NET_STATUS="unknown"
+    NET_VERSION=""
+    rm -f "$out"
+    set +e
+    fdev network execute get --timeout "$GET_TIMEOUT" -o "$out" "$CONTRACT_ID" >"$log" 2>&1
+    local get_rc=$?
+    set -e
+    if [ "$get_rc" -eq 0 ] && [ -s "$out" ]; then
+        set +e
+        inspect_out="$("$TOOL" inspect --state "$out" --parameters "$PARAMS_FILE" 2>&1)"
+        local inspect_rc=$?
+        set -e
+        if [ "$inspect_rc" -ne 0 ]; then
+            printf '%s\n' "$inspect_out" | sed 's/^/      /'
+            die "the network returned bytes for $CONTRACT_ID that do NOT verify under
+our own web-container parameters. Refusing to reason about a version read out
+of state whose provenance is unclear."
+        fi
+        NET_VERSION="$(printf '%s\n' "$inspect_out" | sed -n 's/^version=//p')"
+        case "$NET_VERSION" in
+            ''|*[!0-9]*) die "web-container-tool inspect printed no usable version: '$NET_VERSION'" ;;
+        esac
+        NET_STATUS="known"
+        return 0
+    fi
+    if grep -qF "Contract not found" "$log"; then
+        NET_STATUS="absent"
+    else
+        NET_STATUS="unknown"
+    fi
+}
+
+read_network_version "$WORK/onnet.bin" "$WORK/onnet.log"
+
+case "$NET_STATUS" in
+    known)   say "the network holds version $NET_VERSION (signature verified under our parameters)" ;;
+    absent)  say "the node answered: Contract not found" ;;
+    unknown) tail -3 "$WORK/onnet.log" | sed 's/^/      /'; say "could NOT determine the on-network version" ;;
+esac
+
+DECISION="$(wc_preflight_decision "$NET_STATUS" "$ALLOW_UNVERIFIED" "$ALLOW_FIRST_PUBLISH")"
+if [ "$DECISION" != "proceed" ]; then
+    case "$NET_STATUS" in
+        absent)
+            die "${DECISION#refuse: }
+
+'Contract not found' is proof of absence for a contract that was never
+published. It is not proof for this one: a Freenet GET can dead-end and answer
+NotFound for a contract that exists, and published-contract/ says this contract
+IS live (counter $COUNTER).
+
+Treating that as a first publish would sign at counter+1 with no floor, which is
+how a version that is already in use gets reissued — the 2026-08-04 fork.
+
+Retry, or fix the node. If this really is a brand-new contract, set
+RIVER_WC_ALLOW_FIRST_PUBLISH=1."
+            ;;
+        *)
+            die "${DECISION#refuse: }
+
+That is 'we did not learn', not 'nothing is there'. Signing at counter+1 here
+would be signing at a version we cannot prove is above the live one, which is
+exactly what forked the site on 2026-08-04.
+
+Retry, or fix the node. If you must proceed anyway, set
+RIVER_WC_ALLOW_UNVERIFIED=1 — the post-publish read-back still runs, and will
+tell you if the state did not land."
+            ;;
+    esac
+fi
+if [ "$NET_STATUS" != "known" ] && [ "$SIGN_ONLY" -eq 0 ]; then
+    echo ""
+    echo "  !! proceeding WITHOUT a verified on-network version, by explicit override." >&2
+    echo "  !! the read-back after the publish is the only remaining check." >&2
+fi
+
+# ------------------------------------------------------------ [2] PICK A VERSION
+VERSION="$(wc_next_version "$COUNTER" "$NET_STATUS" "$NET_VERSION")"
+echo ""
+echo "[2] version to sign"
+if [ "$NET_STATUS" = "known" ] && [ "$NET_VERSION" -ge "$COUNTER" ]; then
+    say "local counter $COUNTER is not above the network's $NET_VERSION — using the network as the floor"
+fi
+say "signing version $VERSION (counter $COUNTER, network ${NET_VERSION:-unknown})"
+if [ "$NET_STATUS" = "known" ] && [ "$VERSION" -ne $((NET_VERSION + 1)) ]; then
+    say "note: skipping from $NET_VERSION to $VERSION (gaps are fine — the contract"
+    say "      enforces monotonicity, not contiguity)"
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo ""
+    echo "--dry-run: stopping before signing. Nothing was written."
+    exit 0
+fi
+
+# ------------------------------------------------------------------- [3] SIGN
+echo ""
+echo "[3] signing"
+# Forward-only. Written BEFORE signing so a crash between here and the publish
+# leaves the counter ahead rather than behind: ahead costs a gap, behind costs
+# a reissued version.
+echo "$VERSION" > "$VERSION_FILE"
+# Remove the rollback snapshot the old flow left behind, if a stale one exists.
+rm -f "$VERSION_FILE.prev"
+
+KEY_ARGS=()
+if [ -n "${RIVER_WC_KEY_FILE:-}" ]; then
+    KEY_ARGS=(--key-file "$RIVER_WC_KEY_FILE")
+fi
+"$TOOL" sign \
+    --input "$ARCHIVE" \
+    --output "$METADATA" \
+    --parameters "$SIGNED_PARAMS" \
+    --version "$VERSION" \
+    ${KEY_ARGS[@]+"${KEY_ARGS[@]}"}
+
+# The parameters ARE the contract's identity: the contract ID is derived from
+# (wasm, parameters). If the key we just signed with is not the key this
+# contract belongs to, the publish would go to a different contract entirely
+# and every check after it would be measuring the wrong thing.
+cmp -s "$SIGNED_PARAMS" "$PARAMS_FILE" || die "the key that just signed does not match $PARAMS_FILE.
+Signing with the wrong key publishes to a DIFFERENT contract ID. Check
+~/.config/river/web-container-keys.toml."
+say "signed version $VERSION with the key that owns $CONTRACT_ID"
+
+if [ "$SIGN_ONLY" -eq 1 ]; then
+    echo ""
+    echo "--sign-only: not publishing. Commit $VERSION_FILE only after a successful publish."
+    exit 0
+fi
+
+# ---------------------------------------------------------------- [4] PUBLISH
+echo ""
+echo "[4] publishing"
+set +e
+fdev network publish \
+    --code "$WASM_FILE" \
+    --parameters "$PARAMS_FILE" \
+    --timeout "$PUBLISH_TIMEOUT" \
+    contract \
+    --webapp-archive "$ARCHIVE" \
+    --webapp-metadata "$METADATA" >"$WORK/pub.log" 2>&1
+PUB_RC=$?
+set -e
+tail -5 "$WORK/pub.log" | sed 's/^/    /'
+if [ "$PUB_RC" -eq 0 ]; then
+    say "fdev reported success (exit 0) — which proves nothing on its own"
+else
+    say "fdev reported FAILURE (exit $PUB_RC) — which also proves nothing on its own"
+fi
+
+# --------------------------------------------------------------- [5] READ BACK
+echo ""
+echo "[5] reading the state back"
+echo "    'the publish returned OK' is not evidence: a publish at an already-used"
+echo "    version is a no-op success, and a publish that reports a timeout may"
+echo "    have landed. Only the bytes on the network settle it."
+
+BACK_STATUS="unknown"
+BACK_VERSION=""
+BYTES_MATCH="na"
+OUTCOME="unknown"
+attempt=1
+while [ "$attempt" -le "$READBACK_ATTEMPTS" ]; do
+    say "attempt $attempt/$READBACK_ATTEMPTS"
+    rm -f "$WORK/back.tar.xz"
+    set +e
+    fdev network execute get --timeout "$GET_TIMEOUT" -o "$WORK/back.bin" "$CONTRACT_ID" \
+        >"$WORK/back.log" 2>&1
+    get_rc=$?
+    set -e
+    BACK_STATUS="unknown"
+    BACK_VERSION=""
+    BYTES_MATCH="na"
+    if [ "$get_rc" -eq 0 ] && [ -s "$WORK/back.bin" ]; then
+        set +e
+        inspect_out="$("$TOOL" inspect --state "$WORK/back.bin" --parameters "$PARAMS_FILE" \
+            --archive-out "$WORK/back.tar.xz" 2>&1)"
+        inspect_rc=$?
+        set -e
+        if [ "$inspect_rc" -eq 0 ]; then
+            BACK_VERSION="$(printf '%s\n' "$inspect_out" | sed -n 's/^version=//p')"
+            case "$BACK_VERSION" in
+                ''|*[!0-9]*) BACK_VERSION="" ;;
+            esac
+            if [ -n "$BACK_VERSION" ]; then
+                BACK_STATUS="known"
+                if cmp -s "$WORK/back.tar.xz" "$ARCHIVE"; then
+                    BYTES_MATCH=1
+                else
+                    BYTES_MATCH=0
+                fi
+            fi
+        else
+            printf '%s\n' "$inspect_out" | sed 's/^/      /'
+        fi
+    elif grep -qF "Contract not found" "$WORK/back.log"; then
+        BACK_STATUS="absent"
+    fi
+
+    OUTCOME="$(wc_publish_outcome "$PUB_RC" "$BACK_STATUS" "$BACK_VERSION" "$BYTES_MATCH" "$VERSION")"
+    say "network says: ${BACK_STATUS}${BACK_VERSION:+ version $BACK_VERSION}, archive match: $BYTES_MATCH -> $OUTCOME"
+    # Only 'unknown' is worth retrying: a definite answer that differs from
+    # ours will not change by asking again, and retrying it just delays a
+    # report the operator needs.
+    if [ "$OUTCOME" != "unknown" ]; then
+        break
+    fi
+    attempt=$((attempt + 1))
+    if [ "$attempt" -le "$READBACK_ATTEMPTS" ]; then
+        sleep "$READBACK_DELAY"
+    fi
+done
+
+# ----------------------------------------------------------------- [6] VERDICT
+echo ""
+echo "=============================================================="
+EXIT_CODE="$(wc_outcome_exit_code "$OUTCOME")"
+case "$OUTCOME" in
+    landed)
+        if [ "$PUB_RC" -ne 0 ]; then
+            echo " PUBLISHED — despite fdev exiting $PUB_RC"
+            echo "=============================================================="
+            echo ""
+            echo "  Version $VERSION is live and byte-identical to what we published."
+            echo "  fdev's non-zero exit was a REPORTING failure, not a publish failure."
+            echo "  This is the 2026-08-04 shape exactly: do NOT retry, and do NOT"
+            echo "  roll the counter back. Retrying here is what forked the site."
+        else
+            echo " PUBLISHED"
+            echo "=============================================================="
+            echo ""
+            echo "  Version $VERSION is live and byte-identical to what we published."
+        fi
+        echo ""
+        echo "  Commit the counter:  git add $VERSION_FILE"
+        ;;
+    collision)
+        echo " FORKED — version $VERSION is live carrying DIFFERENT bytes"
+        echo "=============================================================="
+        echo ""
+        echo "  The network holds a state at OUR version whose archive is not ours."
+        echo "  Only our key can sign a state this contract accepts, so this is an"
+        echo "  earlier run of this pipeline: two archives now exist at version"
+        echo "  $VERSION and they will NOT converge — the update gate rejects in"
+        echo "  both directions and the state summary is only the version number."
+        echo ""
+        echo "  Fix: re-run the publish. The pre-flight will now read $VERSION off"
+        echo "  the network and sign at $((VERSION + 1)), which BOTH branches accept."
+        ;;
+    superseded)
+        echo " NOT LIVE — the network is at $BACK_VERSION, above our $VERSION"
+        echo "=============================================================="
+        echo ""
+        echo "  Something published a higher version. Our archive is not what users"
+        echo "  are getting. Re-run the publish to sign above $BACK_VERSION, and find"
+        echo "  out what else is publishing to this contract."
+        ;;
+    not-landed)
+        echo " NOT PUBLISHED — the network is still at $BACK_VERSION"
+        echo "=============================================================="
+        echo ""
+        echo "  The publish did not land. The counter is left at $VERSION and is NOT"
+        echo "  rolled back: $VERSION may have been seen by some peer, and reissuing"
+        echo "  a version that was already used is the 2026-08-04 fork. Gaps are"
+        echo "  fine — the contract enforces monotonicity, not contiguity."
+        echo ""
+        echo "  Re-run the publish; it will sign above whatever the network reports."
+        ;;
+    *)
+        echo " UNKNOWN — could not read the state back"
+        echo "=============================================================="
+        echo ""
+        echo "  We do not know whether version $VERSION landed. The counter is left"
+        echo "  at $VERSION and is NOT rolled back, precisely because we cannot rule"
+        echo "  out that it landed."
+        echo ""
+        echo "  Re-run the publish once the node answers; the pre-flight will read"
+        echo "  the live version and sign above it either way."
+        ;;
+esac
+echo ""
+exit "$EXIT_CODE"

--- a/scripts/publish-web-container.sh
+++ b/scripts/publish-web-container.sh
@@ -54,12 +54,30 @@
 #    anything, because a Freenet GET can dead-end and report NotFound for a
 #    contract that exists, and the web container is one we know is published.
 #
-# 3. RE-READ AFTER PUBLISHING. fdev's exit code is not evidence in either
-#    direction. A publish at an already-used version is a no-op SUCCESS, and a
-#    publish that reports a timeout may have landed anyway — 2026-08-04 was the
-#    second case. So the only thing that establishes "our state is live" is
-#    fetching it back and comparing the archive byte for byte. Signature
-#    validity cannot do it: both forked archives were validly signed.
+# 3. RE-READ AFTER PUBLISHING. fdev's exit code is not evidence. The direction
+#    we have OBSERVED is a publish that reported `put timed out after 1 peer
+#    attempt(s)` and had landed anyway — 2026-08-04. The other direction is not
+#    a claim about any mechanism: a zero exit says the node we published THROUGH
+#    accepted the PUT, which is not the same as "the bytes users fetch are
+#    ours". So the only thing that establishes "our state is live" is fetching
+#    it back and comparing the archive byte for byte. Signature validity cannot
+#    do it: both forked archives were validly signed.
+#
+#    An earlier version of this file justified that with "a publish at an
+#    already-used version is a no-op SUCCESS". That is WRONG for this contract
+#    and should not come back: web-container-contract's `update_state` returns
+#    `InvalidUpdateWithInfo` for `version <= current`
+#    (contracts/web-container-contract/src/lib.rs), and freenet-core maps a
+#    failed PutResponse to an error on the originating node
+#    (crates/core/src/operations/put.rs) — which is how the 2026-08-04 operator
+#    saw `New state version 30000377 must be higher than current version
+#    30000377` at all. The sibling POINTER contract genuinely does accept a
+#    stale update silently, by design; that property is its, not this one's.
+#
+# Every network read here is RETRIED, in both directions. Freenet is eventually
+# consistent, so one GET that does not show our state is a single sample, not
+# evidence that our state is not there. A stale sample reported as NOT PUBLISHED
+# invites precisely the retry that forked the site.
 #
 # ## And one thing that was actively harmful
 #
@@ -75,6 +93,9 @@
 #   scripts/publish-web-container.sh              # sign, publish, verify
 #   scripts/publish-web-container.sh --sign-only  # sign only (cargo make sign-webapp)
 #   scripts/publish-web-container.sh --dry-run    # pre-flight only, sign nothing
+#   scripts/publish-web-container.sh --build      # build the inputs first, under
+#                                                 # the same lock (what the
+#                                                 # cargo-make tasks pass)
 #
 # Environment:
 #   WS_API_PORT                     node the publish goes THROUGH (fdev's own
@@ -86,10 +107,20 @@
 #                                   could not be determined (see below)
 #   RIVER_WC_ALLOW_FIRST_PUBLISH=1  accept "Contract not found" as a genuine
 #                                   first publish (for a NEW contract only)
+#   RIVER_WC_ALLOW_UNPROVEN=1       skip the provenance gate in [0] (clean tree,
+#                                   on main, at origin/main, CI green on that
+#                                   SHA). For one run; never export it.
 #   RIVER_WC_GET_TIMEOUT            seconds, default 180
 #   RIVER_WC_PUBLISH_TIMEOUT        seconds, default 300
+#   RIVER_WC_PREFLIGHT_ATTEMPTS     pre-flight read attempts, default 3
+#   RIVER_WC_PREFLIGHT_DELAY        seconds between them, default 15
 #   RIVER_WC_READBACK_ATTEMPTS      default 3
 #   RIVER_WC_READBACK_DELAY         seconds between read-back attempts, default 15
+#
+#   The four counts above are validated, not clamped. Attempts below 1 refuse:
+#   zero read-back attempts skips the verification this script exists for and
+#   reports UNKNOWN about a publish that landed, which is the stale-read-back
+#   failure reached from the configuration side.
 #   RIVER_WC_KEY_FILE               signing key file (default:
 #                                   ~/.config/river/web-container-keys.toml).
 #                                   Exists so this script can be rehearsed
@@ -104,10 +135,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-# Kept because the flock re-exec below has to hand this script its own
-# arguments, and by then the parse loop has consumed "$@".
-ORIGINAL_ARGS=("$@")
-
 # shellcheck source=scripts/web-container-publish-lib.sh
 . "$SCRIPT_DIR/web-container-publish-lib.sh"
 
@@ -116,10 +143,12 @@ say() { echo "  $*"; }
 
 SIGN_ONLY=0
 DRY_RUN=0
+DO_BUILD=0
 while [ $# -gt 0 ]; do
     case "$1" in
         --sign-only) SIGN_ONLY=1; shift ;;
         --dry-run)   DRY_RUN=1; shift ;;
+        --build)     DO_BUILD=1; shift ;;
         *) die "unknown argument '$1'" ;;
     esac
 done
@@ -132,14 +161,113 @@ ARCHIVE="target/webapp/webapp.tar.xz"
 METADATA="target/webapp/webapp.metadata"
 SIGNED_PARAMS="target/webapp/webapp.parameters"
 TOOL="target/native/x86_64-unknown-linux-gnu/${BUILD_PROFILE:-release}/web-container-tool"
-LOCK_FILE="published-contract/.publish.lock"
 
 GET_TIMEOUT="${RIVER_WC_GET_TIMEOUT:-180}"
 PUBLISH_TIMEOUT="${RIVER_WC_PUBLISH_TIMEOUT:-300}"
+PREFLIGHT_ATTEMPTS="${RIVER_WC_PREFLIGHT_ATTEMPTS:-3}"
+PREFLIGHT_DELAY="${RIVER_WC_PREFLIGHT_DELAY:-15}"
 READBACK_ATTEMPTS="${RIVER_WC_READBACK_ATTEMPTS:-3}"
 READBACK_DELAY="${RIVER_WC_READBACK_DELAY:-15}"
 ALLOW_UNVERIFIED="${RIVER_WC_ALLOW_UNVERIFIED:-0}"
 ALLOW_FIRST_PUBLISH="${RIVER_WC_ALLOW_FIRST_PUBLISH:-0}"
+ALLOW_UNPROVEN="${RIVER_WC_ALLOW_UNPROVEN:-0}"
+
+# ------------------------------------------------------------- PRECONDITIONS
+echo "=============================================================="
+echo " River web-container publish — pre-flight"
+echo "=============================================================="
+echo ""
+
+for tool in fdev cmp git; do
+    command -v "$tool" >/dev/null 2>&1 || die "$tool not found (needed by this script)"
+done
+for f in "$VERSION_FILE" "$PARAMS_FILE" "$WASM_FILE" "$CONTRACT_ID_FILE"; do
+    [ -f "$f" ] || die "$f missing."
+done
+
+# A knob that switches a check off is a hole in the check. Validated, never
+# clamped: RIVER_WC_READBACK_ATTEMPTS=0 makes the read-back loop run zero times,
+# so the script reports UNKNOWN about a publish that plainly landed — the same
+# failure as believing a stale read-back, reached from the configuration side.
+# A wedged config has to be loud, so it refuses rather than quietly using a
+# default the operator did not ask for.
+require_count() { # require_count <name> <value> <min>
+    case "$2" in
+        ''|*[!0-9]*) die "$1 must be a whole number, got '$2'." ;;
+    esac
+    [ "${#2}" -le 10 ] || die "$1 is implausibly large: '$2'."
+    [ "$2" -ge "$3" ] || die "$1 must be at least $3, got '$2'.
+Below that it switches off a check this script exists to perform."
+}
+require_count RIVER_WC_GET_TIMEOUT        "$GET_TIMEOUT"        1
+require_count RIVER_WC_PUBLISH_TIMEOUT    "$PUBLISH_TIMEOUT"    1
+require_count RIVER_WC_PREFLIGHT_ATTEMPTS "$PREFLIGHT_ATTEMPTS" 1
+require_count RIVER_WC_PREFLIGHT_DELAY    "$PREFLIGHT_DELAY"    0
+require_count RIVER_WC_READBACK_ATTEMPTS  "$READBACK_ATTEMPTS"  1
+require_count RIVER_WC_READBACK_DELAY     "$READBACK_DELAY"     0
+
+CONTRACT_ID="$(tr -d '[:space:]' < "$CONTRACT_ID_FILE")"
+[ -n "$CONTRACT_ID" ] || die "$CONTRACT_ID_FILE is empty."
+COUNTER="$(tr -d '[:space:]' < "$VERSION_FILE")"
+case "$COUNTER" in
+    ''|*[!0-9]*) die "$VERSION_FILE does not hold a number: '$COUNTER'" ;;
+esac
+# The container's version field is a u32 (WebContainerMetadata.version), so a
+# counter at u32::MAX has no successor the contract can accept. Checked HERE,
+# before anything is written: left unchecked, the run wrote counter+1 into the
+# version file and only then failed, leaving a value the contract can never
+# take — every later publish wedged until someone hand-edited the file. The
+# length test comes first because a long enough string overflows the arithmetic
+# that would otherwise judge it.
+U32_MAX=4294967295
+[ "${#COUNTER}" -le 10 ] || die "$VERSION_FILE holds a number too large to be a version: '$COUNTER'.
+Nothing has been written."
+if [ "$COUNTER" -ge "$U32_MAX" ]; then
+    die "$VERSION_FILE holds $COUNTER, which leaves no version below u32::MAX
+($U32_MAX) to sign at — the web container's version field is a u32, so this
+contract cannot accept a higher state and no publish can ever succeed.
+Nothing has been written. This needs a decision about the contract, not an
+edit to the counter file."
+fi
+
+# published-contract/ holds the wasm, the parameters AND the id, and nothing
+# used to check that the three agree. The id is DERIVED from (wasm,
+# parameters), so a stale wasm, a stale parameters file or a stale id file
+# means the publish writes to one contract while every check in this script
+# measures another: the pre-flight GET, the version floor and the post-publish
+# byte comparison would all read an address nobody is writing to, and the run
+# would end with a green verdict having published where nobody will look. That
+# is worse than the fork this script exists to prevent, because it is silent in
+# both directions.
+#
+# This is NOT the signing-key check in [3]. That one catches a key that is not
+# this contract's; this one catches a wasm or an id file that is not. Neither
+# stands in for the other.
+say "checking published-contract/ agrees with itself"
+set +e
+DERIVE_OUT="$(fdev get-contract-id --code "$WASM_FILE" --parameters "$PARAMS_FILE" 2>&1)"
+DERIVE_RC=$?
+set -e
+DERIVED_ID="$(printf '%s' "$DERIVE_OUT" | tr -d '[:space:]')"
+if [ "$DERIVE_RC" -ne 0 ] || [ -z "$DERIVED_ID" ]; then
+    printf '%s\n' "$DERIVE_OUT" | sed 's/^/      /'
+    die "could not derive the contract id from $WASM_FILE + $PARAMS_FILE.
+Refusing to publish without knowing which contract these bytes address."
+fi
+if [ "$DERIVED_ID" != "$CONTRACT_ID" ]; then
+    die "published-contract/ disagrees with itself.
+
+  $WASM_FILE
++ $PARAMS_FILE
+  derive  $DERIVED_ID
+  but $CONTRACT_ID_FILE says
+          $CONTRACT_ID
+
+Publishing would write to $DERIVED_ID while every check here measured
+$CONTRACT_ID. One of the three is stale — re-run
+'cargo make update-published-contract' and commit the result."
+fi
+say "wasm + parameters derive $CONTRACT_ID"
 
 # --------------------------------------------------------------- SINGLE WRITER
 #
@@ -148,58 +276,233 @@ ALLOW_FIRST_PUBLISH="${RIVER_WC_ALLOW_FIRST_PUBLISH:-0}"
 # direction. [tasks.sign-webapp] has carried a comment saying "wrap in flock if
 # you need that" since the counter was introduced; nothing ever did.
 #
+# The lock lives OUTSIDE the checkout, keyed by contract id. River development
+# is worktree-based and this machine routinely carries several River worktrees
+# at once, so a lock file inside the repo hands two concurrent publishes two
+# DIFFERENT lock files and serialises nothing — a lock that reads as protection
+# and is not one. What has to be serialised is "publishes to this contract on
+# this machine", and that is exactly what the path below names. (Two different
+# UNIX users would still miss each other where $XDG_RUNTIME_DIR is per-user;
+# one operator per machine is the case this is built for, and the alternative,
+# a fixed name in a world-writable /tmp, trades that for a path another user
+# can squat.)
+#
+# The lock is a file descriptor held open for the life of the script, not a
+# re-exec under `flock <file> <command>`. Nothing has to be handed the script's
+# own path or arguments — a re-exec through "$0" dies under
+# `cd scripts && ./publish-web-container.sh` — and there is no "already locked"
+# environment sentinel that an inherited environment could set to switch the
+# lock off.
+#
 # A missing flock WARNS rather than refusing. flock is Linux-only (these tasks
 # already build x86_64-unknown-linux-gnu, so that is the expected platform), and
 # blocking a release because a lock utility is absent is a worse failure than
 # the race it prevents — the race needs two simultaneous publishes by one
 # operator on one machine.
-if [ -z "${RIVER_WC_PUBLISH_LOCKED:-}" ]; then
-    if command -v flock >/dev/null 2>&1; then
-        mkdir -p "$(dirname "$LOCK_FILE")"
-        : > "$LOCK_FILE" 2>/dev/null || true
-        export RIVER_WC_PUBLISH_LOCKED=1
-        set +e
-        flock --nonblock --conflict-exit-code 75 "$LOCK_FILE" "$0" \
-            ${ORIGINAL_ARGS[@]+"${ORIGINAL_ARGS[@]}"}
-        rc=$?
-        set -e
-        if [ "$rc" -eq 75 ]; then
+LOCK_ID="$(printf '%s' "$CONTRACT_ID" | tr -c 'A-Za-z0-9._-' '_')"
+LOCK_FILE="${XDG_RUNTIME_DIR:-/tmp}/river-web-container-$LOCK_ID.lock"
+if command -v flock >/dev/null 2>&1; then
+    if : >> "$LOCK_FILE" 2>/dev/null; then
+        exec 9>>"$LOCK_FILE"
+        if flock --nonblock 9; then
+            say "single-writer lock held: $LOCK_FILE"
+        else
             die "another web-container publish is already running (lock: $LOCK_FILE).
 Two concurrent runs race the version counter and can sign two different
-archives at the same version. Wait for the other one, or remove the lock file
-if you are certain nothing is running."
+archives at the same version. Wait for the other one to finish."
         fi
-        exit "$rc"
+    else
+        echo "WARNING: could not open the lock file $LOCK_FILE —" >&2
+        echo "         running WITHOUT the single-writer lock." >&2
     fi
+else
     echo "WARNING: flock not found — running WITHOUT the single-writer lock." >&2
     echo "         Do not run a second publish concurrently." >&2
 fi
 
-# ------------------------------------------------------------- PRECONDITIONS
-echo "=============================================================="
-echo " River web-container publish — pre-flight"
-echo "=============================================================="
+# ------------------------------------------------------------- [0] PROVENANCE
+#
+# The web container is ONE fixed contract key serving every River user: whatever
+# is in this checkout is what every user gets, and there is no per-branch
+# staging address to publish to instead. ~/.claude/rules/publish-from-main.md
+# names this key explicitly, and river's `main` carries no branch protection, so
+# nothing upstream of this script enforces any of it.
+#
+# These are the four checks scripts/publish-pointer-records.sh makes before its
+# own network write. They run for a --sign-only run too: signing burns a version
+# and hands back an artifact that `fdev network publish` will take by hand, so
+# it is a release step, not a build step. --dry-run runs them as well, because a
+# pre-flight that skipped the gate would report a publish as fine that the real
+# run then refuses.
 echo ""
+echo "[0] provenance: clean tree, on main, at origin/main, CI green"
+if [ "$ALLOW_UNPROVEN" = "1" ]; then
+    echo "  !! provenance gate SKIPPED by RIVER_WC_ALLOW_UNPROVEN=1." >&2
+    echo "  !! whatever is in this checkout is what every River user will get." >&2
+else
+    git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+        || die "$REPO_ROOT is not a git checkout, so nothing here can say which commit
+is being published to a key every River user resolves.
+Set RIVER_WC_ALLOW_UNPROVEN=1 for this run if you accept that."
 
-for tool in fdev cmp; do
-    command -v "$tool" >/dev/null 2>&1 || die "$tool not found (needed by this script)"
-done
-[ -x "$TOOL" ] || die "$TOOL not found. Run via cargo make so it gets built."
-for f in "$VERSION_FILE" "$PARAMS_FILE" "$WASM_FILE" "$CONTRACT_ID_FILE"; do
-    [ -f "$f" ] || die "$f missing."
-done
-[ -s "$ARCHIVE" ] || die "$ARCHIVE missing or empty. Run 'cargo make compress-webapp' first."
+    # TRACKED modifications, with ONE exemption in ONE direction.
+    #
+    # A modified tracked file means this checkout differs from the commit whose
+    # CI is verified below, which is the whole provenance claim. The counter is
+    # the exception, because it is the one tracked file THIS SCRIPT writes by
+    # design: after any run that reached [3] it is legitimately ahead of HEAD.
+    # Refusing that would refuse the re-run that every non-landed verdict tells
+    # the operator to make, and the reflex when a script says "clean checkout"
+    # and names one file is `git checkout -- <file>` — which IS the 2026-08-04
+    # rollback. A gate must not manufacture pressure toward the incident it
+    # exists to prevent.
+    #
+    # It is safe to exempt because the counter is NOT an input to the archive.
+    # It only seeds wc_next_version, whose result is re-floored against the
+    # version read off the network, so a counter ahead of HEAD cannot change
+    # what users get.
+    #
+    # STRICTLY GREATER only. A working-tree counter at or below HEAD's is the
+    # dangerous direction — something rolled it back — and stays a refusal.
+    DIRTY="$(git status --porcelain --untracked-files=no)"
+    if [ -n "$DIRTY" ]; then
+        DIRTY_OTHER="$(printf '%s\n' "$DIRTY" | grep -v "[[:space:]]${VERSION_FILE}\$" || true)"
+        if [ -n "$DIRTY_OTHER" ]; then
+            printf '%s\n' "$DIRTY_OTHER" | sed 's/^/    /'
+            die "tracked files are modified. Publish only from a clean checkout of main.
+Set RIVER_WC_ALLOW_UNPROVEN=1 for this run if you accept that."
+        fi
+        HEAD_COUNTER="$(git show "HEAD:$VERSION_FILE" 2>/dev/null | tr -d '[:space:]' || true)"
+        case "$HEAD_COUNTER" in
+            ''|*[!0-9]*) die "$VERSION_FILE is modified and HEAD does not hold a number for it.
+Refusing to guess whether that is a burned version or a rollback." ;;
+        esac
+        if [ "${#HEAD_COUNTER}" -le 10 ] && [ "$COUNTER" -gt "$HEAD_COUNTER" ]; then
+            say "note: $VERSION_FILE is ahead of HEAD ($HEAD_COUNTER -> $COUNTER)."
+            say "      That is a version an earlier run burned. COMMIT it. Never"
+            say "      'git checkout' it — that reissues a version that may be live."
+        else
+            die "$VERSION_FILE is modified and holds $COUNTER, which is not above HEAD's
+$HEAD_COUNTER. The counter is forward-only: a value that is not ahead means
+something rolled it back, and reissuing a version that has already been
+published is the 2026-08-04 fork. Restore it to at least $HEAD_COUNTER."
+        fi
+    fi
 
-CONTRACT_ID="$(tr -d '[:space:]' < "$CONTRACT_ID_FILE")"
-COUNTER="$(tr -d '[:space:]' < "$VERSION_FILE")"
-case "$COUNTER" in
-    ''|*[!0-9]*) die "$VERSION_FILE does not hold a number: '$COUNTER'" ;;
-esac
+    # UNTRACKED files. The old note here asserted that they "cannot change what
+    # is published". That is false: the build reaches files by GLOB, not by git.
+    # `--build` runs compress-webapp -> build-ui -> build-tailwind, and
+    # ui/assets/tailwind.css carries `@source "../src/**/*.rs"`, so an untracked
+    # .rs under ui/src contributes class names to the generated stylesheet that
+    # dx bundles and compress-webapp tars into the archive. `dx build` walks
+    # ui/assets the same way. Both were verified against this tree.
+    #
+    # So the demonstrated vectors are refused rather than noted. This does NOT
+    # claim to enumerate every glob the build reaches — which is why the note
+    # below now says what was checked instead of asserting a universal.
+    UNTRACKED="$(git status --porcelain --untracked-files=all | grep '^??' | sed 's/^?? //' || true)"
+    UNTRACKED_BUILD_INPUT="$(printf '%s\n' "$UNTRACKED" | grep '^ui/' || true)"
+    if [ -n "$UNTRACKED_BUILD_INPUT" ]; then
+        printf '%s\n' "$UNTRACKED_BUILD_INPUT" | sed 's/^/    /'
+        die "untracked files under ui/ would be built into the published archive.
+Tailwind globs ui/src/**/*.rs for class names and dx walks ui/assets, so these
+reach the archive without reaching git — the published site would differ from
+both HEAD and the artifact CI tested. Commit them or remove them.
+Set RIVER_WC_ALLOW_UNPROVEN=1 for this run if you accept that."
+    fi
+    if [ -n "$UNTRACKED" ]; then
+        say "note: untracked files present, none under ui/ (the build inputs checked here):"
+        printf '%s\n' "$UNTRACKED" | sed 's/^/      /'
+    fi
+
+    BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+    [ "$BRANCH" = "main" ] || die "on branch '$BRANCH'. Publish only from main.
+This contract key is shared, so a feature-branch publish ships the site without
+whatever merged to main since the branch was cut — see
+~/.claude/rules/publish-from-main.md.
+Set RIVER_WC_ALLOW_UNPROVEN=1 for this run if you accept that."
+
+    git fetch origin main --quiet \
+        || die "could not fetch origin/main, so 'HEAD == origin/main' cannot be checked.
+Set RIVER_WC_ALLOW_UNPROVEN=1 for this run if you accept that."
+    HEAD_SHA="$(git rev-parse HEAD)"
+    ORIGIN_SHA="$(git rev-parse origin/main)"
+    [ "$HEAD_SHA" = "$ORIGIN_SHA" ] || die "HEAD ($HEAD_SHA) != origin/main ($ORIGIN_SHA). Pull first.
+Set RIVER_WC_ALLOW_UNPROVEN=1 for this run if you accept that."
+    say "HEAD == origin/main == $HEAD_SHA"
+
+    command -v gh >/dev/null 2>&1 || die "gh not found — cannot verify CI on $HEAD_SHA"
+    command -v jq >/dev/null 2>&1 || die "jq not found — cannot read the CI status for $HEAD_SHA"
+    RUNS="$(gh run list --repo freenet/river --commit "$HEAD_SHA" \
+        --json conclusion,status,name 2>/dev/null || echo "")"
+    [ -n "$RUNS" ] || die "could not read CI status for $HEAD_SHA.
+Refusing to publish on an unknown signal.
+Set RIVER_WC_ALLOW_UNPROVEN=1 for this run if you accept that."
+
+    # COUNT THE RUNS, not only the bad ones. An empty list yields zero failures,
+    # so a `length == 0` test on its own reports "green" for a commit CI never
+    # ran on — a guard that cannot fail, which is worse than no guard because it
+    # is reassuring. Ask for evidence of success, then for absence of failure.
+    TOTAL="$(printf '%s' "$RUNS" | jq 'length')"
+    [ "$TOTAL" -gt 0 ] || die "NO CI runs exist for $HEAD_SHA.
+That is not the same as green. Either CI has not started, or this commit is not
+what you think it is. Refusing to publish.
+Set RIVER_WC_ALLOW_UNPROVEN=1 for this run if you accept that."
+
+    # Non-SUCCESS conclusions include failure, cancelled and timed_out; a
+    # still-running check is also not a green signal.
+    BAD="$(printf '%s' "$RUNS" | jq '[.[] | select(.status != "completed" or (.conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral"))] | length')"
+    if [ "$BAD" != "0" ]; then
+        gh run list --repo freenet/river --commit "$HEAD_SHA" --limit 20 | sed 's/^/    /'
+        die "$BAD of $TOTAL CI check(s) on $HEAD_SHA are not green.
+Never publish on red or pending CI.
+Set RIVER_WC_ALLOW_UNPROVEN=1 for this run if you accept that."
+    fi
+    say "CI green on $HEAD_SHA ($TOTAL run(s), all successful)"
+fi
 
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
+# ------------------------------------------------------------ [0b] BUILD INPUTS
+#
+# The artifacts are built HERE, inside the lock, instead of being declared as
+# cargo-make dependencies of [tasks.publish-river]. cargo-make runs a task's
+# dependencies to completion BEFORE its script — so a dependency-built archive
+# is produced before this script exists to lock anything. Two overlapping
+# `cargo make publish-river` runs therefore both wrote the shared
+# target/webapp/webapp.tar.xz outside any lock, and the second could replace the
+# archive while the first was signing it, publishing it, or comparing it byte
+# for byte against the read-back. The lock covered sign-to-verify but not the
+# artifact it was verifying, which is not what "one lock across the whole
+# sequence" means. (It degrades to a confusing failure rather than a fork: the
+# first run publishes B's archive under metadata signed for A's, validate_state
+# rejects it, and the read-back says not-landed.)
+if [ "$DO_BUILD" -eq 1 ]; then
+    echo ""
+    echo "[0b] building the inputs, under the same lock"
+    command -v cargo >/dev/null 2>&1 || die "--build was requested but cargo is not on PATH."
+    # --env, not an inherited variable. cargo-make's [env] block OVERRIDES an
+    # environment variable of the same name (verified against cargo-make
+    # 0.37.24), so a nested `cargo make` would rebuild publish-river-debug at
+    # the global default profile and then look for a tool built somewhere else.
+    cargo make --env BUILD_PROFILE="${BUILD_PROFILE:-release}" web-container-build-inputs \
+        || die "the build failed. Nothing has been signed and the counter is untouched."
+    # [0] vouched for a clean tracked tree and the build ran after it. Nothing
+    # in the build is supposed to write a tracked path; if that stops being
+    # true, the commit whose CI we verified is no longer the thing we publish.
+    if [ "$ALLOW_UNPROVEN" != "1" ] && [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+        git status --short --untracked-files=no | sed 's/^/    /'
+        die "the build modified tracked files, so what is about to be published is no
+longer the commit whose CI was verified in [0]. Nothing has been signed."
+    fi
+fi
+
+[ -x "$TOOL" ] || die "$TOOL not found. Run via cargo make so it gets built."
+[ -s "$ARCHIVE" ] || die "$ARCHIVE missing or empty. Run 'cargo make compress-webapp' first."
+
 # --------------------------------------------- [1] READ THE NETWORK, BEFORE SIGNING
+echo ""
 echo "[1] reading the version currently on the network"
 say "contract $CONTRACT_ID (through the node at WS_API_PORT=${WS_API_PORT:-7509})"
 
@@ -240,12 +543,30 @@ of state whose provenance is unclear."
     fi
 }
 
-read_network_version "$WORK/onnet.bin" "$WORK/onnet.log"
+# One failed GET is a missing sample, not a network answer, and refusing a
+# legitimate publish because a single read timed out is a self-inflicted
+# outage — so ask again before concluding `unknown`. `absent` is deliberately
+# NOT retried here: it is a definite answer FROM the node, and whether to
+# believe it for this contract is wc_preflight_decision's call rather than a
+# question of asking harder.
+preflight_attempt=1
+while :; do
+    read_network_version "$WORK/onnet.bin" "$WORK/onnet.log"
+    [ "$NET_STATUS" = "unknown" ] || break
+    [ "$preflight_attempt" -lt "$PREFLIGHT_ATTEMPTS" ] || break
+    tail -3 "$WORK/onnet.log" | sed 's/^/      /'
+    say "attempt $preflight_attempt/$PREFLIGHT_ATTEMPTS did not learn the version; retrying in ${PREFLIGHT_DELAY}s"
+    preflight_attempt=$((preflight_attempt + 1))
+    if [ "$PREFLIGHT_DELAY" -gt 0 ]; then
+        sleep "$PREFLIGHT_DELAY"
+    fi
+done
 
 case "$NET_STATUS" in
     known)   say "the network holds version $NET_VERSION (signature verified under our parameters)" ;;
     absent)  say "the node answered: Contract not found" ;;
-    unknown) tail -3 "$WORK/onnet.log" | sed 's/^/      /'; say "could NOT determine the on-network version" ;;
+    unknown) tail -3 "$WORK/onnet.log" | sed 's/^/      /'
+             say "could NOT determine the on-network version ($preflight_attempt attempt(s))" ;;
 esac
 
 DECISION="$(wc_preflight_decision "$NET_STATUS" "$ALLOW_UNVERIFIED" "$ALLOW_FIRST_PUBLISH")"
@@ -278,10 +599,19 @@ tell you if the state did not land."
             ;;
     esac
 fi
-if [ "$NET_STATUS" != "known" ] && [ "$SIGN_ONLY" -eq 0 ]; then
+# The warning matters MOST in --sign-only mode, not least: that is the one path
+# with no read-back at all, and it still burns a version and hands back a signed
+# artifact `fdev network publish` will take.
+if [ "$NET_STATUS" != "known" ]; then
     echo ""
     echo "  !! proceeding WITHOUT a verified on-network version, by explicit override." >&2
-    echo "  !! the read-back after the publish is the only remaining check." >&2
+    if [ "$SIGN_ONLY" -eq 1 ]; then
+        echo "  !! --sign-only does NOT read back, so NOTHING here will check this" >&2
+        echo "  !! version against the network. If it is not above the live one," >&2
+        echo "  !! publishing the artifact this produces is the 2026-08-04 fork." >&2
+    else
+        echo "  !! the read-back after the publish is the only remaining check." >&2
+    fi
 fi
 
 # ------------------------------------------------------------ [2] PICK A VERSION
@@ -306,6 +636,36 @@ fi
 # ------------------------------------------------------------------- [3] SIGN
 echo ""
 echo "[3] signing"
+
+KEY_ARGS=()
+if [ -n "${RIVER_WC_KEY_FILE:-}" ]; then
+    KEY_ARGS=(--key-file "$RIVER_WC_KEY_FILE")
+fi
+
+# The parameters ARE the contract's identity: the contract ID is derived from
+# (wasm, parameters). If the key is not the key this contract belongs to, the
+# publish would go to a different contract entirely and every check after it
+# would be measuring the wrong thing.
+#
+# Checked BEFORE the counter is written. `export-parameters` reads the key and
+# writes one file into $WORK: it signs nothing and burns nothing. The wrong key
+# has to cost an error message rather than a version — the old order wrote the
+# counter first, so a wrong-key abort consumed a version and published nothing.
+set +e
+"$TOOL" export-parameters --parameters "$WORK/key-check.parameters" \
+    ${KEY_ARGS[@]+"${KEY_ARGS[@]}"} >"$WORK/key-check.log" 2>&1
+KEY_CHECK_RC=$?
+set -e
+if [ "$KEY_CHECK_RC" -ne 0 ]; then
+    sed 's/^/      /' "$WORK/key-check.log"
+    die "could not read the signing key. Check ${RIVER_WC_KEY_FILE:-~/.config/river/web-container-keys.toml}."
+fi
+cmp -s "$WORK/key-check.parameters" "$PARAMS_FILE" || die "the key we would sign with does not match $PARAMS_FILE.
+Signing with the wrong key publishes to a DIFFERENT contract ID. Check
+${RIVER_WC_KEY_FILE:-~/.config/river/web-container-keys.toml}.
+Nothing has been signed and the counter is untouched."
+say "the signing key owns $CONTRACT_ID"
+
 # Forward-only. Written BEFORE signing so a crash between here and the publish
 # leaves the counter ahead rather than behind: ahead costs a gap, behind costs
 # a reissued version.
@@ -313,10 +673,6 @@ echo "$VERSION" > "$VERSION_FILE"
 # Remove the rollback snapshot the old flow left behind, if a stale one exists.
 rm -f "$VERSION_FILE.prev"
 
-KEY_ARGS=()
-if [ -n "${RIVER_WC_KEY_FILE:-}" ]; then
-    KEY_ARGS=(--key-file "$RIVER_WC_KEY_FILE")
-fi
 "$TOOL" sign \
     --input "$ARCHIVE" \
     --output "$METADATA" \
@@ -324,10 +680,8 @@ fi
     --version "$VERSION" \
     ${KEY_ARGS[@]+"${KEY_ARGS[@]}"}
 
-# The parameters ARE the contract's identity: the contract ID is derived from
-# (wasm, parameters). If the key we just signed with is not the key this
-# contract belongs to, the publish would go to a different contract entirely
-# and every check after it would be measuring the wrong thing.
+# The parameters `sign` actually wrote, not the ones `export-parameters` said it
+# would: the same claim, re-checked against the artifact about to be published.
 cmp -s "$SIGNED_PARAMS" "$PARAMS_FILE" || die "the key that just signed does not match $PARAMS_FILE.
 Signing with the wrong key publishes to a DIFFERENT contract ID. Check
 ~/.config/river/web-container-keys.toml."
@@ -335,7 +689,13 @@ say "signed version $VERSION with the key that owns $CONTRACT_ID"
 
 if [ "$SIGN_ONLY" -eq 1 ]; then
     echo ""
-    echo "--sign-only: not publishing. Commit $VERSION_FILE only after a successful publish."
+    # NOT "commit only after a successful publish" — that was the pre-rollback
+    # doctrine, and it implies discarding the counter when the publish fails,
+    # which is the 2026-08-04 rollback. An unpublished burn costs a gap; a
+    # reissue forks the site. --sign-only is also the one path with no
+    # read-back, so nothing here can tell you which of the two you are in.
+    echo "--sign-only: not publishing. COMMIT $VERSION_FILE — version $VERSION is"
+    echo "burned whether or not it is ever published, and reissuing it is the fork."
     exit 0
 fi
 
@@ -362,9 +722,20 @@ fi
 # --------------------------------------------------------------- [5] READ BACK
 echo ""
 echo "[5] reading the state back"
-echo "    'the publish returned OK' is not evidence: a publish at an already-used"
-echo "    version is a no-op success, and a publish that reports a timeout may"
-echo "    have landed. Only the bytes on the network settle it."
+echo "    'the publish returned OK' is not evidence: it says the node we published"
+echo "    THROUGH accepted the PUT, not that the bytes users fetch are ours. And a"
+echo "    publish that reports a timeout may have landed anyway (2026-08-04)."
+echo "    Only the bytes on the network settle it."
+
+# A non-zero publish is the case where the PUT is most likely still in flight —
+# 2026-08-04 exactly. Reading back the instant fdev gives up samples the network
+# before it could have converged, and a stale sample there reads as NOT
+# PUBLISHED, which is the report that invites the retry that forks the site.
+if [ "$PUB_RC" -ne 0 ] && [ "$READBACK_DELAY" -gt 0 ]; then
+    say "waiting ${READBACK_DELAY}s before the first read-back (fdev reported a failure;"
+    say "the PUT may still be in flight, and an immediate read would be a stale read)"
+    sleep "$READBACK_DELAY"
+fi
 
 BACK_STATUS="unknown"
 BACK_VERSION=""
@@ -410,17 +781,20 @@ while [ "$attempt" -le "$READBACK_ATTEMPTS" ]; do
 
     OUTCOME="$(wc_publish_outcome "$PUB_RC" "$BACK_STATUS" "$BACK_VERSION" "$BYTES_MATCH" "$VERSION")"
     say "network says: ${BACK_STATUS}${BACK_VERSION:+ version $BACK_VERSION}, archive match: $BYTES_MATCH -> $OUTCOME"
-    # Only 'unknown' is worth retrying: a definite answer that differs from
-    # ours will not change by asking again, and retrying it just delays a
-    # report the operator needs.
-    if [ "$OUTCOME" != "unknown" ]; then
+    # See wc_readback_is_final. 'not-landed' and 'unknown' are the same claim in
+    # two shapes — "we have not seen our state yet" — and on an eventually
+    # consistent network that is indistinguishable from a read that was simply
+    # too early. Only a settled answer stops the loop.
+    if [ "$(wc_readback_is_final "$OUTCOME")" = "yes" ]; then
         break
     fi
     attempt=$((attempt + 1))
-    if [ "$attempt" -le "$READBACK_ATTEMPTS" ]; then
+    if [ "$attempt" -le "$READBACK_ATTEMPTS" ] && [ "$READBACK_DELAY" -gt 0 ]; then
         sleep "$READBACK_DELAY"
     fi
 done
+READS_MADE="$attempt"
+[ "$READS_MADE" -le "$READBACK_ATTEMPTS" ] || READS_MADE="$READBACK_ATTEMPTS"
 
 # ----------------------------------------------------------------- [6] VERDICT
 echo ""
@@ -443,7 +817,9 @@ case "$OUTCOME" in
             echo "  Version $VERSION is live and byte-identical to what we published."
         fi
         echo ""
-        echo "  Commit the counter:  git add $VERSION_FILE"
+        # `git add` alone leaves the file staged-but-uncommitted, which still
+        # reads as modified to the gate in [0] and to anyone else looking.
+        echo "  Commit the counter:  git commit -m 'chore: bump web-container version' $VERSION_FILE"
         ;;
     collision)
         echo " FORKED — version $VERSION is live carrying DIFFERENT bytes"
@@ -467,7 +843,7 @@ case "$OUTCOME" in
         echo "  out what else is publishing to this contract."
         ;;
     not-landed)
-        echo " NOT PUBLISHED — the network is still at $BACK_VERSION"
+        echo " NOT PUBLISHED — the network is still at $BACK_VERSION after $READS_MADE read(s)"
         echo "=============================================================="
         echo ""
         echo "  The publish did not land. The counter is left at $VERSION and is NOT"
@@ -478,7 +854,7 @@ case "$OUTCOME" in
         echo "  Re-run the publish; it will sign above whatever the network reports."
         ;;
     *)
-        echo " UNKNOWN — could not read the state back"
+        echo " UNKNOWN — could not read the state back after $READS_MADE read(s)"
         echo "=============================================================="
         echo ""
         echo "  We do not know whether version $VERSION landed. The counter is left"
@@ -489,5 +865,15 @@ case "$OUTCOME" in
         echo "  the live version and sign above it either way."
         ;;
 esac
+# Every non-landed verdict above tells the operator to re-run. Say what has to
+# happen first, in the one place all four arms pass through — because the
+# alternative the operator reaches for is `git checkout` on the counter, and
+# that is the 2026-08-04 rollback wearing the clothes of tidying up.
+if [ "$OUTCOME" != "landed" ]; then
+    echo ""
+    echo "  BEFORE re-running: commit $VERSION_FILE (now $VERSION)."
+    echo "  Do NOT 'git checkout' it. $VERSION may already have been seen by a"
+    echo "  peer, and reissuing a used version is what forked the site."
+fi
 echo ""
 exit "$EXIT_CODE"

--- a/scripts/tests/web-container-publish-lib-test.sh
+++ b/scripts/tests/web-container-publish-lib-test.sh
@@ -103,8 +103,9 @@ check "rc!=0 but our bytes are live (the timeout that landed)" \
 check "our version, someone else's bytes" \
     "collision" "$(wc_publish_outcome 0 known 30000377 0 30000377)"
 
-# rc=0 is the no-op success: the container silently kept the older state.
-check "rc=0 but the network is still behind (no-op success)" \
+# The node we published through reported success and the network is still
+# behind: whatever it accepted, our bytes are not what is live.
+check "rc=0 but the network is still behind" \
     "not-landed" "$(wc_publish_outcome 0 known 30000376 0 30000377)"
 
 check "the network moved above us" \
@@ -117,6 +118,25 @@ check "read-back said not found" \
     "unknown" "$(wc_publish_outcome 0 absent "" na 30000377)"
 check "read-back verified but printed no version" \
     "unknown" "$(wc_publish_outcome 0 known "" na 30000377)"
+
+echo "--- wc_readback_is_final: only a settled answer stops asking"
+
+# These three are statements about a state we read. They do not un-happen, and
+# re-reading only delays a report the operator needs.
+for outcome in landed collision superseded; do
+    check "$outcome is final" "yes" "$(wc_readback_is_final "$outcome")"
+done
+
+# THE ONE THAT MATTERS. 'not-landed' says "the network is not showing our
+# state", which on an eventually-consistent network is exactly what a read
+# taken too early says. Calling it final reports a publish that LANDED as NOT
+# PUBLISHED, and that report is what invites the retry that forked the site.
+check "not-landed is NOT final" "no" "$(wc_readback_is_final not-landed)"
+check "unknown is NOT final"    "no" "$(wc_readback_is_final unknown)"
+
+# Anything unrecognised keeps asking rather than settling on a verdict nothing
+# produced.
+check "an unrecognised outcome is not final" "no" "$(wc_readback_is_final garbage)"
 
 echo "--- wc_outcome_exit_code: only a proven publish exits 0"
 

--- a/scripts/tests/web-container-publish-lib-test.sh
+++ b/scripts/tests/web-container-publish-lib-test.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Exercise the web-container publish decisions with stubbed inputs.
+#
+# The publish path cannot be rehearsed end to end — it needs a live network,
+# and testing against the shared contract is out of bounds. So the decisions it
+# turns on live in scripts/web-container-publish-lib.sh, with no I/O in them,
+# and this runs every branch.
+#
+# Run: ./scripts/tests/web-container-publish-lib-test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/web-container-publish-lib.sh
+. "$SCRIPT_DIR/../web-container-publish-lib.sh"
+
+PASS=0
+FAIL=0
+
+check() { # check <label> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: $1"
+        echo "      expected: $2"
+        echo "      actual:   $3"
+    fi
+}
+
+echo "--- wc_next_version: the network is the floor, the counter is a hint"
+
+# The ordinary case: counter is ahead, use it.
+check "counter ahead of network" \
+    "30000386" "$(wc_next_version 30000385 known 30000384)"
+
+# THE 2026-08-04 CASE. The counter was rolled back to 30000376 after a publish
+# that had in fact landed at 30000377. Old behaviour signed 30000377 again.
+# The floor must lift it to 30000378.
+check "counter behind the network (the 1032d373 rollback)" \
+    "30000378" "$(wc_next_version 30000376 known 30000377)"
+
+# Equal is the same trap wearing a different hat: counter+1 would be exactly
+# the live version.
+check "counter equal to the network" \
+    "30000378" "$(wc_next_version 30000377 known 30000377)"
+
+# Strictly greater, not contiguous: a network far ahead is followed, not
+# stepped toward.
+check "network far ahead" \
+    "40000001" "$(wc_next_version 12 known 40000000)"
+
+check "absent has no floor" "31" "$(wc_next_version 30 absent)"
+check "unknown has no floor" "31" "$(wc_next_version 30 unknown)"
+
+check "a bad status is an error, not a version" \
+    "1" "$(wc_next_version 30 nonsense 2>/dev/null >/dev/null; echo $?)"
+
+echo "--- wc_preflight_decision: ambiguity refuses"
+
+check "a verified network version proceeds" \
+    "proceed" "$(wc_preflight_decision known 0 0)"
+
+# 'Could not determine' is not 'nothing is there'. Refuse by default; the
+# override exists because a node outage should not be able to block a release
+# outright, only make the operator say so out loud.
+case "$(wc_preflight_decision unknown 0 0)" in
+    refuse:*) check "unknown refuses by default" "yes" "yes" ;;
+    *)        check "unknown refuses by default" "yes" "no"  ;;
+esac
+check "unknown proceeds under an explicit override" \
+    "proceed" "$(wc_preflight_decision unknown 1 0)"
+
+# NotFound is not proof of absence for a contract we know is published: a
+# Freenet GET can dead-end and answer NotFound for state that exists.
+case "$(wc_preflight_decision absent 0 0)" in
+    refuse:*) check "absent refuses by default" "yes" "yes" ;;
+    *)        check "absent refuses by default" "yes" "no"  ;;
+esac
+check "absent proceeds only for a declared first publish" \
+    "proceed" "$(wc_preflight_decision absent 0 1)"
+
+# The unverified override must NOT quietly also accept a NotFound: they are
+# different claims and one is not a licence for the other.
+case "$(wc_preflight_decision absent 1 0)" in
+    refuse:*) check "allow-unverified does not imply allow-first-publish" "yes" "yes" ;;
+    *)        check "allow-unverified does not imply allow-first-publish" "yes" "no"  ;;
+esac
+
+echo "--- wc_publish_outcome: the exit code decides nothing"
+
+# fdev said OK and our bytes are live: published.
+check "rc=0, our version, our bytes" \
+    "landed" "$(wc_publish_outcome 0 known 30000378 1 30000378)"
+
+# THE 2026-08-04 CASE, from the other end. `put timed out after 1 peer
+# attempt(s)` — non-zero exit — but the state was live all along. Retrying
+# here is what produced the fork.
+check "rc!=0 but our bytes are live (the timeout that landed)" \
+    "landed" "$(wc_publish_outcome 1 known 30000377 1 30000377)"
+
+# Our version is live carrying bytes that are not ours. Both are validly
+# signed, so only the byte comparison can see this.
+check "our version, someone else's bytes" \
+    "collision" "$(wc_publish_outcome 0 known 30000377 0 30000377)"
+
+# rc=0 is the no-op success: the container silently kept the older state.
+check "rc=0 but the network is still behind (no-op success)" \
+    "not-landed" "$(wc_publish_outcome 0 known 30000376 0 30000377)"
+
+check "the network moved above us" \
+    "superseded" "$(wc_publish_outcome 0 known 30000380 0 30000377)"
+
+# No read-back means no verdict. Never 'landed' by default.
+check "read-back failed" \
+    "unknown" "$(wc_publish_outcome 0 unknown "" na 30000377)"
+check "read-back said not found" \
+    "unknown" "$(wc_publish_outcome 0 absent "" na 30000377)"
+check "read-back verified but printed no version" \
+    "unknown" "$(wc_publish_outcome 0 known "" na 30000377)"
+
+echo "--- wc_outcome_exit_code: only a proven publish exits 0"
+
+check "landed exits 0"      "0" "$(wc_outcome_exit_code landed)"
+for outcome in collision superseded not-landed unknown garbage; do
+    rc="$(wc_outcome_exit_code "$outcome")"
+    if [ "$rc" -ne 0 ]; then
+        check "$outcome is non-zero" "yes" "yes"
+    else
+        check "$outcome is non-zero" "yes" "no"
+    fi
+done
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/tests/web-container-publish-rehearsal.sh
+++ b/scripts/tests/web-container-publish-rehearsal.sh
@@ -5,17 +5,26 @@
 # covers the wiring around it, which is where a publish script actually breaks:
 # the fdev argument order, the `Contract not found` string it keys absence off,
 # the `version=` line it parses, whether the counter really is forward-only,
-# and whether the verdict comes out of the read-back rather than the exit code.
-# None of that is reachable from a pure function, and none of it can be
-# exercised against the real network (the web container's key is shared and
-# publishing to it from a test is out of bounds).
+# whether the verdict comes out of the read-back rather than the exit code,
+# whether the single-writer lock is a lock and covers the artifact build, and
+# whether the provenance gate refuses what it says it refuses. None of that is
+# reachable from a pure function, and none of it can be exercised against the
+# real network (the web container's key is shared and publishing to it from a
+# test is out of bounds).
 #
-# So: a throwaway repo layout, a throwaway signing key, and an `fdev` on PATH
-# that is a shell script. The real publish script and the real
-# web-container-tool run unmodified.
+# So: a throwaway repo layout — a real git repo, with a real local bare origin,
+# because the provenance gate is part of the wiring — a throwaway signing key,
+# and `fdev`, `gh` and `cargo` on PATH that are shell scripts. The real publish
+# script and the real web-container-tool run unmodified.
 #
 # Scenario 2 is the 2026-08-04 incident (River commit 1032d373) reproduced:
 # a publish that reports a timeout and lands anyway.
+#
+# NOTE for anyone adding a scenario: this file runs under `set -uo pipefail`
+# with NO `set -e`, so a setup step that fails does not abort the scenario — it
+# silently mis-runs it and can still report a pass. Assert that your setup
+# happened rather than assuming it did. `seed_network` and `git_sync` check
+# their own postconditions for exactly this reason.
 #
 # Run: ./scripts/tests/web-container-publish-rehearsal.sh
 set -uo pipefail
@@ -23,7 +32,30 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-command -v python3 >/dev/null 2>&1 || { echo "SKIP: python3 not available"; exit 0; }
+PASS=0
+FAIL=0
+
+# A missing interpreter used to `exit 0`. This is the ONLY end-to-end coverage
+# of a release path, so reporting success because the machine could not run it
+# is a green signal that no input can turn red — the exact shape this suite
+# exists to catch in the script. Absence is now a failure; the skip is opt-in
+# and must never be set in CI.
+missing_tool() {
+    if [ "${RIVER_WC_REHEARSAL_ALLOW_SKIP:-0}" = "1" ]; then
+        echo "SKIP: $1 not available (RIVER_WC_REHEARSAL_ALLOW_SKIP=1)"
+        exit 0
+    fi
+    echo "FAIL: $1 not available."
+    echo "      This is the only end-to-end coverage of the release path, so a"
+    echo "      missing interpreter is a failure, not a pass. Install it, or set"
+    echo "      RIVER_WC_REHEARSAL_ALLOW_SKIP=1 to skip on purpose (never in CI)."
+    exit 1
+}
+command -v python3 >/dev/null 2>&1 || missing_tool python3
+command -v git     >/dev/null 2>&1 || missing_tool git
+# The provenance gate reads CI status with `gh ... --json | jq`. gh is stubbed
+# below; jq is not, because the script's own jq expressions are under test.
+command -v jq      >/dev/null 2>&1 || missing_tool jq
 
 # ------------------------------------------------------------------- the tool
 
@@ -63,7 +95,7 @@ cp "$REPO_ROOT/scripts/web-container-publish-lib.sh" "$SANDBOX/scripts/"
 cp "$TOOL_SRC" "$SANDBOX/target/native/x86_64-unknown-linux-gnu/release/web-container-tool"
 TOOL="$SANDBOX/target/native/x86_64-unknown-linux-gnu/release/web-container-tool"
 
-# ----------------------------------------------------------- throwaway key
+# ----------------------------------------------------------- throwaway keys
 # Never the production key at ~/.config/river/web-container-keys.toml. The
 # publish script's parameters check would refuse it here anyway, since the
 # sandbox's committed parameters are this key's.
@@ -71,8 +103,12 @@ KEY_FILE="$SANDBOX/keys.toml"
 "$TOOL" generate --output "$KEY_FILE" >/dev/null
 "$TOOL" export-parameters --parameters "$SANDBOX/published-contract/webapp.parameters" \
     --key-file "$KEY_FILE" >/dev/null
-echo "TESTCONTRACTKEYnotarealbase58key" > "$SANDBOX/published-contract/contract-id.txt"
+# A second key that owns a DIFFERENT contract, for the wrong-key scenario.
+OTHER_KEY="$SANDBOX/other-keys.toml"
+"$TOOL" generate --output "$OTHER_KEY" >/dev/null
+
 printf 'not a real wasm' > "$SANDBOX/published-contract/web_container_contract.wasm"
+echo "30000000" > "$SANDBOX/published-contract/contract-version.txt"
 
 # ----------------------------------------------------------------- stub fdev
 # Behaviour is driven entirely by files under $SANDBOX/node:
@@ -82,14 +118,50 @@ printf 'not a real wasm' > "$SANDBOX/published-contract/web_container_contract.w
 #                 read and a post-publish read can behave differently
 #   publish_rc    exit code the publish reports
 #   publish_lands 1 = the publish updates state.bin, 0 = it is a no-op
+#   stale_reads   how many GETs AFTER a landing publish still serve the state
+#                 as it was BEFORE it. Freenet is eventually consistent, so a
+#                 read taken too early legitimately shows the old state; the
+#                 stub has to be able to represent that or the read-back retry
+#                 has nothing to be right about.
+#
+# publish_rc and publish_lands are INDEPENDENT knobs on purpose: the script must
+# not trust the exit code in either direction, so the suite has to be able to
+# present any combination of the two. Do not read a combination as a claim about
+# how the real contract behaves. In particular, a PUT at an already-used version
+# is NOT a silent success — `update_state` returns InvalidUpdateWithInfo and
+# freenet-core surfaces that as an error to the publishing node, which is how
+# the 2026-08-04 operator saw the rejection message.
+#
+# `get-contract-id` derives an id from the bytes it is given, exactly as the
+# real one does, so a stale wasm or a stale parameters file genuinely produces a
+# different id.
 cat > "$SANDBOX/bin/fdev" <<'STUB'
 #!/usr/bin/env bash
 set -uo pipefail
-NODE="${STUB_NODE_DIR:?}"
 args=("$@")
 # Skip the MODE positional if present.
 [ "${args[0]:-}" = "network" ] && args=("${args[@]:1}")
 
+case "${args[0]:-}" in
+  get-contract-id)
+    code=""; params=""
+    i=1
+    while [ $i -lt ${#args[@]} ]; do
+      case "${args[$i]}" in
+        --code)       code="${args[$((i+1))]}"; i=$((i+2)) ;;
+        --parameters) params="${args[$((i+1))]}"; i=$((i+2)) ;;
+        *) i=$((i+1)) ;;
+      esac
+    done
+    if [ ! -f "$code" ] || [ ! -f "$params" ]; then
+      echo "Error: cannot read code/parameters" >&2; exit 1
+    fi
+    echo "ID$(cat "$code" "$params" | md5sum | cut -c1-24)"
+    exit 0
+    ;;
+esac
+
+NODE="${STUB_NODE_DIR:?}"
 case "${args[0]:-}" in
   execute)
     # execute get [--timeout N] [-o FILE] KEY
@@ -108,13 +180,20 @@ case "${args[0]:-}" in
       printf '%s\n' "${modes[*]:1}" > "$NODE/get_modes"
     fi
     case "$mode" in
-      notfound) echo "Error: Contract not found: TESTCONTRACTKEYnotarealbase58key" >&2; exit 1 ;;
+      notfound) echo "Error: Contract not found" >&2; exit 1 ;;
       timeout)  echo "Error: operation timed out after 180s" >&2; exit 1 ;;
     esac
-    if [ ! -s "$NODE/state.bin" ]; then
-      echo "Error: Contract not found: TESTCONTRACTKEYnotarealbase58key" >&2; exit 1
+    # A read that is too early to have seen the last publish.
+    src="$NODE/state.bin"
+    left="$(cat "$NODE/stale_left" 2>/dev/null || echo 0)"
+    if [ "$left" -gt 0 ]; then
+      echo $((left - 1)) > "$NODE/stale_left"
+      src="$NODE/stale.bin"
     fi
-    cp "$NODE/state.bin" "$out"
+    if [ ! -s "$src" ]; then
+      echo "Error: Contract not found" >&2; exit 1
+    fi
+    cp "$src" "$out"
     exit 0
     ;;
   publish)
@@ -127,10 +206,14 @@ case "${args[0]:-}" in
         *) i=$((i+1)) ;;
       esac
     done
+    # Whatever the network held a moment ago is what an early read still sees.
+    if [ -s "$NODE/state.bin" ]; then cp "$NODE/state.bin" "$NODE/stale.bin"; fi
+    cp "$NODE/stale_reads" "$NODE/stale_left" 2>/dev/null || echo 0 > "$NODE/stale_left"
     if [ -s "$NODE/collision.bin" ]; then
-      # Someone else's state, already at the version we are about to publish.
-      # Only our own key can sign one the contract accepts, so in reality this
-      # is an earlier run of this pipeline — the 2026-08-04 fork.
+      # A state that is not ours, planted at (or above) the version we are about
+      # to publish. Only our own key can sign one the contract accepts, so at
+      # our own version this is an earlier run of this pipeline — the 2026-08-04
+      # fork; above it, it is something else publishing to this contract.
       cp "$NODE/collision.bin" "$NODE/state.bin"
       exit "$(cat "$NODE/publish_rc")"
     fi
@@ -143,9 +226,7 @@ open(sys.argv[3],'wb').write(
     struct.pack('>Q', len(meta)) + meta + struct.pack('>Q', len(arch)) + arch)
 PY
       # The container's own gate: `update_state` rejects
-      # `version <= current_version` — and does so as a NO-OP SUCCESS, not an
-      # error. Modelling that here is the point: it is what makes
-      # "fdev exited 0" mean nothing.
+      # `version <= current_version`.
       new="$("$STUB_TOOL" inspect --state "$NODE/incoming.bin" | sed -n 's/^version=//p')"
       cur="$(cat "$NODE/version" 2>/dev/null || echo 0)"
       if [ ! -s "$NODE/state.bin" ] || [ "$new" -gt "$cur" ]; then
@@ -162,13 +243,118 @@ echo "stub fdev: unhandled: $*" >&2
 exit 127
 STUB
 chmod +x "$SANDBOX/bin/fdev"
+
+# ------------------------------------------------------------------- stub gh
+# Only `gh run list` is reached, and only from the provenance gate. The JSON it
+# prints is whatever $SANDBOX/node/ci_runs holds, so a scenario can present a
+# green CI, a red one, or the "no runs at all" case that a `length == 0` test
+# would have called green.
+cat > "$SANDBOX/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+NODE="${STUB_NODE_DIR:?}"
+if [ "${1:-}" = "run" ] && [ "${2:-}" = "list" ]; then
+  case " $* " in
+    *" --json "*) cat "$NODE/ci_runs" ;;
+    *)            echo "(stub gh) run listing" ;;
+  esac
+  exit 0
+fi
+echo "stub gh: unhandled: $*" >&2
+exit 127
+STUB
+chmod +x "$SANDBOX/bin/gh"
+
+# ---------------------------------------------------------------- stub cargo
+# The publish script runs `cargo make web-container-build-inputs` from inside
+# the lock when given --build. Recording the invocation is what lets a scenario
+# assert the build did NOT run when the lock was already held.
+#
+# `cargo_dirties_tree=1` makes it write a TRACKED fixture file, which is the
+# only way to reach the post-build clean-tree re-check: the provenance gate runs
+# before the build, so that re-check is the guard on the seam between the two.
+cat > "$SANDBOX/bin/cargo" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+NODE="${STUB_NODE_DIR:?}"
+printf '%s\n' "$*" >> "$NODE/cargo.log"
+if [ "$(cat "$NODE/cargo_dirties_tree" 2>/dev/null || echo 0)" = "1" ]; then
+    printf 'a build product that should not be here\n' >> "${STUB_TRACKED_FILE:?}"
+fi
+exit 0
+STUB
+chmod +x "$SANDBOX/bin/cargo"
+
 export STUB_NODE_DIR="$SANDBOX/node"
 export STUB_TOOL="$TOOL"
+# A tracked, inert fixture file the stub cargo can dirty on demand. Tracked so
+# it reaches the post-build clean-tree re-check; inert so nothing else reads it.
+printf 'ui source\n' > "$SANDBOX/ui-source.txt"
+export STUB_TRACKED_FILE="$SANDBOX/ui-source.txt"
+# The harness prepends its own bin/ to PATH, so from here down the SYSTEM cargo
+# is shadowed by the stub above — and the stub exits 0 having built nothing.
+# That is safe today for one reason only: the sole cargo invocation that reaches
+# it is the `--build` call inside the publish script, and the web-container-tool
+# build at the top of this file happens BEFORE this line.
+#
+# The failure mode to recognise, because it does not announce itself: a future
+# scenario that needs a REAL cargo gets the stub instead. It will not fail with
+# "command not found" — it will succeed instantly, and the scenario will then
+# fail somewhere else entirely, complaining about a missing artifact or passing
+# for a reason that has nothing to do with what it meant to test. If you add a
+# scenario needing a real build, invoke it by absolute path or move it above
+# this export.
 export PATH="$SANDBOX/bin:$PATH"
 
+# The id the sandbox's wasm + parameters actually derive, written where the
+# script expects to read it. Deriving it rather than inventing a string is what
+# lets a scenario make published-contract/ inconsistent by touching the wasm.
+CONTRACT_ID="$(fdev get-contract-id \
+    --code "$SANDBOX/published-contract/web_container_contract.wasm" \
+    --parameters "$SANDBOX/published-contract/webapp.parameters")"
+case "$CONTRACT_ID" in
+    ID*) : ;;
+    *) echo "FAIL: setup could not derive a contract id (got '$CONTRACT_ID')"; exit 1 ;;
+esac
+echo "$CONTRACT_ID" > "$SANDBOX/published-contract/contract-id.txt"
+
+# The lock path is derived here INDEPENDENTLY of the script, from the rule the
+# script documents: outside the checkout, keyed by contract id. That is the
+# point of deriving it twice — if the lock moves back inside the repo (where
+# two worktrees get two different files and it serialises nothing), the
+# scenario that holds this path stops conflicting and the test fails.
+LOCK_PATH="${XDG_RUNTIME_DIR:-/tmp}/river-web-container-$CONTRACT_ID.lock"
+
+# ---------------------------------------------------- git provenance fixture
+# The publish script refuses to sign or publish unless this is a clean checkout
+# of main, at origin/main, with green CI on that SHA — because the web
+# container is ONE key serving every user and there is no per-branch address to
+# publish to instead. That gate is wiring, so it is rehearsed like the rest: a
+# real repo with a real (local, bare) origin.
+UPSTREAM="$SANDBOX/upstream.git"
+git init -q --bare "$UPSTREAM"
+git -C "$SANDBOX" init -q
+git -C "$SANDBOX" symbolic-ref HEAD refs/heads/main
+git -C "$SANDBOX" config user.email rehearsal@example.invalid
+git -C "$SANDBOX" config user.name  "publish rehearsal"
+cat > "$SANDBOX/.git/info/exclude" <<'EXCLUDE'
+/target/
+/node/
+/bin/
+/upstream.git/
+/keys.toml
+/other-keys.toml
+/seed.*
+/collide.*
+/lock.*
+/git-sync.log
+EXCLUDE
+git -C "$SANDBOX" add scripts published-contract ui-source.txt >/dev/null
+git -C "$SANDBOX" commit -qm "sandbox checkout"
+git -C "$SANDBOX" remote add origin "$UPSTREAM"
+git -C "$SANDBOX" push -q origin main
+
 # ------------------------------------------------------------------- helpers
-PASS=0
-FAIL=0
 check() {
     if [ "$2" = "$3" ]; then PASS=$((PASS + 1)); else
         FAIL=$((FAIL + 1))
@@ -177,10 +363,45 @@ check() {
         echo "      actual:   $3"
     fi
 }
+setup_failed() { FAIL=$((FAIL + 1)); echo "SETUP FAIL: $*"; }
+contains() { # contains <label> <needle>   (searches $RUN_OUT)
+    case "$RUN_OUT" in
+        *"$2"*) check "$1" yes yes ;;
+        *)      check "$1" yes no  ;;
+    esac
+}
+not_zero() { check "$1" "no" "$([ "$RUN_RC" -eq 0 ] && echo yes || echo no)"; }
+
+# Fold whatever a scenario just wrote into the committed state, and make
+# origin/main agree. Checks its own postcondition: nothing in this file has
+# `set -e`, so a silent failure here would leave a scenario testing the
+# provenance gate instead of whatever it meant to test.
+git_sync() {
+    git -C "$SANDBOX" add -u >/dev/null
+    # --allow-empty: from scenario 27 on, the fixture has a second commit, and a
+    # scenario that restores the tree to exactly its parent's state makes the
+    # amend "empty" and fails. Without this the sync silently did nothing and
+    # left the counter staged — which is how the postcondition check below
+    # earned itself twice.
+    git -C "$SANDBOX" commit -q --amend --no-edit --allow-empty >"$SANDBOX/git-sync.log" 2>&1 || \
+        setup_failed "git_sync amend failed: $(tr '\n' ';' < "$SANDBOX/git-sync.log")"
+    git -C "$SANDBOX" push -q --force origin main
+    if [ -n "$(git -C "$SANDBOX" status --porcelain --untracked-files=no)" ]; then
+        setup_failed "git_sync left tracked files modified: $(git -C "$SANDBOX" status --porcelain --untracked-files=no | tr '\n' ';')"
+    elif [ "$(git -C "$SANDBOX" rev-parse HEAD)" != "$(git -C "$SANDBOX" rev-parse origin/main)" ]; then
+        setup_failed "git_sync left HEAD != origin/main"
+    fi
+}
+
+network_version_now() {
+    "$TOOL" inspect --state "$SANDBOX/node/state.bin" \
+        --parameters "$SANDBOX/published-contract/webapp.parameters" \
+        | sed -n 's/^version=//p'
+}
 
 # Put a signed state at $1 carrying archive bytes $2 onto the stub network.
 seed_network() {
-    local version="$1" body="$2"
+    local version="$1" body="$2" got
     local a="$SANDBOX/seed.tar.xz" m="$SANDBOX/seed.metadata" p="$SANDBOX/seed.parameters"
     printf '%s' "$body" > "$a"
     "$TOOL" sign --input "$a" --output "$m" --parameters "$p" \
@@ -193,30 +414,42 @@ arch = open(sys.argv[2],'rb').read()
 open(sys.argv[3],'wb').write(
     struct.pack('>Q', len(meta)) + meta + struct.pack('>Q', len(arch)) + arch)
 PY
+    got="$(network_version_now)"
+    [ "$got" = "$version" ] || setup_failed "seed_network wanted $version, the stub network holds '$got'"
 }
 
 # run <counter> <archive-body> [args...] -> sets RUN_RC / RUN_OUT
+#
+# Knobs a scenario can set for one call:
+#   RUN_SYNC=0   do NOT reconcile the git fixture first (leaves the counter
+#                write showing as a dirty tracked file)
+#   RB_ATTEMPTS  read-back attempts (default 1)
+#   USE_KEY      signing key file (default: the key that owns the contract)
 run() {
     local counter="$1" body="$2"; shift 2
     echo "$counter" > "$SANDBOX/published-contract/contract-version.txt"
     printf '%s' "$body" > "$SANDBOX/target/webapp/webapp.tar.xz"
-    RUN_OUT="$(cd "$SANDBOX" && RIVER_WC_KEY_FILE="$KEY_FILE" \
-        RIVER_WC_READBACK_ATTEMPTS=1 RIVER_WC_READBACK_DELAY=0 \
+    if [ "${RUN_SYNC:-1}" = "1" ]; then git_sync; fi
+    RUN_OUT="$(cd "$SANDBOX" && RIVER_WC_KEY_FILE="${USE_KEY:-$KEY_FILE}" \
+        RIVER_WC_READBACK_ATTEMPTS="${RB_ATTEMPTS:-1}" RIVER_WC_READBACK_DELAY=0 \
+        RIVER_WC_PREFLIGHT_DELAY=0 \
         ./scripts/publish-web-container.sh "$@" 2>&1)"
     RUN_RC=$?
 }
 counter_now() { tr -d '[:space:]' < "$SANDBOX/published-contract/contract-version.txt"; }
-network_version_now() {
-    "$TOOL" inspect --state "$SANDBOX/node/state.bin" \
-        --parameters "$SANDBOX/published-contract/webapp.parameters" \
-        | sed -n 's/^version=//p'
-}
 
 reset_node() {
     echo "ok" > "$SANDBOX/node/get_modes"
     echo "0"  > "$SANDBOX/node/publish_rc"
     echo "1"  > "$SANDBOX/node/publish_lands"
-    rm -f "$SANDBOX/node/state.bin" "$SANDBOX/node/version" "$SANDBOX/node/collision.bin"
+    echo "0"  > "$SANDBOX/node/stale_reads"
+    echo "0"  > "$SANDBOX/node/cargo_dirties_tree"
+    : > "$SANDBOX/node/cargo.log"
+    rm -f "$SANDBOX/node/state.bin" "$SANDBOX/node/version" \
+          "$SANDBOX/node/collision.bin" "$SANDBOX/node/stale.bin" \
+          "$SANDBOX/node/stale_left"
+    printf '%s' '[{"name":"build","status":"completed","conclusion":"success"}]' \
+        > "$SANDBOX/node/ci_runs"
 }
 
 # ------------------------------------------------------------------ scenarios
@@ -228,8 +461,7 @@ run 30000385 "build 386"
 check "exits 0"                 "0"        "$RUN_RC"
 check "signs counter+1"         "30000386" "$(counter_now)"
 check "the network took it"     "30000386" "$(network_version_now)"
-case "$RUN_OUT" in *"PUBLISHED"*) check "reports PUBLISHED" yes yes ;;
-                  *)              check "reports PUBLISHED" yes no  ;; esac
+contains "reports PUBLISHED" "PUBLISHED"
 
 echo "--- 2: the 2026-08-04 incident — a publish that times out and lands anyway"
 reset_node
@@ -240,8 +472,7 @@ run 30000376 "build A of the UI"
 check "exits 0 despite fdev failing"  "0"        "$RUN_RC"
 check "the state IS live"             "30000377" "$(network_version_now)"
 check "the counter is NOT rolled back" "30000377" "$(counter_now)"
-case "$RUN_OUT" in *"despite fdev exiting"*) check "says so out loud" yes yes ;;
-                  *)                         check "says so out loud" yes no  ;; esac
+contains "says so out loud" "despite fdev exiting"
 
 echo "--- 3: the retry that forked the site is now impossible"
 # Same counter the old rollback would have restored, and a DIFFERENT archive —
@@ -258,40 +489,42 @@ reset_node
 seed_network 30000384 "build 384"
 echo "timeout" > "$SANDBOX/node/get_modes"
 run 30000385 "build 386"
-check "does not exit 0"              "no"       "$([ "$RUN_RC" -eq 0 ] && echo yes || echo no)"
+not_zero "does not exit 0"
 check "the counter is untouched"     "30000385" "$(counter_now)"
-case "$RUN_OUT" in *"did not learn"*) check "explains why" yes yes ;;
-                  *)                  check "explains why" yes no  ;; esac
+contains "explains why" "did not learn"
 
 echo "--- 5: 'Contract not found' is not proof of absence for THIS contract"
 reset_node
 echo "notfound" > "$SANDBOX/node/get_modes"
 run 30000385 "build 386"
-check "refuses"                      "no"       "$([ "$RUN_RC" -eq 0 ] && echo yes || echo no)"
+not_zero "refuses"
 check "the counter is untouched"     "30000385" "$(counter_now)"
-case "$RUN_OUT" in *"Contract not found"*) check "names the answer it got" yes yes ;;
-                  *)                       check "names the answer it got" yes no  ;; esac
+# Assert on the line the script prints ONLY when it classified the answer as
+# `absent`. The bare string "Contract not found" is also in the stub's own
+# stderr, which lands in $RUN_OUT whatever the script concluded — so matching
+# that would pass even if absence detection were broken.
+contains "classifies the answer as absence" "the node answered: Contract not found"
 
 echo "--- 6: the override publishes, and the read-back still judges it"
-# Pre-flight read fails, the operator overrides, and the publish is a silent
-# no-op that exits 0 — the shape a stale-version publish takes. The read-back
-# (which succeeds) is the only thing that can catch it.
+# Every pre-flight read fails, the operator overrides, and the node we publish
+# through reports success while our bytes never become what the network serves.
+# The read-back (which succeeds) is the only thing that can catch that.
 reset_node
 seed_network 30000384 "build 384"
-echo "timeout ok" > "$SANDBOX/node/get_modes"
+echo "timeout timeout timeout ok" > "$SANDBOX/node/get_modes"
 echo "0" > "$SANDBOX/node/publish_rc"
 echo "0" > "$SANDBOX/node/publish_lands"
 echo "30000385" > "$SANDBOX/published-contract/contract-version.txt"
 printf 'build 386' > "$SANDBOX/target/webapp/webapp.tar.xz"
+git_sync
 RUN_OUT="$(cd "$SANDBOX" && RIVER_WC_KEY_FILE="$KEY_FILE" RIVER_WC_ALLOW_UNVERIFIED=1 \
-    RIVER_WC_READBACK_ATTEMPTS=1 RIVER_WC_READBACK_DELAY=0 \
+    RIVER_WC_READBACK_ATTEMPTS=1 RIVER_WC_READBACK_DELAY=0 RIVER_WC_PREFLIGHT_DELAY=0 \
     ./scripts/publish-web-container.sh 2>&1)"
 RUN_RC=$?
-check "does not exit 0 on a no-op publish" "no" "$([ "$RUN_RC" -eq 0 ] && echo yes || echo no)"
+not_zero "does not exit 0 when our bytes are not live"
 check "the counter stays forward"          "30000386" "$(counter_now)"
 check "the network never took it"          "30000384" "$(network_version_now)"
-case "$RUN_OUT" in *"NOT PUBLISHED"*) check "reports NOT PUBLISHED" yes yes ;;
-                  *)                  check "reports NOT PUBLISHED" yes no  ;; esac
+contains "reports NOT PUBLISHED" "NOT PUBLISHED"
 
 echo "--- 7: --sign-only signs and stops"
 reset_node
@@ -313,8 +546,6 @@ check "no metadata written"          "no"       "$([ -f "$SANDBOX/target/webapp/
 echo "--- 9: a state we cannot verify is refused outright"
 reset_node
 # Sign the network's state with a DIFFERENT key.
-OTHER_KEY="$SANDBOX/other-keys.toml"
-"$TOOL" generate --output "$OTHER_KEY" >/dev/null
 printf 'foreign build' > "$SANDBOX/seed.tar.xz"
 "$TOOL" sign --input "$SANDBOX/seed.tar.xz" --output "$SANDBOX/seed.metadata" \
     --parameters "$SANDBOX/seed.parameters" --version 99 --key-file "$OTHER_KEY" >/dev/null
@@ -326,10 +557,9 @@ open(sys.argv[3],'wb').write(
     struct.pack('>Q', len(meta)) + meta + struct.pack('>Q', len(arch)) + arch)
 PY
 run 30000385 "build 386"
-check "refuses"                      "no"       "$([ "$RUN_RC" -eq 0 ] && echo yes || echo no)"
+not_zero "refuses"
 check "the counter is untouched"     "30000385" "$(counter_now)"
-case "$RUN_OUT" in *"do NOT verify"*) check "says the provenance is unclear" yes yes ;;
-                  *)                  check "says the provenance is unclear" yes no  ;; esac
+contains "says the provenance is unclear" "do NOT verify"
 
 echo "--- 10: a state at OUR version carrying bytes that are not ours"
 # Both archives are validly signed, so signatures cannot separate them and the
@@ -351,9 +581,491 @@ open(sys.argv[3],'wb').write(
 PYX
 echo "30000386" > "$SANDBOX/node/version"
 run 30000385 "build 386"
-check "does not exit 0"        "no" "$([ "$RUN_RC" -eq 0 ] && echo yes || echo no)"
-case "$RUN_OUT" in *"FORKED"*) check "reports FORKED" yes yes ;;
-                  *)           check "reports FORKED" yes no  ;; esac
+not_zero "does not exit 0"
+contains "reports FORKED" "FORKED"
+
+echo "--- 11: something else published above us"
+# The real shape of a rejected publish: the network moved past our version
+# between the read and the write, so the contract refuses our state. Our archive
+# is not what users are getting and the run must say so rather than exit 0.
+reset_node
+seed_network 30000384 "build 384"
+printf 'somebody elses newer build' > "$SANDBOX/collide.tar.xz"
+"$TOOL" sign --input "$SANDBOX/collide.tar.xz" --output "$SANDBOX/collide.metadata" \
+    --parameters "$SANDBOX/collide.parameters" --version 30000390 \
+    --key-file "$KEY_FILE" >/dev/null
+python3 - "$SANDBOX/collide.metadata" "$SANDBOX/collide.tar.xz" "$SANDBOX/node/collision.bin" <<'PYX'
+import sys, struct
+meta = open(sys.argv[1],'rb').read()
+arch = open(sys.argv[2],'rb').read()
+open(sys.argv[3],'wb').write(
+    struct.pack('>Q', len(meta)) + meta + struct.pack('>Q', len(arch)) + arch)
+PYX
+echo "1" > "$SANDBOX/node/publish_rc"   # the contract rejected it: an ERROR, not a silent success
+run 30000385 "build 386"
+not_zero "does not exit 0"
+check "the counter stays forward"    "30000386" "$(counter_now)"
+contains "reports NOT LIVE" "NOT LIVE"
+
+echo "--- 12: the first read-back is stale, and the publish DID land"
+# Freenet is eventually consistent: the network is not obliged to show our
+# state on the first ask. Stopping at that first answer reports a publish that
+# LANDED as NOT PUBLISHED, and that report is what invites the retry that
+# forked the site. So `not-landed` has to keep asking.
+reset_node
+seed_network 30000384 "build 384"
+echo "1" > "$SANDBOX/node/stale_reads"   # one post-publish read sees the OLD state
+RB_ATTEMPTS=3 run 30000385 "build 386"
+check "exits 0"                      "0"        "$RUN_RC"
+check "the state IS live"            "30000386" "$(network_version_now)"
+contains "reports PUBLISHED" "PUBLISHED"
+
+echo "--- 13: a read-back that never answers leaves the counter forward"
+# Pre-flight reads fine, the publish lands, and then the node stops answering.
+# The verdict is UNKNOWN — and the counter must NOT be rolled back, precisely
+# because we cannot rule out that the version landed. Rolling it back is what
+# handed the 2026-08-04 retry a version that was already in use.
+reset_node
+seed_network 30000384 "build 384"
+echo "ok timeout" > "$SANDBOX/node/get_modes"
+RB_ATTEMPTS=2 run 30000385 "build 386"
+not_zero "does not exit 0"
+check "the counter stays forward"    "30000386" "$(counter_now)"
+contains "reports UNKNOWN" "UNKNOWN"
+
+echo "--- 14: a transient pre-flight failure is retried, not treated as a refusal"
+# One failed GET is a missing sample, not a network answer. Refusing the whole
+# release because the first read timed out is a self-inflicted outage.
+reset_node
+seed_network 30000384 "build 384"
+echo "timeout ok" > "$SANDBOX/node/get_modes"
+run 30000385 "build 386"
+check "exits 0"                      "0"        "$RUN_RC"
+check "used the network as the floor" "30000386" "$(counter_now)"
+check "the network took it"          "30000386" "$(network_version_now)"
+
+echo "--- 15: the wrong signing key costs an error, not a version"
+# The contract ID is derived from (wasm, parameters), so signing with a key
+# that is not this contract's would publish to a DIFFERENT contract. The check
+# has to happen BEFORE the counter is written: a wrong-key run that burns a
+# version and publishes nothing is pure loss.
+reset_node
+seed_network 30000384 "build 384"
+USE_KEY="$OTHER_KEY" run 30000385 "build 386"
+not_zero "refuses"
+check "the counter is untouched"     "30000385" "$(counter_now)"
+check "nothing was published"        "30000384" "$(network_version_now)"
+contains "names the mismatch" "does not match"
+
+echo "--- 16: --sign-only warns LOUDEST that nothing will check the version"
+# --sign-only is the one path with no read-back, and it still burns a version
+# and hands back an artifact `fdev network publish` will take by hand. The
+# unverified-network warning matters more there, not less.
+reset_node
+seed_network 30000384 "build 384"
+echo "timeout" > "$SANDBOX/node/get_modes"
+RUN_OUT="$(cd "$SANDBOX" && RIVER_WC_KEY_FILE="$KEY_FILE" RIVER_WC_ALLOW_UNVERIFIED=1 \
+    RIVER_WC_PREFLIGHT_DELAY=0 \
+    ./scripts/publish-web-container.sh --sign-only 2>&1)"
+RUN_RC=$?
+check "exits 0"                      "0"        "$RUN_RC"
+contains "warns that nothing reads back" "does NOT read back"
+
+# ---------------------------------------------------- self-consistency checks
+
+echo "--- 17: published-contract/ that disagrees with itself refuses"
+# The id is DERIVED from (wasm, parameters). A stale wasm publishes to one
+# address while every check here measures another — a green verdict for a
+# publish nobody can find. Distinct from the wrong-key check in 15: that one
+# catches a key that is not this contract's, this one a wasm that is not.
+reset_node
+seed_network 30000384 "build 384"
+printf 'a DIFFERENT wasm' > "$SANDBOX/published-contract/web_container_contract.wasm"
+run 30000385 "build 386"
+not_zero "refuses"
+check "the counter is untouched"     "30000385" "$(counter_now)"
+check "nothing was published"        "30000384" "$(network_version_now)"
+contains "names the inconsistency" "disagrees with itself"
+printf 'not a real wasm' > "$SANDBOX/published-contract/web_container_contract.wasm"
+git_sync
+check "the fixture is restored" "$CONTRACT_ID" "$(fdev get-contract-id \
+    --code "$SANDBOX/published-contract/web_container_contract.wasm" \
+    --parameters "$SANDBOX/published-contract/webapp.parameters")"
+
+echo "--- 18: a counter at the u32 ceiling refuses before writing anything"
+# The container's version field is a u32. Left unchecked the run wrote
+# counter+1 — 4294967296, a value no publish can ever use — into the version
+# file and only then failed, wedging every later publish until someone
+# hand-edited it.
+reset_node
+seed_network 30000384 "build 384"
+run 4294967295 "build 386"
+not_zero "refuses"
+check "the counter file is untouched" "4294967295" "$(counter_now)"
+check "nothing was published"         "30000384"   "$(network_version_now)"
+contains "names the ceiling" "u32::MAX"
+
+echo "--- 19: one below the ceiling still publishes"
+# The boundary is a refusal at u32::MAX, not at u32::MAX - 1.
+reset_node
+seed_network 4294967290 "build old"
+run 4294967294 "build 386"
+check "exits 0"                       "0"          "$RUN_RC"
+check "signs the last usable version" "4294967295" "$(counter_now)"
+check "the network took it"           "4294967295" "$(network_version_now)"
+
+echo "--- 20: zero read-back attempts refuses instead of reporting UNKNOWN"
+# With no read-back the script cannot tell a publish that landed from one that
+# did not, and used to report UNKNOWN about a publish plainly on the network —
+# the stale-read-back failure reached from the configuration side. A wedged
+# config has to be loud.
+reset_node
+seed_network 30000384 "build 384"
+echo "30000385" > "$SANDBOX/published-contract/contract-version.txt"
+printf 'build 386' > "$SANDBOX/target/webapp/webapp.tar.xz"
+git_sync
+RUN_OUT="$(cd "$SANDBOX" && RIVER_WC_KEY_FILE="$KEY_FILE" \
+    RIVER_WC_READBACK_ATTEMPTS=0 RIVER_WC_PREFLIGHT_DELAY=0 \
+    ./scripts/publish-web-container.sh 2>&1)"
+RUN_RC=$?
+not_zero "refuses"
+check "the counter is untouched"     "30000385" "$(counter_now)"
+check "nothing was published"        "30000384" "$(network_version_now)"
+contains "names the knob" "RIVER_WC_READBACK_ATTEMPTS"
+
+echo "--- 21: a non-numeric knob refuses rather than falling back to a default"
+reset_node
+seed_network 30000384 "build 384"
+echo "30000385" > "$SANDBOX/published-contract/contract-version.txt"
+printf 'build 386' > "$SANDBOX/target/webapp/webapp.tar.xz"
+git_sync
+RUN_OUT="$(cd "$SANDBOX" && RIVER_WC_KEY_FILE="$KEY_FILE" \
+    RIVER_WC_READBACK_ATTEMPTS=three RIVER_WC_PREFLIGHT_DELAY=0 \
+    ./scripts/publish-web-container.sh 2>&1)"
+RUN_RC=$?
+not_zero "refuses"
+check "the counter is untouched"     "30000385" "$(counter_now)"
+contains "says it must be a number" "must be a whole number"
+
+# ------------------------------------------------------------ the lock's reach
+
+echo "--- 22: a second publish is refused while the first holds the lock"
+# The lock is keyed by contract id and lives OUTSIDE the checkout. River
+# development is worktree-based, so a lock inside the repo hands two concurrent
+# publishes two different files and serialises nothing. $LOCK_PATH is derived
+# in this file from the documented rule, not read out of the script: if the
+# lock moves back into the repo, this stops conflicting and the scenario fails.
+#
+# It also runs with --build, and asserts the build never ran: the artifacts are
+# built from INSIDE the lock, so a run that cannot get the lock must not have
+# touched the shared target/webapp/webapp.tar.xz on its way to finding out.
+reset_node
+seed_network 30000384 "build 384"
+if command -v flock >/dev/null 2>&1; then
+    : > "$SANDBOX/lock.wait"
+    rm -f "$SANDBOX/lock.held"
+    (
+        exec 8>>"$LOCK_PATH"
+        flock 8 || exit 1
+        : > "$SANDBOX/lock.held"
+        while [ -e "$SANDBOX/lock.wait" ]; do sleep 0.05; done
+    ) &
+    HOLDER=$!
+    waited=0
+    while [ ! -e "$SANDBOX/lock.held" ] && [ "$waited" -lt 200 ]; do
+        sleep 0.05; waited=$((waited + 1))
+    done
+    if [ ! -e "$SANDBOX/lock.held" ]; then setup_failed "the lock holder never took $LOCK_PATH"; fi
+    check "the holder took the lock" "yes" "$([ -e "$SANDBOX/lock.held" ] && echo yes || echo no)"
+    run 30000385 "build 386" --build
+    not_zero "the second run refuses"
+    contains "names the conflict" "already running"
+    check "it signed nothing"        "30000385" "$(counter_now)"
+    check "it published nothing"     "30000384" "$(network_version_now)"
+    check "it did not build either"  ""         "$(cat "$SANDBOX/node/cargo.log")"
+    rm -f "$SANDBOX/lock.wait"
+    wait "$HOLDER"
+else
+    echo "    (flock not available — lock scenario skipped)"
+fi
+
+echo "--- 23: --build builds from inside the lock"
+reset_node
+seed_network 30000384 "build 384"
+run 30000385 "build 386" --build
+check "exits 0"                      "0"        "$RUN_RC"
+check "the network took it"          "30000386" "$(network_version_now)"
+case "$(cat "$SANDBOX/node/cargo.log")" in
+    *"web-container-build-inputs"*) check "it ran the build task" yes yes ;;
+    *)                              check "it ran the build task" yes no  ;;
+esac
+case "$(cat "$SANDBOX/node/cargo.log")" in
+    *"--env BUILD_PROFILE="*) check "it pins the build profile explicitly" yes yes ;;
+    *)                        check "it pins the build profile explicitly" yes no  ;;
+esac
+
+echo "--- 24: the make tasks run NOTHING before the publish script"
+# Structural, not behavioural: cargo-make runs a task's `dependencies` to
+# completion BEFORE its script, so anything that builds the shared archive from
+# a `dependencies` list — or from a line in the script body ahead of the
+# publish script — runs before the script exists to lock anything. There is no
+# way to observe that from inside the sandbox, so this reads the real Makefile.
+#
+# The earlier version of this pin asked "is there no `dependencies` key, and
+# does the token `--build` appear somewhere in the block". Both were true of a
+# block that had simply moved `cargo make web-container-build-inputs` into the
+# script body, so the bug came back green. It now scrapes the script BODY, with
+# comments and blank lines stripped, and requires that body to be exactly the
+# one exec line: anything else in it runs outside the lock.
+task_block() {
+    awk -v t="[tasks.$1]" '$0==t{f=1;next} /^\[tasks\./{f=0} f' "$REPO_ROOT/Makefile.toml"
+}
+task_script_body() {
+    awk -v t="[tasks.$1]" -v q="'''" '
+        $0==t {f=1; next}
+        /^\[tasks\./ {f=0}
+        f && $0 ~ /^script = / {s=1; next}
+        f && s && $0==q {s=0; next}
+        f && s {print}
+    ' "$REPO_ROOT/Makefile.toml" | grep -v '^[[:space:]]*#' | grep -v '^[[:space:]]*$'
+}
+for task in publish-river publish-river-debug sign-webapp; do
+    blk="$(task_block "$task")"
+    if [ -z "$blk" ]; then
+        setup_failed "could not find [tasks.$task] in $REPO_ROOT/Makefile.toml"
+        continue
+    fi
+    if printf '%s\n' "$blk" | grep -q '^dependencies'; then
+        check "[tasks.$task] has no dependencies list" yes no
+    else
+        check "[tasks.$task] has no dependencies list" yes yes
+    fi
+    body="$(task_script_body "$task")"
+    if [ -z "$body" ]; then
+        setup_failed "could not read the script body of [tasks.$task]"
+        continue
+    fi
+    # Exactly one command, and it is the publish script. A second line — a
+    # `cargo make`, an `npm run`, anything — is a build outside the lock.
+    check "[tasks.$task] body is a single command" "1" "$(printf '%s\n' "$body" | wc -l)"
+    case "$body" in
+        *"./scripts/publish-web-container.sh"*)
+            check "[tasks.$task] body is the publish script" yes yes ;;
+        *)  check "[tasks.$task] body is the publish script" yes no  ;;
+    esac
+    case "$body" in
+        *"--build"*) check "[tasks.$task] passes --build" yes yes ;;
+        *)           check "[tasks.$task] passes --build" yes no  ;;
+    esac
+    # Belt and braces: name the specific reintroduction, so the failure says
+    # what went wrong rather than only that a line count changed.
+    if printf '%s\n' "$body" | grep -q 'cargo make'; then
+        check "[tasks.$task] body does not invoke cargo make" yes no
+    else
+        check "[tasks.$task] body does not invoke cargo make" yes yes
+    fi
+done
+if printf '%s\n' "$(task_block web-container-build-inputs)" | grep -q '^dependencies'; then
+    check "[tasks.web-container-build-inputs] carries the dependencies" yes yes
+else
+    check "[tasks.web-container-build-inputs] carries the dependencies" yes no
+fi
+
+echo "--- 24b: a build that modifies tracked files is caught after the fact"
+# [0] vouches for a clean tracked tree and the build runs after it, so the
+# re-check on that seam is new code guarding two new features against each
+# other. The stub cargo can now dirty a tracked file on demand, which is the
+# only way to reach it.
+reset_node
+seed_network 30000384 "build 384"
+echo "1" > "$SANDBOX/node/cargo_dirties_tree"
+run 30000385 "build 386" --build
+not_zero "refuses"
+check "nothing was published"        "30000384" "$(network_version_now)"
+contains "names the seam" "the build modified tracked files"
+echo "0" > "$SANDBOX/node/cargo_dirties_tree"
+printf 'ui source\n' > "$SANDBOX/ui-source.txt"
+git_sync
+
+# ------------------------------------------------------- provenance scenarios
+#
+# The web container is ONE key serving every River user, and river's main has
+# no branch protection, so this script is the only thing enforcing "publish
+# from a green main". Each of these is a way that claim can be false.
+
+echo "--- 25: a modified tracked file refuses"
+# A tracked file other than the counter, left uncommitted: the checkout differs
+# from the commit whose CI the gate just verified, which is the whole
+# provenance claim. Deliberately NOT the counter — that is the one file the
+# script writes by design, and scenario 33 covers it.
+reset_node
+seed_network 30000384 "build 384"
+printf 'an uncommitted edit\n' >> "$SANDBOX/ui-source.txt"
+RUN_SYNC=0 run 30000385 "build 386"
+not_zero "refuses"
+check "the counter is not advanced"  "30000385" "$(counter_now)"
+check "nothing was published"        "30000384" "$(network_version_now)"
+contains "names the dirty tree" "tracked files are modified"
+printf 'ui source\n' > "$SANDBOX/ui-source.txt"
+git_sync
+
+echo "--- 26: a branch that is not main refuses"
+reset_node
+seed_network 30000384 "build 384"
+echo "30000385" > "$SANDBOX/published-contract/contract-version.txt"
+printf 'build 386' > "$SANDBOX/target/webapp/webapp.tar.xz"
+git_sync
+git -C "$SANDBOX" checkout -q -b not-main
+# RUN_SYNC=0: the tree is already clean and committed, and syncing from a
+# branch that is not main is what the git_sync postcondition check catches.
+RUN_SYNC=0 run 30000385 "build 386"
+not_zero "refuses"
+check "the counter is not advanced"  "30000385" "$(counter_now)"
+contains "names the branch" "on branch 'not-main'"
+git -C "$SANDBOX" checkout -q main
+git -C "$SANDBOX" branch -q -D not-main
+
+echo "--- 27: a HEAD that is ahead of origin/main refuses"
+reset_node
+seed_network 30000384 "build 384"
+echo "30000385" > "$SANDBOX/published-contract/contract-version.txt"
+printf 'build 386' > "$SANDBOX/target/webapp/webapp.tar.xz"
+git_sync
+git -C "$SANDBOX" commit -q --allow-empty -m "unpushed"   # local only
+RUN_SYNC=0 run 30000385 "build 386"
+not_zero "refuses"
+check "the counter is not advanced"  "30000385" "$(counter_now)"
+contains "names the divergence" "!= origin/main"
+git_sync
+
+echo "--- 28: NO CI runs is not the same as green"
+# An empty list yields zero FAILURES, so a guard that only counts bad runs
+# reports a commit CI never ran on as green — a guard that cannot fail.
+reset_node
+seed_network 30000384 "build 384"
+printf '%s' '[]' > "$SANDBOX/node/ci_runs"
+run 30000385 "build 386"
+not_zero "refuses"
+check "the counter is not advanced"  "30000385" "$(counter_now)"
+contains "says there are no runs" "NO CI runs exist"
+
+echo "--- 29: red CI refuses"
+reset_node
+seed_network 30000384 "build 384"
+printf '%s' '[{"name":"build","status":"completed","conclusion":"failure"}]' \
+    > "$SANDBOX/node/ci_runs"
+run 30000385 "build 386"
+not_zero "refuses"
+check "the counter is not advanced"  "30000385" "$(counter_now)"
+contains "says CI is not green" "are not green"
+
+echo "--- 30: pending CI is not green either"
+reset_node
+seed_network 30000384 "build 384"
+printf '%s' '[{"name":"build","status":"in_progress","conclusion":null}]' \
+    > "$SANDBOX/node/ci_runs"
+run 30000385 "build 386"
+not_zero "refuses"
+contains "says CI is not green" "are not green"
+
+echo "--- 31: the documented escape proceeds, loudly"
+reset_node
+seed_network 30000384 "build 384"
+printf '%s' '[]' > "$SANDBOX/node/ci_runs"
+echo "30000385" > "$SANDBOX/published-contract/contract-version.txt"
+printf 'build 386' > "$SANDBOX/target/webapp/webapp.tar.xz"
+# Deliberately NOT synced: dirty tree, no CI runs, and it still goes through.
+RUN_OUT="$(cd "$SANDBOX" && RIVER_WC_KEY_FILE="$KEY_FILE" RIVER_WC_ALLOW_UNPROVEN=1 \
+    RIVER_WC_READBACK_ATTEMPTS=1 RIVER_WC_READBACK_DELAY=0 RIVER_WC_PREFLIGHT_DELAY=0 \
+    ./scripts/publish-web-container.sh 2>&1)"
+RUN_RC=$?
+check "exits 0"                      "0"        "$RUN_RC"
+check "the network took it"          "30000386" "$(network_version_now)"
+contains "says the gate was skipped" "provenance gate SKIPPED"
+
+echo "--- 32: invoked from inside scripts/, not from the repo root"
+# `cd scripts && ./publish-web-container.sh` used to die with
+# `flock: failed to execute` and an exit code outside the documented set,
+# because the lock re-exec handed flock "$0" after the script had already cd'd
+# to the repo root. The lock is now an fd this process holds, so there is
+# nothing to re-exec — this pins that.
+reset_node
+seed_network 30000384 "build 384"
+echo "30000385" > "$SANDBOX/published-contract/contract-version.txt"
+printf 'build 386' > "$SANDBOX/target/webapp/webapp.tar.xz"
+git_sync
+RUN_OUT="$(cd "$SANDBOX/scripts" && RIVER_WC_KEY_FILE="$KEY_FILE" \
+    RIVER_WC_PREFLIGHT_DELAY=0 ./publish-web-container.sh --dry-run 2>&1)"
+RUN_RC=$?
+check "exits 0"                      "0"        "$RUN_RC"
+check "the counter is untouched"     "30000385" "$(counter_now)"
+contains "reached the version step" "signing version 30000386"
+
+echo "--- 33: the re-run every failed verdict recommends is ALLOWED"
+# THE ONE THAT MATTERS. Every non-landed verdict tells the operator to re-run,
+# and the counter it just burned is a TRACKED file — so a gate that refuses any
+# dirty tracked file refuses the recovery it recommends. The operator's two ways
+# out were `git checkout` on the counter, which IS the 2026-08-04 rollback, and
+# an override that drops all four provenance checks at once. Neither is
+# acceptable, so a counter that is strictly AHEAD of HEAD is exempt: it is
+# provably a prior burn, and it cannot change what is published because the
+# version is re-floored against the network anyway.
+reset_node
+seed_network 30000384 "build 384"
+echo "0" > "$SANDBOX/node/publish_lands"   # a publish that does not land
+run 30000385 "build 386"
+not_zero "the first run reports a failure"
+check "it burned a version"          "30000386" "$(counter_now)"
+# ...and now the re-run, WITHOUT committing the counter first, exactly as an
+# operator following the verdict text would do it.
+echo "1" > "$SANDBOX/node/publish_lands"
+RUN_SYNC=0 run 30000386 "build 386"
+check "the re-run is allowed"        "0"        "$RUN_RC"
+check "it signs ABOVE the burned version" "30000387" "$(counter_now)"
+check "the network took it"          "30000387" "$(network_version_now)"
+contains "warns against git checkout" "Never"
+git_sync
+
+echo "--- 34: a counter BELOW HEAD still refuses"
+# The exemption is one-directional on purpose. A working-tree counter that is
+# not ahead of HEAD means something rolled it back, and a rollback is the
+# mechanism of the incident — so that direction stays a hard refusal.
+reset_node
+seed_network 30000384 "build 384"
+RUN_SYNC=0 run 30000001 "build 386"
+not_zero "refuses"
+check "nothing was published"        "30000384" "$(network_version_now)"
+contains "names the rollback" "not above HEAD's"
+git_sync
+
+echo "--- 35: an untracked file under ui/ refuses"
+# The gate used to state that untracked files "cannot change what is
+# published". They can: tailwind globs ui/src/**/*.rs for class names and dx
+# walks ui/assets, so an untracked file under ui/ reaches the archive without
+# reaching git — the published site would differ from the artifact CI tested.
+reset_node
+seed_network 30000384 "build 384"
+mkdir -p "$SANDBOX/ui/src"
+printf 'fn scratch() {}\n' > "$SANDBOX/ui/src/scratch.rs"
+run 30000385 "build 386"
+not_zero "refuses"
+check "the counter is untouched"     "30000385" "$(counter_now)"
+check "nothing was published"        "30000384" "$(network_version_now)"
+contains "names the build inputs" "untracked files under ui/"
+rm -rf "$SANDBOX/ui"
+
+echo "--- 36: an untracked file outside the build inputs is only a note"
+# The refusal is scoped to what was actually checked. Everything else stays a
+# note — and the note no longer claims those files cannot change the archive,
+# only that they are not under the paths this gate examines.
+reset_node
+seed_network 30000384 "build 384"
+printf 'scratch\n' > "$SANDBOX/scratch-note.txt"
+run 30000385 "build 386"
+check "exits 0"                      "0"        "$RUN_RC"
+check "the network took it"          "30000386" "$(network_version_now)"
+contains "notes it without claiming safety" "untracked files present, none under ui/"
+rm -f "$SANDBOX/scratch-note.txt"
 
 echo ""
 echo "$PASS passed, $FAIL failed"

--- a/scripts/tests/web-container-publish-rehearsal.sh
+++ b/scripts/tests/web-container-publish-rehearsal.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+# Rehearse scripts/publish-web-container.sh end to end against a STUB node.
+#
+# The decision logic is unit-tested in web-container-publish-lib-test.sh. This
+# covers the wiring around it, which is where a publish script actually breaks:
+# the fdev argument order, the `Contract not found` string it keys absence off,
+# the `version=` line it parses, whether the counter really is forward-only,
+# and whether the verdict comes out of the read-back rather than the exit code.
+# None of that is reachable from a pure function, and none of it can be
+# exercised against the real network (the web container's key is shared and
+# publishing to it from a test is out of bounds).
+#
+# So: a throwaway repo layout, a throwaway signing key, and an `fdev` on PATH
+# that is a shell script. The real publish script and the real
+# web-container-tool run unmodified.
+#
+# Scenario 2 is the 2026-08-04 incident (River commit 1032d373) reproduced:
+# a publish that reports a timeout and lands anyway.
+#
+# Run: ./scripts/tests/web-container-publish-rehearsal.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+command -v python3 >/dev/null 2>&1 || { echo "SKIP: python3 not available"; exit 0; }
+
+# ------------------------------------------------------------------- the tool
+TOOL_SRC="${RIVER_WC_TOOL:-}"
+if [ -z "$TOOL_SRC" ]; then
+    for candidate in \
+        "$REPO_ROOT/target/native/x86_64-unknown-linux-gnu/release/web-container-tool" \
+        "$REPO_ROOT/target/native/x86_64-unknown-linux-gnu/debug/web-container-tool" \
+        "$REPO_ROOT/target/release/web-container-tool" \
+        "$REPO_ROOT/target/debug/web-container-tool"
+    do
+        [ -x "$candidate" ] && { TOOL_SRC="$candidate"; break; }
+    done
+fi
+if [ -z "$TOOL_SRC" ]; then
+    echo "building web-container-tool..."
+    (cd "$REPO_ROOT" && cargo build -p web-container-tool) || {
+        echo "FAIL: could not build web-container-tool"; exit 1; }
+    TOOL_SRC="$REPO_ROOT/target/debug/web-container-tool"
+fi
+[ -x "$TOOL_SRC" ] || { echo "FAIL: no web-container-tool at $TOOL_SRC"; exit 1; }
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+mkdir -p "$SANDBOX/scripts/tests" \
+         "$SANDBOX/published-contract" \
+         "$SANDBOX/target/webapp" \
+         "$SANDBOX/target/native/x86_64-unknown-linux-gnu/release" \
+         "$SANDBOX/bin" \
+         "$SANDBOX/node"
+cp "$REPO_ROOT/scripts/publish-web-container.sh" "$SANDBOX/scripts/"
+cp "$REPO_ROOT/scripts/web-container-publish-lib.sh" "$SANDBOX/scripts/"
+cp "$TOOL_SRC" "$SANDBOX/target/native/x86_64-unknown-linux-gnu/release/web-container-tool"
+TOOL="$SANDBOX/target/native/x86_64-unknown-linux-gnu/release/web-container-tool"
+
+# ----------------------------------------------------------- throwaway key
+# Never the production key at ~/.config/river/web-container-keys.toml. The
+# publish script's parameters check would refuse it here anyway, since the
+# sandbox's committed parameters are this key's.
+KEY_FILE="$SANDBOX/keys.toml"
+"$TOOL" generate --output "$KEY_FILE" >/dev/null
+"$TOOL" export-parameters --parameters "$SANDBOX/published-contract/webapp.parameters" \
+    --key-file "$KEY_FILE" >/dev/null
+echo "TESTCONTRACTKEYnotarealbase58key" > "$SANDBOX/published-contract/contract-id.txt"
+printf 'not a real wasm' > "$SANDBOX/published-contract/web_container_contract.wasm"
+
+# ----------------------------------------------------------------- stub fdev
+# Behaviour is driven entirely by files under $SANDBOX/node:
+#   state.bin     the packed state the "network" holds (absent = not found)
+#   get_modes     whitespace-separated queue of ok | notfound | timeout, one
+#                 consumed per GET, the last one repeating — so a pre-flight
+#                 read and a post-publish read can behave differently
+#   publish_rc    exit code the publish reports
+#   publish_lands 1 = the publish updates state.bin, 0 = it is a no-op
+cat > "$SANDBOX/bin/fdev" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+NODE="${STUB_NODE_DIR:?}"
+args=("$@")
+# Skip the MODE positional if present.
+[ "${args[0]:-}" = "network" ] && args=("${args[@]:1}")
+
+case "${args[0]:-}" in
+  execute)
+    # execute get [--timeout N] [-o FILE] KEY
+    out=""
+    i=2
+    while [ $i -lt ${#args[@]} ]; do
+      case "${args[$i]}" in
+        -o|--output) out="${args[$((i+1))]}"; i=$((i+2)) ;;
+        --timeout)   i=$((i+2)) ;;
+        *)           i=$((i+1)) ;;
+      esac
+    done
+    read -r -a modes < "$NODE/get_modes"
+    mode="${modes[0]}"
+    if [ "${#modes[@]}" -gt 1 ]; then
+      printf '%s\n' "${modes[*]:1}" > "$NODE/get_modes"
+    fi
+    case "$mode" in
+      notfound) echo "Error: Contract not found: TESTCONTRACTKEYnotarealbase58key" >&2; exit 1 ;;
+      timeout)  echo "Error: operation timed out after 180s" >&2; exit 1 ;;
+    esac
+    if [ ! -s "$NODE/state.bin" ]; then
+      echo "Error: Contract not found: TESTCONTRACTKEYnotarealbase58key" >&2; exit 1
+    fi
+    cp "$NODE/state.bin" "$out"
+    exit 0
+    ;;
+  publish)
+    archive=""; metadata=""
+    i=1
+    while [ $i -lt ${#args[@]} ]; do
+      case "${args[$i]}" in
+        --webapp-archive)  archive="${args[$((i+1))]}"; i=$((i+2)) ;;
+        --webapp-metadata) metadata="${args[$((i+1))]}"; i=$((i+2)) ;;
+        *) i=$((i+1)) ;;
+      esac
+    done
+    if [ -s "$NODE/collision.bin" ]; then
+      # Someone else's state, already at the version we are about to publish.
+      # Only our own key can sign one the contract accepts, so in reality this
+      # is an earlier run of this pipeline — the 2026-08-04 fork.
+      cp "$NODE/collision.bin" "$NODE/state.bin"
+      exit "$(cat "$NODE/publish_rc")"
+    fi
+    if [ "$(cat "$NODE/publish_lands")" = "1" ]; then
+      python3 - "$metadata" "$archive" "$NODE/incoming.bin" <<'PY'
+import sys, struct
+meta = open(sys.argv[1],'rb').read()
+arch = open(sys.argv[2],'rb').read()
+open(sys.argv[3],'wb').write(
+    struct.pack('>Q', len(meta)) + meta + struct.pack('>Q', len(arch)) + arch)
+PY
+      # The container's own gate: `update_state` rejects
+      # `version <= current_version` — and does so as a NO-OP SUCCESS, not an
+      # error. Modelling that here is the point: it is what makes
+      # "fdev exited 0" mean nothing.
+      new="$("$STUB_TOOL" inspect --state "$NODE/incoming.bin" | sed -n 's/^version=//p')"
+      cur="$(cat "$NODE/version" 2>/dev/null || echo 0)"
+      if [ ! -s "$NODE/state.bin" ] || [ "$new" -gt "$cur" ]; then
+        cp "$NODE/incoming.bin" "$NODE/state.bin"
+        echo "$new" > "$NODE/version"
+      fi
+    fi
+    rc="$(cat "$NODE/publish_rc")"
+    [ "$rc" = "0" ] || echo "Error: put timed out after 1 peer attempt(s)" >&2
+    exit "$rc"
+    ;;
+esac
+echo "stub fdev: unhandled: $*" >&2
+exit 127
+STUB
+chmod +x "$SANDBOX/bin/fdev"
+export STUB_NODE_DIR="$SANDBOX/node"
+export STUB_TOOL="$TOOL"
+export PATH="$SANDBOX/bin:$PATH"
+
+# ------------------------------------------------------------------- helpers
+PASS=0
+FAIL=0
+check() {
+    if [ "$2" = "$3" ]; then PASS=$((PASS + 1)); else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: $1"
+        echo "      expected: $2"
+        echo "      actual:   $3"
+    fi
+}
+
+# Put a signed state at $1 carrying archive bytes $2 onto the stub network.
+seed_network() {
+    local version="$1" body="$2"
+    local a="$SANDBOX/seed.tar.xz" m="$SANDBOX/seed.metadata" p="$SANDBOX/seed.parameters"
+    printf '%s' "$body" > "$a"
+    "$TOOL" sign --input "$a" --output "$m" --parameters "$p" \
+        --version "$version" --key-file "$KEY_FILE" >/dev/null
+    echo "$version" > "$SANDBOX/node/version"
+    python3 - "$m" "$a" "$SANDBOX/node/state.bin" <<'PY'
+import sys, struct
+meta = open(sys.argv[1],'rb').read()
+arch = open(sys.argv[2],'rb').read()
+open(sys.argv[3],'wb').write(
+    struct.pack('>Q', len(meta)) + meta + struct.pack('>Q', len(arch)) + arch)
+PY
+}
+
+# run <counter> <archive-body> [args...] -> sets RUN_RC / RUN_OUT
+run() {
+    local counter="$1" body="$2"; shift 2
+    echo "$counter" > "$SANDBOX/published-contract/contract-version.txt"
+    printf '%s' "$body" > "$SANDBOX/target/webapp/webapp.tar.xz"
+    RUN_OUT="$(cd "$SANDBOX" && RIVER_WC_KEY_FILE="$KEY_FILE" \
+        RIVER_WC_READBACK_ATTEMPTS=1 RIVER_WC_READBACK_DELAY=0 \
+        ./scripts/publish-web-container.sh "$@" 2>&1)"
+    RUN_RC=$?
+}
+counter_now() { tr -d '[:space:]' < "$SANDBOX/published-contract/contract-version.txt"; }
+network_version_now() {
+    "$TOOL" inspect --state "$SANDBOX/node/state.bin" \
+        --parameters "$SANDBOX/published-contract/webapp.parameters" \
+        | sed -n 's/^version=//p'
+}
+
+reset_node() {
+    echo "ok" > "$SANDBOX/node/get_modes"
+    echo "0"  > "$SANDBOX/node/publish_rc"
+    echo "1"  > "$SANDBOX/node/publish_lands"
+    rm -f "$SANDBOX/node/state.bin" "$SANDBOX/node/version" "$SANDBOX/node/collision.bin"
+}
+
+# ------------------------------------------------------------------ scenarios
+
+echo "--- 1: an ordinary publish"
+reset_node
+seed_network 30000384 "build 384"
+run 30000385 "build 386"
+check "exits 0"                 "0"        "$RUN_RC"
+check "signs counter+1"         "30000386" "$(counter_now)"
+check "the network took it"     "30000386" "$(network_version_now)"
+case "$RUN_OUT" in *"PUBLISHED"*) check "reports PUBLISHED" yes yes ;;
+                  *)              check "reports PUBLISHED" yes no  ;; esac
+
+echo "--- 2: the 2026-08-04 incident — a publish that times out and lands anyway"
+reset_node
+seed_network 30000376 "build 376"
+echo "1" > "$SANDBOX/node/publish_rc"     # fdev reports failure...
+echo "1" > "$SANDBOX/node/publish_lands"  # ...but the PUT landed
+run 30000376 "build A of the UI"
+check "exits 0 despite fdev failing"  "0"        "$RUN_RC"
+check "the state IS live"             "30000377" "$(network_version_now)"
+check "the counter is NOT rolled back" "30000377" "$(counter_now)"
+case "$RUN_OUT" in *"despite fdev exiting"*) check "says so out loud" yes yes ;;
+                  *)                         check "says so out loud" yes no  ;; esac
+
+echo "--- 3: the retry that forked the site is now impossible"
+# Same counter the old rollback would have restored, and a DIFFERENT archive —
+# the non-reproducible rebuild. The floor must lift it off 30000377.
+reset_node
+seed_network 30000377 "build A of the UI"
+run 30000376 "build B of the UI"
+check "exits 0"                      "0"        "$RUN_RC"
+check "does NOT reissue 30000377"    "30000378" "$(counter_now)"
+check "the network is at 30000378"   "30000378" "$(network_version_now)"
+
+echo "--- 4: an unreadable network refuses BEFORE signing"
+reset_node
+seed_network 30000384 "build 384"
+echo "timeout" > "$SANDBOX/node/get_modes"
+run 30000385 "build 386"
+check "does not exit 0"              "no"       "$([ "$RUN_RC" -eq 0 ] && echo yes || echo no)"
+check "the counter is untouched"     "30000385" "$(counter_now)"
+case "$RUN_OUT" in *"did not learn"*) check "explains why" yes yes ;;
+                  *)                  check "explains why" yes no  ;; esac
+
+echo "--- 5: 'Contract not found' is not proof of absence for THIS contract"
+reset_node
+echo "notfound" > "$SANDBOX/node/get_modes"
+run 30000385 "build 386"
+check "refuses"                      "no"       "$([ "$RUN_RC" -eq 0 ] && echo yes || echo no)"
+check "the counter is untouched"     "30000385" "$(counter_now)"
+case "$RUN_OUT" in *"Contract not found"*) check "names the answer it got" yes yes ;;
+                  *)                       check "names the answer it got" yes no  ;; esac
+
+echo "--- 6: the override publishes, and the read-back still judges it"
+# Pre-flight read fails, the operator overrides, and the publish is a silent
+# no-op that exits 0 — the shape a stale-version publish takes. The read-back
+# (which succeeds) is the only thing that can catch it.
+reset_node
+seed_network 30000384 "build 384"
+echo "timeout ok" > "$SANDBOX/node/get_modes"
+echo "0" > "$SANDBOX/node/publish_rc"
+echo "0" > "$SANDBOX/node/publish_lands"
+echo "30000385" > "$SANDBOX/published-contract/contract-version.txt"
+printf 'build 386' > "$SANDBOX/target/webapp/webapp.tar.xz"
+RUN_OUT="$(cd "$SANDBOX" && RIVER_WC_KEY_FILE="$KEY_FILE" RIVER_WC_ALLOW_UNVERIFIED=1 \
+    RIVER_WC_READBACK_ATTEMPTS=1 RIVER_WC_READBACK_DELAY=0 \
+    ./scripts/publish-web-container.sh 2>&1)"
+RUN_RC=$?
+check "does not exit 0 on a no-op publish" "no" "$([ "$RUN_RC" -eq 0 ] && echo yes || echo no)"
+check "the counter stays forward"          "30000386" "$(counter_now)"
+check "the network never took it"          "30000384" "$(network_version_now)"
+case "$RUN_OUT" in *"NOT PUBLISHED"*) check "reports NOT PUBLISHED" yes yes ;;
+                  *)                  check "reports NOT PUBLISHED" yes no  ;; esac
+
+echo "--- 7: --sign-only signs and stops"
+reset_node
+seed_network 30000384 "build 384"
+run 30000385 "build 386" --sign-only
+check "exits 0"                      "0"        "$RUN_RC"
+check "bumps the counter"            "30000386" "$(counter_now)"
+check "publishes nothing"            "30000384" "$(network_version_now)"
+
+echo "--- 8: --dry-run writes nothing at all"
+reset_node
+seed_network 30000384 "build 384"
+rm -f "$SANDBOX/target/webapp/webapp.metadata"
+run 30000385 "build 386" --dry-run
+check "exits 0"                      "0"        "$RUN_RC"
+check "the counter is untouched"     "30000385" "$(counter_now)"
+check "no metadata written"          "no"       "$([ -f "$SANDBOX/target/webapp/webapp.metadata" ] && echo yes || echo no)"
+
+echo "--- 9: a state we cannot verify is refused outright"
+reset_node
+# Sign the network's state with a DIFFERENT key.
+OTHER_KEY="$SANDBOX/other-keys.toml"
+"$TOOL" generate --output "$OTHER_KEY" >/dev/null
+printf 'foreign build' > "$SANDBOX/seed.tar.xz"
+"$TOOL" sign --input "$SANDBOX/seed.tar.xz" --output "$SANDBOX/seed.metadata" \
+    --parameters "$SANDBOX/seed.parameters" --version 99 --key-file "$OTHER_KEY" >/dev/null
+python3 - "$SANDBOX/seed.metadata" "$SANDBOX/seed.tar.xz" "$SANDBOX/node/state.bin" <<'PY'
+import sys, struct
+meta = open(sys.argv[1],'rb').read()
+arch = open(sys.argv[2],'rb').read()
+open(sys.argv[3],'wb').write(
+    struct.pack('>Q', len(meta)) + meta + struct.pack('>Q', len(arch)) + arch)
+PY
+run 30000385 "build 386"
+check "refuses"                      "no"       "$([ "$RUN_RC" -eq 0 ] && echo yes || echo no)"
+check "the counter is untouched"     "30000385" "$(counter_now)"
+case "$RUN_OUT" in *"do NOT verify"*) check "says the provenance is unclear" yes yes ;;
+                  *)                  check "says the provenance is unclear" yes no  ;; esac
+
+echo "--- 10: a state at OUR version carrying bytes that are not ours"
+# Both archives are validly signed, so signatures cannot separate them and the
+# state summary (just the u32 version) cannot either. Only comparing the bytes
+# we published against the bytes we read back can see this.
+reset_node
+seed_network 30000384 "build 384"
+# The floor will pick 30000386; plant a different archive there.
+printf 'a DIFFERENT build at the same version' > "$SANDBOX/collide.tar.xz"
+"$TOOL" sign --input "$SANDBOX/collide.tar.xz" --output "$SANDBOX/collide.metadata" \
+    --parameters "$SANDBOX/collide.parameters" --version 30000386 \
+    --key-file "$KEY_FILE" >/dev/null
+python3 - "$SANDBOX/collide.metadata" "$SANDBOX/collide.tar.xz" "$SANDBOX/node/collision.bin" <<'PYX'
+import sys, struct
+meta = open(sys.argv[1],'rb').read()
+arch = open(sys.argv[2],'rb').read()
+open(sys.argv[3],'wb').write(
+    struct.pack('>Q', len(meta)) + meta + struct.pack('>Q', len(arch)) + arch)
+PYX
+echo "30000386" > "$SANDBOX/node/version"
+run 30000385 "build 386"
+check "does not exit 0"        "no" "$([ "$RUN_RC" -eq 0 ] && echo yes || echo no)"
+case "$RUN_OUT" in *"FORKED"*) check "reports FORKED" yes yes ;;
+                  *)           check "reports FORKED" yes no  ;; esac
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/tests/web-container-publish-rehearsal.sh
+++ b/scripts/tests/web-container-publish-rehearsal.sh
@@ -26,13 +26,17 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 command -v python3 >/dev/null 2>&1 || { echo "SKIP: python3 not available"; exit 0; }
 
 # ------------------------------------------------------------------- the tool
+
+# CI sets CARGO_TARGET_DIR, so the binary is not necessarily under
+# $REPO_ROOT/target. Look where cargo will actually have put it.
+TARGET_DIR="${CARGO_TARGET_DIR:-$REPO_ROOT/target}"
 TOOL_SRC="${RIVER_WC_TOOL:-}"
 if [ -z "$TOOL_SRC" ]; then
     for candidate in \
-        "$REPO_ROOT/target/native/x86_64-unknown-linux-gnu/release/web-container-tool" \
-        "$REPO_ROOT/target/native/x86_64-unknown-linux-gnu/debug/web-container-tool" \
-        "$REPO_ROOT/target/release/web-container-tool" \
-        "$REPO_ROOT/target/debug/web-container-tool"
+        "$TARGET_DIR/native/x86_64-unknown-linux-gnu/release/web-container-tool" \
+        "$TARGET_DIR/native/x86_64-unknown-linux-gnu/debug/web-container-tool" \
+        "$TARGET_DIR/release/web-container-tool" \
+        "$TARGET_DIR/debug/web-container-tool"
     do
         [ -x "$candidate" ] && { TOOL_SRC="$candidate"; break; }
     done
@@ -41,7 +45,7 @@ if [ -z "$TOOL_SRC" ]; then
     echo "building web-container-tool..."
     (cd "$REPO_ROOT" && cargo build -p web-container-tool) || {
         echo "FAIL: could not build web-container-tool"; exit 1; }
-    TOOL_SRC="$REPO_ROOT/target/debug/web-container-tool"
+    TOOL_SRC="$TARGET_DIR/debug/web-container-tool"
 fi
 [ -x "$TOOL_SRC" ] || { echo "FAIL: no web-container-tool at $TOOL_SRC"; exit 1; }
 

--- a/scripts/web-container-publish-lib.sh
+++ b/scripts/web-container-publish-lib.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Pure decision logic for the web-container publish path.
+#
+# Sourced by scripts/publish-web-container.sh (which does the network I/O) and
+# by scripts/tests/web-container-publish-lib-test.sh (which exercises every
+# branch below with stubbed inputs). Nothing in this file touches the network,
+# the filesystem, or the clock: that is the point — the decisions a publish
+# turns on are the part that has to be testable without a network.
+#
+# See the header of scripts/publish-web-container.sh for the incident these
+# rules come from.
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+#
+# A network read of the web container's state lands in exactly one of three
+# states, and conflating any two of them is how the 2026-08-04 fork happened:
+#
+#   known   we fetched a state and its signature verifies under OUR contract
+#           parameters, so its version number is a fact.
+#   absent  the node answered "Contract not found".
+#   unknown we did not learn. A timeout, a dead node, a malformed answer.
+#
+# "unknown" is NOT "absent", and — for this contract — neither is "absent".
+# See wc_preflight_decision.
+# ---------------------------------------------------------------------------
+
+# wc_next_version <counter> <net_status> <net_version>
+#
+# The version to sign at. The local counter is a convenience; the network is
+# the authority, so the floor is whichever is higher. That is what makes the
+# counter self-healing: a counter that fell behind (a rollback, a discarded
+# working-tree change, a fresh clone) can no longer re-issue a version the
+# network has already seen.
+#
+# Strictly greater, never "exactly one more". The contract enforces
+# monotonicity, not contiguity, so gaps are fine and always have been.
+wc_next_version() {
+    local counter="$1" status="$2" net="${3:-}"
+    case "$status" in
+        known)
+            [ -n "$net" ] || { echo "wc_next_version: known status needs a version" >&2; return 1; }
+            if [ "$net" -ge "$counter" ]; then
+                echo $((net + 1))
+            else
+                echo $((counter + 1))
+            fi
+            ;;
+        absent|unknown)
+            # No floor to raise to. The caller has already decided (via
+            # wc_preflight_decision) whether proceeding at all is allowed.
+            echo $((counter + 1))
+            ;;
+        *)
+            echo "wc_next_version: unknown status '$status'" >&2
+            return 1
+            ;;
+    esac
+}
+
+# wc_preflight_decision <net_status> <allow_unverified> <allow_first_publish>
+#
+# Prints "proceed" or "refuse: <reason>".
+#
+# The judgement call this encodes: refusing when the network cannot be read
+# blocks a release that might have been perfectly fine, and that is annoying
+# but LOUD and self-limiting — the operator retries, or overrides. Signing
+# blind is silent and lasts a release cycle, because two states at the same
+# version never converge and anti-entropy cannot see the difference (the
+# container's summary is just the u32). Loud-and-recoverable beats
+# silent-and-forked, so ambiguity refuses by default and both escapes are
+# explicit.
+wc_preflight_decision() {
+    local status="$1" allow_unverified="$2" allow_first_publish="$3"
+    case "$status" in
+        known)
+            echo "proceed"
+            ;;
+        absent)
+            # "Contract not found" is proof of absence for a contract that has
+            # never been published. It is NOT proof for this one. A Freenet GET
+            # can dead-end and answer NotFound for a contract that exists —
+            # that is a tracked, measured failure mode, not a hypothetical — so
+            # for an artifact we know is live (published-contract/ is committed
+            # and its version counter is non-zero) a NotFound means the request
+            # failed to find it, not that it is gone.
+            if [ "$allow_first_publish" = "1" ]; then
+                echo "proceed"
+            else
+                echo "refuse: the node answered 'Contract not found' for a contract we know is published."
+            fi
+            ;;
+        unknown)
+            if [ "$allow_unverified" = "1" ]; then
+                echo "proceed"
+            else
+                echo "refuse: could not determine the version on the network."
+            fi
+            ;;
+        *)
+            echo "refuse: unrecognised network status '$status'"
+            ;;
+    esac
+}
+
+# wc_publish_outcome <publish_rc> <back_status> <back_version> <bytes_match> <our_version>
+#
+# What actually happened, judged from a read-back rather than from fdev's exit
+# code. `bytes_match` is 1/0/na (na when there are no bytes to compare).
+#
+# The exit code is not evidence in EITHER direction:
+#
+#   - A publish at an already-used version is a no-op SUCCESS. The container
+#     rejects it and nothing tells you.
+#   - A publish that reports a timeout may still have landed. That is exactly
+#     what happened on 2026-08-04: `put timed out after 1 peer attempt(s)`,
+#     and the state was on the network the whole time.
+#
+# Prints one of: landed | collision | superseded | not-landed | unknown
+wc_publish_outcome() {
+    local publish_rc="$1" status="$2" version="${3:-}" bytes_match="$4" ours="$5"
+    case "$status" in
+        known)
+            [ -n "$version" ] || { echo "unknown"; return 0; }
+            if [ "$version" -eq "$ours" ]; then
+                if [ "$bytes_match" = "1" ]; then
+                    # Our bytes, our version, live. True regardless of
+                    # publish_rc — see the timeout case above.
+                    echo "landed"
+                else
+                    # Our version is live carrying somebody else's bytes.
+                    # Only our key can sign a state the contract accepts, so
+                    # "somebody else" means an earlier run of this pipeline:
+                    # this is the fork.
+                    echo "collision"
+                fi
+            elif [ "$version" -gt "$ours" ]; then
+                echo "superseded"
+            else
+                echo "not-landed"
+            fi
+            ;;
+        absent|unknown)
+            echo "unknown"
+            ;;
+        *)
+            echo "unknown"
+            ;;
+    esac
+    # publish_rc is deliberately unused in the classification. It is reported
+    # to the operator, but it decides nothing.
+    : "$publish_rc"
+}
+
+# wc_outcome_exit_code <outcome>
+#
+# 0 only when our state is provably the live one.
+wc_outcome_exit_code() {
+    case "$1" in
+        landed)     echo 0 ;;
+        collision)  echo 3 ;;
+        superseded) echo 4 ;;
+        not-landed) echo 5 ;;
+        unknown)    echo 6 ;;
+        *)          echo 1 ;;
+    esac
+}

--- a/scripts/web-container-publish-lib.sh
+++ b/scripts/web-container-publish-lib.sh
@@ -110,11 +110,18 @@ wc_preflight_decision() {
 #
 # The exit code is not evidence in EITHER direction:
 #
-#   - A publish at an already-used version is a no-op SUCCESS. The container
-#     rejects it and nothing tells you.
+#   - A zero exit says the node we published THROUGH accepted the PUT. It does
+#     not say our bytes are what the network serves.
 #   - A publish that reports a timeout may still have landed. That is exactly
 #     what happened on 2026-08-04: `put timed out after 1 peer attempt(s)`,
 #     and the state was on the network the whole time.
+#
+# Do NOT restate the old "a publish at an already-used version is a no-op
+# SUCCESS" here. It is false for this contract: web-container-contract's
+# `update_state` returns `InvalidUpdateWithInfo` for `version <= current`, and
+# freenet-core maps a failed PutResponse to an error on the originating node —
+# which is how the 2026-08-04 operator saw the rejection message at all. The
+# POINTER contract is the one that accepts a stale update silently, by design.
 #
 # Prints one of: landed | collision | superseded | not-landed | unknown
 wc_publish_outcome() {
@@ -150,6 +157,29 @@ wc_publish_outcome() {
     # publish_rc is deliberately unused in the classification. It is reported
     # to the operator, but it decides nothing.
     : "$publish_rc"
+}
+
+# wc_readback_is_final <outcome>
+#
+# Prints "yes" when the read-back has settled the question and asking the
+# network again cannot change the answer; "no" when it has not.
+#
+# 'landed', 'collision' and 'superseded' are statements about a state we
+# actually read back — the network is at our version with our bytes, at our
+# version with bytes that are not ours, or above us. None of those un-happen,
+# so re-reading only delays a report the operator needs.
+#
+# 'not-landed' and 'unknown' are the same claim wearing two hats: "we have not
+# seen our state yet". Freenet is eventually consistent, so that is exactly
+# what a read taken too early looks like, and one GET is a sample rather than
+# a verdict. Treating 'not-landed' as final is how a publish that LANDED gets
+# reported as NOT PUBLISHED — and that report is what invites the retry that
+# forked the site on 2026-08-04, so it is the direction that hurts.
+wc_readback_is_final() {
+    case "$1" in
+        landed|collision|superseded) echo "yes" ;;
+        *)                           echo "no" ;;
+    esac
 }
 
 # wc_outcome_exit_code <outcome>


### PR DESCRIPTION
## Problem

River's web-container publish path signed at `local counter + 1` and judged the result by `fdev`'s exit code. Neither is evidence, and on **2026-08-04 (commit `1032d373`)** the combination put two different archives on the network at the same version.

`cargo make publish-river` signed version 30000377 and uploaded it. `fdev network publish` reported `put timed out after 1 peer attempt(s)`, so the rollback arm in `[tasks.publish-river]` restored the counter to 30000376. The operator retried; `sign-webapp` rebuilt the UI — producing a **different archive**, because the build is not reproducible — signed it as 30000377 again, and published it. Only then did the network say `New state version 30000377 must be higher than current version 30000377`: the first PUT had landed all along.

**Why that forks the site rather than resolving.** The container is correctly gated — `update_state` rejects `version <= current_version` — which makes *differing* versions converge and does nothing for two states at the **same** version: it rejects in both directions, so each peer keeps whichever it saw first. And `summarize_state` emits only the `u32` version, so anti-entropy between two split peers compares equal summaries and never attempts to heal. The split is silent. The second archive reaches peers because a peer **new** to the contract takes the initial-state bypass, which runs `validate_state` only (signature, `version != 0`), not the gate.

River self-heals at the next successful publish, so exposure is bounded at one release cycle. Bounded, not harmless: for that window two populations of users are on different builds with no signal that they are.

## Approach

Ported, not invented. `scripts/publish-pointer-records.sh` already does the right thing for pointer records; this brings the same discipline to the web container, in `scripts/publish-web-container.sh`.

**1. Read before signing.** The version signed is `max(local counter, on-network version) + 1`, with the on-network version fetched and verified under our own contract parameters before use. The counter becomes bookkeeping; the network is the authority. A counter that fell behind — a rollback, a discarded working-tree change, a fresh clone — can no longer reissue a version the network has already seen. Strictly greater, never "exactly one more": gaps are fine, the contract enforces monotonicity, not contiguity.

**2. Prove absence, don't infer it.** `known` / `absent` / `unknown` are three separate states. This is **stricter than the pointer script on one point**, deliberately: that script treats `Contract not found` as proof of a first publish, which is right for a record that may never have been published. For the web container it is not proof of anything — a Freenet GET can dead-end and report NotFound for a contract that exists, and `published-contract/` says this one is live. So NotFound refuses too, behind its own `RIVER_WC_ALLOW_FIRST_PUBLISH=1` escape.

**3. Re-read after publishing.** `fdev`'s exit code is not evidence in either direction: a zero exit says the node we published *through* accepted the PUT, not that the bytes users fetch are ours, and a publish that reports a timeout may have landed anyway (2026-08-04). The script fetches the state back and compares the archive **byte for byte** against what it published. Signature validity cannot do this — both forked archives were validly signed by the same key — so the byte comparison is the only check that can tell "my state is live" from "a state at my version is live".

This also turns the 2026-08-04 case into a clean success: a publish that reports a timeout but whose state IS live now prints `PUBLISHED — despite fdev exiting N` and tells the operator explicitly not to retry.

**4. The counter no longer rolls back.** The rollback is what handed the retry a version that had, in fact, been used. Forward-only costs a counter gap and nothing else, and the read-before-sign floor recomputes from the network anyway, so a bumped-but-unpublished counter is harmless. A burned version is never reissued.

**5. The double bump.** `[tasks.publish-all]` ran `sign-webapp` and then `publish-river`, which re-ran `sign-webapp` as a dependency in a fresh `cargo make` process: two bumps and two UI builds for one publish, with the `.prev` snapshot overwritten so a failure rolled back only one of them. Those are the gaps visible in the counter's history. `publish-river` now owns the whole sequence and `publish-all` calls it once. Separately, `update-published-contract` now uses `export-parameters` instead of depending on `sign-webapp`, so refreshing the committed contract files no longer burns a counter value it never publishes.

**6. `flock`.** `[tasks.sign-webapp]` has carried a comment saying "wrap in `flock` if you need that" since the counter was introduced; nothing ever did. The lock is now taken by the script itself, across the whole sign to publish to verify sequence rather than the counter write alone — the gap between "sign at N" and "publish N" is where the fork lived. A **missing** `flock` warns rather than refusing: blocking a release because a lock utility is absent is a worse failure than the race it prevents.

### The could-not-determine decision, and why

**Confirmed lower version on the network: publish.** **Could not determine: refuse, with an explicit per-run override.**

Refusing when the network cannot be read may block a release that would have been fine. That failure is annoying but **loud and self-limiting**: the operator sees it, retries, or overrides with `RIVER_WC_ALLOW_UNVERIFIED=1`. Signing blind is **silent and lasts a release cycle**, because two states at one version never converge and anti-entropy cannot even see the difference. Loud-and-recoverable beats silent-and-forked, so ambiguity refuses by default and every escape is explicit.

The override is not a bypass of the whole fix: it skips only the pre-flight floor. The post-publish read-back still runs and still decides the exit code, so an override that publishes into a stale version is reported as `NOT PUBLISHED`, not as success.

## Testing

**What I tested.**

- `web-container-tool inspect` (new subcommand — parses the packed state, verifies the signature against the contract parameters, prints `version=N`, optionally extracts the archive) is unit-tested for the sign/pack/parse/verify round trip, foreign signatures, tampered archives, truncated and lying length fields, `--expect-version` mismatch, and the case where two different archives are both validly signed at one version. `cargo test -p web-container-tool`: 7 passed.
- `scripts/tests/web-container-publish-lib-test.sh` — every decision branch with stubbed inputs: the version floor (including the exact 30000376 with network-at-30000377 case), the three network statuses and their overrides, and the outcome classification including "rc != 0 but our bytes are live" and "rc == 0 but the network is still behind". 27 checks.
- `scripts/tests/web-container-publish-rehearsal.sh` — the **real** publish script and the **real** `web-container-tool` against a throwaway repo layout, a throwaway signing key, and an `fdev` that is a shell script modelling the container's own version gate, plus stubbed `gh` and `cargo`. 36 scenarios, 138 checks, including the 2026-08-04 shape end to end and the retry that used to fork the site. This covers the wiring a pure function cannot: `fdev` argument order, the `Contract not found` string absence is keyed off, the `version=` line the script parses, and that the verdict comes from the read-back.
- **Mutation-tested, not just green.** Removing the network floor fails scenario 3 and 2 lib checks; making the verdict trust `PUB_RC` fails scenario 2; removing the byte comparison fails scenario 10 and 1 lib check. Each was applied and confirmed red before being reverted.
- `shellcheck` clean on all three scripts; `cargo fmt --check` clean; `cargo clippy -p web-container-tool` clean (the 5 warnings in `river-core` are pre-existing toolchain drift, and `clippy.yml` is disabled).
- `cargo make --list-all-steps` loads the rewritten `Makefile.toml`.

Both shell suites are wired into `build.yml`, so they are not tests nobody runs.

**What I did NOT test.**

- **Nothing was published to the network**, and no real publish was run end to end. Every `fdev` invocation in the tests is the stub.
- The real `fdev` argument order and the real `Contract not found` text are matched against `freenet-core`'s `crates/fdev/src/commands.rs` and the existing pointer script, not against a live node. If `fdev`'s CLI or that error string changes, the rehearsal's stub changes with it and stays green — a real `fdev` regression would surface at publish time, not in CI.
- The `flock` path is exercised only in its "lock acquired" form; I did not rehearse two concurrent runs contending.
- The `RIVER_WC_ALLOW_FIRST_PUBLISH=1` path is covered only in the library test, not end to end.

## Residual risk after this change

- **Between the pre-flight read and the PUT there is still a window.** If something else published in that gap, we sign above a version that is no longer live. The read-back catches it (`superseded`) but only after the fact. In practice one key publishes this contract, so the window needs two concurrent operators — which the `flock` covers on one machine and nothing covers across machines.
- **An existing fork is not repaired by this change.** It prevents new ones and detects a live one (`FORKED` verdict, with the remedy: re-run, which signs above it and heals both branches). If the 2026-08-04 fork is somehow still live, it needs a publish, not this PR.
- **The override remains a footgun.** `RIVER_WC_ALLOW_UNVERIFIED=1` in a shell profile or a wrapper script would silently restore the old behaviour for the pre-flight half. Only the read-back would still guard.
- **`--sign-only` can still leave a signed artifact that is never published**, advancing the counter. That is now harmless (forward-only, and the floor recomputes) but it does widen counter gaps.
- **The test-contract path (`sign-webapp-test` / `publish-river-test`) still uses the bump-then-roll-back scheme.** Left deliberately — that contract is throwaway and a fork of it costs nothing — with a comment saying not to copy the pattern back.
- **This does not make the UI build reproducible.** A rebuild still produces a different archive; the fix ensures a different archive can never land at the same version, not that it is the same archive.

Refs the 2026-08-04 incident and commit `1032d373`.

https://claude.ai/code/session_0131oS6YAD9gMWigX8v4QR4J

[AI-assisted - Claude]

