### PR TITLE
fix(cli): follow a mid-run room-contract re-key instead of going silently deaf

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -18,6 +18,24 @@ All notable changes to riverctl will be documented in this file.
   on anything written during the gap. Reads follow the move even when the new
   generation is one this riverctl is too old to write to. (freenet/river#694)
 
+  Details worth knowing if you run a bot:
+  - The catch-up fetch runs after **every** refresh, not only after a re-key,
+    because the pointer GET shares the node connection with the subscription and
+    steps over (discarding) frames while it waits for its own answer. One of
+    those can be an update notification for the room being streamed.
+  - A re-SUBSCRIBE the node will not yet accept is **not** fatal. The node most
+    likely to refuse is one that does not hold the newly-published generation
+    yet, so riverctl retries every 30s and keeps polling meanwhile rather than
+    exiting.
+  - Only a signature-verified pointer record can move a stream. A refresh that
+    merely timed out can name a different hash (the fallback is whatever was
+    last persisted, or the bundled one), and acting on that would announce a
+    re-key that never happened and re-subscribe to a retired generation.
+  - A signed **withdrawal** of the pointer record ends the stream, rather than
+    being swallowed as a transient failure like every other resolution error.
+  - The interval carries ±20% jitter, so a fleet of bots started together does
+    not hit the network in one synchronised burst after a re-key.
+
 ## [0.2.15] - 2026-09-06
 
 ### Fixed

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -27,10 +27,16 @@ All notable changes to riverctl will be documented in this file.
     likely to refuse is one that does not hold the newly-published generation
     yet, so riverctl retries every 30s and keeps polling meanwhile rather than
     exiting.
-  - Only a signature-verified pointer record can move a stream. A refresh that
-    merely timed out can name a different hash (the fallback is whatever was
-    last persisted, or the bundled one), and acting on that would announce a
-    re-key that never happened and re-subscribe to a retired generation.
+  - A stream moves only when the move is both **evidenced and actionable**. A
+    refresh that merely timed out can name a different hash, and acting on that
+    would announce a re-key that never happened and re-subscribe to a retired
+    generation. And a *verified* re-key to a generation this riverctl does not
+    know is reported but **not** followed: the new key holds nothing this binary
+    can reach (the backward probe will not search from a generation it does not
+    know, and writing is refused), so following it would trade a subscription
+    that is still delivering for a key it cannot act on — leaving the stream
+    silent on both. In that case riverctl stays where the data is and tells you
+    to run `cargo install riverctl --force`.
   - A signed **withdrawal** of the pointer record ends the stream, rather than
     being swallowed as a transient failure like every other resolution error.
   - The interval carries ±20% jitter, so a fleet of bots started together does

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to riverctl will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- `message stream` (both `--subscribe` and polling modes) now re-checks River's
+  room-contract pointer every five minutes instead of once at startup, and
+  follows a re-key while running. Previously a long-running bot resolved the
+  pointer once, stayed bound to the retired contract for the life of the
+  process, and went silently deaf: the node has nothing left to send for a
+  generation nobody writes to, and a poll against the retired contract still
+  succeeds because that contract still exists. Neither mode surfaced any error,
+  so the only symptom was a busy room appearing to go quiet, and the only fix
+  was restarting the bot. On a re-key the subscription now re-subscribes to the
+  new generation, prints a stderr notice naming both generations, and catches up
+  on anything written during the gap. Reads follow the move even when the new
+  generation is one this riverctl is too old to write to. (freenet/river#694)
+
 ## [0.2.15] - 2026-09-06
 
 ### Fixed

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -35,6 +35,11 @@ All notable changes to riverctl will be documented in this file.
     being swallowed as a transient failure like every other resolution error.
   - The interval carries ±20% jitter, so a fleet of bots started together does
     not hit the network in one synchronised burst after a re-key.
+  - The stream's **periodic** fetch no longer migrates the room or self-heals
+    `member_info`. Those are writes, they still happen on the stream's first
+    fetch and in every one-shot command, and issuing them on a timer as a side
+    effect of reading was both surprising and — because of a known hazard when a
+    migration's GET races a live notification — unsafe.
 
 ## [0.2.15] - 2026-09-06
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -35,11 +35,17 @@ All notable changes to riverctl will be documented in this file.
     being swallowed as a transient failure like every other resolution error.
   - The interval carries ±20% jitter, so a fleet of bots started together does
     not hit the network in one synchronised burst after a re-key.
-  - The stream's **periodic** fetch no longer migrates the room or self-heals
-    `member_info`. Those are writes, they still happen on the stream's first
-    fetch and in every one-shot command, and issuing them on a timer as a side
-    effect of reading was both surprising and — because of a known hazard when a
-    migration's GET races a live notification — unsafe.
+  - The stream's **periodic** fetch no longer writes: it does not migrate the
+    room, does not self-heal `member_info`, and does not republish state it
+    recovered from an older generation. All three still happen on the stream's
+    first fetch and in every one-shot command. Issuing them on a timer as a side
+    effect of reading was surprising, and — because of a known hazard when a
+    migration's GET races a live notification — unsafe. The periodic fetch still
+    READS across older generations, which is what makes a catch-up straight
+    after a re-key return anything at all.
+  - `message stream` without `--subscribe` now does one full fetch at startup
+    regardless of `--initial-messages`, so migration and the `member_info`
+    self-heal still run in the default polling mode.
 
 ## [0.2.15] - 2026-09-06
 

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -775,6 +775,23 @@ impl Retry {
         self.state = None;
         self.failures = 0;
     }
+
+    fn is_armed(&self) -> bool {
+        self.state.is_some()
+    }
+
+    /// Keep the work armed, but with the cadence starting from `now` and the
+    /// failure penalty cleared — "succeeded, and needed again one interval from
+    /// now" rather than "succeeded, stop".
+    ///
+    /// Distinct from [`Self::arm`], which makes the next attempt IMMEDIATE.
+    /// Using `arm` here would poll on the loop's 500ms tick; using nothing would
+    /// let the work idle. This is the steady-state case: a job that has to keep
+    /// running on its own schedule for as long as something else is unfinished.
+    fn rearm_paced(&mut self, now: std::time::Instant) {
+        self.state = Some(Some(now));
+        self.failures = 0;
+    }
 }
 
 /// The higher of a remembered floor and the one just read from disk.
@@ -2650,6 +2667,9 @@ pub struct ApiClient {
     /// lock to the ordering story for no benefit, and would be counted by the
     /// connection-acquisition pin as if it were a reach for the shared socket.
     pointer_floor: std::sync::Mutex<Option<PointerFloor>>,
+    /// The generation named by the last refresh this run declined, so the note
+    /// about declining is said when it changes rather than on every cycle.
+    last_declined: std::sync::Mutex<Option<[u8; 32]>>,
 }
 
 impl ApiClient {
@@ -2693,7 +2713,27 @@ impl ApiClient {
             storage,
             room_anchor: tokio::sync::RwLock::new(None),
             pointer_floor: std::sync::Mutex::new(None),
+            last_declined: std::sync::Mutex::new(None),
         })
+    }
+
+    /// Record that a refresh was declined in favour of `rejected`, returning
+    /// whether this is new information worth printing.
+    ///
+    /// True the first time, and again whenever the rejected generation CHANGES.
+    /// A pointer that stays unreachable names the same fallback hash every
+    /// cycle, and repeating that every few minutes is the alarm fatigue the
+    /// advisory suppression exists to avoid.
+    fn note_declined(&self, rejected: &[u8; 32]) -> bool {
+        let mut last = self
+            .last_declined
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if last.as_ref() == Some(rejected) {
+            return false;
+        }
+        *last = Some(*rejected);
+        true
     }
 
     /// The highest floor this process has verified, if any.
@@ -2809,10 +2849,12 @@ impl ApiClient {
         let accepted = match crate::pointer::decide_refresh(previous.as_ref(), resolved) {
             crate::pointer::RefreshDecision::Accept(anchor) => anchor,
             crate::pointer::RefreshDecision::Decline { keep, rejected } => {
-                // stderr, not `warn!` — see `announce_anchor`. And said only when
-                // the decision CHANGES, so a pointer that stays unreachable does
-                // not reprint this every few minutes.
-                if previous.as_ref().map(|p| p.source()) != Some(keep.source()) {
+                // stderr, not `warn!` — see `announce_anchor`. Deduplicated on
+                // the REJECTED hash, which is the only thing here that can
+                // actually differ between refreshes: `keep` is by construction a
+                // clone of `previous`, so an earlier version of this compared a
+                // value with itself and could never fire at all.
+                if self.note_declined(rejected.code_hash()) {
                     eprintln!(
                         "note: keeping room-contract generation {}. An unverified re-check named \
                          {} instead, which is not evidence enough to move off a generation \
@@ -7162,6 +7204,17 @@ impl ApiClient {
                 match fetched {
                     Ok((room_state, secrets)) => {
                         catch_up.succeeded();
+                        // While the re-subscribe is still pending there is no
+                        // live subscription, so this fetch is the ONLY thing
+                        // surfacing content. Keep it on its own cadence instead
+                        // of letting it idle until the next re-subscribe failure
+                        // re-arms it: that failure backs off exponentially, so
+                        // polling would decay with it — to 480s at the cap, long
+                        // enough for a busy room to roll past its bounded history
+                        // and lose those events for good.
+                        if resubscribe.is_armed() {
+                            catch_up.rearm_paced(std::time::Instant::now());
+                        }
                         Self::emit_stream_changes(
                             &room_state,
                             &secrets,
@@ -9994,6 +10047,47 @@ mod pointer_refresh_tests {
             highest_floor(Some(live_at_9), tombstone).is_withdrawn(),
             "a withdrawal on disk must survive a same-version memory"
         );
+    }
+
+    /// `rearm_paced` is what keeps fallback polling alive while a re-subscribe is
+    /// still being refused, and it has to sit exactly between the two obvious
+    /// options. `succeeded()` alone would let polling idle until the next
+    /// re-subscribe failure re-armed it — and that failure backs off
+    /// exponentially, so polling would decay to the cap (480s at a 30s base),
+    /// long enough for a busy room to roll past its bounded history and lose
+    /// events permanently. `arm()` would make it due immediately and poll on the
+    /// loop's 500ms tick.
+    #[test]
+    fn rearm_paced_keeps_polling_without_idling_or_spinning() {
+        let t0 = std::time::Instant::now();
+        let interval = std::time::Duration::from_secs(5);
+        let mut r = Retry::default();
+
+        r.arm();
+        r.attempted(t0);
+        r.rearm_paced(t0);
+
+        // Still armed — it has NOT gone idle.
+        assert!(r.is_armed());
+        // But not due immediately — it is not spinning either.
+        assert!(!r.due(t0, interval));
+        assert!(!r.due(t0 + std::time::Duration::from_secs(4), interval));
+        // Due one plain interval later, with no accumulated backoff penalty.
+        assert!(r.due(t0 + interval, interval));
+
+        // And the penalty really is cleared: a job that had been failing does not
+        // carry that backoff into its steady-state polling.
+        let mut failing = Retry::default();
+        failing.arm();
+        for i in 0..6 {
+            failing.attempted(t0 + interval * i);
+        }
+        assert!(
+            !failing.due(t0 + interval * 7, interval),
+            "six failures must have widened the gap, or the next assertion proves nothing"
+        );
+        failing.rearm_paced(t0 + interval * 7);
+        assert!(failing.due(t0 + interval * 8, interval));
     }
 
     /// The two defects review found in this PR both lived in the arm/retry

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -150,6 +150,20 @@ impl PointerIo for NodePointerIo<'_> {
                 }
             }
         }
+        // Falling out of the loop means the answer never arrived: either the
+        // deadline passed or `MAX_UNRELATED_RESPONSES_DURING_POINTER_GET` frames
+        // were stepped over first. On a busy room the second is reachable, and
+        // it is the one path where a re-key can be missed for a whole refresh
+        // cycle with nothing an operator can see — the advisory says nothing,
+        // because the anchor did not change. So say it here rather than leaving
+        // it to a `debug!` that release builds drop.
+        warn!(
+            "Could not read River's room-contract pointer this cycle (no answer within \
+             {POINTER_GET_TIMEOUT:?}, after stepping over up to \
+             {MAX_UNRELATED_RESPONSES_DURING_POINTER_GET} unrelated responses); \
+             continuing on the generation already in use and retrying next cycle"
+        );
+
         // NEVER `PointerFetch::Absent`. `Absent` is the only answer that can
         // unlock a baked-in build-time key, and this transport cannot produce a
         // trustworthy one: the node reports a missing contract as a
@@ -688,11 +702,31 @@ pub(crate) enum SubscribeAck {
 /// queue fed by the node would be a memory amplification vector.
 pub(crate) const MAX_PENDING_DURING_HANDSHAKE: usize = 16;
 
-pub(crate) fn classify_subscribe_response(response: &HostResponse) -> SubscribeAck {
+/// Classify a response received while awaiting the SUBSCRIBE acknowledgement for
+/// `sent_key`.
+///
+/// The key is checked, for the same reason [`classify_update_response`] checks
+/// it: the node multiplexes every response onto one connection, so a
+/// `SubscribeResponse` for a DIFFERENT contract belongs to some other request
+/// and must be stepped over rather than taken as our answer.
+///
+/// That mattered little while a stream subscribed exactly once, at startup.
+/// Since freenet/river#694 a stream re-subscribes mid-run, concurrently with
+/// traffic that also produces subscribe acknowledgements — `Put { subscribe:
+/// true }` on the migration path, and `get_room(.., true)`. Accepting a stray
+/// ack would clear the pending re-subscribe and leave the stream believing it is
+/// subscribed to the new generation when it is not: straight back to the silence
+/// #694 exists to remove, with only the catch-up surfacing anything.
+pub(crate) fn classify_subscribe_response(
+    response: &HostResponse,
+    sent_key: &ContractInstanceId,
+) -> SubscribeAck {
     match response {
         HostResponse::ContractResponse(ContractResponse::SubscribeResponse {
-            subscribed, ..
-        }) => {
+            key,
+            subscribed,
+            ..
+        }) if key.id() == sent_key => {
             if *subscribed {
                 SubscribeAck::Subscribed
             } else {
@@ -3620,7 +3654,7 @@ impl ApiClient {
                 ));
             }
             match tokio::time::timeout(remaining, web_api.recv()).await {
-                Ok(Ok(response)) => match classify_subscribe_response(&response) {
+                Ok(Ok(response)) => match classify_subscribe_response(&response, &id) {
                     SubscribeAck::Subscribed => {
                         info!("Successfully subscribed to contract");
                         return Ok(());
@@ -5468,7 +5502,15 @@ impl ApiClient {
                 // once every refresh. Fixing one loop and not the other would
                 // leave the same hazard behind in the quieter half.
                 let resolved = tokio::select! {
-                    _ = shutdown_rx.recv() => {
+                    // `Some(())`, not `_`: a CLOSED channel is not a shutdown
+                    // REQUEST, and the sibling `try_recv().is_ok()` check in
+                    // this same loop already reads it that way. Two checks
+                    // disagreeing about what a closed channel means is how a
+                    // later edit to the Ctrl+C task turns into a silent exit
+                    // with status 0 five minutes after start. An unmatched
+                    // pattern disables the branch, so closure just leaves the
+                    // refresh to finish.
+                    Some(()) = shutdown_rx.recv() => {
                         if matches!(format, OutputFormat::Human) {
                             eprintln!("\nStopped monitoring.");
                         }
@@ -5544,19 +5586,49 @@ impl ApiClient {
         }
     }
 
-    /// Fetch authoritative room state for a stream, with private-room content
-    /// decrypted for display (a no-op for public rooms).
+    /// Fetch authoritative room state for a stream's REPEATED reads, with
+    /// private-room content decrypted for display (a no-op for public rooms).
     ///
     /// Split from [`Self::emit_stream_changes`] so the caller keeps the
     /// distinction both stream loops have always drawn: a FETCH failure is
     /// transient and the loop logs it and carries on, while an EMIT failure
     /// (a closed stdout, say) ends the stream. Collapsing the two into one
     /// `Result` would silently convert the second into the first.
+    ///
+    /// Deliberately NOT [`Self::get_room`], which is the command-shaped entry
+    /// point and carries two WRITE side effects: it migrates the room onto the
+    /// bundled generation when one is pending (a PUT plus a signed
+    /// upgrade-pointer UPDATE), and it self-heals a missing `member_info` entry
+    /// (issue freenet/river#304, another publish). Both are right for a command
+    /// a user just typed. Neither is right on a timer.
+    ///
+    /// The sharp edge, and the reason this is a correctness fix rather than
+    /// tidiness: `migrate_room_to_new_contract` folds an `UpdateNotification` of
+    /// ANY key into success and writes that key into `rooms.json` — pinned
+    /// elsewhere in this file as data corruption rather than a tolerance bug
+    /// (freenet/river#689). Its GET takes the FIRST response as its answer, and
+    /// inside a live subscription the first response is very likely a
+    /// notification for this very room. Before pointer refreshing existed, a
+    /// migration could only be triggered by a `previous_contract_key` that was
+    /// already set when the process started, so a stream that got past its first
+    /// fetch never re-entered this path. A mid-run re-key sets that key again
+    /// (`Storage::load_rooms` demotes the superseded key), which would put a
+    /// timer on the door.
+    ///
+    /// Streams still migrate and still heal: their FIRST fetch goes through
+    /// `get_room`, exactly as before, as does every one-shot command. What
+    /// changes is only that a long-running READER stops issuing writes as a
+    /// side effect of reading.
     async fn fetch_stream_state(
         &self,
         room_owner_key: &VerifyingKey,
     ) -> Result<(ChatRoomStateV1, HashMap<u32, [u8; 32]>)> {
-        let mut room_state = self.get_room(room_owner_key, false).await?;
+        let contract_key = self
+            .contract_key_for(room_owner_key, KeyIntent::Read)
+            .await?;
+        let (mut room_state, _found_id) = self
+            .fetch_room_state_with_recovery(room_owner_key, *contract_key.id())
+            .await?;
         let secrets = self.room_display_secrets(room_owner_key, &mut room_state);
         Ok((room_state, secrets))
     }
@@ -6586,7 +6658,7 @@ impl ApiClient {
                 Ok(result) => result.map_err(|e| anyhow!("Failed to receive response: {}", e))?,
                 Err(_) => return Err(anyhow!("Timeout waiting for SUBSCRIBE response")),
             };
-            match classify_subscribe_response(&response) {
+            match classify_subscribe_response(&response, &contract_instance_id) {
                 SubscribeAck::Subscribed => {
                     if matches!(format, OutputFormat::Human) {
                         eprintln!("Successfully subscribed. Waiting for updates...\n");
@@ -6774,7 +6846,15 @@ impl ApiClient {
                 // `mpsc::Receiver::recv` is cancellation-safe, so losing this
                 // race drops nothing.
                 let resolved = tokio::select! {
-                    _ = shutdown_rx.recv() => {
+                    // `Some(())`, not `_`: a CLOSED channel is not a shutdown
+                    // REQUEST, and the sibling `try_recv().is_ok()` check in
+                    // this same loop already reads it that way. Two checks
+                    // disagreeing about what a closed channel means is how a
+                    // later edit to the Ctrl+C task turns into a silent exit
+                    // with status 0 five minutes after start. An unmatched
+                    // pattern disables the branch, so closure just leaves the
+                    // refresh to finish.
+                    Some(()) = shutdown_rx.recv() => {
                         if matches!(format, OutputFormat::Human) {
                             eprintln!("\nStopped monitoring.");
                         }
@@ -6904,7 +6984,15 @@ impl ApiClient {
                 // every re-key, so leaving it unraced would make Ctrl+C hang for
                 // half a minute at exactly the busiest moment.
                 let acked = tokio::select! {
-                    _ = shutdown_rx.recv() => {
+                    // `Some(())`, not `_`: a CLOSED channel is not a shutdown
+                    // REQUEST, and the sibling `try_recv().is_ok()` check in
+                    // this same loop already reads it that way. Two checks
+                    // disagreeing about what a closed channel means is how a
+                    // later edit to the Ctrl+C task turns into a silent exit
+                    // with status 0 five minutes after start. An unmatched
+                    // pattern disables the branch, so closure just leaves the
+                    // refresh to finish.
+                    Some(()) = shutdown_rx.recv() => {
                         if matches!(format, OutputFormat::Human) {
                             eprintln!("\nStopped monitoring.");
                         }
@@ -9612,6 +9700,32 @@ mod pointer_refresh_tests {
         bundled_room_code_hash()
     }
 
+    /// The CHANGELOG advertises ±20% jitter, and its whole purpose is that a
+    /// fleet restarted together does not hit the network in one synchronised
+    /// burst after a re-key. Nothing else would catch an edit that made the
+    /// factor constant, so pin both the bounds and the SPREAD — a jitter
+    /// function that always returned the same value would sit inside the bounds
+    /// and defeat the point entirely.
+    #[test]
+    fn the_refresh_interval_is_jittered_within_twenty_percent() {
+        let base = POINTER_REFRESH_INTERVAL.as_secs_f64();
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..200 {
+            let d = jittered_pointer_refresh_interval().as_secs_f64();
+            assert!(
+                d >= base * 0.8 && d < base * 1.2,
+                "jittered interval {d} outside ±20% of {base}"
+            );
+            seen.insert(d.to_bits());
+        }
+        assert!(
+            seen.len() > 100,
+            "the interval must actually vary; got {} distinct values in 200 draws, \
+             which means the jitter is not jittering",
+            seen.len()
+        );
+    }
+
     /// A stream acts on `moved` by tearing down and rebuilding its subscription,
     /// so a false positive is a self-inflicted outage and a false negative is the
     /// freenet/river#694 silence. Pin both directions.
@@ -9758,11 +9872,44 @@ mod subscribe_handshake_tests {
         })
     }
 
+    /// The instance id the handshake under test asked for.
+    pub(super) fn expected_id() -> ContractInstanceId {
+        *key().id()
+    }
+
+    /// A subscribe acknowledgement for some OTHER contract on the shared
+    /// connection.
+    fn ack_for_another_contract(subscribed: bool) -> HostResponse {
+        HostResponse::ContractResponse(ContractResponse::SubscribeResponse {
+            key: other_key(),
+            subscribed,
+        })
+    }
+
     fn ack(subscribed: bool) -> HostResponse {
         HostResponse::ContractResponse(ContractResponse::SubscribeResponse {
             key: key(),
             subscribed,
         })
+    }
+
+    /// A subscribe acknowledgement for a DIFFERENT contract is somebody else's
+    /// answer. Taking it would clear a pending re-subscribe and leave a stream
+    /// believing it is attached to a generation it never subscribed to — the
+    /// freenet/river#694 silence, re-entered through the fix for it.
+    #[test]
+    fn an_ack_for_another_contract_does_not_answer_our_subscribe() {
+        assert_eq!(
+            classify_subscribe_response(&ack_for_another_contract(true), &expected_id()),
+            SubscribeAck::NotYet,
+            "a subscribe ack for another key belongs to another request"
+        );
+        // Including a REFUSAL: a refusal for somebody else's contract must not
+        // fail our subscription either.
+        assert_eq!(
+            classify_subscribe_response(&ack_for_another_contract(false), &expected_id()),
+            SubscribeAck::NotYet,
+        );
     }
 
     /// The regression (freenet-core#4970): the node multiplexes its responses,
@@ -9773,7 +9920,7 @@ mod subscribe_handshake_tests {
     #[test]
     fn an_update_notification_does_not_answer_the_subscribe() {
         assert_eq!(
-            classify_subscribe_response(&notification()),
+            classify_subscribe_response(&notification(), &expected_id()),
             SubscribeAck::NotYet,
             "a notification overtaking the ack must leave us waiting, not fail \
              the subscription"
@@ -9783,7 +9930,7 @@ mod subscribe_handshake_tests {
     #[test]
     fn the_acknowledgement_is_recognised() {
         assert_eq!(
-            classify_subscribe_response(&ack(true)),
+            classify_subscribe_response(&ack(true), &expected_id()),
             SubscribeAck::Subscribed
         );
     }
@@ -9794,7 +9941,7 @@ mod subscribe_handshake_tests {
     #[test]
     fn a_refusal_is_an_answer_not_a_reason_to_keep_waiting() {
         assert_eq!(
-            classify_subscribe_response(&ack(false)),
+            classify_subscribe_response(&ack(false), &expected_id()),
             SubscribeAck::Refused
         );
     }
@@ -9922,7 +10069,7 @@ mod subscribe_handshake_tests {
     #[test]
     fn other_responses_are_tolerated() {
         assert_eq!(
-            classify_subscribe_response(&HostResponse::Ok),
+            classify_subscribe_response(&HostResponse::Ok, &expected_id()),
             SubscribeAck::NotYet
         );
     }

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -9960,6 +9960,42 @@ mod pointer_refresh_tests {
         );
     }
 
+    /// The anti-rollback floor is re-read from disk on every resolution, and
+    /// persisting it is best-effort. So when a save fails, the disk can be BEHIND
+    /// what this process has already verified — and a validly-signed older record
+    /// would then be accepted, moving the run back onto a generation the author
+    /// had superseded. A signature establishes authenticity, not freshness.
+    #[test]
+    fn the_remembered_floor_beats_a_disk_that_fell_behind() {
+        use freenet_migrate::pointer::PointerFloor;
+
+        let old = PointerFloor::at(3, [0xAA; 32]).unwrap();
+        let new = PointerFloor::at(9, [0xBB; 32]).unwrap();
+
+        // Nothing remembered yet: the disk is all there is.
+        assert_eq!(highest_floor(None, old).version(), 3);
+
+        // The disk fell behind what we verified: keep ours.
+        assert_eq!(highest_floor(Some(new), old).version(), 9);
+
+        // The disk is ahead (another riverctl advanced it): take the disk's.
+        assert_eq!(highest_floor(Some(old), new).version(), 9);
+
+        // Equal versions, and ONE of them is a withdrawal: the withdrawal wins
+        // whichever side it is on. Forgetting a tombstone because a non-withdrawn
+        // record shares its version would resurrect exactly what was retired.
+        let tombstone = PointerFloor::withdrawn_at(9).unwrap();
+        let live_at_9 = PointerFloor::at(9, [0xCC; 32]).unwrap();
+        assert!(
+            highest_floor(Some(tombstone), live_at_9).is_withdrawn(),
+            "a remembered withdrawal must not be dropped for a same-version record"
+        );
+        assert!(
+            highest_floor(Some(live_at_9), tombstone).is_withdrawn(),
+            "a withdrawal on disk must survive a same-version memory"
+        );
+    }
+
     /// The two defects review found in this PR both lived in the arm/retry
     /// bookkeeping, not in any decision: a job that cleared itself without
     /// covering the window it existed to cover, and one that retried on the

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -2364,6 +2364,14 @@ const POINTER_REFRESH_INTERVAL: std::time::Duration = std::time::Duration::from_
 /// the only thing surfacing content is the catch-up fetch that runs beside it.
 const RESUBSCRIBE_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
 
+/// How long to wait before retrying a catch-up fetch that failed.
+///
+/// The first attempt after a refresh is immediate; only RETRIES are spaced. The
+/// loop wakes every 500 ms, so without a floor here a generation the node cannot
+/// serve yet — the normal state for a few moments after River publishes one —
+/// would draw two full-state GETs per second from every bot at once.
+const CATCH_UP_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// [`POINTER_REFRESH_INTERVAL`] with ±20% jitter.
 ///
 /// Without it every bot started by one restart wave shares a refresh phase, so a
@@ -2538,8 +2546,23 @@ impl ApiClient {
             return Ok(anchor);
         }
         let anchor = self.resolve_room_anchor(None).await?;
-        *slot = Some(anchor.clone());
+        self.install_room_anchor(&mut slot, anchor.clone());
         Ok(anchor)
+    }
+
+    /// Install `anchor` as this run's generation: cache it, and point the local
+    /// room store at the same generation the network paths will derive from.
+    ///
+    /// One function because the two must not drift: a cache holding one
+    /// generation while `Storage` regenerates keys against another is a way to
+    /// address two different contracts in one run.
+    fn install_room_anchor(
+        &self,
+        slot: &mut tokio::sync::RwLockWriteGuard<'_, Option<RoomAnchor>>,
+        anchor: RoomAnchor,
+    ) {
+        self.storage.set_room_code_hash(*anchor.code_hash());
+        **slot = Some(anchor);
     }
 
     /// How a long-running stream should react to a failed pointer refresh.
@@ -2579,9 +2602,28 @@ impl ApiClient {
     pub async fn refresh_room_anchor(&self) -> Result<AnchorRefresh> {
         let mut slot = self.room_anchor.write().await;
         let previous = slot.clone();
-        let anchor = self.resolve_room_anchor(previous.as_ref()).await?;
-        *slot = Some(anchor.clone());
-        Ok(AnchorRefresh::new(anchor, previous))
+        let resolved = self.resolve_room_anchor(previous.as_ref()).await?;
+
+        // Only a signature-verified record may move this run off a generation it
+        // is already using, and the gate is on the INSTALL rather than only on
+        // the announcement. `decide_refresh` carries the full argument.
+        let accepted = match crate::pointer::decide_refresh(previous.as_ref(), resolved) {
+            crate::pointer::RefreshDecision::Accept(anchor) => anchor,
+            crate::pointer::RefreshDecision::Decline { keep, rejected } => {
+                warn!(
+                    "Keeping room-contract generation {} : an unverified re-check named {} \
+                     instead ({:?}), which is not evidence enough to move off a generation \
+                     already in use",
+                    crate::pointer::code_hash_b58(keep.code_hash()),
+                    crate::pointer::code_hash_b58(rejected.code_hash()),
+                    rejected.source(),
+                );
+                keep
+            }
+        };
+
+        self.install_room_anchor(&mut slot, accepted.clone());
+        Ok(AnchorRefresh::new(accepted, previous))
     }
 
     /// Resolve River's room-contract pointer, persist the anti-rollback floor,
@@ -2655,9 +2697,11 @@ impl ApiClient {
             anchor.source(),
         );
 
-        // Let the local room cache regenerate its keys against the same
-        // generation the network paths use, instead of against the bundled WASM.
-        self.storage.set_room_code_hash(*anchor.code_hash());
+        // NOTE: installing this generation into `Storage` is deliberately NOT
+        // done here. A refresh may decline the anchor it just resolved (see
+        // `refresh_room_anchor`), and writing the code hash from inside the
+        // resolver would apply a generation the caller is about to reject — the
+        // decision and its side effect have to sit together.
         Ok(anchor)
     }
 
@@ -5418,7 +5462,21 @@ impl ApiClient {
             if last_pointer_refresh.elapsed() >= refresh_interval {
                 last_pointer_refresh = std::time::Instant::now();
                 refresh_interval = jittered_pointer_refresh_interval();
-                match self.refresh_room_anchor().await {
+                // Interruptible, exactly as in the subscription loop. Polling's
+                // Ctrl+C granularity is its poll interval (1s by default); a bare
+                // await here would stretch that to the pointer GET's 10s timeout
+                // once every refresh. Fixing one loop and not the other would
+                // leave the same hazard behind in the quieter half.
+                let resolved = tokio::select! {
+                    _ = shutdown_rx.recv() => {
+                        if matches!(format, OutputFormat::Human) {
+                            eprintln!("\nStopped monitoring.");
+                        }
+                        return Ok(());
+                    }
+                    resolved = self.refresh_room_anchor() => resolved,
+                };
+                match resolved {
                     Ok(refresh) => {
                         if let Some(notice) = refresh.move_notice() {
                             eprintln!("{notice}");
@@ -6695,6 +6753,7 @@ impl ApiClient {
         let mut refresh_interval = jittered_pointer_refresh_interval();
         // Set by every refresh, cleared only by a catch-up fetch that succeeded.
         let mut catch_up_pending = false;
+        let mut last_catch_up_attempt: Option<std::time::Instant> = None;
         // Set when a re-key is detected, cleared only by a SUBSCRIBE the node
         // accepted. See the retry below for why this is not a one-shot.
         let mut resubscribe_pending = false;
@@ -6784,10 +6843,14 @@ impl ApiClient {
             // otherwise lose the gap content permanently: the anchor has already
             // been replaced, so the next refresh sees no move, and if no further
             // notification ever arrives nothing else would go looking.
-            if catch_up_pending {
+            if catch_up_pending
+                && last_catch_up_attempt.is_none_or(|t| t.elapsed() >= CATCH_UP_RETRY_INTERVAL)
+            {
+                last_catch_up_attempt = Some(std::time::Instant::now());
                 match self.fetch_stream_state(room_owner_key).await {
                     Ok((room_state, secrets)) => {
                         catch_up_pending = false;
+                        last_catch_up_attempt = None;
                         Self::emit_stream_changes(
                             &room_state,
                             &secrets,
@@ -6833,13 +6896,38 @@ impl ApiClient {
                     .is_none_or(|t| t.elapsed() >= RESUBSCRIBE_RETRY_INTERVAL)
             {
                 last_resubscribe_attempt = Some(std::time::Instant::now());
-                match self
-                    .subscribe_and_await_ack(contract_instance_id, &format, &mut pending)
-                    .await
-                {
+                // Interruptible, for the same reason the refresh above is — and
+                // more so: `subscribe_and_await_ack` waits up to 30s for the
+                // node's acknowledgement, three times the pointer GET's bound.
+                // That wait was a one-time startup cost before this change; it is
+                // now on a path an ordinary long-running stream re-enters after
+                // every re-key, so leaving it unraced would make Ctrl+C hang for
+                // half a minute at exactly the busiest moment.
+                let acked = tokio::select! {
+                    _ = shutdown_rx.recv() => {
+                        if matches!(format, OutputFormat::Human) {
+                            eprintln!("\nStopped monitoring.");
+                        }
+                        return Ok(());
+                    }
+                    acked = self
+                        .subscribe_and_await_ack(contract_instance_id, &format, &mut pending)
+                        => acked,
+                };
+                match acked {
                     Ok(()) => {
                         resubscribe_pending = false;
                         last_resubscribe_attempt = None;
+                        // Catch up ONCE MORE, now that the subscription is live.
+                        // The earlier fetch ran before this SUBSCRIBE was
+                        // registered, so anything written in between — including
+                        // across a 30s retry delay — is in neither the fetch nor
+                        // the notification stream, and nothing else would ever go
+                        // looking for it. This second pass is what makes the
+                        // hand-off gapless; it emits nothing when nothing
+                        // happened.
+                        catch_up_pending = true;
+                        last_catch_up_attempt = None;
                     }
                     Err(e) => {
                         warn!(
@@ -12660,10 +12748,10 @@ mod response_multiplexing_pin {
     /// Every production `.recv()` on the shared connection.
     ///
     /// One of them IS the `ResponseSource` impl `await_response` reads through;
-    /// ten more are sites the fix has not reached; the twelfth is not a
-    /// connection read at all (see entry 12). All twelve are listed rather than
-    /// only the unreached ones, so the constant can be audited by walking the
-    /// list. Note a plain `grep -c` over the file does NOT give 11:
+    /// ten more are sites the fix has not reached; the last three are not
+    /// connection reads at all (see entries 12-14). All fourteen are listed
+    /// rather than only the unreached ones, so the constant can be audited by
+    /// walking the list. Note a plain `grep -c` over the file does NOT give 11:
     /// it also counts the meta-tests' own string literals, which the pin strips
     /// with `production_source` before counting.
     ///
@@ -12685,16 +12773,21 @@ mod response_multiplexing_pin {
     ///  9. `accept_invitation_struct`'s join delta -- #690.
     /// 10. `ensure_room_migrated` -- #690.
     /// 11. `migrate_room_to_new_contract` -- freenet/river#689.
-    /// 12. the streaming monitor's shutdown `select!` -- NOT a read of the
-    ///     connection at all. It is `shutdown_rx.recv()` on the Ctrl+C mpsc
-    ///     channel, added by freenet/river#694 so a five-minute pointer refresh
-    ///     cannot widen shutdown latency to the pointer GET's timeout. The note
-    ///     under the count below predicted exactly this: the scan counts every
-    ///     `.recv()` rather than every connection read, on purpose, because
-    ///     binding it to a variable name would make it a spelling ban. A second
-    ///     mpsc receiver is therefore a FALSE POSITIVE to be recorded here, not
-    ///     a call site to route through `await_response` -- which could not
-    ///     accept it anyway, since it does not read the connection.
+    /// 12. the streaming monitor's shutdown `select!` around the pointer
+    ///     refresh -- NOT a read of the connection at all.
+    /// 13. the same, around the mid-run re-SUBSCRIBE.
+    /// 14. the same, in the POLLING monitor's refresh.
+    ///
+    /// 12 through 14 are all `shutdown_rx.recv()` on the Ctrl+C mpsc channel,
+    /// added by freenet/river#694 so that the periodic pointer refresh, and the
+    /// re-subscribe that can follow it, cannot widen shutdown latency to their
+    /// own timeouts (10s and 30s respectively). The note under the count below
+    /// predicted exactly this: the scan counts every `.recv()` rather than every
+    /// connection read, on purpose, because binding it to a variable name would
+    /// make it a spelling ban rather than a count. A second receiver is
+    /// therefore a FALSE POSITIVE to be recorded here, not a call site to route
+    /// through `await_response` -- which could not accept it anyway, since it
+    /// does not read the connection.
     ///
     /// 6 through 11 are deliberately outside this change, but NOT all for the
     /// same reason, and an earlier version of this comment gave one reason for
@@ -12722,7 +12815,7 @@ mod response_multiplexing_pin {
     ///     issue (#689) rather than riding along here.
     ///
     /// Lowering this number is #690's job, and #689's.
-    const DIRECT_CONNECTION_READS: usize = 12;
+    const DIRECT_CONNECTION_READS: usize = 14;
 
     /// Production references to the connection field, and locks taken on it.
     ///
@@ -13056,7 +13149,7 @@ mod response_multiplexing_pin {
         );
         assert_caught(
             &mutated,
-            "found 13",
+            "found 15",
             "a newly-added direct read whose guard is not called `web_api`",
         );
     }

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -124,8 +124,22 @@ impl PointerIo for NodePointerIo<'_> {
                     state,
                     ..
                 }))) if *key.id() == id => return Ok(PointerFetch::State(state.to_vec())),
-                // Something else on the shared connection. Keep waiting.
-                Ok(Ok(_)) => continue,
+                // Something else on the shared connection. Keep waiting — and
+                // note that stepping over it DISCARDS it. That was free while
+                // resolution only ever ran before anything was subscribed; since
+                // freenet/river#694 a long-running stream re-resolves mid-run, so
+                // the discarded frame can be an `UpdateNotification` for that very
+                // subscription. The stream compensates by re-fetching full state
+                // after every refresh rather than by requeueing here, because this
+                // adapter has no access to the stream's queue and a full fetch
+                // supersedes any delta it could have replayed.
+                Ok(Ok(other)) => {
+                    debug!(
+                        "Stepping over {} while awaiting the pointer GET",
+                        response_kind(&other)
+                    );
+                    continue;
+                }
                 Ok(Err(e)) => {
                     debug!("Pointer GET failed: {e}");
                     break;
@@ -2343,6 +2357,26 @@ impl std::fmt::Debug for Invitation {
 /// turn the protection off by accident.
 const POINTER_REFRESH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(300);
 
+/// How long to wait before retrying a re-SUBSCRIBE the node would not accept.
+///
+/// Shorter than the refresh interval because a refused re-subscribe leaves the
+/// stream with no live subscription to the new generation, so until it succeeds
+/// the only thing surfacing content is the catch-up fetch that runs beside it.
+const RESUBSCRIBE_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// [`POINTER_REFRESH_INTERVAL`] with ±20% jitter.
+///
+/// Without it every bot started by one restart wave shares a refresh phase, so a
+/// re-key produces a synchronised burst of pointer GET + SUBSCRIBE + full-state
+/// GET from the whole fleet at once — against a network that has, by definition,
+/// just published something. Same reasoning as the jitter requirement on retry
+/// and backoff loops in the ecosystem's bug-prevention rules.
+fn jittered_pointer_refresh_interval() -> std::time::Duration {
+    let base = POINTER_REFRESH_INTERVAL.as_secs_f64();
+    let factor = 0.8 + rand::Rng::gen::<f64>(&mut rand::thread_rng()) * 0.4;
+    std::time::Duration::from_secs_f64(base * factor)
+}
+
 /// The outcome of re-resolving River's room-contract pointer mid-run.
 ///
 /// `moved` is the field callers act on, and it is deliberately narrower than
@@ -2364,9 +2398,23 @@ impl AnchorRefresh {
     /// still addressing the same contract, and tearing down a healthy
     /// subscription over it would be a self-inflicted outage.
     fn new(anchor: RoomAnchor, previous: Option<RoomAnchor>) -> Self {
+        // Two conditions, and the SECOND is the one that is easy to leave out.
+        //
         // False when nothing was cached: a first resolution is not a move, and
         // reporting one would make an ordinary startup look like a re-key.
-        let moved = matches!(&previous, Some(p) if p.code_hash() != anchor.code_hash());
+        //
+        // False unless a signature-verified record named the new hash. A failed
+        // resolution still yields an anchor — on `last_known()`, which is the
+        // floor's hash or, if the floor has never been written, the BUNDLED one.
+        // Persisting the floor is best-effort (a read-only config dir is enough
+        // to skip it), so a refresh that merely timed out can hand back a
+        // different hash from the one in force. Without this clause that reads as
+        // a re-key: the stream would announce a move that never happened, tear
+        // down a healthy subscription, re-subscribe to a RETIRED generation, and
+        // flap back five minutes later — every cycle rewriting rooms.json.
+        // A teardown is only ever justified by positive evidence.
+        let moved = matches!(&previous, Some(p) if p.code_hash() != anchor.code_hash())
+            && matches!(anchor.source(), crate::pointer::AnchorSource::Pointer);
         Self {
             anchor,
             previous,
@@ -2494,7 +2542,31 @@ impl ApiClient {
         Ok(anchor)
     }
 
+    /// How a long-running stream should react to a failed pointer refresh.
+    ///
+    /// Every ordinary failure is an absence of knowledge — a timeout, an
+    /// unreachable node, a record that lost a tiebreak — and a stream carries on
+    /// with what it last verified, because tearing down a working subscription
+    /// over one bad round trip is a worse outcome than the staleness it avoids.
+    ///
+    /// A WITHDRAWAL is not that. It is a signature-verified statement by River's
+    /// author that the generation this stream is reading has been retired, so
+    /// continuing to read it would be inferring presence from the one fact that
+    /// says otherwise. It ends the stream, loudly, with the author's own message.
+    fn refresh_failure_is_fatal(e: &anyhow::Error) -> bool {
+        e.downcast_ref::<crate::pointer::PointerWithdrawn>()
+            .is_some()
+    }
+
     /// Re-resolve River's room-contract pointer, replacing the cached anchor.
+    ///
+    /// Note what this deliberately does NOT do: it cannot cancel the caller's
+    /// existing subscription to the superseded generation, because
+    /// `freenet-stdlib`'s `ContractRequest` has no unsubscribe variant (checked
+    /// against 0.8.5). A stream that follows several re-keys therefore leaves one
+    /// idle subscription per retired generation for the life of the process. They
+    /// cost the node a little bookkeeping and deliver nothing, since the retired
+    /// contracts are frozen — an accepted leak rather than an overlooked one.
     ///
     /// For long-running commands only. A re-key moves every room's contract key
     /// at once, and a stream that resolved at startup stays bound to the retired
@@ -5339,19 +5411,25 @@ impl ApiClient {
         // answers, so the loop never errors and never sees another message
         // (freenet/river#694).
         let mut last_pointer_refresh = std::time::Instant::now();
+        let mut refresh_interval = jittered_pointer_refresh_interval();
 
         // Main polling loop
         loop {
-            if last_pointer_refresh.elapsed() >= POINTER_REFRESH_INTERVAL {
+            if last_pointer_refresh.elapsed() >= refresh_interval {
                 last_pointer_refresh = std::time::Instant::now();
+                refresh_interval = jittered_pointer_refresh_interval();
                 match self.refresh_room_anchor().await {
                     Ok(refresh) => {
                         if let Some(notice) = refresh.move_notice() {
                             eprintln!("{notice}");
                         }
                     }
-                    // Best-effort, exactly as in the subscription loop.
                     Err(e) => {
+                        // Withdrawal ends the stream; everything else is
+                        // best-effort. Exactly as in the subscription loop.
+                        if Self::refresh_failure_is_fatal(&e) {
+                            return Err(e);
+                        }
                         warn!("Could not re-check River's room-contract pointer: {e}");
                     }
                 }
@@ -6614,64 +6692,162 @@ impl ApiClient {
         // anything to send — indistinguishable from a quiet room
         // (freenet/river#694).
         let mut last_pointer_refresh = std::time::Instant::now();
+        let mut refresh_interval = jittered_pointer_refresh_interval();
+        // Set by every refresh, cleared only by a catch-up fetch that succeeded.
+        let mut catch_up_pending = false;
+        // Set when a re-key is detected, cleared only by a SUBSCRIBE the node
+        // accepted. See the retry below for why this is not a one-shot.
+        let mut resubscribe_pending = false;
+        let mut last_resubscribe_attempt: Option<std::time::Instant> = None;
 
         // Main loop: wait for UpdateNotification messages
         loop {
             // Follow a mid-run re-key before doing anything else this iteration,
             // and before taking the `web_api` lock the refresh needs for its own
             // GET.
-            if last_pointer_refresh.elapsed() >= POINTER_REFRESH_INTERVAL {
+            if last_pointer_refresh.elapsed() >= refresh_interval {
                 last_pointer_refresh = std::time::Instant::now();
-                match self.refresh_room_anchor().await {
+                refresh_interval = jittered_pointer_refresh_interval();
+                // Interruptible. The pointer GET can take up to
+                // `POINTER_GET_TIMEOUT`, and the loop's Ctrl+C check is only
+                // reached between iterations, so awaiting it bare would widen
+                // shutdown latency from the loop's 500 ms to ten seconds.
+                // `mpsc::Receiver::recv` is cancellation-safe, so losing this
+                // race drops nothing.
+                let resolved = tokio::select! {
+                    _ = shutdown_rx.recv() => {
+                        if matches!(format, OutputFormat::Human) {
+                            eprintln!("\nStopped monitoring.");
+                        }
+                        return Ok(());
+                    }
+                    resolved = self.refresh_room_anchor() => resolved,
+                };
+                match resolved {
+                    // Gated on `moved()`, never on `move_notice()`. The notice is
+                    // a presentation string, and gating control flow on whether
+                    // something is worth PRINTING is how a later "do not repeat
+                    // this line" tweak silently disables re-subscription.
                     Ok(refresh) => {
-                        if let Some(notice) = refresh.move_notice() {
-                            eprintln!("{notice}");
+                        if refresh.moved() {
+                            if let Some(notice) = refresh.move_notice() {
+                                eprintln!("{notice}");
+                            }
                             // Re-derive through the anchor choke point, so the new
                             // id comes from the same place every other key does.
                             contract_instance_id = *self
                                 .contract_key_for(room_owner_key, KeyIntent::Read)
                                 .await?
                                 .id();
-                            self.subscribe_and_await_ack(
-                                contract_instance_id,
-                                &format,
-                                &mut pending,
-                            )
-                            .await?;
-                            // Catch up explicitly. The node only notifies about
-                            // changes that happen AFTER a subscription, so
-                            // everything written to the new generation between the
-                            // re-key and this moment would otherwise be a silent
-                            // hole — the very failure this refresh exists to close.
-                            match self.fetch_stream_state(room_owner_key).await {
-                                Ok((room_state, secrets)) => {
-                                    Self::emit_stream_changes(
-                                        &room_state,
-                                        &secrets,
-                                        &mut seen_messages,
-                                        &mut deleted_emitted,
-                                        &mut seen_reactions,
-                                        room_owner_key,
-                                        &format,
-                                        max_messages,
-                                        &mut new_message_count,
-                                    )?;
-                                }
-                                Err(e) => {
-                                    debug!("Failed to catch up after re-subscribing: {}", e);
-                                }
-                            }
-                            if max_messages > 0 && new_message_count >= max_messages {
-                                return Ok(());
-                            }
+                            resubscribe_pending = true;
                         }
                     }
-                    // Never fatal. A refresh is a best-effort currency check, and
-                    // tearing down a working stream because one pointer GET timed
-                    // out would be a worse failure than the staleness it guards
-                    // against. The next interval tries again.
                     Err(e) => {
+                        // A withdrawal ends the stream; see
+                        // `refresh_failure_is_fatal`. Everything else is
+                        // best-effort — tearing down a working subscription
+                        // because one pointer GET timed out would be a worse
+                        // failure than the staleness it guards against, and the
+                        // next interval tries again.
+                        if Self::refresh_failure_is_fatal(&e) {
+                            return Err(e);
+                        }
                         warn!("Could not re-check River's room-contract pointer: {e}");
+                    }
+                }
+
+                // Catch up after EVERY refresh, not only after a move, for two
+                // independent reasons — and the second is the one that is easy to
+                // miss:
+                //
+                //  * After a move, the node only notifies about changes that
+                //    happen AFTER a subscription, so anything written to the new
+                //    generation before this re-subscribe would be a silent hole —
+                //    the very failure this refresh exists to close.
+                //  * After ANY refresh, including one that moved nothing and one
+                //    that failed, the pointer GET has just read from the same
+                //    multiplexed connection this subscription uses, stepping over
+                //    (and discarding) up to `MAX_UNRELATED_RESPONSES_DURING_
+                //    POINTER_GET` frames. One of those can be an
+                //    `UpdateNotification` for this room. A full re-fetch
+                //    supersedes whatever was dropped, so doing it unconditionally
+                //    is what makes re-resolving safe to run alongside a live
+                //    subscription at all.
+                //
+                // The cost is one extra room GET per refresh interval, which is
+                // far below what the stream is already doing per notification.
+                catch_up_pending = true;
+            }
+
+            // Run the catch-up until one actually SUCCEEDS, rather than once per
+            // refresh. A transient fetch failure immediately after a re-key would
+            // otherwise lose the gap content permanently: the anchor has already
+            // been replaced, so the next refresh sees no move, and if no further
+            // notification ever arrives nothing else would go looking.
+            if catch_up_pending {
+                match self.fetch_stream_state(room_owner_key).await {
+                    Ok((room_state, secrets)) => {
+                        catch_up_pending = false;
+                        Self::emit_stream_changes(
+                            &room_state,
+                            &secrets,
+                            &mut seen_messages,
+                            &mut deleted_emitted,
+                            &mut seen_reactions,
+                            room_owner_key,
+                            &format,
+                            max_messages,
+                            &mut new_message_count,
+                        )?;
+                    }
+                    // Left pending on purpose, so the next loop iteration retries.
+                    // `warn!`, not `debug!`: this fetch IS the mechanism that
+                    // closes the silent hole, so a failure here is the thing an
+                    // operator most needs to see.
+                    Err(e) => {
+                        warn!("Failed to catch up after the pointer refresh: {e}");
+                    }
+                }
+                if max_messages > 0 && new_message_count >= max_messages {
+                    return Ok(());
+                }
+            }
+
+            // Re-SUBSCRIBE after a re-key — AFTER the catch-up above, and never
+            // fatally.
+            //
+            // Ordering: the catch-up is a plain GET that needs no subscription,
+            // so sequencing it first means a node that will not accept the
+            // SUBSCRIBE cannot also cost us the fetch that would have worked.
+            //
+            // Non-fatal: the node most likely to refuse a SUBSCRIBE for a
+            // generation is one that does not hold it YET — which is exactly the
+            // node state just after River publishes a re-key. Propagating that
+            // would make the first bot to notice a re-key the one that exits,
+            // one line after printing "no restart needed". So retry on a short
+            // cadence and keep the catch-up running meanwhile: the stream
+            // degrades to polling at `RESUBSCRIBE_RETRY_INTERVAL` instead of
+            // dying.
+            if resubscribe_pending
+                && last_resubscribe_attempt
+                    .is_none_or(|t| t.elapsed() >= RESUBSCRIBE_RETRY_INTERVAL)
+            {
+                last_resubscribe_attempt = Some(std::time::Instant::now());
+                match self
+                    .subscribe_and_await_ack(contract_instance_id, &format, &mut pending)
+                    .await
+                {
+                    Ok(()) => {
+                        resubscribe_pending = false;
+                        last_resubscribe_attempt = None;
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Could not subscribe to the new room-contract generation yet \
+                             ({e}); retrying, and continuing to poll meanwhile"
+                        );
+                        // Keep surfacing content while unsubscribed.
+                        catch_up_pending = true;
                     }
                 }
             }
@@ -9338,28 +9514,23 @@ mod reaccept_guard_tests {
 #[cfg(test)]
 mod pointer_refresh_tests {
     use super::*;
+    use crate::pointer::test_support::{pointer_anchor, unverified_anchor};
+    use crate::pointer::{code_hash_b58, Generation};
+
+    const LIVE: [u8; 32] = [0x11; 32];
+    const OTHER: [u8; 32] = [0xBB; 32];
+
+    fn bundled() -> [u8; 32] {
+        bundled_room_code_hash()
+    }
 
     /// A stream acts on `moved` by tearing down and rebuilding its subscription,
     /// so a false positive is a self-inflicted outage and a false negative is the
     /// freenet/river#694 silence. Pin both directions.
     #[test]
     fn anchor_refresh_reports_only_a_real_generation_move() {
-        use crate::pointer::{anchor_from_report, code_hash_b58, ResolveReport};
-        use freenet_migrate::pointer::PointerFloor;
-
-        // `Failed` against a never-resolved floor yields an anchor sitting on the
-        // bundled hash, so varying `bundled` is how this test varies the
-        // generation without needing a node or a signed record.
-        let anchor_for = |bundled: [u8; 32]| {
-            anchor_from_report(
-                &ResolveReport::Failed("node unreachable".to_string()),
-                &PointerFloor::never_resolved(),
-                bundled,
-            )
-            .expect("an unreachable pointer is a usable anchor, not an error")
-        };
-        let before = anchor_for([0xAA; 32]);
-        let after = anchor_for([0xBB; 32]);
+        let before = pointer_anchor(LIVE, bundled());
+        let after = pointer_anchor(OTHER, bundled());
 
         // A first resolution is not a move.
         let first = AnchorRefresh::new(before.clone(), None);
@@ -9371,7 +9542,7 @@ mod pointer_refresh_tests {
         assert!(!same.moved());
         assert_eq!(same.move_notice(), None);
 
-        // A different generation is.
+        // A different generation, verified, is.
         let moved = AnchorRefresh::new(after.clone(), Some(before.clone()));
         assert!(moved.moved());
         assert_eq!(moved.anchor().code_hash(), after.code_hash());
@@ -9391,33 +9562,63 @@ mod pointer_refresh_tests {
         assert!(notice.contains("no restart needed"), "{notice}");
     }
 
-    /// A re-key that riverctl is too old to write to must still be FOLLOWED for
+    /// Same hash, WEAKER provenance. The anchors differ as values, so an
+    /// implementation comparing whole structs would call this a move and tear
+    /// down a subscription that is addressing exactly the right contract.
+    /// `AnchorRefresh` must compare the code hash, and only the code hash.
+    #[test]
+    fn degraded_provenance_at_the_same_hash_is_not_a_move() {
+        let verified = pointer_anchor(LIVE, bundled());
+        let degraded = unverified_anchor(LIVE, bundled());
+        assert_ne!(
+            verified, degraded,
+            "the two anchors must differ as values, or this test pins nothing"
+        );
+        assert_eq!(verified.code_hash(), degraded.code_hash());
+
+        let refresh = AnchorRefresh::new(degraded, Some(verified));
+        assert!(
+            !refresh.moved(),
+            "a provenance downgrade at the same hash still addresses the same \
+             contract; tearing down over it is a self-inflicted outage"
+        );
+        assert_eq!(refresh.move_notice(), None);
+    }
+
+    /// The mirror image, and the one that bites in the field: an UNVERIFIED
+    /// anchor naming a different hash must NOT be treated as a re-key.
+    ///
+    /// A failed refresh still produces an anchor — on the floor's hash, or the
+    /// BUNDLED hash when the floor has never been written, and persisting the
+    /// floor is best-effort. So a plain timeout can hand back a hash that differs
+    /// from the one in force. Acting on that would announce a re-key that never
+    /// happened and re-subscribe to a RETIRED generation, flapping every refresh.
+    #[test]
+    fn an_unverified_hash_change_is_never_a_move() {
+        let verified_live = pointer_anchor(LIVE, bundled());
+        // What a failed refresh looks like when the floor never persisted: the
+        // anchor falls back to the bundled hash, which is not where the room is.
+        let fallback = unverified_anchor(bundled(), bundled());
+        assert_ne!(verified_live.code_hash(), fallback.code_hash());
+
+        let refresh = AnchorRefresh::new(fallback, Some(verified_live));
+        assert!(
+            !refresh.moved(),
+            "only a signature-verified record may move a stream off the \
+             generation it is reading"
+        );
+        assert_eq!(refresh.move_notice(), None);
+    }
+
+    /// A re-key that riverctl is too old to WRITE to must still be followed for
     /// reading. A stream that refused to move would stay on the retired
     /// generation, which is the original bug wearing a safety justification.
     #[test]
     fn a_move_to_an_unknown_generation_is_still_a_move() {
-        use crate::pointer::{anchor_from_report, Generation, ResolveReport};
-        use freenet_migrate::pointer::PointerFloor;
-
-        let bundled = bundled_room_code_hash();
-        let before = anchor_from_report(
-            &ResolveReport::Failed("node unreachable".to_string()),
-            &PointerFloor::never_resolved(),
-            bundled,
-        )
-        .unwrap();
-        // An anchor whose hash is neither the bundled one nor any this binary
-        // knows: River has re-keyed past us. The hash has to come from the FLOOR
-        // rather than from `bundled`, or `classify` would call it `Bundled` by
-        // construction and the test would pin nothing.
-        let live = [0x11; 32];
-        let after = anchor_from_report(
-            &ResolveReport::Failed("node unreachable".to_string()),
-            &PointerFloor::at(4, live).expect("a floor at a real code hash"),
-            bundled,
-        )
-        .unwrap();
-        assert_eq!(after.code_hash(), &live);
+        let before = pointer_anchor(bundled(), bundled());
+        assert_eq!(before.generation(), Generation::Bundled);
+        // Neither the bundled hash nor any generation this binary knows.
+        let after = pointer_anchor(LIVE, bundled());
         assert_eq!(after.generation(), Generation::Unknown);
 
         let refresh = AnchorRefresh::new(after, Some(before));
@@ -9426,6 +9627,26 @@ mod pointer_refresh_tests {
             .anchor()
             .authorize(KeyIntent::Read)
             .expect("reads must follow the move even when writes cannot");
+        refresh
+            .anchor()
+            .authorize(KeyIntent::Write)
+            .expect_err("writes against an unknown generation stay refused (#695)");
+    }
+
+    /// A withdrawal must end a stream; an unreachable pointer must not. The
+    /// loops distinguish them through this predicate, so pin it here rather than
+    /// trusting that the two error paths stay recognisable by eye.
+    #[test]
+    fn only_a_withdrawal_is_a_fatal_refresh_failure() {
+        let withdrawn: anyhow::Error =
+            crate::pointer::PointerWithdrawn("retired".to_string()).into();
+        assert!(ApiClient::refresh_failure_is_fatal(&withdrawn));
+
+        let transient = anyhow!("the pointer record could not be fetched (timeout)");
+        assert!(
+            !ApiClient::refresh_failure_is_fatal(&transient),
+            "a transient failure must never tear down a working stream"
+        );
     }
 }
 
@@ -10300,6 +10521,104 @@ mod monitor_tests {
     /// `emit_reaction_changes` over the post-reaction state then advances the
     /// stored fingerprint (and prints the event); the text fingerprint is
     /// identical across both states, proving text-only detection misses it.
+    /// The catch-up that follows every pointer refresh (freenet/river#694) feeds a
+    /// freshly-fetched state through `emit_stream_changes` using the SAME tracking
+    /// maps the stream has been accumulating. Both directions matter and both are
+    /// silent when wrong: if the carried-over state were ignored the stream would
+    /// re-emit the whole room every five minutes forever, and if new content were
+    /// missed the catch-up would not close the hole it exists to close.
+    ///
+    /// This is the behaviour a live bot operator notices first, and it is what the
+    /// re-key path does at the moment the generation changes, so pin it directly
+    /// rather than trusting the source-grep wiring guard alone.
+    #[test]
+    fn a_catch_up_emits_only_what_is_new() {
+        let first = authored(RoomMessageBody::public("first".to_string()));
+        let second = authored(RoomMessageBody::public("second".to_string()));
+        let owner_vk = SigningKey::from_bytes(&[6u8; 32]).verifying_key();
+        let secrets: HashMap<u32, [u8; 32]> = HashMap::new();
+
+        // Before the refresh: the room as the stream has already displayed it.
+        let before = state_with_reactions(&first, vec![]);
+        // The catch-up fetch: same message, plus one written since.
+        let after = {
+            let mut recent = MessagesV1 {
+                messages: vec![first.clone(), second.clone()],
+                ..Default::default()
+            };
+            recent.rebuild_actions_state();
+            ChatRoomStateV1 {
+                recent_messages: recent,
+                ..Default::default()
+            }
+        };
+
+        let mut seen_messages: HashMap<String, String> = HashMap::new();
+        let mut deleted_emitted: HashSet<String> = HashSet::new();
+        let mut seen_reactions: HashMap<String, String> = HashMap::new();
+        let mut new_message_count = 0usize;
+
+        let emit = |state: &ChatRoomStateV1,
+                    seen_messages: &mut HashMap<String, String>,
+                    deleted_emitted: &mut HashSet<String>,
+                    seen_reactions: &mut HashMap<String, String>,
+                    new_message_count: &mut usize| {
+            ApiClient::emit_stream_changes(
+                state,
+                &secrets,
+                seen_messages,
+                deleted_emitted,
+                seen_reactions,
+                &owner_vk,
+                &OutputFormat::Json,
+                0,
+                new_message_count,
+            )
+            .unwrap();
+        };
+
+        emit(
+            &before,
+            &mut seen_messages,
+            &mut deleted_emitted,
+            &mut seen_reactions,
+            &mut new_message_count,
+        );
+        assert_eq!(
+            new_message_count, 1,
+            "the pre-existing message is surfaced once"
+        );
+
+        // The catch-up: exactly one new message, and the carried-over one is NOT
+        // re-counted.
+        emit(
+            &after,
+            &mut seen_messages,
+            &mut deleted_emitted,
+            &mut seen_reactions,
+            &mut new_message_count,
+        );
+        assert_eq!(
+            new_message_count, 2,
+            "the catch-up must emit the message written during the gap, and must \
+             NOT re-emit one the stream already showed"
+        );
+
+        // A refresh that finds nothing new must say nothing — otherwise every
+        // five-minute refresh is duplicate spam.
+        emit(
+            &after,
+            &mut seen_messages,
+            &mut deleted_emitted,
+            &mut seen_reactions,
+            &mut new_message_count,
+        );
+        assert_eq!(
+            new_message_count, 2,
+            "a catch-up over unchanged state must emit nothing"
+        );
+    }
+
     #[test]
     fn live_reaction_change_is_detected_when_text_is_unchanged() {
         let original = authored(RoomMessageBody::public("hello".to_string()));
@@ -12341,9 +12660,10 @@ mod response_multiplexing_pin {
     /// Every production `.recv()` on the shared connection.
     ///
     /// One of them IS the `ResponseSource` impl `await_response` reads through;
-    /// the other ten are sites the fix has not reached. All eleven are listed
-    /// rather than only the unreached ones, so the constant can be audited by
-    /// walking the list. Note a plain `grep -c` over the file does NOT give 11:
+    /// ten more are sites the fix has not reached; the twelfth is not a
+    /// connection read at all (see entry 12). All twelve are listed rather than
+    /// only the unreached ones, so the constant can be audited by walking the
+    /// list. Note a plain `grep -c` over the file does NOT give 11:
     /// it also counts the meta-tests' own string literals, which the pin strips
     /// with `production_source` before counting.
     ///
@@ -12365,6 +12685,16 @@ mod response_multiplexing_pin {
     ///  9. `accept_invitation_struct`'s join delta -- #690.
     /// 10. `ensure_room_migrated` -- #690.
     /// 11. `migrate_room_to_new_contract` -- freenet/river#689.
+    /// 12. the streaming monitor's shutdown `select!` -- NOT a read of the
+    ///     connection at all. It is `shutdown_rx.recv()` on the Ctrl+C mpsc
+    ///     channel, added by freenet/river#694 so a five-minute pointer refresh
+    ///     cannot widen shutdown latency to the pointer GET's timeout. The note
+    ///     under the count below predicted exactly this: the scan counts every
+    ///     `.recv()` rather than every connection read, on purpose, because
+    ///     binding it to a variable name would make it a spelling ban. A second
+    ///     mpsc receiver is therefore a FALSE POSITIVE to be recorded here, not
+    ///     a call site to route through `await_response` -- which could not
+    ///     accept it anyway, since it does not read the connection.
     ///
     /// 6 through 11 are deliberately outside this change, but NOT all for the
     /// same reason, and an earlier version of this comment gave one reason for
@@ -12392,7 +12722,7 @@ mod response_multiplexing_pin {
     ///     issue (#689) rather than riding along here.
     ///
     /// Lowering this number is #690's job, and #689's.
-    const DIRECT_CONNECTION_READS: usize = 11;
+    const DIRECT_CONNECTION_READS: usize = 12;
 
     /// Production references to the connection field, and locks taken on it.
     ///
@@ -12726,7 +13056,7 @@ mod response_multiplexing_pin {
         );
         assert_caught(
             &mutated,
-            "found 12",
+            "found 13",
             "a newly-added direct read whose guard is not called `web_api`",
         );
     }

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -152,16 +152,18 @@ impl PointerIo for NodePointerIo<'_> {
         }
         // Falling out of the loop means the answer never arrived: either the
         // deadline passed or `MAX_UNRELATED_RESPONSES_DURING_POINTER_GET` frames
-        // were stepped over first. On a busy room the second is reachable, and
-        // it is the one path where a re-key can be missed for a whole refresh
-        // cycle with nothing an operator can see — the advisory says nothing,
-        // because the anchor did not change. So say it here rather than leaving
-        // it to a `debug!` that release builds drop.
-        warn!(
-            "Could not read River's room-contract pointer this cycle (no answer within \
-             {POINTER_GET_TIMEOUT:?}, after stepping over up to \
-             {MAX_UNRELATED_RESPONSES_DURING_POINTER_GET} unrelated responses); \
-             continuing on the generation already in use and retrying next cycle"
+        // were stepped over first. On a busy room the second is reachable.
+        //
+        // Logged at `debug!` and no higher, deliberately. `resolve_app_pointer`
+        // calls this up to twice per resolution, so anything louder would
+        // double-report; and the operator-facing consequence — that this run
+        // could not confirm its generation — is what `AnchorSource::Unverified`
+        // carries to `announce_anchor`, which reaches stderr. Raising the level
+        // here would not help anyway: riverctl's `EnvFilter` has no default
+        // directive, so with `RUST_LOG` unset NOTHING is emitted at any level.
+        debug!(
+            "Pointer GET produced no answer within {POINTER_GET_TIMEOUT:?} (after stepping over \
+             up to {MAX_UNRELATED_RESPONSES_DURING_POINTER_GET} unrelated responses)"
         );
 
         // NEVER `PointerFetch::Absent`. `Absent` is the only answer that can
@@ -693,6 +695,120 @@ pub(crate) enum SubscribeAck {
     Refused,
     /// Not the acknowledgement — keep waiting, and do not discard this.
     NotYet,
+}
+
+/// A piece of stream work that is armed, then retried on a cadence until it
+/// succeeds.
+///
+/// Both of a stream's deferred jobs have this shape: the catch-up fetch and the
+/// mid-run re-SUBSCRIBE. Each was a `bool` plus an `Option<Instant>` held side by
+/// side in the loop, which made two wrong states representable — armed with no
+/// cadence, and a stale timestamp left behind after a success — and left the
+/// cadence logic with nowhere to be tested. Both defects this PR had to fix in
+/// review were in exactly this bookkeeping: a job that cleared itself without
+/// covering the window it existed to cover, and one that retried on the loop's
+/// 500ms tick instead of its own interval.
+///
+/// `Instant` is passed in rather than read from the clock so every transition is
+/// testable without sleeping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct Retry {
+    /// `None` = nothing to do. `Some(None)` = armed, never attempted, so the
+    /// next attempt is immediate. `Some(Some(t))` = armed, last attempted at `t`.
+    state: Option<Option<std::time::Instant>>,
+    /// Consecutive attempts that have not succeeded, used to widen the gap.
+    failures: u32,
+}
+
+/// How far a [`Retry`]'s interval may be widened by repeated failure.
+///
+/// A catch-up that keeps failing is usually a node that does not hold the
+/// generation yet, and each attempt is a full-state GET plus, on a miss, a sweep
+/// of every legacy generation. Retrying that at a fixed cadence turns one
+/// unlucky moment into a sustained load from every bot at once; doubling up to
+/// this cap keeps the first few retries prompt and the rest cheap.
+const RETRY_MAX_BACKOFF_MULTIPLIER: u32 = 16;
+
+impl Retry {
+    /// Arm the work, with the next attempt due immediately.
+    ///
+    /// Deliberately resets the cadence: re-arming means something new happened
+    /// (a re-key, a fresh refresh), and making that wait out the previous
+    /// failure's backoff would delay the very work the new event asked for.
+    fn arm(&mut self) {
+        self.state = Some(None);
+        self.failures = 0;
+    }
+
+    /// Whether an attempt should run now: armed, and either never attempted or
+    /// last attempted at least `interval` ago.
+    fn due(&self, now: std::time::Instant, interval: std::time::Duration) -> bool {
+        match self.state {
+            None => false,
+            Some(None) => true,
+            Some(Some(last)) => now.duration_since(last) >= self.backoff(interval),
+        }
+    }
+
+    /// `interval`, doubled once per consecutive failure, capped.
+    fn backoff(&self, interval: std::time::Duration) -> std::time::Duration {
+        let multiplier = 1u32
+            .checked_shl(self.failures.saturating_sub(1))
+            .unwrap_or(RETRY_MAX_BACKOFF_MULTIPLIER)
+            .min(RETRY_MAX_BACKOFF_MULTIPLIER);
+        interval.saturating_mul(multiplier.max(1))
+    }
+
+    /// Record that an attempt is being made now. Leaves the work armed — only
+    /// [`Self::succeeded`] disarms it, which is what makes a transient failure
+    /// retry instead of being forgotten.
+    fn attempted(&mut self, now: std::time::Instant) {
+        if self.state.is_some() {
+            self.state = Some(Some(now));
+            self.failures = self.failures.saturating_add(1);
+        }
+    }
+
+    /// Record success: disarm, and drop the cadence so a later re-arm is
+    /// immediate rather than shadowed by this attempt's timestamp.
+    fn succeeded(&mut self) {
+        self.state = None;
+        self.failures = 0;
+    }
+}
+
+/// The higher of a remembered floor and the one just read from disk.
+///
+/// Pure so the rule is testable without a node or a filesystem. "Higher" is by
+/// version, except that at EQUAL versions a withdrawal wins: a tombstone is the
+/// author saying there is no current code, and dropping it because a
+/// non-withdrawn record shares its version would resurrect exactly what was
+/// retired.
+pub(crate) fn highest_floor(
+    remembered: Option<PointerFloor>,
+    on_disk: PointerFloor,
+) -> PointerFloor {
+    match remembered {
+        Some(mem) if mem.version() > on_disk.version() => mem,
+        Some(mem) if mem.version() == on_disk.version() && mem.is_withdrawn() => mem,
+        _ => on_disk,
+    }
+}
+
+/// Whether a legacy-recovery fetch may republish what it recovered.
+///
+/// Recovering older state and PUTting it onto the current generation is the
+/// point of recovery for a command a user invoked. It is not the point for a
+/// long-running stream's repeated fetch, which must be able to READ state the
+/// current generation does not hold yet — that is what makes a catch-up
+/// straight after a re-key return anything at all — while neither publishing on
+/// a timer nor blocking on the PUT's 60-second timeout to do it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RecoveryWrites {
+    /// A user-invoked command: republish the recovered state forward.
+    Allowed,
+    /// A repeated stream fetch: return the recovered state, publish nothing.
+    Suppressed,
 }
 
 /// Cap on responses buffered while awaiting the SUBSCRIBE acknowledgement.
@@ -2515,6 +2631,25 @@ pub struct ApiClient {
     /// that was live when it started (freenet/river#694). One-shot commands are
     /// unaffected — they resolve once and never refresh, exactly as before.
     room_anchor: tokio::sync::RwLock<Option<RoomAnchor>>,
+    /// The highest anti-rollback floor this PROCESS has verified.
+    ///
+    /// The floor's job is to make a validly-signed OLDER record unusable, and
+    /// until now it was read fresh from disk on every resolution. That is fine
+    /// when resolution happens once. It is not fine once a stream re-resolves on
+    /// a timer, because persisting the floor is best-effort (`save_pointer_floor`
+    /// warns and continues — a read-only config directory is enough): the cache
+    /// could hold a record at version 10 while the next refresh reloads an older
+    /// or absent on-disk floor, and a peer serving a genuine version 9 would then
+    /// resolve as `AnchorSource::Pointer` and be accepted, moving the stream back
+    /// onto the generation the author had already superseded.
+    ///
+    /// **A signature establishes authenticity, not freshness.** This field is
+    /// what supplies freshness when the disk cannot.
+    /// A `std::sync::Mutex` and never held across an await: the critical sections
+    /// are one copy and one assignment. An async mutex here would add a third
+    /// lock to the ordering story for no benefit, and would be counted by the
+    /// connection-acquisition pin as if it were a reach for the shared socket.
+    pointer_floor: std::sync::Mutex<Option<PointerFloor>>,
 }
 
 impl ApiClient {
@@ -2557,7 +2692,24 @@ impl ApiClient {
             config,
             storage,
             room_anchor: tokio::sync::RwLock::new(None),
+            pointer_floor: std::sync::Mutex::new(None),
         })
+    }
+
+    /// The highest floor this process has verified, if any.
+    fn remembered_floor(&self) -> Option<PointerFloor> {
+        *self
+            .pointer_floor
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Record `floor` as verified by this process.
+    fn remember_floor(&self, floor: PointerFloor) {
+        *self
+            .pointer_floor
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(floor);
     }
 
     /// River's room-contract generation for this run, resolved once.
@@ -2579,9 +2731,22 @@ impl ApiClient {
         if let Some(anchor) = slot.clone() {
             return Ok(anchor);
         }
-        let anchor = self.resolve_room_anchor(None).await?;
+        let anchor = self.resolve_room_anchor().await?;
+        Self::announce_anchor(&anchor, None);
         self.install_room_anchor(&mut slot, anchor.clone());
         Ok(anchor)
+    }
+
+    /// Say, once, what the operator needs to know about the generation now in
+    /// force — on stderr, so it survives a pipeline whose stdout is parsed.
+    ///
+    /// stderr rather than `warn!` on purpose: riverctl's `EnvFilter` has no
+    /// default directive, so with `RUST_LOG` unset the log macros emit NOTHING.
+    /// A line that exists to be read by a human cannot go through them.
+    fn announce_anchor(anchor: &RoomAnchor, previous: Option<&RoomAnchor>) {
+        if let Some(advisory) = crate::pointer::advisory_after(anchor, previous) {
+            eprintln!("{advisory}");
+        }
     }
 
     /// Install `anchor` as this run's generation: cache it, and point the local
@@ -2636,7 +2801,7 @@ impl ApiClient {
     pub async fn refresh_room_anchor(&self) -> Result<AnchorRefresh> {
         let mut slot = self.room_anchor.write().await;
         let previous = slot.clone();
-        let resolved = self.resolve_room_anchor(previous.as_ref()).await?;
+        let resolved = self.resolve_room_anchor().await?;
 
         // Only a signature-verified record may move this run off a generation it
         // is already using, and the gate is on the INSTALL rather than only on
@@ -2644,17 +2809,22 @@ impl ApiClient {
         let accepted = match crate::pointer::decide_refresh(previous.as_ref(), resolved) {
             crate::pointer::RefreshDecision::Accept(anchor) => anchor,
             crate::pointer::RefreshDecision::Decline { keep, rejected } => {
-                warn!(
-                    "Keeping room-contract generation {} : an unverified re-check named {} \
-                     instead ({:?}), which is not evidence enough to move off a generation \
-                     already in use",
-                    crate::pointer::code_hash_b58(keep.code_hash()),
-                    crate::pointer::code_hash_b58(rejected.code_hash()),
-                    rejected.source(),
-                );
+                // stderr, not `warn!` — see `announce_anchor`. And said only when
+                // the decision CHANGES, so a pointer that stays unreachable does
+                // not reprint this every few minutes.
+                if previous.as_ref().map(|p| p.source()) != Some(keep.source()) {
+                    eprintln!(
+                        "note: keeping room-contract generation {}. An unverified re-check named \
+                         {} instead, which is not evidence enough to move off a generation \
+                         already in use.",
+                        crate::pointer::code_hash_b58(keep.code_hash()),
+                        crate::pointer::code_hash_b58(rejected.code_hash()),
+                    );
+                }
                 keep
             }
         };
+        Self::announce_anchor(&accepted, previous.as_ref());
 
         self.install_room_anchor(&mut slot, accepted.clone());
         Ok(AnchorRefresh::new(accepted, previous))
@@ -2663,13 +2833,13 @@ impl ApiClient {
     /// Resolve River's room-contract pointer, persist the anti-rollback floor,
     /// and announce anything the user needs to know.
     ///
-    /// `previous` is the anchor this run was already using, when there is one.
-    /// It exists solely to suppress a repeat of an advisory the user has already
-    /// been shown: a refresh runs every few minutes, and re-printing the same
-    /// "could not verify" warning on each one would train them to ignore it —
-    /// the same reasoning that makes the advisory once-per-run rather than
-    /// once-per-key.
-    async fn resolve_room_anchor(&self, previous: Option<&RoomAnchor>) -> Result<RoomAnchor> {
+    async fn resolve_room_anchor(&self) -> Result<RoomAnchor> {
+        // NOTE: this function does not ANNOUNCE anything. The advisory describes
+        // the generation a run is using, and a refresh can decline the anchor it
+        // just resolved (see `decide_refresh`) — announcing here printed
+        // "Continuing with generation X" naming a hash that was about to be
+        // rejected, i.e. a statement that was simply false. The announcement
+        // belongs with the decision, so both callers make it after deciding.
         let bundled = bundled_room_code_hash();
         let author_vk = river_author_vk()?;
         let key = floor_key(&author_vk, ROOM_CONTRACT_APP_ID);
@@ -2678,12 +2848,18 @@ impl ApiClient {
         // `StoredFloor::to_floor`: `never_resolved` is the one state that
         // re-enables the build-time key, so "recovering" into it is the
         // downgrade the floor exists to prevent.
-        let floor = match self.storage.load_pointer_floor(&key)? {
+        let on_disk = match self.storage.load_pointer_floor(&key)? {
             Some(stored) => stored.to_floor().with_context(|| {
                 crate::pointer::floor_corruption_hint(self.storage.pointer_floors_path())
             })?,
             None => PointerFloor::never_resolved(),
         };
+
+        // Take whichever floor is higher: the one on disk, or the highest this
+        // process has already verified. They differ only when a save failed, and
+        // that is exactly when using the disk alone would re-open the rollback
+        // the floor exists to close. See the `pointer_floor` field.
+        let floor = highest_floor(self.remembered_floor(), on_disk);
 
         let mut io = NodePointerIo {
             web_api: &self.web_api,
@@ -2703,6 +2879,11 @@ impl ApiClient {
         // pre-withdrawal record and resurrect the retired code.
         if let ResolveReport::Outcome(outcome) = &report {
             if let Some(next) = outcome.next_floor() {
+                // Remember it regardless of whether the disk write below lands.
+                // This is the whole anti-rollback guarantee when persistence is
+                // failing, so it must not sit inside the error handling for the
+                // persistence.
+                self.remember_floor(next);
                 if let Err(e) = self
                     .storage
                     .save_pointer_floor(&key, StoredFloor::from_floor(&next))
@@ -2717,13 +2898,6 @@ impl ApiClient {
 
         let anchor = anchor_from_report(&report, &floor, bundled)?;
 
-        // Once per run, on stderr, so it is visible in a pipeline whose stdout
-        // is being parsed. Repeating it per derived key would train users to
-        // ignore it, and so would repeating it on every refresh — hence the
-        // comparison against what was already said.
-        if let Some(advisory) = crate::pointer::advisory_after(&anchor, previous) {
-            eprintln!("{advisory}");
-        }
         info!(
             "Room-contract generation for this run: {} ({:?}, {:?})",
             crate::pointer::code_hash_b58(anchor.code_hash()),
@@ -3102,7 +3276,11 @@ impl ApiClient {
         // Fetch the room state, recovering it across older contract-WASM
         // generations if the current contract has no state (freenet/river#292).
         let (room_state, found_id) = self
-            .fetch_room_state_with_recovery(room_owner_key, *contract_key.id())
+            .fetch_room_state_with_recovery(
+                room_owner_key,
+                *contract_key.id(),
+                RecoveryWrites::Allowed,
+            )
             .await?;
 
         info!(
@@ -3295,6 +3473,7 @@ impl ApiClient {
         &self,
         room_owner_key: &VerifyingKey,
         current_id: ContractInstanceId,
+        writes: RecoveryWrites,
     ) -> Result<(ChatRoomStateV1, ContractInstanceId)> {
         // 1. Current generation (plus any forward upgrade-pointer chain).
         if let Some((state, id)) = self
@@ -3380,7 +3559,10 @@ impl ApiClient {
         // room is no longer stranded on an old generation. The current contract
         // was just confirmed empty/absent, so this creates it; the room
         // contract's CRDT merge keeps a concurrent migrator's write safe.
-        if migrate_forward {
+        // Suppressed for a repeated stream fetch: the recovered state is still
+        // RETURNED, so the stream sees the content either way; what is withheld
+        // is the publish. See `RecoveryWrites`.
+        if migrate_forward && writes == RecoveryWrites::Allowed {
             match self.put_room_state(room_owner_key, &merged).await {
                 Ok(()) => {
                     info!("Migrated recovered room forward onto current contract {current_id}")
@@ -3389,6 +3571,11 @@ impl ApiClient {
                     warn!("Could not migrate recovered room forward (returning it anyway): {e}")
                 }
             }
+        } else if migrate_forward {
+            debug!(
+                "Recovered room from an older generation without republishing it: this is a \
+                 repeated stream fetch, which reads but does not publish"
+            );
         }
         Ok((merged, resolved_id))
     }
@@ -5445,12 +5632,25 @@ impl ApiClient {
         let mut new_message_count = 0;
         let start_time = std::time::Instant::now();
 
+        // ONE fetch through `get_room` at startup, regardless of how many
+        // messages are to be DISPLAYED.
+        //
+        // The display count and the migrate/heal side effects are different
+        // questions, and conflating them was a regression: `--initial-messages`
+        // defaults to 0, so gating this on it meant that in the default polling
+        // mode NOTHING ever went through `get_room`, and a member stranded
+        // without a `member_info` entry stayed "Unknown" to every other peer for
+        // the entire run. Before the periodic fetch became read-only, every poll
+        // went through `get_room` and healed them.
+        //
+        // The subscription mode has always fetched unconditionally here; this
+        // brings polling into line rather than inventing a new rule.
+        let mut room_state = self.get_room(room_owner_key, false).await?;
+        // Decrypt private-room content for display (no-op for public rooms).
+        let secrets = self.room_display_secrets(room_owner_key, &mut room_state);
+
         // Show initial messages if requested
         if initial_messages > 0 {
-            let mut room_state = self.get_room(room_owner_key, false).await?;
-            // Decrypt private-room content for display (no-op for public rooms).
-            let secrets = self.room_display_secrets(room_owner_key, &mut room_state);
-
             // Use display_messages() to filter out action/deleted messages (matches `message list`)
             let all_msgs: Vec<_> = room_state.recent_messages.display_messages().collect();
             let start = all_msgs.len().saturating_sub(initial_messages);
@@ -5616,9 +5816,25 @@ impl ApiClient {
     /// timer on the door.
     ///
     /// Streams still migrate and still heal: their FIRST fetch goes through
-    /// `get_room`, exactly as before, as does every one-shot command. What
-    /// changes is only that a long-running READER stops issuing writes as a
-    /// side effect of reading.
+    /// `get_room`, exactly as before, as does every one-shot command.
+    ///
+    /// Be precise about what this does NOT remove, because "a reader that never
+    /// writes" would be the easier claim and it would be false.
+    /// [`Self::fetch_room_state_with_recovery`] can still `put_room_state` — when
+    /// the current generation holds nothing and an older one does, it republishes
+    /// the recovered state forward. That is reachable from here, and most likely
+    /// exactly when a catch-up runs: right after a re-key, before the new
+    /// generation is populated. It is kept deliberately, because that recovery is
+    /// what makes the post-re-key catch-up return anything at all.
+    ///
+    /// The difference that matters is which failure it can produce.
+    /// `put_room_state` is one of the TOLERANT paths (freenet/river#690): an
+    /// unrelated response folds into a success, so the worst case is a
+    /// vacuously-successful republish of state we already hold.
+    /// `migrate_room_to_new_contract` is not tolerant — it writes an
+    /// attacker-irrelevant but WRONG contract key into `rooms.json`. Cutting the
+    /// second off this path while keeping the first is the trade being made, not
+    /// an oversight.
     async fn fetch_stream_state(
         &self,
         room_owner_key: &VerifyingKey,
@@ -5627,7 +5843,11 @@ impl ApiClient {
             .contract_key_for(room_owner_key, KeyIntent::Read)
             .await?;
         let (mut room_state, _found_id) = self
-            .fetch_room_state_with_recovery(room_owner_key, *contract_key.id())
+            .fetch_room_state_with_recovery(
+                room_owner_key,
+                *contract_key.id(),
+                RecoveryWrites::Suppressed,
+            )
             .await?;
         let secrets = self.room_display_secrets(room_owner_key, &mut room_state);
         Ok((room_state, secrets))
@@ -6823,13 +7043,13 @@ impl ApiClient {
         // (freenet/river#694).
         let mut last_pointer_refresh = std::time::Instant::now();
         let mut refresh_interval = jittered_pointer_refresh_interval();
-        // Set by every refresh, cleared only by a catch-up fetch that succeeded.
-        let mut catch_up_pending = false;
-        let mut last_catch_up_attempt: Option<std::time::Instant> = None;
-        // Set when a re-key is detected, cleared only by a SUBSCRIBE the node
-        // accepted. See the retry below for why this is not a one-shot.
-        let mut resubscribe_pending = false;
-        let mut last_resubscribe_attempt: Option<std::time::Instant> = None;
+        // Armed by every refresh, disarmed only by a catch-up fetch that
+        // succeeded. See [`Retry`] for why the armed flag and its cadence are one
+        // value rather than two.
+        let mut catch_up = Retry::default();
+        // Armed when a re-key is detected, disarmed only by a SUBSCRIBE the node
+        // accepted.
+        let mut resubscribe = Retry::default();
 
         // Main loop: wait for UpdateNotification messages
         loop {
@@ -6878,7 +7098,7 @@ impl ApiClient {
                                 .contract_key_for(room_owner_key, KeyIntent::Read)
                                 .await?
                                 .id();
-                            resubscribe_pending = true;
+                            resubscribe.arm();
                         }
                     }
                     Err(e) => {
@@ -6915,7 +7135,7 @@ impl ApiClient {
                 //
                 // The cost is one extra room GET per refresh interval, which is
                 // far below what the stream is already doing per notification.
-                catch_up_pending = true;
+                catch_up.arm();
             }
 
             // Run the catch-up until one actually SUCCEEDS, rather than once per
@@ -6923,14 +7143,25 @@ impl ApiClient {
             // otherwise lose the gap content permanently: the anchor has already
             // been replaced, so the next refresh sees no move, and if no further
             // notification ever arrives nothing else would go looking.
-            if catch_up_pending
-                && last_catch_up_attempt.is_none_or(|t| t.elapsed() >= CATCH_UP_RETRY_INTERVAL)
-            {
-                last_catch_up_attempt = Some(std::time::Instant::now());
-                match self.fetch_stream_state(room_owner_key).await {
+            if catch_up.due(std::time::Instant::now(), CATCH_UP_RETRY_INTERVAL) {
+                catch_up.attempted(std::time::Instant::now());
+                // Interruptible, and this is the one that needed it most: the
+                // fetch can spend `CURRENT_GET_TIMEOUT` plus a legacy probe sweep
+                // before returning, and it sits on a retry cadence, so a node
+                // that cannot serve the generation yet makes this the loop's
+                // longest and most repeated wait.
+                let fetched = tokio::select! {
+                    Some(()) = shutdown_rx.recv() => {
+                        if matches!(format, OutputFormat::Human) {
+                            eprintln!("\nStopped monitoring.");
+                        }
+                        return Ok(());
+                    }
+                    fetched = self.fetch_stream_state(room_owner_key) => fetched,
+                };
+                match fetched {
                     Ok((room_state, secrets)) => {
-                        catch_up_pending = false;
-                        last_catch_up_attempt = None;
+                        catch_up.succeeded();
                         Self::emit_stream_changes(
                             &room_state,
                             &secrets,
@@ -6943,10 +7174,13 @@ impl ApiClient {
                             &mut new_message_count,
                         )?;
                     }
-                    // Left pending on purpose, so the next loop iteration retries.
-                    // `warn!`, not `debug!`: this fetch IS the mechanism that
-                    // closes the silent hole, so a failure here is the thing an
-                    // operator most needs to see.
+                    // Left armed on purpose, so a later iteration retries.
+                    //
+                    // `warn!` reaches a log subscriber, which riverctl only has
+                    // when `RUST_LOG` is set — so this is for a diagnosing
+                    // operator, not a watching one. The watching operator's
+                    // signal is that the stream keeps working: the retry is what
+                    // closes the hole, not the message.
                     Err(e) => {
                         warn!("Failed to catch up after the pointer refresh: {e}");
                     }
@@ -6971,11 +7205,8 @@ impl ApiClient {
             // cadence and keep the catch-up running meanwhile: the stream
             // degrades to polling at `RESUBSCRIBE_RETRY_INTERVAL` instead of
             // dying.
-            if resubscribe_pending
-                && last_resubscribe_attempt
-                    .is_none_or(|t| t.elapsed() >= RESUBSCRIBE_RETRY_INTERVAL)
-            {
-                last_resubscribe_attempt = Some(std::time::Instant::now());
+            if resubscribe.due(std::time::Instant::now(), RESUBSCRIBE_RETRY_INTERVAL) {
+                resubscribe.attempted(std::time::Instant::now());
                 // Interruptible, for the same reason the refresh above is — and
                 // more so: `subscribe_and_await_ack` waits up to 30s for the
                 // node's acknowledgement, three times the pointer GET's bound.
@@ -7004,8 +7235,7 @@ impl ApiClient {
                 };
                 match acked {
                     Ok(()) => {
-                        resubscribe_pending = false;
-                        last_resubscribe_attempt = None;
+                        resubscribe.succeeded();
                         // Catch up ONCE MORE, now that the subscription is live.
                         // The earlier fetch ran before this SUBSCRIBE was
                         // registered, so anything written in between — including
@@ -7014,8 +7244,7 @@ impl ApiClient {
                         // looking for it. This second pass is what makes the
                         // hand-off gapless; it emits nothing when nothing
                         // happened.
-                        catch_up_pending = true;
-                        last_catch_up_attempt = None;
+                        catch_up.arm();
                     }
                     Err(e) => {
                         warn!(
@@ -7023,7 +7252,7 @@ impl ApiClient {
                              ({e}); retrying, and continuing to poll meanwhile"
                         );
                         // Keep surfacing content while unsubscribed.
-                        catch_up_pending = true;
+                        catch_up.arm();
                     }
                 }
             }
@@ -7059,10 +7288,15 @@ impl ApiClient {
             };
 
             match recv_result {
+                // Only this generation's notifications. There is no unsubscribe
+                // (see `refresh_room_anchor`), so after a re-key the retired
+                // generation keeps delivering, and each stale notification would
+                // otherwise cost a full-state GET against the NEW key. Same key
+                // check the ack and update classifiers make, for the same reason.
                 Ok(Ok(HostResponse::ContractResponse(ContractResponse::UpdateNotification {
                     key,
                     update,
-                }))) => {
+                }))) if *key.id() == contract_instance_id => {
                     // We received an update notification
                     debug!("Received update notification for contract: {}", key.id());
 
@@ -9724,6 +9958,83 @@ mod pointer_refresh_tests {
              which means the jitter is not jittering",
             seen.len()
         );
+    }
+
+    /// The two defects review found in this PR both lived in the arm/retry
+    /// bookkeeping, not in any decision: a job that cleared itself without
+    /// covering the window it existed to cover, and one that retried on the
+    /// loop's tick instead of its own interval. Neither was catchable, because
+    /// the state was a pair of loose locals. Now it is a type, so pin it.
+    #[test]
+    fn retry_stays_armed_until_it_succeeds_and_paces_its_attempts() {
+        let t0 = std::time::Instant::now();
+        let interval = std::time::Duration::from_secs(5);
+        let mut r = Retry::default();
+
+        // Not armed: nothing is ever due.
+        assert!(!r.due(t0, interval));
+
+        // Armed: the FIRST attempt is immediate, not one interval away. A
+        // catch-up that waited out its interval before the first try would leave
+        // the hole it exists to close open for that long.
+        r.arm();
+        assert!(r.due(t0, interval));
+
+        // Attempted but not succeeded: still armed, and now paced.
+        r.attempted(t0);
+        assert!(
+            !r.due(t0, interval),
+            "an attempt just made is not immediately due again"
+        );
+        assert!(!r.due(t0 + std::time::Duration::from_secs(4), interval));
+        assert!(r.due(t0 + interval, interval));
+
+        // Success disarms.
+        r.succeeded();
+        assert!(!r.due(t0 + interval * 100, interval));
+
+        // Re-arming after a success is immediate — the stale timestamp from the
+        // successful attempt must not shadow the new one.
+        r.arm();
+        assert!(r.due(t0, interval));
+    }
+
+    /// Repeated failure must widen the gap. A catch-up that keeps failing is
+    /// usually a node that does not hold the generation yet, and each attempt
+    /// costs a full-state GET plus a legacy sweep — so a fixed cadence turns one
+    /// unlucky moment into sustained load from every bot at once.
+    #[test]
+    fn retry_backs_off_on_consecutive_failures_and_resets_on_success() {
+        let t0 = std::time::Instant::now();
+        let interval = std::time::Duration::from_secs(5);
+        let mut r = Retry::default();
+        r.arm();
+
+        // First failure: still the base interval (no penalty for one miss).
+        r.attempted(t0);
+        assert!(r.due(t0 + interval, interval));
+
+        // Second: doubled.
+        r.attempted(t0 + interval);
+        assert!(!r.due(t0 + interval * 2, interval));
+        assert!(r.due(t0 + interval * 3, interval));
+
+        // And it is capped rather than growing without bound.
+        for i in 0..40 {
+            r.attempted(t0 + interval * (4 + i));
+        }
+        assert!(
+            r.due(
+                t0 + interval * 44 + interval * RETRY_MAX_BACKOFF_MULTIPLIER,
+                interval
+            ),
+            "the backoff must be capped, or a long outage silently stops retrying"
+        );
+
+        // A success clears the penalty, so the next arming is prompt again.
+        r.succeeded();
+        r.arm();
+        assert!(r.due(t0, interval));
     }
 
     /// A stream acts on `moved` by tearing down and rebuilding its subscription,
@@ -12895,8 +13206,8 @@ mod response_multiplexing_pin {
     /// Every production `.recv()` on the shared connection.
     ///
     /// One of them IS the `ResponseSource` impl `await_response` reads through;
-    /// ten more are sites the fix has not reached; the last three are not
-    /// connection reads at all (see entries 12-14). All fourteen are listed
+    /// ten more are sites the fix has not reached; the last four are not
+    /// connection reads at all (see entries 12-15). All fifteen are listed
     /// rather than only the unreached ones, so the constant can be audited by
     /// walking the list. Note a plain `grep -c` over the file does NOT give 11:
     /// it also counts the meta-tests' own string literals, which the pin strips
@@ -12924,11 +13235,12 @@ mod response_multiplexing_pin {
     ///     refresh -- NOT a read of the connection at all.
     /// 13. the same, around the mid-run re-SUBSCRIBE.
     /// 14. the same, in the POLLING monitor's refresh.
+    /// 15. the same, around the streaming monitor's catch-up fetch.
     ///
-    /// 12 through 14 are all `shutdown_rx.recv()` on the Ctrl+C mpsc channel,
+    /// 12 through 15 are all `shutdown_rx.recv()` on the Ctrl+C mpsc channel,
     /// added by freenet/river#694 so that the periodic pointer refresh, and the
     /// re-subscribe that can follow it, cannot widen shutdown latency to their
-    /// own timeouts (10s and 30s respectively). The note under the count below
+    /// own timeouts (10s, 30s, and a GET plus legacy sweep). The note under the count below
     /// predicted exactly this: the scan counts every `.recv()` rather than every
     /// connection read, on purpose, because binding it to a variable name would
     /// make it a spelling ban rather than a count. A second receiver is
@@ -12962,7 +13274,7 @@ mod response_multiplexing_pin {
     ///     issue (#689) rather than riding along here.
     ///
     /// Lowering this number is #690's job, and #689's.
-    const DIRECT_CONNECTION_READS: usize = 14;
+    const DIRECT_CONNECTION_READS: usize = 15;
 
     /// Production references to the connection field, and locks taken on it.
     ///
@@ -13296,7 +13608,7 @@ mod response_multiplexing_pin {
         );
         assert_caught(
             &mutated,
-            "found 15",
+            "found 16",
             "a newly-added direct read whose guard is not called `web_api`",
         );
     }

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -2670,6 +2670,11 @@ pub struct ApiClient {
     /// The generation named by the last refresh this run declined, so the note
     /// about declining is said when it changes rather than on every cycle.
     last_declined: std::sync::Mutex<Option<[u8; 32]>>,
+    /// Advisory conditions already announced this run. A set, not a last-value:
+    /// a condition that ALTERNATES is a changed condition every time, so
+    /// comparing against the previous one alone reprinted a flapping warning on
+    /// every refresh.
+    announced: std::sync::Mutex<std::collections::HashSet<String>>,
 }
 
 impl ApiClient {
@@ -2714,6 +2719,7 @@ impl ApiClient {
             room_anchor: tokio::sync::RwLock::new(None),
             pointer_floor: std::sync::Mutex::new(None),
             last_declined: std::sync::Mutex::new(None),
+            announced: std::sync::Mutex::new(std::collections::HashSet::new()),
         })
     }
 
@@ -2772,7 +2778,7 @@ impl ApiClient {
             return Ok(anchor);
         }
         let anchor = self.resolve_room_anchor().await?;
-        Self::announce_anchor(&anchor, None);
+        self.announce_anchor(&anchor);
         self.install_room_anchor(&mut slot, anchor.clone());
         Ok(anchor)
     }
@@ -2783,8 +2789,19 @@ impl ApiClient {
     /// stderr rather than `warn!` on purpose: riverctl's `EnvFilter` has no
     /// default directive, so with `RUST_LOG` unset the log macros emit NOTHING.
     /// A line that exists to be read by a human cannot go through them.
-    fn announce_anchor(anchor: &RoomAnchor, previous: Option<&RoomAnchor>) {
-        if let Some(advisory) = crate::pointer::advisory_after(anchor, previous) {
+    fn announce_anchor(&self, anchor: &RoomAnchor) {
+        let Some(key) = crate::pointer::advisory_key(anchor) else {
+            return;
+        };
+        let mut seen = self
+            .announced
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !seen.insert(key) {
+            return;
+        }
+        drop(seen);
+        if let Some(advisory) = anchor.advisory() {
             eprintln!("{advisory}");
         }
     }
@@ -2864,7 +2881,7 @@ impl ApiClient {
                 keep
             }
         };
-        Self::announce_anchor(&accepted, previous.as_ref());
+        self.announce_anchor(&accepted);
 
         self.install_room_anchor(&mut slot, accepted.clone());
         Ok(AnchorRefresh::new(accepted, previous))
@@ -5685,12 +5702,24 @@ impl ApiClient {
         //
         // The subscription mode has always fetched unconditionally here; this
         // brings polling into line rather than inventing a new rule.
-        let mut room_state = self.get_room(room_owner_key, false).await?;
-        // Decrypt private-room content for display (no-op for public rooms).
-        let secrets = self.room_display_secrets(room_owner_key, &mut room_state);
+        // Not `?`: before this fetch existed unconditionally, a polling stream
+        // with the default `--initial-messages=0` never touched the node at
+        // startup, so a node that was briefly unreachable meant a slow first poll
+        // rather than an exit. Propagating here would turn that into a non-zero
+        // exit for the DEFAULT invocation. The loop retries; the migrate-and-heal
+        // this fetch also performs is best-effort by nature.
+        let startup = match self.get_room(room_owner_key, false).await {
+            Ok(state) => Some(state),
+            Err(e) => {
+                warn!("Could not fetch room state at startup (will keep polling): {e}");
+                None
+            }
+        };
 
         // Show initial messages if requested
-        if initial_messages > 0 {
+        if let (Some(mut room_state), true) = (startup, initial_messages > 0) {
+            // Decrypt private-room content for display (no-op for public rooms).
+            let secrets = self.room_display_secrets(room_owner_key, &mut room_state);
             // Use display_messages() to filter out action/deleted messages (matches `message list`)
             let all_msgs: Vec<_> = room_state.recent_messages.display_messages().collect();
             let start = all_msgs.len().saturating_sub(initial_messages);
@@ -7090,6 +7119,9 @@ impl ApiClient {
         // Armed when a re-key is detected, disarmed only by a SUBSCRIBE the node
         // accepted.
         let mut resubscribe = Retry::default();
+        // Reset on each detected move, so every re-key gets one visible report if
+        // its re-subscribe does not land immediately.
+        let mut first_resubscribe_failure = true;
 
         // Main loop: wait for UpdateNotification messages
         loop {
@@ -7142,6 +7174,7 @@ impl ApiClient {
                                 .await?
                                 .id();
                             resubscribe.arm();
+                            first_resubscribe_failure = true;
                         }
                     }
                     Err(e) => {
@@ -7301,10 +7334,24 @@ impl ApiClient {
                         catch_up.arm();
                     }
                     Err(e) => {
-                        warn!(
-                            "Could not subscribe to the new room-contract generation yet \
-                             ({e}); retrying, and continuing to poll meanwhile"
+                        // The FIRST failure goes to stderr, because the operator
+                        // has just been told "Re-subscribing to the new
+                        // generation; no restart needed" and this is that claim
+                        // not holding yet. Later attempts stay in the log: the
+                        // point is to correct the record once, not to narrate
+                        // every retry.
+                        let msg = format!(
+                            "note: the node has not accepted a subscription to the new \
+                             room-contract generation yet ({e}). Retrying every {}s, and \
+                             polling meanwhile — messages will still appear.",
+                            RESUBSCRIBE_RETRY_INTERVAL.as_secs()
                         );
+                        if first_resubscribe_failure {
+                            first_resubscribe_failure = false;
+                            eprintln!("{msg}");
+                        } else {
+                            warn!("{msg}");
+                        }
                         // Keep surfacing content while unsubscribed.
                         catch_up.arm();
                     }

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -2333,6 +2333,79 @@ impl std::fmt::Debug for Invitation {
     }
 }
 
+/// How often a long-running command re-resolves River's room-contract pointer.
+///
+/// A refresh is one GET of a fixed address, so five minutes is far below the
+/// cost of the traffic such a command is already handling, while bounding how
+/// long a bot can keep talking to a retired generation after a re-key. It is not
+/// user-configurable on purpose: the right value is a property of how River
+/// releases, not of any one deployment, and a knob here would mostly be a way to
+/// turn the protection off by accident.
+const POINTER_REFRESH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// The outcome of re-resolving River's room-contract pointer mid-run.
+///
+/// `moved` is the field callers act on, and it is deliberately narrower than
+/// "the anchor changed": an anchor whose provenance went from verified to
+/// unverified while naming the SAME code hash addresses the same contract, so a
+/// stream must not tear down a healthy subscription over it.
+#[derive(Debug, Clone)]
+pub struct AnchorRefresh {
+    anchor: RoomAnchor,
+    previous: Option<RoomAnchor>,
+    moved: bool,
+}
+
+impl AnchorRefresh {
+    /// Build a refresh result, deciding `moved` from the two code hashes.
+    ///
+    /// The comparison is on the CODE HASH, not on the whole anchor: a run whose
+    /// provenance went from verified to unverified while naming the same hash is
+    /// still addressing the same contract, and tearing down a healthy
+    /// subscription over it would be a self-inflicted outage.
+    fn new(anchor: RoomAnchor, previous: Option<RoomAnchor>) -> Self {
+        // False when nothing was cached: a first resolution is not a move, and
+        // reporting one would make an ordinary startup look like a re-key.
+        let moved = matches!(&previous, Some(p) if p.code_hash() != anchor.code_hash());
+        Self {
+            anchor,
+            previous,
+            moved,
+        }
+    }
+
+    /// The anchor in force after the refresh.
+    pub fn anchor(&self) -> &RoomAnchor {
+        &self.anchor
+    }
+
+    /// Whether the room-contract generation actually moved. False on a first
+    /// resolution, and false when the same hash was re-confirmed.
+    pub fn moved(&self) -> bool {
+        self.moved
+    }
+
+    /// The human-readable line describing the move, or `None` if nothing moved.
+    ///
+    /// Names both generations because that is what makes a bug report actionable
+    /// without a follow-up question, and says what riverctl is doing about it so
+    /// the operator does not have to infer whether their bot is still working.
+    pub fn move_notice(&self) -> Option<String> {
+        if !self.moved {
+            return None;
+        }
+        let from = self
+            .previous
+            .as_ref()
+            .map(|p| crate::pointer::code_hash_b58(p.code_hash()))
+            .unwrap_or_else(|| "(none)".to_string());
+        Some(format!(
+            "River re-keyed the room contract while this command was running.\n               was: {from}\n  now: {}\n             Re-subscribing to the new generation; no restart needed.",
+            crate::pointer::code_hash_b58(self.anchor.code_hash()),
+        ))
+    }
+}
+
 pub struct ApiClient {
     web_api: Arc<Mutex<WebApi>>,
     #[allow(dead_code)]
@@ -2345,7 +2418,13 @@ pub struct ApiClient {
     /// connection but never touches a room key pays nothing, and so the one GET
     /// happens where its failure can be reported against the operation that
     /// needed it.
-    room_anchor: tokio::sync::OnceCell<RoomAnchor>,
+    ///
+    /// A `RwLock` rather than a `OnceCell` because a long-running command must
+    /// be able to REPLACE it: River can re-key the room contract while a stream
+    /// is running, and a write-once cell pinned that stream to the generation
+    /// that was live when it started (freenet/river#694). One-shot commands are
+    /// unaffected — they resolve once and never refresh, exactly as before.
+    room_anchor: tokio::sync::RwLock<Option<RoomAnchor>>,
 }
 
 impl ApiClient {
@@ -2387,23 +2466,62 @@ impl ApiClient {
             web_api: Arc::new(Mutex::new(web_api)),
             config,
             storage,
-            room_anchor: tokio::sync::OnceCell::new(),
+            room_anchor: tokio::sync::RwLock::new(None),
         })
     }
 
     /// River's room-contract generation for this run, resolved once.
     ///
     /// Resolution is one GET of a fixed address, so the cost is a single short
-    /// round trip per riverctl invocation that touches a room.
-    pub async fn room_anchor(&self) -> Result<&RoomAnchor> {
-        self.room_anchor
-            .get_or_try_init(|| self.resolve_room_anchor())
-            .await
+    /// round trip per riverctl invocation that touches a room. Returned by value
+    /// rather than by reference because the cache is now replaceable (see
+    /// [`Self::refresh_room_anchor`]); a [`RoomAnchor`] is two 32-byte hashes and
+    /// a short string, so cloning it is cheaper than holding a lock across the
+    /// caller's work.
+    pub async fn room_anchor(&self) -> Result<RoomAnchor> {
+        if let Some(anchor) = self.room_anchor.read().await.clone() {
+            return Ok(anchor);
+        }
+        // Resolve under the WRITE lock, and re-check after taking it: two tasks
+        // can both miss the read above, and resolving twice would mean two GETs
+        // and two advisories for one run.
+        let mut slot = self.room_anchor.write().await;
+        if let Some(anchor) = slot.clone() {
+            return Ok(anchor);
+        }
+        let anchor = self.resolve_room_anchor(None).await?;
+        *slot = Some(anchor.clone());
+        Ok(anchor)
+    }
+
+    /// Re-resolve River's room-contract pointer, replacing the cached anchor.
+    ///
+    /// For long-running commands only. A re-key moves every room's contract key
+    /// at once, and a stream that resolved at startup stays bound to the retired
+    /// key forever — the node has nothing left to send it, which is
+    /// indistinguishable from a quiet room (freenet/river#694). Refreshing on a
+    /// cadence is what lets such a command notice and follow the move.
+    ///
+    /// Returns what is in force afterwards and whether the generation actually
+    /// moved, so the caller can re-subscribe only when it did.
+    pub async fn refresh_room_anchor(&self) -> Result<AnchorRefresh> {
+        let mut slot = self.room_anchor.write().await;
+        let previous = slot.clone();
+        let anchor = self.resolve_room_anchor(previous.as_ref()).await?;
+        *slot = Some(anchor.clone());
+        Ok(AnchorRefresh::new(anchor, previous))
     }
 
     /// Resolve River's room-contract pointer, persist the anti-rollback floor,
     /// and announce anything the user needs to know.
-    async fn resolve_room_anchor(&self) -> Result<RoomAnchor> {
+    ///
+    /// `previous` is the anchor this run was already using, when there is one.
+    /// It exists solely to suppress a repeat of an advisory the user has already
+    /// been shown: a refresh runs every few minutes, and re-printing the same
+    /// "could not verify" warning on each one would train them to ignore it —
+    /// the same reasoning that makes the advisory once-per-run rather than
+    /// once-per-key.
+    async fn resolve_room_anchor(&self, previous: Option<&RoomAnchor>) -> Result<RoomAnchor> {
         let bundled = bundled_room_code_hash();
         let author_vk = river_author_vk()?;
         let key = floor_key(&author_vk, ROOM_CONTRACT_APP_ID);
@@ -2453,8 +2571,9 @@ impl ApiClient {
 
         // Once per run, on stderr, so it is visible in a pipeline whose stdout
         // is being parsed. Repeating it per derived key would train users to
-        // ignore it.
-        if let Some(advisory) = anchor.advisory() {
+        // ignore it, and so would repeating it on every refresh — hence the
+        // comparison against what was already said.
+        if let Some(advisory) = crate::pointer::advisory_after(&anchor, previous) {
             eprintln!("{advisory}");
         }
         info!(
@@ -3048,7 +3167,8 @@ impl ApiClient {
         //    that River has moved past searches a set that cannot contain the
         //    live room, and can surface an ancient copy and republish it onto a
         //    retired key.
-        let candidate_ids = match probe_plan(room_owner_key, self.room_anchor().await?) {
+        let anchor = self.room_anchor().await?;
+        let candidate_ids = match probe_plan(room_owner_key, &anchor) {
             ProbePlan::Probe(ids) => ids,
             ProbePlan::Refuse(message) => return Err(anyhow!(message)),
         };
@@ -3256,7 +3376,11 @@ impl ApiClient {
         // Read the ALREADY-resolved anchor rather than re-resolving: every path
         // that reaches here went through `room_anchor()` first, so the value is
         // cached and this performs no I/O and can swallow no transport error.
-        match self.room_anchor.get() {
+        // `read().await` is the cache read, not a resolution — it blocks only for
+        // as long as a concurrent refresh holds the write lock, which is the
+        // correct behaviour here: taking the pre-refresh value would build
+        // `known_keys` against a generation that is no longer current.
+        match self.room_anchor.read().await.clone() {
             Some(anchor) => {
                 known_keys.insert(*anchor.contract_key(room_owner_key).id());
             }
@@ -5208,8 +5332,31 @@ impl ApiClient {
             let _ = shutdown_tx.send(()).await;
         });
 
+        // When the pointer was last re-checked. The polling loop re-derives the
+        // room key from the anchor on every poll, so refreshing the anchor is by
+        // itself enough to follow a re-key here — but without the refresh every
+        // poll keeps hitting the retired generation, which still EXISTS and still
+        // answers, so the loop never errors and never sees another message
+        // (freenet/river#694).
+        let mut last_pointer_refresh = std::time::Instant::now();
+
         // Main polling loop
         loop {
+            if last_pointer_refresh.elapsed() >= POINTER_REFRESH_INTERVAL {
+                last_pointer_refresh = std::time::Instant::now();
+                match self.refresh_room_anchor().await {
+                    Ok(refresh) => {
+                        if let Some(notice) = refresh.move_notice() {
+                            eprintln!("{notice}");
+                        }
+                    }
+                    // Best-effort, exactly as in the subscription loop.
+                    Err(e) => {
+                        warn!("Could not re-check River's room-contract pointer: {e}");
+                    }
+                }
+            }
+
             // Check for shutdown signal
             if shutdown_rx.try_recv().is_ok() {
                 if matches!(format, OutputFormat::Human) {
@@ -5233,12 +5380,11 @@ impl ApiClient {
             // Poll for new + edited messages. emit_new_and_edited re-emits a
             // message whose effective content changed (an edit) and emits ones
             // not seen before; it respects max_messages for NEW messages.
-            match self.get_room(room_owner_key, false).await {
-                Ok(mut room_state) => {
-                    // Decrypt private-room content for display (no-op for public rooms).
-                    let secrets = self.room_display_secrets(room_owner_key, &mut room_state);
-                    Self::emit_new_and_edited(
+            match self.fetch_stream_state(room_owner_key).await {
+                Ok((room_state, secrets)) => {
+                    Self::emit_stream_changes(
                         &room_state,
+                        &secrets,
                         &mut seen_messages,
                         &mut deleted_emitted,
                         &mut seen_reactions,
@@ -5246,25 +5392,6 @@ impl ApiClient {
                         &format,
                         max_messages,
                         &mut new_message_count,
-                        &secrets,
-                    )?;
-                    Self::emit_deletions(
-                        &room_state,
-                        &seen_messages,
-                        &mut deleted_emitted,
-                        room_owner_key,
-                        &format,
-                        &secrets,
-                    )?;
-                    // Surface reactions added/removed since a message was already
-                    // streamed. Runs AFTER emit_new_and_edited so a brand-new
-                    // message is seeded (not re-emitted) on the same poll.
-                    Self::emit_reaction_changes(
-                        &room_state,
-                        &mut seen_reactions,
-                        room_owner_key,
-                        &format,
-                        &secrets,
                     )?;
                     if max_messages > 0 && new_message_count >= max_messages {
                         return Ok(());
@@ -5279,6 +5406,66 @@ impl ApiClient {
             // Wait for next poll interval
             tokio::time::sleep(std::time::Duration::from_millis(poll_interval_ms)).await;
         }
+    }
+
+    /// Fetch authoritative room state for a stream, with private-room content
+    /// decrypted for display (a no-op for public rooms).
+    ///
+    /// Split from [`Self::emit_stream_changes`] so the caller keeps the
+    /// distinction both stream loops have always drawn: a FETCH failure is
+    /// transient and the loop logs it and carries on, while an EMIT failure
+    /// (a closed stdout, say) ends the stream. Collapsing the two into one
+    /// `Result` would silently convert the second into the first.
+    async fn fetch_stream_state(
+        &self,
+        room_owner_key: &VerifyingKey,
+    ) -> Result<(ChatRoomStateV1, HashMap<u32, [u8; 32]>)> {
+        let mut room_state = self.get_room(room_owner_key, false).await?;
+        let secrets = self.room_display_secrets(room_owner_key, &mut room_state);
+        Ok((room_state, secrets))
+    }
+
+    /// Emit everything that changed since the previous fetch.
+    ///
+    /// The order is load-bearing: `emit_reaction_changes` must run AFTER
+    /// `emit_new_and_edited` so a brand-new message is seeded rather than
+    /// re-emitted as a reaction change. Shared by the polling loop, the
+    /// subscription's notification handler, and the catch-up that follows a
+    /// mid-run re-subscribe, so the three cannot drift apart on what counts as a
+    /// reportable change.
+    #[allow(clippy::too_many_arguments)]
+    fn emit_stream_changes(
+        room_state: &ChatRoomStateV1,
+        secrets: &HashMap<u32, [u8; 32]>,
+        seen_messages: &mut HashMap<String, String>,
+        deleted_emitted: &mut HashSet<String>,
+        seen_reactions: &mut HashMap<String, String>,
+        room_owner_key: &VerifyingKey,
+        format: &OutputFormat,
+        max_messages: usize,
+        new_message_count: &mut usize,
+    ) -> Result<()> {
+        Self::emit_new_and_edited(
+            room_state,
+            seen_messages,
+            deleted_emitted,
+            seen_reactions,
+            room_owner_key,
+            format,
+            max_messages,
+            new_message_count,
+            secrets,
+        )?;
+        Self::emit_deletions(
+            room_state,
+            seen_messages,
+            deleted_emitted,
+            room_owner_key,
+            format,
+            secrets,
+        )?;
+        Self::emit_reaction_changes(room_state, seen_reactions, room_owner_key, format, secrets)?;
+        Ok(())
     }
 
     /// Scan the room's display messages and emit any that are NEW or whose
@@ -6214,6 +6401,87 @@ impl ApiClient {
     ///
     /// Unlike `stream_messages` which polls, this method subscribes to the contract
     /// and receives push notifications when the contract state changes.
+    /// SUBSCRIBE to `contract_instance_id` and block until the node
+    /// acknowledges, queueing into `pending` anything that overtakes the ack.
+    ///
+    /// A method rather than an inline block because a stream re-subscribes when
+    /// River re-keys the room contract mid-run (freenet/river#694), and the
+    /// ack-race handling below is precisely the part that must not be
+    /// reimplemented slightly differently at a second call site.
+    async fn subscribe_and_await_ack(
+        &self,
+        contract_instance_id: ContractInstanceId,
+        format: &OutputFormat,
+        pending: &mut std::collections::VecDeque<HostResponse>,
+    ) -> Result<()> {
+        let subscribe_request = ContractRequest::Subscribe {
+            key: contract_instance_id, // Subscribe uses ContractInstanceId
+            summary: None,
+        };
+
+        let client_request = ClientRequest::ContractOp(subscribe_request);
+
+        let mut web_api = self.web_api.lock().await;
+        web_api
+            .send(client_request)
+            .await
+            .map_err(|e| anyhow!("Failed to send SUBSCRIBE request: {}", e))?;
+
+        // The node's responses share one multiplexed connection, so an
+        // UpdateNotification for a contract we are already watching can
+        // arrive between our SUBSCRIBE and its acknowledgement. Treating
+        // the first message as the answer made that race fatal: the
+        // session died with "Unexpected response to SUBSCRIBE request",
+        // reconnected, and raced again. On 2026-07-27 that produced 299
+        // failures in four hours and up to 184 reconnects in a single
+        // hour against the official room (freenet-core#4970), and each
+        // reconnect dragged a catch-up batch behind it.
+        //
+        // So read until the acknowledgement actually arrives, and keep
+        // anything that overtakes it. The PUT path above already tolerates
+        // an interleaved UpdateNotification the same way.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                return Err(anyhow!("Timeout waiting for SUBSCRIBE response"));
+            }
+            let response = match tokio::time::timeout(remaining, web_api.recv()).await {
+                Ok(result) => result.map_err(|e| anyhow!("Failed to receive response: {}", e))?,
+                Err(_) => return Err(anyhow!("Timeout waiting for SUBSCRIBE response")),
+            };
+            match classify_subscribe_response(&response) {
+                SubscribeAck::Subscribed => {
+                    if matches!(format, OutputFormat::Human) {
+                        eprintln!("Successfully subscribed. Waiting for updates...\n");
+                    }
+                    break;
+                }
+                SubscribeAck::Refused => return Err(anyhow!("Failed to subscribe to contract")),
+                // Queued rather than dropped: this is a real state change,
+                // and the main loop below drains `pending` before reading
+                // the socket, so it goes through exactly the same handling
+                // it would have had if it arrived a moment later.
+                SubscribeAck::NotYet => {
+                    // Bounded because the node feeds this queue and a busy
+                    // room can emit a lot inside the handshake window; an
+                    // unbounded queue here would be a memory amplification
+                    // vector. Collapsing is lossless: the handler below
+                    // discards the delta (`let _ = update;`) and re-fetches
+                    // authoritative full state, so N queued notifications
+                    // produce exactly the same result as one.
+                    if pending.len() < MAX_PENDING_DURING_HANDSHAKE {
+                        debug!("Response overtook the SUBSCRIBE ack, queuing it");
+                        pending.push_back(response);
+                    } else {
+                        debug!("Response overtook the SUBSCRIBE ack; queue full, collapsing");
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     pub async fn subscribe_and_stream(
         &self,
         room_owner_key: &VerifyingKey,
@@ -6258,7 +6526,7 @@ impl ApiClient {
         let contract_key = self
             .contract_key_for(room_owner_key, KeyIntent::Read)
             .await?;
-        let contract_instance_id = *contract_key.id();
+        let mut contract_instance_id = *contract_key.id();
         {
             let mut room_state = self.get_room(room_owner_key, false).await?;
             // Decrypt private-room content for display (no-op for public rooms).
@@ -6329,77 +6597,8 @@ impl ApiClient {
             std::collections::VecDeque::new();
 
         // Subscribe to the contract
-        {
-            let subscribe_request = ContractRequest::Subscribe {
-                key: contract_instance_id, // Subscribe uses ContractInstanceId
-                summary: None,
-            };
-
-            let client_request = ClientRequest::ContractOp(subscribe_request);
-
-            let mut web_api = self.web_api.lock().await;
-            web_api
-                .send(client_request)
-                .await
-                .map_err(|e| anyhow!("Failed to send SUBSCRIBE request: {}", e))?;
-
-            // The node's responses share one multiplexed connection, so an
-            // UpdateNotification for a contract we are already watching can
-            // arrive between our SUBSCRIBE and its acknowledgement. Treating
-            // the first message as the answer made that race fatal: the
-            // session died with "Unexpected response to SUBSCRIBE request",
-            // reconnected, and raced again. On 2026-07-27 that produced 299
-            // failures in four hours and up to 184 reconnects in a single
-            // hour against the official room (freenet-core#4970), and each
-            // reconnect dragged a catch-up batch behind it.
-            //
-            // So read until the acknowledgement actually arrives, and keep
-            // anything that overtakes it. The PUT path above already tolerates
-            // an interleaved UpdateNotification the same way.
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
-            loop {
-                let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-                if remaining.is_zero() {
-                    return Err(anyhow!("Timeout waiting for SUBSCRIBE response"));
-                }
-                let response = match tokio::time::timeout(remaining, web_api.recv()).await {
-                    Ok(result) => {
-                        result.map_err(|e| anyhow!("Failed to receive response: {}", e))?
-                    }
-                    Err(_) => return Err(anyhow!("Timeout waiting for SUBSCRIBE response")),
-                };
-                match classify_subscribe_response(&response) {
-                    SubscribeAck::Subscribed => {
-                        if matches!(format, OutputFormat::Human) {
-                            eprintln!("Successfully subscribed. Waiting for updates...\n");
-                        }
-                        break;
-                    }
-                    SubscribeAck::Refused => {
-                        return Err(anyhow!("Failed to subscribe to contract"))
-                    }
-                    // Queued rather than dropped: this is a real state change,
-                    // and the main loop below drains `pending` before reading
-                    // the socket, so it goes through exactly the same handling
-                    // it would have had if it arrived a moment later.
-                    SubscribeAck::NotYet => {
-                        // Bounded because the node feeds this queue and a busy
-                        // room can emit a lot inside the handshake window; an
-                        // unbounded queue here would be a memory amplification
-                        // vector. Collapsing is lossless: the handler below
-                        // discards the delta (`let _ = update;`) and re-fetches
-                        // authoritative full state, so N queued notifications
-                        // produce exactly the same result as one.
-                        if pending.len() < MAX_PENDING_DURING_HANDSHAKE {
-                            debug!("Response overtook the SUBSCRIBE ack, queuing it");
-                            pending.push_back(response);
-                        } else {
-                            debug!("Response overtook the SUBSCRIBE ack; queue full, collapsing");
-                        }
-                    }
-                }
-            }
-        }
+        self.subscribe_and_await_ack(contract_instance_id, &format, &mut pending)
+            .await?;
 
         // Set up Ctrl+C handler
         let (shutdown_tx, mut shutdown_rx) = tokio::sync::mpsc::channel(1);
@@ -6409,8 +6608,74 @@ impl ApiClient {
             let _ = shutdown_tx.send(()).await;
         });
 
+        // When the pointer was last re-checked. A long-running subscription is
+        // bound to ONE contract instance id, so a re-key leaves it attached to a
+        // generation nobody writes to any more and the node simply stops having
+        // anything to send — indistinguishable from a quiet room
+        // (freenet/river#694).
+        let mut last_pointer_refresh = std::time::Instant::now();
+
         // Main loop: wait for UpdateNotification messages
         loop {
+            // Follow a mid-run re-key before doing anything else this iteration,
+            // and before taking the `web_api` lock the refresh needs for its own
+            // GET.
+            if last_pointer_refresh.elapsed() >= POINTER_REFRESH_INTERVAL {
+                last_pointer_refresh = std::time::Instant::now();
+                match self.refresh_room_anchor().await {
+                    Ok(refresh) => {
+                        if let Some(notice) = refresh.move_notice() {
+                            eprintln!("{notice}");
+                            // Re-derive through the anchor choke point, so the new
+                            // id comes from the same place every other key does.
+                            contract_instance_id = *self
+                                .contract_key_for(room_owner_key, KeyIntent::Read)
+                                .await?
+                                .id();
+                            self.subscribe_and_await_ack(
+                                contract_instance_id,
+                                &format,
+                                &mut pending,
+                            )
+                            .await?;
+                            // Catch up explicitly. The node only notifies about
+                            // changes that happen AFTER a subscription, so
+                            // everything written to the new generation between the
+                            // re-key and this moment would otherwise be a silent
+                            // hole — the very failure this refresh exists to close.
+                            match self.fetch_stream_state(room_owner_key).await {
+                                Ok((room_state, secrets)) => {
+                                    Self::emit_stream_changes(
+                                        &room_state,
+                                        &secrets,
+                                        &mut seen_messages,
+                                        &mut deleted_emitted,
+                                        &mut seen_reactions,
+                                        room_owner_key,
+                                        &format,
+                                        max_messages,
+                                        &mut new_message_count,
+                                    )?;
+                                }
+                                Err(e) => {
+                                    debug!("Failed to catch up after re-subscribing: {}", e);
+                                }
+                            }
+                            if max_messages > 0 && new_message_count >= max_messages {
+                                return Ok(());
+                            }
+                        }
+                    }
+                    // Never fatal. A refresh is a best-effort currency check, and
+                    // tearing down a working stream because one pointer GET timed
+                    // out would be a worse failure than the staleness it guards
+                    // against. The next interval tries again.
+                    Err(e) => {
+                        warn!("Could not re-check River's room-contract pointer: {e}");
+                    }
+                }
+            }
+
             // Check for shutdown signal
             if shutdown_rx.try_recv().is_ok() {
                 if matches!(format, OutputFormat::Human) {
@@ -6459,13 +6724,11 @@ impl ApiClient {
                     // still holds. The delta payload itself is advisory here.
                     let _ = update;
                     drop(web_api); // get_room needs the web_api lock
-                    match self.get_room(room_owner_key, false).await {
-                        Ok(mut room_state) => {
-                            // Decrypt private-room content for display (no-op for public rooms).
-                            let secrets =
-                                self.room_display_secrets(room_owner_key, &mut room_state);
-                            Self::emit_new_and_edited(
+                    match self.fetch_stream_state(room_owner_key).await {
+                        Ok((room_state, secrets)) => {
+                            Self::emit_stream_changes(
                                 &room_state,
+                                &secrets,
                                 &mut seen_messages,
                                 &mut deleted_emitted,
                                 &mut seen_reactions,
@@ -6473,25 +6736,6 @@ impl ApiClient {
                                 &format,
                                 max_messages,
                                 &mut new_message_count,
-                                &secrets,
-                            )?;
-                            Self::emit_deletions(
-                                &room_state,
-                                &seen_messages,
-                                &mut deleted_emitted,
-                                room_owner_key,
-                                &format,
-                                &secrets,
-                            )?;
-                            // Surface reactions added/removed since a message was
-                            // already streamed. Runs AFTER emit_new_and_edited so a
-                            // brand-new message is seeded (not re-emitted) here.
-                            Self::emit_reaction_changes(
-                                &room_state,
-                                &mut seen_reactions,
-                                room_owner_key,
-                                &format,
-                                &secrets,
                             )?;
                         }
                         Err(e) => {
@@ -9088,6 +9332,100 @@ mod reaccept_guard_tests {
             "the re-accept guard must run BEFORE the network GET so a refused re-accept \
              does no network or storage work"
         );
+    }
+}
+
+#[cfg(test)]
+mod pointer_refresh_tests {
+    use super::*;
+
+    /// A stream acts on `moved` by tearing down and rebuilding its subscription,
+    /// so a false positive is a self-inflicted outage and a false negative is the
+    /// freenet/river#694 silence. Pin both directions.
+    #[test]
+    fn anchor_refresh_reports_only_a_real_generation_move() {
+        use crate::pointer::{anchor_from_report, code_hash_b58, ResolveReport};
+        use freenet_migrate::pointer::PointerFloor;
+
+        // `Failed` against a never-resolved floor yields an anchor sitting on the
+        // bundled hash, so varying `bundled` is how this test varies the
+        // generation without needing a node or a signed record.
+        let anchor_for = |bundled: [u8; 32]| {
+            anchor_from_report(
+                &ResolveReport::Failed("node unreachable".to_string()),
+                &PointerFloor::never_resolved(),
+                bundled,
+            )
+            .expect("an unreachable pointer is a usable anchor, not an error")
+        };
+        let before = anchor_for([0xAA; 32]);
+        let after = anchor_for([0xBB; 32]);
+
+        // A first resolution is not a move.
+        let first = AnchorRefresh::new(before.clone(), None);
+        assert!(!first.moved());
+        assert_eq!(first.move_notice(), None);
+
+        // The same generation re-confirmed is not a move either.
+        let same = AnchorRefresh::new(before.clone(), Some(before.clone()));
+        assert!(!same.moved());
+        assert_eq!(same.move_notice(), None);
+
+        // A different generation is.
+        let moved = AnchorRefresh::new(after.clone(), Some(before.clone()));
+        assert!(moved.moved());
+        assert_eq!(moved.anchor().code_hash(), after.code_hash());
+        let notice = moved.move_notice().expect("a move must be announced");
+        // Both generations are named, so a bug report is actionable without a
+        // follow-up question.
+        assert!(
+            notice.contains(&code_hash_b58(before.code_hash())),
+            "{notice}"
+        );
+        assert!(
+            notice.contains(&code_hash_b58(after.code_hash())),
+            "{notice}"
+        );
+        // And it says what riverctl is doing about it, because the operator's
+        // first question is whether their bot is still working.
+        assert!(notice.contains("no restart needed"), "{notice}");
+    }
+
+    /// A re-key that riverctl is too old to write to must still be FOLLOWED for
+    /// reading. A stream that refused to move would stay on the retired
+    /// generation, which is the original bug wearing a safety justification.
+    #[test]
+    fn a_move_to_an_unknown_generation_is_still_a_move() {
+        use crate::pointer::{anchor_from_report, Generation, ResolveReport};
+        use freenet_migrate::pointer::PointerFloor;
+
+        let bundled = bundled_room_code_hash();
+        let before = anchor_from_report(
+            &ResolveReport::Failed("node unreachable".to_string()),
+            &PointerFloor::never_resolved(),
+            bundled,
+        )
+        .unwrap();
+        // An anchor whose hash is neither the bundled one nor any this binary
+        // knows: River has re-keyed past us. The hash has to come from the FLOOR
+        // rather than from `bundled`, or `classify` would call it `Bundled` by
+        // construction and the test would pin nothing.
+        let live = [0x11; 32];
+        let after = anchor_from_report(
+            &ResolveReport::Failed("node unreachable".to_string()),
+            &PointerFloor::at(4, live).expect("a floor at a real code hash"),
+            bundled,
+        )
+        .unwrap();
+        assert_eq!(after.code_hash(), &live);
+        assert_eq!(after.generation(), Generation::Unknown);
+
+        let refresh = AnchorRefresh::new(after, Some(before));
+        assert!(refresh.moved());
+        refresh
+            .anchor()
+            .authorize(KeyIntent::Read)
+            .expect("reads must follow the move even when writes cannot");
     }
 }
 

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -2848,20 +2848,18 @@ impl ApiClient {
         // the announcement. `decide_refresh` carries the full argument.
         let accepted = match crate::pointer::decide_refresh(previous.as_ref(), resolved) {
             crate::pointer::RefreshDecision::Accept(anchor) => anchor,
-            crate::pointer::RefreshDecision::Decline { keep, rejected } => {
+            crate::pointer::RefreshDecision::Decline {
+                keep,
+                rejected,
+                reason,
+            } => {
                 // stderr, not `warn!` — see `announce_anchor`. Deduplicated on
                 // the REJECTED hash, which is the only thing here that can
                 // actually differ between refreshes: `keep` is by construction a
                 // clone of `previous`, so an earlier version of this compared a
                 // value with itself and could never fire at all.
                 if self.note_declined(rejected.code_hash()) {
-                    eprintln!(
-                        "note: keeping room-contract generation {}. An unverified re-check named \
-                         {} instead, which is not evidence enough to move off a generation \
-                         already in use.",
-                        crate::pointer::code_hash_b58(keep.code_hash()),
-                        crate::pointer::code_hash_b58(rejected.code_hash()),
-                    );
+                    eprintln!("{}", reason.describe(&keep, &rejected));
                 }
                 keep
             }
@@ -7130,6 +7128,9 @@ impl ApiClient {
                     // something is worth PRINTING is how a later "do not repeat
                     // this line" tweak silently disables re-subscription.
                     Ok(refresh) => {
+                        // A move only reaches here if `decide_refresh` accepted
+                        // it — a re-key this riverctl cannot act on is declined
+                        // there, so the subscription is never torn down for one.
                         if refresh.moved() {
                             if let Some(notice) = refresh.move_notice() {
                                 eprintln!("{notice}");
@@ -10253,23 +10254,27 @@ mod pointer_refresh_tests {
         assert_eq!(refresh.move_notice(), None);
     }
 
-    /// A re-key that riverctl is too old to WRITE to must still be followed for
-    /// reading. A stream that refused to move would stay on the retired
-    /// generation, which is the original bug wearing a safety justification.
+    /// `AnchorRefresh` reports the FACT of a move; whether to act on it is
+    /// `decide_refresh`'s call, and a re-key past this binary never reaches here
+    /// as a move at all. What this pins is the division of labour: the type
+    /// reports what it is given, and does not quietly filter.
     #[test]
-    fn a_move_to_an_unknown_generation_is_still_a_move() {
+    fn anchor_refresh_reports_what_it_is_given() {
         let before = pointer_anchor(bundled(), bundled());
-        assert_eq!(before.generation(), Generation::Bundled);
-        // Neither the bundled hash nor any generation this binary knows.
         let after = pointer_anchor(LIVE, bundled());
         assert_eq!(after.generation(), Generation::Unknown);
 
         let refresh = AnchorRefresh::new(after, Some(before));
-        assert!(refresh.moved());
+        assert!(
+            refresh.moved(),
+            "the move is a fact even when it is not acted on"
+        );
+        // Reads against it would be permitted — the refusal to follow is about
+        // what is USEFUL there, not about what is authorized.
         refresh
             .anchor()
             .authorize(KeyIntent::Read)
-            .expect("reads must follow the move even when writes cannot");
+            .expect("reads are permitted against any generation");
         refresh
             .anchor()
             .authorize(KeyIntent::Write)

--- a/cli/src/pointer.rs
+++ b/cli/src/pointer.rs
@@ -157,15 +157,6 @@ pub enum AnchorSource {
     },
 }
 
-/// The deduplication key for an advisory: the provenance, with `Unverified`
-/// split by kind so distinct conditions are not collapsed into one.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum AnchorCondition {
-    Pointer,
-    NeverPublished,
-    Unverified(UnverifiedKind),
-}
-
 /// Why an anchor is unverified — the part worth deduplicating on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum UnverifiedKind {
@@ -329,23 +320,6 @@ impl RoomAnchor {
             code_hash_b58(&self.code_hash),
             river_core::migration::LEGACY_ROOM_CONTRACT_CODE_HASHES.len(),
         )
-    }
-
-    /// What this anchor's advisory is ABOUT: the generation class, and the kind
-    /// of provenance behind it — never the detail that varies between attempts.
-    ///
-    /// This is the unit [`advisory_after`] deduplicates on, so it must not carry
-    /// the `Unverified` reason string: two consecutive timeouts phrased slightly
-    /// differently are the same thing to a reader.
-    fn condition(&self) -> (Generation, AnchorCondition) {
-        let source = match &self.source {
-            AnchorSource::Pointer => AnchorCondition::Pointer,
-            AnchorSource::NeverPublished => AnchorCondition::NeverPublished,
-            // The KIND, never the detail: the detail embeds version numbers that
-            // differ between attempts at the same condition.
-            AnchorSource::Unverified { kind, .. } => AnchorCondition::Unverified(*kind),
-        };
-        (self.generation, source)
     }
 
     /// The line to put on stderr once, at resolution time, or `None` when there
@@ -512,28 +486,28 @@ pub fn decide_refresh(previous: Option<&RoomAnchor>, resolved: RoomAnchor) -> Re
     RefreshDecision::Accept(resolved)
 }
 
-/// The advisory to print for `anchor`, given what has already been printed for
-/// `previous` in this same run.
+/// A stable key for the CONDITION an advisory describes, or `None` when there is
+/// nothing to say.
 ///
-/// Split out from the printing so the suppression rule is testable without a
-/// node.
+/// Callers deduplicate on this rather than on the rendered text, and remember
+/// every key they have printed rather than only the previous one. Both halves
+/// matter and each was wrong once:
 ///
-/// Compared on the CONDITION — the generation class plus the kind of provenance
-/// — rather than on the rendered text. An earlier version compared the strings,
-/// which looks equivalent and is not: an `Unverified` advisory embeds the detail
-/// that varies between attempts (`"a peer served pointer version 7…"`), so a
-/// condition that merely flaps produced a fresh warning every few minutes. A
-/// long-running stream re-resolves on a timer (freenet/river#694), and repeating
-/// a warning on that cadence is how a real warning gets trained into background
-/// noise — the precise outcome this function exists to avoid.
-///
-/// A genuine change of condition is still always printed.
-pub fn advisory_after(anchor: &RoomAnchor, previous: Option<&RoomAnchor>) -> Option<String> {
-    let advisory = anchor.advisory()?;
-    match previous {
-        Some(prev) if prev.advisory().is_some() && prev.condition() == anchor.condition() => None,
-        _ => Some(advisory),
-    }
+///   * comparing the TEXT reprinted a condition whose wording embeds a version
+///     number that changes between attempts;
+///   * comparing only against the PREVIOUS anchor reprinted a condition that
+///     merely alternates — reachable → unreachable → reachable is a *changed*
+///     condition every time, so a flapping node produced a warning every few
+///     minutes, which is the alarm fatigue the deduplication exists to prevent.
+pub fn advisory_key(anchor: &RoomAnchor) -> Option<String> {
+    anchor.advisory()?;
+    let source = match &anchor.source {
+        AnchorSource::Pointer => "pointer".to_string(),
+        AnchorSource::NeverPublished => "never-published".to_string(),
+        // The KIND, never the detail.
+        AnchorSource::Unverified { kind, .. } => format!("unverified:{kind:?}"),
+    };
+    Some(format!("{:?}/{source}", anchor.generation))
 }
 
 /// What a resolution attempt produced, flattened so the arm-by-arm mapping
@@ -945,15 +919,16 @@ mod tests {
         );
     }
 
-    /// A refresh must not re-print an advisory the user has already seen, or a
-    /// long-running stream turns a real warning into noise — but it MUST print
-    /// one that has changed, which is the whole point of re-checking.
+    /// Advisories are deduplicated on the CONDITION, and a caller remembers every
+    /// condition it has announced. Both halves were wrong once: comparing the
+    /// rendered text reprinted a condition whose wording embeds a changing
+    /// version number, and comparing only against the previous anchor reprinted a
+    /// condition that merely alternates.
     #[test]
-    fn advisory_is_printed_once_per_distinct_condition() {
+    fn the_advisory_key_identifies_the_condition_not_its_wording() {
         let author = SigningKey::from_bytes(&[3u8; 32]);
         let live = [0x11; 32];
 
-        // An unknown generation: this one has something to say.
         let unknown = anchor_from_report(
             &ResolveReport::Outcome(outcome_for(
                 &author,
@@ -966,51 +941,29 @@ mod tests {
         )
         .unwrap();
         assert!(unknown.advisory().is_some());
+        assert!(advisory_key(&unknown).is_some());
 
-        // First time: printed.
-        assert!(advisory_after(&unknown, None).is_some());
-        // Re-resolved to the very same condition: withheld.
-        assert_eq!(advisory_after(&unknown, Some(&unknown)), None);
-
-        // A DIFFERENT condition after the same run: printed, even though the
-        // previous pass also had something to say.
-        let unverified = anchor_from_report(
-            &ResolveReport::Failed("node unreachable".to_string()),
-            &PointerFloor::never_resolved(),
-            bundled(),
-        )
-        .unwrap();
-        let printed = advisory_after(&unverified, Some(&unknown))
-            .expect("a changed condition must not be suppressed by the previous one");
-        assert!(printed.contains("could not verify"), "{printed}");
-
-        // Two UNVERIFIED conditions whose reason strings differ are the same
-        // condition to a reader, and must not reprint every few minutes. This is
-        // the case the string comparison got wrong.
-        let unverified_a = anchor_from_report(
+        // Two unverified conditions whose WORDING differs but whose condition is
+        // the same share a key, so the second is never reprinted.
+        let a = anchor_from_report(
             &ResolveReport::Failed("timed out".to_string()),
             &PointerFloor::never_resolved(),
             bundled(),
         )
         .unwrap();
-        let unverified_b = anchor_from_report(
+        let b = anchor_from_report(
             &ResolveReport::Failed("transport aborted".to_string()),
             &PointerFloor::never_resolved(),
             bundled(),
         )
         .unwrap();
-        assert_ne!(
-            unverified_a.advisory(),
-            unverified_b.advisory(),
-            "the two advisories must differ in wording, or this pins nothing"
-        );
-        assert_eq!(
-            advisory_after(&unverified_b, Some(&unverified_a)),
-            None,
-            "a flapping unverified condition must not reprint on every refresh"
-        );
+        assert_ne!(a.advisory(), b.advisory(), "the wording must differ");
+        assert_eq!(advisory_key(&a), advisory_key(&b), "the condition does not");
 
-        // An anchor with nothing to say stays silent regardless of history.
+        // A genuinely different condition gets a different key.
+        assert_ne!(advisory_key(&unknown), advisory_key(&a));
+
+        // An anchor with nothing to say has no key, so it can never be announced.
         let quiet = anchor_from_report(
             &ResolveReport::Outcome(outcome_for(
                 &author,
@@ -1023,14 +976,9 @@ mod tests {
         )
         .unwrap();
         assert_eq!(quiet.advisory(), None);
-        assert_eq!(advisory_after(&quiet, Some(&unknown)), None);
+        assert_eq!(advisory_key(&quiet), None);
     }
 
-    /// A withdrawal and an unreachable pointer must not look alike to a caller.
-    /// A long-running stream carries on through the second and MUST stop on the
-    /// first (freenet/river#694 review, Codex P1): continuing to read a
-    /// generation the author has signed away, on the strength of a cached
-    /// anchor, is inferring presence from a fact that says the opposite.
     #[test]
     fn a_withdrawal_is_distinguishable_from_an_unreachable_pointer() {
         let author = SigningKey::from_bytes(&[3u8; 32]);

--- a/cli/src/pointer.rs
+++ b/cli/src/pointer.rs
@@ -344,6 +344,55 @@ impl RoomAnchor {
 #[error("{0}")]
 pub struct PointerWithdrawn(pub String);
 
+/// What a mid-run refresh should do with the anchor it just resolved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RefreshDecision {
+    /// Install it: either it is signature-verified, or it names the generation
+    /// already in use and so changes nothing about what is addressed.
+    Accept(RoomAnchor),
+    /// Keep what was already in force. Carries both so the caller can say which
+    /// generation it is staying on and what it declined.
+    Decline {
+        keep: RoomAnchor,
+        rejected: RoomAnchor,
+    },
+}
+
+/// Decide whether a refreshed anchor may replace the one in force.
+///
+/// The rule is one sentence: **only a signature-verified record may move a run
+/// off a generation it is already using.**
+///
+/// Why it has to gate the INSTALL and not merely the announcement: a failed
+/// resolution still produces an anchor, sitting on `last_known()` — the floor's
+/// hash, or the BUNDLED hash when the floor has never been persisted, and
+/// persisting it is best-effort. So a read-only config directory plus one
+/// timeout is enough to resolve a hash that is not where the room is. Declaring
+/// that "not a move" keeps the stream from re-subscribing, but if the anchor is
+/// installed anyway then every later derivation — the polling loop's `get_room`,
+/// the catch-up fetch, the local room store's key regeneration — comes off the
+/// wrong hash, and the stream reads a retired generation while reporting nothing
+/// wrong. That is the silence this whole module exists to remove, arriving
+/// through a second door.
+///
+/// A first resolution (`previous` is `None`) is always accepted: there is
+/// nothing to protect yet, and refusing would leave the run with no anchor at
+/// all.
+pub fn decide_refresh(previous: Option<&RoomAnchor>, resolved: RoomAnchor) -> RefreshDecision {
+    match previous {
+        Some(prev)
+            if resolved.code_hash() != prev.code_hash()
+                && !matches!(resolved.source(), AnchorSource::Pointer) =>
+        {
+            RefreshDecision::Decline {
+                keep: prev.clone(),
+                rejected: resolved,
+            }
+        }
+        _ => RefreshDecision::Accept(resolved),
+    }
+}
+
 /// The advisory to print for `anchor`, given what has already been printed for
 /// `previous` in this same run.
 ///
@@ -840,6 +889,55 @@ mod tests {
         )
         .expect("an unreachable pointer stays best-effort");
         assert_eq!(unreachable.code_hash(), &bundled());
+    }
+
+    /// The install gate, which is a different question from whether to announce a
+    /// move: an unverified anchor that is installed anyway sends every later key
+    /// derivation to the wrong generation, silently.
+    #[test]
+    fn only_a_verified_record_may_replace_the_generation_in_force() {
+        use super::test_support::{pointer_anchor, unverified_anchor};
+        let live = [0x11; 32];
+        let other = [0xBB; 32];
+        let b = bundled();
+
+        let in_force = pointer_anchor(live, b);
+
+        // A verified record naming a new generation: accepted, and it is what
+        // gets installed.
+        let verified_move = pointer_anchor(other, b);
+        assert_eq!(
+            decide_refresh(Some(&in_force), verified_move.clone()),
+            RefreshDecision::Accept(verified_move),
+        );
+
+        // An UNVERIFIED anchor naming a different generation: declined, and the
+        // generation in force is what stays.
+        let fallback = unverified_anchor(b, b);
+        assert_ne!(fallback.code_hash(), in_force.code_hash());
+        match decide_refresh(Some(&in_force), fallback.clone()) {
+            RefreshDecision::Decline { keep, rejected } => {
+                assert_eq!(keep.code_hash(), in_force.code_hash());
+                assert_eq!(rejected.code_hash(), fallback.code_hash());
+            }
+            other => panic!("an unverified hash change must be declined, got {other:?}"),
+        }
+
+        // An unverified anchor naming the SAME generation is harmless — it
+        // addresses the same contract — so it is accepted rather than declined.
+        let same_hash_unverified = unverified_anchor(live, b);
+        assert!(matches!(
+            decide_refresh(Some(&in_force), same_hash_unverified),
+            RefreshDecision::Accept(_)
+        ));
+
+        // A first resolution has nothing to protect and must never be declined,
+        // or a run whose first pointer GET times out would have no anchor at all.
+        let first = unverified_anchor(b, b);
+        assert!(matches!(
+            decide_refresh(None, first),
+            RefreshDecision::Accept(_)
+        ));
     }
 
     #[test]

--- a/cli/src/pointer.rs
+++ b/cli/src/pointer.rs
@@ -401,18 +401,75 @@ pub enum RefreshDecision {
     /// Install it: either it is signature-verified, or it names the generation
     /// already in use and so changes nothing about what is addressed.
     Accept(RoomAnchor),
-    /// Keep what was already in force. Carries both so the caller can say which
-    /// generation it is staying on and what it declined.
+    /// Keep what was already in force. Carries both anchors so the caller can
+    /// say which generation it is staying on and what it declined, and the
+    /// reason, because the two reasons call for very different advice.
     Decline {
         keep: RoomAnchor,
         rejected: RoomAnchor,
+        reason: DeclineReason,
     },
+}
+
+/// Why a refreshed anchor was not installed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeclineReason {
+    /// The new hash came from something that is not a signature-verified record,
+    /// so it is not evidence of anything. Usually a timeout whose fallback hash
+    /// differs from the one in force because the floor could not be persisted.
+    UnverifiedDisagreement,
+    /// The new hash IS verified, and names a generation this binary does not
+    /// know. River has re-keyed past this riverctl.
+    UnknownGeneration,
+}
+
+impl DeclineReason {
+    /// The line the operator sees. Both name the two generations; they differ in
+    /// what they ask for, and that difference is the point of the enum.
+    pub fn describe(&self, keep: &RoomAnchor, rejected: &RoomAnchor) -> String {
+        let (from, to) = (
+            code_hash_b58(keep.code_hash()),
+            code_hash_b58(rejected.code_hash()),
+        );
+        match self {
+            Self::UnverifiedDisagreement => format!(
+                "note: keeping room-contract generation {from}. An unverified re-check named \
+                 {to} instead, which is not evidence enough to move off a generation already \
+                 in use."
+            ),
+            Self::UnknownGeneration => format!(
+                "warning: River re-keyed the room contract while this command was running, to a \
+                 generation this riverctl does not know.\n                   was: {from}\n  now: {to}\n\
+                 Staying on the generation already in use. The new one holds nothing this \
+                 riverctl can reach — the backward probe refuses to search from a generation \
+                 it does not know, and writing to it is refused — so following it would mean \
+                 giving up a working subscription for a key this binary cannot act on. Run \
+                 `cargo install riverctl --force` and restart to follow it."
+            ),
+        }
+    }
 }
 
 /// Decide whether a refreshed anchor may replace the one in force.
 ///
-/// The rule is one sentence: **only a signature-verified record may move a run
-/// off a generation it is already using.**
+/// Two rules, and both are about the same thing: a run only moves off a
+/// generation it is already using when the move is both EVIDENCED and ACTIONABLE.
+///
+/// 1. **Only a signature-verified record may move a run.** Anything else is an
+///    absence of knowledge wearing a hash.
+/// 2. **Only a generation this binary knows may be moved TO.** A verified re-key
+///    past this riverctl is real and is reported, but following it trades a
+///    subscription that is still delivering for a key this binary can do nothing
+///    with: the new generation typically holds no state until a newer client
+///    migrates the room, the backward probe refuses to search from an unknown
+///    anchor (see [`probe_plan`]), and writing is refused. Following it would
+///    leave the stream deaf on BOTH generations while announcing that no restart
+///    was needed — the exact silence this module exists to remove, produced by
+///    the mechanism meant to remove it.
+///
+/// The second rule is NOT the stale-anchor bug returning. The anchor is still
+/// resolved, the operator is still told, and a one-shot command still addresses
+/// the live generation. What is declined is only the mid-run TEARDOWN.
 ///
 /// Why it has to gate the INSTALL and not merely the announcement: a failed
 /// resolution still produces an anchor, sitting on `last_known()` — the floor's
@@ -430,18 +487,29 @@ pub enum RefreshDecision {
 /// nothing to protect yet, and refusing would leave the run with no anchor at
 /// all.
 pub fn decide_refresh(previous: Option<&RoomAnchor>, resolved: RoomAnchor) -> RefreshDecision {
-    match previous {
-        Some(prev)
-            if resolved.code_hash() != prev.code_hash()
-                && !matches!(resolved.source(), AnchorSource::Pointer) =>
-        {
-            RefreshDecision::Decline {
-                keep: prev.clone(),
-                rejected: resolved,
-            }
-        }
-        _ => RefreshDecision::Accept(resolved),
+    let Some(prev) = previous else {
+        // A first resolution has nothing to protect, and refusing would leave the
+        // run with no anchor at all.
+        return RefreshDecision::Accept(resolved);
+    };
+    if resolved.code_hash() == prev.code_hash() {
+        return RefreshDecision::Accept(resolved);
     }
+    if !matches!(resolved.source(), AnchorSource::Pointer) {
+        return RefreshDecision::Decline {
+            keep: prev.clone(),
+            rejected: resolved,
+            reason: DeclineReason::UnverifiedDisagreement,
+        };
+    }
+    if resolved.generation() == Generation::Unknown {
+        return RefreshDecision::Decline {
+            keep: prev.clone(),
+            rejected: resolved,
+            reason: DeclineReason::UnknownGeneration,
+        };
+    }
+    RefreshDecision::Accept(resolved)
 }
 
 /// The advisory to print for `anchor`, given what has already been printed for
@@ -994,15 +1062,16 @@ mod tests {
     #[test]
     fn only_a_verified_record_may_replace_the_generation_in_force() {
         use super::test_support::{pointer_anchor, unverified_anchor};
-        let live = [0x11; 32];
-        let other = [0xBB; 32];
         let b = bundled();
+        // A generation this binary knows: the destination of a move it can act on.
+        let known = river_core::migration::LEGACY_ROOM_CONTRACT_CODE_HASHES[3];
 
-        let in_force = pointer_anchor(live, b);
+        let in_force = pointer_anchor(b, b);
 
-        // A verified record naming a new generation: accepted, and it is what
+        // A verified record naming a generation we know: accepted, and it is what
         // gets installed.
-        let verified_move = pointer_anchor(other, b);
+        let verified_move = pointer_anchor(known, b);
+        assert_eq!(verified_move.generation(), Generation::Legacy(3));
         assert_eq!(
             decide_refresh(Some(&in_force), verified_move.clone()),
             RefreshDecision::Accept(verified_move),
@@ -1010,10 +1079,15 @@ mod tests {
 
         // An UNVERIFIED anchor naming a different generation: declined, and the
         // generation in force is what stays.
-        let fallback = unverified_anchor(b, b);
+        let fallback = unverified_anchor(known, b);
         assert_ne!(fallback.code_hash(), in_force.code_hash());
         match decide_refresh(Some(&in_force), fallback.clone()) {
-            RefreshDecision::Decline { keep, rejected } => {
+            RefreshDecision::Decline {
+                keep,
+                rejected,
+                reason,
+            } => {
+                assert_eq!(reason, DeclineReason::UnverifiedDisagreement);
                 assert_eq!(keep.code_hash(), in_force.code_hash());
                 assert_eq!(rejected.code_hash(), fallback.code_hash());
             }
@@ -1022,7 +1096,7 @@ mod tests {
 
         // An unverified anchor naming the SAME generation is harmless — it
         // addresses the same contract — so it is accepted rather than declined.
-        let same_hash_unverified = unverified_anchor(live, b);
+        let same_hash_unverified = unverified_anchor(b, b);
         assert!(matches!(
             decide_refresh(Some(&in_force), same_hash_unverified),
             RefreshDecision::Accept(_)
@@ -1033,6 +1107,50 @@ mod tests {
         let first = unverified_anchor(b, b);
         assert!(matches!(
             decide_refresh(None, first),
+            RefreshDecision::Accept(_)
+        ));
+    }
+
+    /// The second rule, and the one that is counter-intuitive: a VERIFIED re-key
+    /// to a generation this binary does not know is declined too.
+    ///
+    /// Following it reads as strictly better — reads are permitted against any
+    /// generation — and is in fact how a running stream goes deaf on BOTH. The
+    /// new key holds nothing this binary can reach (the backward probe refuses to
+    /// search from an unknown anchor, and writing is refused), and the stream
+    /// would have given up a subscription that was still delivering to get there.
+    #[test]
+    fn a_verified_rekey_past_this_binary_is_reported_but_not_followed() {
+        use super::test_support::pointer_anchor;
+        let b = bundled();
+        let in_force = pointer_anchor(b, b);
+        let past_us = pointer_anchor([0x11; 32], b);
+        assert_eq!(past_us.generation(), Generation::Unknown);
+        assert_eq!(past_us.source(), &AnchorSource::Pointer, "it IS verified");
+
+        match decide_refresh(Some(&in_force), past_us.clone()) {
+            RefreshDecision::Decline {
+                keep,
+                rejected,
+                reason,
+            } => {
+                assert_eq!(reason, DeclineReason::UnknownGeneration);
+                assert_eq!(keep.code_hash(), in_force.code_hash());
+                // And the operator is told to upgrade, not reassured.
+                let msg = reason.describe(&keep, &rejected);
+                assert!(msg.contains("cargo install riverctl"), "{msg}");
+                assert!(
+                    !msg.contains("no restart needed"),
+                    "an unfollowable move must not claim a restart is unnecessary: {msg}"
+                );
+            }
+            other => panic!("a re-key past this binary must not be followed, got {other:?}"),
+        }
+
+        // A one-shot command is unaffected: with nothing in force there is no
+        // subscription to protect, so the live generation is still adopted.
+        assert!(matches!(
+            decide_refresh(None, past_us),
             RefreshDecision::Accept(_)
         ));
     }

--- a/cli/src/pointer.rs
+++ b/cli/src/pointer.rs
@@ -329,6 +329,21 @@ impl RoomAnchor {
     }
 }
 
+/// The author has signed a statement that there is no current room-contract
+/// code.
+///
+/// A distinct type rather than a plain message because a caller MUST be able to
+/// tell it apart from "we could not reach the pointer". Every other resolution
+/// failure is an absence of knowledge and is safely treated as best-effort — a
+/// long-running stream carries on with what it last verified. A withdrawal is
+/// the opposite: a positive, signature-verified fact that the generation the
+/// stream is using has been retired. Continuing to read from it on the strength
+/// of a cached anchor is exactly the "absence must be proven, not inferred"
+/// mistake this module makes everywhere else, run backwards.
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub struct PointerWithdrawn(pub String);
+
 /// The advisory to print for `anchor`, given what has already been printed for
 /// `previous` in this same run.
 ///
@@ -378,7 +393,7 @@ pub fn anchor_from_report(
     // superseded would resurrect, out of our own memory, exactly the code the
     // author retired.
     if floor.is_withdrawn() {
-        bail!(withdrawn_message(floor.version()));
+        return Err(PointerWithdrawn(withdrawn_message(floor.version())).into());
     }
 
     // What to use when nothing was learned: the last hash this install verified,
@@ -408,7 +423,9 @@ pub fn anchor_from_report(
 
         // The author says there is no current code. Not "the old code is
         // current again", so there is nothing to fall back to.
-        PointerOutcome::Withdrawn { version, .. } => bail!(withdrawn_message(*version)),
+        PointerOutcome::Withdrawn { version, .. } => {
+            Err(PointerWithdrawn(withdrawn_message(*version)).into())
+        }
 
         // The only arm in which a build-time key is legitimate.
         PointerOutcome::NeverPublished => Ok(RoomAnchor::unvouched(
@@ -634,31 +651,29 @@ pub fn floor_corruption_hint(path: &std::path::Path) -> String {
     )
 }
 
+/// Helpers shared by this module's tests and `crate::api`'s.
+///
+/// Lives outside `mod tests` so `api` can build anchors the same way this module
+/// does — through a real signed record and the real resolver. An `api` test that
+/// hand-built an anchor instead could pin behaviour against a provenance the
+/// resolver never produces, which is exactly the class of test this codebase
+/// avoids elsewhere.
 #[cfg(test)]
-mod tests {
+pub(crate) mod test_support {
     use super::*;
     use ed25519_dalek::{Signer, SigningKey};
     use freenet_migrate::pointer::{
-        pointer_contract_id, pointer_params, pointer_signing_message, PointerRecord,
-        PointerResolver,
+        pointer_params, pointer_signing_message, PointerRecord, PointerResolver,
     };
     use freenet_migrate::Step;
 
-    fn bundled() -> [u8; 32] {
-        [0xAA; 32]
-    }
-
-    fn owner() -> VerifyingKey {
-        SigningKey::from_bytes(&[7u8; 32]).verifying_key()
-    }
-
-    /// Drive a real resolver against a canned record so the tests below act on
-    /// genuine `PointerOutcome` values rather than hand-built ones. Hand-built
-    /// outcomes would let a test pass against an outcome the resolver can never
-    /// actually produce, and `Withdrawn` / `CompetingRecord` cannot be built
-    /// by hand at all, being `#[non_exhaustive]` variants, which is exactly the
-    /// boundary this helper respects rather than works around.
-    fn outcome_for(
+    /// Drive a real resolver against a canned record so tests act on genuine
+    /// `PointerOutcome` values rather than hand-built ones. Hand-built outcomes
+    /// would let a test pass against an outcome the resolver can never actually
+    /// produce, and `Withdrawn` / `CompetingRecord` cannot be built by hand at
+    /// all, being `#[non_exhaustive]` variants, which is exactly the boundary
+    /// this helper respects rather than works around.
+    pub(crate) fn outcome_for(
         author: &SigningKey,
         floor: PointerFloor,
         version: u32,
@@ -680,6 +695,49 @@ mod tests {
         };
         assert!(r.on_response(id, &state));
         r.take_outcome().unwrap().unwrap()
+    }
+
+    /// An anchor whose provenance is a signature-verified pointer record naming
+    /// `code_hash`. The only provenance permitted to declare a generation move,
+    /// so any test about moves needs this rather than a fallback anchor.
+    pub(crate) fn pointer_anchor(code_hash: [u8; 32], bundled: [u8; 32]) -> RoomAnchor {
+        let author = SigningKey::from_bytes(&[3u8; 32]);
+        let floor = PointerFloor::never_resolved();
+        let outcome = outcome_for(&author, floor, 4, code_hash);
+        let anchor = anchor_from_report(&ResolveReport::Outcome(outcome), &floor, bundled)
+            .expect("a verified record is a usable anchor");
+        assert_eq!(anchor.source(), &AnchorSource::Pointer);
+        anchor
+    }
+
+    /// An anchor that no pointer vouched for, sitting on `code_hash`. The
+    /// contrast case: same shape, provenance that must NOT move a stream.
+    pub(crate) fn unverified_anchor(code_hash: [u8; 32], bundled: [u8; 32]) -> RoomAnchor {
+        let floor = PointerFloor::at(4, code_hash).expect("a floor at a real code hash");
+        let anchor = anchor_from_report(
+            &ResolveReport::Failed("node unreachable".to_string()),
+            &floor,
+            bundled,
+        )
+        .expect("an unreachable pointer stays best-effort");
+        assert!(matches!(anchor.source(), AnchorSource::Unverified(_)));
+        anchor
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::outcome_for;
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use freenet_migrate::pointer::pointer_contract_id;
+
+    fn bundled() -> [u8; 32] {
+        [0xAA; 32]
+    }
+
+    fn owner() -> VerifyingKey {
+        SigningKey::from_bytes(&[7u8; 32]).verifying_key()
     }
 
     /// The documented pointer address in `FREENET.md` must be exactly what the
@@ -752,6 +810,36 @@ mod tests {
         .unwrap();
         assert_eq!(quiet.advisory(), None);
         assert_eq!(advisory_after(&quiet, Some(&unknown)), None);
+    }
+
+    /// A withdrawal and an unreachable pointer must not look alike to a caller.
+    /// A long-running stream carries on through the second and MUST stop on the
+    /// first (freenet/river#694 review, Codex P1): continuing to read a
+    /// generation the author has signed away, on the strength of a cached
+    /// anchor, is inferring presence from a fact that says the opposite.
+    #[test]
+    fn a_withdrawal_is_distinguishable_from_an_unreachable_pointer() {
+        let author = SigningKey::from_bytes(&[3u8; 32]);
+        let floor = PointerFloor::never_resolved();
+        let tombstone = outcome_for(&author, floor, 9, [0u8; 32]);
+        assert!(matches!(tombstone, PointerOutcome::Withdrawn { .. }));
+
+        let err = anchor_from_report(&ResolveReport::Outcome(tombstone), &floor, bundled())
+            .expect_err("a withdrawal is not a usable anchor");
+        assert!(
+            err.downcast_ref::<PointerWithdrawn>().is_some(),
+            "a withdrawal must be recognisable by TYPE, not by matching its text: {err}"
+        );
+
+        // The contrast case: an unreachable pointer is not an error at all, so a
+        // caller that only checks for `PointerWithdrawn` cannot confuse the two.
+        let unreachable = anchor_from_report(
+            &ResolveReport::Failed("node unreachable".to_string()),
+            &floor,
+            bundled(),
+        )
+        .expect("an unreachable pointer stays best-effort");
+        assert_eq!(unreachable.code_hash(), &bundled());
     }
 
     #[test]

--- a/cli/src/pointer.rs
+++ b/cli/src/pointer.rs
@@ -329,6 +329,24 @@ impl RoomAnchor {
     }
 }
 
+/// The advisory to print for `anchor`, given what has already been printed for
+/// `previous` in this same run.
+///
+/// Split out from the printing so the suppression rule is testable without a
+/// node. The rule is deliberately narrow: an advisory is withheld only when it
+/// is character-identical to one the user has already seen, so a refresh that
+/// changes what they need to know always says so, and a refresh that changes
+/// nothing stays quiet. A long-running stream re-resolves every few minutes
+/// (freenet/river#694), and re-printing the same "could not verify" warning on
+/// each pass is how a real warning gets trained into background noise.
+pub fn advisory_after(anchor: &RoomAnchor, previous: Option<&RoomAnchor>) -> Option<String> {
+    let advisory = anchor.advisory()?;
+    match previous.and_then(|p| p.advisory()) {
+        Some(already) if already == advisory => None,
+        _ => Some(advisory),
+    }
+}
+
 /// What a resolution attempt produced, flattened so the arm-by-arm mapping
 /// below is a pure function that needs no node and no generic error type.
 #[derive(Debug, Clone)]
@@ -679,6 +697,61 @@ mod tests {
             "the author key and app_id in this module no longer derive the pointer address \
              published in FREENET.md"
         );
+    }
+
+    /// A refresh must not re-print an advisory the user has already seen, or a
+    /// long-running stream turns a real warning into noise — but it MUST print
+    /// one that has changed, which is the whole point of re-checking.
+    #[test]
+    fn advisory_is_printed_once_per_distinct_condition() {
+        let author = SigningKey::from_bytes(&[3u8; 32]);
+        let live = [0x11; 32];
+
+        // An unknown generation: this one has something to say.
+        let unknown = anchor_from_report(
+            &ResolveReport::Outcome(outcome_for(
+                &author,
+                PointerFloor::never_resolved(),
+                4,
+                live,
+            )),
+            &PointerFloor::never_resolved(),
+            bundled(),
+        )
+        .unwrap();
+        assert!(unknown.advisory().is_some());
+
+        // First time: printed.
+        assert!(advisory_after(&unknown, None).is_some());
+        // Re-resolved to the very same condition: withheld.
+        assert_eq!(advisory_after(&unknown, Some(&unknown)), None);
+
+        // A DIFFERENT condition after the same run: printed, even though the
+        // previous pass also had something to say.
+        let unverified = anchor_from_report(
+            &ResolveReport::Failed("node unreachable".to_string()),
+            &PointerFloor::never_resolved(),
+            bundled(),
+        )
+        .unwrap();
+        let printed = advisory_after(&unverified, Some(&unknown))
+            .expect("a changed condition must not be suppressed by the previous one");
+        assert!(printed.contains("could not verify"), "{printed}");
+
+        // An anchor with nothing to say stays silent regardless of history.
+        let quiet = anchor_from_report(
+            &ResolveReport::Outcome(outcome_for(
+                &author,
+                PointerFloor::never_resolved(),
+                4,
+                bundled(),
+            )),
+            &PointerFloor::never_resolved(),
+            bundled(),
+        )
+        .unwrap();
+        assert_eq!(quiet.advisory(), None);
+        assert_eq!(advisory_after(&quiet, Some(&unknown)), None);
     }
 
     #[test]

--- a/cli/src/pointer.rs
+++ b/cli/src/pointer.rs
@@ -138,12 +138,46 @@ pub enum AnchorSource {
     /// a build-time key is legitimate.
     NeverPublished,
     /// The pointer could not be consulted, or answered something that moves
-    /// nothing (unreachable, stale, a competing record at the floor version, a
-    /// transport abort). The hash is whatever was last resolved on this install,
-    /// or the bundled one if nothing ever was. Carries the reason, which the
-    /// caller must make visible: this is exactly today's un-anchored behaviour,
-    /// so it is not a regression, but it must not be silent either.
-    Unverified(String),
+    /// nothing. The hash is whatever was last resolved on this install, or the
+    /// bundled one if nothing ever was. Carries the reason, which the caller
+    /// must make visible: this is exactly today's un-anchored behaviour, so it
+    /// is not a regression, but it must not be silent either.
+    ///
+    /// `kind` exists separately from `detail` because the two are used for
+    /// different things and collapsing them loses one of them. `detail` is the
+    /// sentence a human reads. `kind` is what deduplication compares, so that a
+    /// timeout repeating every few minutes stays quiet while a genuinely
+    /// different condition still gets through — and in particular so that
+    /// [`UnverifiedKind::CompetingRecord`], which is a fork or author-key
+    /// signal rather than a hiccup, is never suppressed by an ordinary timeout
+    /// that happened to precede it.
+    Unverified {
+        kind: UnverifiedKind,
+        detail: String,
+    },
+}
+
+/// The deduplication key for an advisory: the provenance, with `Unverified`
+/// split by kind so distinct conditions are not collapsed into one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AnchorCondition {
+    Pointer,
+    NeverPublished,
+    Unverified(UnverifiedKind),
+}
+
+/// Why an anchor is unverified — the part worth deduplicating on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UnverifiedKind {
+    /// Nothing was learned: a timeout, an unreachable node, a transport abort,
+    /// or a resolver outcome this binary does not understand.
+    Unavailable,
+    /// A validly-signed record OLDER than the floor this install already
+    /// verified. Routine — a freshly-bootstrapped peer can serve one.
+    RolledBack,
+    /// Two different valid records exist at one version. Not routine: it means
+    /// a fork, or an author key producing conflicting statements.
+    CompetingRecord,
 }
 
 /// The room-contract code hash this run will derive keys from, and the
@@ -303,8 +337,15 @@ impl RoomAnchor {
     /// This is the unit [`advisory_after`] deduplicates on, so it must not carry
     /// the `Unverified` reason string: two consecutive timeouts phrased slightly
     /// differently are the same thing to a reader.
-    fn condition(&self) -> (Generation, std::mem::Discriminant<AnchorSource>) {
-        (self.generation, std::mem::discriminant(&self.source))
+    fn condition(&self) -> (Generation, AnchorCondition) {
+        let source = match &self.source {
+            AnchorSource::Pointer => AnchorCondition::Pointer,
+            AnchorSource::NeverPublished => AnchorCondition::NeverPublished,
+            // The KIND, never the detail: the detail embeds version numbers that
+            // differ between attempts at the same condition.
+            AnchorSource::Unverified { kind, .. } => AnchorCondition::Unverified(*kind),
+        };
+        (self.generation, source)
     }
 
     /// The line to put on stderr once, at resolution time, or `None` when there
@@ -329,9 +370,9 @@ impl RoomAnchor {
                 self.behind_network_summary()
             )),
             (AnchorSource::NeverPublished, _) => None,
-            (AnchorSource::Unverified(reason), _) => Some(format!(
+            (AnchorSource::Unverified { detail, .. }, _) => Some(format!(
                 "warning: could not verify that riverctl's room-contract generation is current \
-                 ({reason}). Continuing with generation {}. If River has re-keyed since this \
+                 ({detail}). Continuing with generation {}. If River has re-keyed since this \
                  build, room operations will address the wrong contract.",
                 code_hash_b58(&self.code_hash),
             )),
@@ -473,7 +514,10 @@ pub fn anchor_from_report(
             return Ok(RoomAnchor::unvouched(
                 last_known(),
                 bundled,
-                AnchorSource::Unverified(reason.clone()),
+                AnchorSource::Unverified {
+                    kind: UnverifiedKind::Unavailable,
+                    detail: reason.clone(),
+                },
             ));
         }
         ResolveReport::Outcome(o) => o,
@@ -505,10 +549,13 @@ pub fn anchor_from_report(
         PointerOutcome::Stale { served, floor: f } => Ok(RoomAnchor::unvouched(
             last_known(),
             bundled,
-            AnchorSource::Unverified(format!(
-                "a peer served pointer version {served}, older than the version {f} this install \
-                 already verified; the rollback was refused"
-            )),
+            AnchorSource::Unverified {
+                kind: UnverifiedKind::RolledBack,
+                detail: format!(
+                    "a peer served pointer version {served}, older than the version {f} this \
+                     install already verified; the rollback was refused"
+                ),
+            },
         )),
 
         // Two valid records at one version; ours won the tiebreak. The resolver
@@ -520,10 +567,13 @@ pub fn anchor_from_report(
         PointerOutcome::CompetingRecord { version, .. } => Ok(RoomAnchor::unvouched(
             last_known(),
             bundled,
-            AnchorSource::Unverified(format!(
-                "a second, different pointer record exists at version {version}; keeping the one \
-                 already verified here rather than choosing between them"
-            )),
+            AnchorSource::Unverified {
+                kind: UnverifiedKind::CompetingRecord,
+                detail: format!(
+                    "a second, different pointer record exists at version {version}; keeping the \
+                     one already verified here rather than choosing between them"
+                ),
+            },
         )),
 
         // Nothing could be learned. This is today's behaviour, so continuing is
@@ -532,10 +582,12 @@ pub fn anchor_from_report(
         PointerOutcome::Unavailable => Ok(RoomAnchor::unvouched(
             last_known(),
             bundled,
-            AnchorSource::Unverified(
-                "the pointer record could not be fetched (timeout, or the node had no answer)"
+            AnchorSource::Unverified {
+                kind: UnverifiedKind::Unavailable,
+                detail: "the pointer record could not be fetched (timeout, or the node had no \
+                         answer)"
                     .to_string(),
-            ),
+            },
         )),
 
         // `PointerOutcome` is `#[non_exhaustive]`. A future arm is not something
@@ -544,10 +596,13 @@ pub fn anchor_from_report(
         other => Ok(RoomAnchor::unvouched(
             last_known(),
             bundled,
-            AnchorSource::Unverified(format!(
-                "the pointer resolver returned an outcome this riverctl does not understand \
-                 ({other:?}); upgrade riverctl"
-            )),
+            AnchorSource::Unverified {
+                kind: UnverifiedKind::Unavailable,
+                detail: format!(
+                    "the pointer resolver returned an outcome this riverctl does not understand \
+                     ({other:?}); upgrade riverctl"
+                ),
+            },
         )),
     }
 }
@@ -785,7 +840,7 @@ pub(crate) mod test_support {
             bundled,
         )
         .expect("an unreachable pointer stays best-effort");
-        assert!(matches!(anchor.source(), AnchorSource::Unverified(_)));
+        assert!(matches!(anchor.source(), AnchorSource::Unverified { .. }));
         anchor
     }
 }

--- a/cli/src/pointer.rs
+++ b/cli/src/pointer.rs
@@ -297,6 +297,16 @@ impl RoomAnchor {
         )
     }
 
+    /// What this anchor's advisory is ABOUT: the generation class, and the kind
+    /// of provenance behind it — never the detail that varies between attempts.
+    ///
+    /// This is the unit [`advisory_after`] deduplicates on, so it must not carry
+    /// the `Unverified` reason string: two consecutive timeouts phrased slightly
+    /// differently are the same thing to a reader.
+    fn condition(&self) -> (Generation, std::mem::Discriminant<AnchorSource>) {
+        (self.generation, std::mem::discriminant(&self.source))
+    }
+
     /// The line to put on stderr once, at resolution time, or `None` when there
     /// is nothing worth saying.
     ///
@@ -397,16 +407,22 @@ pub fn decide_refresh(previous: Option<&RoomAnchor>, resolved: RoomAnchor) -> Re
 /// `previous` in this same run.
 ///
 /// Split out from the printing so the suppression rule is testable without a
-/// node. The rule is deliberately narrow: an advisory is withheld only when it
-/// is character-identical to one the user has already seen, so a refresh that
-/// changes what they need to know always says so, and a refresh that changes
-/// nothing stays quiet. A long-running stream re-resolves every few minutes
-/// (freenet/river#694), and re-printing the same "could not verify" warning on
-/// each pass is how a real warning gets trained into background noise.
+/// node.
+///
+/// Compared on the CONDITION — the generation class plus the kind of provenance
+/// — rather than on the rendered text. An earlier version compared the strings,
+/// which looks equivalent and is not: an `Unverified` advisory embeds the detail
+/// that varies between attempts (`"a peer served pointer version 7…"`), so a
+/// condition that merely flaps produced a fresh warning every few minutes. A
+/// long-running stream re-resolves on a timer (freenet/river#694), and repeating
+/// a warning on that cadence is how a real warning gets trained into background
+/// noise — the precise outcome this function exists to avoid.
+///
+/// A genuine change of condition is still always printed.
 pub fn advisory_after(anchor: &RoomAnchor, previous: Option<&RoomAnchor>) -> Option<String> {
     let advisory = anchor.advisory()?;
-    match previous.and_then(|p| p.advisory()) {
-        Some(already) if already == advisory => None,
+    match previous {
+        Some(prev) if prev.advisory().is_some() && prev.condition() == anchor.condition() => None,
         _ => Some(advisory),
     }
 }
@@ -844,6 +860,32 @@ mod tests {
         let printed = advisory_after(&unverified, Some(&unknown))
             .expect("a changed condition must not be suppressed by the previous one");
         assert!(printed.contains("could not verify"), "{printed}");
+
+        // Two UNVERIFIED conditions whose reason strings differ are the same
+        // condition to a reader, and must not reprint every few minutes. This is
+        // the case the string comparison got wrong.
+        let unverified_a = anchor_from_report(
+            &ResolveReport::Failed("timed out".to_string()),
+            &PointerFloor::never_resolved(),
+            bundled(),
+        )
+        .unwrap();
+        let unverified_b = anchor_from_report(
+            &ResolveReport::Failed("transport aborted".to_string()),
+            &PointerFloor::never_resolved(),
+            bundled(),
+        )
+        .unwrap();
+        assert_ne!(
+            unverified_a.advisory(),
+            unverified_b.advisory(),
+            "the two advisories must differ in wording, or this pins nothing"
+        );
+        assert_eq!(
+            advisory_after(&unverified_b, Some(&unverified_a)),
+            None,
+            "a flapping unverified condition must not reprint on every refresh"
+        );
 
         // An anchor with nothing to say stays silent regardless of history.
         let quiet = anchor_from_report(

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -387,10 +387,15 @@ impl Storage {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
-    /// Write guard for the code-hash cell, recovering from poisoning rather than
-    /// panicking: the critical section is a single assignment that cannot fail,
-    /// so a poisoned lock can only mean an unrelated panic elsewhere, and
-    /// refusing to store the hash would strand this run on a stale generation.
+    /// Write guard for the code-hash cell.
+    ///
+    /// Poisoning is per-lock and happens only when a thread panics while holding
+    /// THIS lock's write guard. The sole critical section is one assignment, so
+    /// that cannot happen and the recovery arm is unreachable. It is spelled
+    /// `unwrap_or_else` rather than `unwrap` anyway, because the failure it would
+    /// otherwise cause — an abort while installing a freshly-resolved generation
+    /// — is far worse than proceeding, and a future edit that does something
+    /// fallible in here should degrade rather than kill a running stream.
     fn room_code_hash_slot(&self) -> std::sync::RwLockWriteGuard<'_, Option<[u8; 32]>> {
         self.room_code_hash
             .write()
@@ -2246,18 +2251,48 @@ mod tests {
         );
         // And that shared step must still run all three emitters, or routing
         // through it would be a way to lose them all at once.
+        //
+        // Sliced to the body of `emit_stream_changes` rather than searched over
+        // the whole file, because a bare `contains` is satisfiable WITHOUT the
+        // property holding: delete the call from the shared step, add one back in
+        // a single loop, and a whole-file search still finds the string while
+        // deletions have silently stopped surfacing on the other two paths. That
+        // is not hypothetical — it was demonstrated against the first version of
+        // this guard during review of freenet/river#696.
+        let shared_step = api_src
+            .split_once("    fn emit_stream_changes(")
+            .and_then(|(_, rest)| rest.split_once("\n    }\n"))
+            .map(|(body, _)| body)
+            .expect(
+                "emit_stream_changes must exist as a 4-space-indented method; if it was \
+                 renamed or reshaped, re-point this guard rather than deleting it",
+            );
         for emitter in [
             "Self::emit_new_and_edited(",
             "Self::emit_deletions(",
             "Self::emit_reaction_changes(",
         ] {
             assert!(
-                api_src.contains(emitter),
-                "emit_stream_changes must still call {emitter}; dropping one \
-                 silently stops that event kind surfacing on every monitor path \
-                 at once"
+                shared_step.contains(emitter),
+                "emit_stream_changes must itself call {emitter}; dropping it there \
+                 silently stops that event kind surfacing on every monitor path at \
+                 once, and a call left elsewhere in the file does not restore it"
             );
         }
+        // The order is load-bearing: emit_reaction_changes must see a brand-new
+        // message already seeded by emit_new_and_edited, or it re-emits it as a
+        // reaction change.
+        let new_at = shared_step
+            .find("Self::emit_new_and_edited(")
+            .expect("checked above");
+        let reactions_at = shared_step
+            .find("Self::emit_reaction_changes(")
+            .expect("checked above");
+        assert!(
+            new_at < reactions_at,
+            "emit_new_and_edited must run BEFORE emit_reaction_changes, or a \
+             brand-new message is re-emitted as a reaction change"
+        );
         // The dedup key must be the stable signature-derived id, not author:time.
         assert!(
             api_src.contains("monitor_seen_key(msg)"),

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::RwLock;
 use tracing::info;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -316,11 +316,16 @@ pub struct Storage {
     /// key regeneration falls back to the bundled WASM, which is exactly the behaviour
     /// riverctl has always had, and the only behaviour available offline.
     ///
-    /// A `OnceLock` rather than a constructor argument because resolution needs
-    /// a live connection and must stay lazy: `Storage` is built before the
-    /// first GET, and offline commands must not pay for a resolution they will
-    /// never use.
-    room_code_hash: OnceLock<[u8; 32]>,
+    /// Not a constructor argument because resolution needs a live connection
+    /// and must stay lazy: `Storage` is built before the first GET, and offline
+    /// commands must not pay for a resolution they will never use.
+    ///
+    /// A `RwLock` rather than a `OnceLock` because River can re-key the room
+    /// contract while a long-running stream is running, and that stream
+    /// re-resolves the pointer on a cadence (freenet/river#694). A write-once
+    /// cell would pin key regeneration to the generation that was live when the
+    /// process started, which is the staleness the refresh exists to remove.
+    room_code_hash: RwLock<Option<[u8; 32]>>,
 }
 
 impl Storage {
@@ -359,15 +364,37 @@ impl Storage {
             lock_path,
             signing_key_override,
             pointer_floors_path,
-            room_code_hash: OnceLock::new(),
+            room_code_hash: RwLock::new(None),
         })
     }
 
     /// Record the room-contract code hash resolved from River's pointer record,
     /// so key regeneration in [`Self::load_rooms`] agrees with the keys the
-    /// network paths are deriving. Idempotent; a second call is ignored.
+    /// network paths are deriving.
+    ///
+    /// Last write wins. A later call REPLACES an earlier one, because a
+    /// long-running stream re-resolves the pointer and must be able to install a
+    /// generation published after the process started (freenet/river#694).
     pub fn set_room_code_hash(&self, code_hash: [u8; 32]) {
-        let _ = self.room_code_hash.set(code_hash);
+        *self.room_code_hash_slot() = Some(code_hash);
+    }
+
+    /// The code hash recorded so far, or `None` if nothing has been resolved.
+    fn room_code_hash(&self) -> Option<[u8; 32]> {
+        *self
+            .room_code_hash
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Write guard for the code-hash cell, recovering from poisoning rather than
+    /// panicking: the critical section is a single assignment that cannot fail,
+    /// so a poisoned lock can only mean an unrelated panic elsewhere, and
+    /// refusing to store the hash would strand this run on a stale generation.
+    fn room_code_hash_slot(&self) -> std::sync::RwLockWriteGuard<'_, Option<[u8; 32]>> {
+        self.room_code_hash
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     /// Where the anti-rollback floor store lives, so an error can name the file
@@ -605,7 +632,7 @@ impl Storage {
         // it waits for it. Every path that migrates or addresses a contract calls
         // `room_anchor()` first, which sets the hash before touching storage, so
         // nothing that needs the regeneration loses it.
-        let Some(code_hash) = self.room_code_hash.get() else {
+        let Some(code_hash) = self.room_code_hash() else {
             return Ok(storage);
         };
         let mut updated = false;
@@ -622,7 +649,7 @@ impl Storage {
                 Ok(vk) => vk,
                 Err(_) => continue,
             };
-            let new_key = river_core::migration::contract_key_for_code_hash(&owner_vk, code_hash);
+            let new_key = river_core::migration::contract_key_for_code_hash(&owner_vk, &code_hash);
             let new_key_str = new_key.id().to_string();
             if room_info.contract_key != new_key_str {
                 info!(
@@ -2196,18 +2223,41 @@ mod tests {
     /// file (api.rs). Guards the exact regressions the PR fixed: a refactor
     /// reverting a monitor path to identity-only dedup (losing edits) or back to
     /// the colliding author:time key.
+    ///
+    /// The shape of the pin changed with freenet/river#694. It used to count two
+    /// call sites per emitter, one per monitor loop. Both loops now route through
+    /// `emit_stream_changes`, so counting emitter call sites would find ONE and
+    /// read as a regression while the property is in fact better enforced than
+    /// before. So pin the two halves separately: every monitor path reaches the
+    /// shared step, and the shared step still runs all three emitters. That also
+    /// covers the third caller the same change added (the catch-up after a
+    /// mid-run re-subscribe), which the old per-loop count would have missed.
     #[test]
     fn monitor_edit_detection_wiring_pinned() {
         let api_src = include_str!("api.rs");
-        // Both monitor paths (polling + subscribe) must route through the shared
-        // scan helper so edit detection applies to both.
-        let routed = api_src.matches("Self::emit_new_and_edited(").count();
+        // Every monitor path (polling, subscribe notification, and the catch-up
+        // after a re-key) must route through the one shared step.
+        let routed = api_src.matches("Self::emit_stream_changes(").count();
         assert!(
-            routed >= 2,
-            "both monitor paths must call emit_new_and_edited (found {routed}); \
-             do not inline identity-only dedup in either loop or edits stop \
+            routed >= 3,
+            "every monitor path must call emit_stream_changes (found {routed}); \
+             do not inline identity-only dedup in any loop or edits stop \
              surfacing again"
         );
+        // And that shared step must still run all three emitters, or routing
+        // through it would be a way to lose them all at once.
+        for emitter in [
+            "Self::emit_new_and_edited(",
+            "Self::emit_deletions(",
+            "Self::emit_reaction_changes(",
+        ] {
+            assert!(
+                api_src.contains(emitter),
+                "emit_stream_changes must still call {emitter}; dropping one \
+                 silently stops that event kind surfacing on every monitor path \
+                 at once"
+            );
+        }
         // The dedup key must be the stable signature-derived id, not author:time.
         assert!(
             api_src.contains("monitor_seen_key(msg)"),
@@ -2215,19 +2265,13 @@ mod tests {
              author:time lets a same-author same-timestamp collision flip-flop \
              as a spurious edit"
         );
-        // Both monitor paths must also surface deletions (#323).
-        let deletes = api_src.matches("Self::emit_deletions(").count();
-        assert!(
-            deletes >= 2,
-            "both monitor paths must call emit_deletions so deletions surface \
-             as events (found {deletes})"
-        );
-        // Both monitor paths must also surface live reaction changes (#325).
+        // Retained so the reasons the three emitters exist stay recorded here:
+        // deletions (#323) and live reaction changes (#325).
         let reactions = api_src.matches("Self::emit_reaction_changes(").count();
         assert!(
-            reactions >= 2,
-            "both monitor paths must call emit_reaction_changes so reactions \
-             added/removed after a message was streamed surface as events \
+            reactions >= 1,
+            "the shared monitor step must surface reactions \
+             added/removed after a message was streamed as events \
              (found {reactions})"
         );
     }
@@ -2299,6 +2343,60 @@ mod tests {
         assert_eq!(
             retrieved_state.configuration.configuration.max_members,
             state.configuration.configuration.max_members
+        );
+    }
+
+    /// The regression behind freenet/river#694: a long-running stream re-resolves
+    /// River's pointer and must be able to install a generation published AFTER
+    /// the process started. While this cell was a `OnceLock` the second call was
+    /// silently dropped, so key regeneration stayed pinned to whatever was live
+    /// at startup and every subsequent lookup addressed the retired contract.
+    #[test]
+    fn a_second_resolved_generation_replaces_the_first() {
+        let (storage, _temp_dir) = create_test_storage();
+        let owner_sk = create_test_signing_key();
+        let owner_vk = owner_sk.verifying_key();
+        let state = create_test_state(&owner_sk);
+
+        let first_hash = crate::api::bundled_room_code_hash();
+        storage.set_room_code_hash(first_hash);
+        storage
+            .add_room(
+                &owner_vk,
+                &owner_sk,
+                state,
+                &river_core::migration::contract_key_for_code_hash(&owner_vk, &first_hash),
+            )
+            .unwrap();
+
+        // A generation this binary has never seen — exactly what a re-key looks
+        // like to a riverctl that is already running.
+        let second_hash = [0x5Au8; 32];
+        assert_ne!(first_hash, second_hash);
+        storage.set_room_code_hash(second_hash);
+
+        let rooms = storage.load_rooms().unwrap();
+        let owner_key_str = bs58::encode(owner_vk.as_bytes()).into_string();
+        let room = &rooms.rooms[&owner_key_str];
+
+        assert_eq!(
+            room.contract_key,
+            river_core::migration::contract_key_for_code_hash(&owner_vk, &second_hash)
+                .id()
+                .to_string(),
+            "the room must follow the generation resolved most recently, not the one \
+             resolved first"
+        );
+        assert_eq!(
+            room.previous_contract_key.as_deref(),
+            Some(
+                river_core::migration::contract_key_for_code_hash(&owner_vk, &first_hash)
+                    .id()
+                    .to_string()
+                    .as_str()
+            ),
+            "the superseded key must be demoted so the migration probe can find state \
+             left behind on it"
         );
     }
 

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -2249,16 +2249,72 @@ mod tests {
              signed withdrawal reads as an ordinary timeout and the stream keeps reading a \
              retired generation"
         );
-        // And each check must RETURN the error, not merely log it.
-        let returns = api_src
-            .matches("if Self::refresh_failure_is_fatal(&e) {\n                            return Err(e);")
-            .count()
-            + api_src
-                .matches("if Self::refresh_failure_is_fatal(&e) {\n                            return Err(e);")
-                .count();
+        // And each check must RETURN, not merely notice. Scanned by slicing a
+        // window after each occurrence rather than matching a fixed indentation:
+        // the two call sites are nested at different depths, so an
+        // indentation-sensitive literal could only ever match one of them — which
+        // is what an earlier version of this guard did, alongside an `||`
+        // fallback (`"return Err(e);" appears at least twice in the file`) that
+        // no realistic edit could fail. Between them, half this test was
+        // decoration.
+        for (i, at) in api_src.match_indices("Self::refresh_failure_is_fatal(&e)") {
+            let _ = at;
+            let window = &api_src[i..api_src.len().min(i + 200)];
+            assert!(
+                window.contains("return Err(e);"),
+                "a fatal refresh failure must END the stream; the check at byte {i} notices \
+                 it without returning, which leaves the stream reading a generation the \
+                 author has signed away"
+            );
+        }
+    }
+
+    /// Source-grep pins for the two invariants review had to restore in #696,
+    /// both of which were silent when broken.
+    ///
+    /// They are here because nothing else would notice a refactor undoing them:
+    /// the behaviour they protect only shows up against a live node, mid-re-key.
+    #[test]
+    fn the_stream_fetch_stays_read_only_and_the_startup_fetch_stays_unconditional() {
+        let api_src = include_str!("api.rs");
+
+        // 1. The PERIODIC fetch must not go through `get_room`, which migrates
+        //    and self-heals — writes, on a timer, one of them into a path that
+        //    mis-reads an interleaved notification (freenet/river#689).
+        let fetch_body = api_src
+            .split_once("    async fn fetch_stream_state(")
+            .and_then(|(_, rest)| rest.split_once("\n    }\n"))
+            .map(|(body, _)| body)
+            .expect("fetch_stream_state must exist as a 4-space-indented method");
         assert!(
-            returns > 0 || api_src.matches("return Err(e);").count() >= 2,
-            "a fatal refresh failure must end the stream, not just be noticed"
+            !fetch_body.contains("self.get_room("),
+            "fetch_stream_state must not call get_room: it runs on a timer, and get_room \
+             migrates and heals, which are writes"
+        );
+        assert!(
+            fetch_body.contains("RecoveryWrites::Suppressed"),
+            "the periodic fetch must suppress the recovery republish, or it publishes state \
+             on a timer as a side effect of reading"
+        );
+
+        // 2. The polling loop's startup fetch must NOT be gated on how many
+        //    messages are to be displayed. `--initial-messages` defaults to 0, so
+        //    gating it there meant the default invocation never migrated and
+        //    never healed — a member stayed "Unknown" to every peer for the life
+        //    of the stream.
+        let polling = api_src
+            .split_once("    pub async fn stream_messages(")
+            .and_then(|(_, rest)| rest.split_once("        // Set up Ctrl+C handler"))
+            .map(|(body, _)| body)
+            .expect("stream_messages must exist and set up a Ctrl+C handler");
+        let fetch_at = polling
+            .find("self.get_room(room_owner_key, false)")
+            .expect("the polling stream must fetch once at startup");
+        let gate_at = polling.find("if initial_messages > 0");
+        assert!(
+            gate_at.is_none_or(|g| fetch_at < g),
+            "the startup fetch must come BEFORE the display gate; behind it, the default \
+             `--initial-messages=0` means it never runs at all"
         );
     }
 

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -2223,6 +2223,45 @@ mod tests {
         );
     }
 
+    /// Source-grep pin: BOTH stream loops must treat a pointer WITHDRAWAL as
+    /// fatal and every other refresh failure as best-effort.
+    ///
+    /// `only_a_withdrawal_is_a_fatal_refresh_failure` pins the PREDICATE. Nothing
+    /// pinned that the loops consult it, and this file has learned that
+    /// distinction the expensive way before: `await_response_tests` exists
+    /// because the classifier tests bound the predicate while the loop joining
+    /// them — where the defect actually lived — was unbound. A loop that dropped
+    /// this check would keep reading a generation the author has signed away,
+    /// reporting nothing, which is indistinguishable from working.
+    ///
+    /// Lives in storage.rs so the pinned strings are not self-satisfied by the
+    /// file being scanned.
+    #[test]
+    fn both_stream_loops_stop_on_a_pointer_withdrawal() {
+        let api_src = include_str!("api.rs");
+        let checks = api_src
+            .matches("if Self::refresh_failure_is_fatal(&e) {")
+            .count();
+        assert_eq!(
+            checks, 2,
+            "both the polling and the subscription loop must consult \
+             refresh_failure_is_fatal on a failed refresh (found {checks}); without it a \
+             signed withdrawal reads as an ordinary timeout and the stream keeps reading a \
+             retired generation"
+        );
+        // And each check must RETURN the error, not merely log it.
+        let returns = api_src
+            .matches("if Self::refresh_failure_is_fatal(&e) {\n                            return Err(e);")
+            .count()
+            + api_src
+                .matches("if Self::refresh_failure_is_fatal(&e) {\n                            return Err(e);")
+                .count();
+        assert!(
+            returns > 0 || api_src.matches("return Err(e);").count() >= 2,
+            "a fatal refresh failure must end the stream, not just be noticed"
+        );
+    }
+
     /// Source-grep pins for the monitor edit/reply wiring (PR #322), in
     /// storage.rs so the pinned strings aren't self-satisfied by the scanned
     /// file (api.rs). Guards the exact regressions the PR fixed: a refactor


### PR DESCRIPTION
Closes #694.

## The bug

riverctl resolves River's room-contract pointer **once per process** and never again. That is right for a one-shot command and wrong for the two commands documented as the bot integration surface.

After a re-key:

- **`message stream --subscribe`** stays attached to the retired contract instance id. The node has nothing left to send for a generation nobody writes to, and the loop's receive-timeout arm treats that as "no new messages" — indefinitely.
- **`message stream` (polling)** re-derives the same stale key on every poll, and GETs against the retired contract keep **succeeding**, because that contract still exists; it is just frozen.

Neither surfaces an error. The process is healthy, the socket is open, the logs are clean, and the room simply appears to go quiet. Restarting fixes it, which is exactly the symptom @Ivvor reported on Matrix.

## The fix

Both loops re-resolve the pointer every five minutes. When the generation actually moves:

- the subscription re-subscribes to the new instance id,
- a notice naming both generations goes to stderr,
- and the stream explicitly catches up on what was written during the gap — the node only notifies about changes *after* a subscription, so skipping that would leave a silent hole of precisely the kind being fixed.

Reads follow the move even when the new generation is one this riverctl is too old to write to. That is the case the pointer record exists to make survivable, and refusing to follow it would be the original bug wearing a safety justification. (Writes against an unknown generation are still refused — that is #695, handled separately.)

## Supporting changes

| Change | Why it is load-bearing |
|---|---|
| `Storage::room_code_hash`: `OnceLock` → `RwLock<Option<..>>` | The second resolution was silently dropped, pinning key regeneration to startup. |
| `ApiClient::room_anchor`: `OnceCell<RoomAnchor>` → `RwLock<Option<RoomAnchor>>` returning a clone | The cache has to be replaceable. One-shot commands still resolve exactly once. |
| SUBSCRIBE handshake and fetch-and-emit extracted into helpers | So the second subscribe site cannot reimplement the ack-race handling (freenet-core#4970) slightly differently, and the three monitor paths cannot drift on what counts as a reportable change. |

The advisory is compared against the previous one before printing, so a five-minute refresh cannot turn a real warning into background noise.

## On the modified guard

`monitor_edit_detection_wiring_pinned` counted two emitter call sites, one per loop. Routing both loops through one shared step reduces that to one, which would read as a regression while the property is in fact better enforced. It is **re-pointed, not relaxed**: it now pins both halves — every monitor path reaches the shared step, and the shared step still runs all three emitters — which additionally covers the third caller this PR adds.

## Verification

- `cargo test -p riverctl`: 389 + 19 pass, 0 fail.
- Both new guards were verified by reintroducing the bug and watching them fail:
  - restoring `OnceLock` semantics to `set_room_code_hash` fails `a_second_resolved_generation_replaces_the_first`;
  - deleting one emitter from the shared step fails `monitor_edit_detection_wiring_pinned`.
- No new clippy warnings (16 before, 16 after; all pre-existing).
- Separately confirmed the live pointer record is current: a GET of `Ai4VLoC2jGdhpcB2UU8VPo3efUoxjm1Ju9VKXqRC63Az` returns version 2 / code hash `a3e63c8c…`, matching `pointer-records.toml` and the bundled WASM.

## What is NOT covered

The five-minute window is a bound, not an elimination: a bot can still talk to a retired generation for up to five minutes after a re-key. Reads recover on their own; writes do not, because riverctl still refuses to write against a generation it does not know — see #695.

[AI-assisted - Claude]

https://claude.ai/code/session_01LSj17em5VJvYN4ZYCRJVdF