### PR TITLE
fix(ui): use_effect has the same contended-try_read latch as use_memo; 7 sites unguarded

### DIFF
--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -160,11 +160,22 @@ pub fn App() -> Element {
     //   processes again). Project rule "Never defer signal clears in
     //   `use_effect`" is explicit about this.
     use_effect(move || {
+        // freenet/river#559: anchor before the fallible try_read below — this
+        // effect's ONLY read is `INTERCEPTED_INVITATION_CODE`, so a contended
+        // pass would otherwise come out with zero subscriptions and never
+        // re-run for the rest of the session (same defect as #555, but for
+        // `use_effect`'s `reset_and_run_in`, not `Memo`'s).
+        crate::util::signal_guard::anchor();
         let pending = {
-            let g = crate::components::invite_click_interceptor::INTERCEPTED_INVITATION_CODE
+            match crate::components::invite_click_interceptor::INTERCEPTED_INVITATION_CODE
                 .try_read()
-                .ok();
-            g.and_then(|opt| opt.clone())
+            {
+                Ok(opt) => opt.clone(),
+                Err(_) => {
+                    crate::util::signal_guard::schedule_nudge();
+                    None
+                }
+            }
         };
         let Some(code) = pending else {
             return;
@@ -312,9 +323,18 @@ pub fn App() -> Element {
     // the Err path can mask a present invitation for a render tick; pin
     // the "writes always defer" invariant via grep when extending callers.
     use_effect(move || {
+        // freenet/river#559: anchor before the fallible try_read below — same
+        // single-fallible-dependency latch risk as the click-interceptor
+        // bridge above.
+        crate::util::signal_guard::anchor();
         let pending = {
-            let g = PRESENT_INVITATION_REQUEST.try_read().ok();
-            g.and_then(|opt| opt.clone())
+            match PRESENT_INVITATION_REQUEST.try_read() {
+                Ok(opt) => opt.clone(),
+                Err(_) => {
+                    crate::util::signal_guard::schedule_nudge();
+                    None
+                }
+            }
         };
         let Some(inv) = pending else {
             return;
@@ -414,9 +434,20 @@ pub fn App() -> Element {
     // auto-seeded as already-read (Codex / Skeptical found that the
     // previous always-run version defeated the unread feature).
     use_effect(|| {
+        // freenet/river#559: anchor before the fallible ROOMS read below —
+        // this effect's only read is ROOMS, so a contended pass would
+        // otherwise leave it with zero subscriptions and it would never
+        // re-run, silently defeating the seeding this comment describes.
+        crate::util::signal_guard::anchor();
         // Touch ROOMS to register a subscription so this effect re-runs
         // on hydration.
-        let _hydration_marker = ROOMS.try_read().map(|r| r.map.len()).unwrap_or(0);
+        let _hydration_marker = match ROOMS.try_read() {
+            Ok(r) => r.map.len(),
+            Err(_) => {
+                crate::util::signal_guard::schedule_nudge();
+                0
+            }
+        };
         crate::components::direct_messages::seed_dm_last_seen_if_needed();
     });
 
@@ -428,7 +459,17 @@ pub fn App() -> Element {
     // We deliberately do NOT subscribe to OUTBOUND_DMS here — that
     // would loop, since prune mutates OUTBOUND_DMS.
     use_effect(|| {
-        let _rooms_marker = ROOMS.try_read().map(|r| r.map.len()).unwrap_or(0);
+        // freenet/river#559: anchor before the fallible ROOMS read below —
+        // same single-fallible-dependency latch risk as the DM-seed effect
+        // above (this effect's only read is ROOMS too).
+        crate::util::signal_guard::anchor();
+        let _rooms_marker = match ROOMS.try_read() {
+            Ok(r) => r.map.len(),
+            Err(_) => {
+                crate::util::signal_guard::schedule_nudge();
+                0
+            }
+        };
         crate::components::app::chat_delegate::prune_outbound_dms_for_purges();
     });
 
@@ -439,6 +480,13 @@ pub fn App() -> Element {
         // Watch NEEDS_SYNC signal for USER-initiated changes only
         // This prevents infinite loops from network response updates to ROOMS
         use_effect(move || {
+            // freenet/river#559: anchor before the fallible ROOMS read below.
+            // This effect also unconditionally reads NEEDS_SYNC above, so a
+            // contended ROOMS pass degrades (it stays subscribed to
+            // NEEDS_SYNC) rather than latching — but nudge anyway so a
+            // dropped `has_rooms` doesn't wait on the next unrelated
+            // NEEDS_SYNC write to retry.
+            crate::util::signal_guard::anchor();
             let rooms_needing_sync = NEEDS_SYNC.read().clone();
 
             if !rooms_needing_sync.is_empty() {
@@ -449,7 +497,13 @@ pub fn App() -> Element {
 
                 // Get all the data we need upfront to avoid nested borrows
                 let message_sender = SYNCHRONIZER.read().get_message_sender();
-                let has_rooms = ROOMS.try_read().map(|r| !r.map.is_empty()).unwrap_or(false);
+                let has_rooms = match ROOMS.try_read() {
+                    Ok(r) => !r.map.is_empty(),
+                    Err(_) => {
+                        crate::util::signal_guard::schedule_nudge();
+                        false
+                    }
+                };
                 let has_invitations = !PENDING_INVITES.read().map.is_empty();
 
                 // Save and clear NEEDS_SYNC synchronously to prevent infinite re-runs

--- a/ui/src/components/app/document_title.rs
+++ b/ui/src/components/app/document_title.rs
@@ -647,8 +647,19 @@ pub fn count_unread_behind_rooms_panel() -> usize {
     // silently stuck. The non-try read first guarantees at least the
     // CURRENT_ROOM subscription always survives (same pattern as
     // `current_room_label` in conversation.rs).
+    //
+    // This function is called as `use_memo(count_unread_behind_rooms_panel)`
+    // (`conversation.rs`'s `panel_unread`) — the fallible read lives OUTSIDE
+    // the `use_memo(...)` body text, so `signal_guard`'s source-scrape pin
+    // (which only scans inside `use_memo(...)` parens) cannot see it. Anchor
+    // and nudge here anyway (freenet/river#559): CURRENT_ROOM already
+    // degrades safely, but nudging lets a contended pass retry promptly
+    // instead of waiting on an unrelated CURRENT_ROOM change. See
+    // `count_unread_behind_rooms_panel_anchors_and_nudges` below for the pin.
+    crate::util::signal_guard::anchor();
     let current = CURRENT_ROOM.read().owner_key;
     let Ok(rooms) = ROOMS.try_read() else {
+        crate::util::signal_guard::schedule_nudge();
         return 0;
     };
     count_unread_excluding_room(&rooms.map, &rooms.notification_modes, current.as_ref())
@@ -1019,6 +1030,65 @@ mod tests {
                  is freenet/river#500"
             );
         }
+    }
+
+    /// freenet/river#559: `count_unread_behind_rooms_panel` is called as
+    /// `use_memo(count_unread_behind_rooms_panel)` in `conversation.rs`'s
+    /// `panel_unread` — the fallible `ROOMS.try_read()` lives in THIS
+    /// function, outside the `use_memo(...)` body text, so
+    /// `signal_guard`'s pin (which only scans inside `use_memo(...)`
+    /// parens) cannot see it. Pin it here instead: a contended pass that
+    /// drops the anchor/nudge would leave `panel_unread` degraded, only
+    /// re-evaluating on an unrelated `CURRENT_ROOM` change.
+    #[test]
+    fn count_unread_behind_rooms_panel_anchors_and_nudges() {
+        let source = include_str!("document_title.rs");
+        let prod = &source[..source
+            .find("#[cfg(test)]\nmod tests {")
+            .expect("document_title.rs should have a `#[cfg(test)] mod tests` block")];
+        let code: String = prod
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let squashed: String = code.chars().filter(|c| !c.is_whitespace()).collect();
+
+        let marker = "pubfncount_unread_behind_rooms_panel()->usize{";
+        let start = squashed.find(marker).unwrap_or_else(|| {
+            panic!(
+                "count_unread_behind_rooms_panel's signature changed shape — \
+                 re-anchor this pin, do not delete it"
+            )
+        });
+        let body = &squashed[start..];
+        let end = body[marker.len()..]
+            .find("pubfn")
+            .map(|i| i + marker.len())
+            .unwrap_or(body.len());
+        let body = &body[..end];
+
+        let anchor = body.find("signal_guard::anchor()").unwrap_or_else(|| {
+            panic!(
+                "count_unread_behind_rooms_panel reads ROOMS with try_read() but \
+                 never calls signal_guard::anchor() before it. Called as \
+                 `use_memo(count_unread_behind_rooms_panel)` in conversation.rs, \
+                 a contended pass can leave that memo without the guard \
+                 (freenet/river#559)."
+            )
+        });
+        let first_try = body
+            .find("try_read(")
+            .expect("count_unread_behind_rooms_panel should still call ROOMS.try_read()");
+        assert!(
+            anchor < first_try,
+            "signal_guard::anchor() must be called BEFORE the first try_read() \
+             in count_unread_behind_rooms_panel"
+        );
+        assert!(
+            body.contains("signal_guard::schedule_nudge()"),
+            "count_unread_behind_rooms_panel must call schedule_nudge() on the \
+             ROOMS.try_read() Err branch (freenet/river#559)"
+        );
     }
 
     use crate::constants::ROOM_CONTRACT_WASM;

--- a/ui/src/components/direct_messages/dm_thread_modal.rs
+++ b/ui/src/components/direct_messages/dm_thread_modal.rs
@@ -141,10 +141,22 @@ fn DmThreadModalBody(room: VerifyingKey, peer: MemberId) -> Element {
     //    correct semantics regardless: we only ever want to merge
     //    once per DM_DRAFT arrival.
     use_effect(move || {
+        // freenet/river#559: anchor before the fallible try_read below —
+        // `room`/`peer` are plain captured props (not signals) and `draft`
+        // is read via `peek()` further down (deliberately non-reactive), so
+        // DM_DRAFT is this effect's ONLY subscription. A contended pass would
+        // otherwise leave it with zero subscriptions and it would never
+        // re-fire, permanently breaking the invite-via-DM draft merge for
+        // this thread.
+        crate::util::signal_guard::anchor();
         let pending = {
-            let g = DM_DRAFT.try_read().ok();
-            g.and_then(|opt| opt.clone())
-                .filter(|(r, p, _)| *r == room && *p == peer)
+            match DM_DRAFT.try_read() {
+                Ok(opt) => opt.clone().filter(|(r, p, _)| *r == room && *p == peer),
+                Err(_) => {
+                    crate::util::signal_guard::schedule_nudge();
+                    None
+                }
+            }
         };
         if let Some((_, _, body)) = pending {
             // Clear DM_DRAFT SYNCHRONOUSLY before any further state

--- a/ui/src/components/members.rs
+++ b/ui/src/components/members.rs
@@ -1712,9 +1712,18 @@ fn ExportIdentityModal(is_active: Signal<bool>) -> Element {
     // Generate the export token when modal opens
     use_effect(move || {
         if *is_active.read() {
+            // freenet/river#559: anchor before the fallible ROOMS read below.
+            // `is_active` and `CURRENT_ROOM` are both read infallibly first,
+            // so a contended pass degrades rather than latches — but anchor
+            // and nudge anyway for the same reason as the `use_memo` sites
+            // this mirrors (freenet/river#555): consistency, and so a
+            // contended pass retries promptly instead of waiting on an
+            // unrelated `is_active`/`CURRENT_ROOM` change.
+            crate::util::signal_guard::anchor();
             let room_owner = CURRENT_ROOM.read().owner_key;
             if let Some(owner_key) = room_owner {
                 let Ok(rooms_read) = ROOMS.try_read() else {
+                    crate::util::signal_guard::schedule_nudge();
                     return;
                 };
                 if let Some(room_data) = rooms_read.map.get(&owner_key) {

--- a/ui/src/util/signal_guard.rs
+++ b/ui/src/util/signal_guard.rs
@@ -161,6 +161,24 @@ mod tests {
         ),
     ];
 
+    /// Same requirement as [`GUARDED_MEMO_SITES`], for `use_effect(...)`
+    /// bodies (freenet/river#559). `use_effect` rebuilds its dependency set
+    /// on every pass via the same `reset_and_run_in` primitive `Memo` uses
+    /// (`dioxus-hooks-0.7.9/src/use_effect.rs:34`), so an effect that
+    /// early-returns on a contended `try_read()` and reads nothing else is
+    /// subscribed to nothing and dead for the rest of the session.
+    const GUARDED_EFFECT_SITES: &[(&str, &str)] = &[
+        ("app.rs", include_str!("../components/app.rs")),
+        (
+            "members.rs ExportIdentityModal",
+            include_str!("../components/members.rs"),
+        ),
+        (
+            "dm_thread_modal.rs DM_DRAFT merge",
+            include_str!("../components/direct_messages/dm_thread_modal.rs"),
+        ),
+    ];
+
     /// Cut production source at the test module so a needle appearing only in a
     /// test cannot satisfy the pin. Splits on `mod tests`, not
     /// `#[cfg(test)]`, because attributes also decorate non-test items.
@@ -184,21 +202,22 @@ mod tests {
             .join("\n")
     }
 
-    /// Body of each `use_memo(...)`, delimited by balancing the parenthesis the
-    /// call opens. Whole-file scanning is not good enough: these files also
-    /// `try_read()` from event handlers, which is legitimate and unrelated, and a
-    /// naive "first try_read in the file" check flags it.
+    /// Body of each `<prefix>(...)` call (e.g. `use_memo(` or `use_effect(`),
+    /// delimited by balancing the parenthesis the call opens. Whole-file
+    /// scanning is not good enough: these files also `try_read()` from event
+    /// handlers, which is legitimate and unrelated, and a naive "first
+    /// try_read in the file" check flags it.
     /// Scans BYTES, not chars: these files contain non-ASCII (em dashes and the
     /// like), so char indices and byte offsets diverge, and mixing them silently
     /// slices the wrong region — which made an earlier version of this pin report
     /// "no memo reads fallibly" for a file with four of them. `(` and `)` are
     /// ASCII, so byte scanning is exact here.
-    fn memo_bodies(src: &str) -> Vec<(usize, &str)> {
+    fn hook_bodies<'a>(src: &'a str, prefix: &str) -> Vec<(usize, &'a str)> {
         let bytes = src.as_bytes();
         let mut out = Vec::new();
         let mut search = 0usize;
-        while let Some(rel) = src[search..].find("use_memo(") {
-            let open = search + rel + "use_memo(".len() - 1; // byte offset of '('
+        while let Some(rel) = src[search..].find(prefix) {
+            let open = search + rel + prefix.len() - 1; // byte offset of '('
             let start_line = src[..open].matches('\n').count() + 1;
             let mut depth = 0i32;
             let mut end = None;
@@ -221,6 +240,18 @@ mod tests {
             search = open + 1;
         }
         out
+    }
+
+    fn memo_bodies(src: &str) -> Vec<(usize, &str)> {
+        hook_bodies(src, "use_memo(")
+    }
+
+    /// Same shape as [`memo_bodies`], for `use_effect(...)` (freenet/river#559:
+    /// `use_effect` rebuilds its dependency set on every pass via the same
+    /// `reset_and_run_in` primitive as `Memo`, so it has the identical
+    /// contended-`try_read` latch risk).
+    fn effect_bodies(src: &str) -> Vec<(usize, &str)> {
+        hook_bodies(src, "use_effect(")
     }
 
     /// Every memo that reads a signal fallibly must read the anchor FIRST and
@@ -294,6 +325,77 @@ mod tests {
              {checked}. If you added or removed a fallible memo, update this \
              number deliberately; if you did not, the matcher has stopped \
              finding memo bodies and this pin has gone vacuous."
+        );
+    }
+
+    /// Same requirement as [`every_fallible_memo_anchors_before_its_first_try_read_and_nudges`],
+    /// for `use_effect(...)` bodies (freenet/river#559). Checked per effect
+    /// body, not per file: each effect rebuilds its own dependency set, so an
+    /// anchor in a sibling effect (or in a memo elsewhere in the same file)
+    /// protects nothing.
+    #[test]
+    fn every_fallible_effect_anchors_before_its_first_try_read_and_nudges() {
+        let mut checked = 0usize;
+        for (name, src) in GUARDED_EFFECT_SITES {
+            let prod = strip_line_comments(production_only(src));
+            let bodies = effect_bodies(&prod);
+            assert!(
+                !bodies.is_empty(),
+                "{name}: no use_effect found; the brace matcher or the file \
+                 changed shape. Fix the pin rather than deleting it."
+            );
+            let mut fallible_in_file = 0usize;
+            for (line, body) in bodies {
+                let Some(first_try) = body.find("try_read(") else {
+                    continue;
+                };
+                fallible_in_file += 1;
+                checked += 1;
+                let anchor = body.find("signal_guard::anchor").unwrap_or_else(|| {
+                    panic!(
+                        "{name}: use_effect at line {line} reads a signal with \
+                         try_read() but never calls signal_guard::anchor(). A \
+                         contended pass can leave it with zero subscriptions and \
+                         it will never re-run for the rest of the session \
+                         (freenet/river#559)."
+                    )
+                });
+                assert!(
+                    anchor < first_try,
+                    "{name}: use_effect at line {line} calls \
+                     signal_guard::anchor() AFTER its first try_read( — on the \
+                     Err path the anchor is never reached, so it registers \
+                     nothing (freenet/river#559)."
+                );
+                let reads = body.matches("try_read(").count();
+                let nudges = body.matches("signal_guard::schedule_nudge").count();
+                assert!(
+                    nudges >= reads,
+                    "{name}: use_effect at line {line} has {reads} fallible \
+                     read(s) but only {nudges} schedule_nudge() call(s). Every \
+                     read that can fail needs a nudge on its own failure \
+                     branch, or that signal's subscription is dropped with \
+                     nothing to restore it (freenet/river#559)."
+                );
+            }
+            assert!(
+                fallible_in_file > 0,
+                "{name}: listed in GUARDED_EFFECT_SITES but no use_effect reads \
+                 fallibly. Remove the entry rather than leaving a vacuous pin."
+            );
+        }
+        // EXACT count, not a floor — see the sibling memo test's comment for
+        // why: a floor would stay green even if the matcher stopped finding
+        // some of app.rs's five fallible effects. Seven fallible use_effect
+        // reads across the three files (app.rs has five, members.rs and
+        // dm_thread_modal.rs one each) is the full set freenet/river#559
+        // identified.
+        assert_eq!(
+            checked, 7,
+            "expected to check exactly the 7 known fallible effects, checked \
+             {checked}. If you added or removed a fallible effect, update this \
+             number deliberately; if you did not, the matcher has stopped \
+             finding effect bodies and this pin has gone vacuous."
         );
     }
 


### PR DESCRIPTION
## Problem

`use_effect` runs through the same `ReactiveContext::reset_and_run_in` primitive as `Memo` (`dioxus-hooks-0.7.9/src/use_effect.rs:34`), so it rebuilds its dependency set every pass. An effect that early-returns on a contended `try_read()` and reads nothing else is subscribed to nothing and is dead for the session — the same defect #555/#558 fixed for `use_memo`, but the fix was never applied to `use_effect` call sites.

Seven sites had this gap:

- `app.rs` — `INTERCEPTED_INVITATION_CODE.try_read()` (in-app invite-link click bridge) — single fallible dependency, latch.
- `app.rs` — `PRESENT_INVITATION_REQUEST.try_read()` (DM-card in-app accept bridge) — single fallible dependency, latch.
- `app.rs` — `ROOMS.try_read()` (DM-last-seen seeding) — single fallible dependency, latch.
- `app.rs` — `ROOMS.try_read()` (outbound-DM cache pruning) — single fallible dependency, latch.
- `app.rs` — `ROOMS.try_read()` inside the `NEEDS_SYNC` effect — degrades (also reads `NEEDS_SYNC` unconditionally) rather than latches.
- `members.rs` — `ROOMS.try_read()` in the identity-export-token effect — degrades (reads `is_active`/`CURRENT_ROOM` first).
- `dm_thread_modal.rs` — `DM_DRAFT.try_read()` in the invite-via-DM draft merge — single fallible dependency, latch (this one was mis-classified as "degrade" in the issue, but on inspection it has no other reactive read — `room`/`peer` are plain props and `draft` is read via `.peek()`).

Also covered the eighth site the issue called out: `use_memo(count_unread_behind_rooms_panel)` in `conversation.rs` calls a function in `document_title.rs` whose fallible `ROOMS.try_read()` lives *outside* the `use_memo(...)` body text — invisible to the existing source-scrape pin, which only scans inside `use_memo(...)` parens.

## Approach

Applied the existing `signal_guard::anchor()`/`schedule_nudge()` primitives from #558 verbatim to all 7 `use_effect` sites, and to `count_unread_behind_rooms_panel` directly (guarding the function itself since the fallible read isn't inside a macro body a generic pin can see).

Extended `signal_guard.rs`'s pin test to scan `use_effect(...)` bodies the same way it already scans `use_memo(...)` bodies — generalized the paren-balancing scanner into `hook_bodies(src, prefix)` — and added a dedicated source-scrape pin for `count_unread_behind_rooms_panel`. Both new pins assert an *exact* count (7, and the single site respectively) so a matcher regression can't silently go vacuous, matching the existing memo pin's style.

## Testing

- `cargo test -p river-ui --bins`: 940 passed, including the two new pin tests (`every_fallible_effect_anchors_before_its_first_try_read_and_nudges`, `count_unread_behind_rooms_panel_anchors_and_nudges`).
- `cargo check -p river-ui --target wasm32-unknown-unknown --features no-sync`: clean.
- `cargo clippy -p river-ui --bins`: no new warnings from touched files.
- `cargo fmt -p river-ui -- --check`: clean.

No delegate/contract/common WASM touched — UI-only change, no migration needed.

Closes freenet/river#559

[AI-assisted - Claude]