### PR TITLE
feat(cli): surface member verifying keys in member list

### DIFF
--- a/cli/src/commands/member.rs
+++ b/cli/src/commands/member.rs
@@ -127,7 +127,19 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
                     let party = deputies.party(id);
                     let granted_by: Vec<MemberId> =
                         deputized_by.get(&id).cloned().unwrap_or_default();
-                    (party, deputies.deputies_of(id).to_vec(), granted_by)
+                    // The full verifying key — the collision-proof identity to
+                    // compare when trusting a member (the `member_id` label is a
+                    // 40-bit truncation). `None` for a member with no key in
+                    // state (e.g. a pruned deputy named only by a signed grant).
+                    let verifying_key = deputies
+                        .verifying_key(id)
+                        .map(|vk| bs58::encode(vk.as_bytes()).into_string());
+                    (
+                        party,
+                        deputies.deputies_of(id).to_vec(),
+                        granted_by,
+                        verifying_key,
+                    )
                 })
                 .collect();
 
@@ -137,7 +149,7 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
                         println!("No members found in room.");
                     } else {
                         println!("\n{} member(s) found:\n", members.len());
-                        for (party, _own_deputies, granted_by) in &members {
+                        for (party, _own_deputies, granted_by, verifying_key) in &members {
                             // Escaped and quoted: an unescaped nickname can
                             // forge a row that reads as a real deputy grant,
                             // and `colored` drops the colour that would
@@ -156,6 +168,12 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
                                 print!("{}", format!("  deputy of: {}", names.join(", ")).yellow());
                             }
                             println!();
+                            // The collision-proof identifier. Printed plain (no
+                            // colour) so it copies cleanly into an allow-list;
+                            // absent only for a member with no key in state.
+                            if let Some(vk) = verifying_key {
+                                println!("      key: {}", vk);
+                            }
                         }
                         println!();
                     }
@@ -163,8 +181,13 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
                 OutputFormat::Json => {
                     let json_members: Vec<_> = members
                         .into_iter()
-                        .map(|(party, own_deputies, granted_by)| {
-                            member_list_json(&party, &own_deputies, &granted_by)
+                        .map(|(party, own_deputies, granted_by, verifying_key)| {
+                            member_list_json(
+                                &party,
+                                &own_deputies,
+                                &granted_by,
+                                verifying_key.as_deref(),
+                            )
                         })
                         .collect();
                     println!("{}", serde_json::to_string_pretty(&json_members)?);
@@ -484,9 +507,15 @@ fn member_list_json(
     party: &DeputyParty,
     own_deputies: &[MemberId],
     granted_by: &[MemberId],
+    verifying_key: Option<&str>,
 ) -> serde_json::Value {
     serde_json::json!({
         "member_id": party.member_id,
+        // The base58 ed25519 public key — the collision-proof identity, matching
+        // `identity whoami`'s `verifying_key` field. `null` (not "") when no key
+        // is in state for this member, since absence of a key is meaningful (a
+        // consumer must not treat a missing key as an empty string to compare).
+        "verifying_key": verifying_key,
         "nickname": party.nickname.clone().unwrap_or_default(),
         "deputies": ids_to_strings(own_deputies),
         "deputized_by": ids_to_strings(granted_by),
@@ -668,7 +697,7 @@ mod tests {
             is_owner: false,
             in_room: true,
         };
-        let json = member_list_json(&party, &[b], &[]);
+        let json = member_list_json(&party, &[b], &[], Some("SoMeBaSe58Key"));
         assert_eq!(json["member_id"], a.to_string());
         assert_eq!(json["nickname"], "Alice");
         assert_eq!(json["deputies"][0], b.to_string());
@@ -676,6 +705,9 @@ mod tests {
             json["deputized_by"].as_array().unwrap().is_empty(),
             "an empty list, not null"
         );
+        // The collision-proof identity is surfaced as base58, mirroring
+        // `whoami`'s `verifying_key` field.
+        assert_eq!(json["verifying_key"], "SoMeBaSe58Key");
 
         // A member with no readable nickname renders as an empty string, not
         // null, matching the pre-deputy-command behaviour.
@@ -685,10 +717,13 @@ mod tests {
             is_owner: false,
             in_room: true,
         };
-        let json = member_list_json(&anonymous, &[], &[a]);
+        let json = member_list_json(&anonymous, &[], &[a], None);
         assert_eq!(json["nickname"], "");
         assert!(!json["nickname"].is_null());
         assert_eq!(json["deputized_by"][0], a.to_string());
+        // No key in state for this member => explicit null (a consumer must be
+        // able to tell "no key known" from an empty string it might compare).
+        assert!(json["verifying_key"].is_null());
     }
 
     #[test]

--- a/cli/src/commands/member.rs
+++ b/cli/src/commands/member.rs
@@ -128,9 +128,12 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
                     let granted_by: Vec<MemberId> =
                         deputized_by.get(&id).cloned().unwrap_or_default();
                     // The full verifying key — the collision-proof identity to
-                    // compare when trusting a member (the `member_id` label is a
-                    // 40-bit truncation). `None` for a member with no key in
-                    // state (e.g. a pruned deputy named only by a signed grant).
+                    // compare when trusting a member (the `member_id` label is
+                    // only a 40-bit truncation). Every id iterated here holds a
+                    // `member_info` record, and `MemberInfoV1::verify` requires
+                    // such a record's member to be the owner or a current
+                    // member, so on verified state this is always `Some`; the
+                    // `None` arm below is defensive.
                     let verifying_key = deputies
                         .verifying_key(id)
                         .map(|vk| bs58::encode(vk.as_bytes()).into_string());
@@ -168,9 +171,13 @@ pub async fn execute(command: MemberCommands, api: ApiClient, format: OutputForm
                                 print!("{}", format!("  deputy of: {}", names.join(", ")).yellow());
                             }
                             println!();
-                            // The collision-proof identifier. Printed plain (no
-                            // colour) so it copies cleanly into an allow-list;
-                            // absent only for a member with no key in state.
+                            // Shown for every member by default (deliberately
+                            // not behind a flag): the point is to make the
+                            // collision-proof identity visible so people stop
+                            // trusting the 40-bit short id. Printed plain (no
+                            // colour) so it copies cleanly into an allow-list.
+                            // On verified state the key is always present (see
+                            // the map closure above); this guard is defensive.
                             if let Some(vk) = verifying_key {
                                 println!("      key: {}", vk);
                             }

--- a/cli/src/deputies.rs
+++ b/cli/src/deputies.rs
@@ -233,9 +233,9 @@ impl<'a> RoomDeputies<'a> {
 
     /// The member's ed25519 verifying key — their cryptographic identity — when
     /// this room state carries it: the room owner, or a current member of
-    /// `members.members`. Returns `None` for a member named only by a
-    /// deputizer's signed record (e.g. one pruned for inactivity), for whom no
-    /// key is stored.
+    /// `members.members`. Returns `None` for any other id — for example one that
+    /// appears only in a deputizer's signed `deputies` record with no member of
+    /// its own — for whom no key is stored.
     ///
     /// This is the collision-PROOF identifier. The `member_id` label printed
     /// elsewhere is a 40-bit truncation of a 64-bit non-cryptographic hash, so

--- a/cli/src/deputies.rs
+++ b/cli/src/deputies.rs
@@ -159,6 +159,10 @@ pub struct RoomDeputies<'a> {
     subtrees: HashMap<MemberId, HashSet<MemberId>>,
     /// Index required by `MembersV1::is_ban_authorized`, built once.
     members_by_id: HashMap<MemberId, &'a AuthorizedMember>,
+    /// The room owner's verifying key. The owner is never in `members_by_id`
+    /// (they are not in `members.members`), so their key is held separately to
+    /// answer [`Self::verifying_key`] for the owner.
+    owner_vk: VerifyingKey,
 }
 
 impl<'a> RoomDeputies<'a> {
@@ -223,6 +227,26 @@ impl<'a> RoomDeputies<'a> {
             known_ids,
             subtrees,
             members_by_id,
+            owner_vk: *owner_vk,
+        }
+    }
+
+    /// The member's ed25519 verifying key — their cryptographic identity — when
+    /// this room state carries it: the room owner, or a current member of
+    /// `members.members`. Returns `None` for a member named only by a
+    /// deputizer's signed record (e.g. one pruned for inactivity), for whom no
+    /// key is stored.
+    ///
+    /// This is the collision-PROOF identifier. The `member_id` label printed
+    /// elsewhere is a 40-bit truncation of a 64-bit non-cryptographic hash, so
+    /// anything making a trust decision about a member (e.g. a bot allow-list)
+    /// MUST compare this key, never the short label. See the note on
+    /// `MemberId` in `river-core` (`room_state::member`).
+    pub fn verifying_key(&self, id: MemberId) -> Option<VerifyingKey> {
+        if id == self.owner_id {
+            Some(self.owner_vk)
+        } else {
+            self.members_by_id.get(&id).map(|m| m.member.member_vk)
         }
     }
 
@@ -740,6 +764,25 @@ mod tests {
 
     fn no_secrets() -> HashMap<u32, [u8; 32]> {
         HashMap::new()
+    }
+
+    #[test]
+    fn verifying_key_resolves_owner_and_members_and_is_none_for_unknown() {
+        let owner = key(1);
+        let alice = key(2);
+        let bob = key(3);
+        let stranger = key(9); // never a member of this room
+        let state = room(&owner, &[&alice, &bob]);
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+
+        // Owner: keyed separately since the owner is never in `members.members`.
+        assert_eq!(d.verifying_key(id(&owner)), Some(owner.verifying_key()));
+        // Current members resolve to their real signing identity.
+        assert_eq!(d.verifying_key(id(&alice)), Some(alice.verifying_key()));
+        assert_eq!(d.verifying_key(id(&bob)), Some(bob.verifying_key()));
+        // An id with no member/owner record yields None, never a wrong key.
+        assert_eq!(d.verifying_key(id(&stranger)), None);
     }
 
     #[test]

--- a/common/src/room_state/member.rs
+++ b/common/src/room_state/member.rs
@@ -689,8 +689,28 @@ impl fmt::Debug for Member {
 }
 
 /*
-Finding a VerifyingKey that would have a MemberId collision would require approximately
-3 * 10^59 years on current hardware.
+`MemberId` is a 64-bit *non-cryptographic* `FastHash` (a Java-style `h*31 + byte`
+polynomial hash) of the member's `VerifyingKey`, NOT a cryptographic digest. The
+8-char base32 `Display` label is lossier still — only 40 of those 64 bits.
+
+Collision cost is therefore modest, not astronomical (an earlier version of this
+comment claimed ~3 * 10^59 years, which was wrong):
+  - 40-bit `Display` label, targeted second-preimage: ~2^40 keypair generations
+    (hours on a GPU / small cluster). Any-collision (birthday): ~2^20, seconds.
+  - Full 64-bit id, targeted: ~2^64 (large but finite brute force over keypairs,
+    not 10^59 years). Any-collision (birthday): ~2^32, ~hours single-core.
+The one thing that keeps this from being trivial is that a usable member needs a
+real keypair (to sign), so the weak hash can't be inverted algebraically — an
+attacker must brute-force by generating ed25519 keypairs and hashing the pubkey.
+
+Why a collision is not a full compromise: authorization is anchored on the full
+ed25519 keys and signatures. `member_vk` carries the full key, and the invite
+chain verifies signatures against the looked-up member's real `member_vk`; a
+member colliding with the owner's id (or full key) is rejected in `verify`. A
+`MemberId` collision buys identity confusion / member-map shadowing (bans,
+invite refs and the member map are keyed by the 64-bit id), NOT signature
+forgery. The cheap 40-bit label is UI/mention-token only and never keys these
+maps. See `mention.rs` for the label's lossy round-trip handling.
 */
 #[derive(Eq, PartialEq, Hash, Serialize, Deserialize, Clone, Ord, PartialOrd, Copy)]
 pub struct MemberId(pub FastHash);


### PR DESCRIPTION
## Problem

River identifies members by an 8-character short id (`MemberId`'s `Display`).
That label is `truncated_base32(fast_hash(verifying_key))` — the first **40
bits** of a **64-bit non-cryptographic** polynomial hash. A *targeted*
collision on the 40-bit label costs roughly `2^40` keypair generations (hours
on a GPU), so the short id is not safe to use as a trust anchor.

This came up from a real user building a River bot that wants to accept
commands only from certain trusted members. `riverctl` gave them no
collision-proof identifier for *other* members: `member list` printed only the
short id, `ban`/`deputize` take the short id as input, and `debug` shows only
aggregate counts. `identity whoami` exposes the full key — but only for
*yourself*, which does not help an allow-list.

Every member's full ed25519 verifying key is already in room state; the CLI
just never surfaced it for anyone but you.

## Approach

Surface each member's full verifying key (base58) in `member list`, matching
the existing `identity whoami` `verifying_key` field so the two are
consistent:

- **Human output** gains an indented `key:` line per member, printed plain (no
  colour) so it copies cleanly into an allow-list.
- **JSON output** gains a `verifying_key` field: base58 when the key is known,
  or `null` when it is not (a member named only by a signed deputy grant, e.g.
  one pruned for inactivity). `null` rather than `""` so a consumer can tell
  "no key known" from an empty string it might compare against.

New `RoomDeputies::verifying_key(id)` accessor resolves the owner (kept
separately, since the owner is never in `members.members`) and current members,
and returns `None` for an id with no key in state — never a wrong key.

The full key is the collision-proof identity every signature check already
verifies against, so anything making a trust decision about a member should
compare **it**, not the 40-bit label. (Also fixes a misleading comment on
`MemberId` that claimed a collision would take ~3x10^59 years.)

No wire-format, contract, or delegate change — this is a read-only CLI output
addition, additive to the JSON shape.

## Testing

- `RoomDeputies::verifying_key` resolves owner + members and is `None` for an
  unknown id.
- `member_list_json` includes `verifying_key` (base58 present, and `null` when
  absent); the pre-existing pinned JSON shape test still passes (field is
  additive).
- Full `riverctl` lib suite green (`cargo test -p riverctl`), fmt + clippy
  clean (no new warnings).

[AI-assisted - Claude]
