### PR TITLE
feat(ui): show member's full verifying key in the member-info modal

### DIFF
--- a/ui/src/components.rs
+++ b/ui/src/components.rs
@@ -118,6 +118,7 @@ mod volatile_value_binding_audit {
         r#"components/members/invite_member_modal.rs <input> invitation_code"#,
         r#"components/members/invite_member_modal.rs <input> invitation_url"#,
         r#"components/members/member_info_modal.rs <input> "{member_id_str}""#,
+        r#"components/members/member_info_modal.rs <input> "{vk_str}""#,
         r#"components/room_list/edit_room_modal.rs <input> "{bs58::encode(room_data.owner_vk.as_bytes()).into_string()}""#,
         r#"components/room_list/edit_room_modal.rs <input> "{room_data.contract_key.id()}""#,
         r#"components/room_list/edit_room_modal.rs <input> "{secret_version}""#,

--- a/ui/src/components/members/member_info_modal.rs
+++ b/ui/src/components/members/member_info_modal.rs
@@ -425,6 +425,18 @@ pub fn MemberInfoModal() -> Element {
         // Get the member ID string to display
         let member_id_str = member_id.to_string();
 
+        // The member's full ed25519 verifying key (base58) — the collision-proof
+        // identity, matching what riverctl's `member list` / `identity whoami`
+        // print as `verifying_key`. The short "Member ID" above is only a 40-bit
+        // truncation two members can share; this key names exactly one member,
+        // so it is what to compare when you must be sure who a member is. For the
+        // owner it's the room key; otherwise the member's own key.
+        let verifying_key_str = if is_owner {
+            owner_key_signal().map(|vk| bs58::encode(vk.as_bytes()).into_string())
+        } else {
+            member.map(|m| bs58::encode(m.member.member_vk.as_bytes()).into_string())
+        };
+
         rsx! {
             // Modal backdrop
             div {
@@ -597,6 +609,26 @@ pub fn MemberInfoModal() -> Element {
                                 class: "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text font-mono text-sm",
                                 value: "{member_id_str}",
                                 readonly: true
+                            }
+                        }
+
+                        // The full verifying key — the collision-proof identity.
+                        // Shown as its own read-only field so it can be copied
+                        // into an allow-list; the short Member ID above is a
+                        // 40-bit truncation and should not be trusted for that.
+                        if let Some(vk_str) = verifying_key_str.as_ref() {
+                            div {
+                                class: "mb-4",
+                                label {
+                                    class: "block text-sm font-medium text-text-muted mb-2",
+                                    "Verifying key"
+                                }
+                                input {
+                                    "data-testid": "member-info-verifying-key-input",
+                                    class: "w-full px-3 py-2 bg-surface border border-border rounded-lg text-text font-mono text-sm",
+                                    value: "{vk_str}",
+                                    readonly: true
+                                }
                             }
                         }
 


### PR DESCRIPTION
## Problem

The River member-info modal identified a member only by the 8-character short
Member ID — a 40-bit truncation of a non-cryptographic hash that two members can
share, so it's unsafe to trust for "is this really who I think it is?". The full
verifying key was already in state but never shown in the UI. This is the UI
counterpart to #661 / #667, which exposed the same key in `riverctl`.

## Approach

Add a read-only **Verifying key** field to the member-info modal, directly below
Member ID, showing the member's full base58 ed25519 key:
- the room owner key when the member is the owner (who isn't in the members
  list),
- the member's own `member_vk` otherwise.

It mirrors the existing read-only key field in `edit_room_modal` (same
`bs58::encode(vk.as_bytes())` + `readonly: true` input pattern), and is pinned in
the `volatile_value_binding_audit` as a display-only control (so it can't
silently drop out of the audit). `data-testid="member-info-verifying-key-input"`
for automation.

No contract or delegate WASM change — this is UI only. It does require a **Freenet
webapp republish** (`publish-river`) to reach users; that's a separate deploy
step, not part of this PR.

## Testing

- `cargo test -p river-ui --bins` green (932 tests), including the updated
  `volatile_value_binding_audit` (new binding pinned as display-only).
- `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync`
  compiles.

[AI-assisted - Claude]
