### PR TITLE
fix(ui): gate outbound-DM save on delegate hydration to stop truncating saves

### DIFF
--- a/.claude/rules/dioxus-signal-safety.md
+++ b/.claude/rules/dioxus-signal-safety.md
@@ -295,3 +295,44 @@ re-renders when the signal driving its open/close state changes), or
 reset per-open `use_signal` scratch state with a `use_effect` keyed on
 that open/close signal. freenet/river#291 (the invite-via-DM picker
 showing the previous invitee's name) was exactly this bug.
+
+## A readiness latch must flip from inside the same macrotask as the work it certifies
+
+A boolean "is X ready" flag that gates a later read of some state MUST be
+set from WITHIN the same deferred macrotask that actually performs the
+write making X ready — never set synchronously alongside code that only
+SCHEDULES that write via `defer()`/`safe_spawn_local()`.
+
+`defer()`'s `setTimeout(0)` guarantees FIFO ordering only among macrotasks
+registered against the SAME event-loop queue. It says nothing about a
+MICROTASK-resumed continuation (an already-suspended `.await` on a channel,
+a promise, another future) — that can run in between "a macrotask was
+registered" and "that macrotask actually executed," because microtasks
+drain before the next macrotask, not before the current synchronous call
+returns. Setting the flag synchronously, "because anything checking it must
+run later," conflates "runs later" with "runs after every already-scheduled
+macrotask" — those are not the same thing.
+
+The fix: schedule the flag-flip itself via `defer()`, positioned textually
+AFTER the `defer()` calls whose work it depends on, in the same synchronous
+function. Then the flag literally cannot become `true` until those merges
+have executed — the invariant is structural (a precondition of the flip
+existing at all), not an argument about scheduling order that has to be
+re-derived by every future reader.
+
+freenet/river#530 (PR #670, round 2 of review) hit exactly this: an
+outbound-DM hydration latch was set synchronously in
+`handle_outbound_dms_get_response`, in the same call as merely scheduling
+(not performing) the disk-baseline merge. `LiveImportSeam::flush` — already
+suspended on an unrelated `.await` — could resume via a microtask, observe
+the latch as `true`, and read the signals before the merge had landed,
+truncating the saved blob. See `direct-messages.md`'s "Hydration gate"
+section for the concrete fix and `chat_delegate.rs`'s
+`mark_outbound_dms_hydrated` doc comment for the full reasoning.
+
+**Test consequence:** a source-scrape pin that only checks a flag-setting
+call EXISTS and is gated correctly is not enough — also check it is
+scheduled via `defer()` (not called bare) AND that, textually, it comes
+AFTER the `defer()` calls for the work it depends on. A pin that misses the
+ordering check passes even after the ordering is silently broken by a later
+edit (e.g. hoisting the flag-flip above the merge calls "for readability").

--- a/.claude/rules/direct-messages.md
+++ b/.claude/rules/direct-messages.md
@@ -146,7 +146,17 @@ plaintext in the chat delegate.
   failure). `Ok(())` from `save_outbound_dms_to_delegate` always means the
   write was actually attempted — this is load-bearing for
   `LiveImportSeam::flush` in `freenet_api/delegate_migration.rs`, which seals
-  a predecessor as migrated on `Ok`.
+  a predecessor as migrated on `Ok`. **The latch flip itself must go through
+  `crate::util::defer`, never a bare synchronous call** — it is registered
+  AFTER `hydrate_hidden_dm_threads` / `hydrate_outbound_dms_cache` in the
+  same synchronous handler call, so `setTimeout(0)` FIFO ordering guarantees
+  it can't run (and the latch can't become `true`) until those two have
+  already executed their merges. A synchronous flip let a MICROTASK-resumed
+  caller (e.g. `LiveImportSeam::flush`, which awaits this function directly)
+  observe the latch as `true` before the merge had landed — reproducing the
+  truncation bug in a rarer, timing-dependent form (round-2/3 review on
+  PR #670; see `dioxus-signal-safety.md`'s readiness-latch rule for the
+  general pattern).
 - **Prune path**: `prune_outbound_dms_for_purges` (UI) and
   `prune_outbound_cache_for_room` (CLI) act ONLY on entries whose
   `(room, recipient, token)` appears in some recipient's

--- a/.claude/rules/direct-messages.md
+++ b/.claude/rules/direct-messages.md
@@ -135,6 +135,18 @@ plaintext in the chat delegate.
   delegate writes. `save_outbound_dms_to_delegate` and
   `save_rooms_to_delegate` both share the helper — grep `CoalesceState`
   to find every caller.
+  **Hydration gate (freenet/river#530):** before that, `save_outbound_dms_to_delegate`
+  awaits the `OUTBOUND_DMS_HYDRATED` latch (bounded by `await_flag_with_bound`,
+  15s worst case), so a save can never read `OUTBOUND_DMS`/`HIDDEN_DM_THREADS`
+  before they've merged whatever the CURRENT delegate already has on disk —
+  otherwise the save's full-blob overwrite would truncate it. The latch is set
+  by `mark_outbound_dms_hydrated()`, called only from the CURRENT (non-legacy)
+  delegate's `OUTBOUND_DMS_STORAGE_KEY` `GetResponse` handler in
+  `response_handler.rs`, on every return path (no blob / parsed / parse
+  failure). `Ok(())` from `save_outbound_dms_to_delegate` always means the
+  write was actually attempted — this is load-bearing for
+  `LiveImportSeam::flush` in `freenet_api/delegate_migration.rs`, which seals
+  a predecessor as migrated on `Ok`.
 - **Prune path**: `prune_outbound_dms_for_purges` (UI) and
   `prune_outbound_cache_for_room` (CLI) act ONLY on entries whose
   `(room, recipient, token)` appears in some recipient's

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -3927,6 +3927,121 @@ mod tests {
         );
     }
 
+    // ===== A save before hydration must not truncate the delegate blob
+    // (freenet/river#530) =====
+    //
+    // `do_save_outbound_dms_to_delegate` snapshots and fully overwrites the
+    // `OutboundDmStore` blob. Before the CURRENT delegate's
+    // `OUTBOUND_DMS_STORAGE_KEY` `GetResponse` lands, `OUTBOUND_DMS` /
+    // `HIDDEN_DM_THREADS` haven't merged whatever is already on disk, so a
+    // save that races ahead of hydration would persist a truncated view and
+    // permanently destroy every entry the in-memory signals don't know about
+    // yet. `save_outbound_dms_to_delegate` now gates on
+    // `OUTBOUND_DMS_HYDRATED` and records a pending save instead;
+    // `mark_outbound_dms_hydrated` (called from the current-delegate
+    // `GetResponse` handler in `response_handler.rs`) drains it once the
+    // disk baseline is known.
+
+    /// Serializes the tests below that mutate the process-global
+    /// `OUTBOUND_DMS_HYDRATED` / `OUTBOUND_DMS_SAVE_PENDING_PRE_HYDRATION`
+    /// statics, mirroring `DEDUP_TEST_LOCK`'s rationale.
+    static OUTBOUND_DMS_HYDRATION_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// A save requested before hydration must be a harmless no-op — it must
+    /// NOT reach `do_save_outbound_dms_to_delegate` (the real network write) —
+    /// and must record that a save is owed, or the mutation it was meant to
+    /// persist is silently lost forever.
+    #[test]
+    fn outbound_dms_save_defers_before_hydration_and_marks_pending() {
+        let _guard = OUTBOUND_DMS_HYDRATION_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        reset_outbound_dms_hydration_state_for_test();
+
+        let result = futures::executor::block_on(save_outbound_dms_to_delegate());
+        assert!(
+            result.is_ok(),
+            "a pre-hydration save must be a harmless no-op, not an error: {:?}",
+            result
+        );
+        assert!(
+            OUTBOUND_DMS_SAVE_PENDING_PRE_HYDRATION.load(Ordering::SeqCst),
+            "a save requested before hydration must be recorded as owed"
+        );
+
+        reset_outbound_dms_hydration_state_for_test();
+    }
+
+    /// Once hydration completes, a save that was deferred pre-hydration must
+    /// be drained — otherwise a user action taken before hydration (e.g.
+    /// archiving a thread) is remembered in memory but never reaches the
+    /// delegate, and the next reload reads the stale disk copy.
+    #[test]
+    fn mark_hydrated_drains_a_pending_pre_hydration_save() {
+        let _guard = OUTBOUND_DMS_HYDRATION_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        reset_outbound_dms_hydration_state_for_test();
+        OUTBOUND_DMS_SAVE_PENDING_PRE_HYDRATION.store(true, Ordering::SeqCst);
+
+        mark_outbound_dms_hydrated();
+
+        assert!(
+            OUTBOUND_DMS_HYDRATED.load(Ordering::SeqCst),
+            "the hydration latch must be set"
+        );
+        assert!(
+            !OUTBOUND_DMS_SAVE_PENDING_PRE_HYDRATION.load(Ordering::SeqCst),
+            "the pending flag must be drained so the deferred save doesn't replay twice"
+        );
+
+        reset_outbound_dms_hydration_state_for_test();
+    }
+
+    /// Marking hydrated with nothing pending must not schedule a spurious
+    /// save — the common case (no user action before hydration completes).
+    #[test]
+    fn mark_hydrated_is_a_noop_when_nothing_is_pending() {
+        let _guard = OUTBOUND_DMS_HYDRATION_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        reset_outbound_dms_hydration_state_for_test();
+
+        mark_outbound_dms_hydrated();
+
+        assert!(OUTBOUND_DMS_HYDRATED.load(Ordering::SeqCst));
+        assert!(!OUTBOUND_DMS_SAVE_PENDING_PRE_HYDRATION.load(Ordering::SeqCst));
+
+        reset_outbound_dms_hydration_state_for_test();
+    }
+
+    /// Source-order pin: the hydration check inside
+    /// `save_outbound_dms_to_delegate` must run BEFORE the `coalesce_save`
+    /// call that reaches the real network write. Without this ordering a
+    /// pre-hydration caller could still fall through to the delegate write
+    /// this issue is about. (The end-to-end network path isn't
+    /// unit-testable off-WASM — see the `WEB_API` note elsewhere in this
+    /// file — so this pins the guard's position in the source instead.)
+    #[test]
+    fn outbound_dms_save_checks_hydration_before_coalescing() {
+        let src = include_str!("chat_delegate.rs");
+        let fn_start = src
+            .find("pub async fn save_outbound_dms_to_delegate")
+            .expect("save_outbound_dms_to_delegate must exist");
+        let body = &src[fn_start..];
+        let hydrated_check = body
+            .find("OUTBOUND_DMS_HYDRATED.load")
+            .expect("must check the hydration latch");
+        let coalesce_call = body
+            .find("&OUTBOUND_DMS_SAVE_STATE")
+            .expect("must still coalesce the real save once hydrated");
+        assert!(
+            hydrated_check < coalesce_call,
+            "the hydration check must run BEFORE coalesce_save, or a \
+             pre-hydration caller could still reach the network write"
+        );
+    }
+
     // ===== Outbound DM revives hidden thread (Codex P1 fix) =====
     // The testing-reviewer's BLOCKING #3 on PR #265. The "explicit
     // unhide on outbound" path lives in `dm_thread_modal::do_send` /
@@ -7240,11 +7355,66 @@ pub fn unhide_dm_thread_if_dm_is_newer(
 /// (freenet/river#246 extracted the shared primitive).
 static OUTBOUND_DMS_SAVE_STATE: CoalesceState = CoalesceState::new();
 
+/// Set once the CURRENT (non-legacy) chat delegate's `OUTBOUND_DMS_STORAGE_KEY`
+/// `GetResponse` has been processed — see [`mark_outbound_dms_hydrated`] and
+/// freenet/river#530. Before this point, `OUTBOUND_DMS`/`HIDDEN_DM_THREADS`
+/// have not yet merged whatever is already on disk, so a save would
+/// overwrite the persisted blob with a truncated view (permanently losing
+/// every archive/plaintext entry the in-memory signals don't know about yet).
+static OUTBOUND_DMS_HYDRATED: AtomicBool = AtomicBool::new(false);
+
+/// Set by [`save_outbound_dms_to_delegate`] when a save was requested before
+/// hydration completed, so [`mark_outbound_dms_hydrated`] can replay it once
+/// the disk baseline is known. freenet/river#530.
+static OUTBOUND_DMS_SAVE_PENDING_PRE_HYDRATION: AtomicBool = AtomicBool::new(false);
+
+/// Mark the outbound-DM store hydrated from the CURRENT delegate, and replay
+/// any save that [`save_outbound_dms_to_delegate`] deferred while waiting
+/// (freenet/river#530).
+///
+/// Call exactly once per session, from the CURRENT (non-legacy) delegate's
+/// `OUTBOUND_DMS_STORAGE_KEY` `GetResponse` — regardless of whether a blob was
+/// present, since "no blob" is itself the authoritative disk baseline for a
+/// new user. A LEGACY delegate's response must NOT call this: its data still
+/// needs merging into the current-delegate baseline, and marking hydrated
+/// early would let a save land before that baseline is known.
+pub(crate) fn mark_outbound_dms_hydrated() {
+    OUTBOUND_DMS_HYDRATED.store(true, Ordering::Release);
+    if OUTBOUND_DMS_SAVE_PENDING_PRE_HYDRATION.swap(false, Ordering::AcqRel) {
+        info!("Replaying outbound-DM save that was deferred pending hydration (freenet/river#530)");
+        crate::util::safe_spawn_local(async {
+            if let Err(e) = save_outbound_dms_to_delegate().await {
+                warn!(
+                    "Failed to persist outbound-DM save deferred pending hydration: {}",
+                    e
+                );
+            }
+        });
+    }
+}
+
+/// Reset the hydration latch. For tests only; production sets it exactly
+/// once per session via [`mark_outbound_dms_hydrated`].
+#[cfg(test)]
+pub(crate) fn reset_outbound_dms_hydration_state_for_test() {
+    OUTBOUND_DMS_HYDRATED.store(false, Ordering::SeqCst);
+    OUTBOUND_DMS_SAVE_PENDING_PRE_HYDRATION.store(false, Ordering::SeqCst);
+}
+
 /// Serialize the current [`OUTBOUND_DMS`] cache and persist it via the
 /// chat delegate. Caller is responsible for having already mutated the
 /// cache before invoking this. Fire-and-forget at most call sites —
 /// the StoreResponse comes back through the normal message loop and is
 /// logged but not awaited on the hot path.
+///
+/// **Defers until hydration completes (freenet/river#530).** Before the
+/// CURRENT delegate's `OUTBOUND_DMS_STORAGE_KEY` `GetResponse` has been
+/// processed, `OUTBOUND_DMS`/`HIDDEN_DM_THREADS` may not yet reflect
+/// whatever is already persisted. Writing now would publish a truncated
+/// snapshot that permanently overwrites the disk copy — the mechanism
+/// behind the #530 archive/plaintext loss. Instead, record that a save is
+/// owed; [`mark_outbound_dms_hydrated`] replays it once the baseline is
+/// known, so the eventual write is over the fully-merged state.
 ///
 /// Coalesced via [`coalesce_save`] (was a hand-rolled copy of the same
 /// pattern until freenet/river#246 extracted the primitive): a chain
@@ -7253,6 +7423,11 @@ static OUTBOUND_DMS_SAVE_STATE: CoalesceState = CoalesceState::new();
 /// authoritative result of the catch-up save that covered its
 /// mutation.
 pub async fn save_outbound_dms_to_delegate() -> Result<(), String> {
+    if !OUTBOUND_DMS_HYDRATED.load(Ordering::Acquire) {
+        OUTBOUND_DMS_SAVE_PENDING_PRE_HYDRATION.store(true, Ordering::Release);
+        info!("Outbound-DMs save deferred until delegate hydration completes (freenet/river#530)");
+        return Ok(());
+    }
     coalesce_save(
         &OUTBOUND_DMS_SAVE_STATE,
         "Outbound-DMs",

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -4058,38 +4058,40 @@ mod tests {
             .map(|i| i + "\n}\n".len())
             .expect("function must have a closing brace");
         let body = &after[..fn_end];
-        assert!(
-            !body.contains("return Ok"),
-            "save_outbound_dms_to_delegate must not have an early-return \
-             shortcut — an early Ok(()) reintroduces the LiveImportSeam::flush \
-             durability bug this PR's redesign closes (freenet/river#530)"
+        // A blacklist approach (banning `return Ok`, then `if `) was tried
+        // across rounds 1-2 and each version was defeated by a shape it
+        // didn't anticipate — round 2's `!body.contains("if ")` still lets a
+        // `match` arm skip the real write with no `if` and no `return`
+        // anywhere (testing-review, round 3):
+        //
+        //   match cond {
+        //       true => Ok(()),
+        //       false => coalesce_save(&OUTBOUND_DMS_SAVE_STATE, "Outbound-Dms", do_save_outbound_dms_to_delegate).await,
+        //   }
+        //
+        // Blacklisting keywords is an open-ended arms race. Whitelist
+        // instead: normalize whitespace and require the body be BYTE-EQUAL
+        // to the one known-correct unconditional shape. Any control-flow
+        // construct at all — `if`, `match`, `?`, a second `return` — changes
+        // the normalized text and fails the comparison, regardless of what
+        // form it takes.
+        let normalized_body: String = body.split_whitespace().collect::<Vec<_>>().join(" ");
+        let expected_body = format!(
+            "{} {{ {}().await; coalesce_save( &OUTBOUND_DMS_SAVE_STATE, \"Outbound-DMs\", {}, ) .await }}",
+            signature.trim_end_matches(" {"),
+            "await_outbound_dms_hydration",
+            "do_save_outbound_dms_to_delegate",
         );
-        // `!body.contains("return Ok")` alone doesn't catch a conditional
-        // TAIL expression bypassing the real write with no `return` keyword
-        // at all, e.g. `if cond { Ok(()) } else { coalesce_save(...).await }`
-        // — both anchor strings below would still appear, in order, while
-        // the real control flow skips the write (testing-review, round 2).
-        // The correct body is a flat two-statement sequence with no
-        // branching at all, so also require there be no `if` in it.
-        assert!(
-            !body.contains("if "),
-            "save_outbound_dms_to_delegate must be an unconditional sequence \
-             — hydrate, then always save. A conditional here (even one that \
-             still textually mentions both the hydration wait and \
-             coalesce_save) could skip the real write on some branch, \
-             reintroducing the LiveImportSeam::flush durability bug \
-             (freenet/river#530)"
-        );
-        let await_hydration = body
-            .find("await_outbound_dms_hydration().await")
-            .expect("must await the hydration latch");
-        let coalesce_call = body
-            .find("coalesce_save(")
-            .expect("must still coalesce the real save");
-        assert!(
-            await_hydration < coalesce_call,
-            "the hydration wait must run BEFORE coalesce_save, or a \
-             pre-hydration caller could still reach the network write early"
+        assert_eq!(
+            normalized_body, expected_body,
+            "save_outbound_dms_to_delegate must be EXACTLY the two-statement \
+             unconditional sequence \"await hydration, then always save\" — \
+             any other shape (a conditional, an early return, a `?`, a \
+             `match`) can skip the real write on some path, reintroducing \
+             the LiveImportSeam::flush durability bug this PR's redesign \
+             closes (freenet/river#530). If this function's SHAPE \
+             legitimately needs to change, update `expected_body` here \
+             deliberately — don't just relax the check."
         );
     }
 

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -4064,6 +4064,22 @@ mod tests {
              shortcut — an early Ok(()) reintroduces the LiveImportSeam::flush \
              durability bug this PR's redesign closes (freenet/river#530)"
         );
+        // `!body.contains("return Ok")` alone doesn't catch a conditional
+        // TAIL expression bypassing the real write with no `return` keyword
+        // at all, e.g. `if cond { Ok(()) } else { coalesce_save(...).await }`
+        // — both anchor strings below would still appear, in order, while
+        // the real control flow skips the write (testing-review, round 2).
+        // The correct body is a flat two-statement sequence with no
+        // branching at all, so also require there be no `if` in it.
+        assert!(
+            !body.contains("if "),
+            "save_outbound_dms_to_delegate must be an unconditional sequence \
+             — hydrate, then always save. A conditional here (even one that \
+             still textually mentions both the hydration wait and \
+             coalesce_save) could skip the real write on some branch, \
+             reintroducing the LiveImportSeam::flush durability bug \
+             (freenet/river#530)"
+        );
         let await_hydration = body
             .find("await_outbound_dms_hydration().await")
             .expect("must await the hydration latch");
@@ -7407,6 +7423,18 @@ static OUTBOUND_DMS_HYDRATED: AtomicBool = AtomicBool::new(false);
 /// new user. A LEGACY delegate's response must NOT call this: its data still
 /// needs merging into the current-delegate baseline, and marking hydrated
 /// early would let a save land before that baseline is known.
+///
+/// **Always call this via `crate::util::defer`, never bare/synchronously**
+/// (round-2 skeptical review on PR #670). `handle_outbound_dms_get_response`
+/// registers this AFTER `hydrate_hidden_dm_threads` / `hydrate_outbound_dms_cache`,
+/// whose own signal writes are themselves scheduled via `defer`. Deferring
+/// this call too means it can only run — and the latch can only become
+/// `true` — once those macrotasks have already executed (`setTimeout(0)`
+/// tasks run FIFO). Calling it bare would flip the latch synchronously,
+/// before the merge it depends on has actually landed; a caller resumed via
+/// a MICROTASK (not gated by macrotask FIFO at all) could then observe
+/// `true` and read the signals early, reproducing the #530 truncation bug in
+/// a rarer, timing-dependent form.
 pub(crate) fn mark_outbound_dms_hydrated() {
     OUTBOUND_DMS_HYDRATED.store(true, Ordering::Release);
 }
@@ -7431,6 +7459,18 @@ const OUTBOUND_DMS_HYDRATION_POLL_INTERVAL: std::time::Duration =
 /// silent data loss for the rest of the session (skeptical review on PR
 /// #670): without a bound, every subsequent archive/DM-send would await
 /// forever instead of eventually completing (with a logged warning).
+///
+/// **Accepted residual (skeptical review, round 2):** if the wait genuinely
+/// times out — the `GetResponse` never arrives at all within 15s — the save
+/// that follows IS the original #530 truncation bug, just gated behind a
+/// much rarer trigger (total silence from the delegate for 15s, vs. any
+/// user action landing in a normally-sub-second window). This is a
+/// deliberate trade-off, not an oversight: the alternative (waiting forever)
+/// converts a rare truncation into a certain, permanent, silent no-op for
+/// the rest of the session, which is worse. Closing this residual fully
+/// would mean re-firing `fire_load_outbound_dms_request` on timeout rather
+/// than giving up — out of scope for this fix; tracked as a follow-up
+/// consideration, not a blocking gap.
 const OUTBOUND_DMS_HYDRATION_MAX_POLLS: u32 = 300;
 
 /// Poll `flag` every `interval` (yielding via [`crate::util::sleep`] between

--- a/ui/src/components/app/chat_delegate.rs
+++ b/ui/src/components/app/chat_delegate.rs
@@ -3936,109 +3936,144 @@ mod tests {
     // `HIDDEN_DM_THREADS` haven't merged whatever is already on disk, so a
     // save that races ahead of hydration would persist a truncated view and
     // permanently destroy every entry the in-memory signals don't know about
-    // yet. `save_outbound_dms_to_delegate` now gates on
-    // `OUTBOUND_DMS_HYDRATED` and records a pending save instead;
-    // `mark_outbound_dms_hydrated` (called from the current-delegate
-    // `GetResponse` handler in `response_handler.rs`) drains it once the
-    // disk baseline is known.
+    // yet. `save_outbound_dms_to_delegate` now WAITS for
+    // `OUTBOUND_DMS_HYDRATED` (bounded, so a lost `GetResponse` can't hang
+    // forever) before reading the signals, so `Ok(())` always means the
+    // write was actually attempted — never a silent, unwritten success. That
+    // matters beyond user-triggered saves: `LiveImportSeam::flush` (in
+    // `freenet_api/delegate_migration.rs`) treats `Ok` from this function as
+    // proof of durability before sealing a predecessor as migrated (code-first
+    // review on PR #670) — an early no-op `Ok` there would have reproduced
+    // exactly the "sealed Done over data never saved" bug that file's own
+    // `merge_outbound_dms` comment (lines ~816-837) was written to prevent.
 
     /// Serializes the tests below that mutate the process-global
-    /// `OUTBOUND_DMS_HYDRATED` / `OUTBOUND_DMS_SAVE_PENDING_PRE_HYDRATION`
-    /// statics, mirroring `DEDUP_TEST_LOCK`'s rationale.
+    /// `OUTBOUND_DMS_HYDRATED` static, mirroring `DEDUP_TEST_LOCK`'s
+    /// rationale.
     static OUTBOUND_DMS_HYDRATION_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-    /// A save requested before hydration must be a harmless no-op — it must
-    /// NOT reach `do_save_outbound_dms_to_delegate` (the real network write) —
-    /// and must record that a save is owed, or the mutation it was meant to
-    /// persist is silently lost forever.
+    /// Already-set fast path: no polling, returns essentially immediately.
     #[test]
-    fn outbound_dms_save_defers_before_hydration_and_marks_pending() {
-        let _guard = OUTBOUND_DMS_HYDRATION_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        reset_outbound_dms_hydration_state_for_test();
-
-        let result = futures::executor::block_on(save_outbound_dms_to_delegate());
+    fn await_flag_with_bound_returns_immediately_when_already_set() {
+        static FLAG: AtomicBool = AtomicBool::new(true);
+        let start = std::time::Instant::now();
+        futures::executor::block_on(await_flag_with_bound(
+            &FLAG,
+            std::time::Duration::from_secs(5),
+            1,
+        ));
         assert!(
-            result.is_ok(),
-            "a pre-hydration save must be a harmless no-op, not an error: {:?}",
-            result
+            start.elapsed() < std::time::Duration::from_secs(1),
+            "an already-set flag must not wait a single poll interval"
         );
-        assert!(
-            OUTBOUND_DMS_SAVE_PENDING_PRE_HYDRATION.load(Ordering::SeqCst),
-            "a save requested before hydration must be recorded as owed"
-        );
-
-        reset_outbound_dms_hydration_state_for_test();
     }
 
-    /// Once hydration completes, a save that was deferred pre-hydration must
-    /// be drained — otherwise a user action taken before hydration (e.g.
-    /// archiving a thread) is remembered in memory but never reaches the
-    /// delegate, and the next reload reads the stale disk copy.
+    /// If the flag flips while a wait is in progress, the wait must return as
+    /// soon as it's observed — not sit out the full `max_polls` budget. Proven
+    /// by racing a flipper (no delay) against the waiter (a real, larger poll
+    /// interval + generous max_polls) and asserting the combined wait
+    /// completes far under the full budget.
     #[test]
-    fn mark_hydrated_drains_a_pending_pre_hydration_save() {
-        let _guard = OUTBOUND_DMS_HYDRATION_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        reset_outbound_dms_hydration_state_for_test();
-        OUTBOUND_DMS_SAVE_PENDING_PRE_HYDRATION.store(true, Ordering::SeqCst);
-
-        mark_outbound_dms_hydrated();
-
+    fn await_flag_with_bound_returns_once_flag_set_mid_wait() {
+        static FLAG: AtomicBool = AtomicBool::new(false);
+        FLAG.store(false, Ordering::SeqCst);
+        let start = std::time::Instant::now();
+        let waiter = await_flag_with_bound(&FLAG, std::time::Duration::from_millis(20), 100);
+        let flipper = async {
+            FLAG.store(true, Ordering::SeqCst);
+        };
+        futures::executor::block_on(futures::future::join(waiter, flipper));
         assert!(
-            OUTBOUND_DMS_HYDRATED.load(Ordering::SeqCst),
-            "the hydration latch must be set"
+            start.elapsed() < std::time::Duration::from_millis(200),
+            "must return on the first poll after the flag flips, not exhaust \
+             the full 100*20ms=2s budget: took {:?}",
+            start.elapsed()
         );
-        assert!(
-            !OUTBOUND_DMS_SAVE_PENDING_PRE_HYDRATION.load(Ordering::SeqCst),
-            "the pending flag must be drained so the deferred save doesn't replay twice"
-        );
-
-        reset_outbound_dms_hydration_state_for_test();
     }
 
-    /// Marking hydrated with nothing pending must not schedule a spurious
-    /// save — the common case (no user action before hydration completes).
+    /// A flag that never flips must still return (not hang) once `max_polls`
+    /// is exhausted — the whole point of bounding the wait.
     #[test]
-    fn mark_hydrated_is_a_noop_when_nothing_is_pending() {
+    fn await_flag_with_bound_gives_up_after_max_polls_when_never_set() {
+        static FLAG: AtomicBool = AtomicBool::new(false);
+        FLAG.store(false, Ordering::SeqCst);
+        // Small bound so the test itself stays fast; the production bound
+        // (300 * 50ms = 15s) is a separate, deliberate constant.
+        futures::executor::block_on(await_flag_with_bound(
+            &FLAG,
+            std::time::Duration::from_millis(1),
+            3,
+        ));
+        assert!(
+            !FLAG.load(Ordering::SeqCst),
+            "sanity: this test doesn't set the flag"
+        );
+        // Reaching this point at all is the assertion — a bug that removed
+        // the `max_polls` bound would hang the test instead of failing it.
+    }
+
+    /// `mark_outbound_dms_hydrated` sets the latch.
+    #[test]
+    fn mark_outbound_dms_hydrated_sets_the_latch() {
         let _guard = OUTBOUND_DMS_HYDRATION_TEST_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         reset_outbound_dms_hydration_state_for_test();
 
         mark_outbound_dms_hydrated();
-
         assert!(OUTBOUND_DMS_HYDRATED.load(Ordering::SeqCst));
-        assert!(!OUTBOUND_DMS_SAVE_PENDING_PRE_HYDRATION.load(Ordering::SeqCst));
 
         reset_outbound_dms_hydration_state_for_test();
     }
 
-    /// Source-order pin: the hydration check inside
-    /// `save_outbound_dms_to_delegate` must run BEFORE the `coalesce_save`
-    /// call that reaches the real network write. Without this ordering a
-    /// pre-hydration caller could still fall through to the delegate write
-    /// this issue is about. (The end-to-end network path isn't
-    /// unit-testable off-WASM — see the `WEB_API` note elsewhere in this
-    /// file — so this pins the guard's position in the source instead.)
+    /// Source-order pin: `save_outbound_dms_to_delegate` must (a) have NO
+    /// early-return shortcut — `Ok(())` must always mean the write was
+    /// attempted, never a silent no-op — and (b) await hydration BEFORE
+    /// calling `coalesce_save`, the real write path. (The end-to-end
+    /// behavior isn't unit-testable off-WASM: `do_save_outbound_dms_to_delegate`
+    /// reads `OUTBOUND_DMS`/`HIDDEN_DM_THREADS` `GlobalSignal`s, which panic
+    /// with "Must be called from inside a Dioxus runtime" outside one — see
+    /// the `WEB_API` unit-testability note elsewhere in this file for the
+    /// same limitation on the network side.)
     #[test]
-    fn outbound_dms_save_checks_hydration_before_coalescing() {
+    fn outbound_dms_save_awaits_hydration_unconditionally_before_coalescing() {
         let src = include_str!("chat_delegate.rs");
+        // The needle is assembled at runtime so this test's own source does
+        // NOT contain the contiguous signature string (else `find` would
+        // match this test's own needle literal, being earlier in the file,
+        // instead of the real function — see `late_dm_hydration_persists_sanitized_store`
+        // for the same pattern).
+        let signature = format!(
+            "pub async fn {}() -> Result<(), String> {{",
+            "save_outbound_dms_to_delegate"
+        );
         let fn_start = src
-            .find("pub async fn save_outbound_dms_to_delegate")
+            .find(&signature)
             .expect("save_outbound_dms_to_delegate must exist");
-        let body = &src[fn_start..];
-        let hydrated_check = body
-            .find("OUTBOUND_DMS_HYDRATED.load")
-            .expect("must check the hydration latch");
-        let coalesce_call = body
-            .find("&OUTBOUND_DMS_SAVE_STATE")
-            .expect("must still coalesce the real save once hydrated");
+        let after = &src[fn_start..];
+        // The function body is short; its closing brace is the first
+        // column-0 `}` after the opening one.
+        let fn_end = after
+            .find("\n}\n")
+            .map(|i| i + "\n}\n".len())
+            .expect("function must have a closing brace");
+        let body = &after[..fn_end];
         assert!(
-            hydrated_check < coalesce_call,
-            "the hydration check must run BEFORE coalesce_save, or a \
-             pre-hydration caller could still reach the network write"
+            !body.contains("return Ok"),
+            "save_outbound_dms_to_delegate must not have an early-return \
+             shortcut — an early Ok(()) reintroduces the LiveImportSeam::flush \
+             durability bug this PR's redesign closes (freenet/river#530)"
+        );
+        let await_hydration = body
+            .find("await_outbound_dms_hydration().await")
+            .expect("must await the hydration latch");
+        let coalesce_call = body
+            .find("coalesce_save(")
+            .expect("must still coalesce the real save");
+        assert!(
+            await_hydration < coalesce_call,
+            "the hydration wait must run BEFORE coalesce_save, or a \
+             pre-hydration caller could still reach the network write early"
         );
     }
 
@@ -7363,13 +7398,7 @@ static OUTBOUND_DMS_SAVE_STATE: CoalesceState = CoalesceState::new();
 /// every archive/plaintext entry the in-memory signals don't know about yet).
 static OUTBOUND_DMS_HYDRATED: AtomicBool = AtomicBool::new(false);
 
-/// Set by [`save_outbound_dms_to_delegate`] when a save was requested before
-/// hydration completed, so [`mark_outbound_dms_hydrated`] can replay it once
-/// the disk baseline is known. freenet/river#530.
-static OUTBOUND_DMS_SAVE_PENDING_PRE_HYDRATION: AtomicBool = AtomicBool::new(false);
-
-/// Mark the outbound-DM store hydrated from the CURRENT delegate, and replay
-/// any save that [`save_outbound_dms_to_delegate`] deferred while waiting
+/// Mark the outbound-DM store hydrated from the CURRENT delegate
 /// (freenet/river#530).
 ///
 /// Call exactly once per session, from the CURRENT (non-legacy) delegate's
@@ -7380,17 +7409,6 @@ static OUTBOUND_DMS_SAVE_PENDING_PRE_HYDRATION: AtomicBool = AtomicBool::new(fal
 /// early would let a save land before that baseline is known.
 pub(crate) fn mark_outbound_dms_hydrated() {
     OUTBOUND_DMS_HYDRATED.store(true, Ordering::Release);
-    if OUTBOUND_DMS_SAVE_PENDING_PRE_HYDRATION.swap(false, Ordering::AcqRel) {
-        info!("Replaying outbound-DM save that was deferred pending hydration (freenet/river#530)");
-        crate::util::safe_spawn_local(async {
-            if let Err(e) = save_outbound_dms_to_delegate().await {
-                warn!(
-                    "Failed to persist outbound-DM save deferred pending hydration: {}",
-                    e
-                );
-            }
-        });
-    }
 }
 
 /// Reset the hydration latch. For tests only; production sets it exactly
@@ -7398,7 +7416,57 @@ pub(crate) fn mark_outbound_dms_hydrated() {
 #[cfg(test)]
 pub(crate) fn reset_outbound_dms_hydration_state_for_test() {
     OUTBOUND_DMS_HYDRATED.store(false, Ordering::SeqCst);
-    OUTBOUND_DMS_SAVE_PENDING_PRE_HYDRATION.store(false, Ordering::SeqCst);
+}
+
+/// Interval between hydration-latch polls in [`await_flag_with_bound`].
+const OUTBOUND_DMS_HYDRATION_POLL_INTERVAL: std::time::Duration =
+    std::time::Duration::from_millis(50);
+
+/// How many times [`save_outbound_dms_to_delegate`] polls for hydration before
+/// giving up and proceeding anyway (freenet/river#530). `50ms * 300 == 15s`:
+/// the delegate is local (the room-load round-trip caps itself at 10s in
+/// [`await_delegate_response_outcome`]), so this is a generous margin for the
+/// rare case where the initial `GetResponse` is lost or badly delayed.
+/// Bounding it is what stops a lost response from turning into permanent
+/// silent data loss for the rest of the session (skeptical review on PR
+/// #670): without a bound, every subsequent archive/DM-send would await
+/// forever instead of eventually completing (with a logged warning).
+const OUTBOUND_DMS_HYDRATION_MAX_POLLS: u32 = 300;
+
+/// Poll `flag` every `interval` (yielding via [`crate::util::sleep`] between
+/// checks) until it is `true` or `max_polls` checks have elapsed, whichever
+/// comes first. Returns once either condition is met — never hangs.
+///
+/// Extracted as a pure/generic helper (rather than inlined into
+/// [`save_outbound_dms_to_delegate`]) so it's unit-testable with small,
+/// fast intervals instead of the real 15s production bound.
+async fn await_flag_with_bound(flag: &AtomicBool, interval: std::time::Duration, max_polls: u32) {
+    if flag.load(Ordering::Acquire) {
+        return;
+    }
+    for _ in 0..max_polls {
+        crate::util::sleep(interval).await;
+        if flag.load(Ordering::Acquire) {
+            return;
+        }
+    }
+    warn!(
+        "Outbound-DMs hydration wait timed out after {} polls — proceeding with the save \
+         anyway using whatever state is currently in memory (freenet/river#530)",
+        max_polls
+    );
+}
+
+/// Wait for [`OUTBOUND_DMS_HYDRATED`], bounded by
+/// [`OUTBOUND_DMS_HYDRATION_MAX_POLLS`] so a lost `GetResponse` can't hang
+/// forever. See [`await_flag_with_bound`].
+async fn await_outbound_dms_hydration() {
+    await_flag_with_bound(
+        &OUTBOUND_DMS_HYDRATED,
+        OUTBOUND_DMS_HYDRATION_POLL_INTERVAL,
+        OUTBOUND_DMS_HYDRATION_MAX_POLLS,
+    )
+    .await
 }
 
 /// Serialize the current [`OUTBOUND_DMS`] cache and persist it via the
@@ -7407,14 +7475,17 @@ pub(crate) fn reset_outbound_dms_hydration_state_for_test() {
 /// the StoreResponse comes back through the normal message loop and is
 /// logged but not awaited on the hot path.
 ///
-/// **Defers until hydration completes (freenet/river#530).** Before the
+/// **Waits for hydration to complete first (freenet/river#530).** Before the
 /// CURRENT delegate's `OUTBOUND_DMS_STORAGE_KEY` `GetResponse` has been
 /// processed, `OUTBOUND_DMS`/`HIDDEN_DM_THREADS` may not yet reflect
 /// whatever is already persisted. Writing now would publish a truncated
 /// snapshot that permanently overwrites the disk copy — the mechanism
-/// behind the #530 archive/plaintext loss. Instead, record that a save is
-/// owed; [`mark_outbound_dms_hydrated`] replays it once the baseline is
-/// known, so the eventual write is over the fully-merged state.
+/// behind the #530 archive/plaintext loss. `Ok(())` from this function always
+/// means the delegate write was actually attempted (and, barring a
+/// transport error, completed) — callers that depend on that durability
+/// contract (e.g. the crate-migration walk's `LiveImportSeam::flush`, which
+/// seals a predecessor as migrated on `Ok`) are not lied to by an early,
+/// unwritten return.
 ///
 /// Coalesced via [`coalesce_save`] (was a hand-rolled copy of the same
 /// pattern until freenet/river#246 extracted the primitive): a chain
@@ -7423,11 +7494,7 @@ pub(crate) fn reset_outbound_dms_hydration_state_for_test() {
 /// authoritative result of the catch-up save that covered its
 /// mutation.
 pub async fn save_outbound_dms_to_delegate() -> Result<(), String> {
-    if !OUTBOUND_DMS_HYDRATED.load(Ordering::Acquire) {
-        OUTBOUND_DMS_SAVE_PENDING_PRE_HYDRATION.store(true, Ordering::Release);
-        info!("Outbound-DMs save deferred until delegate hydration completes (freenet/river#530)");
-        return Ok(());
-    }
+    await_outbound_dms_hydration().await;
     coalesce_save(
         &OUTBOUND_DMS_SAVE_STATE,
         "Outbound-DMs",

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -18,9 +18,9 @@ use crate::components::app::chat_delegate::{
     fire_legacy_migration_request, hydrate_hidden_dm_threads, hydrate_outbound_dms_cache,
     is_legacy_delegate_key, is_legacy_migration_in_progress, legacy_scoped_correlation,
     load_state_after_probe_legacy, mark_legacy_migration_done, mark_legacy_migration_in_progress,
-    parse_room_storage_key, per_room_terminal, prune_outbound_dms_for_purges,
-    request_legacy_seal_on_quiescence, response_correlation_base, room_storage_key,
-    save_outbound_dms_to_delegate, save_rooms_to_delegate, send_delegate_request,
+    mark_outbound_dms_hydrated, parse_room_storage_key, per_room_terminal,
+    prune_outbound_dms_for_purges, request_legacy_seal_on_quiescence, response_correlation_base,
+    room_storage_key, save_outbound_dms_to_delegate, save_rooms_to_delegate, send_delegate_request,
     send_delegate_request_to, set_load_state_if_current, source_rank_for_delegate_key,
     LegacyMigrationAction, LoadWorkerGuard, PendingDelegateRequest, RoomsLoadState,
     OUTBOUND_DMS_STORAGE_KEY, ROOMS_META_KEY, ROOMS_STORAGE_KEY,
@@ -2012,6 +2012,17 @@ fn hydrate_loaded_rooms_with_authority(
 /// serialized `OutboundDmStore`, and — when the response came from a
 /// legacy delegate — schedules a save so the migrated entries land
 /// under the current delegate's key.
+///
+/// **Marks the hydration latch for the CURRENT delegate (freenet/river#530).**
+/// Every return path for `!is_legacy_delegate` calls
+/// [`mark_outbound_dms_hydrated`] — including "no blob" (an empty disk is
+/// still an authoritative baseline for a new user) and a deserialize failure
+/// (the blob is unreadable either way; the alternative is a save path stuck
+/// deferring forever). The call sits AFTER `hydrate_hidden_dm_threads` /
+/// `hydrate_outbound_dms_cache` in the `Ok` branch so the `setTimeout(0)`
+/// macrotask it may schedule (replaying a save deferred pre-hydration) is
+/// enqueued FIFO-after theirs, and therefore runs after their own deferred
+/// signal writes have landed — see `mark_outbound_dms_hydrated`'s doc.
 fn handle_outbound_dms_get_response(value: Option<Vec<u8>>, is_legacy_delegate: bool) {
     let Some(bytes) = value else {
         info!(
@@ -2022,6 +2033,9 @@ fn handle_outbound_dms_get_response(value: Option<Vec<u8>>, is_legacy_delegate: 
                 "current"
             }
         );
+        if !is_legacy_delegate {
+            mark_outbound_dms_hydrated();
+        }
         return;
     };
 
@@ -2039,6 +2053,9 @@ fn handle_outbound_dms_get_response(value: Option<Vec<u8>>, is_legacy_delegate: 
                     "current"
                 }
             );
+            if !is_legacy_delegate {
+                mark_outbound_dms_hydrated();
+            }
             if is_legacy_delegate && (count > 0 || hidden_count > 0) {
                 // Persist the merged cache under the current delegate
                 // key so subsequent loads find the data without
@@ -2072,6 +2089,9 @@ fn handle_outbound_dms_get_response(value: Option<Vec<u8>>, is_legacy_delegate: 
         }
         Err(e) => {
             error!("Failed to deserialize outbound-DMs blob: {}", e);
+            if !is_legacy_delegate {
+                mark_outbound_dms_hydrated();
+            }
         }
     }
 }
@@ -2473,6 +2493,24 @@ mod tests {
         assert!(
             prod.contains("Failed to deserialize chat delegate response \\\n"),
             "the deser-failure log should carry a hex head"
+        );
+    }
+
+    /// freenet/river#530: `handle_outbound_dms_get_response` must mark the
+    /// hydration latch on EVERY return path for the CURRENT (non-legacy)
+    /// delegate — no blob present, a successfully parsed blob, and a
+    /// deserialize failure. Missing any one of these leaves
+    /// `save_outbound_dms_to_delegate` stuck deferring forever for that
+    /// session, silently dropping every subsequent archive/DM-send.
+    #[test]
+    fn outbound_dms_hydration_latch_is_marked_on_every_current_delegate_return_path() {
+        let src = include_str!("response_handler.rs");
+        let prod = src.split("mod tests {").next().unwrap_or(src);
+        assert_eq!(
+            prod.matches("mark_outbound_dms_hydrated();").count(),
+            3,
+            "handle_outbound_dms_get_response must call mark_outbound_dms_hydrated() \
+             exactly 3 times: no-blob, parsed-ok, and parse-failure"
         );
     }
 

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -2014,20 +2014,36 @@ fn hydrate_loaded_rooms_with_authority(
 /// under the current delegate's key.
 ///
 /// **Marks the hydration latch for the CURRENT delegate (freenet/river#530).**
-/// Every return path for `!is_legacy_delegate` calls
-/// [`mark_outbound_dms_hydrated`] — including "no blob" (an empty disk is
-/// still an authoritative baseline for a new user) and a deserialize failure
-/// (the blob is unreadable either way; the alternative is a save path stuck
-/// waiting forever). `save_outbound_dms_to_delegate` polls this latch with a
-/// real yield between checks (see `await_flag_with_bound`), so any caller
-/// that observes the latch flip has necessarily yielded back to the event
-/// loop at least once first — by which point this function's own
-/// `hydrate_hidden_dm_threads` / `hydrate_outbound_dms_cache` calls (issued
-/// synchronously, earlier in this same call) have already had their
-/// deferred signal writes run. The exact position of the `mark_outbound_dms_hydrated`
-/// call relative to those two calls is therefore NOT load-bearing — only
-/// that all three happen within this one synchronous invocation, which they
-/// do.
+/// Every return path for `!is_legacy_delegate` schedules
+/// [`mark_outbound_dms_hydrated`] via [`crate::util::defer`] — including
+/// "no blob" (an empty disk is still an authoritative baseline for a new
+/// user) and a deserialize failure (the blob is unreadable either way; the
+/// alternative is a save path stuck waiting forever).
+///
+/// **Why deferred, not called synchronously (skeptical review, round 2 on PR
+/// #670).** An earlier version set the latch SYNCHRONOUSLY here, reasoning
+/// that any caller checking it would necessarily do so only after yielding
+/// back to the event loop, by which point this function's own
+/// `hydrate_hidden_dm_threads` / `hydrate_outbound_dms_cache` calls (which
+/// only SCHEDULE their real signal writes via their own `defer`, rather than
+/// performing them inline) would have already run. That reasoning was
+/// unsound: "yielded back to the event loop" does not imply "after every
+/// already-scheduled MACROTASK" — a caller resumed via a MICROTASK (e.g. a
+/// `LiveImportSeam::flush` continuation already suspended on an `.await`)
+/// could observe the latch as `true` and read the signals before the merge
+/// macrotasks had actually executed, reproducing #530 in a rarer,
+/// timing-dependent form. Deferring the latch flip itself into its own
+/// macrotask fixes this structurally: since it is `defer()`-ed AFTER
+/// `hydrate_hidden_dm_threads` / `hydrate_outbound_dms_cache` in the `Ok`
+/// branch, `setTimeout(0)` macrotasks run FIFO, so this macrotask cannot
+/// execute — and therefore the latch cannot become `true` — until AFTER
+/// those two have already run their merges. No caller, microtask- or
+/// macrotask-scheduled, can observe `true` before the merge has happened,
+/// because the merge is a precondition of the flip existing at all. The
+/// "no blob" / parse-failure branches defer for the same reason, uniformly,
+/// even though they have no merge to wait for — so the invariant "the latch
+/// is only ever flipped from inside a deferred macrotask" holds without a
+/// branch-specific exception to remember.
 fn handle_outbound_dms_get_response(value: Option<Vec<u8>>, is_legacy_delegate: bool) {
     let Some(bytes) = value else {
         info!(
@@ -2039,7 +2055,7 @@ fn handle_outbound_dms_get_response(value: Option<Vec<u8>>, is_legacy_delegate: 
             }
         );
         if !is_legacy_delegate {
-            mark_outbound_dms_hydrated();
+            crate::util::defer(mark_outbound_dms_hydrated);
         }
         return;
     };
@@ -2059,7 +2075,7 @@ fn handle_outbound_dms_get_response(value: Option<Vec<u8>>, is_legacy_delegate: 
                 }
             );
             if !is_legacy_delegate {
-                mark_outbound_dms_hydrated();
+                crate::util::defer(mark_outbound_dms_hydrated);
             }
             if is_legacy_delegate && (count > 0 || hidden_count > 0) {
                 // Persist the merged cache under the current delegate
@@ -2095,7 +2111,7 @@ fn handle_outbound_dms_get_response(value: Option<Vec<u8>>, is_legacy_delegate: 
         Err(e) => {
             error!("Failed to deserialize outbound-DMs blob: {}", e);
             if !is_legacy_delegate {
-                mark_outbound_dms_hydrated();
+                crate::util::defer(mark_outbound_dms_hydrated);
             }
         }
     }
@@ -2501,8 +2517,8 @@ mod tests {
         );
     }
 
-    /// freenet/river#530: `handle_outbound_dms_get_response` must mark the
-    /// hydration latch on EVERY return path for the CURRENT (non-legacy)
+    /// freenet/river#530: `handle_outbound_dms_get_response` must schedule the
+    /// hydration latch flip on EVERY return path for the CURRENT (non-legacy)
     /// delegate — no blob present, a successfully parsed blob, and a
     /// deserialize failure — and NEVER for a legacy delegate's response
     /// (whose data still needs merging into the current baseline first; see
@@ -2510,20 +2526,42 @@ mod tests {
     /// tell "gated by `!is_legacy_delegate`" apart from "gated the wrong way
     /// / not gated at all" — inverting or deleting the guard leaves the count
     /// at 3 either way — so this additionally requires each call to be
-    /// immediately preceded by the guard.
+    /// immediately preceded by the guard. Known limitation (testing-review,
+    /// round 2): this is a text scan, not a parser — it does not strip
+    /// comments, so a guard reduced to `// if !is_legacy_delegate {` would
+    /// still satisfy it. Accepted: that shape is not idiomatic Rust and
+    /// would itself look wrong on any human read of the diff.
+    ///
+    /// Also pins the round-2 skeptical-review fix: the latch must be flipped
+    /// from WITHIN a deferred macrotask (`crate::util::defer(mark_outbound_dms_hydrated)`),
+    /// never called bare/synchronously — a bare synchronous call let a
+    /// microtask-scheduled caller (e.g. `LiveImportSeam::flush`) observe the
+    /// latch as `true` before `hydrate_hidden_dm_threads` /
+    /// `hydrate_outbound_dms_cache`'s own deferred merges had actually run,
+    /// reproducing #530 in a rarer, timing-dependent form.
     #[test]
     fn outbound_dms_hydration_latch_is_marked_on_every_current_delegate_return_path() {
         let src = include_str!("response_handler.rs");
         let prod = src.split("mod tests {").next().unwrap_or(src);
+        let deferred_call = "crate::util::defer(mark_outbound_dms_hydrated);";
         assert_eq!(
-            prod.matches("mark_outbound_dms_hydrated();").count(),
+            prod.matches(deferred_call).count(),
             3,
-            "handle_outbound_dms_get_response must call mark_outbound_dms_hydrated() \
-             exactly 3 times: no-blob, parsed-ok, and parse-failure"
+            "handle_outbound_dms_get_response must schedule mark_outbound_dms_hydrated() \
+             via crate::util::defer exactly 3 times: no-blob, parsed-ok, and \
+             parse-failure"
+        );
+        assert!(
+            !prod.contains("mark_outbound_dms_hydrated();"),
+            "mark_outbound_dms_hydrated must never be called bare/synchronously \
+             in this file — it must always be scheduled via crate::util::defer, \
+             or a microtask-scheduled caller could observe the latch flip \
+             before the merge it depends on has actually run (round-2 \
+             skeptical review, freenet/river#530)"
         );
         let guarded = "if !is_legacy_delegate {";
         let guarded_call_count = prod
-            .match_indices("mark_outbound_dms_hydrated();")
+            .match_indices(deferred_call)
             .filter(|(idx, _)| {
                 // The guard's `{` must be the nearest preceding `{` — i.e. no
                 // OTHER brace opens in between — so this can't be fooled by
@@ -2537,10 +2575,10 @@ mod tests {
             .count();
         assert_eq!(
             guarded_call_count, 3,
-            "every mark_outbound_dms_hydrated() call must be the first statement \
-             inside an `if !is_legacy_delegate {{` block — a flipped or missing \
-             guard would let a legacy delegate's response mark hydration early \
-             and reintroduce the #530 truncation bug"
+            "every deferred mark_outbound_dms_hydrated scheduling must be the \
+             first statement inside an `if !is_legacy_delegate {{` block — a \
+             flipped or missing guard would let a legacy delegate's response \
+             mark hydration early and reintroduce the #530 truncation bug"
         );
     }
 

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -2580,6 +2580,42 @@ mod tests {
              flipped or missing guard would let a legacy delegate's response \
              mark hydration early and reintroduce the #530 truncation bug"
         );
+
+        // Round-3 skeptical + big-picture review: the three checks above
+        // don't verify RELATIVE order within the `Ok` arm — a future edit
+        // that hoists the `if !is_legacy_delegate { defer(...) }` block
+        // above the two `hydrate_*` calls (e.g. "for readability") would
+        // pass every check above unchanged while reintroducing the round-2
+        // race, because `defer()`'s macrotask would then be registered
+        // BEFORE the merges' own macrotasks rather than after. Scope this
+        // to just the `Ok` arm (between "Ok(store) => {" and "Err(e) => {")
+        // since that's the only branch with merges to order against.
+        let ok_arm_start = prod
+            .find("Ok(store) => {")
+            .expect("the parsed-blob match arm must exist");
+        let ok_arm_end = prod[ok_arm_start..]
+            .find("Err(e) => {")
+            .map(|i| ok_arm_start + i)
+            .expect("the match must have an Err arm");
+        let ok_arm = &prod[ok_arm_start..ok_arm_end];
+        let hidden_pos = ok_arm
+            .find("hydrate_hidden_dm_threads(")
+            .expect("Ok arm must hydrate hidden threads");
+        let outbound_pos = ok_arm
+            .find("hydrate_outbound_dms_cache(")
+            .expect("Ok arm must hydrate the outbound cache");
+        let defer_pos = ok_arm
+            .find(deferred_call)
+            .expect("Ok arm must defer-mark hydration");
+        assert!(
+            hidden_pos < defer_pos && outbound_pos < defer_pos,
+            "in the Ok arm, both hydrate_hidden_dm_threads and \
+             hydrate_outbound_dms_cache must be called BEFORE \
+             crate::util::defer(mark_outbound_dms_hydrated) — the fix's \
+             correctness depends on setTimeout(0) FIFO ordering registering \
+             their merge macrotasks ahead of the latch-flip macrotask \
+             (round-3 skeptical review, freenet/river#530)"
+        );
     }
 
     use super::*;

--- a/ui/src/components/app/freenet_api/response_handler.rs
+++ b/ui/src/components/app/freenet_api/response_handler.rs
@@ -2018,11 +2018,16 @@ fn hydrate_loaded_rooms_with_authority(
 /// [`mark_outbound_dms_hydrated`] — including "no blob" (an empty disk is
 /// still an authoritative baseline for a new user) and a deserialize failure
 /// (the blob is unreadable either way; the alternative is a save path stuck
-/// deferring forever). The call sits AFTER `hydrate_hidden_dm_threads` /
-/// `hydrate_outbound_dms_cache` in the `Ok` branch so the `setTimeout(0)`
-/// macrotask it may schedule (replaying a save deferred pre-hydration) is
-/// enqueued FIFO-after theirs, and therefore runs after their own deferred
-/// signal writes have landed — see `mark_outbound_dms_hydrated`'s doc.
+/// waiting forever). `save_outbound_dms_to_delegate` polls this latch with a
+/// real yield between checks (see `await_flag_with_bound`), so any caller
+/// that observes the latch flip has necessarily yielded back to the event
+/// loop at least once first — by which point this function's own
+/// `hydrate_hidden_dm_threads` / `hydrate_outbound_dms_cache` calls (issued
+/// synchronously, earlier in this same call) have already had their
+/// deferred signal writes run. The exact position of the `mark_outbound_dms_hydrated`
+/// call relative to those two calls is therefore NOT load-bearing — only
+/// that all three happen within this one synchronous invocation, which they
+/// do.
 fn handle_outbound_dms_get_response(value: Option<Vec<u8>>, is_legacy_delegate: bool) {
     let Some(bytes) = value else {
         info!(
@@ -2499,9 +2504,13 @@ mod tests {
     /// freenet/river#530: `handle_outbound_dms_get_response` must mark the
     /// hydration latch on EVERY return path for the CURRENT (non-legacy)
     /// delegate — no blob present, a successfully parsed blob, and a
-    /// deserialize failure. Missing any one of these leaves
-    /// `save_outbound_dms_to_delegate` stuck deferring forever for that
-    /// session, silently dropping every subsequent archive/DM-send.
+    /// deserialize failure — and NEVER for a legacy delegate's response
+    /// (whose data still needs merging into the current baseline first; see
+    /// `mark_outbound_dms_hydrated`'s doc). A plain call-count check can't
+    /// tell "gated by `!is_legacy_delegate`" apart from "gated the wrong way
+    /// / not gated at all" — inverting or deleting the guard leaves the count
+    /// at 3 either way — so this additionally requires each call to be
+    /// immediately preceded by the guard.
     #[test]
     fn outbound_dms_hydration_latch_is_marked_on_every_current_delegate_return_path() {
         let src = include_str!("response_handler.rs");
@@ -2511,6 +2520,27 @@ mod tests {
             3,
             "handle_outbound_dms_get_response must call mark_outbound_dms_hydrated() \
              exactly 3 times: no-blob, parsed-ok, and parse-failure"
+        );
+        let guarded = "if !is_legacy_delegate {";
+        let guarded_call_count = prod
+            .match_indices("mark_outbound_dms_hydrated();")
+            .filter(|(idx, _)| {
+                // The guard's `{` must be the nearest preceding `{` — i.e. no
+                // OTHER brace opens in between — so this can't be fooled by
+                // an unrelated `if !is_legacy_delegate {` earlier in the file
+                // whose block contains unrelated code before our call.
+                let before = &prod[..*idx];
+                let guard_brace_pos = before.rfind(guarded).map(|p| p + guarded.len() - 1);
+                let last_brace_pos = before.rfind('{');
+                matches!((guard_brace_pos, last_brace_pos), (Some(a), Some(b)) if a == b)
+            })
+            .count();
+        assert_eq!(
+            guarded_call_count, 3,
+            "every mark_outbound_dms_hydrated() call must be the first statement \
+             inside an `if !is_legacy_delegate {{` block — a flipped or missing \
+             guard would let a legacy delegate's response mark hydration early \
+             and reintroduce the #530 truncation bug"
         );
     }
 


### PR DESCRIPTION
## Problem

`do_save_outbound_dms_to_delegate` serialises the **entire current**
`HIDDEN_DM_THREADS` and `OUTBOUND_DMS` signals into a full-overwrite
`StoreRequest`, with no guard that those signals have finished hydrating
from the delegate. On cold start both signals are empty until the
`OUTBOUND_DMS_STORAGE_KEY` `GetResponse` from the current delegate lands.

Any of the three user-initiated saves (`hide_dm_thread`, `unhide_dm_thread`,
`save_outbound_dm`) reachable before that response arrives persists a
truncated blob, permanently destroying every archive entry and cached
outbound-DM plaintext that hadn't loaded yet.

## Approach

**Final design (after two review-driven redesigns — see the review comments
below for what changed and why):**

`save_outbound_dms_to_delegate` now unconditionally **awaits** a hydration
latch (`OUTBOUND_DMS_HYDRATED`) before proceeding to the real coalesced
save — there is no early-return path. The wait is bounded
(`await_flag_with_bound`, polling every 50ms up to 300 times / 15s) so a
lost `GetResponse` degrades to a bounded wait (logged) instead of hanging
forever. `Ok(())` from this function therefore always means the write was
genuinely attempted — this matters beyond user-triggered saves:
`LiveImportSeam::flush` (`freenet_api/delegate_migration.rs`) treats `Ok`
from this function as proof of durability before sealing a crate-migration
predecessor as done, so an early no-op `Ok` would have silently broken that
contract too.

The CURRENT (non-legacy) delegate's `OUTBOUND_DMS_STORAGE_KEY`
`GetResponse` handler (`handle_outbound_dms_get_response` in
`response_handler.rs`) sets the latch via `mark_outbound_dms_hydrated()` on
every return path (no blob, parsed OK, parse failure) — always scheduled
via `crate::util::defer`, never called synchronously, so the latch can only
flip to `true` AFTER `hydrate_hidden_dm_threads` / `hydrate_outbound_dms_cache`'s
own deferred signal merges have actually run (macrotask FIFO ordering
guarantees the ordering). A LEGACY delegate's response never sets the
latch — its data still needs merging into the current baseline first.

I also checked whether the same full-overwrite shape exists for the
per-room `room:<vk>` saves (as the issue suggested). It doesn't: those go
through a per-key read-merge-write CAS (`do_save_rooms_to_delegate`), so a
save before a room's own state is loaded simply never touches that room's
key rather than truncating a shared blob. No changes needed there.

## Testing

- `await_flag_with_bound_returns_immediately_when_already_set` /
  `_returns_once_flag_set_mid_wait` / `_gives_up_after_max_polls_when_never_set`:
  the generic bounded-poll primitive, with small/fast test parameters.
- `mark_outbound_dms_hydrated_sets_the_latch`: the latch itself.
- `outbound_dms_save_awaits_hydration_unconditionally_before_coalescing`:
  source-order pin that `save_outbound_dms_to_delegate` has no early-return
  or conditional bypass and awaits hydration before the real network call
  (the actual delegate I/O isn't unit-testable off-WASM — no `WEB_API` /
  Dioxus runtime in native tests).
- `outbound_dms_hydration_latch_is_marked_on_every_current_delegate_return_path`:
  pins that the latch is scheduled via `crate::util::defer` (never called
  bare/synchronously) on exactly the 3 CURRENT-delegate return paths, each
  gated by `!is_legacy_delegate`.

`cargo test -p river-ui --bins`: 946 passed, 0 failed.
`cargo fmt` / `cargo clippy -p river-ui --bins --tests`: clean (no new
warnings in the touched files).

Only `ui/` files changed — no delegate/contract WASM touched, no migration
needed.

## Review

Full-tier multi-perspective review ran across three rounds as the design
was hardened in response to findings — see the review comments on this PR
for the detailed history. External model (`codex review`) was unavailable
(usage limit, resets 2026-09-07) after one retry; substituted with four
parallel Claude reviewer lenses (code-first, testing, skeptical,
big-picture) per the project's review-fallback policy, each round.

Closes freenet/river#530

[AI-assisted - Claude]
