### PR TITLE
fix(cli): exit so a supervisor restarts `message stream` when River re-keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4782,7 +4782,7 @@ dependencies = [
 
 [[package]]
 name = "riverctl"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -18,6 +18,12 @@ All notable changes to riverctl will be documented in this file.
   with a short delay** (systemd `Restart=on-failure` plus `RestartSec=`), and
   note that a restart with `--initial-messages N` re-emits the last N messages.
   See "Running `message stream` as a long-lived bot" in the README.
+- `message stream` without `--subscribe` no longer re-emits the room's recent
+  history when it starts. It recorded only the messages it displayed, so with the
+  default `--initial-messages 0` the first poll reported every recent message as
+  new, and with `-i N` it reported all but N of them. It now records everything
+  already in the room and shows only the last N, as `--subscribe` always has.
+  This matters more now that streams restart on every re-key.
 
 ## [0.2.15] - 2026-09-06
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -24,6 +24,9 @@ All notable changes to riverctl will be documented in this file.
   new, and with `-i N` it reported all but N of them. It now records everything
   already in the room and shows only the last N, as `--subscribe` always has.
   This matters more now that streams restart on every re-key.
+- A polling `message stream` whose `--poll-interval` is longer than the re-check
+  interval (a few minutes) now also polls at each re-check, so a long interval
+  cannot delay noticing a re-key.
 
 ## [0.2.15] - 2026-09-06
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to riverctl will be documented in this file.
 
+## [0.2.18] - 2026-09-12
+
+### Fixed
+- `message stream` no longer goes silently deaf when River re-keys the room
+  contract while it is running. It used to look up the room's address once at
+  startup and never again, so after a re-key it kept listening to a contract
+  nobody writes to: no error, no output, just a room that appeared to go quiet
+  until the bot was restarted. It now re-checks every few minutes and, when
+  River has re-keyed, **exits with status 75** so a supervisor restarts it — a
+  restarted riverctl follows the new address through the normal startup path.
+  If River has re-keyed to a version newer than this riverctl, it keeps running
+  and prints an upgrade warning instead, since restarting would not help.
+  (freenet/river#694)
+
+  **If you run a bot, run it under something that restarts it**, and treat
+  status 75 as "restart me" rather than as a failure. See "Running
+  `message stream` as a long-lived bot" in the README.
+
 ## [0.2.15] - 2026-09-06
 
 ### Fixed

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -10,15 +10,14 @@ All notable changes to riverctl will be documented in this file.
   startup and never again, so after a re-key it kept listening to a contract
   nobody writes to: no error, no output, just a room that appeared to go quiet
   until the bot was restarted. It now re-checks every few minutes and, when
-  River has re-keyed, **exits with status 75** so a supervisor restarts it — a
-  restarted riverctl follows the new address through the normal startup path.
-  If River has re-keyed to a version newer than this riverctl, it keeps running
-  and prints an upgrade warning instead, since restarting would not help.
+  River's pointer names a different generation, **exits with status 75** so a
+  supervisor restarts it. A restarted riverctl uses the current generation.
   (freenet/river#694)
 
-  **If you run a bot, run it under something that restarts it**, and treat
-  status 75 as "restart me" rather than as a failure. See "Running
-  `message stream` as a long-lived bot" in the README.
+  **If you run a bot, run it under something that restarts it on any failure,
+  with a short delay** (systemd `Restart=on-failure` plus `RestartSec=`), and
+  note that a restart with `--initial-messages N` re-emits the last N messages.
+  See "Running `message stream` as a long-lived bot" in the README.
 
 ## [0.2.15] - 2026-09-06
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riverctl"
-version = "0.2.17"
+version = "0.2.18"
 edition = "2021"
 authors = ["Freenet Project"]
 description = "Command-line interface for River decentralized chat on Freenet"

--- a/cli/README.md
+++ b/cli/README.md
@@ -365,16 +365,17 @@ failures should be left stopped.
 
 **Restarting can re-deliver messages.** A restarted stream starts with no memory
 of what it already emitted. With `--initial-messages N`, it re-emits the last N
-messages as new, which covers anything sent while it was restarting but repeats
-what you had already seen. If the bot acts on messages, deduplicate on
+messages as new, which covers up to N messages sent while it was restarting but
+repeats what you had already seen. If the bot acts on messages, deduplicate on
 `message_id`. Without `--initial-messages`, nothing is repeated, but messages sent
 during the restart are not shown.
 
 If River has re-keyed to a version **newer than your riverctl**, the restarted
 process still streams the room once it has been moved to the new address, and
 prints a warning telling you to upgrade (`cargo install riverctl`). Until the room
-has been moved — which an up-to-date River client does when someone opens it — it
-keeps failing and being restarted.
+has been moved — which an up-to-date River client does when someone opens it —
+`--subscribe` keeps failing and being restarted, while polling mode stays running
+and keeps retrying.
 
 ## Configuration
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -125,7 +125,9 @@ riverctl message stream <room-owner-vk> --format json --no-version-check |
 ```
 
 For a bot that runs unattended, wrap this in something that restarts it — see
-"Running `message stream` as a long-lived bot" below.
+"Running `message stream` as a long-lived bot" below. Note that a pipeline's exit
+status is the LAST command's, so a wrapper around this one sees `jq`'s status, not
+riverctl's; use `set -o pipefail` in bash, or restart on any exit.
 
 `message list` and `message stream --format json` both carry
 `author_verifying_key` — the author's full base58 key, comparable to `whoami`'s
@@ -323,13 +325,15 @@ River's pointer now names a different room-contract generation than this command
 Exiting with status 75 so it can be restarted; a restarted riverctl uses the current generation.
 ```
 
-A restarted `riverctl` looks up the new address and subscribes to it. So **run a
-bot under something that restarts it on any failure, with a short delay** — not
-only on status 75. Right after a re-key, the restarted process can briefly fail
-too (the room may not have been moved to the new address yet), and a wrapper that
-gives up on anything other than 75 would stop the bot for good.
+A restarted `riverctl` looks up the new address and carries on streaming from
+it. So **run a bot under something that restarts it on any failure, with a short
+delay** — not only on status 75. A bot with no restart wrapper at all will now
+**stop** after a re-key, where it used to keep running but silently stop receiving
+messages. Right after a re-key the restarted process can
+fail until the room has been moved to the new address, and a wrapper that gives up
+on anything other than 75 would stop the bot for good.
 
-With systemd:
+With systemd, the relevant `[Service]` lines:
 
 ```ini
 [Service]
@@ -368,7 +372,9 @@ during the restart are not shown.
 
 If River has re-keyed to a version **newer than your riverctl**, the restarted
 process still streams the room once it has been moved to the new address, and
-prints a warning telling you to upgrade (`cargo install riverctl --force`).
+prints a warning telling you to upgrade (`cargo install riverctl`). Until the room
+has been moved — which an up-to-date River client does when someone opens it — it
+keeps failing and being restarted.
 
 ## Configuration
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -124,6 +124,9 @@ riverctl message stream <room-owner-vk> --format json --no-version-check |
   jq -c --arg me "$me" 'select(.author_verifying_key != $me)'
 ```
 
+For a bot that runs unattended, wrap this in something that restarts it — see
+"Running `message stream` as a long-lived bot" below.
+
 `message list` and `message stream --format json` both carry
 `author_verifying_key` — the author's full base58 key, comparable to `whoami`'s
 `verifying_key` and to `member list`'s. It is `null` when the author is no longer
@@ -314,32 +317,58 @@ address. A running `message stream` checks for this every few minutes. When it
 sees one, it **exits with status 75** and says so on stderr:
 
 ```text
-River re-keyed the room contract while this command was running.
+River's pointer now names a different room-contract generation than this command started with.
   was: <old generation>
   now: <new generation>
-Exiting with status 75 so it can be restarted; a restarted riverctl follows the new generation automatically.
+Exiting with status 75 so it can be restarted; a restarted riverctl uses the current generation.
 ```
 
-Restarting is all that is needed: a fresh `riverctl` finds the new address,
-carries the room across, and resubscribes. So run a bot under something that
-restarts it — systemd with `Restart=on-failure`, a supervisor, or a shell loop:
+A restarted `riverctl` looks up the new address and subscribes to it. So **run a
+bot under something that restarts it on any failure, with a short delay** — not
+only on status 75. Right after a re-key, the restarted process can briefly fail
+too (the room may not have been moved to the new address yet), and a wrapper that
+gives up on anything other than 75 would stop the bot for good.
+
+With systemd:
+
+```ini
+[Service]
+ExecStart=/usr/local/bin/riverctl message stream <room-owner-vk> --format json
+Restart=on-failure
+RestartSec=5
+```
+
+`RestartSec` matters: without it, a few quick failures in a row can trip
+systemd's start limit and leave the unit stopped.
+
+Or as a script (save it to a file rather than pasting it into an interactive
+shell):
 
 ```bash
-until riverctl message stream <room-owner-vk> --format json; do
+#!/bin/sh
+while true; do
+  riverctl message stream <room-owner-vk> --format json
   status=$?
-  [ "$status" -eq 75 ] || exit "$status"   # anything else is a real failure
-  sleep 2
+  [ "$status" -eq 75 ] || echo "riverctl exited with status $status; restarting" >&2
+  sleep 5
 done
 ```
 
-Status 75 is `EX_TEMPFAIL` ("temporary failure, retry"), so it is distinct from
-the status 1 every other failure uses, and a wrapper can restart on it without
-parsing stderr. Use `--initial-messages N` if the bot must not miss messages
-sent during the moment it is restarting.
+Status 75 is `EX_TEMPFAIL` ("temporary failure, retry"), distinct from the status
+1 every other failure uses. It is there so a wrapper can tell an expected restart
+from a real failure — for example, to alert only on the latter — not because other
+failures should be left stopped.
 
-If River has re-keyed to a version **newer than your riverctl**, it does *not*
-exit, because a restart of the same binary would not help. It keeps running and
-prints a warning to upgrade (`cargo install riverctl --force`) once per re-key.
+**Restarting can re-deliver messages.** A restarted stream starts with no memory
+of what it already emitted. With `--initial-messages N`, it re-emits the last N
+messages as new, which covers anything sent while it was restarting but repeats
+what you had already seen. If the bot acts on messages, deduplicate on
+`message_id`. Without `--initial-messages`, nothing is repeated, but messages sent
+during the restart are not shown.
+
+If River has re-keyed to a version **newer than your riverctl**, the restarted
+process still streams the room once it has been moved to the new address, and
+prints a warning telling you to upgrade (`cargo install riverctl --force`).
 
 ## Configuration
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -307,6 +307,40 @@ compare like against like (see "Managing your identity" above). Inside `reply_to
 `author` is a display **nickname**, not an ID — the id there is `author_id`, and
 it has no full-key sibling, so it is not something to trust on.
 
+### Running `message stream` as a long-lived bot
+
+River occasionally re-keys its room contract, which moves every room to a new
+address. A running `message stream` checks for this every few minutes. When it
+sees one, it **exits with status 75** and says so on stderr:
+
+```text
+River re-keyed the room contract while this command was running.
+  was: <old generation>
+  now: <new generation>
+Exiting with status 75 so it can be restarted; a restarted riverctl follows the new generation automatically.
+```
+
+Restarting is all that is needed: a fresh `riverctl` finds the new address,
+carries the room across, and resubscribes. So run a bot under something that
+restarts it — systemd with `Restart=on-failure`, a supervisor, or a shell loop:
+
+```bash
+until riverctl message stream <room-owner-vk> --format json; do
+  status=$?
+  [ "$status" -eq 75 ] || exit "$status"   # anything else is a real failure
+  sleep 2
+done
+```
+
+Status 75 is `EX_TEMPFAIL` ("temporary failure, retry"), so it is distinct from
+the status 1 every other failure uses, and a wrapper can restart on it without
+parsing stderr. Use `--initial-messages N` if the bot must not miss messages
+sent during the moment it is restarting.
+
+If River has re-keyed to a version **newer than your riverctl**, it does *not*
+exit, because a restart of the same binary would not help. It keeps running and
+prints a warning to upgrade (`cargo install riverctl --force`) once per re-key.
+
 ## Configuration
 
 - `--node-url <URL>`: override the Freenet node URL (default `ws://127.0.0.1:7509/...`).

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -2487,9 +2487,10 @@ impl ApiClient {
             None => PointerFloor::never_resolved(),
         };
         // Whichever is higher: the disk's floor, or the highest this process has
-        // already verified. They differ only when a save failed, which is exactly
-        // when relying on the disk alone would let a periodic re-check accept an
-        // older signed record. See `crate::pointer::highest_floor`.
+        // already verified. They differ when a save failed — exactly when relying
+        // on the disk alone would let a periodic re-check accept an older signed
+        // record — or when another riverctl has written the disk since. See
+        // `crate::pointer::highest_floor`.
         let floor = crate::pointer::highest_floor(self.remembered_floor(), on_disk);
 
         let mut io = NodePointerIo {
@@ -2546,8 +2547,9 @@ impl ApiClient {
     /// ([`crate::error::RoomContractRekeyed`], exit status 75, restart me), or the
     /// re-check itself failed. The second is not a timeout — an unreachable
     /// pointer comes back as an unverified anchor, not an error — so what reaches
-    /// here is a corrupt anti-rollback floor or a signed withdrawal, both of which
-    /// a fresh process would also refuse at startup.
+    /// here is a corrupt or unreadable anti-rollback floor, or a signed withdrawal.
+    /// A fresh process would refuse those at startup too, so ending the stream as
+    /// an ordinary failure (status 1) is the honest report.
     fn act_on_recheck(result: Result<crate::pointer::Recheck>) -> Result<()> {
         use crate::pointer::{code_hash_b58, Recheck};
         match result? {
@@ -5261,32 +5263,26 @@ impl ApiClient {
         let mut new_message_count = 0;
         let start_time = std::time::Instant::now();
 
-        // Show initial messages if requested
-        if initial_messages > 0 {
-            let mut room_state = self.get_room(room_owner_key, false).await?;
-            // Decrypt private-room content for display (no-op for public rooms).
-            let secrets = self.room_display_secrets(room_owner_key, &mut room_state);
-
-            // Use display_messages() to filter out action/deleted messages (matches `message list`)
-            let all_msgs: Vec<_> = room_state.recent_messages.display_messages().collect();
-            let start = all_msgs.len().saturating_sub(initial_messages);
-
-            for msg in &all_msgs[start..] {
-                let key = monitor_seen_key(msg);
-                seen_messages.insert(
-                    key.clone(),
-                    message_display_text_with_secrets(&room_state, msg, &secrets),
-                );
-                // Seed the reactions fingerprint for shown messages so reactions
-                // already present at startup aren't re-emitted as a live change;
-                // only later changes to them surface.
-                seen_reactions.insert(
-                    key,
-                    reactions_fingerprint(room_state.recent_messages.reactions(&msg.id())),
-                );
-
-                Self::output_message(&room_state, msg, room_owner_key, &format, false, &secrets)?;
+        // Record what the room already holds before streaming, so the first poll
+        // does not report it as new. See `seed_stream`. A failure here is not
+        // fatal — the loop retries — and until a fetch succeeds the stream simply
+        // is not seeded yet; the first successful poll seeds instead of emitting.
+        let mut seeded = false;
+        match self.get_room(room_owner_key, false).await {
+            Ok(mut room_state) => {
+                let secrets = self.room_display_secrets(room_owner_key, &mut room_state);
+                Self::seed_stream(
+                    &room_state,
+                    &secrets,
+                    initial_messages,
+                    &mut seen_messages,
+                    &mut seen_reactions,
+                    room_owner_key,
+                    &format,
+                )?;
+                seeded = true;
             }
+            Err(e) => debug!("Could not fetch room state at stream start (will retry): {e}"),
         }
 
         // Set up Ctrl+C handler
@@ -5333,6 +5329,19 @@ impl ApiClient {
             // message whose effective content changed (an edit) and emits ones
             // not seen before; it respects max_messages for NEW messages.
             match self.get_room(room_owner_key, false).await {
+                Ok(mut room_state) if !seeded => {
+                    let secrets = self.room_display_secrets(room_owner_key, &mut room_state);
+                    Self::seed_stream(
+                        &room_state,
+                        &secrets,
+                        initial_messages,
+                        &mut seen_messages,
+                        &mut seen_reactions,
+                        room_owner_key,
+                        &format,
+                    )?;
+                    seeded = true;
+                }
                 Ok(mut room_state) => {
                     // Decrypt private-room content for display (no-op for public rooms).
                     let secrets = self.room_display_secrets(room_owner_key, &mut room_state);
@@ -5378,6 +5387,54 @@ impl ApiClient {
             // Wait for next poll interval
             tokio::time::sleep(std::time::Duration::from_millis(poll_interval_ms)).await;
         }
+    }
+
+    /// Seed a polling stream with what the room already holds: every current
+    /// message is recorded as seen, and only the last `initial_messages` are
+    /// printed.
+    ///
+    /// Seeding the WHOLE window is the point, and it is what this used to get
+    /// wrong. The startup code recorded only the messages it displayed, so with
+    /// the default `--initial-messages 0` it recorded nothing, and the first poll
+    /// reported every recent message in the room as new; with `-i 5` it reported
+    /// all but five of them. That was an annoyance while restarts were rare. Once
+    /// a stream exits to be restarted on every room-contract re-key
+    /// (freenet/river#694), it would dump the room's recent history into a bot on
+    /// every re-key. The subscription path already seeds the whole window; this
+    /// brings polling into line.
+    ///
+    /// Seeds from `display_messages()`, which excludes deleted messages, so a
+    /// deletion that predates the stream is never in `seen` and needs no
+    /// suppression (see the note on `deleted_emitted` in `stream_messages`).
+    /// Reaction fingerprints are seeded only for the messages actually shown, the
+    /// same rule the subscription path follows: a reaction change on a message the
+    /// stream never displayed is not reported.
+    #[allow(clippy::too_many_arguments)]
+    fn seed_stream(
+        room_state: &ChatRoomStateV1,
+        secrets: &HashMap<u32, [u8; 32]>,
+        initial_messages: usize,
+        seen_messages: &mut HashMap<String, String>,
+        seen_reactions: &mut HashMap<String, String>,
+        room_owner_key: &VerifyingKey,
+        format: &OutputFormat,
+    ) -> Result<()> {
+        let all_msgs: Vec<_> = room_state.recent_messages.display_messages().collect();
+        for msg in &all_msgs {
+            seen_messages.insert(
+                monitor_seen_key(msg),
+                message_display_text_with_secrets(room_state, msg, secrets),
+            );
+        }
+        let start = all_msgs.len().saturating_sub(initial_messages);
+        for msg in &all_msgs[start..] {
+            seen_reactions.insert(
+                monitor_seen_key(msg),
+                reactions_fingerprint(room_state.recent_messages.reactions(&msg.id())),
+            );
+            Self::output_message(room_state, msg, room_owner_key, format, false, secrets)?;
+        }
+        Ok(())
     }
 
     /// Scan the room's display messages and emit any that are NEW or whose
@@ -9703,6 +9760,76 @@ mod monitor_tests {
     /// A `ChatRoomStateV1` whose `recent_messages` contains `original` plus the
     /// given reaction action messages, with `actions_state` rebuilt so
     /// `reactions()` reflects them.
+    /// The polling stream's startup must record EVERY message the room already
+    /// holds, and print only the last `initial_messages`. It used to record only
+    /// the ones it printed, so the first poll re-emitted the rest as new: all of
+    /// them with the default `-i 0`. Once a stream restarts on every re-key
+    /// (freenet/river#694) that would dump the room's history into a bot each time.
+    #[test]
+    fn a_seeded_poll_of_an_unchanged_room_emits_nothing() {
+        let msgs: Vec<_> = ["one", "two", "three"]
+            .iter()
+            .map(|t| authored(RoomMessageBody::public(t.to_string())))
+            .collect();
+        let state = {
+            let mut recent = MessagesV1 {
+                messages: msgs,
+                ..Default::default()
+            };
+            recent.rebuild_actions_state();
+            ChatRoomStateV1 {
+                recent_messages: recent,
+                ..Default::default()
+            }
+        };
+        let owner_vk = SigningKey::from_bytes(&[6u8; 32]).verifying_key();
+        let secrets = HashMap::new();
+
+        for initial in [0usize, 1, 3] {
+            let mut seen = HashMap::new();
+            let mut deleted = HashSet::new();
+            let mut reactions = HashMap::new();
+            ApiClient::seed_stream(
+                &state,
+                &secrets,
+                initial,
+                &mut seen,
+                &mut reactions,
+                &owner_vk,
+                &OutputFormat::Json,
+            )
+            .unwrap();
+            assert_eq!(
+                seen.len(),
+                3,
+                "-i {initial}: every message must be recorded"
+            );
+            assert_eq!(
+                reactions.len(),
+                initial,
+                "-i {initial}: reactions are seeded only for the messages shown"
+            );
+
+            let mut new_count = 0usize;
+            ApiClient::emit_new_and_edited(
+                &state,
+                &mut seen,
+                &mut deleted,
+                &mut reactions,
+                &owner_vk,
+                &OutputFormat::Json,
+                0,
+                &mut new_count,
+                &secrets,
+            )
+            .unwrap();
+            assert_eq!(
+                new_count, 0,
+                "-i {initial}: the first poll of an unchanged room must emit nothing"
+            );
+        }
+    }
+
     fn state_with_reactions(
         original: &AuthorizedMessageV1,
         reaction_actions: Vec<AuthorizedMessageV1>,

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -2363,6 +2363,11 @@ pub struct ApiClient {
     /// happens where its failure can be reported against the operation that
     /// needed it.
     room_anchor: tokio::sync::OnceCell<RoomAnchor>,
+    /// The highest anti-rollback floor this process has verified. Consulted on
+    /// every resolution alongside the one on disk; see
+    /// `crate::pointer::highest_floor`. A `std::sync::Mutex` held only for a copy
+    /// or an assignment, never across an await.
+    pointer_floor: std::sync::Mutex<Option<PointerFloor>>,
 }
 
 impl ApiClient {
@@ -2405,7 +2410,22 @@ impl ApiClient {
             config,
             storage,
             room_anchor: tokio::sync::OnceCell::new(),
+            pointer_floor: std::sync::Mutex::new(None),
         })
+    }
+
+    fn remembered_floor(&self) -> Option<PointerFloor> {
+        *self
+            .pointer_floor
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn remember_floor(&self, floor: PointerFloor) {
+        *self
+            .pointer_floor
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(floor);
     }
 
     /// River's room-contract generation for this run, resolved once.
@@ -2460,12 +2480,17 @@ impl ApiClient {
         // `StoredFloor::to_floor`: `never_resolved` is the one state that
         // re-enables the build-time key, so "recovering" into it is the
         // downgrade the floor exists to prevent.
-        let floor = match self.storage.load_pointer_floor(&key)? {
+        let on_disk = match self.storage.load_pointer_floor(&key)? {
             Some(stored) => stored.to_floor().with_context(|| {
                 crate::pointer::floor_corruption_hint(self.storage.pointer_floors_path())
             })?,
             None => PointerFloor::never_resolved(),
         };
+        // Whichever is higher: the disk's floor, or the highest this process has
+        // already verified. They differ only when a save failed, which is exactly
+        // when relying on the disk alone would let a periodic re-check accept an
+        // older signed record. See `crate::pointer::highest_floor`.
+        let floor = crate::pointer::highest_floor(self.remembered_floor(), on_disk);
 
         let mut io = NodePointerIo {
             web_api: &self.web_api,
@@ -2485,6 +2510,10 @@ impl ApiClient {
         // pre-withdrawal record and resurrect the retired code.
         if let ResolveReport::Outcome(outcome) = &report {
             if let Some(next) = outcome.next_floor() {
+                // Remembered regardless of whether the save below lands: this is
+                // the anti-rollback guarantee for the rest of the run when it
+                // does not.
+                self.remember_floor(next);
                 if let Err(e) = self
                     .storage
                     .save_pointer_floor(&key, StoredFloor::from_floor(&next))
@@ -2513,41 +2542,21 @@ impl ApiClient {
 
     /// Turn a re-check into what a stream loop does next.
     ///
-    /// `Err` ends the stream: either River re-keyed to a generation a restart
-    /// will follow ([`crate::error::RoomContractRekeyed`], exit status 75), or
-    /// the re-check itself failed. The second is not a timeout — an unreachable
+    /// `Err` ends the stream: either River's pointer moved
+    /// ([`crate::error::RoomContractRekeyed`], exit status 75, restart me), or the
+    /// re-check itself failed. The second is not a timeout — an unreachable
     /// pointer comes back as an unverified anchor, not an error — so what reaches
     /// here is a corrupt anti-rollback floor or a signed withdrawal, both of which
     /// a fresh process would also refuse at startup.
-    ///
-    /// `warned` remembers the last generation an upgrade warning was printed for,
-    /// so a stale riverctl says so once per re-key rather than every few minutes.
-    fn act_on_recheck(
-        result: Result<crate::pointer::Recheck>,
-        warned: &mut Option<[u8; 32]>,
-    ) -> Result<()> {
+    fn act_on_recheck(result: Result<crate::pointer::Recheck>) -> Result<()> {
         use crate::pointer::{code_hash_b58, Recheck};
         match result? {
             Recheck::Unchanged => Ok(()),
-            Recheck::RestartToFollow { from, to } => Err(crate::error::RoomContractRekeyed {
+            Recheck::Moved { from, to } => Err(crate::error::RoomContractRekeyed {
                 from: code_hash_b58(&from),
                 to: code_hash_b58(&to),
             }
             .into()),
-            Recheck::UpgradeRequired { from, to } => {
-                if *warned != Some(to) {
-                    *warned = Some(to);
-                    eprintln!(
-                        "warning: River re-keyed the room contract to a generation this riverctl \
-                         does not know.\n  was: {}\n  now: {}\n\
-                         Continuing on the current generation, but restarting will not help: \
-                         upgrade with `cargo install riverctl --force`, then restart.",
-                        code_hash_b58(&from),
-                        code_hash_b58(&to),
-                    );
-                }
-                Ok(())
-            }
         }
     }
 
@@ -5292,7 +5301,6 @@ impl ApiClient {
         // River can re-key the room contract while this runs. See
         // `crate::pointer::Recheck`.
         let mut next_recheck = std::time::Instant::now() + recheck_delay();
-        let mut warned_upgrade: Option<[u8; 32]> = None;
 
         // Main polling loop
         loop {
@@ -5318,7 +5326,7 @@ impl ApiClient {
 
             if std::time::Instant::now() >= next_recheck {
                 next_recheck = std::time::Instant::now() + recheck_delay();
-                Self::act_on_recheck(self.recheck_room_anchor().await, &mut warned_upgrade)?;
+                Self::act_on_recheck(self.recheck_room_anchor().await)?;
             }
 
             // Poll for new + edited messages. emit_new_and_edited re-emits a
@@ -6503,7 +6511,6 @@ impl ApiClient {
         // River can re-key the room contract while this runs. See
         // `crate::pointer::Recheck`.
         let mut next_recheck = std::time::Instant::now() + recheck_delay();
-        let mut warned_upgrade: Option<[u8; 32]> = None;
 
         // Main loop: wait for UpdateNotification messages
         loop {
@@ -6530,7 +6537,7 @@ impl ApiClient {
             // Before taking the connection lock: the re-check needs it too.
             if std::time::Instant::now() >= next_recheck {
                 next_recheck = std::time::Instant::now() + recheck_delay();
-                Self::act_on_recheck(self.recheck_room_anchor().await, &mut warned_upgrade)?;
+                Self::act_on_recheck(self.recheck_room_anchor().await)?;
                 // The re-check's pointer GET reads from the same connection as
                 // this subscription, and steps over (discarding) anything else
                 // that arrives while it waits — which can be a notification for
@@ -9213,46 +9220,21 @@ mod recheck_tests {
     use super::*;
     use crate::pointer::Recheck;
 
-    const A: [u8; 32] = [0xAA; 32];
-    const B: [u8; 32] = [0xBB; 32];
-    const C: [u8; 32] = [0xCC; 32];
-
     #[test]
     fn nothing_moved_means_the_stream_carries_on() {
-        let mut warned = None;
-        ApiClient::act_on_recheck(Ok(Recheck::Unchanged), &mut warned).unwrap();
-        assert_eq!(warned, None);
+        ApiClient::act_on_recheck(Ok(Recheck::Unchanged)).unwrap();
     }
 
-    /// A move a restart will follow ends the stream with the restart status, so
-    /// a supervisor restarts it rather than treating it as a crash.
+    /// A move ends the stream with the restart status, so a supervisor restarts it
+    /// rather than treating it as a crash.
     #[test]
-    fn a_followable_move_ends_the_stream_with_the_restart_status() {
-        let mut warned = None;
-        let err =
-            ApiClient::act_on_recheck(Ok(Recheck::RestartToFollow { from: A, to: B }), &mut warned)
-                .expect_err("a re-key a restart will follow must end the stream");
+    fn a_move_ends_the_stream_with_the_restart_status() {
+        let err = ApiClient::act_on_recheck(Ok(Recheck::Moved {
+            from: [0xAA; 32],
+            to: [0xBB; 32],
+        }))
+        .expect_err("a move must end the stream");
         assert_eq!(crate::error::exit_code_for(&err), 75);
-    }
-
-    /// A move past this binary does NOT end the stream — a restart of the same
-    /// binary would not help — and warns once per re-key, not every few minutes.
-    #[test]
-    fn a_move_past_this_binary_warns_once_per_rekey_and_keeps_running() {
-        let mut warned = None;
-        let past_us = Recheck::UpgradeRequired { from: A, to: B };
-
-        ApiClient::act_on_recheck(Ok(past_us), &mut warned).expect("keeps running");
-        assert_eq!(warned, Some(B));
-
-        // Same re-key seen again on the next re-check: nothing new to say.
-        ApiClient::act_on_recheck(Ok(past_us), &mut warned).expect("keeps running");
-        assert_eq!(warned, Some(B));
-
-        // River re-keys AGAIN, still past us: that is new, so it is said again.
-        ApiClient::act_on_recheck(Ok(Recheck::UpgradeRequired { from: A, to: C }), &mut warned)
-            .expect("keeps running");
-        assert_eq!(warned, Some(C));
     }
 
     /// A failed re-check ends the stream as an ordinary failure (status 1), not
@@ -9260,8 +9242,7 @@ mod recheck_tests {
     /// as an unverified anchor) but a corrupt floor or a signed withdrawal.
     #[test]
     fn a_failed_recheck_is_an_ordinary_failure_not_a_restart() {
-        let mut warned = None;
-        let err = ApiClient::act_on_recheck(Err(anyhow!("floor is corrupt")), &mut warned)
+        let err = ApiClient::act_on_recheck(Err(anyhow!("floor is corrupt")))
             .expect_err("a failed re-check must not be silently ignored");
         assert_eq!(crate::error::exit_code_for(&err), 1);
     }

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -5384,8 +5384,16 @@ impl ApiClient {
                 }
             }
 
-            // Wait for next poll interval
-            tokio::time::sleep(std::time::Duration::from_millis(poll_interval_ms)).await;
+            // Wait for the next poll — but never past the next re-check. With a
+            // `--poll-interval` longer than the re-check interval, sleeping the full
+            // interval would hold off noticing a re-key for as long as the interval
+            // (an hour, for an hourly poll). The cost is an extra poll at each
+            // re-check for such streams, which is one GET every few minutes.
+            let until_recheck = next_recheck.saturating_duration_since(std::time::Instant::now());
+            tokio::time::sleep(
+                std::time::Duration::from_millis(poll_interval_ms).min(until_recheck),
+            )
+            .await;
         }
     }
 

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -2333,6 +2333,23 @@ impl std::fmt::Debug for Invitation {
     }
 }
 
+/// How often a long-running command re-checks River's pointer, before jitter.
+///
+/// A re-check is one GET of a fixed address. Five minutes bounds how long a
+/// stream can keep listening to a retired generation after a re-key, at a cost
+/// far below what the stream already spends.
+const RECHECK_INTERVAL: Duration = Duration::from_secs(300);
+
+/// [`RECHECK_INTERVAL`] with ±20% jitter.
+///
+/// A re-key makes every running stream exit around the same time, and their
+/// supervisors restart them together. Without jitter they would then stay in
+/// lockstep, re-checking — and after the next re-key, restarting — as one burst.
+fn recheck_delay() -> Duration {
+    let factor = 0.8 + rand::Rng::gen::<f64>(&mut rand::thread_rng()) * 0.4;
+    RECHECK_INTERVAL.mul_f64(factor)
+}
+
 pub struct ApiClient {
     web_api: Arc<Mutex<WebApi>>,
     #[allow(dead_code)]
@@ -2404,6 +2421,37 @@ impl ApiClient {
     /// Resolve River's room-contract pointer, persist the anti-rollback floor,
     /// and announce anything the user needs to know.
     async fn resolve_room_anchor(&self) -> Result<RoomAnchor> {
+        let anchor = self.resolve_pointer().await?;
+
+        // Once per run, on stderr, so it is visible in a pipeline whose stdout
+        // is being parsed. Repeating it per derived key would train users to
+        // ignore it.
+        if let Some(advisory) = anchor.advisory() {
+            eprintln!("{advisory}");
+        }
+        info!(
+            "Room-contract generation for this run: {} ({:?}, {:?})",
+            crate::pointer::code_hash_b58(anchor.code_hash()),
+            anchor.generation(),
+            anchor.source(),
+        );
+
+        // Let the local room cache regenerate its keys against the same
+        // generation the network paths use, instead of against the bundled WASM.
+        self.storage.set_room_code_hash(*anchor.code_hash());
+        Ok(anchor)
+    }
+
+    /// Resolve the pointer and persist the anti-rollback floor, WITHOUT
+    /// announcing the result or installing it.
+    ///
+    /// Split from [`Self::resolve_room_anchor`] for the periodic re-check a
+    /// long-running command makes: that re-check only needs to know whether the
+    /// generation moved. Announcing would reprint the same advisory every few
+    /// minutes, and installing is pointless because a moved generation ends the
+    /// process (see [`crate::pointer::Recheck`]). Advancing the floor, on the other
+    /// hand, is exactly as correct mid-run as at startup.
+    async fn resolve_pointer(&self) -> Result<RoomAnchor> {
         let bundled = bundled_room_code_hash();
         let author_vk = river_author_vk()?;
         let key = floor_key(&author_vk, ROOM_CONTRACT_APP_ID);
@@ -2449,25 +2497,58 @@ impl ApiClient {
             }
         }
 
-        let anchor = anchor_from_report(&report, &floor, bundled)?;
+        anchor_from_report(&report, &floor, bundled)
+    }
 
-        // Once per run, on stderr, so it is visible in a pipeline whose stdout
-        // is being parsed. Repeating it per derived key would train users to
-        // ignore it.
-        if let Some(advisory) = anchor.advisory() {
-            eprintln!("{advisory}");
+    /// Re-check River's pointer against the generation this run started with.
+    ///
+    /// For long-running commands. See [`crate::pointer::Recheck`] for why the
+    /// response to a re-key is to exit and be restarted rather than to follow it
+    /// in place.
+    pub async fn recheck_room_anchor(&self) -> Result<crate::pointer::Recheck> {
+        let in_force = self.room_anchor().await?.clone();
+        let fresh = self.resolve_pointer().await?;
+        Ok(crate::pointer::recheck(&in_force, &fresh))
+    }
+
+    /// Turn a re-check into what a stream loop does next.
+    ///
+    /// `Err` ends the stream: either River re-keyed to a generation a restart
+    /// will follow ([`crate::error::RoomContractRekeyed`], exit status 75), or
+    /// the re-check itself failed. The second is not a timeout — an unreachable
+    /// pointer comes back as an unverified anchor, not an error — so what reaches
+    /// here is a corrupt anti-rollback floor or a signed withdrawal, both of which
+    /// a fresh process would also refuse at startup.
+    ///
+    /// `warned` remembers the last generation an upgrade warning was printed for,
+    /// so a stale riverctl says so once per re-key rather than every few minutes.
+    fn act_on_recheck(
+        result: Result<crate::pointer::Recheck>,
+        warned: &mut Option<[u8; 32]>,
+    ) -> Result<()> {
+        use crate::pointer::{code_hash_b58, Recheck};
+        match result? {
+            Recheck::Unchanged => Ok(()),
+            Recheck::RestartToFollow { from, to } => Err(crate::error::RoomContractRekeyed {
+                from: code_hash_b58(&from),
+                to: code_hash_b58(&to),
+            }
+            .into()),
+            Recheck::UpgradeRequired { from, to } => {
+                if *warned != Some(to) {
+                    *warned = Some(to);
+                    eprintln!(
+                        "warning: River re-keyed the room contract to a generation this riverctl \
+                         does not know.\n  was: {}\n  now: {}\n\
+                         Continuing on the current generation, but restarting will not help: \
+                         upgrade with `cargo install riverctl --force`, then restart.",
+                        code_hash_b58(&from),
+                        code_hash_b58(&to),
+                    );
+                }
+                Ok(())
+            }
         }
-        info!(
-            "Room-contract generation for this run: {} ({:?}, {:?})",
-            crate::pointer::code_hash_b58(anchor.code_hash()),
-            anchor.generation(),
-            anchor.source(),
-        );
-
-        // Let the local room cache regenerate its keys against the same
-        // generation the network paths use, instead of against the bundled WASM.
-        self.storage.set_room_code_hash(*anchor.code_hash());
-        Ok(anchor)
     }
 
     /// The room-contract key for `owner_vk` under this run's resolved
@@ -5208,6 +5289,11 @@ impl ApiClient {
             let _ = shutdown_tx.send(()).await;
         });
 
+        // River can re-key the room contract while this runs. See
+        // `crate::pointer::Recheck`.
+        let mut next_recheck = std::time::Instant::now() + recheck_delay();
+        let mut warned_upgrade: Option<[u8; 32]> = None;
+
         // Main polling loop
         loop {
             // Check for shutdown signal
@@ -5228,6 +5314,11 @@ impl ApiClient {
             if max_messages > 0 && new_message_count >= max_messages {
                 debug!("Maximum message count reached, exiting stream");
                 return Ok(());
+            }
+
+            if std::time::Instant::now() >= next_recheck {
+                next_recheck = std::time::Instant::now() + recheck_delay();
+                Self::act_on_recheck(self.recheck_room_anchor().await, &mut warned_upgrade)?;
             }
 
             // Poll for new + edited messages. emit_new_and_edited re-emits a
@@ -6409,6 +6500,11 @@ impl ApiClient {
             let _ = shutdown_tx.send(()).await;
         });
 
+        // River can re-key the room contract while this runs. See
+        // `crate::pointer::Recheck`.
+        let mut next_recheck = std::time::Instant::now() + recheck_delay();
+        let mut warned_upgrade: Option<[u8; 32]> = None;
+
         // Main loop: wait for UpdateNotification messages
         loop {
             // Check for shutdown signal
@@ -6429,6 +6525,27 @@ impl ApiClient {
             if max_messages > 0 && new_message_count >= max_messages {
                 debug!("Maximum message count reached, exiting subscription stream");
                 return Ok(());
+            }
+
+            // Before taking the connection lock: the re-check needs it too.
+            if std::time::Instant::now() >= next_recheck {
+                next_recheck = std::time::Instant::now() + recheck_delay();
+                Self::act_on_recheck(self.recheck_room_anchor().await, &mut warned_upgrade)?;
+                // The re-check's pointer GET reads from the same connection as
+                // this subscription, and steps over (discarding) anything else
+                // that arrives while it waits — which can be a notification for
+                // this very room. Queue one so the handler below re-fetches full
+                // state, exactly as if it had arrived; that handler ignores the
+                // payload. Without this, a message landing during the re-check
+                // would stay unseen until the room's next message.
+                pending.push_back(HostResponse::ContractResponse(
+                    ContractResponse::UpdateNotification {
+                        key: contract_key,
+                        update: freenet_stdlib::prelude::UpdateData::Delta(
+                            freenet_stdlib::prelude::StateDelta::from(Vec::new()),
+                        ),
+                    },
+                ));
             }
 
             // Wait for next message with a short timeout to allow checking shutdown
@@ -9088,6 +9205,83 @@ mod reaccept_guard_tests {
             "the re-accept guard must run BEFORE the network GET so a refused re-accept \
              does no network or storage work"
         );
+    }
+}
+
+#[cfg(test)]
+mod recheck_tests {
+    use super::*;
+    use crate::pointer::Recheck;
+
+    const A: [u8; 32] = [0xAA; 32];
+    const B: [u8; 32] = [0xBB; 32];
+    const C: [u8; 32] = [0xCC; 32];
+
+    #[test]
+    fn nothing_moved_means_the_stream_carries_on() {
+        let mut warned = None;
+        ApiClient::act_on_recheck(Ok(Recheck::Unchanged), &mut warned).unwrap();
+        assert_eq!(warned, None);
+    }
+
+    /// A move a restart will follow ends the stream with the restart status, so
+    /// a supervisor restarts it rather than treating it as a crash.
+    #[test]
+    fn a_followable_move_ends_the_stream_with_the_restart_status() {
+        let mut warned = None;
+        let err =
+            ApiClient::act_on_recheck(Ok(Recheck::RestartToFollow { from: A, to: B }), &mut warned)
+                .expect_err("a re-key a restart will follow must end the stream");
+        assert_eq!(crate::error::exit_code_for(&err), 75);
+    }
+
+    /// A move past this binary does NOT end the stream — a restart of the same
+    /// binary would not help — and warns once per re-key, not every few minutes.
+    #[test]
+    fn a_move_past_this_binary_warns_once_per_rekey_and_keeps_running() {
+        let mut warned = None;
+        let past_us = Recheck::UpgradeRequired { from: A, to: B };
+
+        ApiClient::act_on_recheck(Ok(past_us), &mut warned).expect("keeps running");
+        assert_eq!(warned, Some(B));
+
+        // Same re-key seen again on the next re-check: nothing new to say.
+        ApiClient::act_on_recheck(Ok(past_us), &mut warned).expect("keeps running");
+        assert_eq!(warned, Some(B));
+
+        // River re-keys AGAIN, still past us: that is new, so it is said again.
+        ApiClient::act_on_recheck(Ok(Recheck::UpgradeRequired { from: A, to: C }), &mut warned)
+            .expect("keeps running");
+        assert_eq!(warned, Some(C));
+    }
+
+    /// A failed re-check ends the stream as an ordinary failure (status 1), not
+    /// as a restart request. What can fail here is not a timeout (that comes back
+    /// as an unverified anchor) but a corrupt floor or a signed withdrawal.
+    #[test]
+    fn a_failed_recheck_is_an_ordinary_failure_not_a_restart() {
+        let mut warned = None;
+        let err = ApiClient::act_on_recheck(Err(anyhow!("floor is corrupt")), &mut warned)
+            .expect_err("a failed re-check must not be silently ignored");
+        assert_eq!(crate::error::exit_code_for(&err), 1);
+    }
+
+    /// Without jitter, a fleet of bots restarted together after one re-key stays
+    /// in lockstep for the next. A jitter function that returned a constant would
+    /// pass a bounds check, so pin the spread too.
+    #[test]
+    fn the_recheck_interval_is_jittered_within_twenty_percent() {
+        let base = RECHECK_INTERVAL.as_secs_f64();
+        let mut distinct = std::collections::HashSet::new();
+        for _ in 0..200 {
+            let d = recheck_delay().as_secs_f64();
+            assert!(
+                d >= base * 0.8 && d < base * 1.2,
+                "{d} outside ±20% of {base}"
+            );
+            distinct.insert(d.to_bits());
+        }
+        assert!(distinct.len() > 100, "the interval must actually vary");
     }
 }
 

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -5245,13 +5245,10 @@ impl ApiClient {
         // Track seen messages: key -> last-emitted effective content, so a later
         // edit (content change) is detected and re-emitted, not just new ids.
         let mut seen_messages: HashMap<String, String> = HashMap::new();
-        // Messages for which a deletion has already been emitted (one-shot). The
-        // polling path needs NO startup pre-seed (unlike subscribe): it only ever
-        // inserts into `seen` via `display_messages()` (initial window + each
-        // poll's emit_new_and_edited), which excludes deleted messages — so a
-        // pre-existing deletion is never in `seen` and `should_emit_deletion`
-        // returns false for it. (A future change that seeds `seen` from raw
-        // `messages` here would need a pre-seed like the subscribe path's.)
+        // Messages for which a deletion has already been emitted, or must never be
+        // (one-shot). `seed_stream` pre-fills it with every message the stream did
+        // not show at start, because it records the whole window as seen — see
+        // there.
         let mut deleted_emitted: HashSet<String> = HashSet::new();
         // Reactions fingerprint per SURFACED message, so a reaction added/removed
         // AFTER the message was streamed surfaces as a `reaction` event
@@ -5276,13 +5273,17 @@ impl ApiClient {
                     &secrets,
                     initial_messages,
                     &mut seen_messages,
+                    &mut deleted_emitted,
                     &mut seen_reactions,
                     room_owner_key,
                     &format,
                 )?;
                 seeded = true;
             }
-            Err(e) => debug!("Could not fetch room state at stream start (will retry): {e}"),
+            // Once, on stderr: this used to exit with `-i N`, and it is now a
+            // silent retry unless said. Later poll failures stay at `debug!`, as
+            // they always have.
+            Err(e) => eprintln!("note: could not fetch room state yet ({e}); will keep polling"),
         }
 
         // Set up Ctrl+C handler
@@ -5336,6 +5337,7 @@ impl ApiClient {
                         &secrets,
                         initial_messages,
                         &mut seen_messages,
+                        &mut deleted_emitted,
                         &mut seen_reactions,
                         room_owner_key,
                         &format,
@@ -5411,18 +5413,17 @@ impl ApiClient {
     /// every re-key. The subscription path already seeds the whole window; this
     /// brings polling into line.
     ///
-    /// Seeds from `display_messages()`, which excludes deleted messages, so a
-    /// deletion that predates the stream is never in `seen` and needs no
-    /// suppression (see the note on `deleted_emitted` in `stream_messages`).
-    /// Reaction fingerprints are seeded only for the messages actually shown, the
-    /// same rule the subscription path follows: a reaction change on a message the
-    /// stream never displayed is not reported.
+    /// Deletions are suppressed for every message not shown, so a later deletion
+    /// of one the consumer never received is not reported. Reaction fingerprints
+    /// are seeded only for the messages actually shown. Both follow the rules the
+    /// subscription path already uses.
     #[allow(clippy::too_many_arguments)]
     fn seed_stream(
         room_state: &ChatRoomStateV1,
         secrets: &HashMap<u32, [u8; 32]>,
         initial_messages: usize,
         seen_messages: &mut HashMap<String, String>,
+        deleted_emitted: &mut HashSet<String>,
         seen_reactions: &mut HashMap<String, String>,
         room_owner_key: &VerifyingKey,
         format: &OutputFormat,
@@ -5435,6 +5436,19 @@ impl ApiClient {
             );
         }
         let start = all_msgs.len().saturating_sub(initial_messages);
+        // Recording every message as seen is what stops the first poll replaying
+        // history, but it also makes each of them eligible for a `delete` event.
+        // Suppress that for every message NOT shown now, exactly as the
+        // subscription path does (#324): a consumer must never be told a message
+        // it never received was deleted.
+        let shown_keys: HashSet<String> = all_msgs[start..]
+            .iter()
+            .map(|m| monitor_seen_key(m))
+            .collect();
+        deleted_emitted.extend(deletions_to_suppress_at_start(
+            &room_state.recent_messages.messages,
+            &shown_keys,
+        ));
         for msg in &all_msgs[start..] {
             seen_reactions.insert(
                 monitor_seen_key(msg),
@@ -9765,9 +9779,6 @@ mod monitor_tests {
         AuthorizedMessageV1::new(m, &sk)
     }
 
-    /// A `ChatRoomStateV1` whose `recent_messages` contains `original` plus the
-    /// given reaction action messages, with `actions_state` rebuilt so
-    /// `reactions()` reflects them.
     /// The polling stream's startup must record EVERY message the room already
     /// holds, and print only the last `initial_messages`. It used to record only
     /// the ones it printed, so the first poll re-emitted the rest as new: all of
@@ -9781,7 +9792,7 @@ mod monitor_tests {
             .collect();
         let state = {
             let mut recent = MessagesV1 {
-                messages: msgs,
+                messages: msgs.clone(),
                 ..Default::default()
             };
             recent.rebuild_actions_state();
@@ -9802,6 +9813,7 @@ mod monitor_tests {
                 &secrets,
                 initial,
                 &mut seen,
+                &mut deleted,
                 &mut reactions,
                 &owner_vk,
                 &OutputFormat::Json,
@@ -9835,9 +9847,23 @@ mod monitor_tests {
                 new_count, 0,
                 "-i {initial}: the first poll of an unchanged room must emit nothing"
             );
+
+            // Recording every message as seen must not make each one eligible for
+            // a `delete` event. The first message is never among those shown for
+            // -i 0 or -i 1, so its deletion must be suppressed; with -i 3 it WAS
+            // shown, so its deletion must be reported.
+            let first = &msgs[0];
+            assert_eq!(
+                should_emit_deletion(&seen, &deleted, &monitor_seen_key(first)),
+                initial == 3,
+                "-i {initial}: a deletion is reported only for a message the stream showed"
+            );
         }
     }
 
+    /// A `ChatRoomStateV1` whose `recent_messages` contains `original` plus the
+    /// given reaction action messages, with `actions_state` rebuilt so
+    /// `reactions()` reflects them.
     fn state_with_reactions(
         original: &AuthorizedMessageV1,
         reaction_actions: Vec<AuthorizedMessageV1>,

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -21,3 +21,82 @@ pub enum CliError {
     #[error("Not a member of room: {0}")]
     NotMember(String),
 }
+
+/// Exit status when a long-running command stops because River re-keyed the
+/// room contract underneath it.
+///
+/// 75 is `EX_TEMPFAIL` from sysexits.h: "a temporary failure; the user is
+/// invited to retry". That is exactly the contract — restart riverctl and it
+/// follows the new generation — and it lets a supervisor or wrapper script tell
+/// "restart me" apart from a real failure without parsing stderr.
+pub const EXIT_ROOM_CONTRACT_REKEYED: u8 = 75;
+
+/// River re-keyed the room contract while a long-running command was running.
+///
+/// Not a failure of the command. The process stops so it can be restarted, and
+/// the restarted process follows the new generation through the normal startup
+/// path. See [`crate::pointer::Recheck`].
+#[derive(Error, Debug)]
+#[error(
+    "River re-keyed the room contract while this command was running.\n  \
+     was: {from}\n  now: {to}\n\
+     Exiting with status {code} so it can be restarted; a restarted riverctl follows the new \
+     generation automatically.",
+    code = EXIT_ROOM_CONTRACT_REKEYED
+)]
+pub struct RoomContractRekeyed {
+    pub from: String,
+    pub to: String,
+}
+
+/// The process exit status for a command that ended in `err`.
+///
+/// Split out of `main` so the mapping is testable. Anything other than a re-key
+/// is status 1, which is what `main` returning `Err` produced before this
+/// existed, so no other failure changes its status.
+pub fn exit_code_for(err: &anyhow::Error) -> u8 {
+    if err.downcast_ref::<RoomContractRekeyed>().is_some() {
+        EXIT_ROOM_CONTRACT_REKEYED
+    } else {
+        1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rekeyed() -> RoomContractRekeyed {
+        RoomContractRekeyed {
+            from: "old".to_string(),
+            to: "new".to_string(),
+        }
+    }
+
+    #[test]
+    fn a_rekey_exits_with_the_restart_status_and_everything_else_with_one() {
+        assert_eq!(exit_code_for(&rekeyed().into()), 75);
+        assert_eq!(exit_code_for(&anyhow::anyhow!("an ordinary failure")), 1);
+    }
+
+    /// Commands add `.context(...)` as errors propagate. If that hid the re-key,
+    /// a supervisor would see status 1 and treat a routine restart as a crash.
+    #[test]
+    fn the_restart_status_survives_added_context() {
+        let wrapped = anyhow::Error::from(rekeyed()).context("while streaming messages");
+        assert_eq!(exit_code_for(&wrapped), 75);
+    }
+
+    /// The message names both generations and says what happens next, because
+    /// the operator's first question is whether this is a crash.
+    #[test]
+    fn the_message_says_it_is_a_restart_not_a_crash() {
+        let msg = rekeyed().to_string();
+        assert!(
+            msg.contains("was: old") && msg.contains("now: new"),
+            "{msg}"
+        );
+        assert!(msg.contains("status 75"), "{msg}");
+        assert!(msg.contains("restarted"), "{msg}");
+    }
+}

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -31,7 +31,9 @@ pub enum CliError {
 /// "restart me" apart from a real failure without parsing stderr.
 pub const EXIT_ROOM_CONTRACT_REKEYED: u8 = 75;
 
-/// River re-keyed the room contract while a long-running command was running.
+/// River's pointer names a different room-contract generation than the one a
+/// long-running command started with — usually because River re-keyed while it
+/// ran, sometimes because the command started on a fallback it could not verify.
 ///
 /// Not a failure of the command. The process stops so it can be restarted, and
 /// the restarted process follows the new generation through the normal startup

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -38,10 +38,10 @@ pub const EXIT_ROOM_CONTRACT_REKEYED: u8 = 75;
 /// path. See [`crate::pointer::Recheck`].
 #[derive(Error, Debug)]
 #[error(
-    "River re-keyed the room contract while this command was running.\n  \
-     was: {from}\n  now: {to}\n\
-     Exiting with status {code} so it can be restarted; a restarted riverctl follows the new \
-     generation automatically.",
+    "River's pointer now names a different room-contract generation than this command started \
+     with.\n  was: {from}\n  now: {to}\n\
+     Exiting with status {code} so it can be restarted; a restarted riverctl uses the current \
+     generation.",
     code = EXIT_ROOM_CONTRACT_REKEYED
 )]
 pub struct RoomContractRekeyed {
@@ -59,6 +59,21 @@ pub fn exit_code_for(err: &anyhow::Error) -> u8 {
         EXIT_ROOM_CONTRACT_REKEYED
     } else {
         1
+    }
+}
+
+/// What `main` writes to stderr, and the status it exits with, for a command that
+/// ended in `err`.
+///
+/// Split out of `main` so the whole mapping is testable, not just the status. A
+/// re-key prints its own message rather than the `Error:` debug dump, because it
+/// is a restart request and should not read as a crash. Every other error prints
+/// `Error: {err:?}` and exits 1 — exactly what `main` returning `Result` produced
+/// before, so no other command's output or status changes.
+pub fn report(err: &anyhow::Error) -> (String, u8) {
+    match err.downcast_ref::<RoomContractRekeyed>() {
+        Some(rekeyed) => (rekeyed.to_string(), EXIT_ROOM_CONTRACT_REKEYED),
+        None => (format!("Error: {err:?}"), exit_code_for(err)),
     }
 }
 
@@ -87,16 +102,34 @@ mod tests {
         assert_eq!(exit_code_for(&wrapped), 75);
     }
 
-    /// The message names both generations and says what happens next, because
-    /// the operator's first question is whether this is a crash.
+    /// A re-key prints its own message, names both generations, and says what
+    /// happens next — because the operator's first question is whether it crashed.
     #[test]
-    fn the_message_says_it_is_a_restart_not_a_crash() {
-        let msg = rekeyed().to_string();
+    fn a_rekey_reports_a_restart_not_a_crash() {
+        let (msg, code) = report(&rekeyed().into());
+        assert_eq!(code, 75);
+        assert!(
+            !msg.starts_with("Error:"),
+            "a restart must not read as a crash: {msg}"
+        );
         assert!(
             msg.contains("was: old") && msg.contains("now: new"),
             "{msg}"
         );
-        assert!(msg.contains("status 75"), "{msg}");
-        assert!(msg.contains("restarted"), "{msg}");
+        assert!(
+            msg.contains("status 75") && msg.contains("restarted"),
+            "{msg}"
+        );
+    }
+
+    /// Every other error reports exactly as `main` returning `Result` did: the
+    /// `Error:` debug dump and status 1. This is what keeps the change from
+    /// altering any other command.
+    #[test]
+    fn every_other_error_reports_exactly_as_before() {
+        let err = anyhow::anyhow!("room not found").context("while listing messages");
+        let (msg, code) = report(&err);
+        assert_eq!(code, 1);
+        assert_eq!(msg, format!("Error: {err:?}"));
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -120,7 +120,25 @@ enum Commands {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> std::process::ExitCode {
+    match run().await {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(e) => {
+            // A re-key is a restart request, not a crash: print its own message
+            // rather than the `Error:` debug dump, and exit with the status a
+            // supervisor can recognise. Every other error prints and exits
+            // exactly as it did when `main` returned `Result` directly.
+            if let Some(rekeyed) = e.downcast_ref::<riverctl::error::RoomContractRekeyed>() {
+                eprintln!("{rekeyed}");
+            } else {
+                eprintln!("Error: {e:?}");
+            }
+            std::process::ExitCode::from(riverctl::error::exit_code_for(&e))
+        }
+    }
+}
+
+async fn run() -> Result<()> {
     let cli = Cli::parse();
 
     // Initialize logging (keep stdout clean for user/JSON output)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -124,16 +124,13 @@ async fn main() -> std::process::ExitCode {
     match run().await {
         Ok(()) => std::process::ExitCode::SUCCESS,
         Err(e) => {
-            // A re-key is a restart request, not a crash: print its own message
-            // rather than the `Error:` debug dump, and exit with the status a
-            // supervisor can recognise. Every other error prints and exits
-            // exactly as it did when `main` returned `Result` directly.
-            if let Some(rekeyed) = e.downcast_ref::<riverctl::error::RoomContractRekeyed>() {
-                eprintln!("{rekeyed}");
-            } else {
-                eprintln!("Error: {e:?}");
-            }
-            std::process::ExitCode::from(riverctl::error::exit_code_for(&e))
+            // See `riverctl::error::report`. Written with the error ignored, like
+            // the std `Termination` impl this replaces: a closed stderr must not
+            // turn an ordinary failure into a panic.
+            let (message, code) = riverctl::error::report(&e);
+            use std::io::Write as _;
+            let _ = writeln!(std::io::stderr(), "{message}");
+            std::process::ExitCode::from(code)
         }
     }
 }

--- a/cli/src/pointer.rs
+++ b/cli/src/pointer.rs
@@ -342,17 +342,20 @@ impl RoomAnchor {
 /// that runs on every invocation. A mid-run copy of all that was tried in #696
 /// and did not survive review. So the answer to "River re-keyed" is to exit and
 /// be restarted.
+///
+/// That holds even when the new generation is one this binary does not know. A
+/// stream only reads, and reads are permitted against any generation (see
+/// [`RoomAnchor::authorize`]), so a restarted process can stream the new
+/// generation as soon as anyone has moved the room there — while a process that
+/// stayed put would keep listening to the retired one. The restarted process also
+/// prints the existing "this riverctl is older than River's room contract"
+/// advisory, which is what tells the operator to upgrade.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Recheck {
     /// Nothing that should change what this process is doing.
     Unchanged,
-    /// River re-keyed to a generation this binary knows. A restarted process
-    /// will follow it, so exit and let the supervisor restart.
-    RestartToFollow { from: [u8; 32], to: [u8; 32] },
-    /// River re-keyed to a generation this binary does NOT know. Restarting
-    /// would not help — a fresh process of this same binary cannot use it either
-    /// — so keep running on what still works and say an upgrade is needed.
-    UpgradeRequired { from: [u8; 32], to: [u8; 32] },
+    /// River's pointer now names a different generation: exit and be restarted.
+    Moved { from: [u8; 32], to: [u8; 32] },
 }
 
 /// Compare a freshly-resolved anchor with the one a command started with.
@@ -366,10 +369,31 @@ pub fn recheck(in_force: &RoomAnchor, fresh: &RoomAnchor) -> Recheck {
     if fresh.code_hash() == in_force.code_hash() || fresh.source() != &AnchorSource::Pointer {
         return Recheck::Unchanged;
     }
-    let (from, to) = (*in_force.code_hash(), *fresh.code_hash());
-    match fresh.generation() {
-        Generation::Unknown => Recheck::UpgradeRequired { from, to },
-        Generation::Bundled | Generation::Legacy(_) => Recheck::RestartToFollow { from, to },
+    Recheck::Moved {
+        from: *in_force.code_hash(),
+        to: *fresh.code_hash(),
+    }
+}
+
+/// The higher of a floor this process has already verified and the one just
+/// read from disk.
+///
+/// The anti-rollback floor is what makes a genuinely-signed OLDER record
+/// unusable, and it is re-read from disk on every resolution. Persisting it is
+/// best-effort, though (a read-only config directory is enough to skip it), so
+/// the disk can be behind what this process verified at startup. A periodic
+/// re-check reading only the disk would then accept an older signed record as a
+/// move and restart onto it. A signature establishes authenticity, not
+/// freshness; this supplies the freshness the disk could not.
+///
+/// "Higher" is by version, except that at EQUAL versions a withdrawal wins:
+/// dropping a tombstone for a same-version record would resurrect exactly what
+/// the author retired.
+pub fn highest_floor(remembered: Option<PointerFloor>, on_disk: PointerFloor) -> PointerFloor {
+    match remembered {
+        Some(mem) if mem.version() > on_disk.version() => mem,
+        Some(mem) if mem.version() == on_disk.version() && mem.is_withdrawn() => mem,
+        _ => on_disk,
     }
 }
 
@@ -768,32 +792,64 @@ mod tests {
         assert_eq!(recheck(&in_force, &fallback), Recheck::Unchanged);
     }
 
-    /// A verified re-key to a generation this binary knows: restart to follow.
+    /// A verified re-key to a generation this binary knows: restart.
     #[test]
     fn recheck_restarts_for_a_verified_move_to_a_known_generation() {
         let legacy = river_core::migration::LEGACY_ROOM_CONTRACT_CODE_HASHES[3];
         assert_eq!(
             recheck(&verified(legacy), &verified(bundled())),
-            Recheck::RestartToFollow {
+            Recheck::Moved {
                 from: legacy,
                 to: bundled()
             }
         );
     }
 
-    /// A verified re-key PAST this binary: restarting would not help, so the
-    /// answer is to ask for an upgrade, not to exit.
+    /// A verified re-key PAST this binary restarts too. A stream only reads, and
+    /// reads are permitted against an unknown generation, so a restarted process
+    /// can stream it once the room has been moved there; staying put would keep
+    /// listening to the retired generation.
     #[test]
-    fn recheck_requires_an_upgrade_for_a_move_past_this_binary() {
+    fn recheck_restarts_for_a_verified_move_past_this_binary_too() {
         let past_us = verified([0x11; 32]);
         assert_eq!(past_us.generation(), Generation::Unknown);
+        past_us
+            .authorize(KeyIntent::Read)
+            .expect("the premise: a stale riverctl may READ an unknown generation");
         assert_eq!(
             recheck(&verified(bundled()), &past_us),
-            Recheck::UpgradeRequired {
+            Recheck::Moved {
                 from: bundled(),
                 to: [0x11; 32]
             }
         );
+    }
+
+    /// If the floor could not be saved, the disk can be behind what this process
+    /// verified. The remembered floor must win, or an older signed record would be
+    /// accepted as a move.
+    #[test]
+    fn the_remembered_floor_beats_a_disk_that_fell_behind() {
+        let old = PointerFloor::at(3, [0xAA; 32]).unwrap();
+        let new = PointerFloor::at(9, [0xBB; 32]).unwrap();
+
+        assert_eq!(
+            highest_floor(None, old).version(),
+            3,
+            "nothing remembered yet"
+        );
+        assert_eq!(
+            highest_floor(Some(new), old).version(),
+            9,
+            "disk fell behind"
+        );
+        assert_eq!(highest_floor(Some(old), new).version(), 9, "disk is ahead");
+
+        // Equal versions: a withdrawal wins from either side.
+        let tombstone = PointerFloor::withdrawn_at(9).unwrap();
+        let live_at_9 = PointerFloor::at(9, [0xCC; 32]).unwrap();
+        assert!(highest_floor(Some(tombstone), live_at_9).is_withdrawn());
+        assert!(highest_floor(Some(live_at_9), tombstone).is_withdrawn());
     }
 
     #[test]

--- a/cli/src/pointer.rs
+++ b/cli/src/pointer.rs
@@ -386,13 +386,31 @@ pub fn recheck(in_force: &RoomAnchor, fresh: &RoomAnchor) -> Recheck {
 /// move and restart onto it. A signature establishes authenticity, not
 /// freshness; this supplies the freshness the disk could not.
 ///
-/// "Higher" is by version, except that at EQUAL versions a withdrawal wins:
-/// dropping a tombstone for a same-version record would resurrect exactly what
-/// the author retired.
+/// "Higher" is by version. At EQUAL versions it applies the same tiebreak the
+/// pointer resolver and the network's merge converge on: a withdrawal first (a
+/// tombstone sorts below every real code hash, and dropping it would resurrect
+/// what the author retired), then the LOWER code hash. Picking by any other rule
+/// at equal versions could keep the record the network discards, and a re-check
+/// would then read the canonical record as a move.
 pub fn highest_floor(remembered: Option<PointerFloor>, on_disk: PointerFloor) -> PointerFloor {
-    match remembered {
-        Some(mem) if mem.version() > on_disk.version() => mem,
-        Some(mem) if mem.version() == on_disk.version() && mem.is_withdrawn() => mem,
+    let Some(mem) = remembered else {
+        return on_disk;
+    };
+    if mem.version() != on_disk.version() {
+        return if mem.version() > on_disk.version() {
+            mem
+        } else {
+            on_disk
+        };
+    }
+    if mem.is_withdrawn() {
+        return mem;
+    }
+    if on_disk.is_withdrawn() {
+        return on_disk;
+    }
+    match (mem.code_hash(), on_disk.code_hash()) {
+        (Some(m), Some(d)) if m < d => mem,
         _ => on_disk,
     }
 }
@@ -850,6 +868,21 @@ mod tests {
         let live_at_9 = PointerFloor::at(9, [0xCC; 32]).unwrap();
         assert!(highest_floor(Some(tombstone), live_at_9).is_withdrawn());
         assert!(highest_floor(Some(live_at_9), tombstone).is_withdrawn());
+
+        // Equal versions, two real records: the LOWER code hash wins, from either
+        // side, matching the resolver's tiebreak. Otherwise a failed save could
+        // leave the disk holding the record the network discards, and a re-check
+        // would read the canonical one as a move.
+        let lower = PointerFloor::at(9, [0x11; 32]).unwrap();
+        let higher = PointerFloor::at(9, [0xEE; 32]).unwrap();
+        assert_eq!(
+            highest_floor(Some(lower), higher).code_hash(),
+            Some([0x11; 32])
+        );
+        assert_eq!(
+            highest_floor(Some(higher), lower).code_hash(),
+            Some([0x11; 32])
+        );
     }
 
     #[test]

--- a/cli/src/pointer.rs
+++ b/cli/src/pointer.rs
@@ -329,6 +329,50 @@ impl RoomAnchor {
     }
 }
 
+/// What a long-running command should do after re-checking River's pointer.
+///
+/// A long-running command (`message stream`) resolves the room-contract
+/// generation once, at startup, like every other command. If River re-keys while
+/// it runs, the room's address changes underneath it and it would otherwise keep
+/// listening to a contract nobody writes to, with no error (freenet/river#694).
+///
+/// It does not try to follow the move in place. Everything a re-key needs —
+/// resolving the new generation, migrating the room, healing membership,
+/// subscribing — is what a fresh process already does at startup, through code
+/// that runs on every invocation. A mid-run copy of all that was tried in #696
+/// and did not survive review. So the answer to "River re-keyed" is to exit and
+/// be restarted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Recheck {
+    /// Nothing that should change what this process is doing.
+    Unchanged,
+    /// River re-keyed to a generation this binary knows. A restarted process
+    /// will follow it, so exit and let the supervisor restart.
+    RestartToFollow { from: [u8; 32], to: [u8; 32] },
+    /// River re-keyed to a generation this binary does NOT know. Restarting
+    /// would not help — a fresh process of this same binary cannot use it either
+    /// — so keep running on what still works and say an upgrade is needed.
+    UpgradeRequired { from: [u8; 32], to: [u8; 32] },
+}
+
+/// Compare a freshly-resolved anchor with the one a command started with.
+///
+/// Only a signature-verified record counts as a move. A re-check that could not
+/// reach the pointer still produces an anchor — on the last hash this install
+/// persisted, or the BUNDLED hash if it never persisted one — and that fallback
+/// can differ from the generation in use without River having re-keyed at all.
+/// Restarting on it would make a single timeout look like a re-key.
+pub fn recheck(in_force: &RoomAnchor, fresh: &RoomAnchor) -> Recheck {
+    if fresh.code_hash() == in_force.code_hash() || fresh.source() != &AnchorSource::Pointer {
+        return Recheck::Unchanged;
+    }
+    let (from, to) = (*in_force.code_hash(), *fresh.code_hash());
+    match fresh.generation() {
+        Generation::Unknown => Recheck::UpgradeRequired { from, to },
+        Generation::Bundled | Generation::Legacy(_) => Recheck::RestartToFollow { from, to },
+    }
+}
+
 /// What a resolution attempt produced, flattened so the arm-by-arm mapping
 /// below is a pure function that needs no node and no generic error type.
 #[derive(Debug, Clone)]
@@ -678,6 +722,77 @@ mod tests {
             ROOM_CONTRACT_POINTER_KEY,
             "the author key and app_id in this module no longer derive the pointer address \
              published in FREENET.md"
+        );
+    }
+
+    /// Resolve an anchor from a genuine signed record naming `hash`.
+    fn verified(hash: [u8; 32]) -> RoomAnchor {
+        let author = SigningKey::from_bytes(&[3u8; 32]);
+        anchor_from_report(
+            &ResolveReport::Outcome(outcome_for(
+                &author,
+                PointerFloor::never_resolved(),
+                4,
+                hash,
+            )),
+            &PointerFloor::never_resolved(),
+            bundled(),
+        )
+        .unwrap()
+    }
+
+    /// A re-check that names the generation already in use changes nothing.
+    #[test]
+    fn recheck_ignores_a_reconfirmed_generation() {
+        let anchor = verified(bundled());
+        assert_eq!(recheck(&anchor, &anchor), Recheck::Unchanged);
+    }
+
+    /// The case that makes "restart on any hash change" wrong. A re-check that
+    /// could not reach the pointer falls back to the last persisted hash, or the
+    /// bundled one, and that can differ from the generation in use with no
+    /// re-key having happened. Restarting on it would turn a timeout into a
+    /// restart.
+    #[test]
+    fn recheck_ignores_an_unverified_hash_change() {
+        let legacy = river_core::migration::LEGACY_ROOM_CONTRACT_CODE_HASHES[3];
+        let in_force = verified(legacy);
+        // Unreachable pointer, never-persisted floor: the fallback is bundled.
+        let fallback = anchor_from_report(
+            &ResolveReport::Failed("timed out".to_string()),
+            &PointerFloor::never_resolved(),
+            bundled(),
+        )
+        .unwrap();
+        assert_ne!(fallback.code_hash(), in_force.code_hash());
+        assert_eq!(recheck(&in_force, &fallback), Recheck::Unchanged);
+    }
+
+    /// A verified re-key to a generation this binary knows: restart to follow.
+    #[test]
+    fn recheck_restarts_for_a_verified_move_to_a_known_generation() {
+        let legacy = river_core::migration::LEGACY_ROOM_CONTRACT_CODE_HASHES[3];
+        assert_eq!(
+            recheck(&verified(legacy), &verified(bundled())),
+            Recheck::RestartToFollow {
+                from: legacy,
+                to: bundled()
+            }
+        );
+    }
+
+    /// A verified re-key PAST this binary: restarting would not help, so the
+    /// answer is to ask for an upgrade, not to exit.
+    #[test]
+    fn recheck_requires_an_upgrade_for_a_move_past_this_binary() {
+        let past_us = verified([0x11; 32]);
+        assert_eq!(past_us.generation(), Generation::Unknown);
+        assert_eq!(
+            recheck(&verified(bundled()), &past_us),
+            Recheck::UpgradeRequired {
+                from: bundled(),
+                to: [0x11; 32]
+            }
         );
     }
 

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -2242,6 +2242,13 @@ mod tests {
                 gate < call && !body[gate..call].contains("\n            }"),
                 "{name}'s re-check must sit INSIDE the `>= next_recheck` gate"
             );
+            // And the gate must be re-armed each time it fires, or after the first
+            // expiry it stays open and the re-check runs on every iteration.
+            assert!(
+                body[gate..call]
+                    .contains("next_recheck = std::time::Instant::now() + recheck_delay();"),
+                "{name} must reset `next_recheck` inside the gate before re-checking"
+            );
         }
 
         // The subscription loop's re-check reads from the same connection and can
@@ -2260,6 +2267,59 @@ mod tests {
             "after re-checking the pointer, subscribe_and_stream must queue a re-fetch \
              before it next reads the connection, or a message that arrived during the \
              re-check stays unseen"
+        );
+    }
+
+    /// Source-grep pins for two wirings whose only symptom when lost is silent.
+    ///
+    /// 1. `resolve_pointer` must REMEMBER each floor it verifies, before the
+    ///    best-effort save, and consult that memory on every resolution. The
+    ///    comparison (`pointer::highest_floor`) is unit-tested, but an
+    ///    `ApiClient` cannot be built without a live connection, so nothing else
+    ///    notices the call being dropped — and dropping it reopens the case where
+    ///    a read-only config dir lets a periodic re-check accept an older signed
+    ///    record.
+    /// 2. The polling stream must SEED before it emits, both at startup and on the
+    ///    first successful poll if the startup fetch failed. Without it the first
+    ///    poll reports the room's whole recent history as new, on every restart.
+    #[test]
+    fn floor_memory_and_stream_seeding_are_wired() {
+        let api_src = include_str!("api.rs");
+        let body_of = |start: &str| -> &str {
+            api_src
+                .split_once(start)
+                .and_then(|(_, rest)| rest.split_once("\n    }\n"))
+                .map(|(body, _)| body)
+                .unwrap_or_else(|| panic!("could not isolate the body after `{start}`"))
+        };
+
+        let resolve = body_of("    async fn resolve_pointer(");
+        assert!(
+            resolve.contains("highest_floor(self.remembered_floor(), on_disk)"),
+            "resolve_pointer must consult the floor this process already verified"
+        );
+        let remember = resolve
+            .find("self.remember_floor(next);")
+            .expect("resolve_pointer must remember each floor it verifies");
+        let save = resolve
+            .find(".save_pointer_floor(")
+            .expect("resolve_pointer still persists the floor");
+        assert!(
+            remember < save,
+            "the floor must be remembered BEFORE the best-effort save, so a failed save \
+             cannot skip it"
+        );
+
+        let polling = body_of("    pub async fn stream_messages(");
+        assert_eq!(
+            polling.matches("Self::seed_stream(").count(),
+            2,
+            "stream_messages must seed at startup AND on the first successful poll if \
+             startup could not fetch"
+        );
+        assert!(
+            polling.contains("Ok(mut room_state) if !seeded =>"),
+            "an unseeded polling stream must seed instead of emitting"
         );
     }
 

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -426,7 +426,27 @@ impl Storage {
             } else {
                 FloorStore::default()
             };
-            store.floors.insert(key.to_string(), floor);
+            // Never move a floor backwards, even if the caller asks to. The
+            // read-then-save here is not atomic with the caller's resolution: a
+            // long-running stream re-resolves every few minutes, so another
+            // riverctl sharing this config directory can advance the floor between
+            // this process loading it and saving it. Blindly inserting would then
+            // overwrite the newer floor with an older one, and every later process
+            // would accept records the newer floor exists to reject. Deciding
+            // under the lock, by the same rule the resolver uses, keeps the
+            // persisted floor monotonic. A stored entry that will not decode is
+            // replaced, which is what this did before; loading surfaces that
+            // corruption elsewhere.
+            let chosen = match (
+                store.floors.get(key).map(StoredFloor::to_floor),
+                floor.to_floor(),
+            ) {
+                (Some(Ok(stored)), Ok(proposed)) => {
+                    StoredFloor::from_floor(&crate::pointer::highest_floor(Some(proposed), stored))
+                }
+                _ => floor,
+            };
+            store.floors.insert(key.to_string(), chosen);
             Self::atomic_write(
                 &self.pointer_floors_path,
                 &serde_json::to_string_pretty(&store)?,
@@ -2321,6 +2341,25 @@ mod tests {
             polling.contains("Ok(mut room_state) if !seeded =>"),
             "an unseeded polling stream must seed instead of emitting"
         );
+        // Each seed must actually MARK the stream seeded, or the `!seeded` arm
+        // keeps re-seeding — re-printing the initial window on every poll.
+        for (i, _) in polling.match_indices("Self::seed_stream(") {
+            let after = &polling[i..];
+            let next_arm = after[1..]
+                .find("Self::")
+                .map(|j| j + 1)
+                .unwrap_or(after.len());
+            assert!(
+                after[..after.len().min(next_arm.max(400))].contains("seeded = true;"),
+                "every seed_stream call in stream_messages must be followed by `seeded = true;`"
+            );
+        }
+        // And seeding must suppress deletions of messages it did not show.
+        let seed = body_of("    fn seed_stream(");
+        assert!(
+            seed.contains("deleted_emitted.extend(deletions_to_suppress_at_start("),
+            "seed_stream must suppress deletions of messages it did not show (#324)"
+        );
         // The poll sleep must not outlast the next re-check, or a long
         // `--poll-interval` defeats the re-check interval entirely.
         assert!(
@@ -2437,6 +2476,56 @@ mod tests {
         assert_eq!(
             retrieved_state.configuration.configuration.max_members,
             state.configuration.configuration.max_members
+        );
+    }
+
+    /// A floor save must never move the persisted floor backwards. Another
+    /// riverctl sharing the config directory can advance it between a stream's
+    /// load and its save, and a blind overwrite would then let every later
+    /// process accept records that floor exists to reject.
+    #[test]
+    fn saving_an_older_pointer_floor_does_not_regress_the_stored_one() {
+        use freenet_migrate::pointer::PointerFloor;
+        let (storage, _temp_dir) = create_test_storage();
+        let key = "river.room-contract";
+        let stored = |s: &Storage| {
+            s.load_pointer_floor(key)
+                .unwrap()
+                .expect("a floor was saved")
+                .to_floor()
+                .unwrap()
+        };
+
+        let newer = PointerFloor::at(9, [0xBB; 32]).unwrap();
+        let older = PointerFloor::at(3, [0xAA; 32]).unwrap();
+        storage
+            .save_pointer_floor(key, StoredFloor::from_floor(&newer))
+            .unwrap();
+        storage
+            .save_pointer_floor(key, StoredFloor::from_floor(&older))
+            .unwrap();
+        assert_eq!(stored(&storage).version(), 9, "an older save must not win");
+
+        // A genuinely newer floor still replaces it.
+        let newest = PointerFloor::at(12, [0xCC; 32]).unwrap();
+        storage
+            .save_pointer_floor(key, StoredFloor::from_floor(&newest))
+            .unwrap();
+        assert_eq!(stored(&storage).version(), 12);
+
+        // Equal versions follow the resolver's tiebreak: the lower hash stays.
+        let lower = PointerFloor::at(12, [0x11; 32]).unwrap();
+        storage
+            .save_pointer_floor(key, StoredFloor::from_floor(&lower))
+            .unwrap();
+        assert_eq!(stored(&storage).code_hash(), Some([0x11; 32]));
+        storage
+            .save_pointer_floor(key, StoredFloor::from_floor(&newest))
+            .unwrap();
+        assert_eq!(
+            stored(&storage).code_hash(),
+            Some([0x11; 32]),
+            "the higher hash at the same version must not replace the lower"
         );
     }
 

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -2191,6 +2191,65 @@ mod tests {
         );
     }
 
+    /// Source-grep pin: BOTH `message stream` loops must re-check River's
+    /// pointer, and the subscription loop must re-fetch after doing so.
+    ///
+    /// The decision logic is unit-tested; nothing else notices a loop that stops
+    /// calling it, and the symptom of that — a stream silently listening to a
+    /// retired contract — is the bug this exists to fix (freenet/river#694).
+    ///
+    /// In storage.rs so the pinned strings are not satisfied by this test's own
+    /// source.
+    #[test]
+    fn both_stream_loops_recheck_the_room_contract_pointer() {
+        let api_src = include_str!("api.rs");
+        let body_of = |start: &str, end: &str| -> &str {
+            api_src
+                .split_once(start)
+                .and_then(|(_, rest)| rest.split_once(end))
+                .map(|(body, _)| body)
+                .unwrap_or_else(|| panic!("could not isolate the body after `{start}`"))
+        };
+
+        for (name, body) in [
+            (
+                "stream_messages (polling)",
+                body_of(
+                    "    pub async fn stream_messages(",
+                    "\n    fn emit_new_and_edited(",
+                ),
+            ),
+            (
+                "subscribe_and_stream",
+                body_of("    pub async fn subscribe_and_stream(", "\n}\n"),
+            ),
+        ] {
+            assert!(
+                body.contains("Self::act_on_recheck(self.recheck_room_anchor().await"),
+                "{name} must re-check the pointer and act on the result; without it a \
+                 re-key leaves the stream listening to a contract nobody writes to"
+            );
+        }
+
+        // The subscription loop's re-check reads from the same connection and can
+        // discard a notification for this room, so it must queue a re-fetch.
+        let sub = body_of("    pub async fn subscribe_and_stream(", "\n}\n");
+        let recheck_at = sub.find("Self::act_on_recheck(").expect("checked above");
+        let refetch_at = sub[recheck_at..]
+            .find("pending.push_back(")
+            .map(|i| recheck_at + i);
+        let next_lock = sub[recheck_at..]
+            .find("let mut web_api = self.web_api.lock().await;")
+            .map(|i| recheck_at + i)
+            .expect("the loop must take the connection lock after the re-check");
+        assert!(
+            refetch_at.is_some_and(|r| r < next_lock),
+            "after re-checking the pointer, subscribe_and_stream must queue a re-fetch \
+             before it next reads the connection, or a message that arrived during the \
+             re-check stays unseen"
+        );
+    }
+
     /// Source-grep pins for the monitor edit/reply wiring (PR #322), in
     /// storage.rs so the pinned strings aren't self-satisfied by the scanned
     /// file (api.rs). Guards the exact regressions the PR fixed: a refactor

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -2321,6 +2321,12 @@ mod tests {
             polling.contains("Ok(mut room_state) if !seeded =>"),
             "an unseeded polling stream must seed instead of emitting"
         );
+        // The poll sleep must not outlast the next re-check, or a long
+        // `--poll-interval` defeats the re-check interval entirely.
+        assert!(
+            polling.contains(".min(until_recheck)"),
+            "stream_messages must cap its poll sleep at the next re-check"
+        );
     }
 
     /// Source-grep pins for the monitor edit/reply wiring (PR #322), in

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -2221,19 +2221,32 @@ mod tests {
             ),
             (
                 "subscribe_and_stream",
-                body_of("    pub async fn subscribe_and_stream(", "\n}\n"),
+                body_of("    pub async fn subscribe_and_stream(", "\n    }\n"),
             ),
         ] {
+            let call = body
+                .find("Self::act_on_recheck(self.recheck_room_anchor().await")
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{name} must re-check the pointer and act on the result; without it a \
+                         re-key leaves the stream listening to a contract nobody writes to"
+                    )
+                });
+            // And behind its timer. Without the gate the re-check fires on every
+            // loop iteration — a pointer GET per poll, and in lockstep across a
+            // fleet — and every other test here still passes.
+            let gate = body
+                .find("if std::time::Instant::now() >= next_recheck {")
+                .unwrap_or_else(|| panic!("{name} must gate the re-check on its interval"));
             assert!(
-                body.contains("Self::act_on_recheck(self.recheck_room_anchor().await"),
-                "{name} must re-check the pointer and act on the result; without it a \
-                 re-key leaves the stream listening to a contract nobody writes to"
+                gate < call && !body[gate..call].contains("\n            }"),
+                "{name}'s re-check must sit INSIDE the `>= next_recheck` gate"
             );
         }
 
         // The subscription loop's re-check reads from the same connection and can
         // discard a notification for this room, so it must queue a re-fetch.
-        let sub = body_of("    pub async fn subscribe_and_stream(", "\n}\n");
+        let sub = body_of("    pub async fn subscribe_and_stream(", "\n    }\n");
         let recheck_at = sub.find("Self::act_on_recheck(").expect("checked above");
         let refetch_at = sub[recheck_at..]
             .find("pending.push_back(")


### PR DESCRIPTION
## Problem

`riverctl message stream` looks up River's room-contract address once, at startup. When River re-keys the room contract, every room's address changes and a running stream keeps listening to the old one. Nothing errors: the room just appears to go quiet until someone restarts the bot. @Ivvor reported exactly this on Matrix. (#694)

## Approach

Every few minutes the stream re-checks River's pointer record. If it names a different, **signature-verified** generation, the stream exits with **status 75**. A restarted riverctl then uses the current generation through the same startup path every command already uses.

- **Any verified move exits**, including to a generation newer than this riverctl. A stream only reads, and reads are permitted against any generation, so a restarted stale riverctl can stream the new one once the room has moved there. It also prints riverctl's existing "older than River's room contract" upgrade advisory.
- **An unverified hash change is ignored.** A re-check that can't reach the pointer falls back to a hash that can differ with no re-key at all, and exiting on it would turn a timeout into a restart.
- **The anti-rollback floor is also kept in memory**, so a failed save (a read-only config directory) can't let an older signed record look like a move. At equal versions it uses the same tiebreak as River's resolver.

Status 75 is `EX_TEMPFAIL`, distinct from the status 1 every other failure uses. The README tells bot operators to **restart on any failure with a delay**, shows systemd with `RestartSec`, and states that a bot with no restart wrapper now **stops** after a re-key instead of silently going deaf.

### Why exit instead of following the move

#696 tried to follow the re-key inside the running process. It reached ~2,300 lines and seven review rounds, and nearly every defect was in the interactions inside the mid-run state it needed. A fresh process already does all of it correctly. This is option 2 from #694.

### A pre-existing bug this makes matter

A polling `message stream` (the default, without `--subscribe`) re-emitted the room's recent history on start: it recorded only the messages it displayed, so with `--initial-messages 0` the first poll reported everything as new. That was a nuisance while restarts were rare. Now that a stream restarts on every re-key, it would flood a bot each time, so polling now records the whole window at startup and shows only the last N, as `--subscribe` always has.

### Smaller points

- In `--subscribe` mode, the re-check's pointer GET shares the connection and discards what it steps over, so the loop queues a full-state re-fetch after each re-check.
- A polling stream's sleep is capped at the next re-check, so a long `--poll-interval` can't defeat it.

## Testing

- `pointer::recheck`: reconfirmed generation, unverified hash change, verified move to a known generation, verified move past this binary.
- `pointer::highest_floor`: disk behind, disk ahead, withdrawal at equal versions, lower-hash tiebreak at equal versions.
- `error::report`: a re-key prints its own message with status 75; every other error prints `Error: {err:?}` with status 1, exactly as before.
- Stream behaviour: a seeded poll of an unchanged room emits nothing, for `-i 0`, `1` and `3`; a move ends the stream with status 75; a failed re-check is an ordinary failure; jitter stays within ±20% and actually varies.
- Source pins: both loops re-check inside their timer gate and reset it; the subscription loop re-fetches after re-checking; the polling loop seeds before emitting and caps its sleep; `resolve_pointer` remembers each floor before saving and consults that memory.

Every guard was verified by a **compiling** mutation that reintroduces its bug (13 in total, all caught). `cargo test -p riverctl` passes, with no new clippy warnings.

Reviewed at Full tier over two rounds (four Claude lenses plus Codex each round). Findings and dispositions, including those declined and why, are in the review comments.

Bumps riverctl to 0.2.18 (0.2.17 is the latest on crates.io). No `common/` or WASM changes.

Closes #694

[AI-assisted - Claude]

https://claude.ai/code/session_01LSj17em5VJvYN4ZYCRJVdF
