### PR TITLE
feat(cli): accept full verifying keys as member references; author key in message list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4782,7 +4782,7 @@ dependencies = [
 
 [[package]]
 name = "riverctl"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to riverctl will be documented in this file.
 
+## [0.2.14] - 2026-08-31
+
+### Added
+- Member-targeting commands (`member ban`, `member deputize`,
+  `member revoke-deputy`, `member deputies`, `member deputized-by`) now accept a
+  member's full base58 verifying key in place of the 8-character short ID. A
+  full key names exactly one member (the short ID is a 40-bit truncation that
+  two members can share), so it resolves unambiguously and satisfies
+  `--require-exact-member-id` by construction.
+- `message list --format json` now includes an `author_verifying_key` field
+  (base58, or `null` when the author is no longer in room state), so a bot can
+  identify a message's author by their collision-proof key.
+
 ## [0.2.13] - 2026-08-31
 
 ### Added

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riverctl"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2021"
 authors = ["Freenet Project"]
 description = "Command-line interface for River decentralized chat on Freenet"

--- a/cli/README.md
+++ b/cli/README.md
@@ -47,8 +47,9 @@ End-to-end-encrypted one-to-one messages between two members of the same room.
 They travel inside the room's contract state, so both people must already be
 members — there is no cross-room DM.
 
-The recipient is a member ID: either the short 8-character form that
-`riverctl member list` prints, or the full ID.
+The recipient is a member: either the short 8-character ID that
+`riverctl member list` prints, or the member's full verifying key (also from
+`member list`), which names them unambiguously.
 
 ```bash
 riverctl member list <room-owner-vk>             # Find the recipient's member ID.
@@ -124,6 +125,12 @@ riverctl message stream <room-owner-vk> --format json --no-version-check |
   jq -c --arg me "$me" 'select(.author != $me)'
 ```
 
+`message list --format json` also carries `author_verifying_key` — the author's
+full base58 key (or `null` when the author is no longer in the room). The
+`author` short id can be filtered on cheaply as above, but a bot deciding
+whether to *trust* a command should compare this full key, since the short id is
+a 40-bit truncation. Get the trusted keys from `member list`'s `verifying_key`.
+
 (The `author` inside `reply_to` is a display nickname, not a member ID — only
 the top-level `author` is comparable.)
 
@@ -177,6 +184,14 @@ riverctl member ban          <room-owner-vk> <member-id>
 member banning within their own invite subtree, or a deputy of such a member
 (see below).
 
+Wherever a command takes `<member-id>` (`ban`, `deputize`, `revoke-deputy`,
+`deputies`, `deputized-by`, and `dm send`'s recipient), you can pass either the
+8-character short ID or the member's full **verifying key** — the base58 key
+`member list` prints. The short ID is a 40-bit truncation that two members can
+share (so it can be ambiguous); the full key names exactly one member. Compare
+the full `verifying_key` whenever you must be sure who a member is — for example
+a bot allow-listing which members may issue commands.
+
 ### Deputies
 
 A deputy can ban within their deputizer's invite subtree. Deputies are
@@ -226,9 +241,10 @@ themselves and are printed next to an authority claim, so an unescaped one could
 forge a line that reads as a real deputy grant. The `-f json` output carries the
 faithful nickname.
 
-`member list --format json` gains `deputies` (who this member deputized) and
-`deputized_by` (who deputized them) alongside the existing `member_id` and
-`nickname`. `debug room-state` gains `deputy_grant_count` and `deputy_grants`.
+`member list --format json` carries `member_id`, `nickname`, `verifying_key`
+(the member's full base58 ed25519 key, or `null` when unknown), and the deputy
+fields `deputies` (who this member deputized) and `deputized_by` (who deputized
+them). `debug room-state` gains `deputy_grant_count` and `deputy_grants`.
 
 Two caveats worth knowing:
 

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -5430,34 +5430,23 @@ impl ApiClient {
         let my_member_id: MemberId = signing_key.verifying_key().into();
         let owner_member_id: MemberId = room_owner_key.into();
 
-        // Resolve the member to ban. A full base58 verifying key (from
-        // `member list`'s `verifying_key`) matches its exact derived id; anything
-        // else is matched by the 8-char short ID (prefix / first-8, first-match).
+        // Resolve the member to ban via the same shared resolver the deputy
+        // commands use: a full base58 verifying key (from `member list`) matches
+        // its exact derived id, anything else the 8-char short ID (prefix /
+        // first-8, first-match). No deputy fallback for a ban target.
         let key_target = crate::deputies::member_id_from_key_input(member_id_short);
-        let target_member = room_state
-            .member_info
-            .member_info
-            .iter()
-            .find(|info| {
-                let member_id = info.member_info.member_id;
-                match key_target {
-                    Some(target) => member_id == target,
-                    None => {
-                        let member_id_str = member_id.to_string();
-                        member_id_str.starts_with(member_id_short)
-                            || member_id_str[..8.min(member_id_str.len())]
-                                .eq_ignore_ascii_case(member_id_short)
-                    }
-                }
-            })
-            .ok_or_else(|| {
-                anyhow!(
-                    "Member '{}' not found. Use 'member list' to see member IDs.",
-                    member_id_short
-                )
-            })?;
-
-        let banned_member_id = target_member.member_info.member_id;
+        let banned_member_id = resolve_deputy_target(
+            &room_state.member_info.member_info,
+            &[],
+            member_id_short,
+            false,
+        )
+        .ok_or_else(|| {
+            anyhow!(
+                "Member '{}' not found. Use 'member list' to see member IDs.",
+                member_id_short
+            )
+        })?;
 
         // A full-key input already names the exact member, so it satisfies the
         // require-exact preflight by construction; only a short-id input can be

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -5430,16 +5430,25 @@ impl ApiClient {
         let my_member_id: MemberId = signing_key.verifying_key().into();
         let owner_member_id: MemberId = room_owner_key.into();
 
-        // Find the member to ban by their short ID (first 8 chars of member_id string)
+        // Resolve the member to ban. A full base58 verifying key (from
+        // `member list`'s `verifying_key`) matches its exact derived id; anything
+        // else is matched by the 8-char short ID (prefix / first-8, first-match).
+        let key_target = crate::deputies::member_id_from_key_input(member_id_short);
         let target_member = room_state
             .member_info
             .member_info
             .iter()
             .find(|info| {
-                let member_id_str = info.member_info.member_id.to_string();
-                member_id_str.starts_with(member_id_short)
-                    || member_id_str[..8.min(member_id_str.len())]
-                        .eq_ignore_ascii_case(member_id_short)
+                let member_id = info.member_info.member_id;
+                match key_target {
+                    Some(target) => member_id == target,
+                    None => {
+                        let member_id_str = member_id.to_string();
+                        member_id_str.starts_with(member_id_short)
+                            || member_id_str[..8.min(member_id_str.len())]
+                                .eq_ignore_ascii_case(member_id_short)
+                    }
+                }
             })
             .ok_or_else(|| {
                 anyhow!(
@@ -5450,7 +5459,13 @@ impl ApiClient {
 
         let banned_member_id = target_member.member_info.member_id;
 
-        if safety.require_exact_member_id && banned_member_id.to_string() != member_id_short {
+        // A full-key input already names the exact member, so it satisfies the
+        // require-exact preflight by construction; only a short-id input can be
+        // a non-exact (prefix) match that this guard must reject.
+        if safety.require_exact_member_id
+            && key_target.is_none()
+            && banned_member_id.to_string() != member_id_short
+        {
             return Err(anyhow!(
                 "Safety preflight refused: '{}' is not the exact current member ID '{}'.",
                 member_id_short,
@@ -6147,6 +6162,17 @@ fn resolve_deputy_target(
     member_id_short: &str,
     allow_deputy_fallback: bool,
 ) -> Option<MemberId> {
+    // Exact, collision-proof fast path: a full base58 verifying key names one
+    // member directly, so match its derived id exactly rather than by prefix.
+    if let Some(target) = crate::deputies::member_id_from_key_input(member_id_short) {
+        let present = member_infos
+            .iter()
+            .any(|info| info.member_info.member_id == target);
+        if present || (allow_deputy_fallback && own_deputies.contains(&target)) {
+            return Some(target);
+        }
+        return None;
+    }
     let matches = |id: &MemberId| {
         let s = id.to_string();
         s.starts_with(member_id_short) || s[..8.min(s.len())].eq_ignore_ascii_case(member_id_short)
@@ -6223,6 +6249,41 @@ mod deputy_resolve_tests {
         assert_eq!(
             resolve_deputy_target(&member_infos, &own_deputies, "zzzzzzzz", true),
             None
+        );
+    }
+
+    /// A full base58 verifying key names one member exactly, so it resolves the
+    /// same targets as the short id would — present member in either mode, a
+    /// pruned deputy only under the revoke fallback, a stranger never.
+    #[test]
+    fn resolve_deputy_target_accepts_a_full_verifying_key() {
+        let present = SigningKey::from_bytes(&[7u8; 32]);
+        let pruned_deputy = SigningKey::from_bytes(&[9u8; 32]);
+        let stranger = SigningKey::from_bytes(&[11u8; 32]);
+        let present_id: MemberId = present.verifying_key().into();
+        let pruned_id: MemberId = pruned_deputy.verifying_key().into();
+        let member_infos = vec![info(&present)];
+        let own_deputies = vec![pruned_id];
+        let key = |sk: &SigningKey| bs58::encode(sk.verifying_key().as_bytes()).into_string();
+
+        assert_eq!(
+            resolve_deputy_target(&member_infos, &own_deputies, &key(&present), false),
+            Some(present_id)
+        );
+        assert_eq!(
+            resolve_deputy_target(&member_infos, &own_deputies, &key(&pruned_deputy), true),
+            Some(pruned_id),
+            "revoke resolves a pruned deputy by full key via the fallback"
+        );
+        assert_eq!(
+            resolve_deputy_target(&member_infos, &own_deputies, &key(&pruned_deputy), false),
+            None,
+            "deputize must not resolve a non-member by full key"
+        );
+        assert_eq!(
+            resolve_deputy_target(&member_infos, &own_deputies, &key(&stranger), true),
+            None,
+            "a stranger's key resolves to nobody"
         );
     }
 }

--- a/cli/src/commands/dm.rs
+++ b/cli/src/commands/dm.rs
@@ -1190,6 +1190,27 @@ fn resolve_recipient_vk(
     // error even though both matches resolve to the same destination
     // key (Skeptical-review #4 on pass 3).
     let owner_id = MemberId::from(room_owner_key);
+
+    // Exact fast path: a full base58 verifying key (from `member list`) names one
+    // recipient directly, so resolve it without the ambiguous prefix match.
+    if let Some(target) = crate::deputies::member_id_from_key_input(needle) {
+        if target == owner_id {
+            return Ok(*room_owner_key);
+        }
+        if let Some(m) = state
+            .members
+            .members
+            .iter()
+            .find(|m| m.member.id() == target)
+        {
+            return Ok(m.member.member_vk);
+        }
+        return Err(anyhow!(
+            "No member with verifying key '{}' is in this room (try `riverctl member list`).",
+            needle
+        ));
+    }
+
     let mut matches: Vec<(MemberId, VerifyingKey)> = state
         .members
         .members
@@ -1683,6 +1704,52 @@ mod tests {
                 .to_string();
             assert!(err.contains("ambiguous"), "got: {err}");
         }
+    }
+
+    #[test]
+    fn resolve_recipient_vk_accepts_a_full_verifying_key() {
+        use ed25519_dalek::SigningKey;
+        use river_core::room_state::configuration::{AuthorizedConfigurationV1, Configuration};
+        use river_core::room_state::member::{AuthorizedMember, Member, MembersV1};
+        use river_core::ChatRoomStateV1;
+
+        let owner_sk = SigningKey::from_bytes(&[1u8; 32]);
+        let owner_vk = owner_sk.verifying_key();
+        let owner_id = MemberId::from(&owner_vk);
+        let alice_sk = SigningKey::from_bytes(&[2u8; 32]);
+        let stranger_sk = SigningKey::from_bytes(&[9u8; 32]);
+
+        let alice = AuthorizedMember::new(
+            Member {
+                owner_member_id: owner_id,
+                invited_by: owner_id,
+                member_vk: alice_sk.verifying_key(),
+            },
+            &owner_sk,
+        );
+        let state = ChatRoomStateV1 {
+            configuration: AuthorizedConfigurationV1::new(Configuration::default(), &owner_sk),
+            members: MembersV1 {
+                members: vec![alice],
+            },
+            ..Default::default()
+        };
+        let full = |sk: &SigningKey| bs58::encode(sk.verifying_key().as_bytes()).into_string();
+
+        // A member's full key resolves to their vk exactly; the owner's too.
+        assert_eq!(
+            resolve_recipient_vk(&state, &owner_vk, &full(&alice_sk)).unwrap(),
+            alice_sk.verifying_key()
+        );
+        assert_eq!(
+            resolve_recipient_vk(&state, &owner_vk, &full(&owner_sk)).unwrap(),
+            owner_vk
+        );
+        // A well-formed key for a non-member errors, never a wrong recipient.
+        let err = resolve_recipient_vk(&state, &owner_vk, &full(&stranger_sk))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("verifying key"), "got: {err}");
     }
 
     /// `apply_per_pair_cap` must drop the oldest entries for any

--- a/cli/src/commands/member.rs
+++ b/cli/src/commands/member.rs
@@ -26,7 +26,8 @@ pub enum MemberCommands {
     Ban {
         /// Room ID (owner key in base58)
         room_id: String,
-        /// Member ID to ban (8-character short ID from member list)
+        /// Member to ban: an 8-character short ID, or the member's full verifying
+        /// key (from `member list`) to name one exactly.
         member_id: String,
         /// Refuse prefix/case-folded resolution; the supplied ID must match exactly.
         #[arg(long)]
@@ -42,14 +43,16 @@ pub enum MemberCommands {
     Deputize {
         /// Room ID (owner key in base58)
         room_id: String,
-        /// Member ID to deputize (8-character short ID from member list)
+        /// Member to deputize: an 8-character short ID, or the member's full verifying
+        /// key (from `member list`) to name one exactly.
         member_id: String,
     },
     /// Revoke a member's deputy authority (their prior bans stop enforcing)
     RevokeDeputy {
         /// Room ID (owner key in base58)
         room_id: String,
-        /// Member ID whose deputy authority to revoke (8-character short ID)
+        /// Member whose deputy authority to revoke: an 8-character short ID, or
+        /// the member's full verifying key (from `member list`).
         member_id: String,
     },
     /// Show the deputies a member has appointed ("who has X deputized?")
@@ -63,8 +66,9 @@ pub enum MemberCommands {
     Deputies {
         /// Room ID (owner key in base58)
         room_id: String,
-        /// Member ID whose deputies to list (8-character short ID from member
-        /// list). Defaults to your own identity in this room.
+        /// Member whose deputies to list: an 8-character short ID, or the
+        /// member's full verifying key (from `member list`). Defaults to your
+        /// own identity in this room.
         member_id: Option<String>,
     },
     /// Show who has deputized a member ("is X a deputy of anyone?")
@@ -76,7 +80,8 @@ pub enum MemberCommands {
     DeputizedBy {
         /// Room ID (owner key in base58)
         room_id: String,
-        /// Member ID to look up (8-character short ID from member list)
+        /// Member to look up: an 8-character short ID, or the member's full verifying
+        /// key (from `member list`) to name one exactly.
         member_id: String,
     },
 }
@@ -549,7 +554,8 @@ fn resolve_or_explain(deputies: &RoomDeputies<'_>, short: &str) -> Result<Member
             short
         ),
         ResolveError::Ambiguous(ids) => anyhow!(
-            "Member ID '{}' is ambiguous: it matches {}. Pass the full 8-character ID.",
+            "Member ID '{}' is ambiguous: it matches {}. Pass the full 8-character ID, \
+             or the member's full verifying key (from 'member list') to name one exactly.",
             short,
             ids.join(", ")
         ),

--- a/cli/src/commands/message.rs
+++ b/cli/src/commands/message.rs
@@ -338,15 +338,15 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
                     // an older message), since their key is no longer in state.
                     // JSON only: a bot reading messages allow-lists on this key,
                     // whereas the human chat view stays terse.
-                    let owner_id = MemberId::from(&room_owner_key);
-                    let members_by_id = room_state.members.members_by_member_id();
+                    // Reuse the same owner/member resolution as `member list`
+                    // (`RoomDeputies::verifying_key`) rather than reimplementing
+                    // it, so the two cannot drift.
+                    let deputies =
+                        crate::deputies::RoomDeputies::new(&room_state, &room_owner_key, &secrets);
                     let author_verifying_key = |author: MemberId| -> Option<String> {
-                        let vk = if author == owner_id {
-                            Some(room_owner_key)
-                        } else {
-                            members_by_id.get(&author).map(|m| m.member.member_vk)
-                        };
-                        vk.map(|k| bs58::encode(k.as_bytes()).into_string())
+                        deputies
+                            .verifying_key(author)
+                            .map(|k| bs58::encode(k.as_bytes()).into_string())
                     };
                     let json_messages: Vec<_> = messages
                         .iter()
@@ -719,6 +719,31 @@ mod tests {
         assert!(
             squashed.contains(r#""reactors":reactors,"#),
             "message list must expose who reacted, not only a count"
+        );
+    }
+
+    #[test]
+    fn message_list_json_exposes_author_verifying_key() {
+        let source = include_str!("message.rs");
+        // Scan production only (see the cut rationale above), else the needle
+        // matches its own literal here and the pin passes vacuously.
+        let production = source
+            .split_once("mod tests")
+            .map(|(before, _)| before)
+            .expect("test module marker missing; the cut would scan everything");
+        let squashed: String = production.chars().filter(|c| !c.is_whitespace()).collect();
+
+        // The author's full key is the collision-proof identity a bot allow-lists
+        // on; it must be in the JSON, resolved via the shared RoomDeputies helper
+        // (whose owner/member/None behaviour is unit-tested in `deputies`).
+        assert!(
+            squashed
+                .contains(r#""author_verifying_key":author_verifying_key(msg.message.author),"#),
+            "message list JSON must expose the author's verifying key"
+        );
+        assert!(
+            squashed.contains("RoomDeputies::new(&room_state,&room_owner_key,&secrets)"),
+            "author key must resolve via the shared RoomDeputies helper, not a re-implementation"
         );
     }
 

--- a/cli/src/commands/message.rs
+++ b/cli/src/commands/message.rs
@@ -5,6 +5,7 @@ use base64::Engine;
 use chrono::{DateTime, Local, Utc};
 use clap::Subcommand;
 use ed25519_dalek::{SigningKey, VerifyingKey};
+use river_core::room_state::member::MemberId;
 use river_core::room_state::message::MessageId;
 use serde_json::json;
 
@@ -330,6 +331,23 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
                     }
                 }
                 OutputFormat::Json => {
+                    // Resolve an author's full verifying key (base58) — the
+                    // collision-proof identity, matching `member list`'s
+                    // `verifying_key`. `None` when the author is neither the
+                    // owner nor a current member (e.g. a since-departed author of
+                    // an older message), since their key is no longer in state.
+                    // JSON only: a bot reading messages allow-lists on this key,
+                    // whereas the human chat view stays terse.
+                    let owner_id = MemberId::from(&room_owner_key);
+                    let members_by_id = room_state.members.members_by_member_id();
+                    let author_verifying_key = |author: MemberId| -> Option<String> {
+                        let vk = if author == owner_id {
+                            Some(room_owner_key)
+                        } else {
+                            members_by_id.get(&author).map(|m| m.member.member_vk)
+                        };
+                        vk.map(|k| bs58::encode(k.as_bytes()).into_string())
+                    };
                     let json_messages: Vec<_> = messages
                         .iter()
                         .map(|msg| {
@@ -406,6 +424,7 @@ pub async fn execute(command: MessageCommands, api: ApiClient, format: OutputFor
                             json!({
                                 "message_id": message_id_str,
                                 "author": author_str,
+                                "author_verifying_key": author_verifying_key(msg.message.author),
                                 "nickname": nickname,
                                 "content": content,
                                 "timestamp": datetime.to_rfc3339(),

--- a/cli/src/deputies.rs
+++ b/cli/src/deputies.rs
@@ -267,6 +267,15 @@ impl<'a> RoomDeputies<'a> {
         if short.is_empty() {
             return Err(ResolveError::NotFound);
         }
+        // Exact, collision-proof fast path: a full base58 verifying key resolves
+        // directly to its member, bypassing the ambiguous 8-char prefix match.
+        if let Some(target) = member_id_from_key_input(short) {
+            return if self.known_ids.contains(&target) {
+                Ok(target)
+            } else {
+                Err(ResolveError::NotFound)
+            };
+        }
         let matches: Vec<MemberId> = self
             .known_ids
             .iter()
@@ -515,6 +524,21 @@ fn invite_subtrees(state: &ChatRoomStateV1) -> HashMap<MemberId, HashSet<MemberI
 /// the already-tested walk, carries the cycle guard the contract omits, and a
 /// room is small enough that a one-off single-root variant would only be a
 /// second thing to keep correct.
+/// If `input` is a full base58-encoded 32-byte ed25519 verifying key, the
+/// [`MemberId`] it derives to; otherwise `None`.
+///
+/// This is the exact, collision-proof way to name a member on the command line:
+/// unlike the 8-character short id (a 40-bit truncation that two members can
+/// share), a full verifying key identifies exactly one member. A caller uses
+/// this as a fast path and falls back to short-id matching when it returns
+/// `None`. The base58 form matches what `member list` / `identity whoami` print
+/// as `verifying_key`, so a key copied from either resolves here.
+pub fn member_id_from_key_input(input: &str) -> Option<MemberId> {
+    let bytes = bs58::decode(input.trim()).into_vec().ok()?;
+    let arr: [u8; 32] = bytes.try_into().ok()?;
+    VerifyingKey::from_bytes(&arr).ok().map(MemberId::from)
+}
+
 pub fn ban_removal_set(state: &ChatRoomStateV1, target: MemberId) -> HashSet<MemberId> {
     let mut removed = invite_subtrees(state).remove(&target).unwrap_or_default();
     removed.insert(target);
@@ -783,6 +807,44 @@ mod tests {
         assert_eq!(d.verifying_key(id(&bob)), Some(bob.verifying_key()));
         // An id with no member/owner record yields None, never a wrong key.
         assert_eq!(d.verifying_key(id(&stranger)), None);
+    }
+
+    #[test]
+    fn member_id_from_key_input_parses_full_keys_and_rejects_non_keys() {
+        let alice = key(2);
+        let alice_key = bs58::encode(alice.verifying_key().as_bytes()).into_string();
+        // A full base58 verifying key derives its member id.
+        assert_eq!(member_id_from_key_input(&alice_key), Some(id(&alice)));
+        // The 8-char short id, empty input, and non-base58 garbage are not keys.
+        assert_eq!(member_id_from_key_input(&id(&alice).to_string()), None);
+        assert_eq!(member_id_from_key_input(""), None);
+        assert_eq!(member_id_from_key_input("not a key 0OIl"), None);
+        // A base58 blob of the wrong length is not a 32-byte key.
+        assert_eq!(
+            member_id_from_key_input(&bs58::encode([1u8; 31]).into_string()),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_short_id_accepts_a_full_verifying_key_exactly() {
+        let owner = key(1);
+        let alice = key(2);
+        let bob = key(3);
+        let stranger = key(9);
+        let state = room(&owner, &[&alice, &bob]);
+        let secrets = no_secrets();
+        let d = RoomDeputies::new(&state, &owner.verifying_key(), &secrets);
+        let full = |sk: &SigningKey| bs58::encode(sk.verifying_key().as_bytes()).into_string();
+
+        // A member's full key resolves to their exact id (owner included).
+        assert_eq!(d.resolve_short_id(&full(&alice)), Ok(id(&alice)));
+        assert_eq!(d.resolve_short_id(&full(&owner)), Ok(id(&owner)));
+        // A well-formed key for a non-member is NotFound, never a wrong member.
+        assert_eq!(
+            d.resolve_short_id(&full(&stranger)),
+            Err(ResolveError::NotFound)
+        );
     }
 
     #[test]

--- a/cli/src/deputies.rs
+++ b/cli/src/deputies.rs
@@ -515,6 +515,23 @@ fn invite_subtrees(state: &ChatRoomStateV1) -> HashMap<MemberId, HashSet<MemberI
     subtrees
 }
 
+/// If `input` is a full base58-encoded 32-byte ed25519 verifying key, the
+/// [`MemberId`] it derives to; otherwise `None`.
+///
+/// This is the precise way to name a member on the command line: unlike the
+/// 8-character short id (a 40-bit truncation that two members can share), a full
+/// verifying key resolves via its derived 64-bit `MemberId` — the same id the
+/// room keys every member by, so it names exactly one member of any given room
+/// (two distinct members cannot occupy one `MemberId`). A caller uses this as a
+/// fast path and falls back to short-id matching when it returns `None`. The
+/// base58 form matches what `member list` / `identity whoami` print as
+/// `verifying_key`, so a key copied from either resolves here.
+pub fn member_id_from_key_input(input: &str) -> Option<MemberId> {
+    let bytes = bs58::decode(input.trim()).into_vec().ok()?;
+    let arr: [u8; 32] = bytes.try_into().ok()?;
+    VerifyingKey::from_bytes(&arr).ok().map(MemberId::from)
+}
+
 /// Everyone a ban of `target` would remove from the room: `target` themselves
 /// PLUS their entire transitive invite subtree — exactly what the contract's
 /// `check_banned_members` inserts (the banned user) and then extends with
@@ -524,21 +541,6 @@ fn invite_subtrees(state: &ChatRoomStateV1) -> HashMap<MemberId, HashSet<MemberI
 /// the already-tested walk, carries the cycle guard the contract omits, and a
 /// room is small enough that a one-off single-root variant would only be a
 /// second thing to keep correct.
-/// If `input` is a full base58-encoded 32-byte ed25519 verifying key, the
-/// [`MemberId`] it derives to; otherwise `None`.
-///
-/// This is the exact, collision-proof way to name a member on the command line:
-/// unlike the 8-character short id (a 40-bit truncation that two members can
-/// share), a full verifying key identifies exactly one member. A caller uses
-/// this as a fast path and falls back to short-id matching when it returns
-/// `None`. The base58 form matches what `member list` / `identity whoami` print
-/// as `verifying_key`, so a key copied from either resolves here.
-pub fn member_id_from_key_input(input: &str) -> Option<MemberId> {
-    let bytes = bs58::decode(input.trim()).into_vec().ok()?;
-    let arr: [u8; 32] = bytes.try_into().ok()?;
-    VerifyingKey::from_bytes(&arr).ok().map(MemberId::from)
-}
-
 pub fn ban_removal_set(state: &ChatRoomStateV1, target: MemberId) -> HashSet<MemberId> {
     let mut removed = invite_subtrees(state).remove(&target).unwrap_or_default();
     removed.insert(target);


### PR DESCRIPTION
## Problem

Follow-up to #661 (member-list verifying keys), from a bot author who needs to
identify members by a collision-proof key rather than the 8-char short id (a
40-bit truncation two members can share). Two gaps remained:

1. Member-targeting commands (`ban`, `deputize`, `revoke-deputy`, `deputies`,
   `deputized-by`) only accepted the short id as input — so even after you read
   a member's full key from `member list`, you couldn't *act* on them by it.
2. `message list` showed only the short id for a message's author, so a bot
   reading messages had no collision-proof way to check who sent a command.

## Approach

**Accept full verifying keys as member references.** New shared helper
`deputies::member_id_from_key_input` returns the derived `MemberId` when the
input parses as a full base58 32-byte ed25519 key, else `None`. All three
resolution sites use it as an exact-match fast path before the existing
prefix/first-8 short-id matching:
- `RoomDeputies::resolve_short_id` (drives `deputies` / `deputized-by`)
- `resolve_deputy_target` (drives `deputize` / `revoke-deputy`)
- `ban_member_with_safety`'s inline find

A full-key input names exactly one member, so it also satisfies
`--require-exact-member-id` by construction (the guard only rejects a non-exact
*short-id* match). Short-id behavior is unchanged. Help text and the ambiguity
error now mention the full-key option.

**Author key in `message list`.** `--format json` gains `author_verifying_key`
(base58, or `null` when the author is neither owner nor a current member — e.g.
a since-departed author of an older message, whose key is no longer in state).
JSON only: a bot allow-lists on this key, while the human chat view stays terse.

Bumps riverctl to 0.2.14. No wire-format, contract, or delegate change.

## Testing

- `member_id_from_key_input` parses full keys and rejects short ids / empty /
  non-base58 / wrong-length blobs.
- `resolve_short_id` and `resolve_deputy_target` resolve a member (and, for
  revoke, a pruned deputy) by full key, and return NotFound/None for a
  stranger's key — never a wrong member.
- Full `riverctl` lib suite green (351 tests), fmt + clippy clean (no new
  warnings).

[AI-assisted - Claude]
