### PR TITLE
fix(publish): make the web-container version counter forward-only

### DIFF
--- a/.claude/rules/river-publish.md
+++ b/.claude/rules/river-publish.md
@@ -91,7 +91,9 @@ cargo make publish-river  # bumps published-contract/contract-version.txt
 ```bash
 # `cargo make sign-webapp` (run transitively by publish-river) incremented
 # the counter. Commit it together with whatever other changes the publish
-# included.
+# included — and commit it EVEN IF the publish reported a failure. See
+# "Version policy" below: the counter is forward-only, because a reported
+# failure is not evidence the state did not land.
 git add published-contract/contract-version.txt
 git commit -m "chore: bump web-container version after publish"
 curl -s http://127.0.0.1:7509/v1/contract/web/raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv/ | head -5
@@ -117,6 +119,10 @@ already-used version is a no-op *success*, so the network will never tell you
 it was ignored.
 
 **Version policy:** the canonical source is `published-contract/contract-version.txt`, which `cargo make sign-webapp` increments and writes back each publish. NEVER base the version on wall-clock time (`date +%s / 60`) — the previous scheme bit us 2026-05-16 when the on-network version had drifted ahead of the timestamp-derived value. The counter file makes the version a strict monotonic local invariant; gaps are fine (the contract enforces monotonicity, not contiguity).
+
+**The counter is forward-only. Never re-use a version, and never hand-edit it downwards.** A publish that reports a failure is not evidence the state did not land — on 2026-08-04 `fdev` reported `put timed out after 1 peer attempt(s)` while the state was on the network the whole time. The old flow rolled the counter back on that exit code, the operator retried, the rebuild was not byte-reproducible, and a *different* archive got signed at the *same* version. Two states at one version never converge (the contract rejects `version <= current` in both directions, and the state summary carries only the version, so anti-entropy cannot tell them apart), and the only recovery is the next publish at a higher version. Burning a version costs a gap in the sequence and nothing else.
+
+So: **commit the bumped counter whether or not the publish reported success.** `publish-river` then reads the state back and prints an advisory report — the live version, and whether its archive is byte-for-byte the one you just published. Read it before deciding anything. It is a report, not a gate: it cannot fail a publish, and `NOT SEEN YET` means "one GET did not find it yet", which on an eventually-consistent network is not the same as "it did not land". Re-read with `fdev network execute get <contract_id> -o /tmp/state.bin` rather than republishing on a single early read.
 
 ## Two independent release surfaces
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,6 +278,16 @@ jobs:
       # tool and the verifying contract agree on the parameter encoding.
       run: cargo test -p web-container-contract -p web-container-tool
 
+    - name: Test publish guards (forward-only counter + read-back)
+      # The publish path is shell inside cargo-make script blocks, so its
+      # tests are shell too. This asserts that no publish task rolls the
+      # web-container version counter back on a failed publish -- the step
+      # that handed a retry an already-used version and forked the site on
+      # 2026-08-04 -- and that the post-publish read-back classifies what the
+      # network answered without ever failing the publish. A guard no job runs
+      # is a guard that passes by default (freenet/river#614).
+      run: ./scripts/tests/publish-guards-test.sh
+
   ui-playwright-tests:
     # Ubicloud, NOT a GitHub-hosted larger runner -- see the `build` job above.
     runs-on: ubicloud-standard-8

--- a/.gitignore
+++ b/.gitignore
@@ -48,11 +48,12 @@ ui/tests/test-results/
 # Manual e2e test screenshots (see #244 review feedback)
 /dm-*.png
 
-# Web-container version-counter rollback snapshot. Created by
-# `cargo make sign-webapp` BEFORE bumping the counter; removed on
-# successful publish, or moved back over the counter on failure.
-# Should never appear in commits.
+# Web-container version-counter rollback snapshot. No longer produced —
+# the counter is forward-only (see [tasks.sign-webapp] in Makefile.toml),
+# so nothing writes this file. Kept ignored so a stale one left by an
+# older checkout cannot be committed by accident.
 /published-contract/contract-version.txt.prev
+/test-contract/contract-version.txt.prev
 
 # Syncthing in-flight transfer files (`.syncthing.<name>.tmp` are
 # created by the syncthing daemon while a file is being received).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,7 +181,11 @@ number strictly higher than the current published version. The version
 is tracked by a committed counter at
 `published-contract/contract-version.txt`; `cargo make sign-webapp`
 increments it. Commit the bumped counter alongside other publish
-artifacts.
+artifacts — **including when the publish reports a failure**. The counter
+is forward-only: a reported failure is not evidence the state did not
+land, and re-using a version is what forked the site on 2026-08-04.
+`publish-river` prints an advisory read-back of what is actually live;
+read it before retrying. See `.claude/rules/river-publish.md`.
 
 **Contract ID:** `raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv`
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -212,33 +212,37 @@ script = '''
 # was 30000208 while the timestamp gave 29649402, so the publish was
 # rejected.
 #
-# Counter lifecycle:
-# 1. `sign-webapp` here writes a `.prev-version` snapshot BEFORE bumping
-#    the counter file, so a downstream `publish-river` failure can roll
-#    back atomically (see [tasks.publish-river]'s `on-failure` arm).
-# 2. The counter file is bumped to `current+1` and the new metadata is
+# Counter lifecycle — FORWARD-ONLY. The counter is bumped here and is
+# NEVER rolled back, not even when the publish that follows fails:
+# 1. The counter file is bumped to `current+1` and the new metadata is
 #    signed with that value.
-# 3. After a successful `fdev publish`, the caller commits the bumped
-#    counter file (the snapshot is left for the publish task to clean
-#    up). Skeptical-review (#258) flagged that bumping before publish
-#    risks leaving the local file ahead of on-network if publish fails;
-#    the .prev-version snapshot + rollback closes that window.
+# 2. Whatever `publish-river` then reports, the bumped value stands. The
+#    caller commits the bumped counter file.
+#
+# Why forward-only (freenet/river#634, the 2026-08-04 fork): the counter
+# used to be snapshotted here and rolled back by `publish-river` when
+# `fdev network publish` exited non-zero. But that exit code is not
+# evidence the state did not land, so the rollback handed the operator's
+# retry a version the network had already accepted, and the rebuild was
+# not byte-reproducible. Full account in scripts/publish-readback.sh.
+#
+# A burned version costs a gap in the sequence and nothing else — the
+# contract enforces monotonicity, not contiguity — which makes rolling
+# back all cost and no benefit.
 #
 # Locking: this script is NOT safe under two parallel `publish-river`
 # runs on the same workstation — they would race the read-modify-write.
 # Wrap in `flock` if you need that:
 #     flock published-contract/contract-version.txt cargo make publish-river
 version_file="published-contract/contract-version.txt"
-prev_snapshot="$version_file.prev"
 if [ ! -f "$version_file" ]; then
     echo "ERROR: $version_file missing. Seed it with the current on-network version."
     exit 1
 fi
 current=$(cat "$version_file" | tr -d '[:space:]')
 version=$((current + 1))
-cp "$version_file" "$prev_snapshot"
 echo "$version" > "$version_file"
-echo "Web-container version: $current -> $version (commit $version_file after a successful publish)"
+echo "Web-container version: $current -> $version (commit $version_file — the bump stands whatever publish reports)"
 target/native/x86_64-unknown-linux-gnu/${BUILD_PROFILE}/web-container-tool sign \
   --input target/webapp/webapp.tar.xz \
   --output target/webapp/webapp.metadata \
@@ -372,27 +376,41 @@ fi
 contract_id=$(cat published-contract/contract-id.txt)
 echo "Publishing using committed contract: $contract_id"
 version_file="published-contract/contract-version.txt"
-prev_snapshot="$version_file.prev"
-if fdev network publish \
+version=$(tr -d '[:space:]' < "$version_file")
+
+fdev network publish \
   --code published-contract/web_container_contract.wasm \
   --parameters published-contract/webapp.parameters \
   contract \
   --webapp-archive target/webapp/webapp.tar.xz \
-  --webapp-metadata target/webapp/webapp.metadata; then
-    # Publish succeeded — the bumped counter file is the new truth.
-    # Discard the snapshot. Caller must commit $version_file.
-    rm -f "$prev_snapshot"
+  --webapp-metadata target/webapp/webapp.metadata \
+  && publish_rc=0 || publish_rc=$?
+
+# Advisory read-back. It REPORTS what the network actually holds; it
+# never gates, never refuses, and its own failure is not a publish
+# failure — hence the `|| true`. See scripts/publish-readback.sh.
+#
+# This is the piece that breaks the 2026-08-04 chain, which was
+# "timeout -> operator believed it failed -> operator retried". A
+# read-back that says "it landed despite the timeout, do not retry"
+# stops that at the second step.
+./scripts/publish-readback.sh \
+  "$contract_id" \
+  published-contract/webapp.parameters \
+  target/webapp/webapp.tar.xz \
+  "$version" \
+  "$publish_rc" \
+  "target/native/x86_64-unknown-linux-gnu/${BUILD_PROFILE}/web-container-tool" || true
+
+if [ "$publish_rc" -eq 0 ]; then
     echo "Publish OK. Remember to commit $version_file."
 else
-    rc=$?
-    # Publish failed — roll the counter back so subsequent retries
-    # don't accumulate a drift. The on-network version is unchanged,
-    # and our local counter is now matched to it again.
-    if [ -f "$prev_snapshot" ]; then
-        mv "$prev_snapshot" "$version_file"
-        echo "Publish failed (exit $rc); rolled $version_file back to its pre-publish value." >&2
-    fi
-    exit $rc
+    # The counter is NOT rolled back — see the lifecycle note in
+    # [tasks.sign-webapp]. Version $version is burned whether or not the
+    # publish landed, and burning one costs only a gap in the sequence.
+    echo "fdev network publish exited $publish_rc. $version_file stays at $version; commit it." >&2
+    echo "Read the read-back above before retrying: a timeout does not mean the state is not live." >&2
+    exit "$publish_rc"
 fi
 '''
 
@@ -407,22 +425,32 @@ if [ ! -f "published-contract/contract-id.txt" ]; then
 fi
 contract_id=$(cat published-contract/contract-id.txt)
 echo "Publishing using committed contract in debug mode: $contract_id"
+# Same production contract and same production counter as
+# [tasks.publish-river], so the same forward-only rule and the same
+# advisory read-back apply. See [tasks.sign-webapp] for why.
 version_file="published-contract/contract-version.txt"
-prev_snapshot="$version_file.prev"
-if fdev network publish \
+version=$(tr -d '[:space:]' < "$version_file")
+
+fdev network publish \
   --code published-contract/web_container_contract.wasm \
   --parameters published-contract/webapp.parameters \
   contract \
   --webapp-archive target/webapp/webapp.tar.xz \
-  --webapp-metadata target/webapp/webapp.metadata; then
-    rm -f "$prev_snapshot"
-else
-    rc=$?
-    if [ -f "$prev_snapshot" ]; then
-        mv "$prev_snapshot" "$version_file"
-        echo "Publish failed (exit $rc); rolled $version_file back to its pre-publish value." >&2
-    fi
-    exit $rc
+  --webapp-metadata target/webapp/webapp.metadata \
+  && publish_rc=0 || publish_rc=$?
+
+./scripts/publish-readback.sh \
+  "$contract_id" \
+  published-contract/webapp.parameters \
+  target/webapp/webapp.tar.xz \
+  "$version" \
+  "$publish_rc" \
+  "target/native/x86_64-unknown-linux-gnu/${BUILD_PROFILE}/web-container-tool" || true
+
+if [ "$publish_rc" -ne 0 ]; then
+    echo "fdev network publish exited $publish_rc. $version_file stays at $version; commit it." >&2
+    echo "Read the read-back above before retrying: a timeout does not mean the state is not live." >&2
+    exit "$publish_rc"
 fi
 '''
 
@@ -550,16 +578,17 @@ fi
 # as the production publish (see [tasks.sign-webapp] for the 2026-05-16
 # incident). Test contract counter is NOT committed since the test
 # contract ID is regenerated freely.
-# .prev snapshot is captured here for the publish task to roll back on
-# failure — same pattern as the production sign/publish flow.
+# Forward-only, same as the production flow: the bump is never rolled
+# back on a failed publish, because a failed publish is not evidence the
+# state did not land, and re-issuing a version the network already
+# accepted is what forked the site on 2026-08-04. See
+# [tasks.sign-webapp].
 version_file="test-contract/contract-version.txt"
-prev_snapshot="$version_file.prev"
 if [ ! -f "$version_file" ]; then
     echo "0" > "$version_file"
 fi
 current=$(cat "$version_file" | tr -d '[:space:]')
 version=$((current + 1))
-cp "$version_file" "$prev_snapshot"
 echo "$version" > "$version_file"
 echo "Test web-container version: $current -> $version"
 target/native/x86_64-unknown-linux-gnu/${BUILD_PROFILE}/web-container-tool sign \
@@ -600,21 +629,28 @@ contract_id=$(fdev get-contract-id \
 
 echo "Publishing TEST contract: $contract_id"
 version_file="test-contract/contract-version.txt"
-prev_snapshot="$version_file.prev"
-if fdev network publish \
+version=$(tr -d '[:space:]' < "$version_file")
+
+fdev network publish \
   --code target/wasm32-unknown-unknown/release/web_container_contract.wasm \
   --parameters target/webapp/webapp-test.parameters \
   contract \
   --webapp-archive target/webapp/webapp-test.tar.xz \
-  --webapp-metadata target/webapp/webapp-test.metadata; then
-    rm -f "$prev_snapshot"
-else
-    rc=$?
-    if [ -f "$prev_snapshot" ]; then
-        mv "$prev_snapshot" "$version_file"
-        echo "Test publish failed (exit $rc); rolled $version_file back." >&2
-    fi
-    exit $rc
+  --webapp-metadata target/webapp/webapp-test.metadata \
+  && publish_rc=0 || publish_rc=$?
+
+./scripts/publish-readback.sh \
+  "$contract_id" \
+  target/webapp/webapp-test.parameters \
+  target/webapp/webapp-test.tar.xz \
+  "$version" \
+  "$publish_rc" \
+  "target/native/x86_64-unknown-linux-gnu/${BUILD_PROFILE}/web-container-tool" || true
+
+if [ "$publish_rc" -ne 0 ]; then
+    # Forward-only: the counter is not rolled back. See [tasks.sign-webapp].
+    echo "Test publish exited $publish_rc. $version_file stays at $version." >&2
+    exit "$publish_rc"
 fi
 
 echo ""

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -400,7 +400,7 @@ fdev network publish \
   target/webapp/webapp.tar.xz \
   "$version" \
   "$publish_rc" \
-  "target/native/x86_64-unknown-linux-gnu/${BUILD_PROFILE}/web-container-tool" || true
+  "target/native/x86_64-unknown-linux-gnu/release/web-container-tool" || true
 
 if [ "$publish_rc" -eq 0 ]; then
     echo "Publish OK. Remember to commit $version_file."
@@ -439,13 +439,20 @@ fdev network publish \
   --webapp-metadata target/webapp/webapp.metadata \
   && publish_rc=0 || publish_rc=$?
 
+# `release`, NOT ${BUILD_PROFILE}. This task sets BUILD_PROFILE=dev, and
+# cargo's `dev` profile emits into `debug/`, never `dev/` — so
+# `${BUILD_PROFILE}` here names a path that cannot exist and the read-back
+# would silently short-circuit on "no web-container-tool", on the one task
+# that publishes to the PRODUCTION contract and counter. (The tool itself is
+# always the release build: a cargo-make task's `env` does not reach its
+# dependencies, so `sign-webapp` builds it under the default profile.)
 ./scripts/publish-readback.sh \
   "$contract_id" \
   published-contract/webapp.parameters \
   target/webapp/webapp.tar.xz \
   "$version" \
   "$publish_rc" \
-  "target/native/x86_64-unknown-linux-gnu/${BUILD_PROFILE}/web-container-tool" || true
+  "target/native/x86_64-unknown-linux-gnu/release/web-container-tool" || true
 
 if [ "$publish_rc" -ne 0 ]; then
     echo "fdev network publish exited $publish_rc. $version_file stays at $version; commit it." >&2
@@ -645,7 +652,7 @@ fdev network publish \
   target/webapp/webapp-test.tar.xz \
   "$version" \
   "$publish_rc" \
-  "target/native/x86_64-unknown-linux-gnu/${BUILD_PROFILE}/web-container-tool" || true
+  "target/native/x86_64-unknown-linux-gnu/release/web-container-tool" || true
 
 if [ "$publish_rc" -ne 0 ]; then
     # Forward-only: the counter is not rolled back. See [tasks.sign-webapp].

--- a/contracts/web-container-contract/web-container-tool/src/main.rs
+++ b/contracts/web-container-contract/web-container-tool/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use ed25519_dalek::{Signer, SigningKey};
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 use river_core::crypto_values::CryptoValue;
 use river_core::web_container::WebContainerMetadata;
 use std::fs;
@@ -58,6 +58,34 @@ enum Commands {
         /// Key file to use (default: ~/.config/river/web-container-keys.toml)
         #[arg(long, short)]
         key_file: Option<String>,
+    },
+    /// Read a PACKED web-container state — the bytes `fdev execute get`
+    /// returns — and report the version it carries.
+    ///
+    /// This exists so the publish path can answer "what is actually live right
+    /// now?" after a publish. Before it, the only signal was `fdev`'s exit
+    /// code, and that is not evidence in either direction: on 2026-08-04 the
+    /// publish reported `put timed out after 1 peer attempt(s)` while the
+    /// state had in fact landed, the operator retried, and a second
+    /// non-reproducible archive was signed at the same version.
+    ///
+    /// Prints `version=<n>` on stdout so callers can
+    /// `sed -n 's/^version=//p'`.
+    Inspect {
+        /// Packed state file (`[u64 metadata_len][metadata][u64 web_len][web]`)
+        #[arg(long)]
+        state: String,
+        /// Contract parameters (the raw 32-byte verifying key). When given,
+        /// the embedded signature MUST verify under it or this fails.
+        ///
+        /// Pass it. A version read out of unverified bytes is not evidence of
+        /// anything: it is whatever the responder chose to say.
+        #[arg(long)]
+        parameters: Option<String>,
+        /// Write the embedded webapp archive here, so the caller can compare
+        /// it byte-for-byte against the archive it published.
+        #[arg(long)]
+        archive_out: Option<String>,
     },
 }
 
@@ -299,6 +327,120 @@ fn export_parameters(
     write_parameters(&signing_key, &parameters)
 }
 
+/// The parsed pieces of a packed web-container state.
+struct PackedWebApp {
+    version: u32,
+    signature: Signature,
+    archive: Vec<u8>,
+}
+
+impl PackedWebApp {
+    /// Parse the packed WebApp container:
+    /// `[metadata_len: u64 BE][metadata: CBOR][web_len: u64 BE][web]`.
+    ///
+    /// That layout is defined by `WebApp::pack` in freenet-core and read back
+    /// by this contract's own `validate_state`. Those two are the authority;
+    /// `sign_output_parses_back_and_verifies` below pins that this parser
+    /// still agrees with what `sign` produces.
+    fn parse(bytes: &[u8]) -> Result<Self, String> {
+        fn take_u64(bytes: &[u8], off: &mut usize) -> Result<u64, String> {
+            let end = off
+                .checked_add(8)
+                .ok_or_else(|| "length field offset overflows".to_string())?;
+            let slice = bytes
+                .get(*off..end)
+                .ok_or_else(|| "state truncated: no room for a length field".to_string())?;
+            *off = end;
+            let mut buf = [0u8; 8];
+            buf.copy_from_slice(slice);
+            Ok(u64::from_be_bytes(buf))
+        }
+
+        fn take<'a>(bytes: &'a [u8], off: &mut usize, len: u64) -> Result<&'a [u8], String> {
+            let len =
+                usize::try_from(len).map_err(|_| "declared length exceeds usize".to_string())?;
+            let end = off
+                .checked_add(len)
+                .ok_or_else(|| "declared length overflows".to_string())?;
+            let slice = bytes.get(*off..end).ok_or_else(|| {
+                format!(
+                    "state truncated: declared {len} bytes, {} remain",
+                    bytes.len().saturating_sub(*off)
+                )
+            })?;
+            *off = end;
+            Ok(slice)
+        }
+
+        let mut off = 0usize;
+        let metadata_len = take_u64(bytes, &mut off)?;
+        let metadata_bytes = take(bytes, &mut off, metadata_len)?;
+        let metadata: WebContainerMetadata = ciborium::de::from_reader(metadata_bytes)
+            .map_err(|e| format!("metadata is not valid WebContainerMetadata CBOR: {e}"))?;
+        let web_len = take_u64(bytes, &mut off)?;
+        let archive = take(bytes, &mut off, web_len)?.to_vec();
+
+        Ok(Self {
+            version: metadata.version,
+            signature: metadata.signature,
+            archive,
+        })
+    }
+
+    /// Verify the state's signature against the contract parameters.
+    ///
+    /// The parameters file is exactly the 32-byte verifying key (see
+    /// `write_parameters`), and the contract ID is derived from
+    /// `(wasm, parameters)`. So "verifies under these parameters" means "this
+    /// state was signed by the key that owns this contract" — which is the
+    /// only reason to believe a version number that came off the network. An
+    /// unverified version is not evidence; it is whatever the responder chose
+    /// to say.
+    fn verify(&self, parameters: &[u8]) -> Result<(), String> {
+        let key_bytes: [u8; 32] = parameters
+            .try_into()
+            .map_err(|_| format!("parameters must be 32 bytes, got {}", parameters.len()))?;
+        let verifying_key = VerifyingKey::from_bytes(&key_bytes)
+            .map_err(|e| format!("parameters are not a valid verifying key: {e}"))?;
+
+        // The signed message is `version || archive`, exactly as `sign_webapp`
+        // builds it and `validate_state` re-builds it.
+        let mut message = self.version.to_be_bytes().to_vec();
+        message.extend_from_slice(&self.archive);
+
+        verifying_key
+            .verify(&message, &self.signature)
+            .map_err(|e| format!("signature does not verify under the contract parameters: {e}"))
+    }
+}
+
+/// Report what a packed state actually holds. Purely a reader: it never
+/// contacts the network and never decides anything about a publish.
+fn inspect_state(
+    state: String,
+    parameters: Option<String>,
+    archive_out: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let bytes = fs::read(&state).map_err(|e| format!("failed to read state '{state}': {e}"))?;
+    let parsed = PackedWebApp::parse(&bytes)?;
+
+    if let Some(parameters) = parameters.as_deref() {
+        let params = fs::read(parameters)
+            .map_err(|e| format!("failed to read parameters '{parameters}': {e}"))?;
+        parsed.verify(&params)?;
+    }
+
+    // Written before the version is printed: a caller that trusts stdout must
+    // not be handed a version for a state whose archive it failed to receive.
+    if let Some(path) = archive_out.as_deref() {
+        fs::write(path, &parsed.archive)
+            .map_err(|e| format!("failed to write archive to '{path}': {e}"))?;
+    }
+
+    println!("version={}", parsed.version);
+    Ok(())
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
@@ -315,6 +457,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             parameters,
             key_file,
         } => export_parameters(parameters, key_file),
+        Commands::Inspect {
+            state,
+            parameters,
+            archive_out,
+        } => inspect_state(state, parameters, archive_out),
     }
 }
 
@@ -397,5 +544,119 @@ mod tests {
         );
 
         fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Pack a state the way `fdev network publish ... contract --webapp-*`
+    /// does: `[metadata_len: u64 BE][metadata][web_len: u64 BE][web]`.
+    fn pack(metadata: &[u8], web: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&(metadata.len() as u64).to_be_bytes());
+        out.extend_from_slice(metadata);
+        out.extend_from_slice(&(web.len() as u64).to_be_bytes());
+        out.extend_from_slice(web);
+        out
+    }
+
+    /// The post-publish read-back is only as good as this parser: it is what
+    /// turns the bytes `fdev execute get` returns into "the network is at
+    /// version N carrying these archive bytes". Pin it against `sign`'s own
+    /// output, which is the other end of the same format, so a drift in
+    /// either direction fails here rather than misreporting a live publish.
+    #[test]
+    fn sign_output_parses_back_and_verifies() {
+        let dir = tmpdir("inspect-roundtrip");
+        let signing_key = SigningKey::from_bytes(&[11u8; 32]);
+        let key_file = write_key_file(&dir, &signing_key);
+
+        let archive_bytes = b"pretend this is webapp.tar.xz".to_vec();
+        let archive = dir.join("webapp.tar.xz");
+        fs::write(&archive, &archive_bytes).unwrap();
+
+        let metadata_path = dir.join("webapp.metadata");
+        let params_path = dir.join("webapp.parameters");
+        sign_webapp(
+            archive.to_str().unwrap().to_string(),
+            metadata_path.to_str().unwrap().to_string(),
+            params_path.to_str().unwrap().to_string(),
+            30000377,
+            Some(key_file.to_str().unwrap().to_string()),
+        )
+        .unwrap();
+
+        let state = pack(&fs::read(&metadata_path).unwrap(), &archive_bytes);
+        let parsed = PackedWebApp::parse(&state).expect("sign output must parse back");
+
+        assert_eq!(
+            parsed.version, 30000377,
+            "version must survive the round trip"
+        );
+        assert_eq!(
+            parsed.archive, archive_bytes,
+            "the archive handed back is what the caller byte-compares against \
+             the one it published; it must be exact"
+        );
+        parsed
+            .verify(&fs::read(&params_path).unwrap())
+            .expect("a state signed by this key must verify under its own parameters");
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A version read out of unverified bytes is not evidence of anything.
+    /// The 2026-08-04 fork is exactly two archives sharing one version, so a
+    /// verifier that accepted the version while ignoring the archive would
+    /// report the fork as a clean landing.
+    #[test]
+    fn verify_rejects_a_state_whose_archive_was_swapped() {
+        let dir = tmpdir("inspect-swap");
+        let signing_key = SigningKey::from_bytes(&[13u8; 32]);
+        let key_file = write_key_file(&dir, &signing_key);
+
+        let archive = dir.join("webapp.tar.xz");
+        fs::write(&archive, b"the archive that was signed").unwrap();
+
+        let metadata_path = dir.join("webapp.metadata");
+        let params_path = dir.join("webapp.parameters");
+        sign_webapp(
+            archive.to_str().unwrap().to_string(),
+            metadata_path.to_str().unwrap().to_string(),
+            params_path.to_str().unwrap().to_string(),
+            42,
+            Some(key_file.to_str().unwrap().to_string()),
+        )
+        .unwrap();
+
+        // Same metadata (so same version, same signature), different archive.
+        let state = pack(
+            &fs::read(&metadata_path).unwrap(),
+            b"a DIFFERENT archive at the same version",
+        );
+        let parsed = PackedWebApp::parse(&state).unwrap();
+        assert_eq!(parsed.version, 42);
+        assert!(
+            parsed.verify(&fs::read(&params_path).unwrap()).is_err(),
+            "a signature covering a different archive must not verify"
+        );
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A truncated or malformed answer must be an error, never a version. The
+    /// read-back reports "could not read the network" for these, and that is
+    /// only safe if the parser refuses to invent a number.
+    #[test]
+    fn parse_refuses_truncated_states() {
+        assert!(PackedWebApp::parse(&[]).is_err(), "empty state");
+        assert!(
+            PackedWebApp::parse(&[0u8; 4]).is_err(),
+            "too short for a length field"
+        );
+        // Declares 4096 bytes of metadata and supplies none.
+        let mut lying = 4096u64.to_be_bytes().to_vec();
+        lying.extend_from_slice(b"nope");
+        assert!(
+            PackedWebApp::parse(&lying).is_err(),
+            "declared length longer than the buffer"
+        );
     }
 }

--- a/scripts/publish-readback.sh
+++ b/scripts/publish-readback.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# Advisory post-publish read-back for the River web container.
+#
+# Fetches the web-container state back and tells the operator what is ACTUALLY
+# live: the on-network version, and whether its archive is byte-for-byte the
+# one just published.
+#
+# THIS SCRIPT REPORTS; IT DOES NOT GATE. It always exits 0, whatever it finds
+# and whatever goes wrong inside it. A publish that succeeded is not
+# un-succeeded by a read that failed, and a check that can block a release is
+# a check that gets disabled.
+#
+# It also derives NO version floor from what it reads. Reading the network
+# BEFORE signing and signing at a floor taken from that read looks like a
+# stronger design and is not: Freenet is eventually consistent, so a
+# stale-but-validly-signed read plus a local counter that is behind yields a
+# signature at a version the network has already accepted -- the same fork,
+# reached more elaborately.
+#
+# The incident (2026-08-04, freenet/river#634):
+#   1. `fdev network publish` reported `put timed out after 1 peer attempt(s)`.
+#   2. The state had in fact landed. The exit code said otherwise.
+#   3. The publish path rolled the version counter back, so the operator's
+#      retry re-used version 30000377.
+#   4. The rebuild was not byte-reproducible, so a DIFFERENT archive was
+#      signed at that same version, and both were on the network.
+#
+# Two states at one version never converge: the contract rejects
+# `version <= current` in both directions, and `summarize_state` emits only the
+# version, so anti-entropy sees them as equal. Recovery is the next successful
+# publish at a higher version -- so the exposure is one release cycle, and no
+# data is lost.
+#
+# Step 3 is fixed at the source: the counter is forward-only now (see
+# [tasks.sign-webapp] in Makefile.toml). This script addresses step 2, which is
+# what set the retry in motion. "It landed despite the timeout, do not retry"
+# is the sentence that breaks the chain.
+
+set -u
+
+if [ "$#" -ne 6 ]; then
+    cat >&2 <<'USAGE'
+usage: publish-readback.sh <contract_id> <parameters> <expected_archive> \
+                          <our_version> <publish_rc> <web_container_tool>
+USAGE
+    # Still 0: a caller that invokes this wrongly has a broken read-back, not
+    # a broken publish.
+    exit 0
+fi
+
+contract_id="$1"
+parameters="$2"
+expected_archive="$3"
+our_version="$4"
+publish_rc="$5"
+tool="$6"
+
+# fdev's own default is 300s, far too long to sit on after a publish that has
+# already reported its result.
+readback_timeout="${RIVER_READBACK_TIMEOUT:-60}"
+
+workdir=""
+# shellcheck disable=SC2317  # invoked via the EXIT trap below
+cleanup() {
+    [ -n "$workdir" ] && rm -rf "$workdir"
+    return 0
+}
+trap cleanup EXIT
+
+# Every exit from here on goes through `done_` so the advisory framing is
+# never lost, and so no path can return non-zero.
+done_() {
+    cat <<'FOOTER'
+
+This read-back is advisory: it reports what the network answered, and does not
+decide whether the publish succeeded.
+=========================================
+
+FOOTER
+    exit 0
+}
+
+echo ""
+echo "=== post-publish read-back (advisory) ==="
+
+case "$our_version$publish_rc" in
+    *[!0-9]* | "")
+        echo "Skipped: version '$our_version' / exit code '$publish_rc' are not"
+        echo "both plain integers."
+        done_
+        ;;
+esac
+
+if [ ! -x "$tool" ] && ! command -v "$tool" >/dev/null 2>&1; then
+    echo "Could not read the network: no web-container-tool at '$tool'."
+    done_
+fi
+
+if ! command -v fdev >/dev/null 2>&1; then
+    echo "Could not read the network: 'fdev' is not on PATH."
+    done_
+fi
+
+workdir="$(mktemp -d)" || { echo "Could not read the network: mktemp failed."; done_; }
+state_file="$workdir/state.bin"
+archive_file="$workdir/archive.bin"
+log="$workdir/log"
+
+reread_hint="    fdev network execute get $contract_id -o /tmp/river-state.bin"
+
+if ! fdev network execute get "$contract_id" \
+        --timeout "$readback_timeout" -o "$state_file" >"$log" 2>&1; then
+    echo "Could not read the network back (fdev execute get failed):"
+    sed 's/^/    /' "$log"
+    echo ""
+    echo "That says nothing about whether the publish landed. Re-read with"
+    echo "$reread_hint"
+    echo "before concluding anything; do NOT republish on this line alone."
+    done_
+fi
+
+if [ ! -s "$state_file" ]; then
+    echo "Could not read the network back: the node returned an empty state."
+    done_
+fi
+
+# `--parameters` is not optional: it makes the tool check the state's signature
+# against the key that owns this contract. Without it the version is just
+# whatever the responder chose to say.
+net_version=""
+if "$tool" inspect --state "$state_file" --parameters "$parameters" \
+        --archive-out "$archive_file" >"$workdir/out" 2>"$log"; then
+    net_version="$(sed -n 's/^version=//p' "$workdir/out")"
+fi
+case "$net_version" in
+    *[!0-9]* | "") net_version="" ;;
+esac
+
+if [ -z "$net_version" ]; then
+    echo "Read a state back, but could not make sense of it:"
+    sed 's/^/    /' "$log"
+    echo ""
+    echo "An unverified state is not evidence of anything, so this is being"
+    echo "reported as unknown rather than as a version."
+    done_
+fi
+
+if [ "$net_version" -gt "$our_version" ]; then
+    cat <<EOF
+SUPERSEDED. The network is at version $net_version, above the $our_version just
+published -- someone published after this run. Nothing to do; the newer state
+wins.
+EOF
+    done_
+fi
+
+if [ "$net_version" -lt "$our_version" ]; then
+    cat <<EOF
+NOT SEEN YET. The network answered with version $net_version, below the
+$our_version just published.
+
+Freenet is eventually consistent and one GET is a sample, not a verdict, so
+this is also what a read taken too early looks like. Wait and re-read:
+$reread_hint
+Republishing on the strength of a single early read is how the same version
+gets signed twice.
+EOF
+    done_
+fi
+
+if ! cmp -s "$archive_file" "$expected_archive"; then
+    cat <<EOF
+FORKED. The network is serving version $net_version -- our version -- but its
+archive is NOT the one just published.
+
+Two different states now share one version, and they cannot converge: the
+contract rejects version <= current in both directions, and the state summary
+carries only the version, so anti-entropy sees them as equal.
+
+Recovery is a fresh publish at a HIGHER version. Bump the counter and publish
+again; do not try to republish at $net_version.
+EOF
+    done_
+fi
+
+echo "LANDED. The network is serving version $net_version with the exact archive"
+echo "just published."
+if [ "$publish_rc" -ne 0 ]; then
+    cat <<EOF
+
+Note that fdev exited $publish_rc. It landed anyway -- a timeout is not proof of
+failure. Do NOT republish: commit the bumped version counter and stop here.
+Republishing after a spurious failure is what forked the site on 2026-08-04.
+EOF
+fi
+done_

--- a/scripts/publish-readback.sh
+++ b/scripts/publish-readback.sh
@@ -84,13 +84,20 @@ FOOTER
 echo ""
 echo "=== post-publish read-back (advisory) ==="
 
-case "$our_version$publish_rc" in
-    *[!0-9]* | "")
-        echo "Skipped: version '$our_version' / exit code '$publish_rc' are not"
-        echo "both plain integers."
-        done_
-        ;;
-esac
+# Validated SEPARATELY, not concatenated: an empty version next to rc 0
+# concatenates to "0" and would sail through a joint check, leaving both later
+# comparisons to error out and fall through to a LANDED that was never
+# measured. A check whose own inputs are broken must report unknown, never
+# success.
+for field in "$our_version" "$publish_rc"; do
+    case "$field" in
+        *[!0-9]* | "")
+            echo "Skipped: version '$our_version' / exit code '$publish_rc' are"
+            echo "not both plain integers, so nothing here can be compared."
+            done_
+            ;;
+    esac
+done
 
 if [ ! -x "$tool" ] && ! command -v "$tool" >/dev/null 2>&1; then
     echo "Could not read the network: no web-container-tool at '$tool'."
@@ -109,10 +116,30 @@ log="$workdir/log"
 
 reread_hint="    fdev network execute get $contract_id -o /tmp/river-state.bin"
 
-if ! fdev network execute get "$contract_id" \
+# The outer timeout(1) is what makes "advisory" true by wall clock as well as
+# by exit code. `fdev --timeout` bounds only the `client.recv()` wait; the
+# WebSocket connect, the send and the close are unbounded, so a node that
+# accepts the TCP handshake but never completes the upgrade blocks here
+# forever -- and `|| true` at the call site cannot rescue a hang, only a
+# non-zero exit. An operator left at a prompt that never returns, with the
+# counter bumped but uncommitted, is one Ctrl-C away from the `git checkout`
+# on the counter file that this whole change exists to prevent.
+hard_timeout=$((readback_timeout + 10))
+get_cmd=(fdev)
+if command -v timeout >/dev/null 2>&1; then
+    get_cmd=(timeout -k 5 "$hard_timeout" fdev)
+fi
+
+if ! "${get_cmd[@]}" network execute get "$contract_id" \
         --timeout "$readback_timeout" -o "$state_file" >"$log" 2>&1; then
-    echo "Could not read the network back (fdev execute get failed):"
-    sed 's/^/    /' "$log"
+    get_rc=$?
+    if [ "$get_rc" -eq 124 ] || [ "$get_rc" -eq 137 ]; then
+        echo "Gave up reading the network back after ${hard_timeout}s -- the node"
+        echo "did not answer. (The publish itself is unaffected by this.)"
+    else
+        echo "Could not read the network back (fdev execute get failed):"
+        sed 's/^/    /' "$log"
+    fi
     echo ""
     echo "That says nothing about whether the publish landed. Re-read with"
     echo "$reread_hint"
@@ -146,16 +173,27 @@ if [ -z "$net_version" ]; then
     done_
 fi
 
+# One explicit three-way branch. LANDED is reached only by proving equality --
+# never by falling out of the bottom of a chain of failed comparisons, which
+# is the direction that hurts: false reassurance at the exact moment the
+# operator is deciding whether to retry.
 if [ "$net_version" -gt "$our_version" ]; then
     cat <<EOF
 SUPERSEDED. The network is at version $net_version, above the $our_version just
-published -- someone published after this run. Nothing to do; the newer state
-wins.
+published.
+
+Two causes, and they need different responses:
+  * Somebody else published after this run. Nothing to do; the newer state
+    wins.
+  * Your counter was BEHIND the network, so the state signed at $our_version was
+    rejected and YOUR CHANGES ARE NOT LIVE. The contract refuses any version
+    at or below what it holds.
+
+If nobody else published, it is the second: set the counter above $net_version
+and publish again.
 EOF
     done_
-fi
-
-if [ "$net_version" -lt "$our_version" ]; then
+elif [ "$net_version" -lt "$our_version" ]; then
     cat <<EOF
 NOT SEEN YET. The network answered with version $net_version, below the
 $our_version just published.
@@ -167,9 +205,38 @@ Republishing on the strength of a single early read is how the same version
 gets signed twice.
 EOF
     done_
+elif [ "$net_version" -ne "$our_version" ]; then
+    # Unreachable while both operands are validated integers. Kept so that a
+    # future change which breaks that lands here rather than in LANDED.
+    echo "Could not compare version $net_version against $our_version. Reporting"
+    echo "this as unknown rather than as a result."
+    done_
 fi
 
-if ! cmp -s "$archive_file" "$expected_archive"; then
+# `cmp` returns 0 for same, 1 for differ, and >= 2 for "could not compare" --
+# an unreadable file among them. Treating >= 2 as "differ" renders a local
+# tooling problem as FORKED, the most alarming verdict this script has.
+if [ ! -r "$expected_archive" ] || [ ! -s "$expected_archive" ]; then
+    cat <<EOF
+The network is at version $net_version, our version -- but the archive we
+published is missing or empty locally ($expected_archive), so there is nothing
+to compare it against. Reporting this as unknown: it is a local problem, and
+says nothing about what the network holds.
+EOF
+    done_
+fi
+
+cmp -s "$archive_file" "$expected_archive"
+cmp_rc=$?
+
+if [ "$cmp_rc" -ge 2 ]; then
+    echo "The network is at version $net_version, our version -- but the two"
+    echo "archives could not be compared (cmp exited $cmp_rc). Reporting this as"
+    echo "unknown rather than guessing which way it went."
+    done_
+fi
+
+if [ "$cmp_rc" -eq 1 ]; then
     cat <<EOF
 FORKED. The network is serving version $net_version -- our version -- but its
 archive is NOT the one just published.

--- a/scripts/publish-readback.sh
+++ b/scripts/publish-readback.sh
@@ -124,15 +124,36 @@ reread_hint="    fdev network execute get $contract_id -o /tmp/river-state.bin"
 # non-zero exit. An operator left at a prompt that never returns, with the
 # counter bumped but uncommitted, is one Ctrl-C away from the `git checkout`
 # on the counter file that this whole change exists to prevent.
+
+# The timeout is validated here, at its first arithmetic use: an operator-supplied
+# RIVER_READBACK_TIMEOUT that is not a number would otherwise abort the whole
+# script with a raw bash error and no footer, which contradicts the promise at
+# the top of this file that it always exits 0 with a report.
+case "$readback_timeout" in
+    "" | *[!0-9]* | 0*)
+        echo "Ignoring RIVER_READBACK_TIMEOUT='$readback_timeout' (not a positive"
+        echo "integer); using 60s."
+        readback_timeout=60
+        ;;
+esac
+
 hard_timeout=$((readback_timeout + 10))
 get_cmd=(fdev)
 if command -v timeout >/dev/null 2>&1; then
     get_cmd=(timeout -k 5 "$hard_timeout" fdev)
 fi
+# Without timeout(1) the hang is back. Left unhandled deliberately: the tool
+# path this script is called with hard-codes x86_64-unknown-linux-gnu, so a
+# host running this without coreutils is not a case that occurs.
 
-if ! "${get_cmd[@]}" network execute get "$contract_id" \
-        --timeout "$readback_timeout" -o "$state_file" >"$log" 2>&1; then
-    get_rc=$?
+# `|| get_rc=$?` and NOT `if ! cmd; then get_rc=$?`. Inside `if !` the status
+# read by `$?` is the NEGATED one, so it is always 0 and the 124/137 branch
+# below would be dead code.
+get_rc=0
+"${get_cmd[@]}" network execute get "$contract_id" \
+    --timeout "$readback_timeout" -o "$state_file" >"$log" 2>&1 || get_rc=$?
+
+if [ "$get_rc" -ne 0 ]; then
     if [ "$get_rc" -eq 124 ] || [ "$get_rc" -eq 137 ]; then
         echo "Gave up reading the network back after ${hard_timeout}s -- the node"
         echo "did not answer. (The publish itself is unaffected by this.)"

--- a/scripts/tests/publish-guards-test.sh
+++ b/scripts/tests/publish-guards-test.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+#
+# Tests for the two publish guards added after the 2026-08-04 web-container
+# fork (freenet/river#634):
+#
+#   1. the version counter is FORWARD-ONLY -- no publish path rolls it back;
+#   2. the post-publish read-back classifies what the network answered, and
+#      never fails the publish while doing it.
+#
+# Run: ./scripts/tests/publish-guards-test.sh
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readback="$repo_root/scripts/publish-readback.sh"
+makefile="$repo_root/Makefile.toml"
+
+failures=0
+checks=0
+
+ok() {
+    checks=$((checks + 1))
+    printf 'ok   %s\n' "$1"
+}
+
+fail() {
+    checks=$((checks + 1))
+    failures=$((failures + 1))
+    printf 'FAIL %s\n' "$1"
+    shift
+    for line in "$@"; do printf '       %s\n' "$line"; done
+}
+
+# ---------------------------------------------------------------------------
+# 1. The counter is forward-only.
+#
+# A source scrape, because the thing being asserted is an ABSENCE and the code
+# lives in cargo-make script blocks that cannot be invoked without a network,
+# a signing key and a built UI. The rollback that caused the fork was six
+# lines of shell in four near-identical copies, and the realistic regression
+# is someone reinstating one of them (or adding a fifth publish task that
+# copies the old pattern) -- which is exactly what this catches.
+# ---------------------------------------------------------------------------
+
+if [[ ! -f "$makefile" ]]; then
+    fail "Makefile.toml is readable" "not found at $makefile"
+else
+    offenders="$(grep -n 'prev_snapshot\|contract-version\.txt\.prev' "$makefile" || true)"
+    if [[ -n "$offenders" ]]; then
+        mapfile -t offender_lines <<<"$offenders"
+        fail "no publish task snapshots the version counter" "${offender_lines[@]}"
+    else
+        ok "no publish task snapshots the version counter"
+    fi
+
+    # The rollback itself: any `mv`/`cp` of something back over the counter
+    # file. Comment lines are stripped first -- the whole point of the change
+    # is that the Makefile now EXPLAINS at length why it does not roll back,
+    # so matching comment text would make the fix fail its own test.
+    rollbacks="$(grep -n 'version_file' "$makefile" |
+        grep -v ':[[:space:]]*#' |
+        grep -E '\b(mv|cp)\b' || true)"
+    if [[ -n "$rollbacks" ]]; then
+        mapfile -t rollback_lines <<<"$rollbacks"
+        fail "no publish task rolls the version counter back" "${rollback_lines[@]}"
+    else
+        ok "no publish task rolls the version counter back"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Read-back classification.
+#
+# The network and the tool are stubbed. What is under test is the decision --
+# which of landed / forked / superseded / not-seen / unknown the operator is
+# told -- plus the invariant that every one of them exits 0. The parsing the
+# stub stands in for is pinned by the web-container-tool unit tests
+# (`sign_output_parses_back_and_verifies`), which is the right level for it.
+# ---------------------------------------------------------------------------
+
+sandbox="$(mktemp -d)"
+trap 'rm -rf "$sandbox"' EXIT
+
+bin="$sandbox/bin"
+mkdir -p "$bin"
+
+# Stub fdev: writes whatever $STUB_STATE says into the -o path, or fails when
+# STUB_GET_FAILS is set.
+cat >"$bin/fdev" <<'STUB'
+#!/usr/bin/env bash
+out=""
+prev=""
+for arg in "$@"; do
+    if [[ "$prev" == "-o" ]]; then out="$arg"; fi
+    prev="$arg"
+done
+if [[ -n "${STUB_GET_FAILS:-}" ]]; then
+    echo "put timed out after 1 peer attempt(s)" >&2
+    exit 1
+fi
+printf '%s' "${STUB_STATE:-some-state-bytes}" >"$out"
+exit 0
+STUB
+chmod +x "$bin/fdev"
+
+# Stub web-container-tool: reports $STUB_VERSION and writes $STUB_ARCHIVE.
+tool="$sandbox/web-container-tool"
+cat >"$tool" <<'STUB'
+#!/usr/bin/env bash
+archive_out=""
+prev=""
+for arg in "$@"; do
+    if [[ "$prev" == "--archive-out" ]]; then archive_out="$arg"; fi
+    prev="$arg"
+done
+if [[ -n "${STUB_INSPECT_FAILS:-}" ]]; then
+    echo "signature does not verify under the contract parameters" >&2
+    exit 1
+fi
+[[ -n "$archive_out" ]] && printf '%s' "${STUB_ARCHIVE:-}" >"$archive_out"
+echo "version=${STUB_VERSION:-1}"
+exit 0
+STUB
+chmod +x "$tool"
+
+params="$sandbox/webapp.parameters"
+printf 'x%.0s' {1..32} >"$params"
+published="$sandbox/webapp.tar.xz"
+printf 'the archive we published' >"$published"
+
+# run_readback <our_version> <publish_rc> -> stdout in $out, status in $status
+run_readback() {
+    out="$(PATH="$bin:$PATH" "$readback" \
+        "someContractId" "$params" "$published" "$1" "$2" "$tool" 2>&1)"
+    status=$?
+}
+
+expect() {
+    local name="$1" want="$2"
+    if [[ "$status" -ne 0 ]]; then
+        fail "$name" "the read-back exited $status; it must always exit 0" "$out"
+        return
+    fi
+    if [[ "$out" != *"$want"* ]]; then
+        fail "$name" "expected output to contain: $want" "got:" "$out"
+        return
+    fi
+    ok "$name"
+}
+
+# landed: our version, our bytes, clean publish
+STUB_VERSION=100 STUB_ARCHIVE="the archive we published" run_readback 100 0
+expect "landed is reported when our version and our bytes are live" "LANDED."
+
+# landed after a reported failure: the sentence that breaks the 2026-08-04 chain
+STUB_VERSION=100 STUB_ARCHIVE="the archive we published" run_readback 100 1
+expect "a publish that timed out but landed says do NOT republish" "Do NOT republish"
+
+# forked: our version, somebody else's bytes
+STUB_VERSION=100 STUB_ARCHIVE="a different archive entirely" run_readback 100 0
+expect "a version carrying different bytes is reported as a fork" "FORKED."
+
+# superseded
+STUB_VERSION=101 STUB_ARCHIVE="whatever" run_readback 100 0
+expect "a higher on-network version is reported as superseded" "SUPERSEDED."
+
+# not seen yet -- must NOT advise republishing
+STUB_VERSION=99 STUB_ARCHIVE="whatever" run_readback 100 0
+expect "a lower on-network version is reported as not-yet-seen" "NOT SEEN YET."
+if [[ "$out" == *"Republishing on the strength of a single early read"* ]]; then
+    ok "not-yet-seen warns against republishing on one early read"
+else
+    fail "not-yet-seen warns against republishing on one early read" "$out"
+fi
+
+# unreadable network: advisory, still exit 0, no verdict
+STUB_GET_FAILS=1 run_readback 100 0
+expect "an unreadable network is reported without a verdict" "Could not read the network back"
+
+# unverifiable state: an unverified version is not evidence
+STUB_INSPECT_FAILS=1 run_readback 100 0
+expect "a state that will not verify is reported as unknown" "could not make sense of it"
+
+# a publish failure must not turn into a read-back failure
+STUB_GET_FAILS=1 run_readback 100 7
+if [[ "$status" -eq 0 ]]; then
+    ok "the read-back never propagates the publish's exit code"
+else
+    fail "the read-back never propagates the publish's exit code" "exited $status"
+fi
+
+printf '\n%d checks, %d failures\n' "$checks" "$failures"
+[[ "$failures" -eq 0 ]]

--- a/scripts/tests/publish-guards-test.sh
+++ b/scripts/tests/publish-guards-test.sh
@@ -66,6 +66,72 @@ else
     else
         ok "no publish task rolls the version counter back"
     fi
+
+    # ---------------------------------------------------------------------
+    # The advisory invariant, at the call site.
+    #
+    # This is the load-bearing property of the whole design: the read-back
+    # must not be able to fail a publish. Dropping `|| true` from an
+    # invocation converts it into a publish gate -- the one thing the design
+    # forbids -- and nothing else in this suite notices, because the script's
+    # own exit-0 discipline is what the other checks exercise.
+    #
+    # Walks each invocation across its backslash continuations and requires
+    # the last line to end in `|| true`. The count is pinned too, so deleting
+    # an invocation is caught by the same scrape.
+    # ---------------------------------------------------------------------
+    unguarded="$(awk '
+      /\.\/scripts\/publish-readback\.sh/ { inv = 1; line = $0; start = NR }
+      inv {
+        line = $0
+        if ($0 !~ /\\[[:space:]]*$/) {
+          total++
+          if (line !~ /\|\|[[:space:]]*true[[:space:]]*$/)
+            printf "%d: invocation not terminated by `|| true`\n", start
+          inv = 0
+        }
+      }
+      END { printf "count=%d\n", total }
+    ' "$makefile")"
+
+    invocation_count="$(sed -n 's/^count=//p' <<<"$unguarded")"
+    unguarded="$(grep -v '^count=' <<<"$unguarded" || true)"
+
+    if [[ -n "$unguarded" ]]; then
+        mapfile -t unguarded_lines <<<"$unguarded"
+        fail "every read-back invocation is guarded by || true" "${unguarded_lines[@]}"
+    else
+        ok "every read-back invocation is guarded by || true"
+    fi
+
+    # `^fdev network publish` at column 0 is the invocation; the same words
+    # appear in comments and in the failure-path echo, which are not call
+    # sites.
+    publish_count="$(grep -c '^fdev network publish' "$makefile" || true)"
+    if [[ "$invocation_count" == "$publish_count" && "$invocation_count" -eq 3 ]]; then
+        ok "every publish task calls the read-back ($invocation_count of $publish_count)"
+    else
+        fail "every publish task calls the read-back" \
+            "read-back invocations: $invocation_count" \
+            "fdev network publish sites: $publish_count" \
+            "expected both to be 3"
+    fi
+
+    # The tool path must be a literal, never `${BUILD_PROFILE}`.
+    # `publish-river-debug` sets BUILD_PROFILE=dev while cargo's dev profile
+    # emits into `debug/`, so an interpolated path there names a directory
+    # that cannot exist and the read-back silently short-circuits -- on the
+    # task that publishes to the PRODUCTION contract and counter. The other
+    # two sites are only accidentally safe (they run under the default
+    # `release`), so the rule is uniform rather than per-site.
+    interpolated="$(grep -n 'web-container-tool" || true' "$makefile" |
+        grep 'BUILD_PROFILE' || true)"
+    if [[ -n "$interpolated" ]]; then
+        mapfile -t interpolated_lines <<<"$interpolated"
+        fail "the read-back's tool path is a literal profile" "${interpolated_lines[@]}"
+    else
+        ok "the read-back's tool path is a literal profile"
+    fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -98,6 +164,12 @@ if [[ -n "${STUB_GET_FAILS:-}" ]]; then
     echo "put timed out after 1 peer attempt(s)" >&2
     exit 1
 fi
+# A node that accepts the connection and then never answers. `fdev --timeout`
+# does not cover the WebSocket connect/send/close, so this is what a wedged
+# node looks like from the script's side: nothing, indefinitely.
+if [[ -n "${STUB_GET_HANGS:-}" ]]; then
+    sleep 300
+fi
 printf '%s' "${STUB_STATE:-some-state-bytes}" >"$out"
 exit 0
 STUB
@@ -128,11 +200,19 @@ printf 'x%.0s' {1..32} >"$params"
 published="$sandbox/webapp.tar.xz"
 printf 'the archive we published' >"$published"
 
-# run_readback <our_version> <publish_rc> -> stdout in $out, status in $status
+# run_readback <our_version> <publish_rc> [expected_archive]
+#   -> stdout in $out, status in $status, wall-clock seconds in $elapsed
+#
+# The outer `timeout 40` is a harness backstop, not part of what is under
+# test: without it, a regression that drops the script's own timeout would
+# hang this suite rather than failing it.
 run_readback() {
-    out="$(PATH="$bin:$PATH" "$readback" \
-        "someContractId" "$params" "$published" "$1" "$2" "$tool" 2>&1)"
+    local archive="${3:-$published}"
+    local started=$SECONDS
+    out="$(PATH="$bin:$PATH" timeout 40 "$readback" \
+        "someContractId" "$params" "$archive" "$1" "$2" "$tool" 2>&1)"
     status=$?
+    elapsed=$((SECONDS - started))
 }
 
 expect() {
@@ -160,9 +240,13 @@ expect "a publish that timed out but landed says do NOT republish" "Do NOT repub
 STUB_VERSION=100 STUB_ARCHIVE="a different archive entirely" run_readback 100 0
 expect "a version carrying different bytes is reported as a fork" "FORKED."
 
-# superseded
+# superseded -- and it must name the cause where the operator's own publish
+# was REJECTED (their counter was behind the network), because in that case
+# their changes are not live and "nothing to do" is the wrong instruction.
 STUB_VERSION=101 STUB_ARCHIVE="whatever" run_readback 100 0
 expect "a higher on-network version is reported as superseded" "SUPERSEDED."
+expect "superseded names the case where the publish was rejected" \
+    "YOUR CHANGES ARE NOT LIVE"
 
 # not seen yet -- must NOT advise republishing
 STUB_VERSION=99 STUB_ARCHIVE="whatever" run_readback 100 0
@@ -187,6 +271,38 @@ if [[ "$status" -eq 0 ]]; then
     ok "the read-back never propagates the publish's exit code"
 else
     fail "the read-back never propagates the publish's exit code" "exited $status"
+fi
+
+# A wedged node must not hang the publish. `|| true` at the call site cannot
+# rescue a hang -- only a bounded wall clock can -- so this is the check that
+# makes "advisory" true in the second sense.
+STUB_GET_HANGS=1 RIVER_READBACK_TIMEOUT=1 run_readback 100 0
+if [[ "$status" -eq 0 && "$elapsed" -lt 25 ]]; then
+    ok "a node that never answers is abandoned, not waited on (${elapsed}s)"
+else
+    fail "a node that never answers is abandoned, not waited on" \
+        "exited $status after ${elapsed}s (expected 0, under 25s)"
+fi
+
+# A missing local archive is a LOCAL problem. Rendering it as FORKED raises
+# the scariest verdict the script has over a tooling slip.
+STUB_VERSION=100 STUB_ARCHIVE="whatever" run_readback 100 0 "$sandbox/not-here.tar.xz"
+if [[ "$out" != *"FORKED."* && "$out" == *"missing or empty locally"* ]]; then
+    ok "a missing local archive is reported as unknown, not as a fork"
+else
+    fail "a missing local archive is reported as unknown, not as a fork" "$out"
+fi
+
+# A version comparison whose inputs are broken must not fall through to
+# LANDED. The archive here MATCHES on purpose: with a mismatching one the
+# fall-through lands on FORKED and the test would pass for the wrong reason,
+# hiding exactly the false-reassurance direction this guards.
+STUB_VERSION=100 STUB_ARCHIVE="the archive we published" run_readback "" 0
+if [[ "$status" -eq 0 && "$out" != *"LANDED."* && "$out" == *"Skipped"* ]]; then
+    ok "a non-integer version is reported as unknown, never as LANDED"
+else
+    fail "a non-integer version is reported as unknown, never as LANDED" \
+        "exited $status" "$out"
 fi
 
 printf '\n%d checks, %d failures\n' "$checks" "$failures"

--- a/scripts/tests/publish-guards-test.sh
+++ b/scripts/tests/publish-guards-test.sh
@@ -124,9 +124,23 @@ else
     # task that publishes to the PRODUCTION contract and counter. The other
     # two sites are only accidentally safe (they run under the default
     # `release`), so the rule is uniform rather than per-site.
-    interpolated="$(grep -n 'web-container-tool" || true' "$makefile" |
-        grep 'BUILD_PROFILE' || true)"
-    if [[ -n "$interpolated" ]]; then
+    # Needle is the tool-path ARGUMENT line -- indented, quoted -- not
+    # `web-container-tool" || true`. The sibling scrape above deliberately
+    # tolerates `|| true` on its own continuation line, so requiring it here
+    # too would let a reformat plus a profile revert pass both checks
+    # together. The count is asserted as well: a needle that stops matching
+    # anything passes vacuously, which is the failure this whole check exists
+    # to avoid.
+    tool_needle='^[[:space:]]+"target/native/[^"]*web-container-tool"'
+    tool_lines="$(grep -nE "$tool_needle" "$makefile" || true)"
+    tool_count="$(grep -cE "$tool_needle" "$makefile" || true)"
+    interpolated="$(grep 'BUILD_PROFILE' <<<"$tool_lines" || true)"
+
+    if [[ "$tool_count" -ne 3 ]]; then
+        fail "the read-back's tool path is a literal profile" \
+            "expected 3 tool-path argument lines, found $tool_count" \
+            "(the needle no longer matches, so this check proves nothing)"
+    elif [[ -n "$interpolated" ]]; then
         mapfile -t interpolated_lines <<<"$interpolated"
         fail "the read-back's tool path is a literal profile" "${interpolated_lines[@]}"
     else
@@ -282,6 +296,25 @@ if [[ "$status" -eq 0 && "$elapsed" -lt 25 ]]; then
 else
     fail "a node that never answers is abandoned, not waited on" \
         "exited $status after ${elapsed}s (expected 0, under 25s)"
+fi
+# ...and it must SAY it timed out. Asserting only status and elapsed time
+# leaves the whole rc-124 branch deletable with the suite still green: the
+# script would fall into the generic "fdev execute get failed" arm, which is
+# the wrong report and hides that the node never answered at all.
+expect "a timed-out read says so, rather than reporting a generic failure" \
+    "Gave up reading the network back"
+
+# A junk RIVER_READBACK_TIMEOUT must not abort the script. Its first use is
+# arithmetic, so without validation `set -u` kills the run with a raw bash
+# error and no footer -- contradicting the always-exits-0-with-a-report
+# promise in the script's own header.
+STUB_VERSION=100 STUB_ARCHIVE="the archive we published" \
+    RIVER_READBACK_TIMEOUT=abc run_readback 100 0
+if [[ "$status" -eq 0 && "$out" == *"Ignoring RIVER_READBACK_TIMEOUT"* ]]; then
+    ok "a non-numeric read-back timeout falls back with a warning"
+else
+    fail "a non-numeric read-back timeout falls back with a warning" \
+        "exited $status" "$out"
 fi
 
 # A missing local archive is a LOCAL problem. Rendering it as FORKED raises


### PR DESCRIPTION
Replaces #634, which is being closed. Same bug, much smaller fix.

## Problem

On 2026-08-04 the River web container forked. The sequence:

1. `fdev network publish` reported `put timed out after 1 peer attempt(s)`.
2. The state had in fact landed. The exit code said otherwise.
3. `[tasks.publish-river]` treated that exit code as proof of failure and **rolled the version counter back**.
4. The operator retried. The rollback had handed the retry version 30000377, which the network had already accepted.
5. The rebuild is not byte-reproducible, so a **different** archive was signed at that same version, and both landed.

Two states at one version never converge: the contract rejects `version <= current` in both directions, and `summarize_state` emits only the version, so anti-entropy sees them as equal.

Recovery is simply the next successful publish at a higher version, so exposure is one release cycle and no data is lost. That bound is why this is a small fix rather than a large one.

## Approach

Two changes, at the two links in the chain above.

**1. The counter is forward-only (step 3).** No publish task snapshots it, and none rolls it back. A burned version costs a gap in the sequence and nothing else — the contract enforces monotonicity, not contiguity, so gaps have always been fine. That makes the rollback all cost and no benefit.

Five sites touch a counter, and all five are covered: the two signing tasks that bump it (`sign-webapp`, `sign-webapp-test`) and the three publish tasks that used to roll it back (`publish-river`, `publish-river-debug`, `publish-river-test`). `publish-river-debug` matters because it shares the production counter *and* the production contract; the test pair carried a copy-pasted duplicate of the same rollback.

**2. An advisory post-publish read-back (step 2).** `scripts/publish-readback.sh` fetches the state back and reports what is actually live: the on-network version, and whether its archive is byte-for-byte the one just published. It classifies as `LANDED` / `FORKED` / `SUPERSEDED` / `NOT SEEN YET` / unreadable.

This is the piece that addresses the operator's side of the incident, which was *timeout → believed it failed → retried*. A read-back that says "it landed despite the timeout, do not republish" stops that at the second step.

It **reports; it does not gate**, in both senses — exit code and wall clock:

- it always exits 0, whatever it finds and whatever goes wrong inside it;
- the network read is wrapped in `timeout(1)`, so a node that wedges cannot hang the publish. `|| true` rescues a non-zero exit, not a hang, so the exit-code discipline alone was not enough;
- `publish-river` calls it with `|| true`, so it cannot fail a publish that otherwise succeeded;
- it derives **no version floor** from what it reads. Reading the network *before* signing and signing at a floor taken from that read looks stronger and is not — Freenet is eventually consistent, so a stale-but-validly-signed read plus a counter that is behind produces a signature at a version the network has already accepted. That is the same fork reached more elaborately, and it is why #634's pre-flight read was abandoned;
- `NOT SEEN YET` explicitly advises re-reading rather than republishing, because one GET is a sample and not a verdict.

Reading the version back needs the packed state parsed and its signature checked, so `web-container-tool` gains an `inspect` subcommand: it parses `[metadata_len u64 BE][metadata CBOR][web_len u64 BE][web]`, verifies the signature against the contract parameters, prints `version=<n>`, and can write the embedded archive out for a byte comparison. `--parameters` matters: a version read out of unverified bytes is not evidence of anything, it is whatever the responder chose to say.

### What is deliberately not here

No machine-global publish lock, no CI provenance gate, no contract-id derivation, no pre-flight network read, no version floor, no new escape-hatch env vars. Those were #634's scope and are out of proportion to a bug whose recovery is a republish.

## Testing

**`contracts/.../web-container-tool/src/main.rs`** — three unit tests, run by the existing `cargo test -p web-container-tool` CI step:

- `sign_output_parses_back_and_verifies` — a state packed from `sign`'s own output parses back to the version signed, hands back the exact archive bytes, and verifies under the parameters `sign` wrote. This pins the read-back's parser against the other end of the same format.
- `verify_rejects_a_state_whose_archive_was_swapped` — same metadata, different archive: must not verify. A verifier that checked the version and ignored the archive would report the 2026-08-04 fork as a clean landing.
- `parse_refuses_truncated_states` — malformed or truncated answers are errors, never a version.

**`scripts/tests/publish-guards-test.sh`** — 11 checks, wired into `build.yml` (a guard no job runs is a guard that passes by default, per #614):

- two source scrapes asserting no publish task snapshots or rolls back the counter. A source scrape because the assertion is an *absence*, and the code lives in cargo-make script blocks that cannot run without a network, a signing key and a built UI. The realistic regression is someone reinstating one of the four near-identical copies;
- the read-back's five classifications, driven by stubbed `fdev` and `web-container-tool`, plus the invariant that every path exits 0.

**Mutation results** — each change was reverted, the test confirmed RED, then restored:

| Mutation | Test that caught it |
|---|---|
| Reinstate the `.prev` snapshot + rollback in `publish-river` | both counter scrapes FAIL |
| `cmp` always reports a match | `a version carrying different bytes is reported as a fork` FAIL |
| Read-back exits with the publish's code | `the read-back never propagates the publish's exit code` FAIL |
| Drop the "do NOT republish" guidance | `a publish that timed out but landed says do NOT republish` FAIL |
| Drop the not-yet-seen warning | `not-yet-seen warns against republishing on one early read` FAIL |
| Length fields read little-endian | `sign_output_parses_back_and_verifies` + swap test FAIL |
| `verify()` accepts anything | `verify_rejects_a_state_whose_archive_was_swapped` FAIL |

`shellcheck -x` clean on both scripts. `cargo fmt` and `cargo clippy -p web-container-tool --all-targets` clean.

Not exercised against a live node — the read-back's network call is `fdev network execute get`, stubbed in tests.

[AI-assisted - Claude]

